### PR TITLE
chore(deps): P2Pool v4.16 (+ recommended monerod config) + Caddy 2.11.4 (for 1.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 First stable release.
 
+Bundled, SHA-pinned upstream components: **P2Pool v4.16**, **Monero v0.18.5.0**, **XMRig-proxy
+6.26.0**, **Tari/minotari_node v5.3.1-mainnet**, **Caddy 2.11.4**, **docker-socket-proxy v0.4.2**.
+The exact image digests for each release ship in the GitHub Release's ingredients manifest.
+
 ### Fixed
 
 - **Disconnected workers never fell off the "Workers Alive" table (#182 regression).** A worker that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ Bundled, SHA-pinned upstream components: **P2Pool v4.16**, **Monero v0.18.5.0**,
 6.26.0**, **Tari/minotari_node v5.3.1-mainnet**, **Caddy 2.11.4**, **docker-socket-proxy v0.4.2**.
 The exact image digests for each release ship in the GitHub Release's ingredients manifest.
 
+monerod follows P2Pool v4.16's recommendations where they're compatible with the Tor-first model:
+`in-peers=64` (the inbound/open-files cap) is honored exactly, and the optional clearnet initial sync
+(#183) runs monerod as a clearnet node should — `out-peers=32` + P2Pool's recommended priority nodes
+(`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`) for that window. The DNS-based recommendations
+(priority hostnames, DNS blocklist/checkpointing) stay off in Tor mode — they leak clearnet DNS
+(#161) — with monerod's compiled-in checkpoints as the substitute. `./pithead doctor` now also checks
+that the **system clock is NTP-synchronized** (clock skew gets shares/blocks rejected), per P2Pool's
+"synchronize your clock before mining" guidance.
+
 ### Fixed
 
 - **Disconnected workers never fell off the "Workers Alive" table (#182 regression).** A worker that

--- a/build/monero/bitmonero.conf.template
+++ b/build/monero/bitmonero.conf.template
@@ -24,9 +24,12 @@ public-node=1
 # ZeroMQ publisher for block notifications (Required for P2Pool)
 zmq-pub=tcp://0.0.0.0:18083
 
-# Peer Management. out-peers raised for Tor: each peer is roughly one bandwidth-capped
-# Tor circuit, so more peers = more aggregate download bandwidth in parallel. This is
-# network tuning (not CPU) — it does NOT scale with cores, unlike prep-blocks-threads below.
+# Peer Management. P2Pool v4.16 recommends out-peers=32 / in-peers=64 for a clearnet node, where
+# in-peers=64 is the one that matters: it caps INBOUND connections so they can't grow past ~1000 and
+# hit Linux's open-files limit — we honor it exactly. out-peers is raised to 48 here because each
+# peer is roughly one bandwidth-capped Tor circuit, so more peers = more aggregate download bandwidth
+# over Tor (this is network tuning, not CPU — it doesn't scale with cores). The optional clearnet
+# initial sync (#183) drops out-peers back to the recommended 32 + adds P2Pool's priority nodes.
 out-peers=48
 in-peers=64
 

--- a/build/monero/entrypoint.sh
+++ b/build/monero/entrypoint.sh
@@ -9,20 +9,33 @@ CONFIG_PATH="${CONFIG_PATH:-/root/.bitmonero/bitmonero.conf}"
 # sync already completed — come up on Tor." Default matches the compose mount; overridable for tests.
 CLEARNET_MARKER="${CLEARNET_MARKER:-/clearnet-state/monero.synced}"
 
-# Optional clearnet initial sync (#183). DEFAULT OFF. Transforms an already-rendered config:
-#   - strip the single `proxy=` line that forces ALL P2P over Tor → monerod then dials its
-#     compiled-in clearnet seed nodes directly, so the initial block download runs at clearnet
-#     speed instead of crawling over bandwidth-capped Tor circuits.
-#   - lower out-peers from the Tor-tuned 48 to a clearnet-friendly 16 (48 was a circuit-bandwidth
-#     workaround; on clearnet it over-connects and can stress home routers).
-# `tx-proxy=tor,...` is intentionally LEFT IN PLACE, so transaction broadcast stays on Tor
-# (tx-origin privacy preserved) — and there is no tx broadcast during a sync anyway. The only
-# exposure is node-existence: this host's IP is briefly visible to the Monero P2P network.
-# Kept as a function (portable sed, no in-place -e) so the shell test suite can exercise it
-# directly without envsubst or a running monerod.
+# Optional clearnet initial sync (#183). DEFAULT OFF. For the fast clearnet sync window only, this
+# makes monerod match the connectivity P2Pool v4.16 recommends for a clearnet node:
+#   - strip the single `proxy=` line that forces ALL P2P over Tor → monerod dials its compiled-in
+#     clearnet seed nodes (and the priority nodes below) directly, at clearnet speed instead of
+#     crawling over bandwidth-capped Tor circuits.
+#   - out-peers → 32 (P2Pool v4.16's clearnet recommendation; the Tor render uses 48, a circuit-
+#     bandwidth workaround). in-peers stays 64 — the open-files cap, which is the rec we always honor.
+#   - add P2Pool's recommended priority nodes for guaranteed-good peers + block templates. These are
+#     CLEARNET hostnames, so they're added ONLY here: in Tor mode their resolution would leak a
+#     clearnet DNS lookup tied to this host's IP (#161). Connections still arrive over clearnet,
+#     which is exactly the exposure this opt-in window already accepts.
+# `tx-proxy=tor,...` is LEFT IN PLACE so transaction broadcast stays on Tor (tx-origin privacy
+# preserved) — and there's no tx broadcast during a sync anyway. The DNS blocklist / DNS
+# checkpointing the rec also lists are MINING-time protections (bad-node bans, selfish-mining
+# defense) that don't apply to a download-only sync; in Tor mining mode they'd leak DNS (#161), so
+# we keep them off and rely on monerod's compiled-in checkpoints. The Tor render (the untouched
+# template) restores every private default the moment the dashboard flips back.
+# Kept as a function (portable sed, no in-place -e) so the shell test suite can exercise it directly.
 apply_clearnet_initial_sync() {
     local cfg="$1" tmp="$1.tmp"
-    sed -e '/^proxy=/d' -e 's/^out-peers=.*/out-peers=16/' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+    sed -e '/^proxy=/d' -e 's/^out-peers=.*/out-peers=32/' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+    cat >> "$cfg" <<'PRIONODES'
+
+# P2Pool v4.16 recommended priority nodes (clearnet sync window only — removed when flipped to Tor).
+add-priority-node=p2pmd.xmrvsbeast.com:18080
+add-priority-node=nodes.hashvault.pro:18080
+PRIONODES
 }
 
 # True when monerod should sync over clearnet NOW: the flag is on AND the auto-transition marker is

--- a/build/p2pool/Dockerfile
+++ b/build/p2pool/Dockerfile
@@ -1,8 +1,8 @@
 # Pinned by digest (#135) so the ubuntu:24.04 tag can't be silently re-pointed.
 FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
-ARG P2POOL_VERSION=v4.15.1
-ARG P2POOL_HASH=efd8b23579774711a5b86743da980e0936b7c220894063296719116d7f9ba254
+ARG P2POOL_VERSION=v4.16
+ARG P2POOL_HASH=1b03b2e4d4adfe488b2867eb85b57366fbaf8594a7f84cdbf13a3c8519159280
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -457,7 +457,7 @@ services:
   # Bridges the local 127.0.0.1 application binding to the LAN
   # Serves HTTPS or HTTP depending on configuration
   caddy:
-    image: caddy:2.11@sha256:cb9d71ad83182011b79355cd57692686374bd78d6fe327efe0ff8507da03ab13
+    image: caddy:2.11.4@sha256:cfeb0b281bc44a5a51fecde39e9e577c60d863c0b6196e6bbdf58fd00960887f
     container_name: caddy
     # Memory ceiling (#132 — see monerod). Reverse proxy + local TLS only (~13 MiB observed).
     mem_limit: 128m

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -147,7 +147,7 @@ you can enable either, both, or neither.
 
 | | Tor-only (default) | Clearnet initial sync (opt-in) |
 |---|---|---|
-| **Monero** P2P | over Tor (`proxy=172.28.0.25:9050`) | **direct to clearnet seed nodes** (proxy line dropped), `out-peers` lowered 48 → 16 |
+| **Monero** P2P | over Tor (`proxy=172.28.0.25:9050`) | **direct to clearnet seed nodes** (proxy line dropped), `out-peers` 48 → **32** + P2Pool v4.16's recommended **priority nodes** (`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`) for fast, reliable sync |
 | **Monero** tx broadcast | over Tor (`tx-proxy=`) | **still over Tor** — unchanged |
 | **Tari** transport | Tor (`type = "tor"`) | **TCP** (`type = "tcp"`) |
 | **Tari** seeds | onion `peer_seeds`, `dns_seeds = []` | **`dns_seeds = ["seeds.tari.com"]`** (onion seeds are unreachable without Tor), onion `public_addresses` dropped |
@@ -155,8 +155,11 @@ you can enable either, both, or neither.
 ### The privacy trade-off (threat model)
 
 **What is exposed while a flag is on:** your host's **IP address**, to the P2P network of the enabled
-chain — i.e. "this IP is running a Monero/Tari node." For Tari, one **DNS lookup** of `seeds.tari.com`
-also goes to the configured resolvers (`1.1.1.1` / `8.8.8.8` / `9.9.9.9`) to discover clearnet peers.
+chain — i.e. "this IP is running a Monero/Tari node." A few **DNS lookups** also happen over clearnet
+during the window: for Monero, the two P2Pool-recommended priority-node hostnames
+(`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`); for Tari, `seeds.tari.com` (to the configured
+resolvers `1.1.1.1` / `8.8.8.8` / `9.9.9.9`) to discover clearnet peers. This is the same exposure as
+any ordinary clearnet node — which is exactly what this window temporarily is.
 
 **What is *not* exposed:**
 

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 500 dashboard unit tests · 12 contract tests · 31 frontend
-tests · 39 `pithead` shell sections · 16 harness self-test sections ·
+tests · 40 `pithead` shell sections · 16 harness self-test sections ·
 9 live config scenarios (17 axis values) · 6 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 39 `pithead` shell sections · 16 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 500 |
 | 1 — Unit | frontend (node --test) | 31 |
-| 1 — Unit | `pithead` shell suite | 39 sections |
+| 1 — Unit | `pithead` shell suite | 40 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 6 |
@@ -610,7 +610,7 @@ tests · 39 `pithead` shell sections · 16 harness self-test sections ·
 - bandBorderWidth: zero-height segments get no border, real ones keep full width
 - uptimeCell: online shows uptime, offline shows DOWN
 
-### `pithead` shell suite (tests/stack/run.sh) — 39 sections
+### `pithead` shell suite (tests/stack/run.sh) — 40 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -620,6 +620,7 @@ tests · 39 `pithead` shell sections · 16 harness self-test sections ·
 - unit: is_valid_host (#130)
 - unit: describe_change
 - unit: clearnet initial sync helpers (#183)
+- unit: clock_sync_status (mining is time-sensitive)
 - unit: dashboard auth (#8)
 - unit: generate_caddyfile scheme (#140)
 - unit: host detection (#140)
@@ -794,5 +795,5 @@ tests · 39 `pithead` shell sections · 16 harness self-test sections ·
 
 ---
 
-_Grand total: **613** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **614** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -351,6 +351,19 @@ dr_fail() { DR_FAIL=$((DR_FAIL + 1)); printf '  %b✗ FAIL%b %s\n'   "$C_RED"   
 # Neutral note for context lines that aren't pass/fail (e.g. a skipped Linux-only check).
 dr_info() { printf '  %b•%b      %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
 
+# Best-effort system-clock sync status. Mining is time-sensitive — P2Pool/Monero stamp shares and
+# blocks, so a skewed clock gets shares/blocks rejected ("strongly recommended to synchronize your
+# system clock before you start mining"). Prints: synced | unsynced | unknown. Pure given the
+# timedatectl output, so a stubbed timedatectl makes the classification unit-testable.
+clock_sync_status() {
+    command -v timedatectl >/dev/null 2>&1 || { echo unknown; return; }
+    case "$(timedatectl show -p NTPSynchronized --value 2>/dev/null)" in
+        yes) echo synced ;;
+        no)  echo unsynced ;;
+        *)   echo unknown ;;
+    esac
+}
+
 # True if Docker is set to start at boot (docker.service OR docker.socket enabled). systemd only —
 # the caller checks that systemctl exists. Checking docker.socket too covers socket-activated
 # installs where docker.service is "static" but Docker still comes up at boot.
@@ -429,6 +442,13 @@ doctor() {
     else
         dr_warn "AVX2 not detected — mining performance will be poor (performance only, not fatal)."
     fi
+
+    # --- Time sync (mining is time-sensitive; P2Pool strongly recommends NTP before mining) ---
+    case "$(clock_sync_status)" in
+        synced)   dr_ok "System clock is NTP-synchronized." ;;
+        unsynced) dr_warn "System clock is NOT NTP-synchronized — clock skew gets shares/blocks rejected. Enable time sync: 'sudo timedatectl set-ntp true' (or run chrony/systemd-timesyncd/ntpd)." ;;
+        *)        dr_info "Could not verify system-clock sync (no timedatectl) — make sure NTP is running; mining is time-sensitive." ;;
+    esac
 
     # --- Memory (Linux only) ---
     echo ""

--- a/pithead
+++ b/pithead
@@ -192,6 +192,12 @@ stack_upgrade() {
     # Source checkout: rebuild the images from build/. Release install: pull the new published images
     # instead — force a re-pull so a moved tag is refreshed (#44).
     if is_source_checkout; then
+        # Source checkouts build the first-party images locally (--build) and use --pull never so up
+        # never tries to pull an unpublished :dev tag. But the THIRD-PARTY images (caddy, tari, the
+        # socket-proxies) are pinned by digest and CAN change between releases — under --pull never a
+        # bumped digest fails with "No such image". Pull just the non-buildable images first so a new
+        # digest is fetched; best-effort (older compose without --ignore-buildable falls through).
+        docker compose pull --ignore-buildable 2>/dev/null || true
         compose_up_checked -d --build || error "Upgrade failed during 'docker compose up' — see the error above."
     else
         PITHEAD_PULL=always compose_up_checked -d || error "Upgrade failed during 'docker compose up' — see the error above."

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -901,6 +901,10 @@ assert_eq "upgrade preserves the proxy token"               "$(run_sourced "$U" 
 # require_deployed command (up/apply/upgrade) errors "run setup" on an already-deployed box.
 assert_eq "upgrade preserves DEPLOYMENT_COMPLETED (require_deployed survives)" "$(run_sourced "$U" env_get_file "$U/.env" DEPLOYMENT_COMPLETED)" "true"
 assert_contains "upgrade still rebuilds images (source mode)" "$(cat "$UL")" "compose up --pull never -d --build"
+# Third-party images (caddy/tari/socket-proxies) are digest-pinned and can change between releases;
+# a source-mode upgrade pulls the non-buildable ones first so a bumped digest is fetched (not "No
+# such image" under --pull never). Best-effort, so it runs before the build.
+assert_contains "upgrade pulls non-buildable images first (digest bumps)" "$(cat "$UL")" "compose pull --ignore-buildable"
 
 echo "== black-box: apply recovers from a failed 'compose up' (#125) =="
 # A docker stub that fails `compose up -d --remove-orphans` only when FAIL_UP=1 (else succeeds).

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -179,7 +179,11 @@ case "$(grep -E '^proxy=' "$MONT" || true)" in
     *)  bad "monero clearnet: P2P proxy= line stripped (#183)" "still present" ;;
 esac
 assert_contains "monero clearnet: tx-proxy stays on Tor (#183)"   "$(cat "$MONT")" "tx-proxy=tor"
-assert_contains "monero clearnet: out-peers lowered to 16 (#183)"  "$(cat "$MONT")" "out-peers=16"
+# P2Pool v4.16 clearnet recommendation: out-peers 32 + the recommended priority nodes (added only in
+# the clearnet window; the Tor template has neither — the #161 check below guards that).
+assert_contains "monero clearnet: out-peers=32 (p2pool v4.16 rec)"  "$(cat "$MONT")" "out-peers=32"
+assert_contains "monero clearnet: xmrvsbeast priority node (v4.16)" "$(cat "$MONT")" "add-priority-node=p2pmd.xmrvsbeast.com:18080"
+assert_contains "monero clearnet: hashvault priority node (v4.16)"  "$(cat "$MONT")" "add-priority-node=nodes.hashvault.pro:18080"
 # The committed template (the Tor-only default) keeps the proxy line + the Tor-tuned out-peers.
 assert_contains "monero default: Tor P2P proxy present (#183)" "$(cat "$ROOT/build/monero/bitmonero.conf.template")" 'proxy=${NETWORK_PREFIX}.25:9050'
 assert_contains "monero default: out-peers 48 for Tor (#183)"  "$(cat "$ROOT/build/monero/bitmonero.conf.template")" "out-peers=48"
@@ -214,6 +218,14 @@ assert_contains "tari entrypoint never mutates the canonical config (#234)" "$(c
 # wrapper entrypoint that chains to the upstream start_tari_app.sh.
 assert_contains "compose mounts clearnet-state into monerod (#234)" "$(cat "$ROOT/docker-compose.yml")" ':/clearnet-state:ro'
 assert_contains "compose wires the tari wrapper entrypoint (#234)"  "$(cat "$ROOT/docker-compose.yml")" '/var/tari/config/entrypoint.sh'
+
+echo "== unit: clock_sync_status (mining is time-sensitive) =="
+# doctor's NTP check classifies timedatectl's NTPSynchronized: yes→synced, no→unsynced, else unknown.
+CLKBIN="$SANDBOX/clk-bin"; mkdir -p "$CLKBIN"
+mk_timedatectl() { printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s"\n' "$1" > "$CLKBIN/timedatectl"; chmod +x "$CLKBIN/timedatectl"; }
+mk_timedatectl "yes"; assert_eq "clock_sync_status: NTP yes => synced"   "$(PATH="$CLKBIN:$PATH" run_sourced "$SANDBOX" clock_sync_status)" "synced"
+mk_timedatectl "no";  assert_eq "clock_sync_status: NTP no => unsynced"  "$(PATH="$CLKBIN:$PATH" run_sourced "$SANDBOX" clock_sync_status)" "unsynced"
+mk_timedatectl "";    assert_eq "clock_sync_status: blank => unknown"     "$(PATH="$CLKBIN:$PATH" run_sourced "$SANDBOX" clock_sync_status)" "unknown"
 
 echo "== unit: dashboard auth (#8) =="
 # Dashboard login (#8): enabling/changing is DEST (caddy is recreated), disabling is INFO. The bcrypt

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -107,7 +107,7 @@ expect_min "log rotation on every service" "max-size:" 9
 # Image digest pinning (#135): the externally-pulled images must reference an immutable @sha256
 # digest, not just a mutable tag, so a re-pushed tag can't silently change the running image.
 expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:"
-expect_present "caddy pinned by digest" "caddy:2.11@sha256:"
+expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:"
 expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:"
 
 # Per-service precision checks via the JSON render (cleaner than grepping the flat YAML): the


### PR DESCRIPTION
Dependency refresh for the **1.0.0** release.

## Updated
- **P2Pool `v4.15.1` → `v4.16`** ([release](https://github.com/SChernykh/p2pool/releases/tag/v4.16)) — `build/p2pool/Dockerfile` version + SHA256 re-pinned to the v4.16 linux-x64 asset (`1b03b2e4…`). **Verified** by downloading the official release asset and building the image: `p2pool.tar.gz: OK` (checksum matched) and the built binary reports `P2Pool v4.16`.
- **Caddy `2.11` → `2.11.4`** — `docker-compose.yml` re-pinned to the current 2.11 patch digest (`cb9d71a…` → `cfeb0b28…`); digest pulls cleanly. `test_compose.sh` digest-pin assertion updated.

## Checked, already latest (no change)
Monero `v0.18.5.0`, XMRig-proxy `6.26.0`, Tari/minotari_node `v5.3.1-mainnet`, docker-socket-proxy `v0.4.2`, `ubuntu:24.04` base.

## Validation
Full `make test` green; the **Build image (p2pool)** CI job builds v4.16 from source; deployed + health-checked on gouda. CHANGELOG notes the bundled, SHA-pinned component versions for 1.0.0.