### PR TITLE
feat(dashboard): opt-in Tor onion for remote dashboard access (#343)

### DIFF
--- a/build/tor/entrypoint.sh
+++ b/build/tor/entrypoint.sh
@@ -9,4 +9,17 @@ set -eu
 
 sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" /etc/tor/torrc.template >/tmp/torrc
 
+# Dashboard hidden service (#343): opt-in, default off. Appended only when pithead sets the flag, so
+# the default stack publishes exactly the three mining onions and nothing else. The target is the
+# bridge gateway (NETWORK_PREFIX.1), where host-networked Caddy binds the auth-gated onion vhost —
+# NOT the dashboard's raw :8000 (which has no auth of its own). Tor supplies the transport encryption.
+if [ "${DASHBOARD_ONION_ENABLED:-false}" = "true" ]; then
+    cat >>/tmp/torrc <<EOF
+
+# Dashboard Hidden Service (#343)
+HiddenServiceDir /var/lib/tor/dashboard/
+HiddenServicePort 80 ${NETWORK_PREFIX}.1:80
+EOF
+fi
+
 exec tor -f /tmp/torrc

--- a/config.reference.json
+++ b/config.reference.json
@@ -64,6 +64,10 @@
         "auth": {
             "username": "admin",
             "password": ""
+        },
+        "onion": {
+            "enabled": false,
+            "client_auth": true
         }
     },
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       # Dashboard onion (#343): opt-in, default off. When true the entrypoint appends a hidden
       # service for the dashboard (fronting Caddy on the bridge gateway, never the LAN).
       - DASHBOARD_ONION_ENABLED=${DASHBOARD_ONION_ENABLED:-false}
+      # Client-auth toggle (#343): the entrypoint doesn't read it, but listing it here means a change
+      # recreates tor so it re-reads authorized_clients/ (pithead writes/clears that before recreate).
+      - DASHBOARD_ONION_CLIENT_AUTH=${DASHBOARD_ONION_CLIENT_AUTH:-false}
     volumes:
       - ${TOR_DATA_DIR}:/var/lib/tor
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     environment:
       # Subnet prefix (#180): the entrypoint envsubst's it into the rendered torrc's bridge IPs.
       - NETWORK_PREFIX=${NETWORK_PREFIX:-172.28.0}
+      # Dashboard onion (#343): opt-in, default off. When true the entrypoint appends a hidden
+      # service for the dashboard (fronting Caddy on the bridge gateway, never the LAN).
+      - DASHBOARD_ONION_ENABLED=${DASHBOARD_ONION_ENABLED:-false}
     volumes:
       - ${TOR_DATA_DIR}:/var/lib/tor
     networks:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,8 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
 | `dashboard.auth.username` | `admin` | Login name for the dashboard when a password is set (see below). Letters, digits, and `. _ @ -`, 1–64 chars. Ignored while `dashboard.auth.password` is empty. |
 | `dashboard.auth.password` | `""` _(off)_ | Optional password to open the dashboard. Turns on a Caddy [HTTP basic-auth](https://caddyserver.com/docs/caddyfile/directives/basic_auth) prompt in front of every page. `""` (default) = no login, anyone who can reach the dashboard sees it (fine for a private LAN appliance). Any 8–128-character string (no double-quotes) turns the prompt on. The plaintext lives only in your owner-only `config.json`; pithead bcrypt-hashes it with the pinned Caddy image and stores only the hash in `.env`, so the password itself is never persisted in rendered state. Basic-auth credentials travel in cleartext over HTTP, so keep `dashboard.secure: true` (the default); pithead warns if you set a password with `secure: false`. See [Exposing the dashboard safely](#exposing-the-dashboard-safely). |
+| `dashboard.onion.enabled` | `false` _(off)_ | Privacy-relevant, default off. `true` publishes the dashboard as a Tor v3 onion service so you can reach it remotely over Tor — no port-forward, no VPN, no public IP. It fronts the authenticated Caddy login on the internal bridge, never the LAN. pithead **fails closed**: it refuses to enable the onion without a `dashboard.auth.password` and requires that password to be at least 16 characters. See [Remote access over Tor](#remote-access-over-tor-onion-service). |
+| `dashboard.onion.client_auth` | `true` _(on)_ | Only applies when `dashboard.onion.enabled` is `true`. Keeps Tor v3 **client authorization** on: the onion does not respond at all without your client key, so the address can't be scanned or brute-forced — the password becomes a second factor behind it. pithead generates the keypair and prints the client line via `pithead onion-client-key`. Set to `false` for a deliberately password-only onion. |
 | `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = the host machine's timezone (auto-detected, falling back to `Etc/UTC`); set an IANA name (e.g. `America/Chicago`) to override. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
 | `dashboard.check_for_updates` | `true` _(on)_ | The dashboard periodically asks GitHub whether a newer Pithead release exists and, if so, shows a header badge linking to it (e.g. "New release v1.4.0 available"). Notify-only: it never updates anything; you upgrade with `./pithead upgrade` on your own terms. On by default because the check is routed over Tor (the same bridge SOCKS as the XvB fetch, `socks5h` so the DNS lookup goes through Tor too), so GitHub sees a Tor exit, not your IP. It's cached (hourly) and fails silently offline. Set to `false` to opt out entirely. See [Privacy › Runtime egress](privacy.md#runtime-egress). |
@@ -218,28 +220,43 @@ The stack already runs Tor for the mining traffic; this rides the same daemon.
 ```json
 "dashboard": {
     "secure": true,
-    "onion": { "enabled": true },
+    "onion": { "enabled": true, "client_auth": true },
     "auth": { "username": "admin", "password": "a long passphrase you choose" }
 }
 ```
 
 Because a published `.onion` puts a control panel at a stable address, pithead **fails closed**:
 
-- It refuses to render the onion unless `dashboard.auth.password` is set, and requires at least 16
-  characters for it — a published address is reachable by anyone who learns it, and per-request
-  rate-limiting is meaningless over Tor (every request arrives from the local Tor daemon, so there
-  is no source IP to throttle). Use a passphrase.
+- It refuses to render the onion unless `dashboard.auth.password` is set, requires at least 16
+  characters, and rejects obviously weak choices (a single repeated character, well-known patterns).
+  A published address is reachable by anyone who learns it, and per-request rate-limiting is
+  meaningless over Tor — every request arrives from the local Tor daemon, so there is no source IP
+  to throttle. Use a passphrase.
+- **Client authorization is on by default** (`client_auth: true`). A client-auth'd onion does not
+  respond at all without your client key, so the address cannot be scanned or brute-forced — the
+  password becomes a second factor behind it. This is the strong primary gate.
 - The onion serves plain HTTP inside the Tor tunnel (Tor encrypts the transport), fronted by the
   same login as the LAN path. It is bound to the internal Docker bridge, not the LAN, so it is
   reachable only through Tor.
 
-After `apply`, read the generated address from `pithead status` (it is printed only to that local
-output). Treat the `.onion` as a secret: anyone who has it can reach the login.
+After `apply`, read the address from `pithead status` (printed only to that local output). Treat the
+`.onion` as a secret: anyone who has it can _attempt_ the login (and, without client-auth, reach it).
 
-> The password is currently the only lock on the onion. It is therefore online-guessable by anyone
-> with the address — which is why the 16-character floor is enforced. Stronger Tor v3 client
-> authorization (the service does not respond at all without a client key) is planned; track it in
-> [#343](https://github.com/p2pool-starter-stack/pithead/issues/343).
+**Setting up client authorization on your device.** Run `pithead onion-client-key` — it prints a
+single line containing your client PRIVATE key (kept out of `status`, which is a shareable report):
+
+```text
+<address>:descriptor:x25519:<private-key>
+```
+
+Save that line into a file (e.g. `dashboard.auth_private`) inside your local Tor client's
+`ClientOnionAuthDir`, then reach the dashboard at `http://<address>.onion`. Without it, the onion is
+invisible. Set `client_auth: false` for a deliberately password-only onion (weaker — the address
+becomes online-guessable, so lean on the password).
+
+**Rotation.** A leaked `.onion` address or client key is otherwise permanent. Run
+`pithead rotate-dashboard-onion` to mint a fresh address and client key; the old ones stop working
+immediately, and the command prints the new client line.
 
 Prefer a mesh VPN like Tailscale instead? Point it at the LAN yourself — the stack does not ship a
 profile for it, and the onion service is the supported remote path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,17 +243,23 @@ Because a published `.onion` puts a control panel at a stable address, pithead *
 After `apply`, read the address from `pithead status` (printed only to that local output). Treat the
 `.onion` as a secret: anyone who has it can _attempt_ the login (and, without client-auth, reach it).
 
-**Setting up client authorization on your device.** Run `pithead onion-client-key` — it prints a
-single line containing your client PRIVATE key (kept out of `status`, which is a shareable report):
+**Connecting with client authorization.** With `client_auth: true` the onion won't answer at all
+until your Tor client presents the private key. Run `pithead onion-client-key` on the host — it
+prints the address and the key in both forms you might need (it's kept out of `status`, which is a
+shareable report). Then pick your client:
 
-```text
-<address>:descriptor:x25519:<private-key>
-```
+- **Tor Browser (easiest).** Open `http://<address>.onion`. Tor Browser prompts for the onion's
+  private key — paste the bare key (the value after `x25519:`) and continue. Nothing else to set up.
+- **System Tor or Orbot (persistent).** Add a line to your `torrc`:
+  `ClientOnionAuthDir /var/lib/tor/onion_auth` (any dir you own, mode `0700`). Inside it, create
+  `dashboard.auth_private` containing the one-line form
+  `<address>:descriptor:x25519:<private-key>`, then reload Tor. Now any Tor-aware client on that
+  machine can reach the onion.
 
-Save that line into a file (e.g. `dashboard.auth_private`) inside your local Tor client's
-`ClientOnionAuthDir`, then reach the dashboard at `http://<address>.onion`. Without it, the onion is
-invisible. Set `client_auth: false` for a deliberately password-only onion (weaker — the address
-becomes online-guessable, so lean on the password).
+After that, browse to `http://<address>.onion` and log in with your dashboard username/password.
+Without the client key the onion is invisible — that's the point. Set `client_auth: false` for a
+deliberately password-only onion (weaker: the address becomes online-guessable, so lean on the
+password).
 
 **Rotation.** A leaked `.onion` address or client key is otherwise permanent. Run
 `pithead rotate-dashboard-onion` to mint a fresh address and client key; the old ones stop working

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,11 +203,46 @@ How it works and what to keep in mind:
   port miners connect to is a separate surface; gate that with
   [`p2pool.stratum_password`](#configuration-reference) and `p2pool.stratum_bind`.
 - Exposing to the public internet is still discouraged. A password plus HTTPS is the right baseline,
-  but the safest remote-access path remains a VPN / SSH tunnel / Tailscale back to the LAN rather than
-  a forwarded port. Basic-auth has no rate-limiting or lockout on its own.
+  but for reaching the dashboard from outside the LAN, publish it as a Tor onion service (below)
+  rather than forwarding a port. Basic-auth has no rate-limiting or lockout on its own.
 
 To remove the login again, clear the password (`"password": ""`) and `apply`. pithead drops the
 `basic_auth` block and the dashboard is open on the LAN as before.
+
+### Remote access over Tor (onion service)
+
+Set `dashboard.onion.enabled: true` to publish the dashboard as a Tor v3 hidden service. You then
+reach it from anywhere over Tor — no port-forward, no VPN, no public IP, no inbound firewall hole.
+The stack already runs Tor for the mining traffic; this rides the same daemon.
+
+```json
+"dashboard": {
+    "secure": true,
+    "onion": { "enabled": true },
+    "auth": { "username": "admin", "password": "a long passphrase you choose" }
+}
+```
+
+Because a published `.onion` puts a control panel at a stable address, pithead **fails closed**:
+
+- It refuses to render the onion unless `dashboard.auth.password` is set, and requires at least 16
+  characters for it — a published address is reachable by anyone who learns it, and per-request
+  rate-limiting is meaningless over Tor (every request arrives from the local Tor daemon, so there
+  is no source IP to throttle). Use a passphrase.
+- The onion serves plain HTTP inside the Tor tunnel (Tor encrypts the transport), fronted by the
+  same login as the LAN path. It is bound to the internal Docker bridge, not the LAN, so it is
+  reachable only through Tor.
+
+After `apply`, read the generated address from `pithead status` (it is printed only to that local
+output). Treat the `.onion` as a secret: anyone who has it can reach the login.
+
+> The password is currently the only lock on the onion. It is therefore online-guessable by anyone
+> with the address — which is why the 16-character floor is enforced. Stronger Tor v3 client
+> authorization (the service does not respond at all without a client key) is planned; track it in
+> [#343](https://github.com/p2pool-starter-stack/pithead/issues/343).
+
+Prefer a mesh VPN like Tailscale instead? Point it at the LAN yourself — the stack does not ship a
+profile for it, and the onion service is the supported remote path.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
 | `dashboard.auth.username` | `admin` | Login name for the dashboard when a password is set (see below). Letters, digits, and `. _ @ -`, 1–64 chars. Ignored while `dashboard.auth.password` is empty. |
 | `dashboard.auth.password` | `""` _(off)_ | Optional password to open the dashboard. Turns on a Caddy [HTTP basic-auth](https://caddyserver.com/docs/caddyfile/directives/basic_auth) prompt in front of every page. `""` (default) = no login, anyone who can reach the dashboard sees it (fine for a private LAN appliance). Any 8–128-character string (no double-quotes) turns the prompt on. The plaintext lives only in your owner-only `config.json`; pithead bcrypt-hashes it with the pinned Caddy image and stores only the hash in `.env`, so the password itself is never persisted in rendered state. Basic-auth credentials travel in cleartext over HTTP, so keep `dashboard.secure: true` (the default); pithead warns if you set a password with `secure: false`. See [Exposing the dashboard safely](#exposing-the-dashboard-safely). |
-| `dashboard.onion.enabled` | `false` _(off)_ | Privacy-relevant, default off. `true` publishes the dashboard as a Tor v3 onion service so you can reach it remotely over Tor — no port-forward, no VPN, no public IP. It fronts the authenticated Caddy login on the internal bridge, never the LAN. pithead **fails closed**: it refuses to enable the onion without a `dashboard.auth.password` and requires that password to be at least 16 characters. See [Remote access over Tor](#remote-access-over-tor-onion-service). |
+| `dashboard.onion.enabled` | `false` _(off)_ | Privacy-relevant, default off. `true` publishes the dashboard as a Tor v3 onion service so you can reach it remotely over Tor — no port-forward, no VPN, no public IP. It fronts the authenticated Caddy login on the internal bridge, never the LAN. pithead **fails closed**: if no `dashboard.auth.password` is set it generates a strong one (saved to `config.json`, login `admin`); a password you set yourself must be at least 16 characters. See [Remote access over Tor](#remote-access-over-tor-onion-service). |
 | `dashboard.onion.client_auth` | `true` _(on)_ | Only applies when `dashboard.onion.enabled` is `true`. Keeps Tor v3 **client authorization** on: the onion does not respond at all without your client key, so the address can't be scanned or brute-forced — the password becomes a second factor behind it. pithead generates the keypair and prints the client line via `pithead onion-client-key`. Set to `false` for a deliberately password-only onion. |
 | `dashboard.timezone` | `auto` | Timezone for the dashboard's timestamps and charts. `auto` = the host machine's timezone (auto-detected, falling back to `Etc/UTC`); set an IANA name (e.g. `America/Chicago`) to override. |
 | `dashboard.data_dir` | `auto` | Where the dashboard's database lives. `auto` = `./data/dashboard`. |
@@ -227,11 +227,12 @@ The stack already runs Tor for the mining traffic; this rides the same daemon.
 
 Because a published `.onion` puts a control panel at a stable address, pithead **fails closed**:
 
-- It refuses to render the onion unless `dashboard.auth.password` is set, requires at least 16
-  characters, and rejects obviously weak choices (a single repeated character, well-known patterns).
-  A published address is reachable by anyone who learns it, and per-request rate-limiting is
-  meaningless over Tor — every request arrives from the local Tor daemon, so there is no source IP
-  to throttle. Use a passphrase.
+- If you enable the onion without a `dashboard.auth.password`, pithead **generates a strong one**,
+  saves it to `config.json`, and uses `admin` as the login — so the onion is never published without
+  a password. If you set the password yourself it must be at least 16 characters, and pithead rejects
+  obviously weak choices (a single repeated character, well-known patterns). A published address is
+  reachable by anyone who learns it, and per-request rate-limiting is meaningless over Tor — every
+  request arrives from the local Tor daemon, so there is no source IP to throttle. Use a passphrase.
 - **Client authorization is on by default** (`client_auth: true`). A client-auth'd onion does not
   respond at all without your client key, so the address cannot be scanned or brute-forced — the
   password becomes a second factor behind it. This is the strong primary gate.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -51,6 +51,11 @@ address): monerod, Tari, and P2Pool each get one from the built-in Tor daemon. S
   setup`/`doctor` warn if your host has a public IP. Lock it down with `p2pool.stratum_bind`, a
   firewall, and/or an optional `p2pool.stratum_password` that requires each rig to authenticate.
   See [Connecting miners › Firewall](workers.md#firewall) and [Authentication](workers.md#authentication).
+- The **dashboard** can get a fourth, optional onion (`dashboard.onion.enabled`, default off) so you
+  can reach it remotely over Tor without a port-forward or public IP. It fronts the authenticated
+  Caddy login, and pithead refuses to publish it without a 16-character password. This is **inbound**
+  access over Tor and does not change the egress table below. See
+  [Remote access over Tor](configuration.md#remote-access-over-tor-onion-service).
 
 ---
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -53,8 +53,9 @@ address): monerod, Tari, and P2Pool each get one from the built-in Tor daemon. S
   See [Connecting miners › Firewall](workers.md#firewall) and [Authentication](workers.md#authentication).
 - The **dashboard** can get a fourth, optional onion (`dashboard.onion.enabled`, default off) so you
   can reach it remotely over Tor without a port-forward or public IP. It fronts the authenticated
-  Caddy login, and pithead refuses to publish it without a 16-character password. This is **inbound**
-  access over Tor and does not change the egress table below. See
+  Caddy login, defaults to Tor v3 client authorization (the onion won't respond without your client
+  key), and pithead refuses to publish it without a 16-character password. This is **inbound** access
+  over Tor and does not change the egress table below. See
   [Remote access over Tor](configuration.md#remote-access-over-tor-onion-service).
 
 ---

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 795 dashboard unit tests · 12 contract tests · 66 frontend
-tests · 52 `pithead` shell sections · 18 harness self-test sections ·
+tests · 53 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 8 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 52 `pithead` shell sections · 18 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 795 |
 | 1 — Unit | frontend (node --test) | 66 |
-| 1 — Unit | `pithead` shell suite | 52 sections |
+| 1 — Unit | `pithead` shell suite | 53 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 8 |
@@ -958,7 +958,7 @@ tests · 52 `pithead` shell sections · 18 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 52 sections
+### `pithead` shell suite (tests/stack/run.sh) — 53 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -981,6 +981,7 @@ tests · 52 `pithead` shell sections · 18 harness self-test sections ·
 - unit: monero_address_type — p2pool needs a PRIMARY address (#250)
 - unit: dashboard auth (#8)
 - unit: generate_caddyfile scheme (#140)
+- unit: generate_caddyfile onion vhost (#343)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
 - unit: pull-vs-build mode (#44)
@@ -1172,5 +1173,5 @@ tests · 52 `pithead` shell sections · 18 harness self-test sections ·
 
 ---
 
-_Grand total: **960** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **961** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 795 dashboard unit tests · 12 contract tests · 66 frontend
-tests · 53 `pithead` shell sections · 18 harness self-test sections ·
+tests · 54 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 8 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 53 `pithead` shell sections · 18 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 795 |
 | 1 — Unit | frontend (node --test) | 66 |
-| 1 — Unit | `pithead` shell suite | 53 sections |
+| 1 — Unit | `pithead` shell suite | 54 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 8 |
@@ -958,7 +958,7 @@ tests · 53 `pithead` shell sections · 18 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 53 sections
+### `pithead` shell suite (tests/stack/run.sh) — 54 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -982,6 +982,7 @@ tests · 53 `pithead` shell sections · 18 harness self-test sections ·
 - unit: dashboard auth (#8)
 - unit: generate_caddyfile scheme (#140)
 - unit: generate_caddyfile onion vhost (#343)
+- unit: onion client-auth crypto (#343)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
 - unit: pull-vs-build mode (#44)
@@ -1173,5 +1174,5 @@ tests · 53 `pithead` shell sections · 18 harness self-test sections ·
 
 ---
 
-_Grand total: **961** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **962** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -5,7 +5,7 @@ edit by hand** — re-run the target to refresh. See [Testing Strategy](testing-
 how the tiers fit together._
 
 **Totals:** 795 dashboard unit tests · 12 contract tests · 66 frontend
-tests · 54 `pithead` shell sections · 18 harness self-test sections ·
+tests · 55 `pithead` shell sections · 18 harness self-test sections ·
 9 live config scenarios (17 axis values) · 8 mini-stack scenarios.
 
 > Counts are **test functions / named cases** (parametrized pytest cases expand to more at
@@ -16,7 +16,7 @@ tests · 54 `pithead` shell sections · 18 harness self-test sections ·
 |---|---|---|
 | 1 — Unit | dashboard pytest | 795 |
 | 1 — Unit | frontend (node --test) | 66 |
-| 1 — Unit | `pithead` shell suite | 54 sections |
+| 1 — Unit | `pithead` shell suite | 55 sections |
 | 1 — Unit | compose interpolation + hardening (#90) | 1 |
 | 2 — Contract | fake-daemon clients | 12 |
 | 3 — Mini-stack | docker control-plane scenarios | 8 |
@@ -958,7 +958,7 @@ tests · 54 `pithead` shell sections · 18 harness self-test sections ·
 - edgePath: column-crossing edges route orthogonally through a clear lane
 - route palette + names cover every route the server can emit
 
-### `pithead` shell suite (tests/stack/run.sh) — 54 sections
+### `pithead` shell suite (tests/stack/run.sh) — 55 sections
 - unit: resolve_default
 - unit: assert_safe_dir
 - unit: is_public_ip classifier (#113)
@@ -983,6 +983,7 @@ tests · 54 `pithead` shell sections · 18 harness self-test sections ·
 - unit: generate_caddyfile scheme (#140)
 - unit: generate_caddyfile onion vhost (#343)
 - unit: onion client-auth crypto (#343)
+- unit: ensure_onion_password auto-generates (#343)
 - unit: host detection (#140)
 - unit: release.sh pure logic (#44)
 - unit: pull-vs-build mode (#44)
@@ -1174,5 +1175,5 @@ tests · 54 `pithead` shell sections · 18 harness self-test sections ·
 
 ---
 
-_Grand total: **962** enumerated cases/sections across the four tiers (plus the live
+_Grand total: **963** enumerated cases/sections across the four tiers (plus the live
 lifecycle and fault-injection phases, which are exercised on a real server)._

--- a/pithead
+++ b/pithead
@@ -752,6 +752,16 @@ doctor() {
                 dr_ok "$k set."
             fi
         done
+        # Dashboard onion (#343): only meaningful when opted in. Print the actual address — it is the
+        # capability an operator needs to reach the panel — but only to this local status output.
+        if [ "$(env_get DASHBOARD_ONION_ENABLED)" == "true" ]; then
+            onion=$(env_get DASHBOARD_ONION_ADDRESS)
+            if [ -z "$onion" ] || [ "$onion" == "placeholder" ]; then
+                dr_warn "DASHBOARD_ONION_ADDRESS is not provisioned yet — re-run 'pithead setup' or 'pithead apply'."
+            else
+                dr_ok "Dashboard onion: http://$onion (login required)"
+            fi
+        fi
     fi
 
     # --- Containers (best-effort) ---
@@ -1817,9 +1827,27 @@ parse_and_validate_config() {
             DASHBOARD_AUTH_HASH_B64=$(caddy_hash_password_b64 "$dash_pw") ||
                 error "Could not hash dashboard.auth.password (is Docker running and the Caddy image pulled? Run '$0 setup' first)."
         fi
-        # basic_auth credentials are only safe over TLS; warn (don't fail) on plain HTTP.
-        if [ "$DASHBOARD_SECURE" != "true" ]; then
+        # basic_auth credentials are only safe over TLS; warn (don't fail) on plain HTTP. This is
+        # about the LAN vhost — the onion vhost (#343) serves plain HTTP by design (Tor is the
+        # transport), so it is exempt and does not trip this.
+        if [ "$DASHBOARD_SECURE" != "true" ] && [ "$(config_bool '.dashboard.onion.enabled' false)" != "true" ]; then
             warn "dashboard.auth is set but dashboard.secure is false — login credentials would travel over plain HTTP. Set dashboard.secure: true for HTTPS."
+        fi
+    fi
+
+    # Optional dashboard onion (#343). Opt-in, default off. When on, pithead publishes the dashboard
+    # as a Tor v3 hidden service — reachable from anywhere over Tor, no exposed ports, no public IP.
+    # Because that puts a CONTROL PANEL at a stable address, FAIL CLOSED: refuse to enable it without
+    # a login, and demand a stronger password than the LAN 8-char floor — a published .onion is
+    # online-brute-forceable (per-IP throttling is meaningless over Tor; every request arrives from
+    # the local tor daemon, so there is no source IP to rate-limit against).
+    DASHBOARD_ONION_ENABLED=$(normalize_bool "$(config_bool '.dashboard.onion.enabled' false)")
+    if [ "$DASHBOARD_ONION_ENABLED" == "true" ]; then
+        if [ -z "$dash_pw" ]; then
+            error "dashboard.onion.enabled is true but dashboard.auth.password is empty. Publishing the dashboard as a Tor onion exposes a control panel at a stable address — it must sit behind a login. Set a strong dashboard.auth.password (16+ characters) and re-run."
+        fi
+        if [ "$(printf '%s' "$dash_pw" | wc -c)" -lt 16 ]; then
+            error "dashboard.auth.password must be at least 16 characters when dashboard.onion.enabled is true (a published .onion is online-brute-forceable and per-IP throttling is meaningless over Tor). Use a passphrase."
         fi
     fi
 }
@@ -1832,12 +1860,14 @@ load_preserved_state() {
     MONERO_ONION=$(env_get MONERO_ONION_ADDRESS)
     TARI_ONION=$(env_get TARI_ONION_ADDRESS)
     P2POOL_ONION=$(env_get P2POOL_ONION_ADDRESS)
+    DASHBOARD_ONION=$(env_get DASHBOARD_ONION_ADDRESS)
     PRESERVED_HOST_IP=$(env_get HOST_IP)
 
     [ -n "$PROXY_AUTH_TOKEN" ] || PROXY_AUTH_TOKEN=$(openssl rand -hex 12)
     [ -n "$MONERO_ONION" ] || MONERO_ONION="placeholder"
     [ -n "$TARI_ONION" ] || TARI_ONION="placeholder"
     [ -n "$P2POOL_ONION" ] || P2POOL_ONION="placeholder"
+    [ -n "$DASHBOARD_ONION" ] || DASHBOARD_ONION="placeholder"
     return 0
 }
 
@@ -1956,6 +1986,27 @@ provision_tor() {
     MONERO_ONION=$(docker exec tor cat /var/lib/tor/monero/hostname)
     TARI_ONION=$(docker exec tor cat /var/lib/tor/tari/hostname)
     P2POOL_ONION=$(docker exec tor cat /var/lib/tor/p2pool/hostname)
+    provision_dashboard_onion # #343: reads the dashboard onion too, but only when it's enabled
+}
+
+# Read the dashboard onion hostname from the running tor container into DASHBOARD_ONION (#343).
+# No-op unless the onion is enabled. Its HiddenServiceDir is rendered conditionally
+# (build/tor/entrypoint.sh), so poll for the hostname — Tor publishes it a few seconds after
+# (re)start. Used by both first-time setup (provision_tor) and a later `apply` that turns it on.
+provision_dashboard_onion() {
+    [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] || return 0
+    log "Waiting for the dashboard Tor hidden service..."
+    local elapsed=0 timeout=60
+    until docker exec tor test -f /var/lib/tor/dashboard/hostname; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+            # Non-fatal: the onion still serves; the address just isn't captured for `status` yet.
+            warn "Timed out after ${timeout}s waiting for the dashboard Tor hidden-service hostname; run 'pithead status' later to see the address."
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    DASHBOARD_ONION=$(docker exec tor cat /var/lib/tor/dashboard/hostname)
 }
 
 # Single writer for the env file. Derives every value from the parsed config plus the preserved
@@ -2188,6 +2239,7 @@ TARI_WALLET_ADDRESS=$TARI_WALLET
 MONERO_ONION_ADDRESS=$MONERO_ONION
 TARI_ONION_ADDRESS=$TARI_ONION
 P2POOL_ONION_ADDRESS=$P2POOL_ONION
+DASHBOARD_ONION_ADDRESS=$DASHBOARD_ONION
 P2POOL_FLAGS=$p2pool_flags
 P2POOL_PORT=$p2pool_port
 STRATUM_BIND=$STRATUM_BIND
@@ -2250,6 +2302,7 @@ MONERO_RPC_PORT=$rpc_port
 MONERO_ZMQ_PORT=$zmq_port
 COMPOSE_PROFILES=$profiles
 DASHBOARD_SECURE=$DASHBOARD_SECURE
+DASHBOARD_ONION_ENABLED=$DASHBOARD_ONION_ENABLED
 DASHBOARD_TZ=$DASHBOARD_TZ
 DASHBOARD_AUTH_USER=$DASHBOARD_AUTH_USER
 DASHBOARD_AUTH_HASH_B64=$DASHBOARD_AUTH_HASH_B64
@@ -2329,6 +2382,25 @@ EOF
         log "Generating Caddyfile for HTTP ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF >"Caddyfile"
 http://$HOST_IP {
+$auth
+    reverse_proxy 127.0.0.1:8000
+}
+EOF
+    fi
+
+    # Onion vhost (#343): a second site reachable ONLY from the tor container, via the bridge gateway
+    # (NETWORK_PREFIX.1 — the /24's first host, where host-networked Caddy binds and bridge containers
+    # route out). It is never on the LAN. Plain HTTP: Tor provides the transport encryption inside the
+    # tunnel, so no `tls internal` here. It MUST carry the same auth block — refuse to publish an
+    # unauthenticated control panel (config validation already fails closed; this is belt-and-suspenders).
+    if [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ]; then
+        if [ -z "$auth" ]; then
+            error "Refusing to render the dashboard onion vhost without a login: dashboard.onion.enabled is on but no auth hash is set."
+        fi
+        log "Adding onion vhost for the dashboard (${NETWORK_PREFIX}.1, login required)..."
+        cat <<EOF >>"Caddyfile"
+
+http://${NETWORK_PREFIX}.1 {
 $auth
     reverse_proxy 127.0.0.1:8000
 }
@@ -2826,7 +2898,7 @@ apply() {
         for key in "${changed[@]}"; do
             old=$(env_get_file "$ENV_FILE" "$key")
             new=$(env_get_file "$newenv" "$key")
-            case "$key" in HOST_IP | DASHBOARD_SECURE | DASHBOARD_AUTH_USER | DASHBOARD_AUTH_HASH_B64) caddy_changed=1 ;; esac
+            case "$key" in HOST_IP | DASHBOARD_SECURE | DASHBOARD_AUTH_USER | DASHBOARD_AUTH_HASH_B64 | DASHBOARD_ONION_ENABLED) caddy_changed=1 ;; esac
             line=$(describe_change "$key" "$old" "$new")
             flag=${line%%$'\t'*}
             msg=${line#*$'\t'}
@@ -2884,6 +2956,12 @@ apply() {
     # Caddy mounts the Caddyfile read-only, so a content change alone won't recreate it.
     if [ "$caddy_changed" -eq 1 ]; then
         docker compose restart caddy
+    fi
+    # If the dashboard onion was just turned on, the recreated tor container generated its hostname;
+    # read it back into .env so `pithead status` can surface the address (#343). The onion already
+    # serves via Caddy regardless — this only makes the address visible to the operator.
+    if [ "$DASHBOARD_ONION_ENABLED" == "true" ] && { [ -z "$DASHBOARD_ONION" ] || [ "$DASHBOARD_ONION" == "placeholder" ]; }; then
+        provision_dashboard_onion && render_env
     fi
     rm -f "$apply_marker"
     log "Configuration applied."

--- a/pithead
+++ b/pithead
@@ -2167,12 +2167,20 @@ onion_client_key() {
         error "The dashboard onion isn't fully provisioned yet — run '$0 apply' first."
     cat <<EOF
 Tor onion client-auth for the dashboard (#343) — KEEP THIS PRIVATE, it is a secret key.
-Add this one line to a file in your Tor client's ClientOnionAuthDir
-(e.g. /var/lib/tor/onion_auth/dashboard.auth_private, the dir set by ClientOnionAuthDir, mode 0700):
+Dashboard onion address:  http://$onion
 
-  ${onion%.onion}:descriptor:x25519:${privkey}
+Pick whichever Tor client you use to reach it:
 
-Then reach the dashboard at:  http://$onion
+• Tor Browser (easiest): open  http://$onion  — it prompts for the onion's
+  private key. Paste JUST this key:
+
+    $privkey
+
+• System Tor / Orbot (persistent): put this one line in a file (e.g.
+  dashboard.auth_private) inside the directory set by ClientOnionAuthDir in your
+  torrc (create it mode 0700), then reload Tor:
+
+    ${onion%.onion}:descriptor:x25519:$privkey
 EOF
 }
 

--- a/pithead
+++ b/pithead
@@ -2100,11 +2100,15 @@ provision_tor() {
 provision_onion_client_auth() {
     [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] || return 0
     local hs_dir="$TOR_DATA_DIR/dashboard"
+    # TOR_DATA_DIR is owned by the tor container's own uid (100 in the Alpine tor image, NOT the
+    # first-party APP_UID). If we can't write it directly, elevate — the same sudo ensure_owner uses.
+    # (Tests point TOR_DATA_DIR at a user-owned temp dir, so `run` stays empty and no sudo is used.)
+    local run=""
+    [ -w "$TOR_DATA_DIR" ] || run="sudo"
     if [ "${DASHBOARD_ONION_CLIENT_AUTH:-false}" != "true" ]; then
-        if [ -d "$hs_dir/authorized_clients" ]; then
+        if $run test -d "$hs_dir/authorized_clients"; then
             log "Disabling Tor onion client-auth for the dashboard — the onion becomes password-only (#343)."
-            sudo rm -rf "$hs_dir/authorized_clients" 2>/dev/null ||
-                rm -rf "$hs_dir/authorized_clients" 2>/dev/null || true
+            $run rm -rf "$hs_dir/authorized_clients"
         fi
         return 0
     fi
@@ -2116,12 +2120,15 @@ provision_onion_client_auth() {
         DASHBOARD_ONION_CLIENT_PRIVKEY="${kp##* }"
         log "Generated a Tor onion client-auth key for the dashboard (#343)."
     fi
-    mkdir -p "$hs_dir/authorized_clients"
-    printf 'descriptor:x25519:%s\n' "$DASHBOARD_ONION_CLIENT_PUBKEY" >"$hs_dir/authorized_clients/dashboard.auth"
-    # Tor refuses a HiddenServiceDir that is group/other-accessible or owned by another user.
-    chmod 700 "$hs_dir" "$hs_dir/authorized_clients" 2>/dev/null || true
-    chmod 600 "$hs_dir/authorized_clients/dashboard.auth" 2>/dev/null || true
-    ensure_owner "$hs_dir" "$APP_UID" "$APP_GID"
+    $run mkdir -p "$hs_dir/authorized_clients"
+    printf 'descriptor:x25519:%s\n' "$DASHBOARD_ONION_CLIENT_PUBKEY" | $run tee "$hs_dir/authorized_clients/dashboard.auth" >/dev/null
+    # Tor refuses a HiddenServiceDir that is group/other-accessible; keep it 0700/0600 and owned by
+    # whatever uid already owns the tor data dir, so tor can read authorized_clients.
+    $run chmod 700 "$hs_dir" "$hs_dir/authorized_clients"
+    $run chmod 600 "$hs_dir/authorized_clients/dashboard.auth"
+    local owner
+    owner=$($run stat -c '%u:%g' "$TOR_DATA_DIR" 2>/dev/null) || owner=""
+    [ -n "$owner" ] && $run chown -R "$owner" "$hs_dir"
 }
 
 # Read the dashboard onion hostname from the running tor container into DASHBOARD_ONION (#343).

--- a/pithead
+++ b/pithead
@@ -1704,6 +1704,23 @@ monero_address_type() {
     esac
 }
 
+# When the dashboard onion is enabled but no password is set, generate a strong one and save it to
+# config.json (#343). Keeps the fail-closed onion usable without forcing the operator to invent a
+# 16+ char secret; the plaintext lives in owner-only config.json, exactly like a hand-set password
+# (login stays "admin"). Runs only on the config-writing paths (setup/apply), before parse validates
+# — never on read-only commands, which must not mutate config.json.
+ensure_onion_password() {
+    [ -f "$CONFIG_FILE" ] || return 0
+    [ "$(config_bool '.dashboard.onion.enabled' false)" == "true" ] || return 0
+    [ -z "$(jq -r '.dashboard.auth.password // ""' "$CONFIG_FILE")" ] || return 0
+    local gen tmp
+    gen=$(generate_node_password) # 32 alnum chars: clears the >=16 floor, no quotes, no weak pattern
+    tmp=$(mktemp) || error "Could not create a temp file to save the generated dashboard password."
+    jq --arg p "$gen" '.dashboard.auth.password = $p' "$CONFIG_FILE" >"$tmp" && mv "$tmp" "$CONFIG_FILE" ||
+        error "Could not save the generated dashboard password to $CONFIG_FILE."
+    log "Dashboard onion is on but no password was set — generated one and saved it to config.json (login: admin; see dashboard.auth.password)."
+}
+
 parse_and_validate_config() {
     log "Parsing configuration..."
     if ! jq -e . "$CONFIG_FILE" >/dev/null 2>&1; then
@@ -2141,13 +2158,15 @@ onion_client_key() {
     privkey=$(env_get DASHBOARD_ONION_CLIENT_PRIVKEY)
     { [ -n "$onion" ] && [ "$onion" != "placeholder" ] && [ -n "$privkey" ] && [ "$privkey" != "placeholder" ]; } ||
         error "The dashboard onion isn't fully provisioned yet — run '$0 apply' first."
-    echo "Tor onion client-auth for the dashboard (#343) — KEEP THIS PRIVATE, it is a secret key."
-    echo "Add this one line to a file in your Tor client's ClientOnionAuthDir"
-    echo "(e.g. /var/lib/tor/onion_auth/dashboard.auth_private, the dir set by ClientOnionAuthDir, mode 0700):"
-    echo ""
-    echo "  ${onion%.onion}:descriptor:x25519:${privkey}"
-    echo ""
-    echo "Then reach the dashboard at:  http://$onion"
+    cat <<EOF
+Tor onion client-auth for the dashboard (#343) — KEEP THIS PRIVATE, it is a secret key.
+Add this one line to a file in your Tor client's ClientOnionAuthDir
+(e.g. /var/lib/tor/onion_auth/dashboard.auth_private, the dir set by ClientOnionAuthDir, mode 0700):
+
+  ${onion%.onion}:descriptor:x25519:${privkey}
+
+Then reach the dashboard at:  http://$onion
+EOF
 }
 
 # `rotate-dashboard-onion` (#343): mint a fresh .onion address and a fresh client-auth key. A leaked
@@ -2845,6 +2864,7 @@ setup() {
 
     check_prerequisites
     ensure_config_exists
+    ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one
     parse_and_validate_config
     preflight_resources          # WARN-only: low disk/RAM heads-up before committing to a sync (#87)
     check_stratum_exposure setup # WARN-only: public-IP host => unauthenticated stratum :3333 exposed (#113)
@@ -3072,6 +3092,7 @@ apply() {
     done
 
     require_env
+    ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one
     parse_and_validate_config
     load_preserved_state
     if [ "$MONERO_ONION" == "placeholder" ] || ! is_deployed; then

--- a/pithead
+++ b/pithead
@@ -752,12 +752,15 @@ doctor() {
                 dr_ok "$k set."
             fi
         done
-        # Dashboard onion (#343): only meaningful when opted in. Print the actual address — it is the
-        # capability an operator needs to reach the panel — but only to this local status output.
+        # Dashboard onion (#343): only meaningful when opted in. Print the address — the operator needs
+        # it to reach the panel — but never the client PRIVATE key: this status is a paste-able report,
+        # so the key lives behind the explicit 'onion-client-key' command instead.
         if [ "$(env_get DASHBOARD_ONION_ENABLED)" == "true" ]; then
             onion=$(env_get DASHBOARD_ONION_ADDRESS)
             if [ -z "$onion" ] || [ "$onion" == "placeholder" ]; then
                 dr_warn "DASHBOARD_ONION_ADDRESS is not provisioned yet — re-run 'pithead setup' or 'pithead apply'."
+            elif [ "$(env_get DASHBOARD_ONION_CLIENT_AUTH)" == "true" ]; then
+                dr_ok "Dashboard onion: http://$onion (client-auth ON + login; get your client key with '$0 onion-client-key')"
             else
                 dr_ok "Dashboard onion: http://$onion (login required)"
             fi
@@ -1102,6 +1105,15 @@ Maintenance:
                             dashboard's database from a backup archive (prompts before
                             overwriting; fixes Tor ownership).
                               -y, --yes        restore without the confirmation prompt.
+
+  onion-client-key          Print the Tor client-auth line for the dashboard onion (#343) —
+                            the client PRIVATE key, kept out of 'status'. Add it to your Tor
+                            client's ClientOnionAuthDir to reach a client-auth'd onion.
+
+  rotate-dashboard-onion [-y|--yes]
+                            Mint a fresh dashboard .onion address and client-auth key (#343);
+                            the old address and any client keys you handed out stop working.
+                              -y, --yes        skip the confirmation prompt.
 
   help, -h, --help          Show this message.
 
@@ -1502,6 +1514,57 @@ generate_node_password() {
     printf '%s' "${raw:0:32}"
 }
 
+# --- Tor v3 onion client authorization (#343) ---
+# Base32-encode a hex string (RFC 4648, no padding, uppercase) — the encoding Tor wants for its
+# x25519 client-auth keys. Implemented in awk so it needs no `base32` binary (absent on macOS),
+# which keeps it portable and unit-testable everywhere. Input: an even-length hex string.
+b32encode_hex() {
+    awk -v hex="$1" 'BEGIN {
+        alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+        bits = ""
+        n = length(hex)
+        for (i = 1; i <= n; i++) {
+            v = index("0123456789abcdef", tolower(substr(hex, i, 1))) - 1
+            if (v < 0) { exit 1 }
+            for (j = 3; j >= 0; j--) bits = bits ((int(v / (2 ^ j)) % 2))
+        }
+        out = ""
+        for (i = 1; i + 4 <= length(bits); i += 5) {
+            val = 0
+            for (j = 0; j < 5; j++) val = val * 2 + substr(bits, i + j, 1)
+            out = out substr(alpha, val + 1, 1)
+        }
+        rem = length(bits) % 5
+        if (rem > 0) {
+            chunk = substr(bits, length(bits) - rem + 1, rem)
+            for (k = rem; k < 5; k++) chunk = chunk "0"
+            val = 0
+            for (j = 1; j <= 5; j++) val = val * 2 + substr(chunk, j, 1)
+            out = out substr(alpha, val + 1, 1)
+        }
+        print out
+    }'
+}
+
+# Generate an x25519 keypair for Tor v3 onion client auth. Echoes "PUBKEY PRIVKEY", both base32
+# (unpadded, uppercase) — the form tor's authorized_clients/ and ClientOnionAuthDir want. The raw
+# 32-byte keys are the trailing 32 bytes of the DER encoding (the documented extraction). Returns
+# non-zero if openssl lacks x25519. Runs on the host at setup/apply/rotate.
+generate_onion_client_keypair() {
+    command -v openssl >/dev/null 2>&1 || return 1
+    local tmp priv_hex pub_hex
+    tmp=$(mktemp) || return 1
+    if ! openssl genpkey -algorithm x25519 -out "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        return 1
+    fi
+    priv_hex=$(openssl pkey -in "$tmp" -outform DER 2>/dev/null | tail -c 32 | od -An -v -tx1 | tr -d ' \n')
+    pub_hex=$(openssl pkey -in "$tmp" -pubout -outform DER 2>/dev/null | tail -c 32 | od -An -v -tx1 | tr -d ' \n')
+    rm -f "$tmp"
+    [ "${#priv_hex}" -eq 64 ] && [ "${#pub_hex}" -eq 64 ] || return 1
+    printf '%s %s' "$(b32encode_hex "$pub_hex")" "$(b32encode_hex "$priv_hex")"
+}
+
 # A stored local-node credential needs (re)generating when it is empty or still the shipped
 # template placeholder (an instruction string, not a real secret). Used in `if` conditions.
 cred_needs_generating() {
@@ -1842,13 +1905,29 @@ parse_and_validate_config() {
     # online-brute-forceable (per-IP throttling is meaningless over Tor; every request arrives from
     # the local tor daemon, so there is no source IP to rate-limit against).
     DASHBOARD_ONION_ENABLED=$(normalize_bool "$(config_bool '.dashboard.onion.enabled' false)")
+    # Tor v3 client authorization (#343): the strong PRIMARY gate. Default ON whenever the onion is
+    # on — a client-auth'd onion does not respond at all without the operator's client key, which
+    # defeats address-scanning and brute force entirely (the password becomes a second factor behind
+    # it). Set dashboard.onion.client_auth:false only for a deliberately password-only onion.
+    DASHBOARD_ONION_CLIENT_AUTH=false
     if [ "$DASHBOARD_ONION_ENABLED" == "true" ]; then
+        DASHBOARD_ONION_CLIENT_AUTH=$(normalize_bool "$(config_bool '.dashboard.onion.client_auth' true)")
         if [ -z "$dash_pw" ]; then
             error "dashboard.onion.enabled is true but dashboard.auth.password is empty. Publishing the dashboard as a Tor onion exposes a control panel at a stable address — it must sit behind a login. Set a strong dashboard.auth.password (16+ characters) and re-run."
         fi
         if [ "$(printf '%s' "$dash_pw" | wc -c)" -lt 16 ]; then
             error "dashboard.auth.password must be at least 16 characters when dashboard.onion.enabled is true (a published .onion is online-brute-forceable and per-IP throttling is meaningless over Tor). Use a passphrase."
         fi
+        # Reject obviously weak 16+ char choices the length floor alone would pass: a single repeated
+        # character, or a well-known weak pattern. Not a full dictionary — the floor handles the rest.
+        if [ "$(printf '%s' "$dash_pw" | fold -w1 | sort -u | wc -l | tr -d ' ')" -eq 1 ]; then
+            error "dashboard.auth.password is a single repeated character — choose a real passphrase."
+        fi
+        case "$(printf '%s' "$dash_pw" | tr 'A-Z' 'a-z')" in
+        *passwordpassword* | *0123456789* | *qwertyuiop* | *changeme* | *letmein*)
+            error "dashboard.auth.password contains a well-known weak pattern — choose a real passphrase (16+ characters)."
+            ;;
+        esac
     fi
 }
 
@@ -1861,6 +1940,8 @@ load_preserved_state() {
     TARI_ONION=$(env_get TARI_ONION_ADDRESS)
     P2POOL_ONION=$(env_get P2POOL_ONION_ADDRESS)
     DASHBOARD_ONION=$(env_get DASHBOARD_ONION_ADDRESS)
+    DASHBOARD_ONION_CLIENT_PUBKEY=$(env_get DASHBOARD_ONION_CLIENT_PUBKEY)
+    DASHBOARD_ONION_CLIENT_PRIVKEY=$(env_get DASHBOARD_ONION_CLIENT_PRIVKEY)
     PRESERVED_HOST_IP=$(env_get HOST_IP)
 
     [ -n "$PROXY_AUTH_TOKEN" ] || PROXY_AUTH_TOKEN=$(openssl rand -hex 12)
@@ -1868,6 +1949,8 @@ load_preserved_state() {
     [ -n "$TARI_ONION" ] || TARI_ONION="placeholder"
     [ -n "$P2POOL_ONION" ] || P2POOL_ONION="placeholder"
     [ -n "$DASHBOARD_ONION" ] || DASHBOARD_ONION="placeholder"
+    [ -n "$DASHBOARD_ONION_CLIENT_PUBKEY" ] || DASHBOARD_ONION_CLIENT_PUBKEY="placeholder"
+    [ -n "$DASHBOARD_ONION_CLIENT_PRIVKEY" ] || DASHBOARD_ONION_CLIENT_PRIVKEY="placeholder"
     return 0
 }
 
@@ -1968,6 +2051,8 @@ resolve_dashboard_host() {
 
 provision_tor() {
     log "Initializing Tor service to generate Onion addresses..."
+    # Client-auth keys must be in place before tor starts, since it reads authorized_clients then (#343).
+    provision_onion_client_auth
     docker compose up --pull "$(resolve_pull_policy)" -d tor
     # Poll for the three hidden-service hostname files instead of a fixed sleep — Tor can take
     # more or less than 15s to publish them, especially on first run.
@@ -1989,6 +2074,39 @@ provision_tor() {
     provision_dashboard_onion # #343: reads the dashboard onion too, but only when it's enabled
 }
 
+# Prepare Tor v3 client authorization for the dashboard onion (#343). Generates the client keypair
+# once (preserved across applies) and writes the PUBLIC key into the hidden service's
+# authorized_clients/ dir, so the onion is unreachable without the matching private key. MUST run
+# BEFORE the tor container (re)starts — tor reads authorized_clients at startup. No-op unless the
+# onion is on. When the onion is on but client-auth is off, it clears any prior authorized_clients so
+# the onion falls back to password-only.
+provision_onion_client_auth() {
+    [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] || return 0
+    local hs_dir="$TOR_DATA_DIR/dashboard"
+    if [ "${DASHBOARD_ONION_CLIENT_AUTH:-false}" != "true" ]; then
+        if [ -d "$hs_dir/authorized_clients" ]; then
+            log "Disabling Tor onion client-auth for the dashboard — the onion becomes password-only (#343)."
+            sudo rm -rf "$hs_dir/authorized_clients" 2>/dev/null ||
+                rm -rf "$hs_dir/authorized_clients" 2>/dev/null || true
+        fi
+        return 0
+    fi
+    if [ -z "$DASHBOARD_ONION_CLIENT_PUBKEY" ] || [ "$DASHBOARD_ONION_CLIENT_PUBKEY" == "placeholder" ]; then
+        local kp
+        kp=$(generate_onion_client_keypair) ||
+            error "Could not generate the Tor onion client-auth keypair (need openssl built with x25519, plus od + awk)."
+        DASHBOARD_ONION_CLIENT_PUBKEY="${kp%% *}"
+        DASHBOARD_ONION_CLIENT_PRIVKEY="${kp##* }"
+        log "Generated a Tor onion client-auth key for the dashboard (#343)."
+    fi
+    mkdir -p "$hs_dir/authorized_clients"
+    printf 'descriptor:x25519:%s\n' "$DASHBOARD_ONION_CLIENT_PUBKEY" >"$hs_dir/authorized_clients/dashboard.auth"
+    # Tor refuses a HiddenServiceDir that is group/other-accessible or owned by another user.
+    chmod 700 "$hs_dir" "$hs_dir/authorized_clients" 2>/dev/null || true
+    chmod 600 "$hs_dir/authorized_clients/dashboard.auth" 2>/dev/null || true
+    ensure_owner "$hs_dir" "$APP_UID" "$APP_GID"
+}
+
 # Read the dashboard onion hostname from the running tor container into DASHBOARD_ONION (#343).
 # No-op unless the onion is enabled. Its HiddenServiceDir is rendered conditionally
 # (build/tor/entrypoint.sh), so poll for the hostname — Tor publishes it a few seconds after
@@ -2007,6 +2125,74 @@ provision_dashboard_onion() {
         elapsed=$((elapsed + 2))
     done
     DASHBOARD_ONION=$(docker exec tor cat /var/lib/tor/dashboard/hostname)
+}
+
+# `onion-client-key` (#343): print the operator's Tor client-auth line for the dashboard onion. Its
+# own command — deliberately NOT part of `status`, which is a shareable report — because it prints
+# the client PRIVATE key. The operator drops this line into their Tor client's ClientOnionAuthDir.
+onion_client_key() {
+    require_env
+    [ "$(env_get DASHBOARD_ONION_ENABLED)" == "true" ] ||
+        error "The dashboard onion is not enabled (set dashboard.onion.enabled: true, then '$0 apply')."
+    [ "$(env_get DASHBOARD_ONION_CLIENT_AUTH)" == "true" ] ||
+        error "Client authorization is off for the dashboard onion (dashboard.onion.client_auth: false) — it is password-only, so there is no client key."
+    local onion privkey
+    onion=$(env_get DASHBOARD_ONION_ADDRESS)
+    privkey=$(env_get DASHBOARD_ONION_CLIENT_PRIVKEY)
+    { [ -n "$onion" ] && [ "$onion" != "placeholder" ] && [ -n "$privkey" ] && [ "$privkey" != "placeholder" ]; } ||
+        error "The dashboard onion isn't fully provisioned yet — run '$0 apply' first."
+    echo "Tor onion client-auth for the dashboard (#343) — KEEP THIS PRIVATE, it is a secret key."
+    echo "Add this one line to a file in your Tor client's ClientOnionAuthDir"
+    echo "(e.g. /var/lib/tor/onion_auth/dashboard.auth_private, the dir set by ClientOnionAuthDir, mode 0700):"
+    echo ""
+    echo "  ${onion%.onion}:descriptor:x25519:${privkey}"
+    echo ""
+    echo "Then reach the dashboard at:  http://$onion"
+}
+
+# `rotate-dashboard-onion` (#343): mint a fresh .onion address and a fresh client-auth key. A leaked
+# address or client key is otherwise permanent. Wipes only the dashboard hidden-service dir (the
+# mining onions are untouched), then re-provisions and restarts caddy.
+rotate_dashboard_onion() {
+    local assume_yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        *) error "Unknown option for rotate-dashboard-onion: $arg. Run '$0 help'." ;;
+        esac
+    done
+    require_env
+    parse_and_validate_config
+    load_preserved_state
+    [ "$DASHBOARD_ONION_ENABLED" == "true" ] ||
+        error "The dashboard onion is not enabled — nothing to rotate."
+    warn "This regenerates the dashboard's .onion ADDRESS and its client-auth key. The old address and any client keys you handed out stop working immediately."
+    if [ "$assume_yes" -eq 0 ]; then
+        read -r -p "Rotate the dashboard onion now? (y/N): " CONFIRM || true
+        [[ "$CONFIRM" =~ ^[Yy] ]] || {
+            log "Rotation cancelled."
+            return 0
+        }
+    fi
+    local hs_dir="$TOR_DATA_DIR/dashboard"
+    [ -n "$TOR_DATA_DIR" ] && [ "${hs_dir##*/}" == "dashboard" ] ||
+        error "Refusing to wipe an unexpected path (\"$hs_dir\")."
+    log "Stopping tor and wiping the dashboard hidden service..."
+    docker compose stop tor >/dev/null 2>&1 || true
+    sudo rm -rf "$hs_dir" 2>/dev/null || rm -rf "$hs_dir" 2>/dev/null || true
+    # Force fresh keys + address on the next provision.
+    DASHBOARD_ONION="placeholder"
+    DASHBOARD_ONION_CLIENT_PUBKEY="placeholder"
+    DASHBOARD_ONION_CLIENT_PRIVKEY="placeholder"
+    provision_tor # rewrites authorized_clients (fresh key), starts tor, reads the new address
+    render_env    # persist the new address + keys
+    docker compose restart caddy >/dev/null 2>&1 || true
+    log "Dashboard onion rotated."
+    if [ "$DASHBOARD_ONION_CLIENT_AUTH" == "true" ]; then
+        onion_client_key
+    else
+        log "New dashboard onion: http://$(env_get DASHBOARD_ONION_ADDRESS)"
+    fi
 }
 
 # Single writer for the env file. Derives every value from the parsed config plus the preserved
@@ -2240,6 +2426,8 @@ MONERO_ONION_ADDRESS=$MONERO_ONION
 TARI_ONION_ADDRESS=$TARI_ONION
 P2POOL_ONION_ADDRESS=$P2POOL_ONION
 DASHBOARD_ONION_ADDRESS=$DASHBOARD_ONION
+DASHBOARD_ONION_CLIENT_PUBKEY=$DASHBOARD_ONION_CLIENT_PUBKEY
+DASHBOARD_ONION_CLIENT_PRIVKEY=$DASHBOARD_ONION_CLIENT_PRIVKEY
 P2POOL_FLAGS=$p2pool_flags
 P2POOL_PORT=$p2pool_port
 STRATUM_BIND=$STRATUM_BIND
@@ -2303,6 +2491,7 @@ MONERO_ZMQ_PORT=$zmq_port
 COMPOSE_PROFILES=$profiles
 DASHBOARD_SECURE=$DASHBOARD_SECURE
 DASHBOARD_ONION_ENABLED=$DASHBOARD_ONION_ENABLED
+DASHBOARD_ONION_CLIENT_AUTH=$DASHBOARD_ONION_CLIENT_AUTH
 DASHBOARD_TZ=$DASHBOARD_TZ
 DASHBOARD_AUTH_USER=$DASHBOARD_AUTH_USER
 DASHBOARD_AUTH_HASH_B64=$DASHBOARD_AUTH_HASH_B64
@@ -2795,6 +2984,25 @@ describe_change() {
         # carries the user-facing message. Emit no message so the preview shows one line, not two.
         msg=""
         ;;
+    DASHBOARD_ONION_ENABLED)
+        flag=DEST
+        if [ "$new" == "true" ]; then
+            msg="Dashboard Tor onion ENABLED (#343) — the dashboard is published as a hidden service reachable over Tor; tor and caddy are recreated."
+        else
+            msg="Dashboard Tor onion DISABLED (#343) — the onion is withdrawn; tor and caddy are recreated."
+        fi
+        ;;
+    DASHBOARD_ONION_CLIENT_AUTH)
+        msg="Dashboard onion client-auth → $([ "$new" == "true" ] && echo ON || echo OFF) (#343)$([ "$new" == "true" ] && echo " — the onion won't respond without your client key" || echo " — the onion is password-only")."
+        ;;
+    DASHBOARD_ONION_ADDRESS | DASHBOARD_ONION_CLIENT_PUBKEY)
+        # Provisioned values that co-change with the toggle above; keep the preview to one line.
+        msg=""
+        ;;
+    DASHBOARD_ONION_CLIENT_PRIVKEY)
+        # Secret client key — never echo it into the change preview / logs.
+        msg=""
+        ;;
     HOST_IP)
         msg="Dashboard hostname: $old → $new."
         ;;
@@ -2934,6 +3142,10 @@ apply() {
         warn "A previous apply updated the config but did not finish recreating containers — retrying."
     fi
 
+    # Client-auth keys must be written before tor is recreated below, so an onion just turned on (or a
+    # client-auth toggle) takes effect on this apply rather than the next (#343).
+    provision_onion_client_auth
+
     log "Updating containers..."
     migrate_compose_project
     # (Re)assert the Tor-only egress firewall BEFORE compose recreates anything — same ordering as
@@ -2960,7 +3172,7 @@ apply() {
     # If the dashboard onion was just turned on, the recreated tor container generated its hostname;
     # read it back into .env so `pithead status` can surface the address (#343). The onion already
     # serves via Caddy regardless — this only makes the address visible to the operator.
-    if [ "$DASHBOARD_ONION_ENABLED" == "true" ] && { [ -z "$DASHBOARD_ONION" ] || [ "$DASHBOARD_ONION" == "placeholder" ]; }; then
+    if [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] && { [ -z "${DASHBOARD_ONION:-}" ] || [ "${DASHBOARD_ONION:-}" == "placeholder" ]; }; then
         provision_dashboard_onion && render_env
     fi
     rm -f "$apply_marker"
@@ -3026,6 +3238,8 @@ main() {
         ;;
     backup) stack_backup "$@" ;;
     restore) stack_restore "$@" ;;
+    onion-client-key) onion_client_key ;;
+    rotate-dashboard-onion) rotate_dashboard_onion "$@" ;;
     help | -h | --help) show_help ;;
     *) error "Unknown command: $cmd. Run '$0 help'." ;;
     esac

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -722,6 +722,46 @@ case "$caddy_http" in
 *) ok "caddyfile insecure has no TLS" ;;
 esac
 
+echo "== unit: generate_caddyfile onion vhost (#343) =="
+# With the dashboard onion enabled, generate_caddyfile appends a SECOND site bound to the bridge
+# gateway (NETWORK_PREFIX.1) — reachable only from the tor container, never the LAN — serving plain
+# HTTP (Tor is the transport) and carrying the SAME basic_auth block as the LAN site.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_onion="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        DASHBOARD_ONION_ENABLED=true NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "onion vhost bound to the bridge gateway" "$caddy_onion" "http://172.28.0.1 {"
+assert_contains "onion vhost carries basic_auth" "$caddy_onion" "basic_auth"
+# The onion site (everything after the gateway address) must not get a TLS directive.
+onion_site="${caddy_onion#*172.28.0.1}"
+case "$onion_site" in
+*"tls internal"*) bad "onion vhost is plain HTTP" "'tls internal' present on the onion site" ;;
+*) ok "onion vhost is plain HTTP (no tls internal)" ;;
+esac
+# Fail-closed belt: onion enabled but NO auth hash -> generate_caddyfile must refuse (rc 1).
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" \
+        DASHBOARD_ONION_ENABLED=true NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+)
+assert_rc "onion without a login refuses to render" "$?" "1"
+# Onion OFF -> no gateway vhost appears at all.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_noonion="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        DASHBOARD_ONION_ENABLED=false NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_not_contains "no onion vhost when disabled" "$caddy_noonion" "172.28.0.1"
+
 echo "== unit: host detection (#140) =="
 # detect_os reads ID / VERSION_ID / PRETTY_NAME from an overridable os-release (drives the
 # 'supported on Ubuntu 24.04' check); a missing file leaves the fields empty (caller warns).
@@ -1361,6 +1401,25 @@ out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 rc=$?
 assert_rc "too-short dashboard.auth.password rejected" "$rc" "1"
 assert_contains "dashboard.auth.password message" "$out" "dashboard.auth.password"
+
+# Dashboard onion (#343): FAIL CLOSED. Enabling the onion without a login must abort apply — a
+# published .onion is a control panel at a stable address and cannot be unauthenticated.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","onion":{"enabled":true}} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+rc=$?
+assert_rc "onion without a password rejected" "$rc" "1"
+assert_contains "onion-needs-login message" "$out" "dashboard.auth.password is empty"
+# And a weak (LAN-acceptable but <16-char) password is rejected once the onion is on. This case
+# passes the length regex and so reaches the bcrypt step, which reads docker-compose.yml for the
+# pinned Caddy image — make sure it's present here (it's copied for later tests further down too).
+cp "$ROOT/docker-compose.yml" "$V/docker-compose.yml"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","onion":{"enabled":true},"auth":{"username":"admin","password":"shortish12"}} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+rc=$?
+assert_rc "onion with a <16-char password rejected" "$rc" "1"
+assert_contains "onion strong-password message" "$out" "at least 16 characters"
 
 # Wallet-type hard-fail (#250): p2pool pays via coinbase, which CANNOT reach a subaddress or an
 # integrated address — a wrong type MINES but is NEVER paid, silently. monero_address_type is

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -665,6 +665,14 @@ INFO*) ok "dash login fingerprint stays silent (no preview line)" ;;
 *) bad "dash login fingerprint stays silent" "unexpected message emitted" ;;
 esac
 
+# Dashboard onion (#343): enabling is DEST (tor+caddy recreated); the client PRIVATE key must never
+# surface in the change preview, even though a fresh key co-changes with the toggle.
+assert_contains "onion enable is DEST" "$(run_sourced "$SANDBOX" describe_change DASHBOARD_ONION_ENABLED false true)" "DEST"
+case "$(run_sourced "$SANDBOX" describe_change DASHBOARD_ONION_CLIENT_PRIVKEY OLDPRIVKEYVALUE NEWPRIVKEYVALUE)" in
+*OLDPRIVKEYVALUE* | *NEWPRIVKEYVALUE*) bad "onion client privkey hidden in preview" "the client private key leaked into the change preview" ;;
+*) ok "onion client privkey hidden in preview (no value shown)" ;;
+esac
+
 # New-release check toggle (#224): enabling/disabling is INFO, and the message names GitHub + Tor.
 assert_contains "update-check enable is INFO" "$(run_sourced "$SANDBOX" describe_change DASHBOARD_CHECK_UPDATES false true)" "INFO"
 assert_contains "update-check enable mentions GitHub/Tor" "$(run_sourced "$SANDBOX" describe_change DASHBOARD_CHECK_UPDATES false true)" "GitHub"
@@ -761,6 +769,44 @@ caddy_noonion="$(
     cat Caddyfile
 )"
 assert_not_contains "no onion vhost when disabled" "$caddy_noonion" "172.28.0.1"
+
+echo "== unit: onion client-auth crypto (#343) =="
+# Portable base32 (RFC 4648 vectors) — no external `base32` binary (absent on macOS).
+assert_eq "b32encode_hex('f') = MY" "$(run_sourced "$SANDBOX" b32encode_hex 66)" "MY"
+assert_eq "b32encode_hex('foobar') = MZXW6YTBOI" "$(run_sourced "$SANDBOX" b32encode_hex 666f6f626172)" "MZXW6YTBOI"
+# x25519 client-auth keypair: two distinct 52-char base32 keys.
+kp="$(run_sourced "$SANDBOX" generate_onion_client_keypair)"
+set -- $kp
+assert_eq "client pubkey is 52-char base32" "${#1}" "52"
+assert_eq "client privkey is 52-char base32" "${#2}" "52"
+if [ "$1" != "$2" ]; then ok "client pub != priv"; else bad "client pub != priv" "identical keys generated"; fi
+case "$1$2" in *[!A-Z2-7]*) bad "client keys use the base32 alphabet" "non-base32 char present" ;; *) ok "client keys use the base32 alphabet" ;; esac
+
+# provision_onion_client_auth writes the authorized_clients descriptor into the hidden-service dir.
+ac_root="$SANDBOX/tor-ac"
+rm -rf "$ac_root"
+mkdir -p "$ac_root"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    ensure_owner() { :; } # skip the sudo chown in the unit sandbox
+    set +e
+    DASHBOARD_ONION_ENABLED=true DASHBOARD_ONION_CLIENT_AUTH=true \
+        DASHBOARD_ONION_CLIENT_PUBKEY=placeholder TOR_DATA_DIR="$ac_root" \
+        APP_UID=$(id -u) APP_GID=$(id -g) provision_onion_client_auth >/dev/null 2>&1
+)
+ac_file="$ac_root/dashboard/authorized_clients/dashboard.auth"
+if [ -f "$ac_file" ]; then ok "authorized_clients/dashboard.auth is written"; else bad "authorized_clients/dashboard.auth is written" "file missing"; fi
+assert_contains "authorized_clients carries a v3 descriptor" "$(cat "$ac_file" 2>/dev/null)" "descriptor:x25519:"
+# With client-auth OFF, an existing authorized_clients dir is cleared (onion falls back to password-only).
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_ONION_ENABLED=true DASHBOARD_ONION_CLIENT_AUTH=false TOR_DATA_DIR="$ac_root" \
+        provision_onion_client_auth >/dev/null 2>&1
+)
+if [ -d "$ac_root/dashboard/authorized_clients" ]; then bad "client-auth off clears authorized_clients" "dir still present"; else ok "client-auth off clears authorized_clients"; fi
 
 echo "== unit: host detection (#140) =="
 # detect_os reads ID / VERSION_ID / PRETTY_NAME from an overridable os-release (drives the
@@ -1420,6 +1466,40 @@ out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 rc=$?
 assert_rc "onion with a <16-char password rejected" "$rc" "1"
 assert_contains "onion strong-password message" "$out" "at least 16 characters"
+# Weak-password denylist: even at 16+ chars, a single repeated character or a well-known pattern is
+# rejected once the onion is on.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","onion":{"enabled":true},"auth":{"username":"admin","password":"aaaaaaaaaaaaaaaa"}} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "onion repeated-character password rejected" "$?" "1"
+assert_contains "repeated-character message" "$out" "single repeated character"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","onion":{"enabled":true},"auth":{"username":"admin","password":"changemechangeme"}} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "onion well-known-weak password rejected" "$?" "1"
+assert_contains "well-known-weak message" "$out" "well-known weak pattern"
+
+# onion-client-key (#343): prints the client descriptor line when client-auth is on; errors when off.
+# The line the operator pastes is "<addr-without-.onion>:descriptor:x25519:<privkey>".
+cat >"$V/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_ONION_ENABLED=true
+DASHBOARD_ONION_CLIENT_AUTH=true
+DASHBOARD_ONION_ADDRESS=abcd234.onion
+DASHBOARD_ONION_CLIENT_PRIVKEY=UNITTESTPRIVKEYBASE32
+EOF
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead onion-client-key 2>&1)"
+assert_rc "onion-client-key succeeds when client-auth on" "$?" "0"
+assert_contains "onion-client-key prints the descriptor line" "$out" "abcd234:descriptor:x25519:UNITTESTPRIVKEYBASE32"
+cat >"$V/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_ONION_ENABLED=true
+DASHBOARD_ONION_CLIENT_AUTH=false
+DASHBOARD_ONION_ADDRESS=abcd234.onion
+EOF
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead onion-client-key 2>&1)"
+assert_rc "onion-client-key errors when client-auth off" "$?" "1"
+assert_contains "onion-client-key off message" "$out" "password-only"
 
 # Wallet-type hard-fail (#250): p2pool pays via coinbase, which CANNOT reach a subaddress or an
 # integrated address — a wrong type MINES but is NEVER paid, silently. monero_address_type is

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1504,7 +1504,8 @@ DASHBOARD_ONION_CLIENT_PRIVKEY=UNITTESTPRIVKEYBASE32
 EOF
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead onion-client-key 2>&1)"
 assert_rc "onion-client-key succeeds when client-auth on" "$?" "0"
-assert_contains "onion-client-key prints the descriptor line" "$out" "abcd234:descriptor:x25519:UNITTESTPRIVKEYBASE32"
+assert_contains "onion-client-key prints the descriptor line (system Tor)" "$out" "abcd234:descriptor:x25519:UNITTESTPRIVKEYBASE32"
+assert_contains "onion-client-key offers the Tor Browser path" "$out" "Tor Browser"
 cat >"$V/.env" <<EOF
 DEPLOYMENT_COMPLETED=true
 DASHBOARD_ONION_ENABLED=true

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -808,6 +808,28 @@ assert_contains "authorized_clients carries a v3 descriptor" "$(cat "$ac_file" 2
 )
 if [ -d "$ac_root/dashboard/authorized_clients" ]; then bad "client-auth off clears authorized_clients" "dir still present"; else ok "client-auth off clears authorized_clients"; fi
 
+echo "== unit: ensure_onion_password auto-generates (#343) =="
+# Onion on + no password -> generate a strong one into config.json (login stays admin), so the
+# fail-closed onion is usable without the operator inventing a 16+ char secret. CONFIG_FILE is
+# readonly (config.json in the cwd), so drive it via a dedicated dir rather than an override.
+autopw_dir="$SANDBOX/onion-autopw"
+mkdir -p "$autopw_dir"
+autopw_cfg="$autopw_dir/config.json"
+printf '{"dashboard":{"onion":{"enabled":true}}}' >"$autopw_cfg"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(cd "$autopw_dir" && source "$STACK" 2>/dev/null && ensure_onion_password >/dev/null 2>&1)
+genpw="$(jq -r '.dashboard.auth.password // ""' "$autopw_cfg")"
+if [ "${#genpw}" -ge 16 ]; then ok "ensure_onion_password writes a >=16-char password"; else bad "ensure_onion_password writes a >=16-char password" "length ${#genpw}"; fi
+# Idempotent: a second run leaves an already-set password alone (no churn).
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(cd "$autopw_dir" && source "$STACK" 2>/dev/null && ensure_onion_password >/dev/null 2>&1)
+assert_eq "ensure_onion_password leaves an existing password alone" "$(jq -r '.dashboard.auth.password' "$autopw_cfg")" "$genpw"
+# No-op when the onion is off — never touches config.json.
+printf '{"dashboard":{}}' >"$autopw_cfg"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+(cd "$autopw_dir" && source "$STACK" 2>/dev/null && ensure_onion_password >/dev/null 2>&1)
+assert_eq "ensure_onion_password no-op when onion off" "$(jq -r '.dashboard.auth.password // "none"' "$autopw_cfg")" "none"
+
 echo "== unit: host detection (#140) =="
 # detect_os reads ID / VERSION_ID / PRETTY_NAME from an overridable os-release (drives the
 # 'supported on Ubuntu 24.04' check); a missing file leaves the fields empty (caller warns).
@@ -1448,15 +1470,7 @@ rc=$?
 assert_rc "too-short dashboard.auth.password rejected" "$rc" "1"
 assert_contains "dashboard.auth.password message" "$out" "dashboard.auth.password"
 
-# Dashboard onion (#343): FAIL CLOSED. Enabling the onion without a login must abort apply — a
-# published .onion is a control panel at a stable address and cannot be unauthenticated.
-seed_env
-printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan","onion":{"enabled":true}} }\n' "$WALLET" >"$V/config.json"
-out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
-rc=$?
-assert_rc "onion without a password rejected" "$rc" "1"
-assert_contains "onion-needs-login message" "$out" "dashboard.auth.password is empty"
-# And a weak (LAN-acceptable but <16-char) password is rejected once the onion is on. This case
+# Dashboard onion (#343): a weak (LAN-acceptable but <16-char) password is rejected once the onion is on. This case
 # passes the length regex and so reaches the bcrypt step, which reads docker-compose.yml for the
 # pinned Caddy image — make sure it's present here (it's copied for later tests further down too).
 cp "$ROOT/docker-compose.yml" "$V/docker-compose.yml"


### PR DESCRIPTION
## What

Implements **#343** — publish the dashboard as an opt-in, default-off **Tor v3 onion service** with a fully locked-down auth surface. Reach the dashboard from anywhere over Tor: no port-forward, no VPN, no public IP, no inbound firewall hole. Rides the Tor daemon the stack already runs.

```json
"dashboard": {
    "secure": true,
    "onion": { "enabled": true, "client_auth": true },
    "auth": { "username": "admin", "password": "a long passphrase you choose" }
}
```

## Security surface (the point of the feature)

- **Tor v3 client authorization, ON by default.** The onion does not respond at all without the operator's client key — the address can't be scanned or brute-forced. The password is a second factor behind it. pithead generates the x25519 keypair (portable base32, no `base32` binary needed), writes the pubkey into `authorized_clients/` before tor starts, preserves keys across applies. `pithead onion-client-key` prints the client line (the private key) — kept out of `status`, which is a shareable report.
- **Fail-closed auth.** Refuses to publish without `dashboard.auth.password`; requires ≥16 chars; rejects weak choices (single repeated char, well-known patterns). Guarded twice: config validation + `generate_caddyfile`.
- **Onion fronts Caddy, never the raw dashboard.** The dashboard `:8000` has no auth of its own; Caddy carries the login. The onion targets an auth-gated Caddy vhost bound to the internal bridge gateway (`NETWORK_PREFIX.1`), reachable only via Tor, never the LAN. Plain HTTP inside the tunnel (Tor is the transport).
- **Rotation.** `pithead rotate-dashboard-onion` mints a fresh address + client key (a leaked onion is otherwise permanent).
- **Secret hygiene.** The client private key never appears in the apply change preview or `status`; onion enable/disable is a DEST change; a client-auth toggle recreates tor to re-read `authorized_clients`.
- Default stack is byte-for-byte unchanged — the torrc block is appended only when the flag is set.

## #343 work list

- [x] **R1** routing · **R2** opt-in torrc plumbing
- [x] **A1** fail-closed precondition · **A2** Tor v3 client-auth (default on) · **A3** ≥16-char floor + weak-password denylist · **A4** onion vhost carries auth · **A5** plain-HTTP warning exempts the onion · **A6** key rotation + onion-key hygiene
- [x] **D1** docs (configuration.md, privacy.md, config.reference.json)
- [ ] **P1 / P2** proxy-hardening prerequisites — see the comment below; these are orthogonal, invasive, and need bench validation, so they belong in a focused follow-up rather than this PR.

## Tests

`make test-stack` (+19 → 524 pass): base32 RFC-4648 vectors, keypair format, `authorized_clients` write + clear, fail-closed precondition, ≥16-char floor, weak-password denylist, `onion-client-key` output, privkey-hidden-in-preview, onion vhost render. `make lint` / `make test-compose` green; inventory regenerated.

## Not yet validated — needs the bench

The **gateway-bind routing** and the **client-auth end-to-end flow** (tor mints the hostname with `authorized_clients` present; the client key actually gates access) are reasoned-correct but not yet run on a live stack. Wants a gouda run before undraft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
