### PR TITLE
docs(onion): guardrail for the http-vs-https Tor Browser gotcha (#343)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,13 @@ Without the client key the onion is invisible — that's the point. Set `client_
 deliberately password-only onion (weaker: the address becomes online-guessable, so lean on the
 password).
 
+**Use `http://`, not `https://`.** The onion is served as plain HTTP — the Tor circuit already
+encrypts it end to end, and a `.onion` is a secure context, so there is no TLS certificate (adding
+one would only trade this for a self-signed-cert warning). If Tor Browser shows "Unable to connect"
+or "connection refused", it almost certainly auto-upgraded the address to `https://` (its default
+HTTPS-Only Mode), which the onion doesn't serve. Choose **"Continue to HTTP Site"** on the warning
+page, or turn it off under **Settings → Privacy & Security → HTTPS-Only Mode**.
+
 **Rotation.** A leaked `.onion` address or client key is otherwise permanent. Run
 `pithead rotate-dashboard-onion` to mint a fresh address and client key; the old ones stop working
 immediately, and the command prints the new client line.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,9 +265,16 @@ password).
 **Use `http://`, not `https://`.** The onion is served as plain HTTP — the Tor circuit already
 encrypts it end to end, and a `.onion` is a secure context, so there is no TLS certificate (adding
 one would only trade this for a self-signed-cert warning). If Tor Browser shows "Unable to connect"
-or "connection refused", it almost certainly auto-upgraded the address to `https://` (its default
-HTTPS-Only Mode), which the onion doesn't serve. Choose **"Continue to HTTP Site"** on the warning
-page, or turn it off under **Settings → Privacy & Security → HTTPS-Only Mode**.
+or "connection refused", it auto-upgraded the address to `https://`, which the onion doesn't serve.
+Tor Browser has **two** upgrade settings, and turning off only the first is not enough:
+
+1. **Settings → Privacy & Security → HTTPS-Only Mode → "Don't enable"**.
+2. In **`about:config`**, set **`dom.security.https_first`** to **`false`** (this is the silent
+   "HTTPS-First" upgrade that stays on even after you disable HTTPS-Only Mode — it's the "may still
+   upgrade some connections" caveat). Also confirm `dom.security.https_only_mode` is `false`.
+
+Then use **"Forget About This Site"** (History) on the onion so a cached upgrade doesn't linger, and
+retype the `http://…onion` URL fresh rather than picking the auto-completed `https://` one.
 
 **Rotation.** A leaked `.onion` address or client key is otherwise permanent. Run
 `pithead rotate-dashboard-onion` to mint a fresh address and client key; the old ones stop working

--- a/pithead
+++ b/pithead
@@ -2203,8 +2203,9 @@ Pick whichever Tor client you use to reach it:
     ${onion%.onion}:descriptor:x25519:$privkey
 
 Use http://, not https:// — the onion is plain HTTP (the Tor circuit already encrypts it).
-If Tor Browser can't connect, it likely auto-upgraded to https (HTTPS-Only Mode): choose
-"Continue to HTTP Site", or turn it off in Settings → Privacy & Security → HTTPS-Only Mode.
+If Tor Browser can't connect, it auto-upgraded to https. Turn off BOTH: Settings → Privacy &
+Security → HTTPS-Only Mode → "Don't enable", AND in about:config set dom.security.https_first
+to false (the silent upgrade that survives the first toggle). Then retype the http:// URL.
 EOF
 }
 

--- a/pithead
+++ b/pithead
@@ -2201,6 +2201,10 @@ Pick whichever Tor client you use to reach it:
   torrc (create it mode 0700), then reload Tor:
 
     ${onion%.onion}:descriptor:x25519:$privkey
+
+Use http://, not https:// — the onion is plain HTTP (the Tor circuit already encrypts it).
+If Tor Browser can't connect, it likely auto-upgraded to https (HTTPS-Only Mode): choose
+"Continue to HTTP Site", or turn it off in Settings → Privacy & Security → HTTPS-Only Mode.
 EOF
 }
 


### PR DESCRIPTION
The dashboard onion serves **plain HTTP** (the Tor circuit already encrypts it, and a `.onion` is a secure context — no TLS cert). Tor Browser's default **HTTPS-Only Mode** auto-upgrades `http://` → `https://`, which the onion doesn't serve (only virtual port 80), so the browser shows "connection refused". Every default-Tor-Browser operator hits this reaching the dashboard onion (I hit it deploying to prod).

Not a code bug — serving TLS on the onion would only trade this for a self-signed-cert warning, for no security gain. The fix is guidance where the operator actually looks:
- **`pithead onion-client-key`** output now says to use `http://` and how to get past HTTPS-Only Mode ("Continue to HTTP Site", or the Settings toggle).
- **docs/configuration.md** "Remote access over Tor" gains the same troubleshooting note.

Context: this came out of a security pass on the onion exposure. The security posture itself is strong and needed no code change — the onion is fail-closed (never published without a ≥16-char password; `generate_caddyfile` refuses otherwise), `basic_auth` covers every path (verified `401` on `/`, `/api/state`, `/static`), the HTTP surface is read-only, no secrets are in the web payload, and Tor v3 client-auth is on by default. All of that is already tested (run.sh:746/753/785/1576/1583/1588).

`make test` + `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)