### PR TITLE
fix(dashboard): abort a hung /api/state poll so the refresh loop can't freeze

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -597,7 +597,7 @@ export function App({
   }
   return html`<${Fragment}>
         <${Header} state=${state} />
-        ${!connected ? html`<div class="disconnected-banner">Disconnected — showing last known data. Retrying…</div>` : null}
+        ${!connected ? html`<div class="disconnected-banner">Disconnected — showing data from ${state.last_update}. Retrying…</div>` : null}
         ${
           state.syncing
             ? html`<${SyncView} sync=${state.sync} />`

--- a/build/dashboard/mining_dashboard/web/static/dashboard.js
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.js
@@ -11,6 +11,11 @@ import { html, render } from "./preact.mjs";
 
 const root = document.getElementById("app");
 const REFRESH_MS = 30000;
+// Abort a poll that hasn't answered before the next tick would fire. Without this a hung
+// connection (a dropped Tor circuit hangs rather than fails) never rejects, and the `inflight`
+// guard then blocks every later tick — the page freezes on stale data with no banner (#382).
+// Sized just under REFRESH_MS: far above a healthy Tor round-trip, so it only trips on dead links.
+const FETCH_TIMEOUT_MS = 25000;
 
 // A manual-zoom window {from, to} (epoch seconds) read from ?from=&to= so a zoomed URL is
 // shareable and survives reload (Issue #47); null/garbage falls back to the preset range.
@@ -77,7 +82,10 @@ async function tick() {
       ? "from=" + ui.window.from + "&to=" + ui.window.to
       : "range=" + encodeURIComponent(ui.range);
     const qs = base + "&avg=" + encodeURIComponent(ui.avg);
-    const res = await fetch("/api/state?" + qs, { headers: { "X-Requested-With": "fetch" } });
+    const res = await fetch("/api/state?" + qs, {
+      headers: { "X-Requested-With": "fetch" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
     if (!res.ok) throw new Error("HTTP " + res.status);
     state = await res.json();
     connected = true;

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -46,8 +46,9 @@ test('App always renders the theme switcher, even before the first load', () => 
 });
 
 test('operational App shows a disconnected banner when not connected', () => {
-    assert.match(renderApp({ connected: false }), /Disconnected — showing last known data/);
-    assert.doesNotMatch(renderApp({ connected: true }), /Disconnected — showing last known data/);
+    // The banner names the timestamp of the data on screen (#382) — the fixture's last_update.
+    assert.match(renderApp({ connected: false }), /Disconnected — showing data from 00:00:00/);
+    assert.doesNotMatch(renderApp({ connected: true }), /Disconnected — showing data from/);
 });
 
 // --- Header -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #382.

## What

The dashboard's refresh loop fetches `/api/state` every 30s with no timeout, and the `inflight` guard makes every later tick a no-op while one request is pending. Over the Tor onion route (#343) a connection that **hangs** rather than fails never rejects — the page freezes on old numbers with `connected` still `true`: no banner, silently-stale hashrate that reads as a healthy rig.

Two changes, both client-side, no new dependencies:

1. **`AbortSignal.timeout(25000)` on the poll** (`dashboard.js`). Sized just under the 30s interval — far above a healthy Tor round-trip, so it only trips on dead links. The abort rejects into the existing `catch`, so the disconnected banner and per-tick retry machinery (which already existed but could never fire on a hang) now work.
2. **The banner names how stale the data is** (`components.mjs`): "Disconnected — showing data from `<last_update>`. Retrying…" — the timestamp the client already holds.

Worst-case banner delay after a link dies: ~55s (25s abort + next 30s tick). No missed-poll counter — it would be state with no added signal at this cadence.

## Compatibility

`AbortSignal.timeout` is in all evergreen browsers (Chrome 103+, Firefox 100+, Safari 16+); stock Tor Browser (Firefox ESR) is well past it. No polyfill.

## Tests

Tier 1 (per docs/testing-strategy.md — display logic; `dashboard.js` interval wiring is entry-point code the suite covers via component render-smoke): extended the existing disconnected-banner case to assert the timestamp renders and no banner shows when connected. `make lint` and `make test` green locally; `docs/test-inventory.md` unchanged (no test added/removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)