### PR TITLE
test: shared-bench rig flock in the tier-4 harness + allocation docs (#430)

### DIFF
--- a/docs/release-server.md
+++ b/docs/release-server.md
@@ -144,6 +144,43 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 > patched LMDB and stock mdb_copy rejects the format (`MDB_VERSION_MISMATCH`). Often it's simplest
 > to leave the free pages.
 
+## Bench allocation and the rig lock
+
+Ten boxes are shared between this repo's tier-4 harness, RigForge's release gates, and
+production mining. Two automations cycling the same rig's services corrupt each other's results
+(the 2026-07-10 miner-0 incident: an operator "fixed" a service an e2e run had deliberately
+stopped), so ownership is static and every run takes a kernel lock.
+
+Static allocation — each box states its owner in `/etc/bench-role`:
+
+| Box | Owner | Use |
+|---|---|---|
+| miner-0 | RigForge | `e2e-real` / tune gates. Pithead never touches its services. |
+| miner-1, miner-2 | Pithead | Tier-4 loaner rigs: `e2e.sh` repoints one at the test bench for a run, then reverts it. Verify `systemctl is-active xmrig` after any remote restart. |
+| miner-3 … miner-7 | Production | Mining only. No test traffic. |
+| gouda | Pithead | Test bench + release box (the tier-4 target). |
+| pithead-prod | Production | Production stack; deploys only. |
+
+The run lock. Both harnesses take a `flock` on `/var/lock/rig-e2e.lock` before the first
+service-touching action and hold it on an inherited FD for the whole run, so the kernel releases
+it the moment the run dies — `kill -9` included, no stale-lock cleanup. rigforge#183 defines the
+mechanism; [#430](https://github.com/p2pool-starter-stack/pithead/issues/430) is this repo's
+mirror; the shared path on every box is the protocol. Mutating runs hold it exclusive; read-only
+runs (`run.sh --check` / `--readiness`) hold it shared, so concurrent readers coexist but still
+exclude mutators. `tests/integration/run.sh` takes it on the target box (over SSH for `--host`);
+`e2e.sh` also takes it on the loaner rig it borrows. A busy box makes the run exit 75
+(`EX_TEMPFAIL`) naming the holder; set `RIG_LOCK_WAIT=1` to queue instead.
+`/run/rig-e2e.holder` is a display-only sidecar naming the holder — the flock is authoritative,
+and a stale sidecar is harmless.
+
+Off-box actors (a human or an agent over SSH) touch services on a shared box only after the same
+check:
+
+```bash
+ssh <box> 'flock -n -x /var/lock/rig-e2e.lock true' || ssh <box> 'cat /run/rig-e2e.holder'
+ssh <box> 'cat /etc/bench-role'   # the box's static owner
+```
+
 ## Hardening checklist (the pitfalls)
 
 Treat the box as production-sensitive. It holds keys and it's the thing that signs off releases.

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -28,6 +28,11 @@
 
 set -uo pipefail
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# For rig_lock/rig_lock_remote (#430): the shared-bench flock protocol from rigforge#183.
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
 # --- Config (override via env or flags) -------------------------------------
 BENCH_HOST="${BENCH_HOST:-}"
 MINER_HOST="${MINER_HOST:-}"
@@ -268,6 +273,13 @@ preflight() {
         on_miner 'echo ok >/dev/null' || die "Cannot SSH to miner '$MINER_HOST' (use --no-miner to skip)."
         on_miner "test -f '$MINER_XMRIG_CONFIG'" || die "No xmrig config at $MINER_XMRIG_CONFIG on $MINER_HOST."
         ok "SSH to $MINER_HOST + xmrig config found"
+        # Loaner-rig lock (#430/rigforge#183): the borrow repoints (and may restart) the rig's
+        # xmrig, so claim the rig's EXCLUSIVE flock now — before anything is mutated — and hold it
+        # until this process dies. rigforge's gates on the same rig refuse (exit 75, holder named)
+        # instead of colliding mid-borrow, and a busy rig fails us fast, before the bench is
+        # touched. The kernel releases the lock on exit, AFTER the EXIT-trap restore has run.
+        rig_lock_remote pithead "e2e.sh loaner-borrow" "" "$MINER_HOST" "${SSH_OPTS[@]}"
+        ok "rig lock held on $MINER_HOST (loaner) for the life of this run"
     fi
 }
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -253,6 +253,74 @@ monero_caught_up() {
         printf "%s" "$body" | jq -e "(.status==\"OK\") and ((.synchronized==true) or (.target_height==0))" >/dev/null 2>&1'
 }
 
+# --- Shared-bench rig lock (#430; canonical helper from rigforge#183) --------
+# RigForge's release gates and this harness share bench hardware; a kernel flock on one
+# world-known path coordinates them. The lock lives on an open FD, so it dies with its holder
+# (kill -9 included — no stale-lock cleanup), shared (read-only) holders coexist but exclude
+# exclusive (mutating) ones, and a busy box exits 75 (EX_TEMPFAIL) so wrappers can tell
+# "retry later" from a real failure. The helper is copied VERBATIM from rigforge#183 — the
+# same lock path on every box IS the protocol; do not fork the two copies. FD 9 is inherited
+# by children, which is what keeps the lock held for the whole run — never close it.
+# RIG_LOCK_FILE/RIG_LOCK_HOLDER are env-overridable so the tier-1 self-test can sandbox the
+# paths (rigforge#183 note 6). run.sh sets no other EXIT trap; if one is ever added there,
+# fold this rm -f into its body instead of trapping twice — a later `trap … EXIT` replaces,
+# it doesn't stack (rigforge#183 note 3).
+rig_lock() { # rig_lock <project> <suite> [shared]
+    local mode=-x
+    [ "${3:-}" = shared ] && mode=-s
+    exec 9>"${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}"
+    if ! flock -n $mode 9; then
+        if [ "${RIG_LOCK_WAIT:-0}" = 1 ]; then
+            echo "rig busy ($(cat "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" 2>/dev/null || echo unknown)) — waiting..." >&2
+            flock $mode 9
+        else
+            echo "miner-0 busy: $(cat "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" 2>/dev/null || echo unknown). Retry with RIG_LOCK_WAIT=1 to queue." >&2
+            exit 75
+        fi
+    fi
+    printf '%s %s pid=%s started=%s\n' "$1" "$2" "$$" "$(date -Is)" >"${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}"
+    trap 'rm -f "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}"' EXIT
+}
+
+# Take the rig lock ON a remote box and hold it for the lifetime of THIS process. The remote
+# bash receives the verbatim helper over ssh stdin, acquires, answers RIG_LOCK_OK, then blocks
+# reading the still-open pipe; local FD 8 keeps that pipe open, so the remote shell — and with
+# it the kernel lock — dies the moment this process does, kill -9 included: the same crash
+# semantics as holding FD 9 locally, one hop out. Busy propagates as the helper's exit 75; an
+# ssh failure propagates as ssh's own exit code. Uses fixed local FD 8 (bash 3.2 has no
+# dynamic fds), so: one remote lock per process — enough for run.sh (the target box) and
+# e2e.sh (the borrowed loaner rig; its bench lock is taken by the run.sh it launches there).
+RIG_LOCK_SSH_PID=""
+rig_lock_remote() { # rig_lock_remote <project> <suite> <shared|""> <dest> [ssh opts...]
+    local project="$1" suite="$2" shmode="$3" dest="$4"
+    shift 4
+    local d
+    d="$(mktemp -d)" && mkfifo "$d/in" "$d/out" || {
+        it_err "rig_lock_remote: cannot create fifos under ${TMPDIR:-/tmp}"
+        exit 1
+    }
+    ssh "$@" "$dest" "RIG_LOCK_WAIT=$(quote_arg "${RIG_LOCK_WAIT:-0}") RIG_LOCK_FILE=$(quote_arg "${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}") RIG_LOCK_HOLDER=$(quote_arg "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}") bash -s" <"$d/in" >"$d/out" &
+    RIG_LOCK_SSH_PID=$!
+    exec 8>"$d/in"
+    {
+        declare -f rig_lock
+        printf 'rig_lock %s %s %s && echo RIG_LOCK_OK\n' "$(quote_arg "$project")" "$(quote_arg "$suite")" "$(quote_arg "$shmode")"
+    } >&8
+    local ack=""
+    IFS= read -r ack <"$d/out" || true
+    rm -rf "$d" # the open FDs outlive the fifo names
+    if [ "$ack" != "RIG_LOCK_OK" ]; then
+        # No ack: the remote helper exited 75 (its busy message already reached our stderr
+        # via ssh) or ssh itself failed — either way the run must not touch the box.
+        local rc
+        wait "$RIG_LOCK_SSH_PID" 2>/dev/null
+        rc=$?
+        [ "$rc" -eq 0 ] && rc=1 # EOF without the ack is never success
+        it_err "could not take the rig lock on $dest (exit $rc)"
+        exit "$rc"
+    fi
+}
+
 # --- Readiness waiters ------------------------------------------------------
 # Poll a predicate until it succeeds or the timeout elapses. The interval is a *poll* cadence
 # against a real readiness signal — not a fixed "sleep and hope" (issue #54). Returns 0 on

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1235,6 +1235,26 @@ IT_SKIPPED=0
 
 main() {
     parse_args "$@"
+
+    # Bench coordination (#430): take the shared-rig flock ON THE TARGET before the first
+    # service/API-touching action (preflight already reads the box), and hold it for the whole
+    # run — rigforge's gates and pithead runs on the same box refuse (exit 75, holder named)
+    # instead of colliding. Read-only modes take a SHARED lock so concurrent readers coexist;
+    # everything else mutates the stack, so it takes the EXCLUSIVE one. RIG_LOCK_WAIT=1 queues
+    # instead of failing. In --host mode the lock is held on the remote via a long-lived ssh
+    # that dies with this process (see lib.sh:rig_lock_remote).
+    local lock_suite="run.sh matrix" lock_shared=""
+    if [ "$READINESS" = "1" ]; then
+        lock_suite="run.sh --readiness" lock_shared="shared"
+    elif [ "$CHECK_ONLY" = "1" ]; then
+        lock_suite="run.sh --check" lock_shared="shared"
+    fi
+    if [ "$IT_MODE" = "local" ]; then
+        rig_lock pithead "$lock_suite" "$lock_shared"
+    else
+        rig_lock_remote pithead "$lock_suite" "$lock_shared" "$IT_SSH_DEST" "${IT_SSH_OPTS[@]}"
+    fi
+
     preflight
 
     # Non-destructive release-server fitness assessment.

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -258,6 +258,67 @@ assert_num_ge "num_ge passes when equal" 5 5
 assert_num_gt "num_gt passes when greater" 6 5
 [ "$IT_PASS" -gt "$_p" ] && it_pass "passing assertions increment IT_PASS" || it_fail "passing assertions increment IT_PASS" "no increment"
 
+echo "== rig_lock: the shared-bench flock (#430 / rigforge#183) =="
+# The canonical rig lock, exercised in a sandbox via the env-overridable paths — no root, no
+# /var/lock. Holders run as background subshells that acquire, signal readiness, then block on
+# a fifo until released; probes run in their own subshells (rig_lock exits 75 when busy).
+if ! command -v flock >/dev/null 2>&1; then
+    it_warn "flock not found on this host (macOS?) — skipping; CI and the boxes run this section"
+else
+    RL="$TMP/rig-lock"
+    mkdir -p "$RL"
+    RIG_LOCK_FILE="$RL/lock"
+    RIG_LOCK_HOLDER="$RL/holder"
+    mkfifo "$RL/hold-x" "$RL/hold-s"
+
+    # An exclusive holder (a stand-in for a running matrix).
+    (rig_lock pithead "run.sh matrix" && : >"$RL/ready-x" && read -r _ <"$RL/hold-x") &
+    _rl_x=$!
+    wait_for 30 0.2 "exclusive holder to acquire" test -f "$RL/ready-x" || it_fail "exclusive holder acquired" "never signalled ready"
+    if [ -f "$RIG_LOCK_HOLDER" ]; then it_pass "holder sidecar written on acquire"; else it_fail "holder sidecar written on acquire" "no $RIG_LOCK_HOLDER"; fi
+
+    # (a) A second exclusive acquire fails fast: exit 75, message names the holder.
+    out="$( (rig_lock rigforge e2e-real) 2>&1)"
+    rc=$?
+    assert_rc "second exclusive acquire exits 75 (EX_TEMPFAIL)" "$rc" "75"
+    assert_contains "busy message names the holder" "$out" "pithead run.sh matrix"
+    assert_contains "busy message points at RIG_LOCK_WAIT=1" "$out" "RIG_LOCK_WAIT=1"
+
+    # (b) Shared vs an exclusive holder is excluded too.
+    (rig_lock rigforge poll shared) >/dev/null 2>&1
+    rc=$?
+    assert_rc "shared acquire vs exclusive holder exits 75" "$rc" "75"
+
+    # (c) RIG_LOCK_WAIT=1 queues: it blocks while the lock is held (gated on its own waiting
+    # notice — a real signal, not a sleep), then acquires the moment the holder exits.
+    (RIG_LOCK_WAIT=1 rig_lock pithead queued 2>"$RL/waiter.err") &
+    _rl_q=$!
+    wait_for 30 0.2 "queued waiter to block on the held lock" grep -qs waiting "$RL/waiter.err" ||
+        kill "$_rl_q" 2>/dev/null # never acquired-nor-blocked: reap it so wait below fails loudly
+    printf 'go\n' >"$RL/hold-x"   # release the exclusive holder
+    wait "$_rl_q"
+    rc=$?
+    assert_rc "RIG_LOCK_WAIT=1 blocks, then acquires on release" "$rc" "0"
+    wait "$_rl_x"
+
+    # (d) Shared + shared coexist; exclusive vs a shared holder is excluded.
+    (rig_lock pithead "run.sh --check" shared && : >"$RL/ready-s" && read -r _ <"$RL/hold-s") &
+    _rl_s=$!
+    wait_for 30 0.2 "shared holder to acquire" test -f "$RL/ready-s" || it_fail "shared holder acquired" "never signalled ready"
+    (rig_lock rigforge poll shared) >/dev/null 2>&1
+    rc=$?
+    assert_rc "shared + shared coexist (rc 0)" "$rc" "0"
+    (rig_lock rigforge e2e-real) >/dev/null 2>&1
+    rc=$?
+    assert_rc "exclusive vs shared holder exits 75" "$rc" "75"
+    printf 'go\n' >"$RL/hold-s"
+    wait "$_rl_s"
+
+    # (e) Every holder exited normally, so the display-only sidecar is gone (EXIT-trap rm).
+    if [ ! -f "$RIG_LOCK_HOLDER" ]; then it_pass "holder sidecar removed on normal exit"; else it_fail "holder sidecar removed on normal exit" "sidecar still present"; fi
+    unset RIG_LOCK_FILE RIG_LOCK_HOLDER
+fi
+
 # --- Tally ------------------------------------------------------------------
 echo ""
 echo "selftest: $IT_PASS passed, $IT_FAIL failed"


### PR DESCRIPTION
Closes #430 — the pithead mirror of rigforge#183 (the canonical mechanism; all decisions made there, none reopened).

## What

- **`tests/integration/lib.sh` — `rig_lock()`**, copied **verbatim from rigforge#183** with only the amendments its own notes mandate (note 6: `${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}` / `${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}` so tier-1 tests can sandbox the paths). Same path on every box = the protocol. FD 9, exit 75 (`EX_TEMPFAIL`), `RIG_LOCK_WAIT=1` queueing, shared vs exclusive modes — all as decided. Kept the `miner-0 busy:` message text verbatim too; the holder line it prints names the real box's project/suite, and genericizing the wording is a both-repos follow-up if wanted.
- **`rig_lock_remote()`** (lib.sh): holds the lock **on a remote box** for the lifetime of the local process. The remote `bash -s` receives the verbatim helper over ssh stdin, acquires, acks, then blocks on the still-open pipe; local FD 8 keeps that pipe open, so the remote lock dies with the run — `kill -9` included, same crash semantics as FD 9 locally. Verified by hand with a fake-ssh harness: held while the run tree lives, an exclusive probe is refused naming the holder, released the instant the tree is gone, and busy propagates as exit 75.
- **`run.sh`**: `rig_lock pithead "run.sh <mode>"` before preflight (the first box-touching action) — in-process for `--local`, via `rig_lock_remote` for `--host`. Read-only modes (`--check` / `--readiness`) take a **shared** lock (readers coexist, mutators excluded); everything else exclusive. run.sh sets no other EXIT trap, so the helper's own trap is the whole body; a comment pins the composition rule (rigforge#183 note 3) for anyone adding one later.
- **`e2e.sh` — loaner-rig locking is code, not just docs**: the harness's rig-touching path is the `e2e.sh` borrow (it repoints/restarts the loaner's xmrig), so preflight takes the loaner's **exclusive** lock before anything is mutated and holds it until exit — the kernel releases it after the EXIT-trap restore runs. The bench lock itself is taken by the `run.sh` invocations `e2e.sh` launches; e2e's own deploy phases between runs are not lock-covered (out of #430's scope, noted for honesty).
- **Tier-1 tests** (`selftest.sh`, harness self-test pattern, sandboxed env paths, no root): second exclusive acquire exits **75 naming the holder**; **shared+shared coexist**; **shared vs exclusive excludes** (both directions); **`RIG_LOCK_WAIT=1` blocks then acquires** — background subshells + `wait`, gated on real signals (ready-files / the waiter's own notice), no sleep-and-hope. Plus sidecar written-on-acquire / removed-on-normal-exit. Skips with a warning only where `flock` doesn't exist.
- **`docs/release-server.md`**: the static allocation table (miner-0 = RigForge; miner-1/2 = pithead loaners; miner-3..7 = production; gouda = bench + release; pithead-prod = production), the run-lock contract, and the off-box check line. One tweak to the issue's literal command: `cat /run/rig-e2e.holder` runs over ssh too (the issue's form would cat a file on the operator's machine).

## Not in this PR (per the issue)

- Retiring `bench-lease` from the 10 boxes is **post-merge ops** (`/etc/bench-role` stays — static ownership is orthogonal to the run lock).
- The by-hand concurrency check on the real bench (acceptance item 1/2) — to run once this and the rigforge half are deployed; transcript to follow on the issue.
- Sidecar note for ops: `/run` is root-writable, and pithead's harness runs unprivileged on gouda — the flock (on `/var/lock`, 1777) works regardless; pre-creating `/run/rig-e2e.holder` world-writable (tmpfiles.d) makes the display sidecar work for non-root holders too.

## Gates

- `make lint` ✅ (shellcheck, shfmt -i 4, markdownlint, docs-voice, all surfaces)
- `make test` ✅ (120 selftest assertions incl. the new flock section, 0 failed; all tier-1/2 suites green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)