### PR TITLE
fix(xvb): honor the split-cycle p2pool remainder dwell — steady-state tier overshoot (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,21 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Fixed
 
+- **The XvB donation controller no longer overshoots the target tier in steady state (#423).**
+  During a split cycle the p2pool remainder dwell ended on its first 30-second check, because the
+  dwell's early-exit asked "would we donate at all?" — a question the held split answers yes to by
+  construction. The donated share of wall-clock time became slice/(slice + tick) instead of
+  slice/cycle, an order of magnitude above the commanded fraction, and the controller couldn't
+  unwind it: its command was already near zero. Live on v1.3.0 that held the credited averages
+  26-44% above the tier threshold — donation above threshold buys zero extra raffle chance —
+  and the resulting sawtooth intermittently dipped *below* tier too. The dwell now ends early only
+  when the decision actually *changed* (or the fresh 1h average slips under tier — the catch-up
+  path is untouched). A new wall-clock simulation (`run_actuated` in
+  `mining_dashboard/sim/donation_model.py`) replays the run loop through the real dwell rules —
+  the layer the fixed-step #70 sim was blind to — and pins steady state at 1.03x target with the
+  tier held; pre-fix it reproduces the overshoot at 1.17-1.21x with the tier intermittently lost.
+  The split decision log now also carries the instantaneous donated rate (`inst ~N H/s`) next to
+  the credited 1h/24h averages, so a live soak can watch the routed-vs-credited gap directly.
 - **`release.sh` rides out GHCR's read-after-push lag (#429).** A tag the registry just accepted can
   fail to resolve for a few seconds; the digest-capture and smoke-stage manifest reads killed the
   v1.3.1 cut twice this way. Both reads now retry with backoff (5 tries by default, tunable via

--- a/build/dashboard/mining_dashboard/service/algo_service.py
+++ b/build/dashboard/mining_dashboard/service/algo_service.py
@@ -211,14 +211,20 @@ class AlgoService:
         if (XVB_TIME_ALGO_MS - needed_time_ms) < 30000:
             needed_time_ms = XVB_TIME_ALGO_MS
 
+        # The decision log is what a live soak watches converge: keep target and the
+        # credited 1h/24h averages on one line, plus the instantaneous donated rate
+        # (fraction * current hashrate) — the gap between "inst" and "1h/24h" is the
+        # routed-vs-credited gap, the crux of any over-donation diagnosis (#423).
         if needed_time_ms >= XVB_TIME_ALGO_MS:
             logger.info(
-                f"Decision: Full XVB cycle (target {target_hr:.0f}; 1h {avg_1h:.0f} / 24h {avg_24h:.0f})"
+                f"Decision: Full XVB cycle (inst ~{current_hr:.0f} H/s; "
+                f"target {target_hr:.0f}; 1h {avg_1h:.0f} / 24h {avg_24h:.0f})"
             )
             return "XVB", XVB_TIME_ALGO_MS
 
         logger.info(
             f"Decision: Split ({needed_time_ms}ms to XvB; frac {fraction:.3f}; "
+            f"inst ~{fraction * current_hr:.0f} H/s; "
             f"target {target_hr:.0f}; 1h {avg_1h:.0f} / 24h {avg_24h:.0f})"
         )
         return "SPLIT", int(needed_time_ms)
@@ -317,13 +323,60 @@ class AlgoService:
             return xvb_duration_ms / XVB_TIME_ALGO_MS
         return 0.0
 
-    async def _smart_sleep(self, duration_sec, check_interval_sec=None):
+    def _dwell_should_end(
+        self, held_decision, current_hr, stable_hr, p2pool_stats, p2p_stats, xvb_stats, shares
+    ):
         """
-        Sleep through a P2Pool dwell in chunks, re-running the decision each chunk.
-        Returns early if the algorithm would now donate (hashrate dropped or a
-        trailing average fell below tier), so the next cycle reacts in seconds
-        instead of waiting out the full window. Uses only cached state — no extra
-        external API calls.
+        Whether a p2pool dwell should end early. Re-runs the decision WITHOUT
+        advancing the calibration loop and ends the dwell only when it *changed*
+        from the decision the dwell was started under, or when a fresh 1h average
+        has slipped below the tier (catch-up — undershoot loses the tier, which is
+        worse than waste).
+
+        Comparing against ``held_decision`` is the #423 fix. The old test —
+        "would we donate at all?" (``decision in ("XVB", "SPLIT")``) — is a
+        tautology during a SPLIT remainder: the fraction is static while
+        ``advance=False``, so the recomputed decision is SPLIT by construction and
+        every remainder collapsed to a single check tick. The actuated donation
+        duty became slice/(slice + tick) instead of slice/cycle — an order of
+        magnitude above the commanded fraction at small fractions — and the
+        controller could not unwind it (its command was already near 0). That is
+        the sustained credited overshoot of #423.
+        """
+        decision, _ = self.get_decision(
+            current_hr,
+            stable_hr,
+            p2pool_stats,
+            p2p_stats,
+            xvb_stats,
+            shares,
+            advance=False,
+        )
+        # The "under tier -> catch up early" override acts directly on avg_1h,
+        # so suppress it when the read is stale (#311): a frozen below-tier
+        # number would otherwise cut every p2pool dwell short and drift the
+        # effective split far past the computed fraction. A *changed* decision
+        # still ends the dwell — only the avg-driven override pauses.
+        target_hr = self._get_target_donation_hr(stable_hr)
+        under_tier = (
+            not self._stats_are_stale(xvb_stats)
+            and target_hr > 0
+            and xvb_stats.get("avg_1h", 0) < target_hr
+        )
+        return decision != held_decision or under_tier
+
+    async def _smart_sleep(self, duration_sec, check_interval_sec=None, held_decision="P2POOL"):
+        """
+        Sleep through a p2pool dwell in chunks, re-running the decision each chunk.
+        Returns early if the decision changed from ``held_decision`` (hashrate
+        dropped, a constraint tripped) or a trailing average fell below tier, so
+        the next cycle reacts in seconds instead of waiting out the full window.
+        Uses only cached state — no extra external API calls.
+
+        ``held_decision`` names the decision this dwell belongs to: "P2POOL" for a
+        full no-donation cycle, "SPLIT" for the p2pool remainder of a split cycle
+        (which must run its course, or the actuated donation exceeds the commanded
+        fraction — #423).
         """
         if check_interval_sec is None:
             check_interval_sec = UPDATE_INTERVAL
@@ -343,31 +396,9 @@ class AlgoService:
                 p2pool_stats = latest.get("pool", {}).get("pool", {})
                 p2p_stats = latest.get("pool", {}).get("p2p", {})
 
-                # Re-read WITHOUT advancing the calibration loop (that happens once
-                # per real cycle in run()). Bail early if we'd now donate, or if
-                # XvB's 1h average has slipped below the tier and we need to catch
-                # up — so the next cycle reacts in seconds, not after the full dwell.
-                decision, _ = self.get_decision(
-                    current_hr,
-                    stable_hr,
-                    p2pool_stats,
-                    p2p_stats,
-                    xvb_stats,
-                    shares,
-                    advance=False,
-                )
-                # The "under tier -> catch up early" override acts directly on avg_1h,
-                # so suppress it when the read is stale (#311): a frozen below-tier
-                # number would otherwise cut every p2pool dwell short and drift the
-                # effective split far past the computed fraction. The held decision
-                # (XVB/SPLIT) still ends the dwell — only the avg-driven override pauses.
-                target_hr = self._get_target_donation_hr(stable_hr)
-                under_tier = (
-                    not self._stats_are_stale(xvb_stats)
-                    and target_hr > 0
-                    and xvb_stats.get("avg_1h", 0) < target_hr
-                )
-                if decision in ("XVB", "SPLIT") or under_tier:
+                if self._dwell_should_end(
+                    held_decision, current_hr, stable_hr, p2pool_stats, p2p_stats, xvb_stats, shares
+                ):
                     logger.info(
                         "Smart-sleep: donation target needs attention — ending P2Pool dwell early."
                     )
@@ -440,7 +471,10 @@ class AlgoService:
                     remainder = (XVB_TIME_ALGO_MS - xvb_duration) / 1000
                     if remainder > 0:
                         await self.switch_miners("P2POOL", state_label="P2POOL (Split)")
-                        await self._smart_sleep(remainder)
+                        # held_decision="SPLIT": the remainder belongs to the split we
+                        # just decided — a re-read that still says SPLIT must NOT end
+                        # it (#423); only a changed decision or under-tier does.
+                        await self._smart_sleep(remainder, held_decision="SPLIT")
 
             except Exception as e:
                 logger.error(f"Algorithm Error: {e}")

--- a/build/dashboard/mining_dashboard/sim/donation_model.py
+++ b/build/dashboard/mining_dashboard/sim/donation_model.py
@@ -321,6 +321,147 @@ def run_simulation(controller: Controller, scenario: Scenario) -> SimResult:
     return result
 
 
+# --- actuated run-loop simulation (#423) ------------------------------------
+# `run_simulation` models the *decision* (one fixed 10-minute step per cycle) and
+# assumes a SPLIT's p2pool remainder actually runs its course. #423 proved that
+# assumption can break: the remainder is `_smart_sleep`'s to honor, and its
+# early-exit rules set the *actuated* donation duty. This variant replays the
+# `run()` branch structure in wall-clock seconds, calling the real `get_decision`
+# once per cycle and the real `_dwell_should_end` on every dwell tick — so a
+# dwell-rule bug shows up here as credited overshoot, where the fixed-step sim
+# is blind to it (it gave #70 a false all-clear while prod overshot 26-44%).
+
+_SMART_SLEEP_TICK_S = 30  # UPDATE_INTERVAL default: the live _smart_sleep check cadence
+
+
+class _SecondsWindow:
+    """Rolling per-second average over a fixed span, pre-filled with zeros
+    ("fixed" semantics: the average ramps up from 0 like a fresh XvB window)."""
+
+    def __init__(self, span_s: int):
+        from collections import deque
+
+        self.span = span_s
+        self._buf = deque([0.0] * span_s, maxlen=span_s)
+        self._sum = 0.0
+
+    def push(self, rate: float) -> None:
+        self._sum += rate - self._buf[0]  # deque is always full: append evicts left
+        self._buf.append(rate)
+
+    def average(self) -> float:
+        return self._sum / self.span
+
+
+@dataclass
+class ActuatedResult:
+    """Metrics from `run_actuated`. Window averages are sampled once per minute."""
+
+    target_hr: float
+    avg_1h: list[float] = field(default_factory=list)
+    avg_24h: list[float] = field(default_factory=list)
+    donated_s: float = 0.0
+    total_s: float = 0.0
+
+    @property
+    def _tail(self) -> slice:
+        # Steady state: the final day of minute samples (or the back half of short runs).
+        n = len(self.avg_1h)
+        return slice(max(n // 2, n - 24 * 60), n)
+
+    @property
+    def steady_overshoot_1h(self) -> float:
+        tail = self.avg_1h[self._tail]
+        return (sum(tail) / len(tail) / self.target_hr) if tail and self.target_hr else 0.0
+
+    @property
+    def steady_overshoot_24h(self) -> float:
+        tail = self.avg_24h[self._tail]
+        return (sum(tail) / len(tail) / self.target_hr) if tail and self.target_hr else 0.0
+
+    @property
+    def donated_duty(self) -> float:
+        """Share of wall-clock time actually routed to XvB (the actuated duty)."""
+        return self.donated_s / self.total_s if self.total_s else 0.0
+
+    def tier_held(self, tol: float = 0.02) -> bool:
+        """Both credited averages at/above threshold across steady state — the
+        raffle qualification condition (undershoot loses the tier)."""
+        t = self.target_hr * (1 - tol)
+        return (
+            min(self.avg_1h[self._tail], default=0.0) >= t
+            and min(self.avg_24h[self._tail], default=0.0) >= t
+        )
+
+
+def run_actuated(
+    scenario: Scenario, donation_level="vip", tick_s=_SMART_SLEEP_TICK_S, **tuning
+) -> ActuatedResult:
+    """Drive the production `AlgoService` through `scenario` in wall-clock time,
+    honoring the run() loop's actual dwell behavior (see block comment above).
+
+    Models a steady rig only (no noise/drop/lag — the #423 overshoot reproduces
+    without them); `credit_factor`, `ramp_loss_ms` and `p2pool_difficulty` from
+    the scenario apply as in `run_simulation`.
+    """
+    algo = build_controller(donation_level, **tuning)
+    cycle_s = XVB_TIME_ALGO_MS / 1000.0
+    pool_stats = {"pplns_window": _PPLNS_WINDOW, "difficulty": scenario.p2pool_difficulty}
+    win_1h, win_24h = _SecondsWindow(3600), _SecondsWindow(24 * 3600)
+    result = ActuatedResult(target_hr=scenario.target_hr)
+    total_s = scenario.cycles * cycle_s
+    hr = scenario.current_hr
+    ramp_s = scenario.ramp_loss_ms / 1000.0
+    t = 0
+
+    def stats():
+        return {"avg_1h": win_1h.average(), "avg_24h": win_24h.average(), "fail_count": 0}
+
+    def elapse(seconds, rate):
+        nonlocal t
+        for _ in range(int(round(seconds))):
+            win_1h.push(rate)
+            win_24h.push(rate)
+            t += 1
+            if t % 60 == 0:
+                result.avg_1h.append(win_1h.average())
+                result.avg_24h.append(win_24h.average())
+
+    def donate(seconds):
+        # XvB credits the full rig rate during a donated slice, after the
+        # reconnect ramp at the slice start (nothing lands during the ramp).
+        r = min(ramp_s, seconds)
+        elapse(r, 0.0)
+        elapse(seconds - r, hr * scenario.credit_factor)
+        result.donated_s += seconds
+
+    def dwell(seconds, held_decision):
+        # The run() p2pool dwell: sleep in ticks, ending early only when the real
+        # _dwell_should_end predicate says so (the shipping early-exit rules).
+        elapsed = 0.0
+        while elapsed < seconds:
+            step = min(tick_s, seconds - elapsed)
+            elapse(step, 0.0)
+            elapsed += step
+            if algo._dwell_should_end(
+                held_decision, hr, hr, pool_stats, _P2P_MAIN, stats(), _RECENT_SHARES
+            ):
+                return
+
+    while t < total_s:
+        decision, dur_ms = algo.get_decision(hr, hr, pool_stats, _P2P_MAIN, stats(), _RECENT_SHARES)
+        if decision == "P2POOL":
+            dwell(cycle_s, "P2POOL")
+        elif decision == "XVB":
+            donate(cycle_s)
+        else:  # SPLIT: donated slice, then the p2pool remainder dwell
+            donate(dur_ms / 1000.0)
+            dwell((XVB_TIME_ALGO_MS - dur_ms) / 1000.0, "SPLIT")
+
+    result.total_s = t
+    return result
+
+
 def build_controller(donation_level="vip", *, gain=None, reserve_factor=None, tiers=None):
     """Construct the production `AlgoService` wired to a fixed tier table, with
     optional tuning overrides, for simulation. Returns the service so callers can
@@ -412,6 +553,15 @@ def main():  # pragma: no cover - human-facing report, not a test path
             sc = replace(base, measurement=semantics)
             print(f"{sc.name}\n  {_fmt(run_algo(sc))}")
         print()
+
+    print("--- actuated run-loop (wall clock, real dwell rules — #423) ---")
+    for base in DEFAULT_SCENARIOS[:2]:
+        a = run_actuated(base)
+        print(
+            f"{base.name}\n"
+            f"  steady 1h {a.steady_overshoot_1h:4.2f}x  24h {a.steady_overshoot_24h:4.2f}x  "
+            f"duty {a.donated_duty * 100:4.1f}%  tier {a.tier_held()}"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/build/dashboard/tests/service/test_algo_service.py
+++ b/build/dashboard/tests/service/test_algo_service.py
@@ -534,6 +534,53 @@ class TestSmartSleep:
             await algo._smart_sleep(600, check_interval_sec=30)
         assert slept.await_count == 1
 
+    async def test_split_remainder_not_ended_by_held_split_decision(self, algo):
+        """#423: during a SPLIT remainder the re-read decision is SPLIT by
+        construction (the fraction is static with advance=False). That must NOT
+        end the dwell — pre-fix it did, collapsing every remainder to one tick,
+        so the actuated donation duty became slice/(slice+tick) instead of
+        slice/cycle: a sustained credited overshoot the controller couldn't
+        unwind because its commanded fraction was already near zero."""
+        algo.data_service.latest_data = dict(self.LATEST)
+        # In tier: 1h above the VIP threshold, so the catch-up override is quiet.
+        algo.state_manager.get_xvb_stats.return_value = {
+            "avg_24h": 12_000,
+            "avg_1h": 12_000,
+            "fail_count": 0,
+        }
+        algo.get_decision = MagicMock(return_value=("SPLIT", 15_000))
+        with patch("asyncio.sleep", new_callable=AsyncMock) as slept:
+            await algo._smart_sleep(90, check_interval_sec=30, held_decision="SPLIT")
+        assert slept.await_count == 3  # full remainder, no early bail
+
+    async def test_split_remainder_still_bails_when_below_tier(self, algo):
+        """The catch-up override survives the #423 fix: a fresh below-tier 1h
+        average ends even a SPLIT remainder early (undershoot loses the tier)."""
+        algo.data_service.latest_data = dict(self.LATEST)
+        algo.state_manager.get_xvb_stats.return_value = {
+            "avg_24h": 0,
+            "avg_1h": 500,
+            "fail_count": 0,
+        }
+        algo.get_decision = MagicMock(return_value=("SPLIT", 15_000))
+        with patch("asyncio.sleep", new_callable=AsyncMock) as slept:
+            await algo._smart_sleep(600, check_interval_sec=30, held_decision="SPLIT")
+        assert slept.await_count == 1
+
+    async def test_split_remainder_bails_when_decision_changes(self, algo):
+        """A decision that *changed* from the held one (a constraint tripped —
+        shares gone, failures) still ends the remainder early."""
+        algo.data_service.latest_data = dict(self.LATEST)
+        algo.state_manager.get_xvb_stats.return_value = {
+            "avg_24h": 12_000,
+            "avg_1h": 12_000,
+            "fail_count": 0,
+        }
+        algo.get_decision = MagicMock(return_value=("P2POOL", 0))
+        with patch("asyncio.sleep", new_callable=AsyncMock) as slept:
+            await algo._smart_sleep(600, check_interval_sec=30, held_decision="SPLIT")
+        assert slept.await_count == 1
+
     async def test_sleeps_full_duration_when_in_tier_on_p2pool(self, algo):
         algo.data_service.latest_data = dict(self.LATEST)
         # In tier (1h above the VIP threshold) and decision P2POOL -> rest, no bail.
@@ -564,6 +611,30 @@ class TestRunLoop:
             with pytest.raises(Exception):
                 await algo.run()
         assert algo.switch_miners.called
+
+    async def test_run_split_remainder_dwell_holds_split_decision(self, algo):
+        """#423 wiring: the SPLIT branch must hand the remainder to _smart_sleep
+        with held_decision="SPLIT" — the actuated-duty fix lives in that argument."""
+        algo.data_service.latest_data = {
+            "total_live_h10": 46_300,
+            "total_live_h15": 46_300,
+            "pool": {},
+            "shares": [],
+        }
+        algo.state_manager.get_xvb_stats.return_value = {
+            "avg_24h": 12_000,
+            "avg_1h": 12_000,
+            "fail_count": 0,
+        }
+        algo.get_decision = MagicMock(return_value=("SPLIT", 15_000))
+        algo.switch_miners = AsyncMock()
+        algo._smart_sleep = AsyncMock(side_effect=Exception("stop"))
+        # sleeps: initial 5s, the 15s donated slice, then the error-path sleep raises.
+        with patch("asyncio.sleep", side_effect=[None, None, Exception("stop")]):
+            with pytest.raises(Exception):
+                await algo.run()
+        expected_remainder = (XVB_TIME_ALGO_MS - 15_000) / 1000
+        algo._smart_sleep.assert_awaited_once_with(expected_remainder, held_decision="SPLIT")
 
     async def test_run_skips_switching_while_workers_rejected(self, algo):
         # When a node is down and workers are rejected (Issue #31), the proxy is stopped —

--- a/build/dashboard/tests/sim/test_donation_model.py
+++ b/build/dashboard/tests/sim/test_donation_model.py
@@ -18,6 +18,7 @@ from mining_dashboard.sim.donation_model import (
     Scenario,
     build_controller,
     make_algo_controller,
+    run_actuated,
     run_algo,
 )
 
@@ -125,6 +126,54 @@ class TestSelfCalibration:
         last_day = r.credited_1h[-CYCLES_PER_DAY:]
         spread = (max(last_day) - min(last_day)) / sc.target_hr
         assert spread < 0.10  # settled, not oscillating
+
+
+class TestActuatedRunLoop:
+    """The #423 regression, pinned at the tier the fixed-step sim is blind to.
+
+    `run_algo` models the decision and *assumes* the SPLIT remainder dwell runs
+    its course — it was green while prod overshot 26-44%, because the shipping
+    `_smart_sleep` collapsed every remainder to one 30s tick (its early-exit
+    fired on the held SPLIT decision itself). `run_actuated` replays the run()
+    loop in wall-clock seconds through the real dwell predicate, so these tests
+    fail against that pre-fix predicate (steady ~1.17-1.21x AND the tier
+    intermittently lost as the loop sawtooths) and pass with the held-decision
+    fix (steady 1.03x = target + cushion, tier held throughout)."""
+
+    @pytest.mark.parametrize(
+        "current_hr",
+        [46_300, 57_000],  # the #70 field rig, and a prod-#423-sized fleet
+    )
+    def test_actuated_steady_state_converges_to_reference(self, current_hr):
+        sc = Scenario(
+            name=f"actuated-{current_hr}",
+            target_hr=10_000,
+            current_hr=current_hr,
+            p2pool_difficulty=DIFFICULTY,
+            cycles=3 * CYCLES_PER_DAY,
+        )
+        r = run_actuated(sc)
+        # Held: both credited averages stay at/above threshold across steady state
+        # (undershoot drops the tier — worse than the waste this issue is about).
+        assert r.tier_held()
+        # Converged: a hair above threshold (the noise cushion), no sustained
+        # overshoot on either window. Pre-fix this sits at 1.17-1.21x.
+        assert r.steady_overshoot_1h <= 1.06
+        assert r.steady_overshoot_24h <= 1.06
+
+    def test_actuated_duty_matches_command_not_dwell_collapse(self):
+        """The actuated share of time on XvB must be what holding the reference
+        needs (~ref/hr + ramp compensation), not the slice/(slice+tick) duty the
+        collapsed dwell produced (pre-fix: ~32% for a 22% requirement)."""
+        sc = Scenario(
+            name="duty",
+            target_hr=10_000,
+            current_hr=46_300,
+            p2pool_difficulty=DIFFICULTY,
+            cycles=3 * CYCLES_PER_DAY,
+        )
+        r = run_actuated(sc)
+        assert r.donated_duty <= 0.27  # ~10.3k/46.3k plus switch-ramp compensation
 
 
 class TestVipReserve:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -86,8 +86,10 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 |---|---|---|
 | Disabled / zero shares / `fail_count ≥ 3` / no sustainable tier → P2POOL | guards | 1 ✅ |
 | Closed-loop ramp/back-off, cold-start seed, VIP-reserve anti-overshoot (#70) | controller | 1 ✅ |
+| Actuated run-loop duty: split remainder dwell honored, steady state at tier + cushion (#423) | wall-clock sim | 1 ✅ |
 | P2POOL / XVB / SPLIT modes, tiers, smart-sleep early exit | decision | 1 ✅ |
 | Real XvB endpoint reachable / failing | network | 4 (real endpoint) |
+| Credited 1h/24h averages converge to tier on live XvB (soak) | live donation | 4 (real endpoint) |
 
 ### F. Dashboard `/api/state` field states
 


### PR DESCRIPTION
Closes #423

## Root cause

Live on v1.3.0 the swap-algo held the credited XvB averages 26-44% above the target tier (`Decision: Split (frac 0.009; target 10000; 1h 12640 / 24h 14410)`) — every hash above threshold is p2pool earnings donated for zero extra raffle chance (~0.12 XMR/year on prod).

The leak is in the **actuation**, not the control math. During a SPLIT cycle, `run()` hands the p2pool remainder to `_smart_sleep`, whose early-exit asked *"would we donate at all?"* (`decision in ("XVB", "SPLIT")`). During a split remainder that is a tautology: the donation fraction is static while `advance=False`, so the re-read decision is SPLIT by construction — and **every remainder dwell collapsed to a single 30s check tick**. The actuated donation duty became `slice/(slice + tick)` instead of `slice/cycle`, an order of magnitude above the commanded fraction at small fractions. The closed loop could not unwind it: its command was already near zero (`frac 0.009` in the field log while ~1/3 of wall-clock time was routed to XvB). The resulting sawtooth also intermittently dipped *below* tier.

## Why the #70 sim gave a false all-clear

The #70 harness (`run_algo`) models the *decision*: it converts a SPLIT into `dur_ms / XVB_TIME_ALGO_MS` of the cycle — i.e. it **assumes the remainder dwell runs its course**. The dwell rules that set the actuated duty were never in the loop it closed. Its 1.03x steady-state claims are correct for the control math and wrong about the shipped system.

## The fix

- `_dwell_should_end` (factored out of `_smart_sleep`, shared with the sim): a dwell ends early only when the decision **changed** from the one it was started under (`decision != held_decision`), or on the untouched catch-up path — a fresh 1h average under tier still ends any dwell immediately (undershoot loses the tier; worse than waste). The #311 stale-read suppression is unchanged.
- `run()` passes `held_decision="SPLIT"` for the split remainder.

## New actuated simulation (the honest red test)

`run_actuated` (`mining_dashboard/sim/donation_model.py`) replays the `run()` loop in wall-clock seconds through the real `get_decision` **and the real dwell predicate**, with per-second 1h/24h credited windows.

| | steady 1h | steady 24h | actuated duty | tier held (min 1h) |
|---|---|---|---|---|
| pre-fix, field 46.3k rig | **1.17x** | **1.18x** | 31.7% | **NO** (6,276 on a 10k tier) |
| pre-fix, prod-like 57k fleet | **1.20x** | **1.21x** | 27.5% | **NO** (6,254) |
| fixed, field 46.3k rig | 1.03x | 1.03x | 23.3% | yes (10,263) |
| fixed, prod-like 57k fleet | 1.03x | 1.03x | 19.1% | yes (10,260) |

1.03x = threshold + the #9 noise cushion (`min(3%, 1000 H/s)`), exactly the reference. Red-then-green verified: the new sim tests and the `_smart_sleep` unit tests fail against the pre-fix predicate (5 failures) and pass with the fix; all 6 new tests plus the full suite are green after.

## Observability

The decision log keeps target + credited 1h/24h and now adds the instantaneous donated rate — the routed-vs-credited gap is the diagnosis crux:

```
Decision: Split (138500ms to XvB; frac 0.222; inst ~10289 H/s; target 10000; 1h 10310 / 24h 10285)
```

## Live validation plan (tier 4 — required before this is called fixed)

The sim regression test proves the control-loop math and the dwell mechanics; **the credited-average behavior is XvB-server-side and tier-4-live-only** — the sim already gave one false all-clear at this exact spot. The fix is proven only after:

- a **≥24h soak on gouda** (ideally 48h, to fully turn over the 24h credited window), mining and donating to XvB at a **fixed target tier**;
- the decision-log `1h` **and** `24h` credited averages converge to target within a small band (target + cushion, i.e. ~1.00-1.05x) with **no sustained overshoot and no undershoot** — a dropped tier is a worse regression than the waste this fixes;
- p2pool routed hashrate visibly rises to reclaim the previously-wasted donation (the `inst` figure and the dashboard's routed split should sit near `frac x fleet`, not near 1/3 of the fleet).

## Gates

- `make lint` green (ruff check + format, shellcheck/shfmt, docs voice)
- `make test` green (dashboard suite incl. 6 new tests; pithead shell 897 passed; selftest 120; fakes 12)
- `make test-patch-coverage`: **97%** (>=90 gate)
- CHANGELOG under [Unreleased] > Fixed; testing-strategy inventory updated (actuated sim row + tier-4 soak row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)