### PR TITLE
release: digest-pin bundle images + make cosign opt-in (#376)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -228,17 +228,21 @@ preflight() {
     if [ "$DRY_RUN" -eq 0 ] && [ "$SKIP_TESTS" -eq 0 ] && [ "$RESUME_PROMOTE" -eq 0 ]; then
         check_release_toolchain
     fi
-    # Release signing (#376): every promoted digest and the install bundle are cosign-signed with the
-    # key that lives ONLY on this box (COSIGN_KEY/COSIGN_PASSWORD, same handling as GHCR_TOKEN — never
-    # echoed, never in the repo); the committed cosign.pub is what installs verify against. Checked
-    # here so a missing binary/key stops the release before any build, not after promote.
+    # Release signing (#376) is OPT-IN and pure defense-in-depth. The tag-substitution vector it
+    # exists for — the first-party images pull by mutable `:vX.Y.Z` tag, so a re-pointed tag / leaked
+    # registry token could serve a malicious root-running image — is ALREADY closed by digest-pinning
+    # those images in the bundle (make_bundle). cosign additionally signs the promoted digests + the
+    # bundle for operators who want to verify. So a normal cut needs NOTHING off-repo: signing turns
+    # on only when a key is configured on this box AND cosign.pub is committed; otherwise we warn and
+    # skip it rather than block the release.
+    COSIGN_ENABLED=0
     if [ "$DRY_RUN" -eq 0 ]; then
-        command -v cosign >/dev/null 2>&1 ||
-            die "cosign is required to sign the release (#376) — install the pinned build: docs/release-server.md § The release signing key."
-        [ -n "${COSIGN_KEY:-}" ] && [ -f "$COSIGN_KEY" ] ||
-            die "COSIGN_KEY must point at the cosign private key on this box (#376) — one-time setup: docs/release-server.md § The release signing key."
-        [ -f cosign.pub ] ||
-            die "cosign.pub is missing from the repo root (#376) — commit the public half of the release key so installs can verify what this pipeline signs."
+        if command -v cosign >/dev/null 2>&1 && [ -n "${COSIGN_KEY:-}" ] && [ -f "${COSIGN_KEY:-/nonexistent}" ] && [ -f cosign.pub ]; then
+            COSIGN_ENABLED=1
+            ok "Release signing ON (cosign key + committed cosign.pub present)."
+        else
+            warn "Release signing OFF — shipping digest-pinned images + bundle without cosign signatures (#376 is opt-in). Installs are protected by the pinned digests; to also sign, see docs/release-server.md § The release signing key."
+        fi
     fi
 
     STACK_VERSION="$(tr -d ' \t\r\n' <VERSION)"
@@ -465,6 +469,10 @@ promote() {
 # `cosign verify --key cosign.pub --private-infrastructure`. COSIGN_PASSWORD is read by cosign from
 # the environment — it never touches argv, run(), or the log.
 sign_images() {
+    if [ "${COSIGN_ENABLED:-0}" -ne 1 ]; then
+        log "Release signing off — skipping image signatures (the bundle is digest-pinned; #376 opt-in)."
+        return 0
+    fi
     stage "6b/7 Sign the promoted digests (cosign, #376)"
     local suffix digest
     for suffix in "${IMAGES[@]}"; do
@@ -492,8 +500,11 @@ publish() {
     write_manifest "$manifest"
     local bundle="$WORKDIR/pithead.tar.gz" # versionless name → stable /releases/latest/download/ URL
     make_bundle "$bundle"
-    local bundle_sig="$bundle.sig" # pithead.tar.gz.sig — the #59 upgrade runner fetches it by name
-    sign_bundle "$bundle" "$bundle_sig"
+    local bundle_sig="" # pithead.tar.gz.sig — only when signing is on (#376 opt-in)
+    if [ "${COSIGN_ENABLED:-0}" -eq 1 ]; then
+        bundle_sig="$bundle.sig" # the #59 upgrade runner fetches it by name
+        sign_bundle "$bundle" "$bundle_sig"
+    fi
 
     confirm "Create git tag $TAG, push it, and publish the GitHub Release?" ||
         {
@@ -513,7 +524,10 @@ publish() {
         # The images are already promoted, so the draft's install bundle works the moment it's published.
         local gh_args=(release create "$TAG" --title "Pithead $TAG" --notes-file "$notes")
         [ "$DRAFT" -eq 1 ] && gh_args+=(--draft)
-        run gh "${gh_args[@]}" "$bundle" "$bundle_sig" "$manifest"
+        gh_args+=("$bundle")
+        [ -n "$bundle_sig" ] && gh_args+=("$bundle_sig") # the .sig only exists when signing is on
+        gh_args+=("$manifest")
+        run gh "${gh_args[@]}"
         ok "GitHub Release $TAG $([ "$DRAFT" -eq 1 ] && echo 'created as a DRAFT (publish it from the Releases page when ready)' || echo published)."
     else
         warn "gh CLI not found — tag pushed, but create the release by hand. Notes: $notes  Assets: $bundle $bundle_sig $manifest"
@@ -587,6 +601,25 @@ make_bundle() {
         printf '   %s[dry-run]%s would tar -> %s\n' "$C_YELLOW" "$C_RESET" "$out"
         return 0
     fi
+    # Digest-pin the first-party images in the BUNDLED compose (#376). The released images pull by
+    # mutable `:vX.Y.Z` tag, so a re-pointed tag / leaked registry token could substitute a
+    # root-running image under the same tag. Pinning each to the immutable @sha256 digest promote just
+    # published makes the pull content-addressed — this is what actually closes that vector (cosign
+    # signing, when on, is the additional layer). The tag stays for readability; the digest wins.
+    local suffix digest
+    for suffix in "${IMAGES[@]}"; do
+        digest="$(get_digest "$suffix")"
+        [ -n "$digest" ] ||
+            die "make_bundle: no promoted digest for $suffix — refusing to ship an un-pinned bundle (#376)."
+        sed -i.bak "s|\(pithead-${suffix}:\${STACK_VERSION:-dev}\)|\1@${digest}|" "$d/docker-compose.yml"
+    done
+    rm -f "$d/docker-compose.yml.bak"
+    # Post-condition: NEVER ship a partially-pinned bundle. Every first-party image line must now
+    # carry an @sha256 digest.
+    local unpinned
+    unpinned="$(grep -E "pithead-(tor|monero|p2pool|xmrig-proxy|dashboard):" "$d/docker-compose.yml" | grep -v "@sha256:" || true)"
+    [ -z "$unpinned" ] ||
+        die "make_bundle: first-party image(s) left un-pinned in the bundle compose (#376):"$'\n'"$unpinned"
     # --no-xattrs: we cut releases on macOS, where tar is bsdtar and stores each file's extended
     # attributes (incl. macOS's com.apple.provenance) as LIBARCHIVE.xattr.* pax headers. GNU tar on
     # a user's Linux box doesn't know that keyword and warns once per file on extract (#252). Stripping

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -606,12 +606,19 @@ make_bundle() {
     # root-running image under the same tag. Pinning each to the immutable @sha256 digest promote just
     # published makes the pull content-addressed — this is what actually closes that vector (cosign
     # signing, when on, is the additional layer). The tag stays for readability; the digest wins.
-    local suffix digest
+    local suffix digest sha
     for suffix in "${IMAGES[@]}"; do
         digest="$(get_digest "$suffix")"
         [ -n "$digest" ] ||
             die "make_bundle: no promoted digest for $suffix — refusing to ship an un-pinned bundle (#376)."
-        sed -i.bak "s|\(pithead-${suffix}:\${STACK_VERSION:-dev}\)|\1@${digest}|" "$d/docker-compose.yml"
+        # get_digest stores a FULL ref ($repo@sha256:…); we append only the @sha256 part to the
+        # existing image line (which already has the repo + tag), so pin by the bare digest.
+        sha="${digest##*@}"
+        case "$sha" in
+        sha256:*) ;;
+        *) die "make_bundle: digest for $suffix is not a sha256 ref ('$digest') — cannot pin (#376)." ;;
+        esac
+        sed -i.bak "s|\(pithead-${suffix}:\${STACK_VERSION:-dev}\)|\1@${sha}|" "$d/docker-compose.yml"
     done
     rm -f "$d/docker-compose.yml.bak"
     # Post-condition: NEVER ship a partially-pinned bundle. Every first-party image line must now

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1439,11 +1439,23 @@ assert_contains "bundle ships the tari config dir" "$BUILD_MOUNTS" "./build/tari
     TAG=v9.9.9
     REGISTRY=ghcr.io/test
     DRY_RUN=0
+    # make_bundle now digest-pins the first-party images (#376), so it needs the promoted digests
+    # promote would have captured -- a full repo@sha256 ref, as set_digest stores them.
+    for _s in "${IMAGES[@]}"; do set_digest "$_s" "ghcr.io/test/pithead-$_s@sha256:feed${_s}dad"; done
     make_bundle "$WORKDIR/pithead.tar.gz" >/dev/null 2>&1
+    cp "$WORKDIR/pithead/docker-compose.yml" "$SANDBOX/bundle-compose.yml" 2>/dev/null || true
     tar tzf "$WORKDIR/pithead.tar.gz" 2>/dev/null
 ) >"$SANDBOX/bundle.list" 2>/dev/null
 grep -q '^pithead/config.minimal.json$' "$SANDBOX/bundle.list" && ok "bundle ships config.minimal.json (basic quick-start config)" || bad "bundle ships config.minimal.json" "absent from the bundle"
 grep -q '^pithead/$' "$SANDBOX/bundle.list" && ok "bundle unpacks to versionless pithead/" || bad "bundle unpacks to pithead/" "top-level dir is not pithead/"
+# Every first-party image line in the bundled compose must be digest-pinned (#376).
+_bundle_unpinned=$(grep -E 'pithead-(tor|monero|p2pool|xmrig-proxy|dashboard):' "$SANDBOX/bundle-compose.yml" 2>/dev/null | grep -cv '@sha256:')
+[ "${_bundle_unpinned:-1}" -eq 0 ] && ok "bundle compose digest-pins all 5 first-party images (#376)" || bad "bundle digest-pins first-party images (#376)" "unpinned lines: ${_bundle_unpinned:-?}"
+if grep -q 'pithead-dashboard:${STACK_VERSION:-dev}@sha256:feeddashboarddad' "$SANDBOX/bundle-compose.yml" 2>/dev/null; then
+    ok "digest pin appends only the bare sha256, no double-repo (#376)"
+else
+    bad "digest pin format (#376)" "expected tag@sha256:digest on the dashboard image line"
+fi
 _bm_missing=""
 for _m in $BUILD_MOUNTS; do [ -e "$ROOT/$_m" ] || _bm_missing="$_bm_missing $_m"; done
 assert_eq "every compose ./build runtime mount exists in the tree" "${_bm_missing:-none}" "none"
@@ -1618,6 +1630,7 @@ sign_out="$(
     set +eu
     WORKDIR="$SIGN"
     DRY_RUN=0
+    COSIGN_ENABLED=1
     COSIGN_KEY="/release-box/cosign.key"
     export COSIGN_LOG="$SIGN/cosign.log"
     PATH="$SIGN/bin:$PATH"
@@ -1629,6 +1642,24 @@ assert_eq "all 5 promoted digests signed" "$(grep -c '^\[cosign\] sign ' "$SIGN/
 assert_contains "signs the digest with the box key, no Rekor upload" "$(cat "$SIGN/cosign.log")" \
     "sign --key /release-box/cosign.key --tlog-upload=false --yes ghcr.io/test/pithead-dashboard@sha256:feeddashboard"
 assert_not_contains "never signs a mutable tag" "$(cat "$SIGN/cosign.log")" ":v"
+# Opt-in (#376): with signing OFF, sign_images is a no-op -- no cosign calls, and it says why.
+: >"$SIGN/cosign-off.log"
+# shellcheck disable=SC1090,SC2030,SC2031,SC2034  # dynamic source; the globals are consumed inside sign_images
+sign_off_out="$(
+    cd "$ROOT" || exit
+    set --
+    source "$REL" 2>/dev/null
+    set +eu
+    WORKDIR="$SIGN"
+    DRY_RUN=0
+    COSIGN_ENABLED=0
+    export COSIGN_LOG="$SIGN/cosign-off.log"
+    PATH="$SIGN/bin:$PATH"
+    for s in "${IMAGES[@]}"; do set_digest "$s" "ghcr.io/test/pithead-$s@sha256:feed$s"; done
+    sign_images 2>&1
+)"
+assert_eq "signing off means no cosign invocations (#376 opt-in)" "$(grep -c '^\[cosign\]' "$SIGN/cosign-off.log")" "0"
+assert_contains "signing off announces the skip (#376 opt-in)" "$sign_off_out" "skipping image signatures"
 # The bundle gets a detached signature the #59 runner can fetch (pithead.tar.gz.sig), and the
 # committed public key ships INSIDE the bundle so a release install has its verifier beside pithead.
 # shellcheck disable=SC1090,SC2030,SC2031,SC2034


### PR DESCRIPTION
Closes the real supply-chain vector cheaply and drops the release-blocking key requirement.

**The vector:** the 5 first-party images pull by mutable `:vX.Y.Z` tag (unlike the 3 third-party images, which are `@sha256`-pinned). A re-pointed tag or a leaked `GHCR_TOKEN` could serve a malicious root-running image under the same tag; TLS doesn't catch it.

**The fix (no off-repo secret):** `make_bundle` rewrites the 5 first-party image lines in the *bundled* compose to `@sha256:<digest>` — the immutable digest promote just published — so installs pull content-addressed. A post-condition refuses to ship a partially-pinned bundle. Verified: the sed pins all 5 lines on the real compose; the check passes.

**cosign becomes opt-in defense-in-depth**, not a blocker: preflight computes `COSIGN_ENABLED` (cosign + `COSIGN_KEY` + committed `cosign.pub`) and warns+skips when absent instead of `die`-ing; `sign_images`/`sign_bundle`/the `.sig` upload are gated on it. A normal cut needs nothing off-repo. An operator who wants signatures adds a key later — cosign then layers on top of the pinning.

shellcheck clean, bash -n; the digest rewrite is unit-tested against the real compose. Full pipeline exercise happens at the v1.4 cut (needs promote's live digests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)