### PR TITLE
v1.4 documentation coverage + discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ a Tor daemon. The `pithead` script renders config, provisions Tor, and drives do
   guide](docs/privacy.md) maps every connection.
 - 🔌 **One endpoint for every rig.** Point all workers at a single address on port `3333`. No wallet
   address in the miner config; the stack routes the hashrate.
-- 📊 **Live dashboard.** Hashrate, the P2Pool/XvB split, the PPLNS window, and per-worker updates,
-  served over HTTPS on your LAN.
+- 📊 **Live dashboard, now with config editing.** Hashrate, the P2Pool/XvB split, the PPLNS window,
+  and per-worker updates over HTTPS on your LAN. Opt in with `dashboard.control.enabled` to edit
+  `config.json`, one-click upgrade to a new release, and watch the access + config-change audit logs
+  from the browser — every change gated host-side behind a login. See
+  [The Dashboard](docs/dashboard.md).
 - 📟 **Telegram operator bot.** Opt-in alerts for a downed node, a worker that dropped off, sync
   finishing, low disk, a clearnet leak, or a sustained hashrate drop — plus a daily digest and
   read-only commands (`/status`, `/hashrate`, `/workers`, `/earnings`). Routed over Tor. See the
@@ -98,7 +101,7 @@ Full walkthrough: [docs/getting-started.md](docs/getting-started.md)
 | **[Getting Started](docs/getting-started.md)** | Prerequisites, install, first-run setup, and what to expect while the node syncs. |
 | **[Hardware Requirements](docs/hardware.md)** | Minimum vs. recommended specs for the stack host (CPU, RAM, disk, network), and how to run leaner. (Miner specs live in [RigForge](https://github.com/p2pool-starter-stack/rigforge).) |
 | **[Configuration](docs/configuration.md)** | Every `config.json` key, applying changes safely, reusing an existing node, and remote Monero nodes. |
-| **[The Dashboard](docs/dashboard.md)** | Sync Mode and a tour of the live operational view. |
+| **[The Dashboard](docs/dashboard.md)** | Sync Mode, a tour of the live operational view, and the opt-in control channel: editing config, one-click upgrades, and the audit logs from the browser. |
 | **[Connecting Miners](docs/workers.md)** | Point any existing rig at the stack, or spin up a tuned miner with [RigForge](https://github.com/p2pool-starter-stack/rigforge). |
 | **[Architecture](docs/architecture.md)** | The nine services, the privacy model, and the algorithmic XvB switching engine. |
 | **[Privacy & Network Egress](docs/privacy.md)** | Every off-box connection: what's Tor-routed, what's clearnet today, and how to harden it. |
@@ -191,8 +194,10 @@ Everything runs through `pithead` (`./pithead help` lists it all):
 | `./pithead logs [service]` | Follow logs (all, or one service). |
 | `./pithead status` | Container status + health-check of every expected service (warns on anything down). |
 | `./pithead doctor` | Read-only health report (deps, Docker, AVX2, HugePages, RAM/disk, onion state). |
-| `./pithead backup` | Save config, secrets, the Tor onion keys, and the dashboard's database to `backups/` (`--with-chains` adds blockchain data; `-y` / `--yes` skips the prompts). |
-| `./pithead restore <archive>` | Restore those files from a backup archive (asks before overwriting; `-y` / `--yes` skips the prompt). |
+| `./pithead version` | Print the installed stack version on one line (offline; also `-V` / `--version`). |
+| `./pithead backup` | Save config, secrets, the Tor onion keys, and the dashboard's database to a passphrase-encrypted archive under `backups/` (`--with-chains` adds blockchain data; `--no-encrypt` writes plaintext; `-y` / `--yes` skips the prompts). |
+| `./pithead restore <archive>` | Restore those files from a backup archive, encrypted or plaintext (asks before overwriting; `-y` / `--yes` skips the prompt). |
+| `./pithead rotate-secrets` | Regenerate the stack's internal credentials after a suspected leak — see [Rotating the internal secrets](docs/operations.md#rotating-the-internal-secrets). |
 
 Commands chain in one call (`./pithead apply upgrade` runs both, stopping on the first failure;
 nonsense like `up down` is rejected before anything runs), and `source pithead-completion.bash`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,13 +12,13 @@ stack. The other guides cover individual topics once you're running.
 | [Getting Started](getting-started.md) | Prerequisites, installation, first-run setup, and what to expect while the node syncs. |
 | [Hardware Requirements](hardware.md) | Minimum vs. recommended specs for the stack host (CPU, RAM, disk, network, OS), plus lighter-footprint options. (Miner hardware lives in [RigForge](https://github.com/p2pool-starter-stack/rigforge).) |
 | [Configuration](configuration.md) | Every `config.json` key and default, applying changes safely, reusing an existing node via data directories, and connecting to a remote Monero node. |
-| [The Dashboard](dashboard.md) | Sync Mode, the live operational view, and how to read every panel. |
+| [The Dashboard](dashboard.md) | Sync Mode, the live operational view and how to read every panel, plus the opt-in control channel: editing `config.json`, one-click upgrades, and the access + config-change audit logs, all from the browser. |
 | [Monitoring & Alerting](monitoring.md) | Optional Healthchecks.io dead-man's switch — get alerted when your host goes down (power loss, crash), even when it can't tell you itself — plus the Prometheus `/metrics` endpoint for Grafana or any scraper. |
 | [Telegram Bot](telegram.md) | Push operator alerts (node down/recovered, worker offline/back, sync finished) to Telegram and query stack status on demand (`/status`, `/hashrate`, `/workers`, `/sync`) — creating a bot, finding your chat id, per-event toggles, and the command list. |
 | [Connecting Miners](workers.md) | Pointing any existing rig at the stack, plus [RigForge](https://github.com/p2pool-starter-stack/rigforge) for setting up new miners. |
 | [Architecture](architecture.md) | The nine services, how they fit together, the privacy model, and the algorithmic XvB switching engine. |
 | [Privacy & Network Egress](privacy.md) | Every connection the stack makes off-box: what's Tor-routed, what's clearnet today, and how to harden each path. |
-| [Operations & Maintenance](operations.md) | The full `pithead` command reference, upgrades, backups, and troubleshooting. |
+| [Operations & Maintenance](operations.md) | The full `pithead` command reference (including command chaining and tab-completion), upgrades, encrypted backups, rotating the internal secrets, watching for intruders, and troubleshooting. |
 | [Testing Strategy](testing-strategy.md) | The four test tiers (unit → contract → fake-daemon mini-stack → live matrix), the full scenario catalog, and which tier proves each situation. |
 | [Testing Guide](testing-guide.md) | For developers: how to write and run tests, per-change recipes, conventions, and real-hardware gotchas. |
 | Test Inventory | An exhaustive list of every test/scenario across all suites — generated on demand by `make test-inventory` (not committed). |
@@ -32,6 +32,8 @@ stack. The other guides cover individual topics once you're running.
 - **Just want to start mining?** → [Getting Started](getting-started.md)
 - **Will my machine handle it?** → [Hardware Requirements](hardware.md)
 - **Change a setting?** → [Configuration › Changing settings later](configuration.md#changing-settings-later)
+- **Edit config or upgrade from the browser?** → [Dashboard › Configuration view](dashboard.md#configuration-view)
+- **Watching for break-in attempts?** → [Operations › Watching for intruders](operations.md#watching-for-intruders)
 - **Already have a synced Monero node?** → [Configuration › Reusing an existing node](configuration.md#reusing-an-existing-node)
 - **Want to be alerted if the host dies?** → [Monitoring & Alerting](monitoring.md)
 - **Worried about your IP / what leaves the box?** → [Privacy & Network Egress](privacy.md)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -46,9 +46,12 @@ finishes syncing in the background.
 > **Want to skip most of the wait?** Point the stack at an existing synced blockchain, or connect
 > to a remote node. See [Configuration › Reusing an existing node](configuration.md#reusing-an-existing-node).
 
-You can also follow sync progress from the command line:
+You can also follow sync progress from the command line. `./pithead status` prints each chain's
+percent and blocks remaining while it's still syncing (no ETA — block rate isn't sampled), or watch
+the node logs directly:
 
 ```bash
+./pithead status
 ./pithead logs monerod
 ./pithead logs tari
 ```


### PR DESCRIPTION
## v1.4 documentation coverage + discoverability

Audits every `[1.4.0]` CHANGELOG entry against two bars: **documented** in the right doc, and **discoverable** — reachable from README and/or a doc's structure, not only in the CHANGELOG. The maintainer's concern: "we don't want people to not know of these things."

**Finding:** the deep docs on `release/v1.4.0` are already thorough (dashboard.md control channel + audit panels, operations.md rotate-secrets/chaining/completion/intruders, configuration.md control keys, releasing.md signed releases, architecture.md read-only roots, SECURITY.md control model). The real gap was **discoverability at the top level** — the headline new capabilities (edit config from the dashboard, one-click upgrade, audit logs) weren't surfaced in README's feature list, common-commands, or the docs index. This PR fixes that; it does not duplicate the deep docs, it links to them.

### Files changed
- `README.md` — "What it does" dashboard bullet now names the opt-in control channel (edit config / one-click upgrade / audit + access logs, gated host-side behind a login); "Common commands" adds `version` and `rotate-secrets` rows and notes backups are passphrase-encrypted by default; Documentation-table dashboard row points at the control channel.
- `docs/README.md` — index dashboard/operations rows updated; two new Quick-links (Configuration view; Watching for intruders).
- `docs/dashboard.md` — Sync Mode CLI section now mentions `./pithead status` per-chain progress (#384), matching getting-started.

### Audit table (28 entries)

| # | Feature | Documented where | Status |
|---|---|---|---|
| #424 | Tor guard self-heal | operations.md#troubleshooting, monitoring.md, configuration.md (`tor.auto_heal`), command ref | already-covered |
| #425 | Simple view points at calculators | dashboard.md#simple-vs-advanced-view | already-covered |
| #94 | Subcommand chaining + tab-completion | operations.md#chaining-commands / #tab-completion; README common-commands | already-covered |
| #378 | `rotate-secrets` | operations.md#rotating-the-internal-secrets, command ref | **discoverability**: added to README common-commands + docs index |
| #374 | `backup` encrypts by default | operations.md#backups, command ref | **discoverability**: README backup row now notes encryption + `--no-encrypt` |
| #33 | Edit config from the dashboard | dashboard.md#configuration-view, operations.md#editing-config-from-the-dashboard, configuration.md | **discoverability**: surfaced in README "What it does", README + docs index, quick links |
| — | `apply --dry-run [--porcelain]` | operations.md#editing-config-from-the-dashboard | already-covered |
| — | `control-run-pending` | operations.md (host-side runner) | already-covered (internal) |
| #59 | One-click upgrade from the dashboard | dashboard.md#upgrading-from-the-dashboard, operations.md#updating-the-stack | **discoverability**: README "What it does" + index rows |
| #349 | Audit + access logs | dashboard.md#access-log-and-recent-config-changes, operations.md#watching-for-intruders, SECURITY.md | **discoverability**: README "What it does" + docs-index quick link |
| #384 | `status` per-chain sync progress | getting-started.md#first-boot | **discoverability**: added `./pithead status` to dashboard.md Sync Mode |
| #384 | First-run "what happens next" note | getting-started.md#first-boot | already-covered |
| #386 | `pithead version` | operations.md command ref | **discoverability**: added to README common-commands |
| #372 | CODE_OF_CONDUCT.md | CONTRIBUTING links it | already-covered (not a user doc) |
| #373 | tor Dockerfile alpine pin | CHANGELOG (dev/internal) | changelog-only (correct) |
| #371 | CONTRIBUTING `make test` accuracy | CONTRIBUTING.md | already-covered |
| #423 | XvB no longer overshoots | CHANGELOG (fix; no operator-visible config) | changelog-only (correct) |
| #429 | release.sh rides GHCR read lag | CHANGELOG / release tooling | changelog-only (correct) |
| #426 | release.sh preflight lint check | release-server.md referenced | already-covered |
| #373 | build-pruned-chain.sh SRC_DIR | CHANGELOG (dev/test) | changelog-only (correct) |
| #376 | Signed releases, verified before upgrade | releasing.md#signed-releases, operations.md#updating-the-stack, SECURITY.md | already-covered |
| #377 | Read-only root filesystems | architecture.md, SECURITY.md | already-covered |
| #33 | Reject control chars in config strings | SECURITY.md, dashboard.md control model | already-covered (summarized) |
| #33 | Require Tor client-auth for control channel | configuration.md (`dashboard.onion.client_auth`, fails-closed), SECURITY.md | already-covered |
| #33 | Default-deny commit gate | dashboard.md#configuration-view, operations.md, SECURITY.md | already-covered |
| #33 | Bound the root-runner spool | SECURITY.md, operations.md | already-covered (summarized) |
| #33 | Mask `ping_url` + narrow secret mount | SECURITY.md | already-covered |
| #419 | grpcio off yanked release | CHANGELOG (deps) | changelog-only (correct) |

**Genuine gaps fixed (discoverability):** #378, #374, #33 (edit-config), #59, #349, #384 (status), #386.
**Already covered:** everything else; dev/release-internal items correctly stay CHANGELOG-only.

### Lint
- `make lint-docs-voice`: **pass** — no banned words in 31 prose docs.
- `markdownlint`: my three edited files and the whole tracked repo are **clean** (0 findings). Note: `make lint` fails in this worktree only because of pre-existing local pollution — a stale untracked `worker/` dir (extracted to RigForge) and nested sibling worktrees under `.claude/worktrees/`; neither is tracked or present in a CI checkout.

Docs only — no code or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
