### PR TITLE
feat(dashboard): consume RigForge enriched worker feed (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **Read RigForge's enriched worker feed on the dashboard (#235).** A RigForge rig serves an
+  enriched read API on port `8081` — the same `/1/summary` the dashboard already polls, plus a
+  `rigforge` block with the rig's version, tuning state, power draw and efficiency, CPU/firmware
+  health, and watchdog temperatures. Point that rig's `dashboard.workers[]` descriptor `port` at the
+  feed and the Workers Alive table gains a RigForge version badge and health/power/tune/watchdog
+  chips next to the rig — throttling and a non-performance governor read red or amber, the rest are
+  muted read-outs. Because the feed is a strict superset, uptime and per-miner hashrate still come
+  from the same response, and a plain-xmrig rig (no `rigforge` block) reads exactly as before: no
+  chips, no error. A rig whose RigForge is up but whose miner has stopped stays in the table with a
+  **miner down** chip instead of dropping to offline. Every enriched field is nullable, so a rig with
+  no RAPL shows no power chip and a disabled watchdog shows no temperature. The [#122 SSRF
+  guard](docs/workers.md) is unchanged — the dashboard still polls only the operator-set descriptor
+  host/port, never a miner-advertised value. See [Connecting
+  Miners](docs/workers.md#rigforge-enriched-feed).
 - **Confirm Tari payouts on-chain, too (#462).** The Tari sibling of #381, for the other half of
   the merge-mine. Tari merge-mining here is solo — the whole block reward lands at once when your
   hashrate finds a Tari block — so a payout is a rare, large event worth ground-truth confirmation.

--- a/build/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/build/dashboard/mining_dashboard/client/xmrig_client.py
@@ -30,6 +30,55 @@ except ValueError:
     _INTERNAL_NET = ipaddress.ip_network("172.28.0.0/16")
 
 
+def parse_rigforge(payload):
+    """Normalize the optional ``rigforge`` block off a worker ``/1/summary`` (#235).
+
+    A RigForge rig serves an ENRICHED feed on its ``api_port`` (default 8081): the whole XMRig
+    ``/1/summary`` object unchanged, plus one added ``rigforge`` key (rigforge#99). Point the rig's
+    descriptor ``port`` at that feed and the block rides in on the existing poll — no new read path.
+    A plain-xmrig rig has no ``rigforge`` key, so this returns ``None`` and the UI renders it exactly
+    as before (backward compatible).
+
+    Every enriched field is nullable on the wire — no RAPL / non-root → ``power.watts`` null, no
+    governor read → ``governor`` null — so each access is defaulted. A present-but-miner-down rig
+    (``xmrig_api == "unreachable"``, XMRig keys absent) is flagged via ``miner_down`` so the UI can
+    show it as up-but-miner-down rather than offline. Returns a compact dict for the UI, or ``None``.
+    """
+    rf = payload.get("rigforge") if isinstance(payload, dict) else None
+    if not isinstance(rf, dict):
+        return None
+    tune = rf.get("tune") or {}
+    autotune = tune.get("autotune") or {}
+    power = rf.get("power") or {}
+    health = rf.get("health") or {}
+    firmware = health.get("firmware") or {}
+    watchdog = rf.get("watchdog") or {}
+    wd_on = watchdog.get("mode") == "enabled"
+    return {
+        "version": rf.get("version"),
+        "miner_down": rf.get("xmrig_api") == "unreachable",
+        "power": {"watts": power.get("watts"), "hs_per_watt": power.get("hs_per_watt")},
+        "tune": {
+            "target": tune.get("target"),
+            "autotune_enabled": bool(autotune.get("enabled")),
+            "autotune_next": autotune.get("next"),
+        },
+        "health": {
+            "governor": health.get("governor"),
+            "throttling": health.get("throttling"),
+            "board": firmware.get("board"),
+            "hugepages_total": health.get("hugepages_total"),
+        },
+        # thermal_hold/temps are only meaningful while the watchdog is enabled.
+        "watchdog": {
+            "enabled": wd_on,
+            "thermal_hold": watchdog.get("thermal_hold") if wd_on else None,
+            "temp_c": watchdog.get("temp_c") if wd_on else None,
+            "max_temp_c": watchdog.get("max_temp_c") if wd_on else None,
+        },
+    }
+
+
 def _safe_probe_host(ip):
     """Return a safe host string to probe, or None.
 

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -9,7 +9,7 @@ from mining_dashboard.client.docker.docker_control import DockerControl
 from mining_dashboard.client.monero.monero_wallet_client import MoneroWalletClient
 from mining_dashboard.client.tari.tari_client import TariClient
 from mining_dashboard.client.tari.tari_wallet_client import TariWalletClient
-from mining_dashboard.client.xmrig_client import XMRigWorkerClient
+from mining_dashboard.client.xmrig_client import XMRigWorkerClient, parse_rigforge
 from mining_dashboard.client.xvb_client import (
     REG_INVALID,
     REG_NOT_ELIGIBLE,
@@ -230,6 +230,14 @@ def _merge_direct_stats(workers, results, active_pool_port):
         api_ok = extra_stats.get("api_ok") if extra_stats else None
         if api_ok is not None:
             w["api_ok"] = api_ok
+
+        # RigForge enriched feed (#235): a superset /1/summary carries an extra `rigforge` block.
+        # Present only for RigForge rigs whose descriptor port points at the enriched feed; a
+        # plain-xmrig rig parses to None and gets no chips. A miner-down enriched body has no XMRig
+        # keys, so this rides in even when api_ok can't confirm live hashrate.
+        rf = parse_rigforge(extra_stats) if extra_stats else None
+        if rf is not None:
+            w["rigforge"] = rf
 
         if api_ok:  # only a successful probe carries uptime + per-miner hashrate
             w["uptime"] = extra_stats.get("uptime", w["uptime"])

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -592,6 +592,22 @@ function PoolBadge({ pool }) {
   return html`<span class="badge badge-bad">Unknown</span>`;
 }
 
+// RigForge enriched feed (#235): a monospace version badge plus health / power / tune / watchdog
+// chips, all built server-side (views._rigforge_display) so the client stays a dumb renderer. A
+// plain-xmrig worker has no `rigforge` block and renders nothing extra — no chips, no error, no
+// empty placeholder, exactly as today. Each chip is a {text, variant, title}; only present-data
+// chips are emitted, so a rig with no RAPL shows no power chip.
+function RigForgeChips({ rf }) {
+  if (!rf) return null;
+  return html`${
+    rf.version
+      ? html` <span class="badge badge-outline version-badge" title="RigForge version">rf ${rf.version}</span>`
+      : null
+  }${(rf.chips || []).map(
+    (c) => html` <span class=${"badge badge-" + c.variant} title=${c.title || ""}>${c.text}</span>`,
+  )}`;
+}
+
 // Pool-wide proxy share totals (Issue #82) — a footer under the table. Hidden until the proxy
 // has reported any shares so it isn't an all-zero line on a fresh start.
 const ProxyTotals = ({ summary }) => {
@@ -642,7 +658,7 @@ function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort }) {
                               w.api_ok === false
                                 ? html` <span class="badge badge-bad" title="The dashboard couldn't read this worker's xmrig API, so uptime and per-miner hashrate are unavailable (it still mines — figures come from the proxy). Check workers.api_auth / api_port, or the miner's xmrig http settings.">api ⚠</span>`
                                 : null
-                            }</td>
+                            }<${RigForgeChips} rf=${w.rigforge} /></td>
                             <td>${w.ip}</td>
                             <td>${uptimeCell(w)}</td>
                             <td>${w.h60_str}</td>

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -601,6 +601,119 @@ def _reject_flag(accepted, rejected):
     return {"text": "⚠", "title": f"High reject rate: {rate * 100:.1f}% ({rejected} rejected)"}
 
 
+def _num(v):
+    """A number for display, or None for anything non-numeric (incl. bools, which JSON booleans
+    would otherwise pass as 0/1). Every enriched RigForge field is nullable on the wire (#235)."""
+    return v if isinstance(v, (int, float)) and not isinstance(v, bool) else None
+
+
+def _fmt_num(v):
+    """Trim a display number: drop a pointless ``.0`` so ``142.0 W`` reads ``142 W``."""
+    return str(int(v)) if isinstance(v, float) and v.is_integer() else str(v)
+
+
+def _rigforge_display(rf):
+    """A ``{version, miner_down, chips}`` view of a worker's parsed ``rigforge`` block, or ``None``
+    for a plain-xmrig worker (#235). Each chip is ``{text, variant, title}`` (the same shape the
+    Badges component renders) and is emitted ONLY when its data is present — a rig with no RAPL
+    shows no power chip, a disabled watchdog shows no watchdog chip. Building the chip set (and its
+    thresholds) here keeps the client a dumb renderer, matching the ``_reject_flag`` precedent."""
+    if not rf:
+        return None
+    chips = []
+    if rf.get("miner_down"):
+        chips.append(
+            {
+                "text": "miner down",
+                "variant": "bad",
+                "title": "RigForge is up but its XMRig API is unreachable — the rig is present but "
+                "not mining. Live hashrate and uptime come from the proxy.",
+            }
+        )
+
+    health = rf.get("health") or {}
+    if health.get("throttling") is True:
+        chips.append(
+            {"text": "throttling", "variant": "bad", "title": "CPU is thermal/power throttling."}
+        )
+    gov = health.get("governor")
+    if gov:
+        ok = gov == "performance"
+        chips.append(
+            {
+                "text": f"gov: {gov}",
+                "variant": "ok" if ok else "warn",
+                "title": "CPU frequency governor"
+                + ("" if ok else " — 'performance' is recommended for mining."),
+            }
+        )
+    hp = _num(health.get("hugepages_total"))
+    if hp is not None:
+        chips.append(
+            {
+                "text": f"HP {_fmt_num(hp)}",
+                "variant": "outline",
+                "title": f"HugePages allocated: {_fmt_num(hp)}.",
+            }
+        )
+    board = health.get("board")
+    if board:
+        chips.append({"text": board, "variant": "outline", "title": "Mainboard (firmware)."})
+
+    power = rf.get("power") or {}
+    watts = _num(power.get("watts"))
+    hspw = _num(power.get("hs_per_watt"))
+    if watts is not None or hspw is not None:
+        parts = []
+        if watts is not None:
+            parts.append(f"{_fmt_num(round(watts, 1))} W")
+        if hspw is not None:
+            parts.append(f"{_fmt_num(round(hspw, 1))} H/s·W")
+        chips.append(
+            {"text": " · ".join(parts), "variant": "outline", "title": "Power draw / efficiency."}
+        )
+
+    tune = rf.get("tune") or {}
+    if tune.get("target"):
+        chips.append(
+            {
+                "text": f"tune: {tune['target']}",
+                "variant": "outline",
+                "title": "Active tuning target.",
+            }
+        )
+    if tune.get("autotune_enabled") and tune.get("autotune_next"):
+        chips.append(
+            {
+                "text": f"autotune → {tune['autotune_next']}",
+                "variant": "outline",
+                "title": "Next scheduled autotune run.",
+            }
+        )
+
+    wd = rf.get("watchdog") or {}
+    if wd.get("enabled"):
+        temp = _num(wd.get("temp_c"))
+        maxt = _num(wd.get("max_temp_c"))
+        if wd.get("thermal_hold") is True:
+            chips.append(
+                {
+                    "text": "thermal hold",
+                    "variant": "bad",
+                    "title": "Watchdog is holding the rig back — temperature above its ceiling.",
+                }
+            )
+        elif temp is not None:
+            label = f"{_fmt_num(round(temp, 1))}°C"
+            if maxt is not None:
+                label += f" / {_fmt_num(maxt)}°C"
+            chips.append(
+                {"text": label, "variant": "outline", "title": "Watchdog temperature / ceiling."}
+            )
+
+    return {"version": rf.get("version"), "miner_down": bool(rf.get("miner_down")), "chips": chips}
+
+
 def build_system(data):
     """System resource metrics (CPU, RAM, Disk, HugePages) as formatted values + level tokens.
 
@@ -704,6 +817,9 @@ def build_workers(workers):
                     # hashrate unavailable; the client badges it), True = ok, None = not probed
                     # (internal/invalid IP per the SSRF guard) — don't flag the unknown case.
                     "api_ok": worker.get("api_ok"),
+                    # RigForge enriched feed (#235): version badge + health/power/tune/watchdog
+                    # chips, or None for a plain-xmrig worker (renders nothing extra).
+                    "rigforge": _rigforge_display(worker.get("rigforge")),
                 }
             )
         except Exception as e:

--- a/build/dashboard/tests/client/test_xmrig_client.py
+++ b/build/dashboard/tests/client/test_xmrig_client.py
@@ -1,7 +1,44 @@
 import pytest
 
 from mining_dashboard.client import xmrig_client as xc
-from mining_dashboard.client.xmrig_client import XMRigWorkerClient
+from mining_dashboard.client.xmrig_client import XMRigWorkerClient, parse_rigforge
+
+# A full enriched `rigforge` block from the RigForge superset /1/summary (rigforge#99), matching the
+# verified producer contract: version/tune/power/health/watchdog with real field names and units.
+RIGFORGE_BLOCK = {
+    "version": "1.7.0",
+    "xmrig_version": "6.21.0",
+    "xmrig_commit": "a" * 40,
+    "tune": {
+        "applied": {"threads": 8},
+        "target": "perf",
+        "last_best_hs": 12345,
+        "candidates_tried": 4,
+        "autotune": {"enabled": True, "target": "perf", "schedule": "weekly", "next": "Sun 03:00"},
+    },
+    "power": {"watts": 142.0, "hs_per_watt": 86.9},
+    "health": {
+        "service_active": True,
+        "hugepages_total": 1280,
+        "hugepages_1g": 0,
+        "governor": "performance",
+        "msr": "applied",
+        "ram": {"modules": 2, "channels": 2, "mts": 6000, "rated_mts": 6000},
+        "xmp": True,
+        "smt": "on",
+        "firmware": {"vendor": "ASUS", "board": "ProArt X670E"},
+        "clock_pct_of_boost": 96,
+        "throttling": False,
+    },
+    "watchdog": {
+        "mode": "enabled",
+        "thermal_hold": False,
+        "max_temp_c": 85,
+        "resumes_below_c": 75,
+        "temp_c": 62,
+        "strikes": 0,
+    },
+}
 
 
 class FakeResponse:
@@ -343,3 +380,72 @@ async def test_spoofed_name_cannot_redirect_the_token_to_the_miner_ip_when_host_
     session = FakeSession(response=FakeResponse(200, {"ok": True}))
     await XMRigWorkerClient(session).get_stats("8.8.8.8", "rig1")
     assert session.calls[0][0] == "http://192.168.7.9:8080/1/summary"
+
+
+# --- RigForge enriched feed parse (#235) ---------------------------------------------------------
+# The enriched feed is a SUPERSET of /1/summary: the whole XMRig object plus one `rigforge` key.
+# parse_rigforge lifts the display-relevant fields, nullable-safe; a plain-xmrig body → None.
+
+
+def test_parse_rigforge_absent_is_none():
+    # A plain-xmrig worker (no `rigforge` key) parses to None — the UI renders it as today.
+    assert parse_rigforge({"hashrate": {"total": [100]}, "api_ok": True}) is None
+    assert parse_rigforge({}) is None
+    assert parse_rigforge(["not", "a", "dict"]) is None
+
+
+def test_parse_rigforge_full_block():
+    rf = parse_rigforge({"hashrate": {"total": [100]}, "rigforge": RIGFORGE_BLOCK, "api_ok": True})
+    assert rf["version"] == "1.7.0"
+    assert rf["miner_down"] is False
+    assert rf["power"] == {"watts": 142.0, "hs_per_watt": 86.9}
+    assert rf["tune"] == {"target": "perf", "autotune_enabled": True, "autotune_next": "Sun 03:00"}
+    assert rf["health"] == {
+        "governor": "performance",
+        "throttling": False,
+        "board": "ProArt X670E",
+        "hugepages_total": 1280,
+    }
+    assert rf["watchdog"] == {
+        "enabled": True,
+        "thermal_hold": False,
+        "temp_c": 62,
+        "max_temp_c": 85,
+    }
+
+
+def test_parse_rigforge_miner_down_has_no_xmrig_keys():
+    # Miner-down body: XMRig keys drop, only the rigforge block with xmrig_api unreachable remains.
+    rf = parse_rigforge({"rigforge": {"version": "1.7.0", "xmrig_api": "unreachable"}})
+    assert rf["miner_down"] is True
+    assert rf["version"] == "1.7.0"
+    # Absent sub-objects default cleanly — no chip data, no crash.
+    assert rf["power"] == {"watts": None, "hs_per_watt": None}
+    assert rf["watchdog"]["enabled"] is False
+
+
+def test_parse_rigforge_all_null_fields():
+    # Every enriched field is nullable on the wire (no RAPL, non-root, watchdog disabled).
+    block = {
+        "version": "1.7.0",
+        "tune": {"target": None, "autotune": {"enabled": False, "next": None}},
+        "power": {"watts": None, "hs_per_watt": None},
+        "health": {"governor": None, "throttling": None, "firmware": {}, "hugepages_total": None},
+        "watchdog": {"mode": "disabled"},
+    }
+    rf = parse_rigforge({"rigforge": block})
+    assert rf["power"] == {"watts": None, "hs_per_watt": None}
+    assert rf["health"] == {
+        "governor": None,
+        "throttling": None,
+        "board": None,
+        "hugepages_total": None,
+    }
+    assert rf["tune"] == {"target": None, "autotune_enabled": False, "autotune_next": None}
+    # A disabled watchdog masks its temp fields.
+    assert rf["watchdog"] == {
+        "enabled": False,
+        "thermal_hold": None,
+        "temp_c": None,
+        "max_temp_c": None,
+    }

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -400,6 +400,33 @@ test('WorkersTable surfaces the per-rig api-unreadable and reject badges, and th
     assert.match(html, /badge-bad">Unknown/);
 });
 
+test('WorkersTable renders the RigForge version badge + chips when present, nothing when absent (#235)', () => {
+    // A plain-xmrig worker has no `rigforge` (the server sends null) -> no chips, no error.
+    const plain = clone();
+    plain.workers.forEach((w) => (w.rigforge = null));
+    const plainHtml = renderApp({ state: plain });
+    assert.doesNotMatch(plainHtml, /rf 1\.7\.0/);
+    assert.doesNotMatch(plainHtml, /throttling/);
+
+    // A RigForge worker carries the server-built {version, chips} view.
+    const rf = clone();
+    rf.workers[0].rigforge = {
+        version: '1.7.0',
+        miner_down: false,
+        chips: [
+            { text: 'throttling', variant: 'bad', title: 'hot' },
+            { text: 'gov: performance', variant: 'ok', title: '' },
+            { text: '142 W · 86.9 H/s·W', variant: 'outline', title: 'power' },
+        ],
+    };
+    rf.workers[1].rigforge = null; // the other rig is plain xmrig
+    const html = renderApp({ state: rf });
+    assert.match(html, /rf 1\.7\.0/); // version badge
+    assert.match(html, /badge-bad" title="hot">throttling/); // a bad chip
+    assert.match(html, /gov: performance/);
+    assert.match(html, /142 W · 86.9 H\/s·W/);
+});
+
 test('Tari status gates the ✔ on a live gRPC channel, never on active-but-dead (#278/#313)', () => {
     // The ✔ must mean the merge-mine channel is actually up. A dead channel that still reads "active"
     // must show status-warn and NO check — otherwise a TRANSIENT_FAILURE reads as healthy (#278/#313).

--- a/build/dashboard/tests/frontend/fixtures/state.json
+++ b/build/dashboard/tests/frontend/fixtures/state.json
@@ -67,17 +67,24 @@
       }
     ]
   },
+  "control_enabled": false,
   "db_healthy": true,
   "earnings": {
     "available": false,
     "block_reward": "0.0000 XMR",
     "coeff_day": 0.0,
+    "confirmed": {
+      "enabled": false
+    },
     "disclaimer": "Estimated XMR from P2Pool mining only \u2014 excludes XvB donations (donated hashrate earns no P2Pool payout). Tari is merge-mined SOLO by the same hashrate: you get the whole block reward at once when your hashrate finds a Tari block \u2014 roughly every 'time to Tari block' shown \u2014 so the per-day XTM figure is a long-run average, not steady income. Expected values only; mining is variance-heavy, so real payouts swing well above and below these figures. Estimates, not guarantees.",
     "p2pool_hr": 8050.0,
     "p2pool_hr_str": "8.05 kH/s",
     "pool_difficulty": 0,
     "tari_available": false,
     "tari_coeff_day": 0.0,
+    "tari_confirmed": {
+      "enabled": false
+    },
     "tari_difficulty": 0.0,
     "tari_reward": 0
   },
@@ -266,6 +273,7 @@
     "wallet": "Unknown",
     "wallet_short": "Unknown"
   },
+  "stratum_port": 3333,
   "sync": {
     "monero": {
       "current": 3000000,
@@ -552,6 +560,7 @@
       "reject_flag": null,
       "rejected": 1,
       "rejected_str": "1",
+      "rigforge": null,
       "status": "online",
       "uptime": 0,
       "uptime_str": "0m 0s"
@@ -572,6 +581,7 @@
       "reject_flag": null,
       "rejected": 40,
       "rejected_str": "40",
+      "rigforge": null,
       "status": "offline",
       "uptime": 0,
       "uptime_str": "0m 0s"

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -403,6 +403,21 @@ class TestMergeDirectStats:
         assert (w["h10"], w["h60"], w["h15"]) == (1, 2, 3)
         assert w["uptime"] == 7
 
+    def test_rigforge_block_carried_onto_worker(self):
+        # A RigForge enriched feed (#235) rides in on the same result; the parsed block reaches the
+        # worker model. A plain-xmrig result leaves no `rigforge` key.
+        extra = {
+            "api_ok": True,
+            "hashrate": {"total": [1, 2, 3]},
+            "rigforge": {"version": "1.7.0", "power": {"watts": 100.0, "hs_per_watt": 50.0}},
+        }
+        [w] = _merge_direct_stats([self._worker()], [extra], "3333")
+        assert w["rigforge"]["version"] == "1.7.0"
+        assert w["rigforge"]["power"] == {"watts": 100.0, "hs_per_watt": 50.0}
+
+        [plain] = _merge_direct_stats([self._worker()], [{"api_ok": True}], "3333")
+        assert "rigforge" not in plain
+
 
 class TestAggregateHashrate:
     """Total live hashrate, priority 15m > 60s > 10s, online-only (Issue #39)."""

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -26,6 +26,7 @@ from mining_dashboard.web.views import (
     _chart_tension,
     _mode_palette,
     _reject_flag,
+    _rigforge_display,
     _target_points,
     _window_reject_pct,
     build_badges,
@@ -952,6 +953,132 @@ class TestRejectFlag:
     def test_flags_all_rejects_at_floor(self):
         # A worker submitting only rejects trips the floor immediately (rate 100%).
         assert _reject_flag(0, 3) is not None
+
+
+class TestRigForgeDisplay:
+    """The RigForge enriched-feed chip builder (#235). Parsed block in → {version, chips} out; each
+    chip emitted only when its data is present, so nothing renders for a plain-xmrig worker."""
+
+    def _chip_texts(self, disp):
+        return [c["text"] for c in disp["chips"]]
+
+    def test_none_for_plain_xmrig(self):
+        assert _rigforge_display(None) is None
+
+    def test_build_workers_passes_none_for_plain_xmrig(self):
+        # A worker with no parsed rigforge block carries `rigforge: None` — the client renders
+        # nothing extra, exactly as before the enriched feed existed.
+        row = build_workers(
+            [{"name": "r", "ip": "1.1.1.1", "status": "online", "active_pool": "3333"}]
+        )[0]
+        assert row["rigforge"] is None
+
+    def test_full_block_emits_version_and_chips(self):
+        parsed = {
+            "version": "1.7.0",
+            "miner_down": False,
+            "power": {"watts": 142.0, "hs_per_watt": 86.9},
+            "tune": {"target": "perf", "autotune_enabled": True, "autotune_next": "Sun 03:00"},
+            "health": {
+                "governor": "performance",
+                "throttling": False,
+                "board": "ProArt X670E",
+                "hugepages_total": 1280,
+            },
+            "watchdog": {"enabled": True, "thermal_hold": False, "temp_c": 62, "max_temp_c": 85},
+        }
+        disp = _rigforge_display(parsed)
+        assert disp["version"] == "1.7.0"
+        texts = self._chip_texts(disp)
+        assert "gov: performance" in texts
+        assert "HP 1280" in texts
+        assert "ProArt X670E" in texts
+        assert "142 W · 86.9 H/s·W" in texts
+        assert "tune: perf" in texts
+        assert "autotune → Sun 03:00" in texts
+        assert "62°C / 85°C" in texts
+        # Nothing alarming here: no bad-variant chips.
+        assert all(c["variant"] != "bad" for c in disp["chips"])
+
+    def test_throttling_and_bad_governor_flag(self):
+        disp = _rigforge_display(
+            {
+                "version": "1.7.0",
+                "miner_down": False,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": "powersave",
+                    "throttling": True,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": False},
+            }
+        )
+        chips = {c["text"]: c["variant"] for c in disp["chips"]}
+        assert chips["throttling"] == "bad"
+        assert chips["gov: powersave"] == "warn"
+
+    def test_nullable_fields_emit_no_chip(self):
+        # No RAPL, no governor, disabled watchdog, no tune → only the fields that exist render.
+        disp = _rigforge_display(
+            {
+                "version": None,
+                "miner_down": False,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": None,
+                    "throttling": None,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": False, "thermal_hold": None, "temp_c": None},
+            }
+        )
+        assert disp["version"] is None
+        assert disp["chips"] == []
+
+    def test_miner_down_chip(self):
+        disp = _rigforge_display(
+            {
+                "version": "1.7.0",
+                "miner_down": True,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": None,
+                    "throttling": None,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": False},
+            }
+        )
+        assert disp["miner_down"] is True
+        assert disp["chips"][0]["text"] == "miner down"
+        assert disp["chips"][0]["variant"] == "bad"
+
+    def test_thermal_hold_wins_over_temp_chip(self):
+        disp = _rigforge_display(
+            {
+                "version": "1.7.0",
+                "miner_down": False,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": None,
+                    "throttling": None,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": True, "thermal_hold": True, "temp_c": 90, "max_temp_c": 85},
+            }
+        )
+        texts = self._chip_texts(disp)
+        assert "thermal hold" in texts
+        assert not any("°C" in t for t in texts)  # the hold chip replaces the temp chip
 
 
 # --- Tari -----------------------------------------------------------------------------

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -202,6 +202,16 @@ card so columns stay readable. Until the first worker ever connects, the card sh
 ("point each rig at `<host-ip>:3333`") in place of the empty table; see
 [Connecting Miners](workers.md).
 
+A [RigForge](https://github.com/p2pool-starter-stack/rigforge) rig that serves its enriched read API
+adds a version badge and a row of chips next to its name — CPU governor and throttling state,
+firmware board, HugePages, power draw and H/s-per-watt, the active tuning target and next autotune,
+and watchdog temperature. Alarming states (throttling, thermal hold, a non-performance governor) read
+red or amber; the rest are muted read-outs. Each chip shows only when the rig reports that field, so
+a partial reading never leaves a blank, and a plain-xmrig rig shows no chips at all. If RigForge is up
+but its miner isn't, the rig stays in the table with a **miner down** chip rather than dropping to
+offline. Point the rig's descriptor at the enriched feed to turn this on — see
+[Connecting Miners › RigForge enriched feed](workers.md#rigforge-enriched-feed).
+
 Each rig shows accepted and rejected share counts (invalid shares folded into the rejected column as
 `3 (+2 inv)` when present). A rig whose reject rate climbs past ~5% gets a red **⚠** flag next to its
 rejected count — a rig submitting stale or bad shares (bad overclock, flaky network, clock drift)

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -228,6 +228,27 @@ imposter that claims a listed rig's name from pulling that rig's token to its ow
 The standard fleet — everyone on `8080`, token = rig name or open — needs no `dashboard.workers`
 at all.
 
+#### RigForge enriched feed
+
+A [RigForge](https://github.com/p2pool-starter-stack/rigforge) rig also serves an enriched read API
+on port `8081`: the same `/1/summary` the dashboard already polls, plus a `rigforge` block carrying
+the rig's RigForge version, tuning state, power draw and efficiency, CPU/firmware health, and
+watchdog temperatures. Point that rig's descriptor `port` at it to pick the block up:
+
+```jsonc
+"dashboard": {
+    "workers": [
+        { "name": "rig-01", "port": 8081 }
+    ]
+}
+```
+
+Nothing else changes — the enriched feed is a superset, so uptime and per-miner hashrate come from
+the same response. The dashboard then shows a RigForge version badge and health/power/tune/watchdog
+chips for that rig (see [Dashboard › Workers Alive](dashboard.md#workers-alive)). A plain-xmrig rig
+on `8080` sends no `rigforge` block and reads exactly as before — no chips, no error. Auth is
+unchanged: send the rig's `token` only if it sets an `ACCESS_TOKEN` (the read API is open otherwise).
+
 ---
 
 ## New to mining? Start with RigForge


### PR DESCRIPTION
Closes #235.

## What

The dashboard now consumes RigForge's enriched worker feed — a **strict superset** of the XMRig `/1/summary` served on the rig's `api_port` (default `8081`): the whole XMRig object unchanged, plus one added `rigforge` block (version, tune, power/efficiency, CPU/firmware health, watchdog). Point a RigForge rig's `dashboard.workers[]` descriptor `port` at `8081` and the block rides in on the existing poll — **no new read path**. The Workers Alive table then shows a RigForge version badge and per-worker health/power/tune/watchdog chips.

## Backward compatible (2 lines)

- The enriched feed is a superset, so uptime and per-miner hashrate still come from the same `/1/summary` response the dashboard already parses — nothing about the existing path changes.
- A plain-xmrig rig (port `8080`, no `rigforge` key) parses to `None` and renders exactly as today: no chips, no error, no empty placeholder.

## Chips rendered

Version badge, plus (each emitted **only when its data is present**): **health** — throttling (red), CPU governor (green if `performance`, else amber), firmware board, HugePages; **power** — watts + H/s·W (hidden when null); **tune** — active target + next autotune; **watchdog** — temperature/ceiling, or a red **thermal hold**. A RigForge that's up but whose miner has stopped (`xmrig_api: "unreachable"`) stays in the table with a **miner down** chip instead of dropping to offline.

## Nullable everywhere

Every enriched field is nullable on the wire (no RAPL → no power chip; no governor read → no governor chip; disabled watchdog → no temperature). Chip-building lives server-side (`views._rigforge_display`, matching the `_reject_flag` precedent) so the client stays a dumb renderer.

## Security

The #122 SSRF guard is unchanged — the dashboard still polls only the operator-set descriptor host/port, never a miner-advertised value. Auth is the #172 per-worker Bearer, sent iff the rig sets an `ACCESS_TOKEN`.

## Scope

Read/display only. The write path (#185) is out of scope and not built here.

## Tests / lint

- tier-1 pytest: `parse_rigforge` (enriched present / absent / miner-down / all-null), `_rigforge_display` chip + threshold logic, the `_merge_direct_stats` carry.
- frontend `node --test`: RigForgeChips render (present vs absent).
- `make test-dashboard` green (coverage 96.8%, ≥80 gate); patch coverage 98% (≥90 gate); ruff + biome clean; docs voice OK. Docs: `docs/workers.md`, `docs/dashboard.md`, CHANGELOG under `## [Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)