### PR TITLE
fix(#33): restore operator ownership of .env after the root control-apply

### DIFF
--- a/pithead
+++ b/pithead
@@ -4202,6 +4202,30 @@ control_preview() { # <request-file> <id> <actor> <control-dir>
     rm -f "$errf"
 }
 
+# Hand the operator-facing stack files that the ROOT control-runner just wrote back to the stack
+# owner (#33 v1.4). control_run_pending is root (User=root in pithead-control.service), so its
+# `apply` renders `.env` under `umask 077` as root:root 0600 and rewrites the Caddyfile as root —
+# but pithead runs a NON-ROOT operator model ($REAL_USER), and a normal operator-run apply leaves
+# these files owned by the operator. Without this, the operator's next `status`/`apply` can't even
+# read .env (Permission denied), which is what the tier-4 gate caught. The target owner is DERIVED
+# from config.json's on-disk owner — an operator-owned file the dashboard container CANNOT write
+# (its raw config.json mount was dropped in #440; control_commit's `cp` also preserves its inode/
+# owner), so nothing from the request or spool can steer the chown. $USER/$SUDO_USER are NOT usable
+# here — the runner is root, so they read as root. The control-dir (staged/results/audit) is
+# deliberately host-owned and is NOT touched: that rw/ro split is the #33 trust boundary.
+control_reown_operator_files() {
+    local owner f
+    # GNU stat first, BSD fallback (see the provision_onion_client_auth note). No owner → skip.
+    owner=$(stat -c '%u:%g' "$CONFIG_FILE" 2>/dev/null || stat -f '%u:%g' "$CONFIG_FILE" 2>/dev/null) || owner=""
+    [ -n "$owner" ] || return 0
+    for f in "$ENV_FILE" "Caddyfile" "${CONFIG_FILE}.bak-control"; do
+        [ -e "$f" ] || continue
+        # Fail safe: a chown that can't complete leaves the pre-existing bug, never corrupts state.
+        chown "$owner" "$f" 2>/dev/null ||
+            warn "Could not re-own $f to $owner after the control apply — the operator may need to chown it by hand (#33)."
+    done
+}
+
 # Commit: apply the HOST-SIDE staged copy from the matching preview. A tampered second request
 # can't swap the config — commit carries only the id; the config it applies is the one previewed.
 control_commit() { # <id> <actor> <control-dir>
@@ -4235,6 +4259,7 @@ control_commit() { # <id> <actor> <control-dir>
     cp "$staged" "$CONFIG_FILE"
     "$0" apply -y >"$logf" 2>&1 || rc=$?
     if [ "$rc" -eq 0 ]; then
+        control_reown_operator_files # the root apply wrote .env/Caddyfile as root — give them back (#33)
         control_write_result "$cdir/results" "$id" "$(jq -n '{status:"applied",ts:(now|floor)}')"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "commit" "applied" "$keys"
     else

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2572,6 +2572,7 @@ echo "== unit+black-box: secret files are owner-only from creation (#368) =="
 # reverse order is wrong — on Linux `stat -f` is a VALID flag (filesystem status) that succeeds
 # with the wrong output, so the fallback never runs and CI (Linux) reads garbage.
 file_mode() { stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null; }
+file_uid() { stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null; }
 PB="$SANDBOX/perm368"
 mkdir -p "$PB/bin"
 printf '{ "monero": {} }\n' >"$PB/config.json"
@@ -3551,6 +3552,18 @@ assert_eq "committed config landed in config.json" "$(jq -r '.p2pool.pool' "$C/c
 assert_contains "commit ran the real apply (containers recreated)" "$(cat "$CTRL_LOG")" "compose up"
 assert_contains "commit audited with the actor" "$(cat "$AUDIT")" "\"actor\":\"admin\",\"action\":\"commit\",\"status\":\"applied\""
 [ ! -f "$STAGED/$UUID1.json" ] && ok "staged intent consumed on commit" || bad "staged intent consumed on commit" "still staged"
+
+# Operator keeps ownership of the stack files the root runner's apply wrote (#33 v1.4): control_run_pending
+# is root, so its apply would render .env root:root 0600 — unreadable to the non-root operator. The
+# re-own derives the owner from config.json (operator-owned, container can't write it) so a commit
+# matches a normal apply. Assert every operator-facing file is owned by config.json's owner, so a
+# non-root operator can still read .env / re-render on the next apply.
+cfg_uid="$(file_uid "$C/config.json")"
+for reowned in ".env" "Caddyfile" "config.json.bak-control"; do
+    [ -e "$C/$reowned" ] &&
+        assert_eq "$reowned owned by the config.json owner after a control commit" "$(file_uid "$C/$reowned")" "$cfg_uid" ||
+        bad "$reowned present after a control commit" "missing"
+done
 
 echo "== black-box: audit log records names, never values (#349) =="
 # WHAT changed rides in the audit entry as env-key NAMES (main -> mini touches the p2pool keys);


### PR DESCRIPTION
## The bug (tier-4 release gate, confirmed on gouda + prod)

The #33 control channel's root runner `control_run_pending` executes as `root` (via `pithead-control.service`, `User=root`), so its `pithead apply -y` renders `.env` under `umask 077` as **`root:root 0600`** and rewrites the `Caddyfile` as root. But pithead runs a **non-root operator model** (`REAL_USER="${SUDO_USER:-$USER}"`, `sudo` only for privileged bits): a normal operator-run `apply` leaves `.env` owned by the operator (prod `.env` is `vijit:vijit 600`).

So after any dashboard config commit, `.env` flipped to root-owned and the operator's next `./pithead status`/`apply` (as `vijit`) could not even read it — Permission denied. The tier-4 hardening phase caught it: `env_on_box DASHBOARD_CHECK_UPDATES` came back empty and the restore `apply` failed → 240s health timeout.

## The fix

After a **successful** root `apply` in `control_commit`, re-own the operator-facing stack files the root apply wrote back to the stack owner, so a control-apply matches a normal apply.

**Re-owned files:** `.env`, `Caddyfile`, `config.json.bak-control`.

**Owner derivation (not attacker-influenced):** `stat -c %u:%g config.json` (GNU/BSD fallback). `config.json` is the right anchor — it lives at the stack root, is operator-owned, and the container cannot write it (its raw mount was dropped in #440; `control_commit`'s `cp` into it preserves its inode/owner). Nothing from the request or spool touches the owner. `$USER`/`$SUDO_USER` are **not** used — the runner is root, so they read as `root`.

**Trust boundary untouched:** `$CONTROL_DIR/staged`, `results`, `audit` remain host-owned (the container mounts `results/`+`audit/` read-only) — that rw/ro split is the #33 trust boundary and is deliberately not re-owned. `config.json` itself is not touched (`cp` already preserves its owner).

**Fail-safe:** derives the owner once, only chowns files that exist, only on `apply` success; a chown failure logs a warning and continues (worst case is the pre-existing bug, never corrupted state).

## Test

New tier-1 assertions in the #33 block of `tests/stack/run.sh`: after a committed allowlisted change driven through the runner, every re-owned file (`.env`, `Caddyfile`, `config.json.bak-control`) is owned by `config.json`'s owner — i.e. a non-root operator can still read `.env`. The tier-4 `env_on_box DASHBOARD_CHECK_UPDATES` assertion also passes once this lands.

## Verification

- `make lint-sh` clean (shellcheck + `shfmt -i 4 -d`); `shfmt -i 4 -w` run last.
- `make test-stack`: **953 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)