### PR TITLE
test(#33): valid-format wallet probe for the tier-4 approval-gate test

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1330,7 +1330,7 @@ run_hardening() {
         local uuid_bad bad_cfg wallet_before
         uuid_bad="$(_uuid4)"
         wallet_before="$(env_on_box MONERO_WALLET_ADDRESS)"
-        bad_cfg="$(printf '%s' "$ctrl_config" | jq -c '.monero.wallet_address="4TIER4TESTWALLETdoNotApplyThisIsAnIntegrationTestRejectionProbe0000000000000000000000000000000000"')"
+        bad_cfg="$(printf '%s' "$ctrl_config" | jq -c '.monero.wallet_address="4TESTWALLETdoNotUseHandsffGateRejectSensitiveKeyDefautDenyProbeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"')"
         _spool_write "$cdir/requests/$uuid_bad.json" \
             "$(jq -nc --argjson c "$bad_cfg" --arg id "$uuid_bad" '{id:$id,action:"preview",actor:"itest",config:$c}')"
         st="$(_wait_control_status "$cdir" "$uuid_bad" "" 60 || echo timeout)"


### PR DESCRIPTION
One-line test fix. The tier-4 hardening wallet round-trip used an invalid-format probe (96 chars, contains `0`), rejected at preview by validation before reaching the approval gate it's meant to exercise. Valid-format 95-char probe → preview stages, gate refuses at commit. Test-only; needed for the v1.4 release gate to pass. 🤖