### PR TITLE
fix(tier4): --local rig_lock actually holds the flock; portable holder-write + date; reap orphaned control unit

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -269,6 +269,10 @@ rig_lock() { # rig_lock <project> <suite> [shared]
     local mode=-x
     [ "${3:-}" = shared ] && mode=-s
     exec 9>"${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}"
+    # World-writable so a later non-root run can always open FD 9 even if a prior sudo/root run
+    # created the lock file root-owned (otherwise exec 9> fails and the flock is silently not held).
+    # Byte-for-byte with RigForge's canonical rig_lock (rigforge#183/#249) — keep the two identical.
+    chmod 666 "${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}" 2>/dev/null || true
     if ! flock -n $mode 9; then
         if [ "${RIG_LOCK_WAIT:-0}" = 1 ]; then
             echo "rig busy ($(cat "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" 2>/dev/null || echo unknown)) — waiting..." >&2

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -278,8 +278,19 @@ rig_lock() { # rig_lock <project> <suite> [shared]
             exit 75
         fi
     fi
-    printf '%s %s pid=%s started=%s\n' "$1" "$2" "$$" "$(date -Is)" >"${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}"
-    trap 'rm -f "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}"' EXIT
+    # The flock is now HELD on FD 9 and stays held for the whole run (the kernel drops it on
+    # process death). Everything below is DISPLAY-ONLY and strictly best-effort: it must never be
+    # able to drop or prevent the lock. The holder marker lives under /run (root-owned), so a
+    # non-root runner's write gets EACCES — try a plain write, fall back to passwordless sudo, then
+    # swallow any remaining failure with `|| true` so a marker we can't write NEVER aborts the lock
+    # (the bug: a failed holder-write must not leave the box unreserved). Portable UTC stamp — the
+    # GNU-only `date -Is` errors on macOS (the self-test host: "invalid argument 's' for -I").
+    local holder="${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" line
+    line="$(printf '%s %s pid=%s started=%s' "$1" "$2" "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)")"
+    { printf '%s\n' "$line" >"$holder" || printf '%s\n' "$line" | sudo -n tee "$holder" >/dev/null; } 2>/dev/null || true
+    # The trap fires at process exit, when the `holder` local is out of scope — re-derive the path
+    # from the durable env/default so the marker is actually removed (best-effort, may need sudo).
+    trap 'rm -f "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" 2>/dev/null || sudo -n rm -f "${RIG_LOCK_HOLDER:-/run/rig-e2e.holder}" 2>/dev/null || true' EXIT
 }
 
 # Take the rig lock ON a remote box and hold it for the lifetime of THIS process. The remote

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1350,6 +1350,13 @@ run_hardening() {
     # 240s: this apply follows the control enable/disable + a tor restart, so the stack has more to
     # re-settle than a plain apply (180s timed out here on a real run).
     wait_status_ok 240 || true
+
+    # Reap the systemd control unit UNCONDITIONALLY (#33/#424). apply only removes it on a control
+    # on->off transition, so if the restore apply above failed or timed out the root pithead-control.path
+    # is left installed+enabled and a plain re-apply won't strip it. Tear it down directly — idempotent,
+    # runs regardless of the restore apply's exit — so no root unit outlives this phase.
+    it_step "reaping any leftover pithead-control systemd unit…"
+    rx 'sudo systemctl disable --now pithead-control.path 2>/dev/null; sudo rm -f /etc/systemd/system/pithead-control.path /etc/systemd/system/pithead-control.service; sudo systemctl daemon-reload' >/dev/null 2>&1 || true
 }
 
 run_auth_fail_closed() {

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -316,6 +316,40 @@ else
 
     # (e) Every holder exited normally, so the display-only sidecar is gone (EXIT-trap rm).
     if [ ! -f "$RIG_LOCK_HOLDER" ]; then it_pass "holder sidecar removed on normal exit"; else it_fail "holder sidecar removed on normal exit" "sidecar still present"; fi
+
+    # (f) The KERNEL flock is genuinely held for the lifetime of a --local run, and released after —
+    # probed DIRECTLY with flock (not via rig_lock) so we assert the real lock state a colliding
+    # RigForge/pithead run on the box would see. Crucially the holder-marker path is deliberately
+    # UNWRITABLE here (root-owned /run is unwritable for a non-root runner): this proves the marker
+    # write is best-effort and can NEVER stop the flock from being held — the Bug-1 regression where a
+    # failed holder-write left the box unreserved. If acquisition were coupled to the marker, the
+    # holder below would never signal ready and we reap it, so the test FAILS FAST (never hangs).
+    mkfifo "$RL/hold-f"
+    mkdir -p "$RL/noholder" && chmod 000 "$RL/noholder" # unwritable marker dir, mimics /run for non-root
+    (RIG_LOCK_HOLDER="$RL/noholder/x" rig_lock pithead "run.sh matrix" && : >"$RL/ready-f" && read -r _ <"$RL/hold-f") &
+    _rl_f=$!
+    if wait_for 30 0.2 "run holds the flock despite an unwritable marker path" test -f "$RL/ready-f"; then
+        if flock -n -x "$RIG_LOCK_FILE" true 2>/dev/null; then
+            it_fail "flock GENUINELY held mid --local run" "a second exclusive flock succeeded — the box is unreserved (Bug 1)"
+        else
+            it_pass "flock GENUINELY held mid --local run (unwritable marker notwithstanding)"
+        fi
+        printf 'go\n' >"$RL/hold-f" # release the holder (safe: it is alive, reading the fifo)
+        wait "$_rl_f"
+        if flock -n -x "$RIG_LOCK_FILE" true 2>/dev/null; then
+            it_pass "flock released after the --local run exits (kernel drops the FD-held lock)"
+        else
+            it_fail "flock released after the --local run exits" "lock still held after the holder process exited"
+        fi
+    else
+        # Never acquired: the marker write blocked acquisition (the Bug-1 coupling). Fail fast — reap
+        # the holder rather than blocking forever on a fifo write nothing will read.
+        it_fail "flock GENUINELY held mid --local run" "holder never acquired — a failed marker write blocked lock acquisition (Bug 1)"
+        kill "$_rl_f" 2>/dev/null
+        wait "$_rl_f" 2>/dev/null
+    fi
+    chmod 755 "$RL/noholder" # restore so the TMP-dir EXIT cleanup can remove it
+
     unset RIG_LOCK_FILE RIG_LOCK_HOLDER
 fi
 


### PR DESCRIPTION
Three related fixes on the tier-4 integration harness's bench-coordination surface (`tests/integration/lib.sh` + `run.sh`). Test-harness only — no product code (`pithead`, images, dashboard) touched.

## Bug 1 + Bug 2 — `lib.sh:rig_lock` (PRIMARY)
The shared-rig flock acquisition was coupled to a holder-marker write under `/run`, which is root-owned. A non-root `run.sh --local` runner's marker write gets `Permission denied`, and the wrapper depended on that path being healthy — so the reservation the bench-coordination flock (rigforge#183 / pithead#431) provides could be silently lost. The write also used GNU-only `date -Is`, which errors on macOS (the self-test host: `invalid argument 's' for -I`).

Fix — decouple entirely and make acquisition robust:
- Acquire the flock on FD 9 **first** and keep it held for the whole run on the inherited FD; the kernel drops it on process death (kill -9 included). Exclusive for mutating runs, shared for `--check`/`--readiness` (unchanged).
- The holder marker is now **display-only and strictly best-effort**: plain write → fall back to passwordless `sudo -n tee` → swallow any remaining failure with `|| true`. A marker we can't write can **never** abort or drop the lock, so a `--local` run can no longer leave the box unreserved.
- Portable UTC stamp `date -u +%Y-%m-%dT%H:%M:%SZ`; the per-run `Permission denied` noise is suppressed.

## Bug 3 — `run.sh:run_hardening`
A plain re-apply only removes `pithead-control.path` on a control on→off transition, so a failed/timed-out baseline-restore apply left the root systemd path+service units installed and enabled past the phase. The phase now **reaps them unconditionally** (`disable --now` + `rm` + `daemon-reload`, idempotent, run regardless of the restore apply's exit) so no root unit outlives it.

## Self-test
New `(f)` block in `selftest.sh` asserts the flock is **genuinely held** mid `--local` run: a direct `flock -n -x <lockfile>` probe FAILS while a simulated run holds it — with a deliberately **unwritable** marker path, proving the marker write can't block acquisition — and SUCCEEDS after it exits. Uses the env-overridable `RIG_LOCK_FILE`/`RIG_LOCK_HOLDER` sandbox, so it never touches the real `/var/lock` or `/run`. It fails fast (reaps the holder) rather than hanging if acquisition regresses; verified it FAILS against a deliberately-coupled `rig_lock` (marker-before-flock, fatal) in 32s with no hang.

## Verification
- `shellcheck --severity=warning` (repo gate) clean; `shfmt -i 4 -d` clean.
- `make test-integration-selftest`: **122 passed, 0 failed**.
- These run on a real bench at tier-4; the self-test is the honest lower-tier proof. A live `run.sh --local … --hardening` run on gouda is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)