### PR TITLE
fix(cli): -h/--help and unknown flags must not run the subcommand (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,14 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Fixed
 
+- **`pithead <verb> --help` no longer runs the command (#493).** `-h`/`--help` on any subcommand now
+  prints usage and exits 0 **before any side effect** — previously `pithead upgrade --help` ignored
+  the flag and ran a full upgrade (image pull + container recreation). On the v1.4.0 deploy that
+  stray recreation collided with the real upgrade and corrupted the dashboard's SQLite DB (see the
+  auto-heal fix). Unrecognized flags on a no-option verb (`upgrade`, `up`, `down`, `status`,
+  `doctor`, `control-run-pending`, `onion-client-key`) now error and name the bad flag instead of
+  being silently ignored while the command runs anyway. `--dry-run` and other real options are
+  unaffected; `logs` still forwards its args to `docker compose logs`.
 - **The tier-4 e2e harness survives a dirty bench and restores the right stack (#454).** Two
   environmental failures from the v1.4 release gate: provisioning aborted when a leftover untracked
   file (a stray bench script) sat in the disposable `/srv/code/pithead-e2e` checkout — `git checkout`

--- a/pithead
+++ b/pithead
@@ -5280,6 +5280,26 @@ EOF
 
 # --- Main Execution ---
 
+# #493: a subcommand's -h/--help must print usage and exit 0 BEFORE any side effect, and a
+# subcommand that takes no options must reject an unrecognized flag instead of silently ignoring it
+# and running anyway. `pithead upgrade --help` used to run a full upgrade (image pull + container
+# recreation) — on the v1.4.0 deploy that recreation collided with the real upgrade and corrupted
+# the dashboard DB (#489). A --help must never mutate the host.
+_help_requested() { # "$@" — return 0 if any argument is -h/--help
+    local a
+    for a in "$@"; do
+        case "$a" in
+        -h | --help) return 0 ;;
+        esac
+    done
+    return 1
+}
+_reject_options() { # <verb> "$@" — this verb takes no options; error on any leftover argument
+    local verb="$1"
+    shift
+    [ "$#" -eq 0 ] || error "Unknown option for $verb: '$1'. This command takes no options. Run '$0 $verb -h' or '$0 help'."
+}
+
 main() {
     # Chained subcommands (#94): when every argument is a bare subcommand name, run them
     # left-to-right as a chain. Any other token (a flag, a service name, an archive path) keeps
@@ -5300,6 +5320,17 @@ main() {
 
     local cmd="${1:-}"
     if [ -n "$cmd" ]; then shift; fi
+
+    # #493: -h/--help on any subcommand prints help and exits 0 before ANY side effect. `logs` is the
+    # one deliberate passthrough (its args go to `docker compose logs`), so it opts out and forwards
+    # -h/--help downstream. The bare `pithead -h/--help/help` is its own command in the case below.
+    case "$cmd" in
+    "" | help | -h | --help | logs) ;;
+    *) if _help_requested "$@"; then
+        show_help
+        exit 0
+    fi ;;
+    esac
 
     # Make the stack version + build provenance available to any `docker compose [up] build` this
     # invocation runs, so the dashboard image bakes in its version badge (Issue #58).
@@ -5322,10 +5353,12 @@ main() {
         ;;
     apply) apply "$@" ;;
     up)
+        _reject_options up "$@"
         require_deployed
         stack_up
         ;;
     down)
+        _reject_options down "$@"
         require_env
         stack_down
         ;;
@@ -5334,6 +5367,7 @@ main() {
         stack_restart "$@"
         ;;
     upgrade)
+        _reject_options upgrade "$@"
         require_deployed
         stack_upgrade
         ;;
@@ -5343,10 +5377,14 @@ main() {
         docker compose logs -f "$@"
         ;;
     status)
+        _reject_options status "$@"
         require_env
         stack_status || exit 1
         ;;
-    doctor) doctor || exit 1 ;;
+    doctor)
+        _reject_options doctor "$@"
+        doctor || exit 1
+        ;;
     reset-dashboard)
         require_deployed
         reset_dashboard "$@"
@@ -5354,10 +5392,14 @@ main() {
     backup) stack_backup "$@" ;;
     restore) stack_restore "$@" ;;
     control-run-pending)
+        _reject_options control-run-pending "$@"
         require_deployed
         control_run_pending
         ;;
-    onion-client-key) onion_client_key ;;
+    onion-client-key)
+        _reject_options onion-client-key "$@"
+        onion_client_key
+        ;;
     rotate-dashboard-onion) rotate_dashboard_onion "$@" ;;
     rotate-secrets) rotate_secrets "$@" ;;
     version | -V | --version) show_version ;;

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2112,6 +2112,37 @@ out="$(run_sourced "$SANDBOX" validate_chain down upgrade 2>&1)"
 assert_rc "rejects 'down upgrade' (down not last)" "$?" "1"
 assert_contains "down-not-last message" "$out" "last"
 
+echo "== unit: subcommand flag guard (#493) =="
+# `-h/--help` on a subcommand must print help and exit 0 BEFORE any side effect, and a no-option verb
+# must reject an unrecognized flag instead of silently ignoring it and running the command anyway
+# (`pithead upgrade --help` used to run a full upgrade — the trigger for the #489 DB corruption). Run
+# from a NON-deployed sandbox: if the guard failed to short-circuit, `upgrade`/`status` would fall
+# through to require_deployed/stack_upgrade — so exit 0 + help text here proves the guard fired first.
+CLIG="$SANDBOX/cli-guard"
+mkdir -p "$CLIG"
+cp "$STACK" "$CLIG/pithead"
+out="$(cd "$CLIG" && ./pithead upgrade --help 2>&1)"
+assert_rc "upgrade --help exits 0 (no side effect)" "$?" "0"
+assert_contains "upgrade --help prints usage" "$out" "Commands"
+(cd "$CLIG" && ./pithead upgrade -h >/dev/null 2>&1)
+assert_rc "upgrade -h exits 0" "$?" "0"
+out="$(cd "$CLIG" && ./pithead upgrade --bogus 2>&1)"
+assert_rc "upgrade --bogus errors" "$?" "1"
+assert_contains "unknown-flag message names the flag" "$out" "--bogus"
+out="$(cd "$CLIG" && ./pithead status --json 2>&1)"
+assert_rc "status --json (unknown flag) errors" "$?" "1"
+assert_contains "status unknown-flag names the verb" "$out" "status"
+# A mutating verb that parses its own args still gets the help short-circuit before it runs.
+(cd "$CLIG" && ./pithead apply --help >/dev/null 2>&1)
+assert_rc "apply --help exits 0 (no apply)" "$?" "0"
+# `logs` is the deliberate passthrough — --help forwards to docker, not the pithead guard (no exit 0
+# from our guard). It can't run a real docker here, so just assert the guard didn't hijack it: the
+# bare `pithead --help` / `help` still print pithead help and exit 0.
+(cd "$CLIG" && ./pithead --help >/dev/null 2>&1)
+assert_rc "bare --help still exits 0" "$?" "0"
+(cd "$CLIG" && ./pithead help >/dev/null 2>&1)
+assert_rc "help command still exits 0" "$?" "0"
+
 echo "== unit: chain execution — order, fail-fast, exit code (#94) =="
 # run_chain re-invokes pithead per step via PITHEAD_SELF; a stub records the order and can be told
 # to fail a given step, so order/fail-fast/propagation are proven without a stack.


### PR DESCRIPTION
Closes #493.

## The bug
`pithead upgrade --help` did **not** print help — it ran a full `upgrade` (re-render + image pull + container recreation), because `stack_upgrade` (and the other no-option verbs) ignored their args entirely. On the v1.4.0 deploy that unintended dashboard recreation collided with the real upgrade moments later and **corrupted the dashboard SQLite DB** (#489). A `--help` must never mutate the host.

## The fix
- **Central help guard in `main()`**: `-h`/`--help` on any subcommand prints usage and exits `0` **before any side effect**. `logs` opts out (it forwards its args to `docker compose logs`); the bare `pithead -h/--help/help` is unchanged.
- **`_reject_options`** on the no-option verbs (`upgrade`, `up`, `down`, `status`, `doctor`, `control-run-pending`, `onion-client-key`): an unrecognized flag now errors and names the bad flag, instead of being silently ignored while the command runs anyway.
- `--dry-run` and other real options are unaffected; verbs that parse their own args (`apply`, `backup`, `restore`, `setup`, …) still do, and now also get the `--help` short-circuit before they run.

## Tests
10 tier-1 assertions in `tests/stack/run.sh` (`== unit: subcommand flag guard (#493) ==`), run from a non-deployed sandbox so a guard that failed to short-circuit would fall through to `require_deployed`/`stack_upgrade` and fail the assertion:
- `upgrade --help` / `-h` → exit 0, prints usage, no side effect
- `upgrade --bogus`, `status --json` → exit 1, names the bad flag
- `apply --help` → exit 0, no apply
- bare `--help` / `help` still exit 0

`make lint` + `make test-stack` green (1143 passed, 0 failed). No tier-4 needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)