### PR TITLE
feat(dashboard): Worker Inspect enriched stats as a label/value table in the detail view (#507)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -171,7 +171,7 @@ export class WorkerInspect extends Component {
                 <${InfoCard} label="Hashrate (1m)" value=${detail.hashrate || "—"} />
                 <${InfoCard} label="RigForge" value=${detail.rigforge ? detail.rigforge.version || "yes" : "—"} />
             </div>
-            ${detail.rigforge ? html`<${Chips} chips=${detail.rigforge.chips} />` : null}
+            ${detail.rigforge ? html`<${StatsTable} stats=${detail.rigforge.stats} />` : null}
 
             <h4 class="mt-2">Edit config</h4>
             ${
@@ -212,10 +212,23 @@ export class WorkerInspect extends Component {
 const InfoCard = ({ label, value }) => html`
     <div class="stat-card"><h5>${label}</h5><p>${value}</p></div>`;
 
-const Chips = ({ chips }) =>
-  chips && chips.length
-    ? html`<div class="badge-row mt-1">${chips.map(
-        (c) =>
-          html`<span class=${"badge badge-" + c.variant} title=${c.title || ""}>${c.text}</span>`,
-      )}</div>`
+// The compact Workers-Alive list renders the enriched feed as a horizontal badge row; here in the
+// single-rig detail view the same server-built metrics read better as a label → value table (#507).
+// `stats` is the {label, value, variant, title} split of the very chips the list uses. A warn/bad
+// variant (bad governor, throttling, thermal hold) colours its value; `outline` metrics stay plain.
+const STAT_VALUE_CLS = { ok: "status-ok", warn: "status-warn", bad: "status-bad" };
+export const StatsTable = ({ stats }) =>
+  stats && stats.length
+    ? html`
+    <div class="table-scroll mt-1">
+        <table class="worker-history">
+            <tbody>${stats.map(
+              (s) => html`
+                <tr>
+                    <td class="text-muted" title=${s.title || ""}>${s.label}</td>
+                    <td class=${STAT_VALUE_CLS[s.variant] || ""}>${s.value}</td>
+                </tr>`,
+            )}</tbody>
+        </table>
+    </div>`
     : null;

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -614,52 +614,60 @@ def _fmt_num(v):
 
 
 def _rigforge_display(rf):
-    """A ``{version, miner_down, chips}`` view of a worker's parsed ``rigforge`` block, or ``None``
-    for a plain-xmrig worker (#235). Each chip is ``{text, variant, title}`` (the same shape the
-    Badges component renders) and is emitted ONLY when its data is present — a rig with no RAPL
-    shows no power chip, a disabled watchdog shows no watchdog chip. Building the chip set (and its
-    thresholds) here keeps the client a dumb renderer, matching the ``_reject_flag`` precedent."""
+    """A ``{version, miner_down, chips, stats}`` view of a worker's parsed ``rigforge`` block, or
+    ``None`` for a plain-xmrig worker (#235). Each metric is emitted ONLY when its data is present —
+    a rig with no RAPL shows no power row, a disabled watchdog shows no watchdog row.
+
+    Both outputs come from one pass so they can't drift: ``chips`` is the merged ``{text, variant,
+    title}`` badge shape the compact Workers-Alive list renders, and ``stats`` is the same metrics
+    split into ``{label, value, variant, title}`` for the Worker Inspect detail table (#507).
+    Building the set (and its thresholds) here keeps the client a dumb renderer, matching the
+    ``_reject_flag`` precedent."""
     if not rf:
         return None
-    chips = []
+    rows = []
+
+    def add(label, value, chip, variant, title):
+        rows.append(
+            {"label": label, "value": value, "chip": chip, "variant": variant, "title": title}
+        )
+
     if rf.get("miner_down"):
-        chips.append(
-            {
-                "text": "miner down",
-                "variant": "bad",
-                "title": "RigForge is up but its XMRig API is unreachable — the rig is present but "
-                "not mining. Live hashrate and uptime come from the proxy.",
-            }
+        add(
+            "Miner",
+            "down",
+            "miner down",
+            "bad",
+            "RigForge is up but its XMRig API is unreachable — the rig is present but not mining. "
+            "Live hashrate and uptime come from the proxy.",
         )
 
     health = rf.get("health") or {}
     if health.get("throttling") is True:
-        chips.append(
-            {"text": "throttling", "variant": "bad", "title": "CPU is thermal/power throttling."}
-        )
+        add("CPU", "throttling", "throttling", "bad", "CPU is thermal/power throttling.")
     gov = health.get("governor")
     if gov:
         ok = gov == "performance"
-        chips.append(
-            {
-                "text": f"gov: {gov}",
-                "variant": "ok" if ok else "warn",
-                "title": "CPU frequency governor"
-                + ("" if ok else " — 'performance' is recommended for mining."),
-            }
+        add(
+            "Governor",
+            gov,
+            f"gov: {gov}",
+            "ok" if ok else "warn",
+            "CPU frequency governor"
+            + ("" if ok else " — 'performance' is recommended for mining."),
         )
     hp = _num(health.get("hugepages_total"))
     if hp is not None:
-        chips.append(
-            {
-                "text": f"HP {_fmt_num(hp)}",
-                "variant": "outline",
-                "title": f"HugePages allocated: {_fmt_num(hp)}.",
-            }
+        add(
+            "HugePages",
+            _fmt_num(hp),
+            f"HP {_fmt_num(hp)}",
+            "outline",
+            f"HugePages allocated: {_fmt_num(hp)}.",
         )
     board = health.get("board")
     if board:
-        chips.append({"text": board, "variant": "outline", "title": "Mainboard (firmware)."})
+        add("Mainboard", board, board, "outline", "Mainboard (firmware).")
 
     power = rf.get("power") or {}
     watts = _num(power.get("watts"))
@@ -670,26 +678,25 @@ def _rigforge_display(rf):
             parts.append(f"{_fmt_num(round(watts, 1))} W")
         if hspw is not None:
             parts.append(f"{_fmt_num(round(hspw, 1))} H/s·W")
-        chips.append(
-            {"text": " · ".join(parts), "variant": "outline", "title": "Power draw / efficiency."}
-        )
+        text = " · ".join(parts)
+        add("Power / efficiency", text, text, "outline", "Power draw / efficiency.")
 
     tune = rf.get("tune") or {}
     if tune.get("target"):
-        chips.append(
-            {
-                "text": f"tune: {tune['target']}",
-                "variant": "outline",
-                "title": "Active tuning target.",
-            }
+        add(
+            "Tuning target",
+            tune["target"],
+            f"tune: {tune['target']}",
+            "outline",
+            "Active tuning target.",
         )
     if tune.get("autotune_enabled") and tune.get("autotune_next"):
-        chips.append(
-            {
-                "text": f"autotune → {tune['autotune_next']}",
-                "variant": "outline",
-                "title": "Next scheduled autotune run.",
-            }
+        add(
+            "Autotune",
+            tune["autotune_next"],
+            f"autotune → {tune['autotune_next']}",
+            "outline",
+            "Next scheduled autotune run.",
         )
 
     wd = rf.get("watchdog") or {}
@@ -697,22 +704,30 @@ def _rigforge_display(rf):
         temp = _num(wd.get("temp_c"))
         maxt = _num(wd.get("max_temp_c"))
         if wd.get("thermal_hold") is True:
-            chips.append(
-                {
-                    "text": "thermal hold",
-                    "variant": "bad",
-                    "title": "Watchdog is holding the rig back — temperature above its ceiling.",
-                }
+            add(
+                "Watchdog",
+                "thermal hold",
+                "thermal hold",
+                "bad",
+                "Watchdog is holding the rig back — temperature above its ceiling.",
             )
         elif temp is not None:
-            label = f"{_fmt_num(round(temp, 1))}°C"
+            text = f"{_fmt_num(round(temp, 1))}°C"
             if maxt is not None:
-                label += f" / {_fmt_num(maxt)}°C"
-            chips.append(
-                {"text": label, "variant": "outline", "title": "Watchdog temperature / ceiling."}
-            )
+                text += f" / {_fmt_num(maxt)}°C"
+            add("Temp / max", text, text, "outline", "Watchdog temperature / ceiling.")
 
-    return {"version": rf.get("version"), "miner_down": bool(rf.get("miner_down")), "chips": chips}
+    chips = [{"text": r["chip"], "variant": r["variant"], "title": r["title"]} for r in rows]
+    stats = [
+        {"label": r["label"], "value": r["value"], "variant": r["variant"], "title": r["title"]}
+        for r in rows
+    ]
+    return {
+        "version": rf.get("version"),
+        "miner_down": bool(rf.get("miner_down")),
+        "chips": chips,
+        "stats": stats,
+    }
 
 
 def build_system(data):

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import { App } from '../../mining_dashboard/web/static/components.mjs';
+import { StatsTable } from '../../mining_dashboard/web/static/workerview.mjs';
 import { render } from './helpers/render.mjs';
 
 const BASE = JSON.parse(readFileSync(new URL('./fixtures/state.json', import.meta.url)));
@@ -564,4 +565,27 @@ test('no WorkerInspect overlay when none is selected (#185)', () => {
     const s = clone();
     s.control_enabled = true;
     assert.doesNotMatch(renderApp({ state: s }), /worker-inspect-overlay/);
+});
+
+test('StatsTable renders the enriched feed as a label/value table, colouring warn/bad values (#507)', () => {
+    // The detail view swaps the compact list's badge row for a table: label cell + value cell,
+    // driven by the server-built {label, value, variant, title} stats. warn/bad colour the value.
+    const html = render(StatsTable, {
+        stats: [
+            { label: 'Governor', value: 'powersave', variant: 'warn', title: 'CPU governor' },
+            { label: 'HugePages', value: '1280', variant: 'outline', title: '' },
+            { label: 'CPU', value: 'throttling', variant: 'bad', title: 'hot' },
+        ],
+    });
+    assert.match(html, /class="worker-history"/); // reuses the existing detail-table styling
+    assert.doesNotMatch(html, /badge-row/); // NOT the compact list's badge row
+    assert.match(html, /Governor<\/td>/);
+    assert.match(html, /class="status-warn">powersave/); // warn colours its value
+    assert.match(html, /class="status-bad">throttling/); // bad colours its value
+    assert.match(html, /<td class="">1280/); // outline metric stays plain
+});
+
+test('StatsTable renders nothing when a rig reports no metrics (#507)', () => {
+    assert.equal(render(StatsTable, { stats: [] }), '');
+    assert.equal(render(StatsTable, { stats: undefined }), '');
 });

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -958,11 +958,16 @@ class TestRejectFlag:
 
 
 class TestRigForgeDisplay:
-    """The RigForge enriched-feed chip builder (#235). Parsed block in → {version, chips} out; each
-    chip emitted only when its data is present, so nothing renders for a plain-xmrig worker."""
+    """The RigForge enriched-feed builder (#235). Parsed block in → {version, chips, stats} out;
+    each metric emitted only when its data is present, so nothing renders for a plain-xmrig worker.
+    ``chips`` feeds the compact badge row; ``stats`` is the same metrics split into label/value for
+    the Worker Inspect detail table (#507). Both come from one pass, so they stay row-for-row."""
 
     def _chip_texts(self, disp):
         return [c["text"] for c in disp["chips"]]
+
+    def _stats(self, disp):
+        return {s["label"]: s for s in disp["stats"]}
 
     def test_none_for_plain_xmrig(self):
         assert _rigforge_display(None) is None
@@ -1001,6 +1006,60 @@ class TestRigForgeDisplay:
         assert "62°C / 85°C" in texts
         # Nothing alarming here: no bad-variant chips.
         assert all(c["variant"] != "bad" for c in disp["chips"])
+
+        # The detail table (#507) carries the same metrics as label/value pairs, row-for-row with
+        # the chips, so the two renderers can't drift.
+        assert len(disp["stats"]) == len(disp["chips"])
+        stats = self._stats(disp)
+        assert stats["Governor"]["value"] == "performance"
+        assert stats["Governor"]["variant"] == "ok"
+        assert stats["HugePages"]["value"] == "1280"
+        assert stats["Mainboard"]["value"] == "ProArt X670E"
+        assert stats["Power / efficiency"]["value"] == "142 W · 86.9 H/s·W"
+        assert stats["Tuning target"]["value"] == "perf"
+        assert stats["Autotune"]["value"] == "Sun 03:00"
+        assert stats["Temp / max"]["value"] == "62°C / 85°C"
+
+    def test_stats_split_label_from_value_and_colour_warn_states(self):
+        # The label/value split powers the detail table; a bad/warn metric colours its own value.
+        disp = _rigforge_display(
+            {
+                "version": "1.7.0",
+                "miner_down": True,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": "powersave",
+                    "throttling": True,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": False},
+            }
+        )
+        stats = self._stats(disp)
+        assert stats["Miner"]["value"] == "down" and stats["Miner"]["variant"] == "bad"
+        assert stats["CPU"]["value"] == "throttling" and stats["CPU"]["variant"] == "bad"
+        assert stats["Governor"]["value"] == "powersave"
+        assert stats["Governor"]["variant"] == "warn"
+
+    def test_stats_empty_when_no_metrics_present(self):
+        disp = _rigforge_display(
+            {
+                "version": None,
+                "miner_down": False,
+                "power": {"watts": None, "hs_per_watt": None},
+                "tune": {"target": None, "autotune_enabled": False, "autotune_next": None},
+                "health": {
+                    "governor": None,
+                    "throttling": None,
+                    "board": None,
+                    "hugepages_total": None,
+                },
+                "watchdog": {"enabled": False, "thermal_hold": None, "temp_c": None},
+            }
+        )
+        assert disp["stats"] == []
 
     def test_throttling_and_bad_governor_flag(self):
         disp = _rigforge_display(


### PR DESCRIPTION
Closes #507.

## Change
In the **Worker Inspect detail panel only**, render RigForge enriched stats as a label→value table instead of a badge row. The compact Workers-Alive list keeps its badges (unchanged).

- **Server** (`web/views.py`): `_rigforge_display` now derives both outputs from one pass — `chips` (existing badge shape, byte-for-byte unchanged) and a new `stats` (`{label, value, variant, title}`). One source ⇒ the two renderers can't drift.
- **Client** (`workerview.mjs`): detail view uses a new `StatsTable` reusing the existing `worker-history` table classes (no new CSS); warn/bad variants color the value cell.
- Temp row labeled **Temp / max** to stay honest to the underlying `temp_c`/`max_temp_c` fields.

## Tests
Extended `tests/web/test_views.py` (stats/chips parity, coloring, empty case) and `tests/frontend/components.test.mjs` (StatsTable render). Frontend 127/127, pytest 1260 passed, patch coverage 100%, lint clean. Ponytail-reviewed: lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)