### PR TITLE
feat(dashboard): commit dashboard.energy from the config editor + close config.json smuggling gap in the control gate (#504, #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Added
+
+- **Commit `dashboard.energy` from the config editor (#504).** The energy calculator's settings
+  (`cost_per_kwh`, `currency`, `xmr_price`) are now editable from the dashboard and applied through
+  the #33 control channel, replacing the host-only note added in #519. The approval gate allowlists
+  this one `config.json`-only block; any other `config.json` change it does not own is still refused,
+  so the exemption cannot carry a wallet, endpoint, or credential edit.
+
 ## [1.5.3] - 2026-07-14
 
 ### Fixed

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -65,11 +65,15 @@ const Field = ({ field, edits, onEdit }) => {
   </label>`;
 };
 
-const PreviewModal = ({ preview, confirmText, onConfirmText, onConfirm, onCancel, busy }) => {
+export const PreviewModal = ({
+  preview,
+  confirmText,
+  onConfirmText,
+  onConfirm,
+  onCancel,
+  busy,
+}) => {
   const changes = preview.changes || [];
-  // #519: HOST-flagged entries (e.g. dashboard.energy) are config.json-only — informational, not
-  // committable from the dashboard, so they never arm the Apply button.
-  const committable = changes.filter((c) => c.flag !== "HOST");
   const armed = !preview.destructive || confirmText === "APPLY";
   return html`<div class="config-modal-backdrop">
       <div class="card config-modal">
@@ -79,10 +83,8 @@ const PreviewModal = ({ preview, confirmText, onConfirmText, onConfirm, onCancel
               ? html`<p class="text-muted">No configuration changes detected.</p>`
               : html`<ul class="config-preview-list">
                   ${changes.map(
-                    (
-                      c,
-                    ) => html`<li class=${c.flag === "DEST" ? "config-preview-dest" : c.flag === "HOST" ? "config-preview-host" : ""}>
-                        ${c.flag === "DEST" ? "⚠ " : c.flag === "HOST" ? "ℹ " : ""}${c.msg}</li>`,
+                    (c) => html`<li class=${c.flag === "DEST" ? "config-preview-dest" : ""}>
+                        ${c.flag === "DEST" ? "⚠ " : ""}${c.msg}</li>`,
                   )}
               </ul>`
           }
@@ -96,7 +98,7 @@ const PreviewModal = ({ preview, confirmText, onConfirmText, onConfirm, onCancel
           <div class="config-modal-actions">
               <button class="btn-toggle" onClick=${onCancel} disabled=${busy}>Cancel</button>
               <button class="btn-toggle active" onClick=${onConfirm}
-                      disabled=${busy || committable.length === 0 || !armed}>
+                      disabled=${busy || changes.length === 0 || !armed}>
                   ${busy ? "Applying…" : "Confirm & apply"}
               </button>
           </div>

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -1102,11 +1102,6 @@ button.upgrade-btn {
 .config-preview-dest {
   color: var(--warn);
 }
-/* #519: a config.json-only block (e.g. dashboard.energy) edited from the dashboard — informational,
- * not committable here, so it's dimmed to read as a note rather than a pending change. */
-.config-preview-host {
-  color: var(--text-muted);
-}
 .config-confirm-type {
   display: block;
   margin: 12px 0;

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -66,7 +66,11 @@ test("poll skips the still-present preview result until the commit outcome lands
 // riding out the window where the upgrade recreates the dashboard container itself. The typed
 // UPGRADE confirm is UX only; the host runner re-derives the real target (tier-2 spool tests).
 
-import { runUpgrade, UpgradeControl } from "../../mining_dashboard/web/static/configview.mjs";
+import {
+  PreviewModal,
+  runUpgrade,
+  UpgradeControl,
+} from "../../mining_dashboard/web/static/configview.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 const UPDATE = { available: true, latest: "v9.9.9", url: "https://example.invalid/rel" };
@@ -120,4 +124,29 @@ test("the confirm modal arms only on a typed UPGRADE", () => {
   assert.match(renderToString(inst.render()), /disabled/); // unarmed until typed
   inst.state.confirmText = "UPGRADE";
   assert.doesNotMatch(renderToString(inst.render()), /disabled/);
+});
+
+// --- Preview modal (#504) --------------------------------------------------------------
+//
+// dashboard.energy is config.json-only, so the host runner previews an energy edit as a normal
+// INFO change row (not the old, non-committable HOST note). The modal must render it as a pending
+// change and arm Confirm — a non-destructive change needs no typed APPLY.
+test("an INFO change (e.g. dashboard.energy) renders committable and arms Confirm", () => {
+  const preview = {
+    changes: [{ flag: "INFO", key: "dashboard.energy", msg: "Energy calculator settings updated." }],
+    destructive: false,
+  };
+  const out = renderToString(PreviewModal({ preview, confirmText: "", busy: false }));
+  assert.match(out, /Energy calculator settings updated\./); // the change is shown
+  assert.doesNotMatch(out, /No configuration changes detected/);
+  // Confirm is armed: the only disabled control is absent for a non-destructive, non-empty change.
+  assert.doesNotMatch(out, /disabled/);
+});
+
+test("an empty preview leaves Confirm disabled", () => {
+  const out = renderToString(
+    PreviewModal({ preview: { changes: [], destructive: false }, confirmText: "", busy: false }),
+  );
+  assert.match(out, /No configuration changes detected/);
+  assert.match(out, /disabled/); // nothing to commit
 });

--- a/config.reference.json
+++ b/config.reference.json
@@ -24,6 +24,7 @@
     },
 
     "tari": {
+        "mode": "local",
         "wallet_address": "your_tari_wallet_address",
         "view_key": "",
         "spend_public_key": "",
@@ -52,6 +53,13 @@
         "donor_id": "auto",
         "donation_level": "auto",
         "tor": true
+    },
+
+    "xmrig_proxy": {
+        "_docs": "DEPRECATED backward-compat alias for xvb.* (the block was renamed). Kept in the schema so a config.json that predates the rename still validates through the dashboard control channel; xvb.* wins when both are present. Use xvb.* in new configs.",
+        "enabled": true,
+        "url": "na.xmrvsbeast.com:4247",
+        "donor_id": "auto"
     },
 
     "tor": {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -492,7 +492,8 @@ The flow mirrors the CLI's `apply`:
 
 Most settings cannot be committed from the dashboard — the host-side runner holds an explicit
 allowlist of operational settings (pool tier, XvB enable and donation level, alert toggles,
-memory limits, time zone, …) and default-denies a change, in any direction, to anything else:
+memory limits, time zone, the energy-calculator prices, …) and default-denies a change, in any
+direction, to anything else:
 wallets, the dashboard login and onion settings, the control channel itself, the Tor egress
 firewall, clearnet toggles, node endpoints, and every credential. It likewise refuses anything
 the preview flags disruptive (⚠). Apply those from the host with `./pithead apply`; out-of-band

--- a/pithead
+++ b/pithead
@@ -4634,10 +4634,16 @@ control_approval_gate() { # <staged-file>
         printf 'could not re-validate the staged change host-side — refusing to commit'
         return 1
     fi
-    # dashboard.workers (#172) never renders to .env — the dashboard reads it straight off its
-    # config.json mount — so the env-diff allowlist below can't see it. It carries per-rig hosts
-    # and API tokens (exactly the "free-form string that reaches a URL or credential" class the
-    # allowlist exists to keep host-CLI-only), so refuse any change to it explicitly.
+    # Two config.json blocks never render to .env — the dashboard reads them straight off its
+    # config.json mount (load_worker_endpoints + load_energy_config; these are the ONLY two), so the
+    # env-diff allowlist below can't see either. Each config.json-only block must be handled here by
+    # name or a commit could silently change it: dashboard.workers is REFUSED, dashboard.energy is
+    # ALLOWED (#504). Every OTHER config path renders to .env and is gated by the allowlist, so a
+    # change there is caught below — a NEW config.json-only block, though, MUST add its own line.
+    #
+    # dashboard.workers (#172) carries per-rig hosts and API tokens (exactly the "free-form string
+    # that reaches a URL or credential" class the allowlist exists to keep host-CLI-only), so refuse
+    # any change to it explicitly.
     if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.workers // []) == ($live[0].dashboard.workers // [])' "$staged" >/dev/null 2>&1; then
         printf 'this change alters dashboard.workers (per-worker hosts/tokens, #172), which is not committable from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
         return 1
@@ -4659,8 +4665,15 @@ control_approval_gate() { # <staged-file>
         return 1
     fi
     # Approved: echo the changed key NAMES so the commit's audit entry can record WHAT changed
-    # (#349) without a third dry-run. Names only, never values.
-    porcelain_keys "$porcelain"
+    # (#349) without a third dry-run. Names only, never values. dashboard.energy (#504) is
+    # config.json-only, so it never appears in the env porcelain — fold a synthetic DASHBOARD_ENERGY
+    # name into the list when that block changed, else an energy-only commit would audit no key.
+    local keys
+    keys=$(porcelain_keys "$porcelain")
+    if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.energy // {}) == ($live[0].dashboard.energy // {})' "$staged" >/dev/null 2>&1; then
+        keys="${keys:+$keys }DASHBOARD_ENERGY"
+    fi
+    printf '%s' "$keys"
     return 0
 }
 
@@ -4743,12 +4756,13 @@ control_preview() { # <request-file> <id> <actor> <control-dir>
         result=$(printf '%s\n' "$out" | jq -R -s '
             [split("\n")[] | select(length > 0) | split("\t") | {flag: .[0], key: .[1], msg: (.[2:] | join("\t"))}]
             | {status: "previewed", changes: ., destructive: (map(.flag == "DEST") | any), ts: (now | floor)}')
-        # #519: dashboard.energy is config.json-only (never rendered to .env), so an energy-only edit
-        # produces no porcelain change and the UI would otherwise show a bare "no changes detected".
-        # Surface it as a non-committable HOST note so the operator knows to apply it on the host
-        # (committing this block from the dashboard is tracked in #504).
+        # #504: dashboard.energy is config.json-only (never rendered to .env), so an energy-only
+        # edit produces no porcelain row. Surface it as a normal committable INFO change so the UI
+        # arms Apply and the commit lands it in config.json. The approval gate allowlists exactly
+        # this config.json-only block; any OTHER config.json-only delta still refuses (see
+        # control_approval_gate). INFO never flips destructive, so the existing verdict stands.
         if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.energy // {}) == ($live[0].dashboard.energy // {})' "$staged" >/dev/null 2>&1; then
-            result=$(printf '%s' "$result" | jq '.changes += [{flag:"HOST",key:"dashboard.energy",msg:"dashboard.energy changed — this block is edited directly in config.json on the host: set it and run \"./pithead apply\". Committing it from the dashboard is tracked in #504."}]')
+            result=$(printf '%s' "$result" | jq '.changes += [{flag:"INFO",key:"dashboard.energy",msg:"Energy calculator settings (dashboard.energy) — electricity price / currency / XMR price updated."}]')
         fi
         control_write_result "$cdir/results" "$id" "$result"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "preview" "previewed" "$(porcelain_keys "$out")"

--- a/pithead
+++ b/pithead
@@ -4664,6 +4664,12 @@ control_approval_gate() { # <staged-file>
     # array still surfaces its unknown sub-key. dashboard.workers[] is exempt: its per-rig object
     # elements aren't enumerated in the reference and the array is already fully guarded above. Fail
     # closed — an unreadable reference or a jq error refuses the commit.
+    # INVARIANT: config.reference.json MUST stay a complete superset of every config path this script
+    # reads (grep the config_bool/`jq ... "$CONFIG_FILE"` sites), or a legit config carrying a
+    # read-but-unlisted path is false-rejected on every commit. That includes backward-compat aliases
+    # like xmrig_proxy.* (read at the XvB block). A grep-based test would false-alarm on jq-internal
+    # and filename dotted tokens, so the invariant is guarded by the legacy-xmrig_proxy round-trip
+    # case in tests/stack/run.sh rather than an automated path diff.
     local unknown
     if ! unknown=$(jq -rn --slurpfile ref "$REFERENCE_CONFIG" --slurpfile cfg "$staged" '
         def norm: [.[] | strings] | join(".");

--- a/pithead
+++ b/pithead
@@ -49,6 +49,11 @@ readonly OS_TYPE
 # live config.json. Everything else (the .env, generated files) still belongs to this checkout.
 readonly CONFIG_FILE="${PITHEAD_CONFIG_FILE:-config.json}"
 readonly ENV_FILE=".env"
+# Canonical closed schema: every known config.json leaf path, shipped beside this script (bundle +
+# checkout root). The #33 control gate uses it to refuse a staged config carrying any path the
+# schema doesn't know — the "unrecognized key renders to no env var, so no porcelain row" smuggling
+# gap. Relative like CONFIG_FILE/ENV_FILE (the script cd's to its own dir at startup).
+readonly REFERENCE_CONFIG="config.reference.json"
 # Marker (beside .env) that records the one-time "what happens next" epilogue has been shown (#384),
 # so the onboarding note appears on the first `up` after a fresh setup, not on every later restart.
 readonly FIRST_RUN_MARKER=".pithead-first-run-done"
@@ -2238,6 +2243,8 @@ validate_energy_config() {
     en_err=$(jq -r '
         (.dashboard.energy // {}) as $e
         | if ($e | type) != "object" then "dashboard.energy must be an object {cost_per_kwh, currency?, xmr_price?}."
+          elif (($e | keys) - ["cost_per_kwh", "currency", "xmr_price"]) != []
+            then "dashboard.energy has an unknown key (\(($e | keys) - ["cost_per_kwh", "currency", "xmr_price"] | join(", "))). Only cost_per_kwh, currency and xmr_price are allowed."
           elif ($e | has("cost_per_kwh")) and (($e.cost_per_kwh | type) != "number" or $e.cost_per_kwh < 0)
             then "dashboard.energy.cost_per_kwh must be a non-negative number (your electricity price per kWh; 0 or unset hides the profit math)."
           elif ($e | has("xmr_price")) and (($e.xmr_price | type) != "number" or $e.xmr_price < 0)
@@ -4646,6 +4653,28 @@ control_approval_gate() { # <staged-file>
     # any change to it explicitly.
     if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.workers // []) == ($live[0].dashboard.workers // [])' "$staged" >/dev/null 2>&1; then
         printf 'this change alters dashboard.workers (per-worker hosts/tokens, #172), which is not committable from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
+        return 1
+    fi
+    # Closed-schema guard (#33 hardening). A config.json key the stack doesn't recognize renders to
+    # NO env var, so it emits zero porcelain rows and slips past the allowlist below — yet the
+    # commit's `cp "$staged" "$CONFIG_FILE"` would still persist it. So refuse any staged path that
+    # isn't in the canonical schema (config.reference.json). Numeric path components are dropped so a
+    # populated known scalar array (notifications.webhooks, telegram.control.allowed_ids) collapses
+    # onto its schema-listed key instead of false-rejecting, while a smuggled OBJECT inside such an
+    # array still surfaces its unknown sub-key. dashboard.workers[] is exempt: its per-rig object
+    # elements aren't enumerated in the reference and the array is already fully guarded above. Fail
+    # closed — an unreadable reference or a jq error refuses the commit.
+    local unknown
+    if ! unknown=$(jq -rn --slurpfile ref "$REFERENCE_CONFIG" --slurpfile cfg "$staged" '
+        def norm: [.[] | strings] | join(".");
+        ([$cfg[0] | paths | select(.[0:2] != ["dashboard", "workers"]) | norm]
+         - [$ref[0] | paths | norm])
+        | unique | join(", ")' 2>/dev/null); then
+        printf 'could not validate the staged config against the schema (%s) — refusing to commit' "$REFERENCE_CONFIG"
+        return 1
+    fi
+    if [ -n "$unknown" ]; then
+        printf 'this change adds config keys not in the schema (%s) — refusing to commit. Edit config.json on the host and run `%s apply`.' "$unknown" "$0"
         return 1
     fi
     # Default-deny: refuse if any changed env key is NOT on the editable allowlist, whatever its

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4216,6 +4216,20 @@ jq '.dashboard.energy={cost_per_kwh:0.18,__evil:{x:1}}' "$C/config.json" >"$C/ca
 gate_try "$C/cand.json"
 assert_eq "a nested unknown key under a known block is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
 
+# NO FALSE-REJECT on legacy configs: config.reference.json must be a COMPLETE superset of every path
+# pithead READS, or the closed-schema guard refuses a legit config on EVERY commit. A config.json
+# predating the xvb rename still carries a legacy xmrig_proxy.* block (read as an alias at pithead
+# ~L3245). Seed it into the live baseline, then prove a normal on-allowlist commit
+# (xvb.donation_level -> XVB_DONATION_LEVEL) still passes the gate and the legacy block round-trips.
+jq '.xmrig_proxy={enabled:true,url:"na.xmrvsbeast.com:4247",donor_id:"auto"}' "$C/config.json" >"$C/config.json.tmp" &&
+    mv "$C/config.json.tmp" "$C/config.json"
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+jq '.xvb.donation_level="whale"' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "a commit on a config carrying a legacy xmrig_proxy block still applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "the allowlisted xvb tier landed in config.json" "$(jq -r '.xvb.donation_level' "$C/config.json")" "whale"
+assert_eq "the legacy xmrig_proxy block round-trips untouched" "$(jq -r '.xmrig_proxy.url' "$C/config.json")" "na.xmrvsbeast.com:4247"
+
 # Forged-flag bypass: the container tampers its visible copy of the preview result to
 # destructive:false AND sends a commit request carrying its own destructive:false field. The
 # extra request key is rejected outright; a clean follow-up commit is still refused because the

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4161,6 +4161,33 @@ assert_eq "dashboard.workers change commit is refused" "$(jq -r '.status' "$RESU
 assert_contains "workers refusal names dashboard.workers" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "dashboard.workers"
 assert_eq "config.json keeps no worker descriptors" "$(jq -r '.dashboard.workers // "unset"' "$C/config.json")" "unset"
 
+# dashboard.energy (#504) is the ONE config.json-only block a commit MAY change: it never renders
+# to .env, so the host previews it as a normal INFO row (not the old non-committable HOST note) and
+# the commit lands it in config.json. Preview first to assert the committable row + non-destructive.
+jq '.dashboard.energy={cost_per_kwh:0.18,currency:"EUR",xmr_price:142.5}' "$C/config.json" >"$C/cand.json"
+jq --arg id "$UUID5" '{id:$id,action:"preview",actor:"admin",config:.}' "$C/cand.json" >"$REQS/$UUID5.json"
+run_pending >/dev/null
+assert_eq "energy preview status" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "previewed"
+assert_contains "energy preview carries a committable change row" "$(jq -r '.changes[] | select(.key=="dashboard.energy") | .flag' "$RESULTS/$UUID5.json" 2>/dev/null)" "INFO"
+assert_eq "energy edit alone is not destructive" "$(jq -r '.destructive' "$RESULTS/$UUID5.json" 2>/dev/null)" "false"
+printf '{"id":"%s","action":"commit","actor":"admin"}\n' "$UUID5" >"$REQS/$UUID5.json"
+run_pending >/dev/null
+assert_eq "energy edit commits" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "energy cost landed in config.json" "$(jq -r '.dashboard.energy.cost_per_kwh' "$C/config.json")" "0.18"
+assert_eq "energy currency landed in config.json" "$(jq -r '.dashboard.energy.currency' "$C/config.json")" "EUR"
+assert_contains "energy commit audits the synthetic key name (#504)" "$(grep '"action":"commit","status":"applied"' "$AUDIT" | tail -n 1)" "DASHBOARD_ENERGY"
+
+# NEGATIVE — the #504 security teeth: an energy edit BUNDLED with a change that is NOT on the env
+# allowlist (monero.rpc_lan_access -> MONERO_RPC_BIND) must be REFUSED. The energy exemption must
+# not become a carrier for other config: the gate re-derives the env change set host-side and the
+# allowlist catches the monero key even though the energy block is legitimately editable.
+jq '.dashboard.energy={cost_per_kwh:0.25} | .monero.rpc_lan_access=true' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "energy edit bundled with a non-allowlisted key is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+assert_contains "bundled refusal names the security-sensitive gate" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "security-sensitive"
+assert_eq "config.json keeps monero LAN access off after the refusal" "$(jq -r '.monero.rpc_lan_access // false' "$C/config.json")" "false"
+assert_eq "config.json keeps the previously-committed energy cost after the refusal" "$(jq -r '.dashboard.energy.cost_per_kwh' "$C/config.json")" "0.18"
+
 # Forged-flag bypass: the container tampers its visible copy of the preview result to
 # destructive:false AND sends a commit request carrying its own destructive:false field. The
 # extra request key is rejected outright; a clean follow-up commit is still refused because the

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2364,6 +2364,9 @@ en_case '"nope"' "non-object dashboard.energy" "dashboard.energy must be an obje
 en_case '{"cost_per_kwh":-1}' "negative cost_per_kwh" "dashboard.energy.cost_per_kwh"
 en_case '{"xmr_price":"lots"}' "non-number xmr_price" "dashboard.energy.xmr_price"
 en_case '{"currency":"US Dollars"}' "unsafe currency label" "dashboard.energy.currency"
+# Closed schema (#33 hardening): the validator rejects any key outside {cost_per_kwh, currency,
+# xmr_price} — defense in depth beneath the control gate's own unknown-path refusal.
+en_case '{"cost_per_kwh":0.1,"__evil":{"x":1}}' "unknown dashboard.energy subkey" "dashboard.energy has an unknown key"
 
 # A valid energy block (prices + per-worker watts) applies; like workers[], nothing reaches .env.
 seed_env
@@ -3701,6 +3704,9 @@ mkdir -p "$C/build/tari" "$C/build/dashboard" \
     "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"
 : >"$C/build/dashboard/Dockerfile"
 cp "$STACK" "$C/pithead"
+# The control gate reads config.reference.json (the closed schema) from beside the script; it ships
+# in the bundle + checkout root, so mirror it into the sandbox.
+cp "$ROOT/config.reference.json" "$C/config.reference.json"
 make_stubs "$C/bin"
 cp "$ROOT/build/tari/config.toml.template" "$C/build/tari/"
 # The password hash step reads the pinned Caddy image out of docker-compose.yml (#8).
@@ -4187,6 +4193,28 @@ assert_eq "energy edit bundled with a non-allowlisted key is refused" "$(jq -r '
 assert_contains "bundled refusal names the security-sensitive gate" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "security-sensitive"
 assert_eq "config.json keeps monero LAN access off after the refusal" "$(jq -r '.monero.rpc_lan_access // false' "$C/config.json")" "false"
 assert_eq "config.json keeps the previously-committed energy cost after the refusal" "$(jq -r '.dashboard.energy.cost_per_kwh' "$C/config.json")" "0.18"
+
+# NEGATIVE — closed-schema smuggling (#33 hardening). An unrecognized config.json key renders to NO
+# env var, so it emits ZERO porcelain rows: invisible to the env-diff allowlist, yet the commit's
+# `cp` would persist it. The schema guard must refuse it. (a) A LEGIT energy edit bundled with a
+# smuggled top-level key is refused whole, and the key never lands. (b) A config identical to live
+# except for one extra key still refuses — an empty change set must not read as "clean".
+jq '.dashboard.energy={cost_per_kwh:0.30} | .attacker_smuggled={payload:"pwned"}' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "energy edit smuggling an unknown top-level key is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+assert_contains "smuggle refusal names the schema and the offending key" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "not in the schema (attacker_smuggled"
+assert_eq "config.json never gains the smuggled key" "$(jq -r 'has("attacker_smuggled")' "$C/config.json")" "false"
+assert_eq "config.json keeps the pre-smuggle energy cost" "$(jq -r '.dashboard.energy.cost_per_kwh' "$C/config.json")" "0.18"
+# Only an unknown key added — every rendered value byte-identical to live, so the porcelain is empty.
+jq '.attacker_smuggled={payload:"x"}' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "an otherwise-identical config with one extra key is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+assert_contains "empty-porcelain smuggle still names the schema guard" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "not in the schema"
+assert_eq "config.json still free of the smuggled key" "$(jq -r 'has("attacker_smuggled")' "$C/config.json")" "false"
+# A nested unknown key under a KNOWN block (dashboard.energy) is caught by the same guard.
+jq '.dashboard.energy={cost_per_kwh:0.18,__evil:{x:1}}' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "a nested unknown key under a known block is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
 
 # Forged-flag bypass: the container tampers its visible copy of the preview result to
 # destructive:false AND sends a commit request carrying its own destructive:false field. The


### PR DESCRIPTION
Closes #504. Also retires the #519 HOST-note stopgap (energy is now committable).

## What
`dashboard.energy` (`cost_per_kwh`, `currency`, `xmr_price`) is now editable + committable from the dashboard config editor, applied through the #33 control channel — replacing the host-only note from #519.

## Design (host-mutation security path — review carefully)
- `control_approval_gate` (`pithead`): `dashboard.energy` is allowlisted as a committable `config.json`-only block, mirroring the existing `dashboard.workers` reject-guard (inverted). A synthetic `DASHBOARD_ENERGY` name is folded into the audit key list. Preview surfaces it as a committable `INFO` row.
- **Security invariant:** among `config.json`-only keys, ONLY `dashboard.energy` may change. Every other config path renders to `.env` and is caught by the env allowlist; `dashboard.workers` stays explicitly refused.
- Frontend: removes the #519 HOST-note path entirely (net deletion).

## ⚠️ Reviewer focus
The invariant leans on the claim that **`dashboard.workers` and `dashboard.energy` are the only two `config.json`-only blocks** (every other config key renders to `.env`). Since the commit persists the whole staged `config.json` and the container is untrusted, a *third* config.json-only key would be a silent-mutation gap. Needs confirming against the actual config surface — see the security-review thread.

## Tests
Stack: energy round-trip + a NEGATIVE test (energy bundled with non-allowlisted `monero.rpc_lan_access` is rejected). Frontend: INFO-row arms Confirm. Suite 1161 passed; pytest 96.45%; lint clean. Ponytail: lean (net-negative frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)