### PR TITLE
release: bump dashboard pyproject/uv.lock to 1.6.0 (#44)

### DIFF
--- a/build/dashboard/pyproject.toml
+++ b/build/dashboard/pyproject.toml
@@ -7,7 +7,7 @@ name = "mining-dashboard"
 # Keep in lockstep with the top-level VERSION file — the single source of truth for the stack version
 # (#44). A shell test (tests/stack/run.sh) fails if these drift; the dashboard *displays* the version
 # from VERSION (baked in as PITHEAD_VERSION, #58), so this is packaging metadata only.
-version = "1.5.3"
+version = "1.6.0"
 description = "Monitoring dashboard and XvB switching engine for Pithead"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/build/dashboard/uv.lock
+++ b/build/dashboard/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "mining-dashboard"
-version = "1.5.3"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## What

The v1.6.0 release-prep commit (#540) bumped `VERSION`→1.6.0 and finalized the CHANGELOG but did **not** bump the dashboard Python package version. `build/dashboard/pyproject.toml` and `build/dashboard/uv.lock` were left at 1.5.3, tripping the #44 lockstep guard (`pyproject.toml version matches VERSION`) on the develop tip — the Shell-tests check is red (1264 passed, 1 failed).

This is a hard release blocker: the develop pre-cut gate must be green, and `make release`'s test gate runs the same suite.

## Change

Two surgical version-string bumps to 1.6.0 (mirrors the v1.5.3 prep — no `uv lock` regen, to avoid pulling unrelated dependency updates mid-release):
- `build/dashboard/pyproject.toml`
- `build/dashboard/uv.lock` (self-referential editable package version)

## Verify

`VERSION`=1.6.0, pyproject=1.6.0 — #44 assertion matches. No stale 1.5.3 expectations remain in tests/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)