### PR TITLE
test(integration): wait for Tari to resync in the subnet phase (#201)

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1724,6 +1724,11 @@ run_subnet_scenario() {
     wait_monero_synced 120 || true
     wait_miner_running 180 || true
     wait_hashes_flowing 300 || true
+    # The down/up restarted Tari too, so — like the per-scenario deploy path — let it close its
+    # post-restart offline gap before assert_running_state's sync check, or we catch it mid-"loading".
+    if [ "$(jq_get "$config" '.dashboard.tari_required')" = "true" ]; then
+        wait_tari_synced 300 || true
+    fi
 
     # Subnet-specific live checks + the standard running-state battery on the moved subnet.
     assert_subnet_live "$config"


### PR DESCRIPTION
## What

The v1.6.0 release tier-4 e2e (`--mode matrix`) failed on exactly one of 388 assertions:

```
✗ tari synced (required)  — expected [done], got [loading]
```

in the **moved-subnet phase (#201)**. All the actual subnet-move assertions passed (tor torrc / monerod proxy / container IPs / dashboard CIDR / P2POOL_URL on the moved `/24`), and monerod synced fine in the same scenario.

## Root cause (test bug, not a product regression)

`run_subnet_scenario` does a full `down -> up` (Compose can't hot-move the bridge subnet), restarting **every** container including Tari. It waits for `wait_status_ok` / `wait_monero_synced` / `wait_miner_running` / `wait_hashes_flowing`, then asserts the running-state battery — but, unlike the per-scenario deploy path (`run_scenario`, which guards with `wait_tari_synced 300` when `tari_required`), it **never waits for Tari**. Tari re-peers over Tor slowly after a restart, so `assert_running_state` catches it mid-`loading`.

Confirmed live: after the e2e restored the baseline stack (all containers healthy), the dashboard still read `tari: loading` for minutes — Tari always syncs, it's just slow to close its offline gap post-restart.

## Fix

Mirror `run_scenario`'s existing guard in the subnet phase: `wait_tari_synced 300` before the battery when `dashboard.tari_required` is true. Product behaviour is unchanged.

## Verify

`bash -n` clean; `tests/integration/selftest.sh` 132 passed / 0 failed. Re-validated end-to-end by re-running the subnet phase on the release bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)