### PR TITLE
test(integration): #517 tolerate an async rig rollback (poll for terminal)

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1973,8 +1973,8 @@ _rig_control_apply() { # <changes-json> -> echoes change_id
 }
 
 # Poll the rig's /status for <change_id> reaching <want-status>. Returns 0 on match within the window.
-_rig_control_await() { # <change_id> <want-status>
-    local id="$1" want="$2" deadline=$((SECONDS + 30)) sbody
+_rig_control_await() { # <change_id> <want-status> [timeout-s=30]
+    local id="$1" want="$2" deadline=$((SECONDS + ${3:-30})) sbody
     while [ "$SECONDS" -lt "$deadline" ]; do
         sbody="$(rx "curl -fsS --max-time 10 -H $(quote_arg "Authorization: Bearer ${IT_RIG_TOKEN:-}") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")" 2>/dev/null)"
         if [ "$(printf '%s' "$sbody" | jq -r '.change_id // empty' 2>/dev/null)" = "$id" ] &&
@@ -2014,9 +2014,30 @@ run_rigforge_rollback() { # <rig-name>
     it_step "applying the rollback-inducing change via /api/control/worker-apply…"
     res="$(_worker_apply "$rig" "$IT_RIG_ROLLBACK_CHANGES")"
     status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
+    # The rig's rollback (miner restart + up to CONTROL_LIVE_TRIES health polls) can outrun the host
+    # runner's 20s status-poll deadline on a slow rig, so worker-apply honestly returns the non-terminal
+    # "accepted" ("queued on the rig; outcome not yet observed") with the change_id — not a failure.
+    # Poll the rig directly for THAT change_id's terminal rollback (same direct-dial creds as #516;
+    # without them, keep the strict synchronous check).
+    if [ "$status" = "accepted" ] && [ -n "$RIG_HOST" ] && [ -n "${IT_RIG_TOKEN:-}" ]; then
+        local cid
+        cid="$(printf '%s' "$res" | jq -r '.change_id // empty' 2>/dev/null)"
+        if [ -n "$cid" ]; then
+            it_step "worker-apply returned accepted (runner deadline < rollback time) — polling the rig for change $cid to reach rolled_back…"
+            _rig_control_await "$cid" rolled_back 240 && status=rolled_back
+        fi
+    fi
     assert_eq "rig auto-rolled-back the bad change (rigforge#236, #517)" "$status" "rolled_back"
-    assert_eq "the dashboard's per-worker history records the rollback (#517)" \
-        "$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/worker?name=$rig")" 2>/dev/null | jq -r 'first(.history[]?) | .status // empty' 2>/dev/null)" "rolled_back"
+    # The dashboard records the worker-apply outcome (#185): "rolled_back" when the runner caught the
+    # terminal, or the honest "accepted (pending)" when the rollback outran its poll deadline — either
+    # confirms the change was driven end-to-end from the dashboard (the rig-side terminal is asserted
+    # above). ponytail: accept both rather than force a product change to the runner's poll budget.
+    local histstatus
+    histstatus="$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/worker?name=$rig")" 2>/dev/null | jq -r 'first(.history[]?) | .status // empty' 2>/dev/null)"
+    case "$histstatus" in
+    rolled_back | accepted) it_pass "the dashboard's per-worker history records the change (#517: $histstatus)" ;;
+    *) it_fail "the dashboard's per-worker history records the change (#517)" "expected rolled_back|accepted, got [$histstatus]" ;;
+    esac
 }
 
 # --- Main -------------------------------------------------------------------


### PR DESCRIPTION
## What

On the v1.6.0 release tier-4 e2e, the **#517 auto-rollback leg** failed:

```
✗ rig auto-rolled-back the bad change (rigforge#236, #517) — expected [rolled_back], got [accepted]
```

## Root cause (test-expectation issue, verified — not a product bug)

The leg asserted that `/api/control/worker-apply` **synchronously** returns `rolled_back`. But the host runner polls the rig's `/status` for the terminal outcome with a **20s deadline** — and when the rig's rollback (miner restart + up to `CONTROL_LIVE_TRIES` health polls) outruns it on a slow rig, it **honestly** writes the non-terminal `accepted` ("queued on the rig; outcome not yet observed") with the change_id. Designed async fallback, not a failure.

On the release bench miner-1's rollback took ~2-3 min, so worker-apply returned `accepted`. **Verified independently**: miner-1's control `/status` reached `rolled_back` ("miner did not return to a live hashrate") and its config self-healed — the rollback feature works end-to-end.

## Fix

- `_rig_control_await` gains an optional timeout arg (default 30s).
- After `accepted`, #517 polls the rig's `/status` directly for **that change_id** reaching `rolled_back` (240s), verifying the rollback end-to-end. Reuses #516's direct-dial creds; without them the strict synchronous check stands.
- The dashboard-history assertion accepts `rolled_back` **or** the honest async `accepted` — the rig-side terminal is asserted above.

No product change. (Follow-up worth filing: the runner's 20s poll deadline means a slow rollback is never *terminally* recorded in the #185 history — minor UX gap, pre-existing v1.5 behavior, not a v1.6.0 regression.)

## Verify

`bash -n` clean; `selftest.sh` 132/0. Re-validated end-to-end on the release bench against miner-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)