### PR TITLE
fix(#59): upgrade extraction aborts on the install's non-empty build/* dirs

### DIFF
--- a/pithead
+++ b/pithead
@@ -5013,9 +5013,16 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_fail "the $tag download actually contains version ${bundle_version:-unknown} — refusing a version-mismatched (possible rollback) release (#376). The stack keeps running v$PITHEAD_VERSION."
         return 0
     fi
-    # -U (unlink first): the archive contains THIS running script — replacing it via unlink keeps
-    # the running copy executing from its old inode, where an in-place truncate would corrupt it.
-    if ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" 2>"$logf"; then
+    # In-place extraction over the running install, in two passes. Pass 1 lays down everything
+    # EXCEPT the running script with plain tar, which MERGES existing directories — a release
+    # install already carries the non-empty build/* config-template mounts — and overwrites files.
+    # A single `-U` (unlink-first) pass over the whole tree instead tries to unlink those non-empty
+    # build/* dirs first and aborts ("Cannot unlink: Directory not empty"), leaving the install
+    # half-written. Pass 2 is the ONE file that needs -U: the pithead script, unlinked-first so it
+    # lands on a NEW inode and the copy executing this very function keeps running from the old one
+    # (an in-place overwrite would corrupt it mid-run).
+    if ! tar -xzf "$bundle" --strip-components=1 -C "$PWD" --exclude='pithead/pithead' 2>"$logf" ||
+        ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" pithead/pithead 2>>"$logf"; then
         rm -f "$bundle"
         _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
         rm -f "$logf"


### PR DESCRIPTION
## What

The **#459 post-publish smoke** (`make release-smoke --upgrade`), on its first real end-to-end run against the just-published v1.6.0, caught that the **#59 one-click upgrade is broken and non-atomic**:

```
the v1.6.0 release bundle failed to extract:
tar: build: Cannot unlink: Directory not empty
tar: build/tari: Cannot unlink: Directory not empty
tar: build/monero: Cannot unlink: Directory not empty
tar: build/tari-wallet: Cannot unlink: Directory not empty
```

## Root cause

`control_upgrade` extracts the bundle **in place** over the running install with a single `tar -xzUf … -C $PWD`. The `-U` (unlink-first) is deliberate — it replaces the running `pithead` script on a fresh inode. But `-U` also tries to unlink the existing **non-empty `build/*` config-template mount dirs** every release install carries (`build/monero`, `build/tari`, `build/tari-wallet`, …) → `Cannot unlink: Directory not empty` → abort, **part-way** (VERSION, script, compose already overwritten) → install left half-upgraded. The line is identical in v1.5.3 and develop, so this has been latent since #59 shipped; #459 exposed it.

## Fix

Two passes: (1) `tar -xzf … --exclude='pithead/pithead'` lays down everything but the running script (plain tar merges existing dirs, no unlink); (2) `tar -xzUf … pithead/pithead` is the one file that needs unlink-first for the running-inode safety.

## Verify

`bash -n` + shellcheck clean. Ran the fixed 2-pass extraction on a throwaway install carrying non-empty `build/monero`/`build/tari`/`build/tari-wallet` dirs against the real published bundle: succeeds where the single `-U` pass aborted. The #459 `--upgrade` smoke re-validates end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)