### PR TITLE
docs: fix three small accuracy issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -509,7 +509,7 @@ services:
         PITHEAD_GIT_BRANCH: ${PITHEAD_GIT_BRANCH:-}
         PITHEAD_RELEASE: ${PITHEAD_RELEASE:-}
     container_name: dashboard
-    # Memory ceiling (#132 — see monerod). A small Flask + SQLite app (~0.06 GiB observed); a tight
+    # Memory ceiling (#132 — see monerod). A small aiohttp + SQLite app (~0.06 GiB observed); a tight
     # cap is pure upside — a memory regression OOM-restarts the dashboard, not the revenue services.
     mem_limit: 512m
     memswap_limit: 512m

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -196,7 +196,7 @@ Use a **separate** check for the host timer if you want to tell "the host is up"
   enabled` line at startup — if it's absent, no ping URL is configured. The ping is always over
   Tor, so a URL your Tor exit can't reach (e.g. a LAN-only self-hosted instance) will never land;
   ping failures themselves are logged at debug level only.
-- **Test it end to end.** Stop the stack (`./pithead stop`) and wait for the period + grace to
+- **Test it end to end.** Stop the stack (`./pithead down`) and wait for the period + grace to
   elapse — you should get the alert. Start it again and the check recovers.
 - **Too many false alarms.** Increase the **period** and/or **grace** on Healthchecks.io.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,8 +31,8 @@ The product version lives in a top-level [`VERSION`](../VERSION) file: plain tex
 - The dashboard's `pyproject.toml` is kept in lockstep (packaging metadata only); a shell test fails
   if it drifts from `VERSION`.
 
-> NOTE: `VERSION` is `1.0.3`. Set it to the version you want to publish; the `pyproject.toml`
-> metadata must match, enforced by the drift-guard test.
+> NOTE: `VERSION` holds the last released version. Set it to the version you want to publish; the
+> `pyproject.toml` metadata must match, enforced by the drift-guard test.
 
 ## Component pins = an ingredients manifest
 


### PR DESCRIPTION
Closes #554

Three small doc/comment accuracy fixes, one PR:

1. **`docs/monitoring.md:199`** — documented `./pithead stop`, which doesn't exist. The real command is `down` (dispatch case at `pithead:5455`). Grepped all docs for `pithead stop`: this was the only occurrence.
2. **`docs/releasing.md:34`** — hardcoded a stale example version (`1.0.3`; actual `VERSION` is `1.6.1`). Reworded to "`VERSION` holds the last released version" so the note can't go stale again.
3. **`docker-compose.yml:512`** — comment called the dashboard "A small Flask + SQLite app". It's aiohttp (`build/dashboard/mining_dashboard/web/server.py` imports `from aiohttp import web`; `build/dashboard/pyproject.toml` depends on `aiohttp>=3.10.11`). Fixed the comment; no behavior change.

## Test plan

- [x] `make lint-docs-voice` — passes
- [x] `make lint-md` — passes
- [x] `make lint` — all targets pass except `lint-proto` (requires a local Docker daemon, unavailable in this sandbox; unrelated to this docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)