### PR TITLE
fix(#547): collector last-good cache stops PPLNS-share replay from a read race

### DIFF
--- a/build/dashboard/mining_dashboard/collector/pools.py
+++ b/build/dashboard/mining_dashboard/collector/pools.py
@@ -10,21 +10,29 @@ from mining_dashboard.config.config import (
     TARI_STATS_PATH,
 )
 
+# Last-good parse per stats-file path, mirroring how `_merge_proxy_summary` keeps the last-good
+# proxy totals (#141). p2pool rewrites these files in place, so a poll can catch one mid-write;
+# `{}` on that read would replay to every caller as "the counter just dropped to zero" (#547).
+_last_good = {}
+
 
 def _read_json(path):
     """
-    Safely loads a JSON file, returning an empty dictionary on failure.
-    Designed to prevent application crashes during transient file I/O operations.
+    Safely loads a JSON file. On failure, returns the last successfully parsed value for this
+    path (or an empty dictionary if it has never parsed) instead of `{}` — a transient mid-write
+    read must not look like a real reset to callers (#547).
     """
     if os.path.exists(path):
         try:
             with open(path) as f:
-                return json.load(f)
+                data = json.load(f)
+            _last_good[path] = data
+            return data
         except (json.JSONDecodeError, OSError):
             # Fail silently to allow the dashboard to continue running
             # even if a stats file is currently being written to.
             pass
-    return {}
+    return _last_good.get(path, {})
 
 
 def detect_pool_type(peers):
@@ -81,13 +89,17 @@ def get_p2pool_stats():
             "last_block_found": pool_stats.get("lastBlockFound", 0),
             "last_block_ts": pool_stats.get("lastBlockFoundTime", 0),
             "pplns_weight": pool_stats.get("pplnsWeight", 0),
-            "pplns_window": pool_stats.get("pplnsWindowSize", 0),
             "difficulty": pool_stats.get("sidechainDifficulty", 0),
             "total_hashes": pool_stats.get("totalHashes", 0),
             "shares_found": shares_total,
             "last_share_time": last_share_time,
         },
     }
+    # Only materialize pplns_window when the source actually reported it — a read failure
+    # (raw_pool == {}) must leave the key absent so downstream `.get("pplns_window",
+    # DEFAULT_PPLNS_WINDOW)` fallbacks apply, instead of always winning with a 0 (#547).
+    if "pplnsWindowSize" in pool_stats:
+        stats["pool"]["pplns_window"] = pool_stats["pplnsWindowSize"]
     return stats
 
 

--- a/build/dashboard/tests/collector/test_pools.py
+++ b/build/dashboard/tests/collector/test_pools.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import mining_dashboard.collector.pools as pools
@@ -14,6 +15,7 @@ from mining_dashboard.config.config import (
     SECOND_PER_BLOCK_MAIN,
     STRATUM_STATS_PATH,
 )
+from mining_dashboard.service.data_service import _shares_to_record
 
 
 class TestDetectPoolType:
@@ -72,6 +74,14 @@ class TestP2poolStats:
             s = get_p2pool_stats()
         assert s["p2p"]["type"] == "Unknown"
         assert s["pool"]["hashrate"] == 0
+
+    def test_missing_pplns_window_key_omitted(self):
+        # A failed pool-stats read (raw_pool == {}) must leave "pplns_window" OUT of the dict
+        # entirely, not fill it with 0 — a materialized 0 defeats every downstream
+        # `.get("pplns_window", DEFAULT_PPLNS_WINDOW)` fallback (#547).
+        with patch.object(pools, "_read_json", return_value={}):
+            s = get_p2pool_stats()
+        assert "pplns_window" not in s["pool"]
 
 
 class TestNetworkStats:
@@ -141,3 +151,84 @@ class TestReadJson:
         good = tmp_path / "good.json"
         good.write_text('{"a": 1}')
         assert pools._read_json(str(good)) == {"a": 1}
+
+    def test_read_failure_after_a_good_parse_serves_last_good(self, tmp_path):
+        # #547: p2pool rewrites these files in place, so a poll can catch one mid-write. That
+        # must serve the LAST successful parse, not {} — {} looks like a real reset to callers.
+        path = tmp_path / "stratum"
+        path.write_text('{"shares_found": 500}')
+        assert pools._read_json(str(path)) == {"shares_found": 500}
+
+        path.write_text("{not valid")  # caught mid-write
+        assert pools._read_json(str(path)) == {"shares_found": 500}
+
+        path.write_text('{"shares_found": 505}')  # write completes, next poll sees it
+        assert pools._read_json(str(path)) == {"shares_found": 505}
+
+    def test_never_parsed_still_returns_empty(self, tmp_path):
+        # No good parse to fall back to yet -> {} unchanged, no crash (#547 acceptance: the
+        # never-read case must behave exactly as before).
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid")
+        assert pools._read_json(str(bad)) == {}
+        assert pools._read_json(str(tmp_path / "nope.json")) == {}
+
+
+class TestPollSequenceReplay:
+    """#547: a mid-write read race on p2pool's stats files must not replay the cumulative
+    shares_found counter as fresh PPLNS shares, and must not blank pplns_window to 0."""
+
+    def _point_at_tmp(self, tmp_path, monkeypatch):
+        pool_path = tmp_path / "pool_stats"
+        stratum_path = tmp_path / "stratum"
+        p2p_path = tmp_path / "p2p"
+        monkeypatch.setattr(pools, "POOL_STATS_PATH", str(pool_path))
+        monkeypatch.setattr(pools, "STRATUM_STATS_PATH", str(stratum_path))
+        monkeypatch.setattr(pools, "P2P_STATS_PATH", str(p2p_path))
+        p2p_path.write_text("{}")
+        return pool_path, stratum_path
+
+    def test_good_fail_good_records_only_the_delta_and_keeps_the_window(
+        self, tmp_path, monkeypatch
+    ):
+        pool_path, stratum_path = self._point_at_tmp(tmp_path, monkeypatch)
+
+        def write_good(shares_total):
+            pool_path.write_text(json.dumps({"pool_statistics": {"pplnsWindowSize": 2160}}))
+            stratum_path.write_text(
+                json.dumps({"shares_found": shares_total, "last_share_found_time": 1})
+            )
+
+        # Poll 1: good read, cumulative total 500 -> baselines, records nothing (#129).
+        write_good(500)
+        s1 = get_p2pool_stats()
+        recorded, baseline = _shares_to_record(None, s1["pool"]["shares_found"])
+        total_recorded = recorded
+        assert s1["pool"]["pplns_window"] == 2160
+
+        # Poll 2: both stats files caught mid-write -> JSONDecodeError on each.
+        pool_path.write_text("{not valid")
+        stratum_path.write_text("{not valid")
+        s2 = get_p2pool_stats()
+        recorded, baseline = _shares_to_record(baseline, s2["pool"]["shares_found"])
+        total_recorded += recorded
+        assert s2["pool"]["shares_found"] == 500  # last-good served, NOT 0
+        assert s2["pool"]["pplns_window"] == 2160  # last-good served, NEVER 0
+
+        # Poll 3: write completes, cumulative total 505 (5 real shares since poll 1).
+        write_good(505)
+        s3 = get_p2pool_stats()
+        recorded, baseline = _shares_to_record(baseline, s3["pool"]["shares_found"])
+        total_recorded += recorded
+
+        assert total_recorded == 5  # not 505: the read-race poll never replayed the counter
+        assert baseline == 505
+
+    def test_never_read_case_unchanged(self, tmp_path, monkeypatch):
+        # First poll ever fails (files don't exist yet) -> {} behavior, no crash, no shares.
+        self._point_at_tmp(tmp_path, monkeypatch)
+        s = get_p2pool_stats()
+        assert s["pool"]["shares_found"] == 0
+        assert "pplns_window" not in s["pool"]
+        recorded, baseline = _shares_to_record(None, s["pool"]["shares_found"])
+        assert (recorded, baseline) == (0, 0)

--- a/build/dashboard/tests/collector/test_pools.py
+++ b/build/dashboard/tests/collector/test_pools.py
@@ -165,14 +165,6 @@ class TestReadJson:
         path.write_text('{"shares_found": 505}')  # write completes, next poll sees it
         assert pools._read_json(str(path)) == {"shares_found": 505}
 
-    def test_never_parsed_still_returns_empty(self, tmp_path):
-        # No good parse to fall back to yet -> {} unchanged, no crash (#547 acceptance: the
-        # never-read case must behave exactly as before).
-        bad = tmp_path / "bad.json"
-        bad.write_text("{not valid")
-        assert pools._read_json(str(bad)) == {}
-        assert pools._read_json(str(tmp_path / "nope.json")) == {}
-
 
 class TestPollSequenceReplay:
     """#547: a mid-write read race on p2pool's stats files must not replay the cumulative


### PR DESCRIPTION
Closes #547

## Summary

A mid-write read of p2pool's stats files (`_read_json`, `mining_dashboard/collector/pools.py`) returned `{}` on `JSONDecodeError`/`OSError` — anticipated in its own comment, but not tolerated by two downstream consumers:

1. **Share replay (HIGH).** `_shares_to_record` saw `shares_found` drop to 0, read that as a p2pool restart, and rebaselined to 0. The *next* good poll then replayed the entire cumulative share counter as fresh PPLNS shares.
2. **Window zero (MEDIUM).** `pools.py` always materialized `"pplns_window": pool_stats.get("pplnsWindowSize", 0)`, so a failed pool-stats read reported window 0 and defeated every downstream `.get("pplns_window", DEFAULT_PPLNS_WINDOW)` fallback (`metrics.py`, `data_service.py`, `algo_service.py`).

## Fix (once, at the collector boundary)

`build/dashboard/mining_dashboard/collector/pools.py`:
- `_read_json` now keeps a module-level `path -> last-good-parse` cache, mirroring how `_merge_proxy_summary` (`data_service.py`) already keeps last-good proxy totals (#141). On success it updates the cache; on failure it serves the last good parse instead of `{}`, and only returns `{}` before any successful parse for that path ("never-read" case, unchanged behavior).
- `get_p2pool_stats` no longer always materializes `pplns_window`; the key is emitted only when the source pool-stats file actually reported `pplnsWindowSize`, so the existing `DEFAULT_PPLNS_WINDOW` fallbacks (already `.get`-based everywhere they're consumed) become reachable.

This preserves the legitimate p2pool-restart case: a restart writes a *valid* file with a lower counter, which the existing `_shares_to_record` rebaseline already handles correctly (it rebaselines to the observed value, not to 0).

### Deviation from the issue spec

Skipped the **optional** two-step rebaseline for `_shares_to_record` (mirroring `_block_edges` / #336). With the collector fix in place, a backward move in `shares_found` can no longer be caused by a transient read race — `_read_json` never again surfaces a false `{}`/0 to callers. The only remaining trigger is a genuine p2pool restart, and the existing single-step rebaseline already handles that correctly today (`_shares_to_record(1000, 5) == (0, 5)`, then the next real shares delta from that new baseline — never a replay). Adding the two-step machinery would touch the call site's baseline state and its own test coverage for no remaining bug, so it's out of scope here per the issue's "only if cheap" caveat.

## Tests

Added to `build/dashboard/tests/collector/test_pools.py`:
- `TestReadJson::test_read_failure_after_a_good_parse_serves_last_good` — good parse → decode failure → good parse; asserts the failure serves the prior good value.
- `TestP2poolStats::test_missing_pplns_window_key_omitted` — a failed pool-stats read omits `"pplns_window"` entirely (not `0`).
- `TestPollSequenceReplay::test_good_fail_good_records_only_the_delta_and_keeps_the_window` — full poll sequence via the real collector (`get_p2pool_stats()` against real tmp files, patched stats paths) driving `_shares_to_record`: `good(total=500)` → both stats files caught mid-write → `good(total=505)`; asserts **5** shares recorded (not 505) and `pplns_window` stays `2160` throughout (never 0).
- `TestPollSequenceReplay::test_never_read_case_unchanged` — first-ever poll fails (files don't exist): no crash, 0 shares recorded, `pplns_window` absent.

### Test evidence

- `make test-dashboard` (1264 tests): **PASS**, total coverage 96.43% (`mining_dashboard/collector/pools.py` at 100%).
- `make test-patch-coverage`: **100%** patch coverage (7/7 new/changed lines covered; gate is ≥90%).
- `make lint`: ruff check/format, biome, yamllint, markdownlint, docs-voice, taplo all **PASS**. `lint-proto` (Tari gRPC proto, untouched by this change) couldn't run in this sandbox — no local Docker daemon — unrelated to this fix.
- **Revert-proof**: reverted `pools.py` only (kept the new tests), reran `tests/collector/test_pools.py` — the new/updated tests failed against the unfixed code (`test_missing_pplns_window_key_omitted`, `test_read_failure_after_a_good_parse_serves_last_good`, `test_good_fail_good_records_only_the_delta_and_keeps_the_window` — asserted 500, got 0 on the failed-read poll — and `test_never_read_case_unchanged`). Re-applied the fix and the full file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)