### PR TITLE
fix(#552): describe COMPOSE_PROFILES by the local_node token, not emptiness

### DIFF
--- a/pithead
+++ b/pithead
@@ -3989,11 +3989,20 @@ describe_change() {
         msg="Monero pruning ($old → $new) — enabling prunes existing blocks; disabling needs a full re-sync (pruned data can't be restored). Wipe the Monero data dir to fully re-sync."
         ;;
     COMPOSE_PROFILES)
-        flag=DEST
-        if [ -z "$new" ]; then
+        # #552: COMPOSE_PROFILES also carries payout_confirm/tari_payout_confirm (#381/#462), so an
+        # empty-vs-non-empty check misreads those toggles as a node switch. Decide by presence of the
+        # local_node token instead — only a real flip of that token is a node switch (DEST).
+        local old_local=false new_local=false
+        case ",$old," in *,local_node,*) old_local=true ;; esac
+        case ",$new," in *,local_node,*) new_local=true ;; esac
+        if [ "$old_local" = false ] && [ "$new_local" = true ]; then
+            flag=DEST
+            msg="Switching to a LOCAL Monero node — monerod will start and SYNC the blockchain (large download / disk use)."
+        elif [ "$old_local" = true ] && [ "$new_local" = false ]; then
+            flag=DEST
             msg="Switching to a REMOTE Monero node — the local monerod container will be STOPPED and removed (its on-disk data is kept)."
         else
-            msg="Switching to a LOCAL Monero node — monerod will start and SYNC the blockchain (large download / disk use)."
+            msg="Payout confirmation profile changed ($old → $new)."
         fi
         ;;
     MONERO_WALLET_ADDRESS)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -395,6 +395,18 @@ assert_contains "tor auto-heal disable names the manual fix" "$(run_sourced "$SA
 # Dev-fee donate-level (#173): a brief restart (INFO), shown as a percentage.
 assert_contains "donate-level is INFO" "$(run_sourced "$SANDBOX" describe_change PROXY_DONATE_LEVEL 0 1)" "INFO"
 assert_contains "donate-level shows pct" "$(run_sourced "$SANDBOX" describe_change PROXY_DONATE_LEVEL 0 1)" "0% → 1%"
+# COMPOSE_PROFILES (#552): the payout-confirm profiles (#381/#462) share this key with local_node,
+# so the node-switch text must key off the local_node token, not old/new emptiness.
+case "$(run_sourced "$SANDBOX" describe_change COMPOSE_PROFILES "" tari_payout_confirm)" in
+*"LOCAL Monero node"*) bad "payout-confirm enable is not a node switch" "got node-switch text" ;;
+*) ok "payout-confirm enable is not a node switch" ;;
+esac
+case "$(run_sourced "$SANDBOX" describe_change COMPOSE_PROFILES "local_node,payout_confirm" local_node)" in
+*"LOCAL Monero node"* | *"REMOTE Monero node"*) bad "payout-confirm disable (node stays local) is not a node switch" "got node-switch text" ;;
+*) ok "payout-confirm disable (node stays local) is not a node switch" ;;
+esac
+assert_contains "empty to local_node is a LOCAL switch" "$(run_sourced "$SANDBOX" describe_change COMPOSE_PROFILES "" local_node)" "LOCAL Monero node"
+assert_contains "local_node to empty is a REMOTE switch" "$(run_sourced "$SANDBOX" describe_change COMPOSE_PROFILES local_node "")" "REMOTE Monero node"
 assert_contains "wallet is DEST" "$(run_sourced "$SANDBOX" describe_change MONERO_WALLET_ADDRESS a b)" "DEST"
 assert_contains "xvb url is INFO" "$(run_sourced "$SANDBOX" describe_change XVB_POOL_URL a b)" "INFO"
 assert_contains "data_dir is DEST" "$(run_sourced "$SANDBOX" describe_change MONERO_DATA_DIR /a /b)" "DEST"


### PR DESCRIPTION
Closes #552

`describe_change` decided the COMPOSE_PROFILES description by empty-vs-non-empty of the new value; since #381/#462 the variable also carries `payout_confirm`/`tari_payout_confirm`, so those toggles were misreported as a destructive local/remote Monero node switch — on the confirm prompt and in the `--porcelain` output the dashboard renders. The fix keys the node-switch legs (and their DEST flag) off a real flip of the `local_node` token; unchanged-token deltas get a neutral INFO line ("Payout confirmation profile changed").

Tests (tier 1, next to the existing describe_change cases): four cases from the issue — payout-confirm enable/disable produce no node-switch text; `""→local_node` and `local_node→""` still produce the LOCAL/REMOTE switch text.

Revert-proof: with the pithead fix dropped, the two negative cases fail (`✗ payout-confirm enable is not a node switch`, `✗ payout-confirm disable (node stays local) is not a node switch`) and the two regression guards pass; with the fix restored all four pass.

Ponytail review: lean, no findings.

(Implementation started by a delegated agent, finished and verified by the session lead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)