### PR TITLE
fix(#549,#551): verify plaintext archives before restore; clean up + restart on backup failure

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -341,8 +341,10 @@ is typo'd away must fail loudly, not archive your onion keys in plaintext while 
 To write a plaintext archive on purpose, pass `--no-encrypt` (an empty passphrase at the interactive
 prompt does the same, with a warning).
 
-If the stack is running, `backup` stops it for a consistent copy and restarts it when done. Pass
-`-y` / `--yes` to skip both prompts (low-space warning, stop-the-stack question).
+If the stack is running, `backup` stops it for a consistent copy and restarts it when done. A
+failed backup (disk full mid-archive, for example) removes the partial archive and still restarts
+the stack before reporting the error. Pass `-y` / `--yes` to skip both prompts (low-space warning,
+stop-the-stack question).
 
 Include the blockchains (larger, slower) with:
 
@@ -360,7 +362,8 @@ To recover (on a new machine, or after a wipe) copy the archive back and run:
 
 `restore` detects the format from the archive itself — encrypted backups ask for the passphrase
 (or read `PITHEAD_BACKUP_PASSPHRASE`), and plaintext archives from earlier releases restore
-unchanged, no flag needed. A wrong passphrase fails before anything on disk is touched. `restore`
+unchanged, no flag needed. A wrong passphrase, or a corrupt or truncated archive of either format,
+fails before anything on disk is touched. `restore`
 prompts before overwriting anything (pass `-y` / `--yes` to skip). It puts the files back, fixes
 Tor key ownership so the onion address returns unchanged, and restores hashrate history and
 dashboard settings.

--- a/pithead
+++ b/pithead
@@ -1229,10 +1229,17 @@ stack_backup() {
             openssl enc -aes-256-cbc -pbkdf2 -iter 600000 -salt \
                 -pass fd:3 -out "$archive" 3< <(printf '%s' "$pass")); then
             rm -f "$archive"
+            [ "$was_running" -eq 1 ] && stack_up
             error "Backup failed — the partial archive was removed."
         fi
     else
-        (umask 077 && sudo tar -czf "$archive" -C "/" "${rel[@]}")
+        # sudo tar itself opens $archive, so a failed run can still leave a root-owned partial
+        # file behind — guard it the same way as the encrypted branch above (#551).
+        if ! (umask 077 && sudo tar -czf "$archive" -C "/" "${rel[@]}"); then
+            sudo rm -f "$archive"
+            [ "$was_running" -eq 1 ] && stack_up
+            error "Backup failed — the partial archive was removed."
+        fi
     fi
     sudo chown "$REAL_USER":"$REAL_USER" "$archive"
     chmod 600 "$archive"
@@ -1318,6 +1325,12 @@ stack_restore() {
         openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 \
             -pass fd:3 -in "$archive" 2>/dev/null 3< <(printf '%s' "$pass") |
             tar -tzf - >/dev/null 2>&1 ||
+            error "Archive fails integrity verification (tampered or truncated) — nothing was restored."
+    else
+        # Same full-stream verify as the encrypted branch above, minus the decrypt step: a
+        # truncated/corrupt plaintext archive would otherwise abort tar MID-EXTRACTION, leaving
+        # the live config half-overwritten (#549).
+        tar -tzf "$archive" >/dev/null 2>&1 ||
             error "Archive fails integrity verification (tampered or truncated) — nothing was restored."
     fi
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3513,6 +3513,22 @@ assert_rc "plaintext archive still restores" "$rc" "0"
 assert_eq "plaintext restore brings back the Caddyfile" "$(cat "$BK/Caddyfile")" "CADDY-ORIG"
 rm -f "$BK"/backups/pithead-backup-*
 
+# 6b) Truncated plaintext archive (#549): mirrors the encrypted-branch tamper/truncation check
+# (4b above) on the gzip path — a truncated archive must be rejected by a full-stream `tar -tzf`
+# verify BEFORE extraction, with nothing written, instead of half-overwriting config.json/.env.
+out="$(cd "$BK" && PATH="$BK/bin:$PATH" ./pithead backup -y --no-encrypt 2>&1)"
+plain_trunc_src="$(ls "$BK"/backups/pithead-backup-*.tar.gz 2>/dev/null | head -1)"
+config_before="$(cat "$BK/config.json")"
+env_before="$(cat "$BK/.env")"
+head -c "$(($(wc -c <"$plain_trunc_src") / 2))" "$plain_trunc_src" >"$BK/backups/truncated-plain.tar.gz"
+out="$(cd "$BK" && PATH="$BK/bin:$PATH" ./pithead restore -y "$BK/backups/truncated-plain.tar.gz" 2>&1)"
+rc=$?
+[ "$rc" -ne 0 ] && ok "truncated plaintext archive exits non-zero" || bad "truncated plaintext archive exits non-zero" "rc=0"
+assert_contains "truncated plaintext archive names integrity failure" "$out" "integrity"
+assert_eq "truncated plaintext archive leaves config.json untouched" "$(cat "$BK/config.json")" "$config_before"
+assert_eq "truncated plaintext archive leaves .env untouched" "$(cat "$BK/.env")" "$env_before"
+rm -f "$BK"/backups/pithead-backup-* "$BK/backups/truncated-plain.tar.gz"
+
 # 7) A failed encrypted backup (openssl dies mid-stream) removes the partial archive.
 cat >"$BK/bin/openssl" <<'EOF'
 #!/usr/bin/env bash
@@ -3541,6 +3557,51 @@ rc=$?
 [ "$rc" -ne 0 ] && ok "encrypted restore w/o passphrase exits non-zero" || bad "encrypted restore w/o passphrase exits non-zero" "rc=0"
 assert_contains "encrypted restore w/o passphrase explains" "$out" "PITHEAD_BACKUP_PASSPHRASE"
 rm -f "$BK"/backups/pithead-backup-*
+
+echo "== black-box: failed plaintext backup restarts a running stack, removes the partial archive (#551) =="
+# Companion to the #549 test above: a failed tar must not strand the stack stopped, nor leave a
+# partial (root-owned) archive that looks like a valid backup. Shadow tar to fail unconditionally
+# and simulate a RUNNING stack (was_running=1), so the failure path must call stack_up for real —
+# proven here by "compose up" showing up in the docker log, not by stubbing stack_up away.
+FB="$SANDBOX/failbackup"
+mkdir -p "$FB/build/tari" "$FB/data/tor" "$FB/data/dashboard" "$FB/bin"
+cp "$STACK" "$FB/pithead"
+cp "$ROOT/build/tari/config.toml.template" "$FB/build/tari/"
+cat >"$FB/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "[docker] $*" >>"${DOCKER_LOG:-/dev/null}"
+case "$*" in
+  "compose ps --status running -q") echo cid123 ;; # non-empty -> stack treated as RUNNING
+esac
+exit 0
+EOF
+cat >"$FB/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "chown" ] && exit 0
+exec "$@"
+EOF
+cat >"$FB/bin/tar" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FB/bin/docker" "$FB/bin/sudo" "$FB/bin/tar"
+cat >"$FB/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=FBTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$FB/config.json"
+
+out="$(cd "$FB" && DOCKER_LOG="$FB/docker.log" PATH="$FB/bin:$PATH" ./pithead backup -y --no-encrypt 2>&1)"
+rc=$?
+[ "$rc" -ne 0 ] && ok "failed plaintext backup (running stack) exits non-zero" || bad "failed plaintext backup (running stack) exits non-zero" "rc=0"
+assert_contains "failed plaintext backup names the cause" "$out" "partial archive was removed"
+assert_eq "failed plaintext backup leaves no archive behind" "$(ls "$FB"/backups/pithead-backup-* 2>/dev/null | head -1)" ""
+assert_contains "failed plaintext backup restarts the stack" "$(cat "$FB/docker.log" 2>/dev/null)" "compose up"
 
 echo "== black-box: reset-dashboard targets .env dirs, not config.json (#139) =="
 # reset-dashboard must wipe the LIVE deployment's data dirs (from .env), not a path the user may


### PR DESCRIPTION
Closes #549
Closes #551

## Summary

Two companion backup/restore failure-path fixes in the `pithead` CLI:

- **#549 — restore:** the plaintext branch of `stack_restore` extracted with `sudo tar -xzf` and no integrity check, so a truncated pre-#374 archive aborted mid-extraction with config/keys half-overwritten. The fix mirrors the encrypted branch's full-stream verify: `tar -tzf "$archive"` over the whole archive before extraction, refusing with the same integrity-error message and nothing written.
- **#551 — backup:** the plaintext `sudo tar` in `stack_backup` was unguarded — a failure tripped errexit, stranding a stopped stack and leaving a partial root-owned archive that looks valid. Both branches' failure paths now remove the partial archive, restart the stack when it was running (`was_running=1`), then `error` out with the cause. The explicit `if !` style already used by the encrypted branch — no ERR traps. Success path unchanged.

Docs: `docs/operations.md` backup/restore section updated to state both behaviours.

## Test evidence

Tier-1 (`tests/stack/run.sh`), full suite green with the fixes (run twice pre-rebase, backup/restore blocks re-verified post-rebase): **1273 passed, 0 failed**.

New assertions, all passing with the fixes:

```
✓ truncated plaintext archive exits non-zero
✓ truncated plaintext archive names integrity failure
✓ truncated plaintext archive leaves config.json untouched
✓ truncated plaintext archive leaves .env untouched
✓ failed plaintext backup (running stack) exits non-zero
✓ failed plaintext backup names the cause
✓ failed plaintext backup leaves no archive behind
✓ failed plaintext backup restarts the stack
```

Revert-proof (fixes reverted to develop's `pithead`, tests kept):

```
✗ truncated plaintext archive names integrity failure   (tar aborts mid-extraction: "truncated gzip input", on_err fires)
✗ failed plaintext backup names the cause               (errexit fires straight through, no cleanup message)
✗ failed plaintext backup restarts the stack            (docker log has "compose down" but no "compose up")
```

`make lint` passes on every surface except `lint-proto`, which needs the Docker daemon (not running on this dev box) — unrelated to this change. `make lint-sh`, `lint-md`, `lint-docs-voice` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)