### PR TITLE
fix(#548): guard the bundle-VERSION read so a bad bundle can't kill the control runner

### DIFF
--- a/pithead
+++ b/pithead
@@ -5045,8 +5045,17 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # still verify. Refuse unless the bundle's own top-level VERSION matches the host-derived
     # $tag, read WITHOUT extracting (the bundle unpacks to a fixed `pithead/` dir) so a mismatch
     # touches nothing on disk.
+    # #548: the extraction above is a plain assignment, so under errexit a tar failure (a bundle
+    # missing pithead/VERSION — corrupt download or a hostile non-pithead archive) would kill the
+    # runner outright instead of reaching _upg_fail below, leaving this result stuck at "running"
+    # and the claim never released. Guard it like every other dial/extract in this function.
     local bundle_version
-    bundle_version=$(tar -xzOf "$bundle" pithead/VERSION 2>/dev/null | tr -d '[:space:]')
+    if ! bundle_version=$(tar -xzOf "$bundle" pithead/VERSION 2>/dev/null | tr -d '[:space:]') ||
+        [ -z "$bundle_version" ]; then
+        rm -f "$bundle"
+        _upg_fail "the $tag bundle is missing pithead/VERSION (corrupt or not a pithead bundle) — refusing to install it. The stack keeps running v$PITHEAD_VERSION."
+        return 0
+    fi
     if [ "v$bundle_version" != "$tag" ]; then
         rm -f "$bundle"
         _upg_fail "the $tag download actually contains version ${bundle_version:-unknown} — refusing a version-mismatched (possible rollback) release (#376). The stack keeps running v$PITHEAD_VERSION."
@@ -5333,6 +5342,10 @@ control_run_pending() {
     # than an hour that no commit ever claimed, so a burst that is never committed cannot pile up
     # (staged intents already expire per-commit at 10 min; this bounds accumulation regardless).
     find "$cdir/staged" "$cdir/requests" -maxdepth 1 -type f -mmin +60 -delete 2>/dev/null || true
+    # Orphaned claims (#548): a claimed request whose handler died before the loop's own `rm -f
+    # "$claim"` below (an errexit gap, e.g.) leaves a `.claim.<pid>` file sitting directly in
+    # $cdir forever. Same age cutoff — a claim in flight never lives past a single drain.
+    find "$cdir" -maxdepth 1 -type f -name '.claim.*' -mmin +60 -delete 2>/dev/null || true
     local names name req claim n=0
     # Per-run cap (#33 hardening): a single trigger drains at most this many intents, so a flood in
     # the spool can't hold the root runner for an unbounded stretch — the leftovers wait for the

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -140,7 +140,11 @@ verify_release() {
     #    genuinely-signed bundle served at the $TAG URL is caught. Read without extracting — the same
     #    check control_upgrade makes before it unpacks a byte.
     local bv
-    bv="$(tar -xzOf "$bundle" pithead/VERSION 2>/dev/null | tr -d '[:space:]')"
+    # #548: plain assignment — under errexit a tar failure here would kill the smoke test with a
+    # bare trap instead of the die() message below. Guard it like every other check in this script.
+    if ! bv="$(tar -xzOf "$bundle" pithead/VERSION 2>/dev/null | tr -d '[:space:]')"; then
+        die "Published $TAG bundle is missing pithead/VERSION — cannot verify against the tag (corrupt or not a pithead bundle)."
+    fi
     [ "v$bv" = "$TAG" ] ||
         die "Published $TAG bundle contains VERSION '$bv' — a version mismatch (possible rollback). control_upgrade refuses this (#376)."
     ok "Bundle VERSION matches the tag ($TAG) — no rollback substitution."

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4950,6 +4950,10 @@ cp "$UPGB/pithead/pithead" "$UPGB/noversion/pithead/pithead"
 tar -czf "$UPGB/noversion.tar.gz" -C "$UPGB/noversion" pithead
 UUPG2="77777777-7777-4777-8777-777777777777"
 upgrade_intent "$UUPG" "v9.9.9"
+# The drain orders requests by mtime (ls -1tr); a same-second tie breaks differently between GNU
+# (CI) and BSD (macOS) ls, flipping which intent runs first — and the second one is throttled.
+# One second between the writes makes "UUPG first" deterministic everywhere.
+sleep 1
 printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG2" >"$UPGREQS/$UUPG2.json"
 (cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" \
     CURL_API_RESPONSE="$UPGB/api.json" CURL_BUNDLE="$UPGB/noversion.tar.gz" \

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4722,6 +4722,11 @@ touch -t 202001010000 "$REQS/stale-req.json"
 run_pending >/dev/null
 [ ! -f "$STAGED/stale.json" ] && ok "aged staged file swept" || bad "aged staged file swept" "still present"
 [ ! -f "$REQS/stale-req.json" ] && ok "aged request file swept" || bad "aged request file swept" "still present"
+# Orphaned claim sweep (#548): a `.claim.<pid>` left behind by a runner that died mid-dispatch
+# (the errexit gap this issue closes) is swept the same way as stale staged/request files.
+touch -t 202001010000 "$C/data/control/.claim.12345"
+run_pending >/dev/null
+[ ! -f "$C/data/control/.claim.12345" ] && ok "stale orphaned claim swept" || bad "stale orphaned claim swept" "still present"
 # Per-run intake cap: 60 pending intents → one run claims exactly 50 and LEAVES the remainder in
 # requests/ for the next path-unit fire (deterministic overflow — nothing is dropped). Invalid
 # JSON bodies keep each of the 60 on the cheap discard path; they still count against the cap.
@@ -4935,6 +4940,30 @@ assert_eq "version-mismatched (rollback) bundle is refused" "$(jq -r '.status' "
 assert_contains "rollback refusal names the mismatch" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rollback"
 assert_eq "rollback bundle extracts nothing (VERSION untouched)" "$(cat "$UPG/VERSION")" "1.3.1"
 assert_eq "rollback bundle never ran a new pithead" "$(cat "$UPG/upgrade-invocations.log" 2>/dev/null || echo none)" "none"
+
+# #548: a bundle that gzips fine but carries no pithead/VERSION at all (corrupt download, or a
+# hostile non-pithead archive) must fail cleanly — not kill the runner via errexit and leave the
+# result stuck at "running" with an orphaned claim and the rest of the queue abandoned.
+reset_upgrade_state
+mkdir -p "$UPGB/noversion/pithead"
+cp "$UPGB/pithead/pithead" "$UPGB/noversion/pithead/pithead"
+tar -czf "$UPGB/noversion.tar.gz" -C "$UPGB/noversion" pithead
+UUPG2="77777777-7777-4777-8777-777777777777"
+upgrade_intent "$UUPG" "v9.9.9"
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG2" >"$UPGREQS/$UUPG2.json"
+(cd "$UPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$UPG/curl.log" \
+    CURL_API_RESPONSE="$UPGB/api.json" CURL_BUNDLE="$UPGB/noversion.tar.gz" \
+    ./pithead control-run-pending >/dev/null 2>&1)
+assert_eq "bundle missing pithead/VERSION reports failed (not stuck running)" \
+    "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "missing-VERSION failure names the cause" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "missing pithead/VERSION"
+assert_eq "missing-VERSION bundle extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
+[ -z "$(find "$UPG/data/control" -maxdepth 1 -name '.claim.*' 2>/dev/null)" ] &&
+    ok "missing-VERSION failure releases its claim" || bad "missing-VERSION failure releases its claim" "claim file left behind"
+[ -f "$UPGRESULTS/$UUPG2.json" ] &&
+    ok "the rest of the queue is not abandoned (second intent still processed)" ||
+    bad "the rest of the queue is not abandoned (second intent still processed)" "no result written for the second intent"
+rm -f "$UPGRESULTS/$UUPG2.json" "$UPGREQS/$UUPG2.json"
 
 # Throttle: a second attempt straight after is refused for 10 minutes (egress-beacon guard).
 # The happy path replaced $U/pithead with the fake bundle's script — restore the real runner


### PR DESCRIPTION
Closes #548

## Summary

`control_upgrade` read the staged bundle's `pithead/VERSION` with a plain command-substitution assignment. Under `set -Eeuo pipefail`, a bundle that gzips fine but lacks `pithead/VERSION` (corrupt/truncated download, hostile non-pithead archive, future layout change) made the assignment fail and errexit killed the whole runner: the `{status:"running"}` result was never superseded, the `.claim.$$` file was orphaned, and the rest of the drained queue was abandoned.

- **`pithead` (control_upgrade)** — guard the assignment with the same `if ! ...` pattern every other dial/extract in the function uses, so the existing `_upg_fail` leg fires: result becomes `failed` with a missing-VERSION message, the bundle is removed, `return 0` keeps the drain loop going (which releases the claim via its own `rm -f "$claim"`).
- **`pithead` (control_run_pending)** — extend the hourly DoS sweep to also delete orphaned `.claim.*` files older than an hour, defense against any future crash leg.
- **`scripts/release-smoke.sh`** — same guard on the identical latent pattern in the rollback check, so a bad bundle dies with the `die()` message instead of a bare errexit.

## Test evidence (tier 1, `tests/stack/run.sh`)

New tests, following the existing `control upgrade verb (#59)` and stale-sweep patterns:

- bundle-without-VERSION → `status:"failed"` naming the cause, nothing extracted, no `.claim.*` left behind, and a second queued intent is still processed (queue not abandoned)
- stale `.claim.12345` → swept by the hourly sweep

Full suite with the fix: **1271 passed, 0 failed**. `make lint` passes.

Revert-proof (fix stashed, tests kept — the new tests fail and reproduce the exact bug):

```
✗ stale orphaned claim swept
✗ bundle missing pithead/VERSION reports failed (not stuck running)
    expected [failed], got [running]
✗ missing-VERSION failure names the cause
✗ missing-VERSION failure releases its claim
✗ the rest of the queue is not abandoned (second intent still processed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)