### PR TITLE
fix(#546): render the HTTPS onion vhost on the run that captures the address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The dashboard's HTTPS onion vhost now appears on the run that captures the address (#546).**
+  Enabling the onion via `apply` rendered the Caddyfile while the address was still `placeholder`;
+  the capture that runs after `docker compose up` only refreshed `.env`, so the `https://<onion>`
+  vhost (#360) never appeared until some unrelated later config change. `rotate-dashboard-onion`
+  restarted Caddy without regenerating the Caddyfile at all, so it kept serving the retired onion's
+  vhost with none for the new address. Enabling via `upgrade` had the same hole as `apply` (#355's
+  supported path). All three paths now regenerate the Caddyfile (and restart Caddy) the moment the
+  address is captured.
+
 ## [1.6.1] - 2026-07-16
 
 Supersedes 1.6.0, which was withdrawn before general adoption: the #459 post-publish smoke caught

--- a/pithead
+++ b/pithead
@@ -434,8 +434,14 @@ stack_upgrade() {
     # read it back into .env so `status`/`onion-client-key` show the address (mirrors apply's capture at
     # the end of a change). No-op when the onion is off or already captured. Without this, enabling the
     # onion via `upgrade` left the address uncaptured (apply's capture only runs when config changed).
+    # #546: and regenerate the Caddyfile + restart caddy, exactly like apply's capture — the render
+    # preamble above ran while the address was still the placeholder, so without this the HTTPS onion
+    # vhost (#360) would never appear (the next apply no-ops on an unchanged config).
     if [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] && { [ -z "${DASHBOARD_ONION:-}" ] || [ "${DASHBOARD_ONION:-}" == "placeholder" ]; }; then
-        provision_dashboard_onion && render_env
+        if provision_dashboard_onion && render_env; then
+            generate_caddyfile
+            docker compose restart caddy
+        fi
     fi
     update_current_symlink # #455: only a SUCCESSFUL upgrade moves the `current ->` pointer
     log "Stack upgraded."
@@ -3043,7 +3049,8 @@ rotate_dashboard_onion() {
     # doesn't carry it, so preserve the current value — otherwise rotate silently reset the flag to false
     # and the next apply/upgrade errored "Stack is not fully provisioned. Run setup first."
     DEPLOYMENT_COMPLETED=$(env_get DEPLOYMENT_COMPLETED)
-    render_env # persist the new address + keys
+    render_env         # persist the new address + keys
+    generate_caddyfile # #546: without this the Caddyfile still points at the retired address's vhost
     docker compose restart caddy >/dev/null 2>&1 || true
     log "Dashboard onion rotated."
     if [ "$DASHBOARD_ONION_CLIENT_AUTH" == "true" ]; then
@@ -3685,8 +3692,9 @@ EOF
         # CA) for the .onion — a .onion can't get a browser-trusted cert without a manual CA process, and
         # Tor already encrypts the tunnel, so the browser shows a one-time "accept the risk" prompt. SNI
         # (the .onion name) routes this apart from the LAN vhost, both on host-networked :443. Rendered
-        # only once the address is provisioned; a fresh enable serves HTTP now and adds HTTPS on the next
-        # apply once the address is captured.
+        # only once the address is provisioned; a fresh enable serves HTTP immediately, and apply,
+        # upgrade, and rotate-dashboard-onion regenerate this Caddyfile (and restart caddy) the moment
+        # the capture step lands the real address, so HTTPS appears in that same run (#546).
         if [ -n "${DASHBOARD_ONION:-}" ] && [ "${DASHBOARD_ONION:-}" != "placeholder" ]; then
             log "Adding HTTPS onion vhost (self-signed cert for the .onion)..."
             cat <<EOF >>"Caddyfile"
@@ -4509,10 +4517,15 @@ apply() {
         docker compose restart caddy
     fi
     # If the dashboard onion was just turned on, the recreated tor container generated its hostname;
-    # read it back into .env so `pithead status` can surface the address (#343). The onion already
-    # serves via Caddy regardless — this only makes the address visible to the operator.
+    # read it back into .env so `pithead status` can surface the address (#343) — and regenerate the
+    # Caddyfile + restart caddy so the HTTPS onion vhost (#360) actually appears this run instead of
+    # never (#546): a re-render off the committed .env sees no change and no-ops before ever reaching
+    # generate_caddyfile above.
     if [ "${DASHBOARD_ONION_ENABLED:-false}" == "true" ] && { [ -z "${DASHBOARD_ONION:-}" ] || [ "${DASHBOARD_ONION:-}" == "placeholder" ]; }; then
-        provision_dashboard_onion && render_env
+        if provision_dashboard_onion && render_env; then
+            generate_caddyfile
+            docker compose restart caddy
+        fi
     fi
     rm -f "$apply_marker"
     log "Configuration applied."

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1289,7 +1289,7 @@ assert_contains "rotate preserves DEPLOYMENT_COMPLETED across render_env (#356)"
 echo "== black-box: upgrade captures a just-enabled dashboard onion address (#356) =="
 # Enabling the onion via `upgrade` must read the freshly-generated .onion back into .env; apply's
 # capture only runs when the config changed, so an upgrade-based enable left the address uncaptured.
-upg_capture() { # <onion_enabled> <current_onion> -> prints "captured" if provision_dashboard_onion ran
+upg_capture() { # <onion_enabled> <current_onion> -> "captured" when provision runs, "caddyfile-rendered" per generate_caddyfile call
     cd "$SANDBOX" || exit
     # shellcheck disable=SC1090
     source "$STACK"
@@ -1303,20 +1303,129 @@ upg_capture() { # <onion_enabled> <current_onion> -> prints "captured" if provis
     render_env() { :; }
     mv() { :; }
     inject_service_configs() { :; }
-    generate_caddyfile() { :; }
+    generate_caddyfile() { echo caddyfile-rendered; }
     migrate_compose_project() { :; }
     is_source_checkout() { return 1; }
     log() { :; }
     docker() { :; }
     apply_tor_egress_firewall() { :; }
     compose_up_checked() { :; }
-    provision_dashboard_onion() { echo captured; }
+    provision_dashboard_onion() {
+        DASHBOARD_ONION="upgcap5678.onion"
+        echo captured
+    }
     export DASHBOARD_ONION_ENABLED="$1"
     export DASHBOARD_ONION="$2"
     stack_upgrade
 }
 assert_contains "upgrade captures the onion address when enabled + uncaptured (#356)" "$(upg_capture true '')" "captured"
 assert_not_contains "upgrade skips capture when the onion is disabled (#356)" "$(upg_capture false '')" "captured"
+
+# #546: the upgrade-path capture must ALSO regenerate the Caddyfile — the render preamble ran while
+# the address was still the placeholder, so a capture without a re-render leaves the HTTPS onion
+# vhost missing forever (the next apply no-ops on an unchanged config). Count generate_caddyfile
+# calls: once from the preamble, a second time only when the capture leg runs.
+upg_regen_on=$(upg_capture true '' | grep -c "caddyfile-rendered")
+case "$upg_regen_on" in
+2) ok "upgrade capture regenerates the Caddyfile (#546)" ;;
+*) bad "upgrade capture regenerates the Caddyfile (#546)" "generate_caddyfile ran $upg_regen_on time(s), want 2 (preamble + capture)" ;;
+esac
+upg_regen_off=$(upg_capture false '' | grep -c "caddyfile-rendered")
+case "$upg_regen_off" in
+1) ok "upgrade without onion renders the Caddyfile once (#546)" ;;
+*) bad "upgrade without onion renders the Caddyfile once (#546)" "generate_caddyfile ran $upg_regen_off time(s), want 1" ;;
+esac
+
+echo "== black-box: apply captures + renders the HTTPS onion vhost in the SAME run (#546) =="
+# Before the fix, apply's post-up capture block (provision_dashboard_onion && render_env) never
+# re-ran generate_caddyfile, so the https://<onion> vhost (#360) only appeared on some LATER,
+# unrelated apply — a re-apply that changed nothing hit the "No configuration changes detected"
+# early return before ever reaching generate_caddyfile. Drive the real apply() with the heavy
+# machinery stubbed away but generate_caddyfile left REAL, so the Caddyfile is the actual proof.
+AOC="$SANDBOX/apply-onion-capture"
+mkdir -p "$AOC"
+printf 'DEPLOYMENT_COMPLETED=true\n' >"$AOC/.env"
+caddy_apply_capture=$(
+    cd "$AOC" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }
+    ensure_onion_password() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    ensure_directories() { :; }
+    resolve_dashboard_host() { :; }
+    render_env() { :; }
+    mv() { :; }
+    env_changed_keys() { echo DASHBOARD_ONION_ENABLED; }
+    inject_service_configs() { :; }
+    provision_onion_client_auth() { :; }
+    provision_control_runner() { :; }
+    migrate_compose_project() { :; }
+    apply_tor_egress_firewall() { :; }
+    migrate_dashboard_data() { :; }
+    compose_up_checked() { :; }
+    announce_dashboard_url() { :; }
+    log() { :; }
+    warn() { :; }
+    docker() { :; }
+    # The shadowed capture: the address is unknown until the recreated tor container publishes it
+    # post-up, exactly like the real provision_dashboard_onion.
+    provision_dashboard_onion() { DASHBOARD_ONION="captured1234abcd.onion"; }
+    MONERO_ONION=mona.onion HOST_IP=box.lan DASHBOARD_SECURE=true DASHBOARD_AUTH_USER=admin \
+        DASHBOARD_AUTH_HASH_B64="$auth_hb64" NETWORK_PREFIX=172.28.0 DASHBOARD_ONION_ENABLED=true \
+        DASHBOARD_ONION=placeholder apply -y >/dev/null 2>&1
+    cat Caddyfile
+)
+assert_contains "apply: HTTPS onion vhost appears in the SAME apply run (#546)" "$caddy_apply_capture" "https://captured1234abcd.onion {"
+assert_contains "apply: HTTP onion vhost (bridge gateway) still present" "$caddy_apply_capture" "http://172.28.0.1 {"
+
+echo "== black-box: rotate-dashboard-onion regenerates the Caddyfile (#546) =="
+# Before the fix, rotate restarted caddy WITHOUT regenerating the Caddyfile, so caddy kept serving
+# the retired onion's HTTPS vhost and the new address had none. Seed a Caddyfile as if a PRIOR
+# generate_caddyfile ran for the old address, then rotate with a shadowed provision_tor that
+# returns a new one — the fix must leave exactly the new address's vhost behind.
+ROC="$SANDBOX/rotate-onion-capture"
+mkdir -p "$ROC/rot-tor/dashboard"
+cat >"$ROC/Caddyfile" <<'EOF'
+https://box.lan {
+    tls internal
+}
+
+http://172.28.0.1 {
+}
+
+https://oldaddr1234.onion {
+    tls internal
+}
+EOF
+caddy_rotate_capture=$(
+    cd "$ROC" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    require_env() { :; }
+    parse_and_validate_config() { :; }
+    load_preserved_state() { :; }
+    warn() { :; }
+    log() { :; }
+    docker() { :; }
+    sudo() { :; }
+    env_get() { :; }
+    render_env() { :; }
+    resolve_dashboard_host() { HOST_IP=box.lan; }
+    # The shadowed provision the issue asks for: a fresh address on rotate.
+    provision_tor() { DASHBOARD_ONION="newaddr5678.onion"; }
+    onion_client_key() { :; }
+    export DASHBOARD_ONION_ENABLED=true
+    export DASHBOARD_ONION_CLIENT_AUTH=false
+    TOR_DATA_DIR="$ROC/rot-tor" DASHBOARD_SECURE=true DASHBOARD_AUTH_USER=admin \
+        DASHBOARD_AUTH_HASH_B64="$auth_hb64" NETWORK_PREFIX=172.28.0 rotate_dashboard_onion -y >/dev/null 2>&1
+    cat Caddyfile
+)
+assert_not_contains "rotate drops the retired onion's HTTPS vhost (#546)" "$caddy_rotate_capture" "oldaddr1234.onion"
+assert_contains "rotate adds the new onion's HTTPS vhost in the same run (#546)" "$caddy_rotate_capture" "https://newaddr5678.onion {"
 
 echo "== unit: dashboard_onion_status surfaces the onion URL for status/doctor (#343) =="
 # The shared resolver behind both `pithead status` and `pithead doctor`: it returns the onion URL +


### PR DESCRIPTION
Closes #546

The `https://<onion>` SNI vhost (#360) is only emitted by `generate_caddyfile` once the dashboard onion address is captured — but every capture leg ran after the Caddyfile had been rendered with the placeholder, and none re-rendered it:

- **apply**: the post-up capture refreshed `.env` only; the next apply hit the "No configuration changes detected" early return before ever reaching `generate_caddyfile`, so the vhost never appeared (stock Tor Browser's HTTPS-First upgrade then fails the TLS handshake — dashboard unreachable over the onion).
- **upgrade**: the #356 capture leg had the identical hole (found during review; the delegated agent's fix covered apply+rotate, the session lead added the upgrade leg).
- **rotate-dashboard-onion**: restarted Caddy without regenerating at all — kept serving the retired onion's vhost with none for the new address.

All three legs now run `generate_caddyfile` + `docker compose restart caddy` the moment the address lands. Setup is unaffected (`provision_tor` captures before setup's render). The lying comment ("adds HTTPS on the next apply") is fixed.

Tests (tier 1): black-box `apply` and `rotate_dashboard_onion` drives with `generate_caddyfile` left REAL, asserting on the actual Caddyfile (vhost appears in the same apply run; rotate drops the old vhost and adds the new); shadow-driven `stack_upgrade` counting `generate_caddyfile` calls (2 with capture, 1 without).

Revert-proof (pithead fix dropped, tests kept): `✗ upgrade capture regenerates the Caddyfile`, `✗ apply: HTTPS onion vhost appears in the SAME apply run`, `✗ rotate drops the retired onion's HTTPS vhost`, `✗ rotate adds the new onion's HTTPS vhost in the same run` — all pass with the fix restored.

Ponytail review: one finding (duplicated shadow helper) — folded into the existing `upg_capture` helper, −20 lines.

CHANGELOG: Unreleased entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)