### PR TITLE
fix(#550): mkdir before chown -R in prepare_directories and reset_dashboard

### DIFF
--- a/pithead
+++ b/pithead
@@ -1061,9 +1061,11 @@ reset_dashboard() {
 
     log "Recreating data directories..."
     mkdir -p "$dashboard_dir" "$p2pool_dir"
-    # Owned by the non-root uid the dashboard + p2pool containers run as (#255).
-    sudo chown -R "$APP_UID":"$APP_GID" "$p2pool_dir" "$dashboard_dir"
     mkdir -p "$p2pool_dir/stats"
+    # Owned by the non-root uid the dashboard + p2pool containers run as (#255). mkdir runs first
+    # (above) and chown last (#550) — an unprivileged mkdir into an already chown -R'd tree
+    # EACCESes for any operator uid != APP_UID, and here that abort would land AFTER the data wipe.
+    sudo chown -R "$APP_UID":"$APP_GID" "$p2pool_dir" "$dashboard_dir"
     sudo chmod -R 755 "$p2pool_dir/stats"
 
     log "Bringing services back up..."
@@ -2665,12 +2667,14 @@ load_preserved_state() {
 prepare_directories() {
     log "Initializing data directories..."
     mkdir -p "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$TOR_DATA_DIR" "$DASHBOARD_DIR" "$CLEARNET_STATE_DIR"
+    mkdir -p "$P2POOL_DIR/stats"
 
     # Enforce permissions. Each data dir is owned by the uid its container runs as: Tor keeps its
     # alpine 'tor' user (100:101); the built images + tari run non-root as APP_UID:APP_GID (#255).
+    # mkdir runs first (above) and chown last (#550) — an unprivileged mkdir into an already
+    # chown -R'd tree EACCESes for any operator uid != APP_UID.
     sudo chown -R 100:101 "$TOR_DATA_DIR"
     sudo chown -R "$APP_UID":"$APP_GID" "$MONERO_DIR" "$TARI_DIR" "$P2POOL_DIR" "$DASHBOARD_DIR"
-    mkdir -p "$P2POOL_DIR/stats"
     sudo chmod -R 755 "$P2POOL_DIR/stats"
     # World-writable so the dashboard container (its own uid) can drop the clearnet auto-transition
     # marker (#234) while monerod/tari mount it read-only. It holds only non-secret state markers.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -865,6 +865,67 @@ rd_order=$(
 )
 assert_eq "reset-dashboard applies the firewall before 'compose up' (#291)" "$(fw_then_compose "$rd_order")" "firewall,compose,"
 
+echo "== regression: mkdir runs before chown -R of the same tree (#550) =="
+# prepare_directories and reset_dashboard used to `sudo chown -R` a data dir tree and only THEN
+# `mkdir -p` inside it (the p2pool stats subdir) — EACCES for any operator uid != APP_UID, since
+# the tree no longer belongs to them. ensure_directories already got this right (mkdir first,
+# ensure_owner/chown last); pin the other two to the same order. Shadow sudo/mkdir to log just the
+# two ops that matter, in call order — same technique as fw_then_compose above.
+mkdir_before_chown() { printf '%s\n' "$1" | grep -xE 'mkdir-stats|chown-p2pool' | tr '\n' ','; }
+
+pd_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    # shellcheck disable=SC2034  # read by the sourced prepare_directories, unseen here
+    MONERO_DIR="$SANDBOX/pd-monero"
+    # shellcheck disable=SC2034
+    TARI_DIR="$SANDBOX/pd-tari"
+    P2POOL_DIR="$SANDBOX/pd-p2pool"
+    TOR_DATA_DIR="$SANDBOX/pd-tor"
+    DASHBOARD_DIR="$SANDBOX/pd-dashboard"
+    # shellcheck disable=SC2034
+    CLEARNET_STATE_DIR="$SANDBOX/pd-clearnet"
+    log() { :; }
+    prepare_control_dirs() { :; }
+    mkdir() {
+        [[ "$*" == *"$P2POOL_DIR/stats"* ]] && echo mkdir-stats
+        return 0
+    }
+    sudo() {
+        [[ "$*" == *"chown -R"*"$P2POOL_DIR"* ]] && echo chown-p2pool
+        return 0
+    }
+    prepare_directories
+)
+assert_eq "prepare_directories: mkdir p2pool/stats precedes chown -R of P2POOL_DIR" \
+    "$(mkdir_before_chown "$pd_order")" "mkdir-stats,chown-p2pool,"
+
+rd2_order=$(
+    cd "$SANDBOX" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    env_get() { echo "/nonexistent/rd2-$1"; } # non-existent dirs -> the destructive rm is skipped
+    assert_safe_dir() { :; }
+    log() { :; }
+    docker() { :; }
+    apply_tor_egress_firewall() { :; }
+    compose_up_checked() { :; }
+    mkdir() {
+        [[ "$*" == *"/nonexistent/rd2-P2POOL_DATA_DIR/stats"* ]] && echo mkdir-stats
+        return 0
+    }
+    sudo() {
+        [[ "$*" == *"chown -R"*"/nonexistent/rd2-P2POOL_DATA_DIR"* ]] && echo chown-p2pool
+        return 0
+    }
+    reset_dashboard -y
+)
+assert_eq "reset-dashboard: mkdir p2pool/stats precedes chown -R of p2pool_dir" \
+    "$(mkdir_before_chown "$rd2_order")" "mkdir-stats,chown-p2pool,"
+
 echo "== unit: config_bool honours an explicit false (jq // false-coercion guard, #294) =="
 # Regression for #294: `.x // true` returns true even when x is explicitly false (jq treats false as
 # empty), which silently broke the #270 firewall opt-out (config false → .env stayed true) and


### PR DESCRIPTION
Closes #550

## Summary

`prepare_directories` and `reset_dashboard` ran `sudo chown -R` on a data-dir tree and *then* an unprivileged `mkdir -p "$P2POOL_DIR/stats"` inside it. For any operator uid ≠ 1000 (`APP_UID`/`APP_GID` are hardcoded), the mkdir gets EACCES and `set -e` aborts — in `reset-dashboard` the abort lands *after* the data wipe and *before* the containers come back up, stranding the install.

Both functions now match `ensure_directories`: every `mkdir -p` first, `chown -R` last. Pure reordering — no new helpers.

- `prepare_directories` (`pithead`): `mkdir -p "$P2POOL_DIR/stats"` moved above the two `chown -R` lines.
- `reset_dashboard` (`pithead`): `mkdir -p "$p2pool_dir/stats"` moved above the `chown -R`.

## Other `chown -R` sites checked

Grepped `pithead` for every `chown -R`; besides the two fixed:

- `stack_restore` (~line 1342): `chown -R 100:101 "$TOR_DATA_DIR"` — followed only by conditional `ensure_owner` calls on *other* trees; no unprivileged write into `TOR_DATA_DIR` after the chown. Clean.
- `ensure_owner` (~line 2787): the reference-correct helper (`ensure_directories` calls it after all mkdirs). Clean.
- `provision_onion_client_auth` (~line 2952): `$run chown -R` is the *last* op on `$hs_dir`, and every preceding write already uses the same `$run` (sudo) elevation. Clean.
- `CONTROL_DIR`/`CADDY_LOG_DIR`/`CLEARNET_STATE_DIR` in `prepare_control_dirs` are sibling trees under `data/`, not inside any chowned dir. Clean.

## Tests (tier 1, `tests/stack/run.sh`)

New ordering-pin regression block (`== regression: mkdir runs before chown -R of the same tree (#550) ==`), using the existing function-shadowing pattern (same technique as the #291 `fw_then_compose` block): shadow `mkdir`/`sudo` to emit `mkdir-stats` / `chown-p2pool` sentinels and assert the mkdir sentinel precedes the chown sentinel in both `prepare_directories` and `reset_dashboard`.

- `make lint`: pass
- `tests/stack/run.sh` on this branch: **1271 passed, 0 failed**
- Revert-proof: with the pithead reordering reverted (tests kept), both new assertions fail:

  ```text
  ✗ prepare_directories: mkdir p2pool/stats precedes chown -R of P2POOL_DIR
      expected [mkdir-stats,chown-p2pool,], got [chown-p2pool,mkdir-stats,]
  ✗ reset-dashboard: mkdir p2pool/stats precedes chown -R of p2pool_dir
      expected [mkdir-stats,chown-p2pool,], got [chown-p2pool,mkdir-stats,]
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
