### PR TITLE
test(#555): tier-1 fake upgrade bundle reproduces #544 (non-empty build/*)

### DIFF
--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4750,7 +4750,20 @@ UPGAUDIT="$UPG/data/control/audit/control.log"
 mkdir -p "$UPGREQS" "$UPG/data/control/staged" "$UPGRESULTS" "$UPG/data/control/audit"
 cp "$STACK" "$UPG/pithead"
 make_stubs "$UPG/bin"
+# The #544 abort ("Cannot unlink: Directory not empty") is GNU-tar behaviour — macOS's bsdtar -U
+# tolerates non-empty dirs and would mask the regression. CI (Linux) and real installs run GNU
+# tar; on a Mac with gnu-tar installed, route this block's tar there too so the bug reproduces.
+command -v gtar >/dev/null 2>&1 && ln -sf "$(command -v gtar)" "$UPG/bin/tar"
 printf '1.3.1' >"$UPG/VERSION"
+# #544/#555: a real release install carries non-empty build/* config-template mounts (see the
+# bundle's build/* below) — pre-seed them here with STALE content from "the previous version",
+# including a file the new bundle does NOT ship, so the extraction below runs over the exact shape
+# that made v1.6.0's single -U tar pass abort ("Cannot unlink: Directory not empty").
+mkdir -p "$UPG/build/monero" "$UPG/build/tari" "$UPG/build/tari-wallet"
+printf 'stale-monero-template-v1.3.1\n' >"$UPG/build/monero/bitmonero.conf.template"
+printf 'stale-tari-template-v1.3.1\n' >"$UPG/build/tari/config.toml.template"
+printf 'stale-tari-wallet-entry-v1.3.1\n' >"$UPG/build/tari-wallet/entrypoint.sh"
+printf 'leftover-from-a-removed-mount\n' >"$UPG/build/monero/leftover.conf" # absent from the new bundle
 # The stub curl serves the canned API response for the release-API URL and copies the fake bundle
 # for the download URL; every call is logged so the tests can assert what was (not) dialled.
 cat >"$UPG/bin/curl" <<'EOF'
@@ -4774,7 +4787,7 @@ EOF
 chmod +x "$UPG/bin/curl"
 # The fake v9.9.9 release bundle: a pithead that logs its invocation (and can be told to fail).
 UPGB="$SANDBOX/upgrade59-bundle"
-mkdir -p "$UPGB/pithead"
+mkdir -p "$UPGB/pithead/build/monero" "$UPGB/pithead/build/tari" "$UPGB/pithead/build/tari-wallet"
 cat >"$UPGB/pithead/pithead" <<'EOF'
 #!/usr/bin/env bash
 echo "new-pithead $*" >>upgrade-invocations.log
@@ -4783,6 +4796,12 @@ exit 0
 EOF
 chmod +x "$UPGB/pithead/pithead"
 printf '9.9.9' >"$UPGB/pithead/VERSION"
+# build/* members mirror the real bundle layout (scripts/release.sh's compose_build_mounts): every
+# release install carries these non-empty config-template mounts, which is exactly what #544/#555
+# tests below — a bundle with only the "pithead" script can't reproduce that bug.
+printf 'new-monero-template-v9.9.9\n' >"$UPGB/pithead/build/monero/bitmonero.conf.template"
+printf 'new-tari-template-v9.9.9\n' >"$UPGB/pithead/build/tari/config.toml.template"
+printf 'new-tari-wallet-entry-v9.9.9\n' >"$UPGB/pithead/build/tari-wallet/entrypoint.sh"
 tar -czf "$UPGB/bundle.tar.gz" -C "$UPGB" pithead
 printf '{"tag_name":"v9.9.9","html_url":"https://example.invalid/rel"}' >"$UPGB/api.json"
 seed_upgrade_env() { # <control-enabled true|false>
@@ -4922,6 +4941,20 @@ assert_eq "both GitHub dials went over Tor SOCKS" "$(grep -c -- '--socks5-hostna
 assert_eq "no cosign.pub -> no signature dial (documented fallback)" "$(grep -c '\.sig' "$UPG/curl.log" || true)" "0"
 assert_contains "upgrade start audited" "$(cat "$UPGAUDIT")" "\"action\":\"upgrade\",\"status\":\"started\""
 assert_contains "upgrade completion audited" "$(cat "$UPGAUDIT")" "\"action\":\"upgrade\",\"status\":\"upgraded\""
+# #544/#555: the extraction above ran over the non-empty build/* dirs pre-seeded near the top of
+# this block — this is the regression test for the withdrawn v1.6.0 bug. Pin b12082c's documented
+# semantics: pass 1 MERGES directories with plain tar (never purges), so new build/* content lands
+# and a stale file the new bundle doesn't carry survives untouched.
+assert_eq "build/* new content lands (monero template)" "$(cat "$UPG/build/monero/bitmonero.conf.template" 2>/dev/null)" "new-monero-template-v9.9.9"
+assert_eq "build/* new content lands (tari template)" "$(cat "$UPG/build/tari/config.toml.template" 2>/dev/null)" "new-tari-template-v9.9.9"
+assert_eq "build/* new content lands (tari-wallet entrypoint)" "$(cat "$UPG/build/tari-wallet/entrypoint.sh" 2>/dev/null)" "new-tari-wallet-entry-v9.9.9"
+assert_eq "a stale build/* file absent from the new bundle survives the merge" "$(cat "$UPG/build/monero/leftover.conf" 2>/dev/null)" "leftover-from-a-removed-mount"
+# No partial/temp extraction residue after a successful run: the staged bundle + tar log are gone.
+if [ ! -e "$UPG/data/control/staged/.$UUPG.tar.gz" ] && [ ! -e "$UPG/data/control/staged/.$UUPG.log" ]; then
+    ok "no staged bundle/log residue after a successful upgrade"
+else
+    bad "no staged bundle/log residue after a successful upgrade" "leftover staging file present"
+fi
 
 # #376 rollback guard: an attacker who controls the release response serves an OLDER (genuine)
 # bundle at the v9.9.9 URL — its VERSION (1.0.0) does not match the host-derived tag, so the


### PR DESCRIPTION
Closes #555

## Summary

The bug that withdrew v1.6.0 — #544, upgrade extraction aborting on the install's non-empty `build/*` dirs (fixed in b12082c) — had no regression test: the tier-1 fake bundle at `tests/stack/run.sh` contained only the `pithead` script, so the suite structurally could not reproduce it. Test-only change; `pithead` itself is untouched.

- **Bundle fixture enriched**: the fake v9.9.9 bundle now ships `build/monero/bitmonero.conf.template`, `build/tari/config.toml.template` and `build/tari-wallet/entrypoint.sh`, mirroring the real bundle layout from `scripts/release.sh`'s `compose_build_mounts` (the three `./build/*` paths docker-compose mounts at runtime). Every existing upgrade test in the `#59`/`#376` block shares this one fixture — no duplication.
- **Install pre-seeded**: the sandbox install carries non-empty `build/*` dirs with stale previous-version content, including `build/monero/leftover.conf`, a file the new bundle does NOT ship — the exact shape that made v1.6.0's single `-U` tar pass abort with "Cannot unlink: Directory not empty".
- **New assertions on the happy path**, pinning b12082c's documented semantics: the three new `build/*` files land, the stale extra file survives (pass 1 merges directories, never purges), and no staged bundle/log residue (`staged/.<id>.tar.gz` / `.log`) is left after the run.
- **GNU-tar routing**: the #544 abort is GNU-tar behaviour — macOS's bsdtar `-U` tolerates non-empty dirs and would mask the regression. CI (ubuntu) runs GNU tar natively; on a Mac with `gnu-tar` installed the block symlinks `gtar` into the stub bin so the bug reproduces locally too.

## Revert-proof (acceptance criterion)

With b12082c's `pithead` change reverted (`patch -R` of the pithead hunk only, test unchanged), the suite fails 6 assertions in the upgrade block, aborting with the exact #544 error:

```
pithead tests: 1264 passed, 6 failed

✗ failed upgrade points at the host CLI
    [the v9.9.9 release bundle failed to extract: build/monero: Cannot unlink: Directory not empty
    tar: build/tari: Cannot unlink: Directory not empty ...]
✗ upgrade result status
    expected [upgraded], got [failed]
✗ upgrade result carries the host-derived version
    expected [v9.9.9], got [null]
✗ the NEW pithead ran the upgrade
    [] missing [new-pithead upgrade]
✗ upgrade completion audited
    [... "action":"upgrade","status":"started" ... (no "upgraded" entry)]
✗ signed bundle with a valid signature upgrades
    expected [upgraded], got [failed]
```

With the fix in place (this branch, unmodified `pithead`):

```
pithead tests: 1270 passed, 0 failed
```

`make lint` passes (all surfaces, including `lint-sh` shellcheck + shfmt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
