### PR TITLE
fix(#566): resolve pithead's real path for bash-completion service lookup

### DIFF
--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -24,11 +24,30 @@ _pithead_services() {
 }
 
 _pithead() {
-    local cur prev compose
+    local cur prev compose self link i
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD - 1]}"
     if [ "$prev" = "logs" ]; then
-        compose="$(dirname "${COMP_WORDS[0]}")/docker-compose.yml"
+        # Resolve the real script path so this works when pithead is invoked by bare name from
+        # $PATH, not just from the install dir (#566). Bare name (no slash) -> ask the shell where
+        # it lives; fall back to the old behavior if that fails.
+        self="${COMP_WORDS[0]}"
+        case "$self" in
+        */*) ;;
+        *) self="$(command -v -- "$self" 2>/dev/null)" || self="${COMP_WORDS[0]}" ;;
+        esac
+        # Follow symlinks portably instead of GNU-only `readlink -f` — dev checkouts run this on
+        # macOS too (see the pithead script's other GNU/BSD splits). Bounded to dodge a symlink loop.
+        i=0
+        while [ -L "$self" ] && [ "$i" -lt 10 ]; do
+            link="$(readlink -- "$self" 2>/dev/null)" || break
+            case "$link" in
+            /*) self="$link" ;;
+            *) self="$(dirname "$self")/$link" ;;
+            esac
+            i=$((i + 1))
+        done
+        compose="$(dirname "$self")/docker-compose.yml"
         # shellcheck disable=SC2207  # service names never contain whitespace
         COMPREPLY=($(compgen -W "$(_pithead_services "$compose")" -- "$cur"))
         return

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2425,6 +2425,13 @@ out="$(bash -c "source '$COMP'; COMP_WORDS=('./pithead' 'up'); COMP_CWORD=1; _pi
 assert_eq "'up<tab>' offers up + upgrade" "$out" "up upgrade "
 out="$(bash -c "source '$COMP'; COMP_WORDS=('$ROOT/pithead' 'logs' ''); COMP_CWORD=2; _pithead; printf '%s\n' \"\${COMPREPLY[@]}\"" 2>/dev/null | tr '\n' ' ')"
 assert_eq "'logs <tab>' offers the compose service names" "$out" "tor monerod wallet-rpc tari tari-wallet p2pool xmrig-proxy dashboard docker-proxy docker-control caddy "
+# Bare-name invocation via $PATH from an unrelated cwd must resolve the same way (#566) — a
+# symlink in a fake bin dir stands in for a real `$PATH` install.
+BAREBIN="$SANDBOX/completion-barebin"
+mkdir -p "$BAREBIN"
+ln -sf "$ROOT/pithead" "$BAREBIN/pithead"
+out="$(cd "$SANDBOX" && PATH="$BAREBIN:$PATH" bash -c "source '$COMP'; COMP_WORDS=('pithead' 'logs' ''); COMP_CWORD=2; _pithead; printf '%s\n' \"\${COMPREPLY[@]}\"" 2>/dev/null | tr '\n' ' ')"
+assert_eq "'logs <tab>' resolves via \$PATH bare name from an unrelated cwd" "$out" "tor monerod wallet-rpc tari tari-wallet p2pool xmrig-proxy dashboard docker-proxy docker-control caddy "
 
 echo "== black-box: guards =="
 G="$SANDBOX/guard"


### PR DESCRIPTION
## Problem

`pithead-completion.bash:31` resolved the compose file with `dirname "${COMP_WORDS[0]}"`. When `pithead` is invoked by bare name from `$PATH` — the exact case the `complete ... pithead` registration is for — `dirname` yields `.`, so `pithead logs <TAB>` silently completes nothing unless the cwd happens to be the install dir.

## Fix

In `_pithead()`, before taking `dirname`:

1. If `${COMP_WORDS[0]}` has no slash, resolve it with `command -v -- "${COMP_WORDS[0]}"`.
2. Follow symlinks with a bounded, portable loop (max 10 hops) rather than GNU-only `readlink -f` — the `pithead` script itself has several GNU/BSD portability splits (`stat`, `sort -V`, `/proc` vs `sysctl`) because dev checkouts run on macOS too, so the completion script shouldn't assume GNU coreutils either. The bound guards against a self-referential symlink hanging the user's shell on tab-press.
3. Fall back to the original `${COMP_WORDS[0]}` if resolution fails at any step, so behavior is unchanged when `command -v`/`readlink` aren't available or don't resolve.
4. All failures are swallowed (`2>/dev/null`) — completion must never print, per the existing contract.

## Tests

`tests/stack/run.sh` already sources the completion file (`== completion: suggestions (#94) ==`), so I added a case there: install `pithead` into a fake `$PATH` dir via a symlink, `cd` to an unrelated sandbox dir, simulate `COMP_WORDS=(pithead logs '')`, and assert the same service list comes back as the direct-path case.

Ran the completion section as a foreground truncated slice (full `run.sh` needs Docker/sudo stubs for unrelated sections, not worth spinning up for a 2-file diff):

```
== completion: sources cleanly + no drift from the dispatch (#94) ==
  ✓ completion script sources cleanly in bash
  ✓ completion list == pithead's command list
  ✓ dispatch case labels == pithead's command list
  ✓ chainable commands are a subset of the command list
== completion: suggestions (#94) ==
  ✓ 'up<tab>' offers up + upgrade
  ✓ 'logs <tab>' offers the compose service names
  ✓ 'logs <tab>' resolves via $PATH bare name from an unrelated cwd
PASS=7 FAIL=0
```

Also did the manual proof described in the issue — installed a stub `pithead` + `docker-compose.yml` in a scratch "install dir", symlinked it into a fake `$PATH` bin dir, sourced the completion from an unrelated cwd, and simulated `COMP_WORDS`:

```
=== BEFORE fix (simulated old behavior) — bare name, unrelated cwd ===
old compose path resolves to: ./docker-compose.yml
services found (old): []

=== AFTER fix — bare name via $PATH, unrelated cwd ===
COMPREPLY: monerod p2pool

=== fallback: bare name unresolvable via command -v -> silent, falls back to old '.' behavior, no errors ===
rc=1 combined-output=[] COMPREPLY=<empty>

=== two-level symlink chain resolves correctly ===
COMPREPLY: monerod p2pool
```

`bash -n`, `shellcheck`, and `shfmt -d` are all clean on both changed files.

## Acceptance criteria

- [x] `pithead logs <TAB>` completes service names when invoked by bare name from any directory.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)