### PR TITLE
fix(dashboard): /api/state honors the snapshot's own timestamp

### DIFF
--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1505,7 +1505,9 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         # routes 404 when off, so this is display gating only, not a security control. Read at
         # call time (module attribute, not from-import) so tests can flip the flag per-app.
         "control_enabled": config.DASHBOARD_CONTROL_ENABLED,
-        "last_update": format_time_abs(time.time()),
+        # #559: use the snapshot's own timestamp, not now — a restored stale snapshot must
+        # report its true age; falls back to now only when timestamp is missing/0.
+        "last_update": format_time_abs(data.get("timestamp") or time.time()),
         "range": range_arg,
         "window": {"from": window[0], "to": window[1]} if window else None,
         "avg_window": avg_window,

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -1775,6 +1775,26 @@ class TestBuildState:
     def test_window_null_on_preset(self):
         assert build_state(_data(), _state_mgr(), "24h")["window"] is None
 
+    def test_last_update_reflects_snapshot_timestamp_not_now(self):
+        # #559: a restored stale snapshot (dashboard was down) must report its own age, not the
+        # current time -- otherwise stale workers/hashrate read as "just now" until the first
+        # post-restart collection cycle completes.
+        old_ts = time.time() - 6 * 3600
+        st = build_state(_data(timestamp=old_ts), _state_mgr(), "all")
+        assert st["last_update"] == views.format_time_abs(old_ts)
+        assert st["last_update"] != views.format_time_abs(time.time())
+
+    def test_last_update_falls_back_to_now_when_timestamp_missing(self):
+        # No "timestamp" key (or the pre-first-collection default of 0) -> fall back to now
+        # rather than showing "Never".
+        with patch("mining_dashboard.web.views.time.time", return_value=12345.0):
+            assert build_state(_data(), _state_mgr(), "all")["last_update"] == (
+                views.format_time_abs(12345.0)
+            )
+            assert build_state(_data(timestamp=0), _state_mgr(), "all")["last_update"] == (
+                views.format_time_abs(12345.0)
+            )
+
     def test_window_echoed_when_zoomed(self):
         # A custom zoom window is echoed so the client can render Reset / re-request on refresh.
         st = build_state(_data(), _state_mgr(), "all", window=(1000.0, 2000.0))


### PR DESCRIPTION
Closes #559

## Problem

`/api/state` always stamped `last_update` with the current time (`build/dashboard/mining_dashboard/web/views.py`, `build_state()`), even when `latest_data` was restored from a persisted snapshot that could be hours or days old (dashboard down, then back up before the first post-restart collection cycle). The UI showed pre-downtime workers/hashrate/sync state labeled "Last update: <right now>".

## Fix

`build/dashboard/mining_dashboard/web/views.py`, `build_state()`: use the snapshot's own `data.get("timestamp")`, falling back to `time.time()` only when it's missing or `0` (the `data_service.py` pre-first-collection default).

```python
"last_update": format_time_abs(data.get("timestamp") or time.time()),
```

## Frontend check (per issue ask)

Searched `mining_dashboard/web/static/` for anything keyed to `last_update`/staleness:

- `components.mjs:172` — `Last Update: ${state.last_update}` (plain text, header).
- `components.mjs:915` — the disconnected-banner ("Disconnected — showing data from …") — this is about *websocket* connectivity, not snapshot age.

No staleness badge or client-side freshness computation exists anywhere — the frontend just echoes the string verbatim in both spots. With this fix, both now show the snapshot's true age instead of "just now", so a stale snapshot reads as stale. No frontend change needed; there's no existing indicator that needs re-keying.

(Separately, `web/prometheus.py`'s `pithead_snapshot_age_seconds` already computes age from a `snapshot_ts` argument fed by the same `data["timestamp"]` field — confirms this is the right field to use.)

## Tests

`build/dashboard/tests/web/test_views.py`, `TestBuildState`:
- `test_last_update_reflects_snapshot_timestamp_not_now` — seeds an old `timestamp` (6h ago), asserts `last_update` reflects it, not `time.time()`.
- `test_last_update_falls_back_to_now_when_timestamp_missing` — no `timestamp` key, and `timestamp=0`, both fall back to current time (mocked).

Both are revert-proof: reverting the one-line fix in `views.py` (back to `format_time_abs(time.time())`) fails `test_last_update_reflects_snapshot_timestamp_not_now` immediately.

## Verification

- `cd build/dashboard && uv run --locked --extra test python -m pytest` — 1266 passed.
- `make test-dashboard` — 96.45% total coverage (gate: 80%).
- `make test-patch-coverage` — exits 0 (diff-cover reports "No lines with coverage information in this diff": the changed line lives inside a large multi-line `return {...}` dict literal that coverage.py's line-tracker attributes entirely to the `return {` line, so per-line diff attribution isn't possible here — a pre-existing tool limitation, not a coverage gap; the line is exercised by both new tests and the full `build_state` test suite).
- `make lint-py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)