### PR TITLE
chore: ponytail-audit cuts — dead CSS rules + duplicate ATOMIC_PER_XMR

### DIFF
--- a/build/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
+++ b/build/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
@@ -8,11 +8,9 @@ from mining_dashboard.config.config import (
     WALLET_RPC_PASSWORD,
     WALLET_RPC_USERNAME,
 )
+from mining_dashboard.service.earnings import ATOMIC_PER_XMR
 
 logger = logging.getLogger("MoneroWalletClient")
-
-# Monero amounts are reported in atomic units (piconero); 1 XMR = 1e12 atomic.
-ATOMIC_PER_XMR = 1_000_000_000_000
 
 
 class MoneroWalletClient:

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -679,9 +679,6 @@ button.upgrade-btn {
 .items-center {
   align-items: center;
 }
-.justify-end {
-  justify-content: flex-end;
-}
 .text-center {
   text-align: center;
 }
@@ -705,9 +702,6 @@ button.upgrade-btn {
 }
 .mr-2 {
   margin-right: 0.5rem;
-}
-.ml-1 {
-  margin-left: 8px;
 }
 .ml-2 {
   margin-left: 10px;


### PR DESCRIPTION
The applied output of a whole-repo over-engineering audit (three parallel passes: bash, Python, frontend/infra):

- `delete:` `.justify-end` and `.ml-1` — zero users across every template/module/test (verified by grep before cutting).
- `shrink:` `ATOMIC_PER_XMR` was redefined in the monero wallet client; now imported from `service/earnings.py` — the tari client already imports `MICRO_PER_XTM` from there, so the layering precedent exists, and one copy removes a drift risk.

Audit verdicts elsewhere: the bash surface (140 functions) and the Python package (12.2k LOC, all 5 deps earning their keep) came back **lean — zero cuts**. Two candidate findings were discarded on verification: `get_monero_logs` is the test-suite's patch seam (4 patch sites), and the two frontend poll loops differ in every failure leg, so folding them costs more abstraction than the duplication saves. One larger finding (~40 lines: hand-rolled modal overlays → native `<dialog>`) is deferred into #518, which rebuilds exactly those views — noted there.

Tests: dashboard 1264 passed, coverage 96.48%; ruff + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)