### PR TITLE
fix(dashboard): Healthchecks ping only counts 2xx as accepted

### DIFF
--- a/build/dashboard/mining_dashboard/service/healthchecks.py
+++ b/build/dashboard/mining_dashboard/service/healthchecks.py
@@ -11,9 +11,11 @@ Design notes:
   immediately, opens no socket, and logs nothing. Setting a URL is what turns it on.
 - **Always over Tor.** The ping rides the bridge Tor SOCKS proxy so the endpoint sees a Tor
   exit, not the host IP — it's never a clearnet beacon.
-- **Fails silently.** A ping that can't reach the endpoint (offline, or Tor momentarily down)
-  is logged at DEBUG only — never WARNING/ERROR — so the log stays quiet, consistent with the
-  stack's offline check discipline (#59).
+- **Fails silently, but rejection is loud.** A ping that can't *reach* the endpoint (offline, or
+  Tor momentarily down) is logged at DEBUG only, consistent with the stack's offline check
+  discipline (#59). A ping the endpoint *rejects* (non-2xx — a revoked or typo'd URL) is a
+  different failure mode: it doesn't self-heal, so it logs a WARNING, once, on the transition
+  from OK to rejected (and an INFO on recovery) — #560.
 - **Throttled.** :data:`interval` is a floor between pings; the loop calls every cycle but we
   only hit the network once per interval. The throttle clock only advances on a *successful*
   send, so while offline we keep retrying every cycle rather than backing off.
@@ -68,6 +70,7 @@ class HealthchecksClient:
         self._proxies = {"http": tor_proxy, "https": tor_proxy} if tor_proxy else None
         self._clock = clock
         self._last_ping = None  # monotonic time of the last *successful* send
+        self._last_ping_ok = None  # tri-state (None/True/False): logs only on state change
 
         if self.enabled:
             logger.info(
@@ -97,8 +100,8 @@ class HealthchecksClient:
         alive. Node-health alerting — monerod/Tari down while the box is up — is out of scope and
         handled in-stack by the Telegram alerter (#121), which can say more than a red check can.
 
-        Returns ``True`` if a request was sent and accepted, else ``False`` (not configured,
-        throttled, or the request failed).
+        Returns ``True`` if a request was sent and accepted (2xx), else ``False`` (not configured,
+        throttled, the request failed, or the endpoint rejected it — a revoked/typo'd URL, #560).
         """
         if not self.url:
             return False
@@ -108,10 +111,23 @@ class HealthchecksClient:
             return False
 
         try:
-            requests.get(self.url, timeout=_PING_TIMEOUT_SEC, proxies=self._proxies)
-            # Advance the throttle only on success so a transient outage keeps retrying.
-            self._last_ping = now
-            return True
+            resp = requests.get(self.url, timeout=_PING_TIMEOUT_SEC, proxies=self._proxies)
+            if 200 <= resp.status_code < 300:
+                if self._last_ping_ok is False:
+                    logger.info(
+                        "Healthchecks ping recovered (was failing, now %s).", resp.status_code
+                    )
+                self._last_ping_ok = True
+                # Advance the throttle only on success so a transient outage keeps retrying.
+                self._last_ping = now
+                return True
+            # A revoked/typo'd URL still passes the scheme check but never counts as accepted;
+            # don't advance the throttle so the next cycle retries. Warn once on the transition
+            # so a dead URL doesn't spam every cycle.
+            if self._last_ping_ok is not False:
+                logger.warning("Healthchecks ping rejected: HTTP %s.", resp.status_code)
+            self._last_ping_ok = False
+            return False
         except requests.RequestException as e:
             # Offline / Tor down / endpoint hiccup: the whole point is to survive these
             # silently — Healthchecks.io will alert on the missed ping. DEBUG, never noise.

--- a/build/dashboard/tests/service/test_healthchecks.py
+++ b/build/dashboard/tests/service/test_healthchecks.py
@@ -1,7 +1,7 @@
 """Tests for the Healthchecks.io dead-man's-switch client (Issue #79)."""
 
 import logging
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -68,15 +68,77 @@ class TestPingUnconfigured:
         assert not caplog.records
 
 
+def _resp(status_code):
+    r = MagicMock()
+    r.status_code = status_code
+    return r
+
+
 class TestPingSuccess:
     def test_healthy_ping_hits_the_url(self):
         # Pure liveness: every ping hits the configured URL (no /fail path — health-aware was
         # dropped; node-health alerting is the Telegram alerter's job, #121).
         c = _client()
-        with patch.object(hc_mod.requests, "get") as get:
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)) as get:
             assert c.ping() is True
         get.assert_called_once()
         assert get.call_args.args[0] == "https://hc-ping.com/abc"
+
+
+class TestPingRejected:
+    """#560: a non-2xx response (revoked/typo'd ping URL) must not count as accepted."""
+
+    def test_404_returns_false_and_does_not_advance_throttle(self, caplog):
+        clock = _Clock(1000.0)
+        c = _client(clock=clock, interval_seconds=60)
+        with (
+            patch.object(hc_mod.requests, "get", return_value=_resp(404)),
+            caplog.at_level(logging.WARNING, logger="Healthchecks"),
+        ):
+            assert c.ping() is False
+            # Throttle didn't advance -> the very next cycle retries immediately.
+            assert c.ping() is False
+        assert [r for r in caplog.records if r.levelno == logging.WARNING and "404" in r.message]
+
+    def test_200_still_returns_true_and_advances_throttle(self):
+        # Regression guard: the happy path must keep working once status is checked.
+        clock = _Clock(1000.0)
+        c = _client(clock=clock, interval_seconds=60)
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)):
+            assert c.ping() is True
+            assert c.ping() is False  # throttled, since the first ping DID advance the clock
+        clock.t += 61
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)):
+            assert c.ping() is True
+
+    def test_two_consecutive_404s_warn_only_once(self, caplog):
+        clock = _Clock(1000.0)
+        c = _client(clock=clock, interval_seconds=60)
+        with (
+            patch.object(hc_mod.requests, "get", return_value=_resp(404)),
+            caplog.at_level(logging.WARNING, logger="Healthchecks"),
+        ):
+            assert c.ping() is False
+            assert c.ping() is False
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+
+    def test_404_then_200_logs_recovery(self, caplog):
+        clock = _Clock(1000.0)
+        c = _client(clock=clock, interval_seconds=60)
+        with caplog.at_level(logging.DEBUG, logger="Healthchecks"):
+            with patch.object(hc_mod.requests, "get", return_value=_resp(404)):
+                assert c.ping() is False
+            with patch.object(hc_mod.requests, "get", return_value=_resp(200)):
+                assert c.ping() is True
+        recoveries = [r for r in caplog.records if "recovered" in r.message]
+        assert len(recoveries) == 1
+        assert recoveries[0].levelno == logging.INFO
+
+    def test_5xx_also_rejected(self):
+        c = _client()
+        with patch.object(hc_mod.requests, "get", return_value=_resp(503)):
+            assert c.ping() is False
 
 
 class TestTorRouting:
@@ -84,7 +146,7 @@ class TestTorRouting:
         # tor_proxy set → the ping rides the bridge Tor SOCKS (host IP hidden from the endpoint).
         proxy = "socks5h://172.28.0.25:9050"
         c = _client(tor_proxy=proxy)
-        with patch.object(hc_mod.requests, "get") as get:
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)) as get:
             assert c.ping() is True
         assert get.call_args.kwargs["proxies"] == {"http": proxy, "https": proxy}
 
@@ -104,7 +166,7 @@ class TestThrottle:
     def test_second_immediate_ping_is_throttled(self):
         clock = _Clock(1000.0)
         c = _client(clock=clock, interval_seconds=60)
-        with patch.object(hc_mod.requests, "get") as get:
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)) as get:
             assert c.ping() is True  # first ping goes out
             assert c.ping() is False  # within the interval → skipped
         get.assert_called_once()
@@ -112,7 +174,7 @@ class TestThrottle:
     def test_ping_again_after_interval_elapses(self):
         clock = _Clock(1000.0)
         c = _client(clock=clock, interval_seconds=60)
-        with patch.object(hc_mod.requests, "get") as get:
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)) as get:
             assert c.ping() is True
             clock.t += 61  # interval elapsed
             assert c.ping() is True
@@ -121,7 +183,7 @@ class TestThrottle:
     def test_zero_interval_pings_every_call(self):
         clock = _Clock(1000.0)
         c = _client(clock=clock, interval_seconds=0)
-        with patch.object(hc_mod.requests, "get") as get:
+        with patch.object(hc_mod.requests, "get", return_value=_resp(200)) as get:
             assert c.ping() is True
             assert c.ping() is True
         assert get.call_count == 2
@@ -148,7 +210,9 @@ class TestPingFailsSilently:
         clock = _Clock(1000.0)
         c = _client(clock=clock, interval_seconds=60)
         with patch.object(
-            hc_mod.requests, "get", side_effect=[requests.exceptions.ConnectionError("x"), None]
+            hc_mod.requests,
+            "get",
+            side_effect=[requests.exceptions.ConnectionError("x"), _resp(200)],
         ):
             assert c.ping() is False  # failed, no throttle advance
             assert c.ping() is True  # retried immediately, succeeded → throttle set


### PR DESCRIPTION
Closes #560

## Problem

`HealthchecksClient.ping()` (`build/dashboard/mining_dashboard/service/healthchecks.py:110-114`) did `requests.get(...)` with no status-code check, even though its own docstring claimed "sent and accepted". A 404 (revoked or typo'd ping URL — passes the scheme check) or a 5xx counted as an accepted ping: it advanced the throttle and logged nothing above DEBUG, so the operator's only signal was the eventual external "no ping" alert from Healthchecks.io itself.

## Fix

`HealthchecksClient.ping()`:
1. Only `200 <= status_code < 300` counts as accepted.
2. Non-2xx: return `False`, don't advance the throttle (so the next cycle retries), log a WARNING with the status code.
3. Rate-limited to state changes via a simple `_last_ping_ok` tri-state bool (`None`/`True`/`False`) — no existing debounce pattern in this file was reusable as-is (`tor_heal.py`'s streak/sustained-window pattern is built for flapping node probes, overkill for a binary HTTP-status check), so this follows the issue's own suggested fallback. WARNING on the OK→rejected transition, INFO on rejected→OK recovery; repeated failures/successes log nothing further.
3. Network-error handling (the `except requests.RequestException` / generic `except Exception` branches) is unchanged — still DEBUG-only, still returns `False`. Verified by the existing `TestPingFailsSilently` tests, which still pass unmodified in behavior (only their mocks were updated to return a 200 response object where they need one, since `resp.status_code` is now read).

Docstring and module design notes updated to describe the split between "can't reach the endpoint" (silent, DEBUG) and "endpoint rejects" (loud, WARNING/INFO).

## Tests

`build/dashboard/tests/service/test_healthchecks.py`, new `TestPingRejected`:
- `test_404_returns_false_and_does_not_advance_throttle` — 404 → `False`, throttle not advanced (immediate retry), one WARNING with "404" logged.
- `test_200_still_returns_true_and_advances_throttle` — regression guard for the happy path once status is checked.
- `test_two_consecutive_404s_warn_only_once` — exactly one WARNING across two failures.
- `test_404_then_200_logs_recovery` — recovery after a failure logs exactly one INFO.
- `test_5xx_also_rejected`.

Existing tests that mocked `requests.get` with a bare `MagicMock()` (whose `.status_code` isn't a real int) needed their mocks updated to return a 200 response — done via a small `_resp(status_code)` helper, no behavior changes to those tests' assertions.

Revert-proof: reverting the status-code check in `ping()` (back to unconditional `requests.get(...)` + `return True`) fails `test_404_returns_false_and_does_not_advance_throttle` immediately.

## Verification

- `cd build/dashboard && uv run --locked --extra test python -m pytest` — 1269 passed.
- `make test-dashboard` — 96.44% total coverage (gate: 80%).
- `make test-patch-coverage` — 100% on the changed file (`healthchecks.py`, 12/12 new/changed lines covered; gate: 90%).
- `make lint-py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)