### PR TITLE
fix(#556): apply --dry-run no longer writes generated node credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`apply --dry-run` no longer writes to `config.json` (#556).** A dry run that saw empty or
+  placeholder local-node RPC credentials still called `persist_node_credentials`, which generated
+  and saved a fresh password — breaking the documented read-only contract and, over the control
+  channel, dirtying the host-side staged copy the commit gate re-validates. `persist_node_credentials`
+  now skips the write while in dry-run mode; the generated credentials are still used in memory so
+  the preview stays accurate, and a real `apply` persists them exactly as before.
+
 ## [1.6.2] - 2026-07-17
 
 The ten v1.6-milestone findings from the 2026-07 full-repo scan (#546–#555): two high-severity

--- a/pithead
+++ b/pithead
@@ -69,6 +69,10 @@ readonly APP_GID=1000
 REBOOT_REQUIRED=false
 SKIP_OPTIMIZE=0
 SKIP_DEPS=0
+# Set by apply_dry_run before it calls parse_and_validate_config (#556). A dry run must only
+# read — persist_node_credentials checks this to skip its config.json write-back while still
+# generating in-memory creds so the preview/diff is realistic.
+PITHEAD_DRY_RUN=0
 
 # Detect whether we're being sourced (e.g. by the test suite). When sourced we only define
 # functions/constants and skip all side effects (cd, traps, running main).
@@ -2062,6 +2066,9 @@ cred_needs_generating() {
 # rather than aborting, since the in-memory creds still make this run work.
 persist_node_credentials() {
     local user="$1" pass="$2" tmp="${CONFIG_FILE}.tmp"
+    # A dry run must only read (#556) — the caller already generated the creds in memory for the
+    # render/diff; skip the write-back to config.json (or a staged control-channel copy).
+    [ "$PITHEAD_DRY_RUN" -eq 1 ] && return 0
     # Subshell umask (#368): the temp file carries the credentials, so it too must be owner-only
     # from creation — mv preserves its mode onto config.json.
     if (
@@ -4344,6 +4351,7 @@ describe_change() {
 apply_dry_run() {
     local porcelain="$1"
     local newenv="${ENV_FILE}.dryrun"
+    PITHEAD_DRY_RUN=1 # #556: parse_and_validate_config -> persist_node_credentials checks this
     {
         # NOTE: no ensure_onion_password here — it would write an auto-generated password into
         # the candidate config. A dry run must only read; an invalid candidate fails validation.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4082,6 +4082,46 @@ assert_contains "PITHEAD_CONFIG_FILE override is honoured" "$out" "37890" # nano
 out="$(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply --dry-run --porcelain 2>/dev/null)"
 assert_eq "without the override, config.json shows no changes" "$out" ""
 
+echo "== black-box: apply --dry-run is read-only re: node credential generation (#556) =="
+# Direct CLI leg: a fresh/hand-edited local-node config with placeholder/empty creds must not have
+# config.json rewritten by a --dry-run preview — the read-only contract #556 reported broken
+# (persist_node_credentials was writing the freshly-generated creds back to disk).
+printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"","node_password":""},
+          "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"},
+          "dashboard":{"secure":true,"host":"box.lan",
+                       "auth":{"username":"admin","password":"a control passphrase"},
+                       "control":{"enabled":true}} }\n' "$WALLET" >"$C/config.json"
+cp "$C/config.json" "$C/config.json.556before"
+out="$(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" NO_COLOR=1 ./pithead apply --dry-run 2>&1)"
+assert_rc "dry-run with placeholder node creds still validates" "$?" "0"
+if cmp -s "$C/config.json" "$C/config.json.556before"; then
+    ok "dry-run leaves config.json byte-identical with placeholder node creds (#556)"
+else
+    bad "dry-run leaves config.json byte-identical with placeholder node creds (#556)" "config.json was rewritten"
+fi
+assert_contains "dry-run still previews the credential it would generate (in-memory only)" "$out" "Monero node RPC credential"
+rm -f "$C/config.json.556before"
+
+# Control-channel leg: the same blank-creds config staged through the control path must not have
+# its ON-DISK STAGED COPY rewritten by the dry-run re-validation either (#556) — the same write,
+# one level removed, that used to leave a generated secret sitting in data/control/staged/ and
+# could dirty the diff a later commit gate re-derives from that file.
+UUID0="00000000-0000-4000-8000-000000000000"
+REQS0="$C/data/control/requests"
+STAGED0="$C/data/control/staged"
+RESULTS0="$C/data/control/results"
+jq -n --arg w "$WALLET" --arg id "$UUID0" '{id:$id, action:"preview", actor:"admin", config:{
+    monero:{mode:"local",wallet_address:$w,node_username:"",node_password:""},
+    tari:{wallet_address:"T"}, p2pool:{pool:"main"},
+    dashboard:{secure:true,host:"box.lan",auth:{username:"admin",password:"a control passphrase"},control:{enabled:true}}}}' >"$REQS0/$UUID0.json"
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead control-run-pending >/dev/null 2>&1)
+assert_eq "blank-creds preview status" "$(jq -r '.status' "$RESULTS0/$UUID0.json" 2>/dev/null)" "previewed"
+assert_eq "staged copy keeps the blank node_username — not persisted (#556)" "$(jq -r '.monero.node_username' "$STAGED0/$UUID0.json" 2>/dev/null)" ""
+assert_eq "staged copy keeps the blank node_password — not persisted (#556)" "$(jq -r '.monero.node_password' "$STAGED0/$UUID0.json" 2>/dev/null)" ""
+# Clean up: the result/staged counters the tests below assume start from a clean spool.
+rm -f "$RESULTS0/$UUID0.json" "$STAGED0/$UUID0.json"
+control_config main # restore config.json to the state control-run-pending below expects
+
 echo "== black-box: control-run-pending (#33) =="
 UUID1="11111111-1111-4111-8111-111111111111"
 UUID2="22222222-2222-4222-8222-222222222222"


### PR DESCRIPTION
Closes #556

## Summary

`apply --dry-run` is documented as read-only, but `parse_and_validate_config` → `persist_node_credentials` rewrote `config.json` (or a control-channel staged copy, via `PITHEAD_CONFIG_FILE`) whenever the local-node RPC credentials were empty or still the template placeholder. `apply_dry_run` already had a precedent for this exact problem — it skips `ensure_onion_password` with the comment "a dry run must only read" — so the fix reuses that same signal shape.

- Added a global `PITHEAD_DRY_RUN` flag (default `0`), set to `1` at the top of `apply_dry_run()`.
- `persist_node_credentials()` now returns early when `PITHEAD_DRY_RUN=1`, before it ever opens the temp file. The caller (`parse_and_validate_config`) still generates the credentials in memory (`MONERO_USER`/`MONERO_PASS`), so `render_env` and the preview/diff stay accurate — only the disk write is skipped.
- A real `apply` (dry_run=0) is unaffected: `PITHEAD_DRY_RUN` stays `0`, so credentials persist exactly as before.

## $CONFIG_FILE write-site audit

I enumerated every write to `$CONFIG_FILE` in `pithead` and checked whether it's reachable from `apply_dry_run`'s call tree (`parse_and_validate_config`, `load_preserved_state`, `resolve_dashboard_host`, `render_env`):

| Site | Function | Reachable from `apply_dry_run`? | Notes |
|---|---|---|---|
| `pithead:2073-2074` (`mv "$tmp" "$CONFIG_FILE"`) | `persist_node_credentials` | **Yes** — via `parse_and_validate_config` | **The bug.** Fixed by this PR. |
| `pithead:2124-2142`, `2162-2186` (`cat <<EOF >"$CONFIG_FILE"`) | `ensure_config_exists` | No | Only runs from `setup`, before `config.json` exists at all — `apply` requires it to already exist. |
| `pithead:2217` (`mv "$tmp" "$CONFIG_FILE"`) | `ensure_onion_password` | No | `apply_dry_run` explicitly skips calling this (pre-existing guard, the precedent for this fix). |
| `pithead:2740-2742` (`mv "$tmp" "$mdir/config.json"`) | `render_masked_config` | No | Writes a *different* file (`<control-dir>/masked/config.json`, a read-only prefill copy), not `$CONFIG_FILE`. Only called from `prepare_control_dirs`, which `apply_dry_run` never calls. |
| `pithead:3132` (`cp "$CONFIG_FILE" "${CONFIG_FILE}.bak-*"`) | `rotate_secrets` (backup) | No | Only reachable from the `rotate-secrets` subcommand, not `apply --dry-run`. |
| `pithead:3141` (`persist_node_credentials` call inside rotate) | `rotate_secrets` | No | Same — `rotate-secrets` only. |
| `pithead:4907` (`cp "$staged" "$CONFIG_FILE"`) | `control_commit` | No | The real commit path (`apply -y` territory), guarded separately by `control_approval_gate`; not the dry-run preview leg. |

`validate_worker_endpoints` and `validate_energy_config` (also called from `parse_and_validate_config`) are read-only `jq` queries — no writes. `load_preserved_state`, `resolve_dashboard_host`, and `render_env` (the rest of `apply_dry_run`'s call tree) only read `.env`/`$CONFIG_FILE` or write to the `.env.dryrun` scratch file, never `$CONFIG_FILE`.

**`persist_node_credentials` was the only write-on-read side effect reachable from the dry-run path.**

## Files changed

- `pithead` — `PITHEAD_DRY_RUN` flag (near the other global flags, ~line 72), guard in `persist_node_credentials` (~line 2069), flag set in `apply_dry_run` (~line 4354).
- `tests/stack/run.sh` — two new tests under `== black-box: apply --dry-run is read-only re: node credential generation (#556) ==`: a direct-CLI leg (fresh/placeholder local-node creds, `apply --dry-run`, byte-identical `config.json` before/after) and a control-channel leg (stage a blank-creds candidate through `control-run-pending`, assert the staged copy's `node_username`/`node_password` stay blank rather than getting persisted). The existing regression test that a *real* `apply` still persists generated creds (`tests/stack/run.sh:~3213-3223`) was already present and untouched.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Test evidence

Ran a truncated slice of `tests/stack/run.sh` (everything through the new tests) in the foreground — the full suite takes >10 min and CI runs it in full:

```
== black-box: apply --dry-run is read-only re: node credential generation (#556) ==
  ✓ dry-run with placeholder node creds still validates
  ✓ dry-run leaves config.json byte-identical with placeholder node creds (#556)
  ✓ dry-run still previews the credential it would generate (in-memory only)
  ✓ blank-creds preview status
  ✓ staged copy keeps the blank node_username — not persisted (#556)
  ✓ staged copy keeps the blank node_password — not persisted (#556)
SLICE RESULT: 943 passed, 0 failed
```

### Revert-proof

Reverted only the `pithead` fix (kept the new tests), reran the same slice — all 3 new assertions fail exactly as expected:

```
  ✓ dry-run with placeholder node creds still validates
  ✗ dry-run leaves config.json byte-identical with placeholder node creds (#556)
      config.json was rewritten
  ✓ dry-run still previews the credential it would generate (in-memory only)
  ✓ blank-creds preview status
  ✗ staged copy keeps the blank node_username — not persisted (#556)
      expected [], got [admin]
  ✗ staged copy keeps the blank node_password — not persisted (#556)
      expected [], got [KSZhBN8qEfom72aaHyXmE7k3DRErJnzi]
SLICE RESULT: 939 passed, 3 failed
```

Re-applied the fix, reran — back to 943 passed, 0 failed.

Also ran: `bash -n pithead`, `bash -n tests/stack/run.sh`, `shfmt -d -i 4` (clean, no diff), `bash scripts/lint-docs-voice.sh` (clean), and a ponytail-review pass over the diff (no findings — reuses the existing `ensure_onion_password`-skip pattern, no new abstractions, `net: 0 lines possible`).

Not merging — leaving this for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)