### PR TITLE
fix(#557): guard three friendly-error branches unreachable under errexit

### DIFF
--- a/pithead
+++ b/pithead
@@ -369,9 +369,11 @@ verify_release_images() {
     local suffix repo sha image out
     for suffix in tor monero p2pool xmrig-proxy dashboard; do
         repo="${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-${suffix}"
-        sha="$(compose_pinned_digest "$suffix")"
-        [ -n "$sha" ] ||
+        # #557: plain `sha="$(...)"` aborts under errexit on a no-match grep BEFORE this error()
+        # fires — `if !` suspends errexit for the assignment so the crafted diagnostic is reachable.
+        if ! sha="$(compose_pinned_digest "$suffix")" || [ -z "$sha" ]; then
             error "cosign.pub is present but pithead-${suffix} is not digest-pinned in docker-compose.yml — cannot bind verification to the bytes compose pulls; refusing (#451). A signed release bundle pins every first-party image by @sha256 (#461)."
+        fi
         image="${repo}@${sha}"
         if ! out=$(cosign verify --key cosign.pub --private-infrastructure "$image" 2>&1); then
             # Strip control chars: cosign's stderr echoes registry-supplied bytes, and error()
@@ -1083,8 +1085,15 @@ reset_dashboard() {
     # Idempotent if it's already present from `up`; closes the gap where running reset-dashboard on a
     # `down` stack would otherwise bring p2pool up with no firewall installed at all.
     apply_tor_egress_firewall
-    # Route through compose_up_checked so a subnet collision (#180) gets explained, like every other up-path.
-    compose_up_checked -d dashboard p2pool
+    # Route through compose_up_checked so a subnet collision (#180) gets explained, like every other
+    # up-path. #557: wrapped in `if !` (mirroring the apply call site) — a bare call lets a compose
+    # failure trip errexit inside compose_up_checked's own pipeline, before the #180 explanation
+    # prints and before the mktemp temp file is cleaned up.
+    if ! compose_up_checked -d dashboard p2pool; then
+        warn "Data directories were reset, but dashboard/p2pool did NOT come back up ('docker compose up' failed)."
+        warn "Fix the cause shown above, then re-run '$0 up' to bring them back."
+        exit 1
+    fi
 }
 
 # --- Backup / Restore ---

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -668,8 +668,11 @@ main() {
         local suffix repo digest
         for suffix in "${IMAGES[@]}"; do
             repo="$(image_for "$suffix")"
-            digest="$(manifest_digest "$repo:$STAGING_TAG")"
-            [ -n "$digest" ] || die "Cannot resolve a staged digest for $repo:$STAGING_TAG — stage first."
+            # #557: same errexit-unreachable shape as stage_push above — a bare assignment aborts
+            # under errexit once retries are exhausted, before this die() fires.
+            if ! digest="$(manifest_digest "$repo:$STAGING_TAG")" || [ -z "$digest" ]; then
+                die "Cannot resolve a staged digest for $repo:$STAGING_TAG — stage first."
+            fi
             set_digest "$suffix" "$repo@$digest"
         done
     else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -362,8 +362,11 @@ stage_push() {
             log "  digest: $repo@sha256:<dry-run>"
             continue
         fi
-        digest="$(manifest_digest "$repo:$STAGING_TAG")"
-        [ -n "$digest" ] || die "Could not read the pushed manifest digest for $repo:$STAGING_TAG."
+        # #557: plain `digest="$(...)"` aborts under errexit once retries are exhausted, BEFORE this
+        # die() fires — `if !` suspends errexit for the assignment so the message is reachable.
+        if ! digest="$(manifest_digest "$repo:$STAGING_TAG")" || [ -z "$digest" ]; then
+            die "Could not read the pushed manifest digest for $repo:$STAGING_TAG."
+        fi
         set_digest "$suffix" "$repo@$digest"
         log "  digest: $repo@$digest"
     done

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -801,6 +801,23 @@ assert_rc "un-pinned compose + key -> pull aborts (#451)" "$?" "1"
 assert_contains "un-pinned abort explains the missing digest bind" "$out" "not digest-pinned"
 assert_eq "un-pinned -> cosign never asked to verify a tag" "$(cat "$VRI/cosign.log")" ""
 
+# #557: run_sourced disables errexit (`set +e`, right after sourcing) for every test above, which
+# happens to mask a real bug: the bare `sha="$(compose_pinned_digest ...)"` assignment aborts under
+# pithead's own `set -Eeuo pipefail` BEFORE the crafted error() above ever runs, so a real invocation
+# got a silent abort instead of the "not digest-pinned" diagnostic. Reproduce with errexit left ON —
+# source directly and call the function, no run_sourced/`set +e`.
+out557_vri="$(
+    (
+        cd "$UNPINNED" || exit 1
+        PATH="$VRI/bin:/usr/bin:/bin"
+        source "$STACK" 2>/dev/null
+        verify_release_images
+    ) 2>&1
+)"
+assert_rc "un-pinned + key, real errexit -> still aborts (#557)" "$?" "1"
+assert_contains "un-pinned + key, real errexit -> crafted message still reaches the operator (#557)" \
+    "$out557_vri" "not digest-pinned"
+
 # Source checkout: locally built images are unsigned by design — skipped, silently and completely.
 mkdir -p "$VRI/build/dashboard"
 touch "$VRI/build/dashboard/Dockerfile"
@@ -1844,6 +1861,33 @@ assert_contains "exhausted retries -> empty digest (caller dies)" "$exhaust_out"
 # The smoke stage's raw manifest read has the same read-after-push exposure — wire it through the retry.
 assert_contains "smoke stage reads the manifest via retry_registry_read (#429)" \
     "$(cat "$REL")" "retry_registry_read buildx_inspect \"\$repo:\$STAGING_TAG\" --raw"
+
+# #557: the test above disables errexit (`set +eu`, right after sourcing) to observe the bare helper
+# in isolation, which happens to mask a real bug in stage_push itself: the bare
+# `digest="$(manifest_digest ...)"` assignment aborts under release.sh's own `set -euo pipefail`
+# BEFORE the crafted die() ever runs, so a real release run got a silent abort instead of a diagnosed
+# digest-read failure. Reproduce with errexit left ON, driving the REAL stage_push (not the bare
+# helper) so the actual call site is exercised.
+# shellcheck disable=SC1090,SC2034  # dynamic source; the globals are consumed inside stage_push
+stage_push_out="$(
+    (
+        cd "$ROOT" || exit 1
+        set --
+        source "$REL" 2>/dev/null
+        DRY_RUN=0
+        IMAGES=(tor)
+        REGISTRY="ghcr.io/test"
+        REGISTRY_READ_RETRIES=1
+        REGISTRY_READ_BACKOFF=0
+        WORKDIR="$SANDBOX/stagepush557"
+        mkdir -p "$WORKDIR"
+        buildx_inspect() { return 1; } # every registry read fails -> retries exhaust
+        stage_push
+    ) 2>&1
+)"
+assert_rc "stage_push, real errexit: retries-exhausted digest read still aborts (#557)" "$?" "1"
+assert_contains "stage_push, real errexit: crafted die() reaches the operator (#557)" \
+    "$stage_push_out" "Could not read the pushed manifest digest"
 
 echo "== unit: release.sh preflight checks the lint toolchain (#426) =="
 # A reimaged release box loses shellcheck/shfmt/node/uv — the v1.3.0 cut died ~1 min in mid-gate with a
@@ -3818,6 +3862,43 @@ out="$(cd "$R" && SUDO_LOG=/dev/null PATH="$R/bin:$PATH" ./pithead reset-dashboa
 rc=$?
 assert_rc "reset refuses with no data dirs in .env" "$rc" "1"
 assert_contains "reset refuse message" "$out" "refusing to guess"
+
+echo "== black-box: reset-dashboard's final compose_up_checked is if!-guarded, not bare (#557/#180) =="
+# Before #557: the last compose_up_checked call in reset_dashboard was bare (every OTHER call site
+# wraps it in `if !`, per the contract at compose_up_checked's own definition). A bare call let a real
+# compose failure trip errexit INSIDE compose_up_checked's own `docker compose up | tee` pipeline,
+# before the #180 subnet-collision explanation printed. Real `./pithead` (not sourced) arms
+# `trap on_err ERR` exactly like production, so this reproduces the actual operator experience.
+RD557="$SANDBOX/reset557"
+mkdir -p "$RD557/bin" "$RD557/envdir/dashboard" "$RD557/envdir/p2pool"
+cp "$STACK" "$RD557/pithead"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$RD557/bin/sudo"
+cat >"$RD557/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+"compose up"*)
+    echo "Error response from daemon: Pool overlaps with other one on this address space" >&2
+    exit 1
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$RD557/bin/docker" "$RD557/bin/sudo"
+cat >"$RD557/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+HOST_IP=box.lan
+NETWORK_SUBNET=172.28.0.0/24
+DASHBOARD_DATA_DIR=$RD557/envdir/dashboard
+P2POOL_DATA_DIR=$RD557/envdir/p2pool
+EOF
+printf '{ "monero":{"mode":"local","wallet_address":"%s"}, "tari":{"wallet_address":"T"} }\n' "$WALLET" >"$RD557/config.json"
+out="$(cd "$RD557" && PATH="$RD557/bin:$PATH" ./pithead reset-dashboard -y 2>&1)"
+rc=$?
+assert_rc "reset-dashboard: compose failure still exits 1 (fail-closed unchanged)" "$rc" "1"
+assert_contains "reset-dashboard: #180 subnet-collision explanation reaches the operator (#557)" \
+    "$out" "Docker refused the stack's bridge subnet"
+assert_contains "reset-dashboard: crafted failure message names the retry command" "$out" "did NOT come back up"
 
 echo "== black-box: rotate-secrets regenerates the internal credentials (#378) =="
 # One command rotates the local Monero RPC password, the "auto" stratum password, and

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -806,6 +806,7 @@ assert_eq "un-pinned -> cosign never asked to verify a tag" "$(cat "$VRI/cosign.
 # pithead's own `set -Eeuo pipefail` BEFORE the crafted error() above ever runs, so a real invocation
 # got a silent abort instead of the "not digest-pinned" diagnostic. Reproduce with errexit left ON —
 # source directly and call the function, no run_sourced/`set +e`.
+# shellcheck disable=SC1090  # dynamic source: the script under test
 out557_vri="$(
     (
         cd "$UNPINNED" || exit 1

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1889,6 +1889,36 @@ assert_rc "stage_push, real errexit: retries-exhausted digest read still aborts 
 assert_contains "stage_push, real errexit: crafted die() reaches the operator (#557)" \
     "$stage_push_out" "Could not read the pushed manifest digest"
 
+# #557: main()'s --resume-promote branch has the exact same shape (a second, separately-written
+# instance of the bug — found in review, not part of the original 3 sites). Drive the real `main`
+# (preflight/ghcr_login stubbed no-op) with RESUME_PROMOTE=1 and errexit left ON.
+# shellcheck disable=SC1090,SC2034  # dynamic source; the globals are consumed inside main
+resume_out="$(
+    (
+        cd "$ROOT" || exit 1
+        set --
+        source "$REL" 2>/dev/null
+        preflight() { :; }
+        ghcr_login() { :; }
+        promote() { :; }
+        sign_images() { :; }
+        publish() { :; }
+        DRY_RUN=0
+        RESUME_PROMOTE=1
+        IMAGES=(tor)
+        TAG="v9.9.9"
+        STAGING_TAG="v9.9.9-rc.1"
+        REGISTRY="ghcr.io/test"
+        REGISTRY_READ_RETRIES=1
+        REGISTRY_READ_BACKOFF=0
+        buildx_inspect() { return 1; } # every registry read fails -> retries exhaust
+        main
+    ) 2>&1
+)"
+assert_rc "--resume-promote, real errexit: retries-exhausted digest read still aborts (#557)" "$?" "1"
+assert_contains "--resume-promote, real errexit: crafted die() reaches the operator (#557)" \
+    "$resume_out" "Cannot resolve a staged digest"
+
 echo "== unit: release.sh preflight checks the lint toolchain (#426) =="
 # A reimaged release box loses shellcheck/shfmt/node/uv — the v1.3.0 cut died ~1 min in mid-gate with a
 # bare `shellcheck: not found`. check_release_toolchain must fail fast BEFORE building, naming the tool


### PR DESCRIPTION
## Summary

Three friendly-error branches were unreachable because `set -e` aborted on
the assignment/pipeline **before** the crafted diagnostic ran. Fail-closed
behavior is unchanged in all three cases — only the operator-facing message
was being lost, replaced by a generic "pithead aborted unexpectedly (exit 1)".

1. **`verify_release_images`** (`pithead`) — `sha="$(compose_pinned_digest "$suffix")"` aborted on a no-match grep before `error "…not digest-pinned… (#451)"` could fire.
2. **`stage_push`** (`scripts/release.sh`) — `digest="$(manifest_digest …)"` aborted once GHCR-read retries were exhausted, before `die "Could not read the pushed manifest digest"` could fire.
3. **`reset_dashboard`** (`pithead`) — the final `compose_up_checked` call was bare (every other call site wraps it in `if !`). A compose failure tripped errexit inside `compose_up_checked`'s own `docker compose up | tee` pipeline, before the #180 subnet-collision explanation printed and before the `mktemp` temp file was cleaned up.

**+ a 4th identical site found in review, same fix shape:** `main()`'s `--resume-promote` branch (`scripts/release.sh`) has an independent copy of the exact same bare `digest="$(manifest_digest …)"` assignment, aborting under errexit before `die "Cannot resolve a staged digest for … — stage first."` could fire. Out of #557's originally-named 3 sites, but the same bug, so it's fixed alongside them here rather than filed separately.

Same fix shape at each site: wrap the assignment/call in `if ! …; then <diagnostic>; fi` so the failure is a *condition*, not a top-level command — this suspends errexit for exactly that statement, mirroring the existing pattern already used at every other `compose_up_checked` call site (`pithead:196`, `pithead:3163`, `pithead:4527`).

Ponytail-review pass: one-line `if !` guards mirroring an existing codebase pattern verbatim; tests reuse existing sandbox/fixture conventions exactly. Nothing to cut.

## Evidence

Empirically verified with real bash (not zsh — zsh's `set -e`/pipefail semantics for command-substitution assignments differ and will hide this class of bug):

```
$ bash -c 'set -euo pipefail; f(){ return 1; }; echo before; x="$(f)"; echo after'
before
$ echo $?
1
```
`"after"` never prints — a bare `var="$(failing_cmd)"` is a top-level command under errexit, unguarded by `if`/`&&`/`||`/`!`.

Reproduced against each of the four real sites pre-fix (crafted message silently missing, rc 1) and confirmed present post-fix:
- `verify_release_images` on an un-pinned compose + cosign.pub: pre-fix → silent abort; post-fix → `[ERROR] cosign.pub is present but pithead-tor is not digest-pinned … (#451)`.
- `stage_push` with retries exhausted: pre-fix → silent abort; post-fix → `✗ Could not read the pushed manifest digest for …`.
- `--resume-promote` with retries exhausted: pre-fix → silent abort; post-fix → `✗ Cannot resolve a staged digest for … — stage first.`.
- `reset_dashboard` with a faked subnet-overlap `docker compose up` failure, driven through the real `./pithead reset-dashboard -y` (not sourced, so `trap on_err ERR` is armed exactly like production): pre-fix → generic abort only; post-fix → the #180 explanation **and** the new "did NOT come back up" guidance both print, rc still 1.

## Tests (tier 1 — `tests/stack/run.sh`)

Added 4 new test blocks (9 assertions), one per site, each specifically **not** disabling errexit after sourcing (the existing tests in this file call `set +e`/`set +eu` right after sourcing, which happens to mask this exact bug class — that's why it shipped unnoticed):
- `verify_release_images`: reuses the existing `#451` un-pinned-compose fixture, sources directly (no `run_sourced`), asserts the crafted message is present.
- `stage_push`: drives the real function (not the bare `manifest_digest` helper) with `buildx_inspect` forced to fail and retries exhausted.
- `--resume-promote`: drives the real `main()` (`preflight`/`ghcr_login`/`promote`/`sign_images`/`publish` stubbed no-op) with `RESUME_PROMOTE=1` and the same forced-failure `buildx_inspect`.
- `reset_dashboard`: full black-box run of `./pithead reset-dashboard -y` with a fake `docker` that fails `compose up` with a subnet-overlap message; asserts both the #180 explanation and the new failure guidance appear.

### Revert-proof

Temporarily reverted each fix (`git stash` of just the source files, one at a time) and reran the truncated slice: exactly the corresponding "crafted message reaches the operator" assertion(s) failed each time (the "still aborts" rc assertions kept passing, as expected — fail-closed is unaffected), while every other test stayed green. Restored each fix; full slice ends green (886 tests / 0 fail on the 3-site cut; the added 4th-site test independently verified 361/0 then 360/1 reverted then 361/0 restored on its own smaller slice).

Verified with truncated slices (`head -n <past the new tests> tests/stack/run.sh > tests/stack/slice.sh` + `exit 0`, run from the repo root, deleted after) — the full suite is documented to run >10 min and was not run in full.

```
bash -n pithead && bash -n scripts/release.sh && bash -n tests/stack/run.sh   # all OK
shfmt -d -i 4 pithead scripts/release.sh tests/stack/run.sh                  # no diff
```

## Test plan

- [x] `bash -n` on all changed files
- [x] `shfmt -d -i 4` — no diff (4-space, already formatted)
- [x] Truncated `tests/stack/run.sh` slices: all green, 0 fail
- [x] Revert-proof per site: fix removed → exactly that site's message assertion(s) fail; fix restored → all green
- [x] Rebased onto latest `origin/develop`

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)