### PR TITLE
fix(#558): bound is_valid_host's length (dashboard.host validation)

### DIFF
--- a/pithead
+++ b/pithead
@@ -1856,9 +1856,11 @@ check_tor_clearnet_egress() {
 # True if $1 is a plausible hostname or IP literal — i.e. only the characters a host can contain
 # (letters, digits, dot, hyphen, colon for IPv6). Used to validate dashboard.host before it's
 # rendered into the Caddyfile site address: anything with whitespace, a newline, or Caddy-significant
-# characters ({ } /) could break or inject into the generated Caddyfile.
+# characters ({ } /) could break or inject into the generated Caddyfile. Length-capped at 253 (#558),
+# mirroring the worker-host charset check elsewhere in this file (control_worker_apply's host guard,
+# validate_worker_endpoints) — the max length of a DNS name.
 is_valid_host() {
-    [[ "$1" =~ ^[A-Za-z0-9.:_-]+$ ]]
+    [[ "$1" =~ ^[A-Za-z0-9.:_-]{1,253}$ ]]
 }
 
 # Best-effort detection of the host's IANA timezone (Linux + macOS), used as the dashboard

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -368,6 +368,12 @@ run_sourced "$SANDBOX" is_valid_host "a/b" >/dev/null 2>&1
 assert_rc "rejects slash" "$?" "1"
 run_sourced "$SANDBOX" is_valid_host "" >/dev/null 2>&1
 assert_rc "rejects empty" "$?" "1"
+# #558: length-bound at 253 (a DNS name's max length), mirroring the worker-host charset check
+# (control_worker_apply / validate_worker_endpoints) rather than leaving this one check unbounded.
+run_sourced "$SANDBOX" is_valid_host "$(printf 'a%.0s' $(seq 1 253))" >/dev/null 2>&1
+assert_rc "accepts 253 chars (the DNS name bound)" "$?" "0"
+run_sourced "$SANDBOX" is_valid_host "$(printf 'a%.0s' $(seq 1 254))" >/dev/null 2>&1
+assert_rc "rejects 254 chars, past the bound (#558)" "$?" "1"
 
 echo "== unit: describe_change =="
 assert_contains "prune is DEST" "$(run_sourced "$SANDBOX" describe_change MONERO_PRUNE 1 0)" "DEST"


### PR DESCRIPTION
## Summary — important finding first

**#558's core claim is stale.** The issue says `dashboard.host` reaches
`generate_caddyfile` with no charset check. That's no longer true: `is_valid_host()`
already validates it inside `parse_and_validate_config` (`pithead:1856` def, called at
`pithead:2538`), added by **#130 / PR #155 (commit 831277f, 2026-06-04)** — which
predates #558's own baseline commit (`6317162`). It already rejects `{`/`}`/space/newline
with a clear message naming the key and value:

```
[ERROR] dashboard.host must be a hostname or IP address — only letters, digits, dots,
hyphens, and colons (got "evil.lan { respond /pwn 200 } X").
```

and it's already covered by both a unit test suite (`tests/stack/run.sh:356-370`:
accepts hostname/IPv4/IPv6, rejects space/braces/slash/empty) and a black-box test
(`tests/stack/run.sh:2482-2494`: a malicious `dashboard.host` rejected via real
`./pithead apply -y`, before any Caddyfile render). I verified this empirically against
`origin/develop` before writing any code — see Evidence below.

I'm not fabricating a duplicate fix for an already-closed hole. Per this repo's own
standing rule ("source of truth is the code... never invent a fact"), and ponytail's
first rung ("does this need to exist at all?") — it doesn't, the vulnerability #558
describes isn't there.

## What this PR actually does

One real, small gap remained: `is_valid_host`'s regex (`^[A-Za-z0-9.:_-]+$`) has no
length bound, unlike the sibling worker-host charset check elsewhere in this file
(`control_worker_apply`'s host guard, `validate_worker_endpoints`), which caps at 253 —
the max length of a DNS name. This PR adds the same `{1,253}` bound, mirroring that
existing pattern instead of writing a new one (as #558 itself asked: "reuse/mirror the
existing check").

IPv6 is left in place: `is_valid_host` already accepts it and that's already tested
(`accepts IPv6`, `fe80::1`) — #558 asked me to check whether IPv6 is documented before
*adding* it, not to remove an established, tested capability. Removing it would be a
behavior regression with no bearing on the issue.

Ponytail-review pass (x2): a 2-line regex tightening + 2 boundary-test assertions. Nothing to cut.

## Evidence

Reproduced pre-existing rejection against `origin/develop` (no code changes) with a
malicious `dashboard.host`:
```
$ ./pithead apply -y   # dashboard.host = "evil.lan { respond /pwn 200 } X"
[pithead] Parsing configuration...
[ERROR] dashboard.host must be a hostname or IP address — only letters, digits, dots,
hyphens, and colons (got "evil.lan { respond /pwn 200 } X").
```
rc 1, no Caddyfile written — this is the exact acceptance criterion #558 names ("No
unvalidated config value reaches the Caddyfile"), already satisfied before this PR.

Also confirmed a raw newline in `dashboard.host` is caught even earlier, by
`parse_and_validate_config`'s general control-character guard (every config string is
scanned for control chars before any field-specific check runs).

## Tests (tier 1 — `tests/stack/run.sh`)

Added 2 boundary assertions to the existing `is_valid_host` unit block:
- 253 chars (the new bound) → accepted (regression guard, matches the worker-host cap).
- 254 chars (one past the bound) → rejected.

### Revert-proof

`git stash` of just `pithead` (leaving the new tests in place) and reran the truncated
slice: the "rejects 254 chars, past the bound" assertion failed as expected (254-char
value silently accepted pre-fix), "accepts 253 chars" still passed. Restored the fix;
both green.

Verified with truncated slices (`head -n <past the new tests> tests/stack/run.sh >
tests/stack/slice.sh` + `exit 0`, run from the repo root, deleted after) — the full
suite runs >10 min and was not run in full. Two slices checked: the `is_valid_host` unit
block (98 pass / 0 fail) and the black-box `dashboard.host` apply test further down (496
pass / 0 fail, confirming the pre-existing black-box coverage still passes unchanged).

```
bash -n pithead && bash -n tests/stack/run.sh   # OK
shfmt -d -i 4 pithead tests/stack/run.sh        # no diff
```

## Test plan

- [x] `bash -n` on both changed files
- [x] `shfmt -d -i 4` — no diff (4-space, already formatted)
- [x] Truncated slices: unit block 98/0, black-box block 496/0
- [x] Revert-proof: fix removed → the new 254-char assertion fails; fix restored → all green
- [x] Rebased onto latest `origin/develop`

Closes #558 (already substantively resolved by #130; this closes the remaining length-bound gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)