### PR TITLE
feat(#196): time-series persistence backbone (blocks/xvb/network/disk/worker history)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   future core form section (#529). A tier-1 test pins every path in it to an entry in
   `config.reference.json`.
 
+- **Time-series persistence backbone for five telemetry series (#196).** Five dedicated,
+  independently-retained SQLite tables — `blocks` (pool block-found events, permanent),
+  `xvb_history` (XvB scalars, ~5 min wall-clock, 30-day retention), `network_history` (Monero
+  difficulty/height/reward + pool hashrate, hourly, 90-day retention), `disk_growth` (monerod DB
+  size + host disk usage, hourly, permanent), and `worker_history` (per-rig hashrate + share
+  counts, ~5 min wall-clock batched write, 30-day retention). Additive tables (no new columns on
+  the existing `history` table, no row multiplication), each with a per-table "last successful
+  write" health signal so a silently-failing capture hook is visible. Backbone only — capture,
+  storage, retention, and a getter per series; charts/UI and `/api/state` exposure are deliberate
+  follow-ups.
+
 ### Changed
 
 - **The first-run wizard now asks a pool tier and a few shape questions, instead of hardcoding

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -98,6 +98,13 @@ _KHS_TO_HS = 1000
 # (~5 min) this is ~15 min of sustained failure.
 _XVB_REGISTER_FAIL_ALERT = 3
 
+# v1.7 telemetry backbone (#196 Wave-0) capture cadences. All wall-clock gated (`time.time() -
+# last >= N`), NOT `iteration_count % k` — the latter silently changes cadence if UPDATE_INTERVAL
+# is ever reconfigured.
+_XVB_HISTORY_CAPTURE_SEC = 300  # ~5 min
+_HOURLY_CAPTURE_SEC = 3600  # disk_growth + network_history
+_WORKER_HISTORY_CAPTURE_SEC = 300  # ~5 min
+
 
 def _parse_proxy_list_worker(w):
     """Parse one xmrig-proxy 6.x positional row into a worker dict.
@@ -404,6 +411,15 @@ class DataService:
         # Share-health delta baseline (#116): the previous poll's cumulative proxy /summary
         # totals; None until the first poll seeds it (and again after a counter reset).
         self._last_share_totals = None
+        # v1.7 telemetry backbone (#196 Wave-0) capture-cadence state — see the _*_CAPTURE_SEC
+        # constants above. `_last_blocks_found` baselines the cumulative pool blocks_found
+        # counter (reused via `_shares_to_record`, same re-baseline-on-restart contract as
+        # shares); the `_last_*` wall-clock stamps start at 0.0 so each series captures on its
+        # first eligible poll.
+        self._last_blocks_found = None
+        self._last_xvb_history_write = 0.0
+        self._last_hourly_capture = 0.0
+        self._last_worker_capture = 0.0
         # XvB raffle auto-registration (#263): wall-clock of the last successful register() call,
         # None until the wallet is first entered. Drives the daily re-register cadence below.
         self._xvb_last_registered = None
@@ -603,6 +619,23 @@ class DataService:
             return  # fetch failed — keep the last reading + last_update frozen so #311 can detect it
         await asyncio.to_thread(self.state_manager.update_xvb_stats, **real_xvb_stats)
         logger.info(f"External Sync: XvB Stats Updated (1h={real_xvb_stats['avg_1h']:.0f} H/s)")
+
+        # v1.7 telemetry backbone (#196 Wave-0): persist the XvB scalars as a time series, wall-
+        # clock gated to ~5 min so a change to UPDATE_INTERVAL (which also throttles how often
+        # this method is even called) can't silently change the capture cadence.
+        now = time.time()
+        if now - self._last_xvb_history_write >= _XVB_HISTORY_CAPTURE_SEC:
+            xvb = await asyncio.to_thread(self.state_manager.get_xvb_stats)
+            await asyncio.to_thread(
+                self.state_manager.add_xvb_history,
+                now,
+                avg_1h=xvb.get("avg_1h", 0.0),
+                avg_24h=xvb.get("avg_24h", 0.0),
+                fail_count=xvb.get("fail_count", 0),
+                donation_fraction=xvb.get("donation_fraction", 0.0),
+                mode=xvb.get("current_mode", ""),
+            )
+            self._last_xvb_history_write = now
 
     async def _sync_xvb_reward_estimates(self):
         """
@@ -831,6 +864,24 @@ class DataService:
                     network_stats = get_network_stats()
                     tari_stats = get_tari_stats()
                     p2pool_stats = get_p2pool_stats()
+
+                    # v1.7 telemetry backbone (#196 Wave-0): persist a block-found event as a time
+                    # series. The #336 alert already detects a new block via this same cumulative
+                    # blocks_found counter; `_shares_to_record` re-baselines without backfilling on
+                    # the first poll or a p2pool restart (counter goes backwards), so this fires
+                    # exactly once per genuinely new block. `difficulty` is tagged from the network
+                    # stats at detection time (p2pool exposes no per-block effort figure).
+                    blocks_found_total = p2pool_stats["pool"].get("blocks_found", 0) or 0
+                    new_blocks, self._last_blocks_found = _shares_to_record(
+                        self._last_blocks_found, blocks_found_total
+                    )
+                    if new_blocks > 0:
+                        await asyncio.to_thread(
+                            self.state_manager.add_block,
+                            time.time(),
+                            p2pool_stats["pool"].get("last_block_found", 0) or 0,
+                            network_stats.get("difficulty", 0) or 0,
+                        )
 
                     # Record P2Pool shares from the CUMULATIVE shares_found counter, not just
                     # last_share_time: at 30s polls a burst of shares advances the timestamp only
@@ -1098,6 +1149,50 @@ class DataService:
                     snapshot_data = self.latest_data.copy()
                     snapshot_data.pop("shares", None)
                     await asyncio.to_thread(self.state_manager.save_snapshot, snapshot_data)
+
+                    # 6a2. v1.7 telemetry backbone (#196 Wave-0), hourly wall-clock gate: monerod
+                    # DB size + host disk usage (disk_growth, permanent) and Monero
+                    # difficulty/height/reward + pool hashrate (network_history, 90-day
+                    # retention). Both DB-only — nothing reads either per-cycle.
+                    now_ts = time.time()
+                    if now_ts - self._last_hourly_capture >= _HOURLY_CAPTURE_SEC:
+                        await asyncio.to_thread(
+                            self.state_manager.add_disk_growth,
+                            now_ts,
+                            monero_db_bytes=monero_sync.get("db_size", 0) or 0,
+                            disk_used_gb=(disk_usage or {}).get("used_gb", 0) or 0,
+                            disk_total_gb=(disk_usage or {}).get("total_gb", 0) or 0,
+                        )
+                        await asyncio.to_thread(
+                            self.state_manager.add_network_history,
+                            now_ts,
+                            difficulty=network_stats.get("difficulty", 0) or 0,
+                            height=network_stats.get("height", 0) or 0,
+                            reward=network_stats.get("reward", 0) or 0,
+                            pool_hashrate=pool_local.get("hashrate", 0) or 0,
+                        )
+                        self._last_hourly_capture = now_ts
+
+                    # 6a3. v1.7 telemetry backbone (#196 Wave-0), ~5 min wall-clock gate:
+                    # per-worker hashrate/share history, batched into ONE executemany call rather
+                    # than N inserts per cycle. 30-day retention.
+                    if now_ts - self._last_worker_capture >= _WORKER_HISTORY_CAPTURE_SEC:
+                        worker_rows = [
+                            {
+                                "ts": now_ts,
+                                "name": w.get("name", ""),
+                                "h15": w.get("h15", 0) or 0,
+                                "accepted": w.get("accepted", 0) or 0,
+                                "rejected": w.get("rejected", 0) or 0,
+                            }
+                            for w in final_workers
+                            if w.get("status") == "online"
+                        ]
+                        if worker_rows:
+                            await asyncio.to_thread(
+                                self.state_manager.add_worker_history, worker_rows
+                            )
+                        self._last_worker_capture = now_ts
 
                     # 6b. Healthchecks.io dead-man's switch (Issue #79). Ping each cycle so the
                     # external monitor alerts on the *absence* of a ping if the host ever dies

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -35,6 +35,16 @@ _CORRUPTION_MARKERS = ("malformed", "not a database", "image is malformed", "fil
 # How many quarantined copies of a corrupt DB to keep for post-mortem before pruning the oldest.
 _CORRUPT_KEEP = 3
 
+# v1.7 telemetry backbone retention (#196 Wave-0 proposal). blocks/disk_growth are permanent (no
+# pruning — small tables, like payouts); the rest extend the existing 30-day HISTORY_RETENTION_SEC
+# convention. Each table gets its OWN retention (independent of `history`'s), by design.
+XVB_HISTORY_RETENTION_SEC = HISTORY_RETENTION_SEC  # 30 days
+WORKER_HISTORY_RETENTION_SEC = HISTORY_RETENTION_SEC  # 30 days
+NETWORK_HISTORY_RETENTION_SEC = 90 * 24 * 3600  # 90 days
+
+# Table names carrying a per-table write-health signal (see __init__ / _table_write_ok below).
+_TELEMETRY_TABLES = ("blocks", "xvb_history", "network_history", "disk_growth", "worker_history")
+
 
 class StateManager:
     """
@@ -100,6 +110,16 @@ class StateManager:
         self.last_db_reset = (
             None  # {"ts", "reason", "quarantine"} of the most recent reset, for the alert
         )
+
+        # Per-table "last successful write" health signal for the v1.7 telemetry backbone (#196
+        # Wave-0), mirroring db_healthy above but per table: DataService's whole poll loop is one
+        # big try/except, so a capture hook that starts silently raising would otherwise stop
+        # writing forever with no visible symptom. `healthy` flips False on a write failure
+        # (routed through _db_error, so it also trips the global #131 badge); `last_write` is the
+        # wall-clock of the last successful write, None until the first one lands.
+        self.table_health = {
+            name: {"healthy": True, "last_write": None} for name in _TELEMETRY_TABLES
+        }
 
         self._conn = sqlite3.connect(self.db_path, timeout=30.0, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
@@ -280,6 +300,43 @@ class StateManager:
             "(id INTEGER PRIMARY KEY AUTOINCREMENT, worker TEXT, change_id TEXT, ts REAL, "
             "status TEXT, changes TEXT, reason TEXT)"
         )
+        # v1.7 telemetry backbone (#196 Wave-0 proposal): five independent, additive time-series
+        # tables. Each has its own retention (see the RETENTION_SEC constants above) and is
+        # DB-only — nothing reads any of them per-cycle, so there's no in-memory mirror to keep in
+        # sync (keeps RAM flat). No new columns on `history` — that's the whole point of dedicated
+        # tables: independent retention, no row multiplication. Additive, forward-only, same as
+        # payouts/worker_config above: no _migrate_db entry needed.
+        #
+        # blocks: pool block-found events. Permanent (no pruning — a handful of rows/week, like
+        # payouts). `difficulty` is the Monero network difficulty AT DETECTION time (p2pool
+        # exposes no per-block effort figure), so effort-per-block is derivable later.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS blocks (ts REAL, height INTEGER, difficulty REAL)"
+        )
+        # xvb_history: XvB scalars sampled ~5 min wall-clock. 30-day retention.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS xvb_history "
+            "(ts REAL, avg_1h REAL, avg_24h REAL, fail_count INTEGER, "
+            "donation_fraction REAL, mode TEXT)"
+        )
+        # network_history: Monero network difficulty/height/reward + the pool's own hashrate,
+        # sampled hourly wall-clock. 90-day retention.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS network_history "
+            "(ts REAL, difficulty REAL, height INTEGER, reward REAL, pool_hashrate REAL)"
+        )
+        # disk_growth: monerod's on-disk DB size + host disk usage, sampled hourly wall-clock.
+        # Permanent (no pruning — tiny, ~24 rows/day; it's a capacity trend line).
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS disk_growth "
+            "(ts REAL, monero_db_bytes INTEGER, disk_used_gb REAL, disk_total_gb REAL)"
+        )
+        # worker_history: per-rig hashrate window + cumulative accepted/rejected, sampled ~5 min
+        # wall-clock and written in one batched executemany call per cycle. 30-day retention.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS worker_history "
+            "(ts REAL, name TEXT, h15 REAL, accepted INTEGER, rejected INTEGER)"
+        )
 
     def _create_indexes(self):
         """Creates indexes. Called after migrations so the indexed columns are guaranteed to
@@ -290,6 +347,13 @@ class StateManager:
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_worker_config ON worker_config(worker, ts)"
         )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_blocks_ts ON blocks(ts)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_xvb_history_ts ON xvb_history(ts)")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_network_history_ts ON network_history(ts)"
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_disk_growth_ts ON disk_growth(ts)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_worker_history_ts ON worker_history(ts)")
 
     def _migrate_db(self):
         """Handles schema migrations for existing databases."""
@@ -766,6 +830,256 @@ class StateManager:
             if row.get("status") == "applied" and isinstance(row.get("changes"), dict):
                 merged.update(row["changes"])
         return merged
+
+    def _table_write_ok(self, table: str, ts: float):
+        """Stamp a successful write for the v1.7 telemetry backbone's per-table health signal."""
+        self.table_health[table] = {"healthy": True, "last_write": ts}
+
+    def _table_write_failed(self, table: str, where: str, e: Exception):
+        """Flip a table's health signal False and route through the shared #131/#489 error path
+        (flags the global db_healthy badge too, and triggers corruption auto-recovery if that's
+        what this was)."""
+        self.table_health[table]["healthy"] = False
+        self._db_error(where, e)
+
+    def get_table_health(self) -> dict[str, dict[str, Any]]:
+        """Per-table write health for the v1.7 telemetry backbone (#196): ``{table: {"healthy",
+        "last_write"}}``. Lets a caller notice a capture hook that has silently stopped writing —
+        the data-service poll loop is one big try/except, so nothing else would surface that."""
+        return {k: dict(v) for k, v in self.table_health.items()}
+
+    def add_block(self, ts: float, height: int, difficulty: float):
+        """Record one pool block-found event (#196): permanent (no retention prune — a handful of
+        rows/week, like payouts). The caller (DataService) reuses `_shares_to_record` on p2pool's
+        cumulative blocks_found counter so this fires exactly once per genuinely NEW block; a
+        p2pool restart (counter goes backwards) re-baselines instead of replaying history."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return
+                with self._conn:
+                    self._conn.execute(
+                        "INSERT INTO blocks (ts, height, difficulty) VALUES (?, ?, ?)",
+                        (ts, height, difficulty),
+                    )
+            self._table_write_ok("blocks", ts)
+        except sqlite3.Error as e:
+            self._table_write_failed("blocks", "Block Insert Error", e)
+
+    def get_blocks(self, since: float = 0.0) -> list[dict[str, Any]]:
+        """Pool block-found events at or after `since` (default: all), oldest first."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT ts, height, difficulty FROM blocks WHERE ts >= ? ORDER BY ts ASC",
+                    (since,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"Block Read Error: {e}")
+            return []
+
+    def add_xvb_history(
+        self,
+        ts: float,
+        avg_1h: float = 0.0,
+        avg_24h: float = 0.0,
+        fail_count: int = 0,
+        donation_fraction: float = 0.0,
+        mode: str = "",
+    ):
+        """Record one XvB-scalars sample (#196), 30-day retention. The caller wall-clock-gates
+        this to ~5 min (DataService._sync_xvb_stats) so the cadence survives an UPDATE_INTERVAL
+        change, and only calls it on a genuine XvB fetch (never on a failed one)."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return
+                with self._conn:
+                    self._conn.execute(
+                        "INSERT INTO xvb_history "
+                        "(ts, avg_1h, avg_24h, fail_count, donation_fraction, mode) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (ts, avg_1h, avg_24h, fail_count, donation_fraction, mode),
+                    )
+                    if random.random() < 0.05:  # noqa: S311 — pruning sampler, not a security context
+                        self._conn.execute(
+                            "DELETE FROM xvb_history WHERE ts < ?",
+                            (ts - XVB_HISTORY_RETENTION_SEC,),
+                        )
+            self._table_write_ok("xvb_history", ts)
+        except sqlite3.Error as e:
+            self._table_write_failed("xvb_history", "XvB History Insert Error", e)
+
+    def get_xvb_history(self, since: float = 0.0) -> list[dict[str, Any]]:
+        """XvB-scalar samples at or after `since` (default: all), oldest first."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT ts, avg_1h, avg_24h, fail_count, donation_fraction, mode "
+                    "FROM xvb_history WHERE ts >= ? ORDER BY ts ASC",
+                    (since,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"XvB History Read Error: {e}")
+            return []
+
+    def add_network_history(
+        self,
+        ts: float,
+        difficulty: float = 0.0,
+        height: int = 0,
+        reward: float = 0.0,
+        pool_hashrate: float = 0.0,
+    ):
+        """Record one hourly network-stats sample (#196): Monero difficulty/height/reward plus the
+        pool's own hashrate. 90-day retention. DB-only (nothing reads this per-cycle)."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return
+                with self._conn:
+                    self._conn.execute(
+                        "INSERT INTO network_history "
+                        "(ts, difficulty, height, reward, pool_hashrate) VALUES (?, ?, ?, ?, ?)",
+                        (ts, difficulty, height, reward, pool_hashrate),
+                    )
+                    if random.random() < 0.05:  # noqa: S311 — pruning sampler, not a security context
+                        self._conn.execute(
+                            "DELETE FROM network_history WHERE ts < ?",
+                            (ts - NETWORK_HISTORY_RETENTION_SEC,),
+                        )
+            self._table_write_ok("network_history", ts)
+        except sqlite3.Error as e:
+            self._table_write_failed("network_history", "Network History Insert Error", e)
+
+    def get_network_history(self, since: float = 0.0) -> list[dict[str, Any]]:
+        """Hourly network-stats samples at or after `since` (default: all), oldest first."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT ts, difficulty, height, reward, pool_hashrate FROM network_history "
+                    "WHERE ts >= ? ORDER BY ts ASC",
+                    (since,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"Network History Read Error: {e}")
+            return []
+
+    def add_disk_growth(
+        self,
+        ts: float,
+        monero_db_bytes: int = 0,
+        disk_used_gb: float = 0.0,
+        disk_total_gb: float = 0.0,
+    ):
+        """Record one hourly disk-growth sample (#196): monerod's DB size plus host disk usage.
+        Permanent (no retention prune — tiny, ~24 rows/day; it's a capacity trend line)."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return
+                with self._conn:
+                    self._conn.execute(
+                        "INSERT INTO disk_growth "
+                        "(ts, monero_db_bytes, disk_used_gb, disk_total_gb) VALUES (?, ?, ?, ?)",
+                        (ts, monero_db_bytes, disk_used_gb, disk_total_gb),
+                    )
+            self._table_write_ok("disk_growth", ts)
+        except sqlite3.Error as e:
+            self._table_write_failed("disk_growth", "Disk Growth Insert Error", e)
+
+    def get_disk_growth(self, since: float = 0.0) -> list[dict[str, Any]]:
+        """Hourly disk-growth samples at or after `since` (default: all), oldest first."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT ts, monero_db_bytes, disk_used_gb, disk_total_gb FROM disk_growth "
+                    "WHERE ts >= ? ORDER BY ts ASC",
+                    (since,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"Disk Growth Read Error: {e}")
+            return []
+
+    def add_worker_history(self, rows: list[dict[str, Any]]):
+        """Record one poll's per-worker hashrate/share-count samples (#196) in a SINGLE
+        executemany call — the caller batches every online worker for one wall-clock tick rather
+        than issuing N inserts per cycle. 30-day retention. Each row needs ts/name/h15/accepted/
+        rejected; a missing key defaults to 0/''. A no-op on an empty batch."""
+        if not rows:
+            return
+        prune_ts = rows[0].get("ts", time.time())
+        try:
+            values = [
+                (
+                    r.get("ts", prune_ts),
+                    r.get("name", ""),
+                    r.get("h15", 0) or 0,
+                    r.get("accepted", 0) or 0,
+                    r.get("rejected", 0) or 0,
+                )
+                for r in rows
+            ]
+            with self._db_lock:
+                if not self._conn:
+                    return
+                with self._conn:
+                    self._conn.executemany(
+                        "INSERT INTO worker_history (ts, name, h15, accepted, rejected) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        values,
+                    )
+                    if random.random() < 0.05:  # noqa: S311 — pruning sampler, not a security context
+                        self._conn.execute(
+                            "DELETE FROM worker_history WHERE ts < ?",
+                            (prune_ts - WORKER_HISTORY_RETENTION_SEC,),
+                        )
+            self._table_write_ok("worker_history", prune_ts)
+        except sqlite3.Error as e:
+            self._table_write_failed("worker_history", "Worker History Insert Error", e)
+
+    def get_worker_history(
+        self, name: str | None = None, since: float = 0.0
+    ) -> list[dict[str, Any]]:
+        """Per-worker hashrate/share samples at or after `since` (default: all), oldest first.
+        Filters to one rig's `name` when given, else every rig."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                if name is None:
+                    cursor.execute(
+                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
+                        "WHERE ts >= ? ORDER BY ts ASC",
+                        (since,),
+                    )
+                else:
+                    cursor.execute(
+                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
+                        "WHERE ts >= ? AND name = ? ORDER BY ts ASC",
+                        (since, name),
+                    )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"Worker History Read Error: {e}")
+            return []
 
     def get_xvb_stats(self) -> dict[str, Any]:
         """Returns the current XvB mining statistics dictionary."""

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -1054,28 +1054,20 @@ class StateManager:
         except sqlite3.Error as e:
             self._table_write_failed("worker_history", "Worker History Insert Error", e)
 
-    def get_worker_history(
-        self, name: str | None = None, since: float = 0.0
-    ) -> list[dict[str, Any]]:
-        """Per-worker hashrate/share samples at or after `since` (default: all), oldest first.
-        Filters to one rig's `name` when given, else every rig."""
+    def get_worker_history(self, since: float = 0.0) -> list[dict[str, Any]]:
+        """Per-worker hashrate/share samples (every rig) at or after `since` (default: all),
+        oldest first. A per-worker filter isn't needed yet — add a WHERE name = ? when a
+        consumer (e.g. #492) actually reads one rig's series."""
         try:
             with self._db_lock:
                 if not self._conn:
                     return []
                 cursor = self._conn.cursor()
-                if name is None:
-                    cursor.execute(
-                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
-                        "WHERE ts >= ? ORDER BY ts ASC",
-                        (since,),
-                    )
-                else:
-                    cursor.execute(
-                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
-                        "WHERE ts >= ? AND name = ? ORDER BY ts ASC",
-                        (since, name),
-                    )
+                cursor.execute(
+                    "SELECT ts, name, h15, accepted, rejected FROM worker_history "
+                    "WHERE ts >= ? ORDER BY ts ASC",
+                    (since,),
+                )
                 return [dict(row) for row in cursor.fetchall()]
         except sqlite3.Error as e:
             self.logger.error(f"Worker History Read Error: {e}")

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -1490,6 +1490,62 @@ class TestXvbStatsSync:
         await svc._sync_xvb_stats()
         sm.update_xvb_stats.assert_not_called()
 
+    def _svc_with_real_storage(self):
+        # v1.7 telemetry backbone (#196 Wave-0): a real in-memory StateManager so a captured
+        # xvb_history row is provable, not just "the mock was called".
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        svc = DataService(sm, MagicMock(), MagicMock())
+        return svc, sm
+
+    async def test_first_fetch_writes_an_xvb_history_row(self):
+        svc, sm = self._svc_with_real_storage()
+        try:
+            svc.xvb_client.get_stats.return_value = {
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+            }
+            await svc._sync_xvb_stats()
+            rows = sm.get_xvb_history()
+            assert len(rows) == 1
+            assert rows[0]["avg_1h"] == 1000.0
+            assert rows[0]["mode"] == "P2POOL"  # the default xvb state, before any mode switch
+        finally:
+            sm.close()
+
+    async def test_wallclock_gate_suppresses_a_too_soon_second_write(self):
+        # The capture cadence is a wall-clock gate (~5 min), not iteration-count-based — two
+        # fetches back-to-back in the same test must not double-write.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            svc.xvb_client.get_stats.return_value = {
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+            }
+            await svc._sync_xvb_stats()
+            await svc._sync_xvb_stats()
+            assert len(sm.get_xvb_history()) == 1
+        finally:
+            sm.close()
+
+    async def test_gate_reopens_once_the_cadence_elapses(self):
+        svc, sm = self._svc_with_real_storage()
+        try:
+            svc.xvb_client.get_stats.return_value = {
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+            }
+            await svc._sync_xvb_stats()
+            svc._last_xvb_history_write -= 301  # simulate 5+ minutes having passed
+            await svc._sync_xvb_stats()
+            assert len(sm.get_xvb_history()) == 2
+        finally:
+            sm.close()
+
 
 class _RecordingGet:
     """One aiohttp ``session.get()`` async-context-manager that records nothing itself."""
@@ -1702,3 +1758,173 @@ class TestTariPayoutSync:
         sm.load_snapshot.return_value = None
         svc = DataService(sm, MagicMock(), MagicMock())
         assert svc.tari_wallet_client is None
+
+
+class TestTelemetryBackboneHooks:
+    """v1.7 telemetry backbone (#196 Wave-0): the blocks/disk_growth/network_history/
+    worker_history capture hooks wired into run(), verified end-to-end against a real in-memory
+    StateManager so "a row landed" is provable, not just "the mock was called". (xvb_history's
+    hook lives on ``_sync_xvb_stats`` and is covered directly in TestXvbStatsSync above.)"""
+
+    def _svc(self):
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        proxy = MagicMock()
+        svc = DataService(sm, proxy, MagicMock())
+        svc.docker_control = MagicMock()
+        svc.docker_control.stop = AsyncMock(return_value=True)
+        svc.docker_control.start = AsyncMock(return_value=True)
+        return svc, sm, proxy
+
+    async def _run_one(
+        self, svc, *, p2pool_stats=None, network_stats=None, disk_usage=None, monero_sync=None
+    ):
+        worker_client = MagicMock()
+        worker_client.get_stats = AsyncMock(return_value={})
+        tari_client = MagicMock()
+        tari_client.get_sync_status = AsyncMock(
+            return_value={"is_syncing": False, "reachable": True}
+        )
+        tari_client.close = AsyncMock()
+
+        with (
+            patch.object(ds_mod, "ClientSession", _FakeClientSession),
+            patch.object(ds_mod, "XMRigWorkerClient", return_value=worker_client),
+            patch.object(ds_mod, "TariClient", return_value=tari_client),
+            patch.object(ds_mod, "get_stratum_stats", return_value={}),
+            patch.object(
+                ds_mod, "get_network_stats", return_value=network_stats or {"height": 100}
+            ),
+            patch.object(
+                ds_mod, "get_tari_stats", return_value={"active": True, "status": "OK", "height": 3}
+            ),
+            patch.object(
+                ds_mod,
+                "get_p2pool_stats",
+                return_value=p2pool_stats
+                or {"pool": {"last_share_time": 0, "difficulty": 0, "blocks_found": 0}},
+            ),
+            patch.object(
+                ds_mod,
+                "get_monero_sync_status",
+                AsyncMock(return_value=monero_sync or {"is_syncing": False, "reachable": True}),
+            ),
+            patch.object(ds_mod, "get_disk_usage", return_value=disk_usage or {}),
+            patch.object(ds_mod, "get_hugepages_status", return_value=("Enabled", "ok", "1/2")),
+            patch.object(ds_mod, "get_memory_usage", return_value={}),
+            patch.object(ds_mod, "get_load_average", return_value="0"),
+            patch.object(ds_mod, "get_cpu_usage", return_value="0%"),
+            patch.object(ds_mod, "get_cpu_avx2", return_value=True),
+            patch("asyncio.sleep", AsyncMock(side_effect=StopAsyncIteration)),
+        ):
+            with pytest.raises(StopAsyncIteration):
+                await svc.run()
+
+    async def test_block_hook_baselines_without_backfill_on_first_poll(self):
+        # First-ever poll must never backfill the whole historical block count as one event.
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        await self._run_one(
+            svc, p2pool_stats={"pool": {"last_share_time": 0, "difficulty": 0, "blocks_found": 3}}
+        )
+        assert sm.get_blocks() == []
+        assert svc._last_blocks_found == 3
+
+    async def test_block_hook_writes_a_row_on_a_new_block(self):
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        svc._last_blocks_found = 5  # a prior poll already baselined
+        await self._run_one(
+            svc,
+            p2pool_stats={
+                "pool": {
+                    "last_share_time": 0,
+                    "difficulty": 0,
+                    "blocks_found": 6,
+                    "last_block_found": 3_100_000,
+                }
+            },
+            network_stats={"height": 100, "difficulty": 999.0},
+        )
+        rows = sm.get_blocks()
+        assert len(rows) == 1
+        assert rows[0]["height"] == 3_100_000
+        assert rows[0]["difficulty"] == 999.0
+
+    async def test_block_hook_quiet_when_counter_unchanged(self):
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        svc._last_blocks_found = 6
+        await self._run_one(
+            svc, p2pool_stats={"pool": {"last_share_time": 0, "difficulty": 0, "blocks_found": 6}}
+        )
+        assert sm.get_blocks() == []
+
+    async def test_hourly_hooks_write_disk_growth_and_network_history_on_first_poll(self):
+        # `_last_hourly_capture` starts at 0.0, so the first poll is always due.
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        await self._run_one(
+            svc,
+            network_stats={"height": 100, "difficulty": 1e9, "reward": 0.6},
+            disk_usage={"used_gb": 100.0, "total_gb": 500.0},
+            monero_sync={"is_syncing": False, "reachable": True, "db_size": 123456},
+        )
+        disk_rows = sm.get_disk_growth()
+        assert len(disk_rows) == 1
+        assert disk_rows[0]["monero_db_bytes"] == 123456
+        assert disk_rows[0]["disk_used_gb"] == 100.0
+        assert disk_rows[0]["disk_total_gb"] == 500.0
+        net_rows = sm.get_network_history()
+        assert len(net_rows) == 1
+        assert net_rows[0]["difficulty"] == 1e9
+        assert net_rows[0]["reward"] == 0.6
+
+    async def test_hourly_hooks_suppressed_when_gate_not_due(self):
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        svc._last_hourly_capture = time.time()  # just captured — not due for another hour
+        await self._run_one(svc)
+        assert sm.get_disk_growth() == []
+        assert sm.get_network_history() == []
+
+    async def test_worker_history_hook_writes_a_row_for_each_online_worker(self):
+        # proxy list row: connections=1 (online), idx8=1.0 kH/s (h10), idx9=2.0 kH/s (h15).
+        svc, sm, proxy = self._svc()
+        worker_row = ["rig1", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
+        proxy.get_workers.return_value = {"workers": [worker_row]}
+        proxy.get_summary.return_value = {"results": {}}
+        await self._run_one(svc)
+        rows = sm.get_worker_history()
+        assert len(rows) == 1
+        assert rows[0]["name"] == "rig1"
+        assert rows[0]["h15"] == 2000.0
+
+    async def test_worker_history_hook_skips_offline_workers(self):
+        svc, sm, proxy = self._svc()
+        offline_row = ["rig1", "10.0.0.1", 0, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]  # connections=0
+        proxy.get_workers.return_value = {"workers": [offline_row]}
+        await self._run_one(svc)
+        assert sm.get_worker_history() == []
+
+    async def test_worker_history_hook_suppressed_when_gate_not_due(self):
+        svc, sm, proxy = self._svc()
+        worker_row = ["rig1", "10.0.0.1", 1, 0, 0, 0, 0, 0, 1.0, 2.0, 0, 0, 0]
+        proxy.get_workers.return_value = {"workers": [worker_row]}
+        svc._last_worker_capture = time.time()
+        await self._run_one(svc)
+        assert sm.get_worker_history() == []
+
+    async def test_table_health_reflects_a_forced_block_write_failure(self):
+        # The whole poll loop is one try/except, so a hook that starts failing must be visible
+        # via the per-table health signal, not just swallowed silently.
+        svc, sm, proxy = self._svc()
+        proxy.get_workers.return_value = {"workers": []}
+        with sm._db_lock:
+            sm._conn.execute("DROP TABLE blocks")
+        svc._last_blocks_found = 5
+        await self._run_one(
+            svc, p2pool_stats={"pool": {"last_share_time": 0, "difficulty": 0, "blocks_found": 6}}
+        )
+        assert sm.get_table_health()["blocks"]["healthy"] is False

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -1,10 +1,11 @@
 import sqlite3
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
 from mining_dashboard.config.config import HISTORY_RETENTION_SEC, TIER_DEFAULTS
-from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.service.storage_service import NETWORK_HISTORY_RETENTION_SEC, StateManager
 
 
 class TestDefaults:
@@ -751,3 +752,348 @@ class TestPayouts:
         assert state_manager.add_payouts("monero", [{"txid": "x", "amount_atomic": 1}]) == []
         assert state_manager.get_payouts("monero") == []
         assert state_manager.get_payout_max_height("monero") == 0
+
+
+class TestBlocks:
+    """Pool block-found events (#196 Wave-0): permanent — never pruned, unlike the four
+    retention-bound telemetry tables below."""
+
+    def test_add_and_get_roundtrip(self, state_manager):
+        t0 = time.time()
+        state_manager.add_block(t0, height=3_100_000, difficulty=123456.0)
+        rows = state_manager.get_blocks()
+        assert rows == [{"ts": t0, "height": 3_100_000, "difficulty": 123456.0}]
+
+    def test_get_since_filters_the_window(self, state_manager):
+        t0 = time.time()
+        state_manager.add_block(t0 - 1000, height=1, difficulty=1.0)
+        state_manager.add_block(t0, height=2, difficulty=2.0)
+        rows = state_manager.get_blocks(since=t0 - 10)
+        assert [r["height"] for r in rows] == [2]
+
+    def test_never_pruned(self, state_manager, monkeypatch):
+        # Force the probabilistic-prune roll to "always fire" — blocks has no prune code path at
+        # all, so an ancient row must survive regardless.
+        old_ts = time.time() - HISTORY_RETENTION_SEC - 10 * 24 * 3600  # 40 days ago
+        state_manager.add_block(old_ts, height=1, difficulty=1.0)
+        monkeypatch.setattr("mining_dashboard.service.storage_service.random.random", lambda: 0.0)
+        state_manager.add_block(time.time(), height=2, difficulty=2.0)
+        assert len(state_manager.get_blocks()) == 2
+
+    def test_write_error_flags_table_and_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE blocks")
+        state_manager.add_block(time.time(), height=1, difficulty=1.0)
+        assert state_manager.is_db_healthy() is False
+        assert state_manager.get_table_health()["blocks"]["healthy"] is False
+
+    def test_reads_tolerate_a_missing_table(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE blocks")
+        assert state_manager.get_blocks() == []
+
+
+class TestXvbHistory:
+    """XvB scalars over time (#196 Wave-0): 30-day retention, same recipe as share_stats/events."""
+
+    def test_add_and_get_roundtrip(self, state_manager):
+        t0 = time.time()
+        state_manager.add_xvb_history(
+            t0, avg_1h=1000.0, avg_24h=900.0, fail_count=1, donation_fraction=0.5, mode="XVB"
+        )
+        rows = state_manager.get_xvb_history()
+        assert rows == [
+            {
+                "ts": t0,
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 1,
+                "donation_fraction": 0.5,
+                "mode": "XVB",
+            }
+        ]
+
+    def test_get_since_filters_the_window(self, state_manager):
+        t0 = time.time()
+        state_manager.add_xvb_history(t0 - 1000, avg_1h=1.0)
+        state_manager.add_xvb_history(t0, avg_1h=2.0)
+        rows = state_manager.get_xvb_history(since=t0 - 10)
+        assert [r["avg_1h"] for r in rows] == [2.0]
+
+    def test_old_rows_pruned_from_db_when_cleanup_fires(self, state_manager, monkeypatch):
+        old_ts = time.time() - HISTORY_RETENTION_SEC - 10 * 24 * 3600  # 40 days ago
+        with state_manager._db_lock:
+            state_manager._conn.execute(
+                "INSERT INTO xvb_history (ts, avg_1h, avg_24h, fail_count, donation_fraction, mode) "
+                "VALUES (?,?,?,?,?,?)",
+                (old_ts, 1.0, 1.0, 0, 0.0, "P2POOL"),
+            )
+            state_manager._conn.commit()
+        monkeypatch.setattr("mining_dashboard.service.storage_service.random.random", lambda: 0.0)
+        state_manager.add_xvb_history(time.time(), avg_1h=5.0)
+        with state_manager._db_lock:
+            remaining = state_manager._conn.execute(
+                "SELECT COUNT(*) FROM xvb_history WHERE ts < ?",
+                (time.time() - HISTORY_RETENTION_SEC,),
+            ).fetchone()[0]
+        assert remaining == 0
+
+    def test_write_error_flags_table_and_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE xvb_history")
+        state_manager.add_xvb_history(time.time())
+        assert state_manager.is_db_healthy() is False
+        assert state_manager.get_table_health()["xvb_history"]["healthy"] is False
+
+    def test_reads_tolerate_a_missing_table(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE xvb_history")
+        assert state_manager.get_xvb_history() == []
+
+
+class TestNetworkHistory:
+    """Difficulty/height/reward/pool-hashrate over time (#196 Wave-0): 90-day retention, DB-only."""
+
+    def test_add_and_get_roundtrip(self, state_manager):
+        t0 = time.time()
+        state_manager.add_network_history(
+            t0, difficulty=1e12, height=3_100_000, reward=0.6, pool_hashrate=5e6
+        )
+        rows = state_manager.get_network_history()
+        assert rows == [
+            {
+                "ts": t0,
+                "difficulty": 1e12,
+                "height": 3_100_000,
+                "reward": 0.6,
+                "pool_hashrate": 5e6,
+            }
+        ]
+
+    def test_get_since_filters_the_window(self, state_manager):
+        t0 = time.time()
+        state_manager.add_network_history(t0 - 1000, height=1)
+        state_manager.add_network_history(t0, height=2)
+        rows = state_manager.get_network_history(since=t0 - 10)
+        assert [r["height"] for r in rows] == [2]
+
+    def test_old_rows_pruned_from_db_when_cleanup_fires(self, state_manager, monkeypatch):
+        old_ts = time.time() - NETWORK_HISTORY_RETENTION_SEC - 24 * 3600  # 91 days ago
+        with state_manager._db_lock:
+            state_manager._conn.execute(
+                "INSERT INTO network_history (ts, difficulty, height, reward, pool_hashrate) "
+                "VALUES (?,?,?,?,?)",
+                (old_ts, 1.0, 1, 0.0, 0.0),
+            )
+            state_manager._conn.commit()
+        monkeypatch.setattr("mining_dashboard.service.storage_service.random.random", lambda: 0.0)
+        state_manager.add_network_history(time.time(), difficulty=2.0)
+        with state_manager._db_lock:
+            remaining = state_manager._conn.execute(
+                "SELECT COUNT(*) FROM network_history WHERE ts < ?",
+                (time.time() - NETWORK_HISTORY_RETENTION_SEC,),
+            ).fetchone()[0]
+        assert remaining == 0
+
+    def test_retention_is_90_days_not_30(self):
+        assert NETWORK_HISTORY_RETENTION_SEC == 90 * 24 * 3600
+
+    def test_write_error_flags_table_and_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE network_history")
+        state_manager.add_network_history(time.time())
+        assert state_manager.is_db_healthy() is False
+        assert state_manager.get_table_health()["network_history"]["healthy"] is False
+
+    def test_reads_tolerate_a_missing_table(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE network_history")
+        assert state_manager.get_network_history() == []
+
+
+class TestDiskGrowth:
+    """monerod DB size + host disk usage over time (#196 Wave-0): permanent, DB-only."""
+
+    def test_add_and_get_roundtrip(self, state_manager):
+        t0 = time.time()
+        state_manager.add_disk_growth(
+            t0, monero_db_bytes=200_000_000_000, disk_used_gb=210.5, disk_total_gb=500.0
+        )
+        rows = state_manager.get_disk_growth()
+        assert rows == [
+            {
+                "ts": t0,
+                "monero_db_bytes": 200_000_000_000,
+                "disk_used_gb": 210.5,
+                "disk_total_gb": 500.0,
+            }
+        ]
+
+    def test_get_since_filters_the_window(self, state_manager):
+        t0 = time.time()
+        state_manager.add_disk_growth(t0 - 1000, monero_db_bytes=1)
+        state_manager.add_disk_growth(t0, monero_db_bytes=2)
+        rows = state_manager.get_disk_growth(since=t0 - 10)
+        assert [r["monero_db_bytes"] for r in rows] == [2]
+
+    def test_never_pruned(self, state_manager, monkeypatch):
+        old_ts = time.time() - HISTORY_RETENTION_SEC - 10 * 24 * 3600  # 40 days ago
+        state_manager.add_disk_growth(old_ts, monero_db_bytes=1)
+        monkeypatch.setattr("mining_dashboard.service.storage_service.random.random", lambda: 0.0)
+        state_manager.add_disk_growth(time.time(), monero_db_bytes=2)
+        assert len(state_manager.get_disk_growth()) == 2
+
+    def test_write_error_flags_table_and_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE disk_growth")
+        state_manager.add_disk_growth(time.time())
+        assert state_manager.is_db_healthy() is False
+        assert state_manager.get_table_health()["disk_growth"]["healthy"] is False
+
+    def test_reads_tolerate_a_missing_table(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE disk_growth")
+        assert state_manager.get_disk_growth() == []
+
+
+class TestWorkerHistory:
+    """Per-rig hashrate/share history (#196 Wave-0): 30-day retention, batched executemany write."""
+
+    def test_add_and_get_roundtrip(self, state_manager):
+        t0 = time.time()
+        state_manager.add_worker_history(
+            [
+                {"ts": t0, "name": "rig1", "h15": 1000.0, "accepted": 10, "rejected": 1},
+                {"ts": t0, "name": "rig2", "h15": 2000.0, "accepted": 20, "rejected": 0},
+            ]
+        )
+        rows = state_manager.get_worker_history()
+        assert {r["name"] for r in rows} == {"rig1", "rig2"}
+        assert len(rows) == 2
+
+    def test_add_is_a_single_batch_call(self, state_manager, monkeypatch):
+        # Intent: one poll's worker rows land via ONE executemany, not N execute() calls per row.
+        # sqlite3.Connection's methods are read-only slots (can't monkeypatch the real instance),
+        # so swap in a MagicMock connection for this one narrow assertion.
+        mock_conn = MagicMock()
+        monkeypatch.setattr(state_manager, "_conn", mock_conn)
+        t0 = time.time()
+        state_manager.add_worker_history(
+            [
+                {"ts": t0, "name": "rig1", "h15": 1.0, "accepted": 1, "rejected": 0},
+                {"ts": t0, "name": "rig2", "h15": 2.0, "accepted": 2, "rejected": 0},
+                {"ts": t0, "name": "rig3", "h15": 3.0, "accepted": 3, "rejected": 0},
+            ]
+        )
+        assert mock_conn.executemany.call_count == 1
+        values = mock_conn.executemany.call_args.args[1]
+        assert len(values) == 3
+
+    def test_get_filters_by_worker_name(self, state_manager):
+        t0 = time.time()
+        state_manager.add_worker_history(
+            [
+                {"ts": t0, "name": "rig1", "h15": 1.0, "accepted": 1, "rejected": 0},
+                {"ts": t0, "name": "rig2", "h15": 2.0, "accepted": 2, "rejected": 0},
+            ]
+        )
+        rows = state_manager.get_worker_history(name="rig1")
+        assert len(rows) == 1 and rows[0]["name"] == "rig1"
+
+    def test_get_since_filters_the_window(self, state_manager):
+        t0 = time.time()
+        state_manager.add_worker_history(
+            [{"ts": t0 - 1000, "name": "rig1", "h15": 1.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": t0, "name": "rig1", "h15": 2.0, "accepted": 0, "rejected": 0}]
+        )
+        rows = state_manager.get_worker_history(since=t0 - 10)
+        assert [r["h15"] for r in rows] == [2.0]
+
+    def test_empty_batch_is_a_noop(self, state_manager):
+        state_manager.add_worker_history([])
+        assert state_manager.get_worker_history() == []
+
+    def test_old_rows_pruned_from_db_when_cleanup_fires(self, state_manager, monkeypatch):
+        old_ts = time.time() - HISTORY_RETENTION_SEC - 10 * 24 * 3600  # 40 days ago
+        with state_manager._db_lock:
+            state_manager._conn.execute(
+                "INSERT INTO worker_history (ts, name, h15, accepted, rejected) VALUES (?,?,?,?,?)",
+                (old_ts, "rig1", 1.0, 0, 0),
+            )
+            state_manager._conn.commit()
+        monkeypatch.setattr("mining_dashboard.service.storage_service.random.random", lambda: 0.0)
+        state_manager.add_worker_history(
+            [{"ts": time.time(), "name": "rig1", "h15": 2.0, "accepted": 0, "rejected": 0}]
+        )
+        with state_manager._db_lock:
+            remaining = state_manager._conn.execute(
+                "SELECT COUNT(*) FROM worker_history WHERE ts < ?",
+                (time.time() - HISTORY_RETENTION_SEC,),
+            ).fetchone()[0]
+        assert remaining == 0
+
+    def test_write_error_flags_table_and_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_history")
+        state_manager.add_worker_history(
+            [{"ts": time.time(), "name": "rig1", "h15": 1.0, "accepted": 0, "rejected": 0}]
+        )
+        assert state_manager.is_db_healthy() is False
+        assert state_manager.get_table_health()["worker_history"]["healthy"] is False
+
+    def test_reads_tolerate_a_missing_table(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_history")
+        assert state_manager.get_worker_history() == []
+
+
+class TestTelemetryTableHealth:
+    """Per-table 'last successful write' health signal (#196 Wave-0), mirroring db_healthy so a
+    hook that silently stops writing (the whole poll loop is one try/except) is visible."""
+
+    def test_starts_healthy_with_no_write_yet(self, state_manager):
+        health = state_manager.get_table_health()
+        assert set(health) == {
+            "blocks",
+            "xvb_history",
+            "network_history",
+            "disk_growth",
+            "worker_history",
+        }
+        for row in health.values():
+            assert row == {"healthy": True, "last_write": None}
+
+    def test_last_write_stamps_on_success(self, state_manager):
+        t0 = time.time()
+        state_manager.add_block(t0, height=1, difficulty=1.0)
+        assert state_manager.get_table_health()["blocks"] == {"healthy": True, "last_write": t0}
+        # untouched tables stay at their default
+        assert state_manager.get_table_health()["xvb_history"]["last_write"] is None
+
+    def test_returns_a_copy(self, state_manager):
+        state_manager.add_block(time.time(), height=1, difficulty=1.0)
+        health = state_manager.get_table_health()
+        health["blocks"]["healthy"] = False
+        assert state_manager.get_table_health()["blocks"]["healthy"] is True
+
+
+class TestTelemetryTablesAfterClose:
+    """After close() the connection is None — every v1.7 telemetry-table accessor must no-op /
+    read empty, never raise (mirrors TestPayouts.test_reads_and_writes_after_close_are_safe)."""
+
+    def test_all_five_tables_are_safe_after_close(self, state_manager):
+        state_manager.close()
+        state_manager.add_block(time.time(), height=1, difficulty=1.0)
+        state_manager.add_xvb_history(time.time())
+        state_manager.add_network_history(time.time())
+        state_manager.add_disk_growth(time.time())
+        state_manager.add_worker_history(
+            [{"ts": time.time(), "name": "rig1", "h15": 1.0, "accepted": 0, "rejected": 0}]
+        )
+        assert state_manager.get_blocks() == []
+        assert state_manager.get_xvb_history() == []
+        assert state_manager.get_network_history() == []
+        assert state_manager.get_disk_growth() == []
+        assert state_manager.get_worker_history() == []

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -989,17 +989,6 @@ class TestWorkerHistory:
         values = mock_conn.executemany.call_args.args[1]
         assert len(values) == 3
 
-    def test_get_filters_by_worker_name(self, state_manager):
-        t0 = time.time()
-        state_manager.add_worker_history(
-            [
-                {"ts": t0, "name": "rig1", "h15": 1.0, "accepted": 1, "rejected": 0},
-                {"ts": t0, "name": "rig2", "h15": 2.0, "accepted": 2, "rejected": 0},
-            ]
-        )
-        rows = state_manager.get_worker_history(name="rig1")
-        assert len(rows) == 1 and rows[0]["name"] == "rig1"
-
     def test_get_since_filters_the_window(self, state_manager):
         t0 = time.time()
         state_manager.add_worker_history(


### PR DESCRIPTION
## Summary

Implements the **backbone** for the v1.7 telemetry-persistence epic (#196), per the maintainer's
Wave-0 decision proposal comment on the issue: five dedicated, additive SQLite tables — capture +
storage + retention + a per-table health signal + a getter per series. Charts/UI are explicit
follow-ups, not built here.

### The 5 tables

| Table | Series | Cadence | Retention |
|---|---|---|---|
| `blocks (ts, height, difficulty)` | pool block-found events (network difficulty at detection) | event-driven, hooks the existing #336 block-detection edge | permanent (like `payouts`) |
| `xvb_history (ts, avg_1h, avg_24h, fail_count, donation_fraction, mode)` | XvB scalars over time | ~5 min wall-clock gate | 30 days |
| `network_history (ts, difficulty, height, reward, pool_hashrate)` | Monero network stats + pool hashrate | hourly wall-clock | 90 days |
| `disk_growth (ts, monero_db_bytes, disk_used_gb, disk_total_gb)` | monerod DB size + host disk usage | hourly wall-clock | permanent (tiny) |
| `worker_history (ts, name, h15, accepted, rejected)` | per-rig hashrate + share counts, batched `executemany` | ~5 min wall-clock | 30 days |

Design constraints from the spec, all honored:
- Additive tables only — no new columns on `history` (independent retention, no row multiplication).
- Every cadence gate is wall-clock (`time.time() - last >= N`), never `iteration_count % k`, so a
  changed `UPDATE_INTERVAL` can't silently change capture cadence.
- All five tables are DB-only (no in-memory mirror) — nothing in the backbone reads them per-cycle.
- Per-table "last successful write" health signal (`StateManager.get_table_health()`), mirroring
  `db_healthy`, so a hook that starts silently failing inside the data-service's one big
  try/except is visible instead of a permanent silent no-op.
- AVOID list respected: no CPU/RAM/load/HugePages/AVX2, no raw-stratum series, no orphan/stale
  (not collectible — p2pool exposes no such field).

### Deferred (explicitly out of scope here)

- Charts/UI and any `/api/state` exposure of these series (the spec calls this optional for the
  backbone; not shipped).
- #579 (history reconciliation) and #492 (hashrate↔config correlation, rides `worker_history`) —
  independent follow-on issues per the Wave-0 proposal. A per-worker filter on
  `get_worker_history` was deliberately left out (YAGNI — no caller needs it yet); it's a one-line
  addition when #492 lands.

## Test plan

- [x] `make test-dashboard` — 1321 passed, 96.6% total coverage (gate: 80%)
- [x] `make test-patch-coverage` — 100% on changed lines (gate: 90%)
- [x] `make lint-py` — ruff check + format clean
- [x] `bash scripts/lint-docs-voice.sh` — clean
- [x] `/ponytail-review` pass on the diff — one cut applied (see above)
- [x] Manual: fresh `StateManager` on a real file DB creates all 5 tables (`blocks`,
      `xvb_history`, `network_history`, `disk_growth`, `worker_history`) alongside the existing
      ones, no migration errors.
- [x] Per table: insert+read-back, retention prune drops old rows (blocks/disk_growth do NOT
      prune), the getter returns the right window.
- [x] Per capture hook: mocked collector data through one `run()` iteration lands a row; a
      too-soon second write is suppressed by the wall-clock gate.
- [x] Health signal flips `healthy: false` on a forced write failure (dropped table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)