### PR TITLE
feat(#529): config form regroup — core shortlist + collapsed sections + JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,20 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   storage, retention, and a getter per series; charts/UI and `/api/state` exposure are deliberate
   follow-ups.
 
+- **The Configuration view regroups around core-vs-sections, plus a JSON edit mode (#529, RATIFIED
+  Wave-0 decision).** **Form** (the default) now pins a **Core** group at the top — the SAME
+  `config.core-keys.json` shortlist the first-run wizard reads, surfaced to the browser as
+  `_core_keys` on `GET /api/config` (one shared artifact, not a hand-maintained duplicate) — above
+  the rest of the schema, regrouped into its natural top-level sections and collapsed by default
+  (native `<details>`), so a typical edit shows a handful of fields instead of all ~94. **JSON**
+  sits beside it: the whole fetched config as one editable text block, with a **Load from file**
+  fill button (`FileReader`, no upload) — mirroring #518's Worker Inspect editor shape exactly,
+  down to reusing its `jsonSyntaxError` helper. Both modes build the identical staged config object
+  and submit it through the unchanged preview → confirm → commit pipeline; the host-side
+  closed-schema gate is still the only validation authority; neither mode opens a path the other
+  lacks. A masked secret (`{__secret__: true}`) still renders as a blank password field in Form
+  mode and round-trips untouched in JSON mode unless you edit it yourself.
+
 ### Changed
 
 - **The first-run wizard now asks a pool tier and a few shape questions, instead of hardcoding

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -191,6 +191,11 @@ HOST_CONFIG_PATH = os.environ.get("HOST_CONFIG_PATH", "/control/masked/config.js
 # keys the operator happens to have set (#33 "edit every setting"). A missing reference degrades to
 # the host config alone.
 HOST_REFERENCE_PATH = os.environ.get("HOST_REFERENCE_PATH", "/host-config/config.reference.json")
+# config.core-keys.json (#502/#529): the wizard's core-key shortlist, bind-mounted read-only. The
+# SAME file the wizard reads, so the Configuration view can pin the SAME shortlist at the top of
+# the form instead of hand-maintaining a duplicate list. A missing/unreadable file degrades to no
+# core group (control_service.read_config falls back to an empty list).
+HOST_CORE_KEYS_PATH = os.environ.get("HOST_CORE_KEYS_PATH", "/host-config/config.core-keys.json")
 
 # --- Per-worker endpoint descriptors (#172, config.json: workers.list[]) ---
 # [{name, host?, port?, token?}] — per-rig overrides for the worker API probe when a rig doesn't

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -80,6 +80,19 @@ def _deep_merge(base, override):
     return merged
 
 
+def _load_core_keys():
+    """The wizard's core-key shortlist (#502/#529), read from the SAME file ``./pithead setup``
+    reads — the one shared artifact, not a second hand-maintained list. Degrades to an empty list
+    on a missing/unreadable/malformed file, matching the reference-merge fallback below."""
+    try:
+        with open(config.HOST_CORE_KEYS_PATH) as f:
+            keys = json.load(f)
+        return keys if isinstance(keys, list) else []
+    except (OSError, ValueError):
+        logger.warning("config.core-keys.json unavailable — the form renders with no core group.")
+        return []
+
+
 def read_config():
     """The full config schema for the editor's form, every set secret masked to the sentinel.
 
@@ -87,7 +100,11 @@ def read_config():
     pre-masked copy so the form covers the whole schema — a missing/unreadable reference degrades
     to the host copy alone (graft #437). An *empty* secret stays empty, so the UI can tell
     "set — leave blank to keep" from "not set". The copy arrives already masked (#440); the
-    masking pass here is defense-in-depth and runs AFTER the merge."""
+    masking pass here is defense-in-depth and runs AFTER the merge.
+
+    The response also carries ``_core_keys`` (#529) — an underscore-prefixed metadata key, the
+    same convention ``config.reference.json``'s own ``_docs`` uses, so ``buildSections`` on the
+    frontend already skips it as a config section for free."""
     cfg = _load_host_config()
     try:
         with open(config.HOST_REFERENCE_PATH) as f:
@@ -100,6 +117,7 @@ def read_config():
         found, value = _get(cfg, path)
         if found and value:
             _set(cfg, path, dict(SECRET_SENTINEL))
+    cfg["_core_keys"] = _load_core_keys()
     return cfg
 
 

--- a/build/dashboard/mining_dashboard/web/static/configlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configlogic.mjs
@@ -1,9 +1,15 @@
 // Pure logic for the Configuration view (#33), kept DOM-free so node --test covers it.
 //
 // GET /api/config returns the live config.json with every set secret masked to the
-// {__secret__: true} sentinel. buildSections flattens that into render-ready form fields;
-// applyEdits folds the user's edits back into a proposed config for POST /api/control/preview.
-// A secret left blank keeps its sentinel — the server swaps it for the live value ("unchanged").
+// {__secret__: true} sentinel, plus _core_keys — the wizard's core-key shortlist
+// (config.core-keys.json, #502/#529), the SAME shared artifact, not a hand-maintained duplicate.
+// buildSections flattens the config into render-ready form fields; regroupCore (#529) pulls the
+// core-key fields out of their natural sections into one pinned group, mirroring the RATIFIED
+// Wave-0 decision: core shortlist at the top + the config's natural sections, collapsed by
+// default. applyEdits folds the user's edits back into a proposed config for
+// POST /api/control/preview — it takes the ORIGINAL (ungrouped) sections, so it doesn't care
+// whether a field rendered in the core group or its section. A secret left blank keeps its
+// sentinel — the server swaps it for the live value ("unchanged").
 
 export const SECRET_HINT = "set — leave blank to keep";
 
@@ -100,4 +106,48 @@ export function applyEdits(cfg, sections, edits) {
     }
   }
   return proposed;
+}
+
+// The core-vs-sections regroup (#529, RATIFIED Wave-0): lift every field whose dotted key is in
+// the core shortlist out of its natural section into one pinned `core` group; the same sections
+// keep every OTHER field (never emptied outright — the shortlist is a handful of keys against ~94
+// leaves). workers.list isn't a leaf (buildSections already skips arrays, #172), so it never
+// produces a field to lift — it stays core-in-spirit only, exactly like the wizard treats it.
+// coreKeys missing/empty degrades to no core group; every field still renders in its section.
+export function regroupCore(sections, coreKeys) {
+  const coreSet = new Set(coreKeys || []);
+  const core = sections.flatMap((s) => s.fields).filter((f) => coreSet.has(f.key));
+  const rest = sections
+    .map((s) => ({ name: s.name, fields: s.fields.filter((f) => !coreSet.has(f.key)) }))
+    .filter((s) => s.fields.length);
+  return { core, sections: rest };
+}
+
+// JSON mode's own path (#529): the textarea holds the WHOLE candidate config (not a diff, unlike
+// Worker Inspect's writable-key changes, #518) — parse it into the same shape applyEdits produces,
+// so either mode can POST straight to /api/control/preview. Returns { config } or { error }.
+export function parseConfigJson(text) {
+  let cfg;
+  try {
+    cfg = JSON.parse(text);
+  } catch {
+    return { error: "Not valid JSON." };
+  }
+  if (cfg === null || typeof cfg !== "object" || Array.isArray(cfg)) {
+    return { error: "Enter a JSON object." };
+  }
+  return { config: cfg };
+}
+
+// Live syntax check for the JSON textarea, surfaced inline as the operator types (not only on
+// Save). Blank is not an error yet — the operator hasn't finished typing. Shared with
+// workerlogic.mjs's JSON mode (re-exported from there) so both editors give the same feedback.
+export function jsonSyntaxError(text) {
+  if (!text.trim()) return null;
+  try {
+    JSON.parse(text);
+    return null;
+  } catch {
+    return "Not valid JSON.";
+  }
 }

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -4,8 +4,24 @@
 // confirm modal (destructive changes need a typed APPLY) → POST /api/control/commit → result.
 // The view only ever ASKS — every request rides the X-Pithead-Control header (CSRF guard) and
 // the host decides. When the channel is off the routes 404 and this view explains how to enable.
+//
+// Two edit modes (#529, RATIFIED Wave-0 decision — mirrors #518's Worker Inspect shape exactly):
+// **Form** (the default) pins a `core` group — the wizard's own shortlist, `_core_keys` on the
+// fetched config, sourced from config.core-keys.json so the two never drift apart — above the
+// config's natural sections, each a native <details> collapsed by default. **JSON** is the same
+// fetched config as one editable textarea, with a Load-from-file fill button (FileReader, no
+// upload). Both modes build the SAME `proposed` config object and POST it to the SAME
+// /api/control/preview → confirm → /api/control/commit pipeline — the closed-schema gate on the
+// host is the only validation authority; neither mode adds a server-side path the other lacks.
 
-import { applyEdits, buildSections, SECRET_HINT } from "./configlogic.mjs";
+import {
+  applyEdits,
+  buildSections,
+  jsonSyntaxError,
+  parseConfigJson,
+  regroupCore,
+  SECRET_HINT,
+} from "./configlogic.mjs";
 import { Component, html } from "./preact.mjs";
 
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
@@ -38,9 +54,12 @@ async function pollResult(id, skip, max = POLL_MAX) {
   );
 }
 
-const Field = ({ field, edits, onEdit }) => {
+// `full` (#529): the pinned Core card mixes fields from several sections, so its rows need the
+// FULL dotted key ("monero.wallet_address") to stay unambiguous; a natural section already says
+// which section it is via its own heading, so its rows keep the shorter relative label.
+const Field = ({ field, edits, onEdit, full }) => {
   const value = field.key in edits ? edits[field.key] : field.value;
-  const label = field.path.slice(1).join(".") || field.path[0];
+  const label = full ? field.key : field.path.slice(1).join(".") || field.path[0];
   let input;
   if (field.type === "boolean") {
     input = html`<select value=${String(value)} onChange=${(e) => onEdit(field.key, e.target.value)}>
@@ -113,7 +132,11 @@ export class ConfigView extends Component {
       phase: "loading", // loading | disabled | form | previewing | confirm | committing | done | error
       cfg: null,
       sections: [],
+      coreKeys: [],
       edits: {},
+      mode: "form", // form | json (#529)
+      editText: "",
+      jsonError: null,
       preview: null,
       confirmText: "",
       result: null,
@@ -134,10 +157,35 @@ export class ConfigView extends Component {
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const cfg = await res.json();
-      this.setState({ phase: "form", cfg, sections: buildSections(cfg), edits: {} });
+      this.setState({
+        phase: "form",
+        cfg,
+        sections: buildSections(cfg),
+        coreKeys: cfg._core_keys || [],
+        edits: {},
+        editText: JSON.stringify(cfg, null, 2),
+        jsonError: null,
+      });
     } catch (e) {
       this.setState({ phase: "error", error: String(e) });
     }
+  }
+
+  // JSON mode (#529, mirrors WorkerInspect.onJsonInput): live parse-error feedback while typing,
+  // not only on Save.
+  onJsonInput(text) {
+    this.setState({ editText: text, jsonError: jsonSyntaxError(text) });
+  }
+
+  // Fill the JSON textarea from a local file (#529, mirrors WorkerInspect.onFilePick, #518) — a
+  // FileReader read, never an upload; the operator still reviews and clicks Save like any other
+  // JSON-mode edit.
+  onFilePick(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => this.onJsonInput(String(reader.result));
+    reader.readAsText(file);
   }
 
   // Poll the result endpoint until a terminal result lands (shared pollResult above; kept as a
@@ -146,10 +194,24 @@ export class ConfigView extends Component {
     return pollResult(id, skip);
   }
 
+  // Build the SAME staged `proposed` config object regardless of mode (#529) — the form folds
+  // edits back via applyEdits; JSON mode's textarea already IS the candidate config, so it only
+  // needs parsing. Either result feeds the identical preview/commit pipeline below.
+  buildProposed() {
+    const { cfg, sections, edits, mode, editText } = this.state;
+    if (mode === "json") return parseConfigJson(editText);
+    return { config: applyEdits(cfg, sections, edits) };
+  }
+
   async save() {
+    const staged = this.buildProposed();
+    if (staged.error) {
+      this.setState({ error: staged.error });
+      return;
+    }
     this.setState({ phase: "previewing", error: null });
     try {
-      const proposed = applyEdits(this.state.cfg, this.state.sections, this.state.edits);
+      const proposed = staged.config;
       const res = await fetch("/api/control/preview", {
         method: "POST",
         headers: CONTROL_HEADERS,
@@ -190,8 +252,61 @@ export class ConfigView extends Component {
     }
   }
 
+  // Form mode (#529): the core group (pinned, never collapsed) above the config's natural
+  // sections, each a native <details> — collapsed by default (no `open` attribute), which gets
+  // keyboard/a11y toggling for free, the same "native platform feature over JS state" call
+  // Worker Inspect's own <dialog> made (#518).
+  renderForm(core, groups, edits) {
+    const onEdit = (k, v) => this.setState({ edits: { ...edits, [k]: v } });
+    const field = (f, full) =>
+      html`<${Field} field=${f} edits=${edits} full=${full} onEdit=${onEdit} />`;
+    return html`<div class="grid">
+        ${
+          core.length
+            ? html`<div class="card config-section config-section-core">
+                <h3>Core</h3>
+                ${core.map((f) => field(f, true))}
+            </div>`
+            : null
+        }
+        ${groups.map(
+          (s) => html`<details class="card config-section">
+              <summary>${s.name}</summary>
+              ${s.fields.map((f) => field(f))}
+          </details>`,
+        )}
+    </div>`;
+  }
+
+  // JSON mode (#529): the whole candidate config as one textarea, mirroring Worker Inspect's JSON
+  // mode (#518) — inline parse-error feedback, and a Load-from-file fill button.
+  renderJson(editText, jsonError, busy) {
+    return html`<div class="card config-section">
+        <textarea class="worker-edit" spellcheck="false" rows="20" disabled=${busy}
+                  value=${editText} onInput=${(e) => this.onJsonInput(e.target.value)}></textarea>
+        ${jsonError ? html`<p class="status-bad text-xs">${jsonError}</p>` : null}
+        <div class="mt-1">
+            <label class="text-muted text-xs">Load from file:
+                <input type="file" accept="application/json,.json" disabled=${busy} onChange=${(e) => this.onFilePick(e)} />
+            </label>
+        </div>
+    </div>`;
+  }
+
   render() {
-    const { phase, sections, edits, preview, confirmText, result, error } = this.state;
+    const {
+      phase,
+      sections,
+      coreKeys,
+      edits,
+      mode,
+      editText,
+      jsonError,
+      preview,
+      confirmText,
+      result,
+      error,
+    } = this.state;
     if (phase === "loading")
       return html`<div class="card"><p class="text-muted">Loading configuration…</p></div>`;
     if (phase === "disabled") {
@@ -225,21 +340,20 @@ export class ConfigView extends Component {
     }
     const busy = phase === "previewing" || phase === "committing";
     const dirty = Object.keys(edits).length > 0;
+    const canSave = mode === "json" ? !jsonError : dirty;
+    const { core, sections: groups } = regroupCore(sections, coreKeys);
     return html`<div class="config-view">
         ${error ? html`<div class="card"><p class="status-bad">${error}</p></div>` : null}
-        <div class="grid">
-            ${sections.map(
-              (s) => html`<div class="card config-section">
-                  <h3>${s.name}</h3>
-                  ${s.fields.map((f) => html`<${Field} field=${f} edits=${edits} onEdit=${(k, v) => this.setState({ edits: { ...edits, [k]: v } })} />`)}
-              </div>`,
-            )}
+        <div class="toggle-group mb-1">
+            <button class=${"btn-toggle" + (mode === "form" ? " active" : "")} onClick=${() => this.setState({ mode: "form" })}>Form</button>
+            <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setState({ mode: "json" })}>JSON</button>
         </div>
+        ${mode === "form" ? this.renderForm(core, groups, edits) : this.renderJson(editText, jsonError, busy)}
         <div class="config-actions">
-            <button class="btn-toggle active" disabled=${!dirty || busy} onClick=${() => this.save()}>
+            <button class="btn-toggle active" disabled=${!canSave || busy} onClick=${() => this.save()}>
                 ${phase === "previewing" ? "Previewing…" : "Save & preview changes"}
             </button>
-            ${dirty ? html`<button class="btn-toggle" disabled=${busy} onClick=${() => this.setState({ edits: {}, error: null })}>Discard edits</button>` : null}
+            ${mode === "form" && dirty ? html`<button class="btn-toggle" disabled=${busy} onClick=${() => this.setState({ edits: {}, error: null })}>Discard edits</button>` : null}
         </div>
         ${
           phase === "confirm" || phase === "committing"

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -1018,10 +1018,20 @@ button.upgrade-btn {
 /* ---- Configuration view (#33) ----------------------------------------------------------
  * The config editor: sectioned form fields, an inline field warning for high-consequence
  * keys, and the preview/confirm modal listing the same change rows `pithead apply` prints
- * (DEST rows styled as warnings). */
+ * (DEST rows styled as warnings). Sections regroup around a pinned core group + collapsible
+ * natural sections (#529) — collapsed <details>, the same pattern as .egress-details above. */
 .config-section h3 {
   margin-top: 0;
   text-transform: capitalize;
+}
+.config-section > summary {
+  cursor: pointer;
+  font-weight: 600;
+  text-transform: capitalize;
+  margin-bottom: 8px;
+}
+.config-section-core {
+  border-color: var(--accent);
 }
 .config-field {
   display: grid;

--- a/build/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -11,6 +11,11 @@
 
 import { isSecretSentinel } from "./configlogic.mjs";
 
+// jsonSyntaxError is generic (no worker-specific shape) — configlogic.mjs owns it (#529, the
+// Configuration view's own JSON mode uses it too); re-exported here so workerview.mjs's existing
+// import keeps working unchanged.
+export { jsonSyntaxError } from "./configlogic.mjs";
+
 // One row per writable key, typed off the current (last-applied) value's JSON shape. A key never
 // applied yet has no value to type off, so it falls back to an empty JSON sub-editor.
 export function buildFields(writableKeys, lastApplied) {
@@ -77,16 +82,4 @@ export function parseJsonChanges(text, writableKeys) {
   const bad = Object.keys(changes).filter((k) => !allowed.has(k));
   if (bad.length) return { error: `Not writable: ${bad.join(", ")}` };
   return { changes };
-}
-
-// Live syntax check for the JSON textarea, surfaced inline as the operator types (not only on
-// Apply). Blank is not an error yet — the operator hasn't finished typing.
-export function jsonSyntaxError(text) {
-  if (!text.trim()) return null;
-  try {
-    JSON.parse(text);
-    return null;
-  } catch {
-    return "Not valid JSON.";
-  }
 }

--- a/build/dashboard/tests/frontend/configlogic.test.mjs
+++ b/build/dashboard/tests/frontend/configlogic.test.mjs
@@ -11,6 +11,9 @@ import {
   applyEdits,
   buildSections,
   isSecretSentinel,
+  jsonSyntaxError,
+  parseConfigJson,
+  regroupCore,
 } from "../../mining_dashboard/web/static/configlogic.mjs";
 
 const CFG = {
@@ -113,4 +116,82 @@ test("applyEdits: garbage in a number field passes through for the host validato
   const sections = buildSections(CFG);
   const proposed = applyEdits(CFG, sections, { "monero.remote.rpc_port": "lots" });
   assert.equal(proposed.monero.remote.rpc_port, "lots");
+});
+
+// --- Core-vs-sections regroup (#529, RATIFIED Wave-0) ---------------------------------------
+
+const CORE_KEYS = ["monero.wallet_address", "p2pool.pool", "dashboard.auth.username"];
+
+test("regroupCore: lifts core-key fields into one pinned group, out of their sections", () => {
+  const { core, sections } = regroupCore(buildSections(CFG), CORE_KEYS);
+  assert.deepEqual(
+    core.map((f) => f.key).sort(),
+    CORE_KEYS.slice().sort(),
+  );
+  // The lifted fields no longer appear in their natural section...
+  const monero = sections.find((s) => s.name === "monero");
+  assert.ok(!monero.fields.some((f) => f.key === "monero.wallet_address"));
+  // ...but every OTHER field in that section is untouched.
+  assert.ok(monero.fields.some((f) => f.key === "monero.prune"));
+  const dashboard = sections.find((s) => s.name === "dashboard");
+  assert.ok(!dashboard.fields.some((f) => f.key === "dashboard.auth.username"));
+  assert.ok(dashboard.fields.some((f) => f.key === "dashboard.auth.password"));
+});
+
+test("regroupCore: a section left with no remaining fields is dropped, not shown empty", () => {
+  // Every leaf of p2pool is core: the section itself should disappear from the regrouped list.
+  const { sections } = regroupCore(buildSections(CFG), ["p2pool.pool", "p2pool.stratum_password"]);
+  assert.ok(!sections.some((s) => s.name === "p2pool"));
+});
+
+test("regroupCore: no core keys (missing/empty config.core-keys.json) leaves every field in its section", () => {
+  const original = buildSections(CFG);
+  const { core, sections } = regroupCore(original, []);
+  assert.deepEqual(core, []);
+  assert.deepEqual(
+    sections.map((s) => s.fields.length),
+    original.map((s) => s.fields.length),
+  );
+});
+
+test("regroupCore: workers.list isn't a field to begin with (array, #172) — it never appears, core or not", () => {
+  const withWorkers = {
+    ...CFG,
+    workers: { list: [{ name: "rig1" }], api_auth: "none" },
+  };
+  const { core, sections } = regroupCore(buildSections(withWorkers), [
+    ...CORE_KEYS,
+    "workers.list",
+  ]);
+  assert.ok(!core.some((f) => f.key === "workers.list"));
+  assert.ok(!sections.some((s) => s.fields.some((f) => f.key === "workers.list")));
+});
+
+// --- JSON mode's whole-config parse (#529) ----------------------------------------------------
+
+test("parseConfigJson: valid JSON builds the same staged config shape applyEdits does", () => {
+  const sections = buildSections(CFG);
+  const viaForm = applyEdits(CFG, sections, { "p2pool.pool": "main" });
+  const viaJson = parseConfigJson(JSON.stringify(viaForm));
+  assert.deepEqual(viaJson, { config: viaForm });
+});
+
+test("parseConfigJson: a masked secret round-trips verbatim through the textarea (#508/#440)", () => {
+  const out = parseConfigJson(JSON.stringify(CFG));
+  assert.deepEqual(out.config.dashboard.auth.password, { __secret__: true });
+});
+
+test("parseConfigJson: malformed JSON surfaces a parse error", () => {
+  assert.match(parseConfigJson("{not json").error, /Not valid JSON/);
+});
+
+test("parseConfigJson: a non-object (array, primitive) is rejected", () => {
+  assert.match(parseConfigJson("[1, 2]").error, /JSON object/);
+  assert.match(parseConfigJson("42").error, /JSON object/);
+});
+
+test("jsonSyntaxError: live check used for inline feedback while typing", () => {
+  assert.equal(jsonSyntaxError(""), null); // still typing — not an error yet
+  assert.equal(jsonSyntaxError('{"a": 1}'), null);
+  assert.match(jsonSyntaxError("{not json"), /Not valid JSON/);
 });

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -150,3 +150,169 @@ test("an empty preview leaves Confirm disabled", () => {
   assert.match(out, /No configuration changes detected/);
   assert.match(out, /disabled/); // nothing to commit
 });
+
+// --- Core-vs-sections regroup + two edit modes (#529, RATIFIED Wave-0) -----------------------
+//
+// The form/JSON split and the collapse-by-default sections, driven by ConfigView.state directly —
+// the same instance-state pattern workerview.test.mjs uses for WorkerInspect (no DOM, no mount).
+
+import { buildSections } from "../../mining_dashboard/web/static/configlogic.mjs";
+
+function stubSetState(inst) {
+  inst.setState = (patch) => {
+    const next = typeof patch === "function" ? patch(inst.state, inst.props) : patch;
+    Object.assign(inst.state, next);
+  };
+}
+
+const CFG = {
+  monero: { wallet_address: "4AAAA", mode: "local", prune: true },
+  p2pool: { pool: "mini", stratum_password: "" },
+  dashboard: { auth: { username: "admin", password: { __secret__: true } } },
+};
+const CORE_KEYS = ["monero.wallet_address", "p2pool.pool", "dashboard.auth.username"];
+
+function readyView(cfg = CFG, coreKeys = CORE_KEYS) {
+  const inst = new ConfigView({});
+  stubSetState(inst);
+  inst.state = {
+    ...inst.state,
+    phase: "form",
+    cfg,
+    sections: buildSections(cfg),
+    coreKeys,
+    editText: JSON.stringify(cfg, null, 2),
+  };
+  return inst;
+}
+
+test("load() sources the core group from the fetched config's _core_keys (config.core-keys.json, #502/#529)", async () => {
+  const inst = new ConfigView({});
+  stubSetState(inst);
+  const withCore = { ...CFG, _core_keys: CORE_KEYS };
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 200,
+    ok: true,
+    json: async () => withCore,
+  });
+  try {
+    await inst.load();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.deepEqual(inst.state.coreKeys, CORE_KEYS);
+  const out = renderToString(inst.render());
+  assert.match(out, /Core/);
+  assert.match(out, /wallet_address/);
+});
+
+test("form mode: the core section renders pinned fields; each natural section is a collapsed <details>", () => {
+  const out = renderToString(readyView().render());
+  assert.match(out, /config-section-core/); // the pinned core card
+  assert.match(out, /<details/); // natural sections are native <details>
+  assert.doesNotMatch(out, /<details[^>]*\bopen\b/); // collapsed by default, not `open`
+});
+
+test("form mode: a core key is lifted out of its own section (no duplicate row)", () => {
+  const inst = readyView();
+  const out = renderToString(inst.render());
+  // dashboard.auth.username is core (rendered with its FULL key, since the pinned card mixes
+  // several sections); dashboard.auth.password stays behind in the dashboard <details> (rendered
+  // with its short relative label, since the section heading already says "dashboard").
+  const matches = out.match(/config-field-name">[^<]*username/g) || [];
+  assert.equal(matches.length, 1); // rendered once (in Core), not twice
+  assert.match(out, /config-field-name">dashboard\.auth\.username/); // full key inside Core
+  assert.match(out, /config-field-name">auth\.password/); // relative label inside its section
+});
+
+test("mode toggle switches between Form and JSON rendering", () => {
+  const inst = readyView();
+  assert.match(renderToString(inst.render()), /config-section-core/);
+  inst.state.mode = "json";
+  const out = renderToString(inst.render());
+  assert.match(out, /worker-edit/); // the JSON textarea reuses Worker Inspect's own class
+  assert.doesNotMatch(out, /config-section-core/);
+});
+
+// --- buildProposed(): both modes build the same staged config object -------------------------
+
+test("buildProposed: form mode folds edits back the same way applyEdits does", () => {
+  const inst = readyView();
+  inst.state.edits = { "p2pool.pool": "main" };
+  const staged = inst.buildProposed();
+  assert.equal(staged.config.p2pool.pool, "main");
+  assert.equal(staged.config.monero.wallet_address, "4AAAA"); // untouched fields survive
+});
+
+test("buildProposed: JSON mode parses the SAME equivalent edit into an identical staged object", () => {
+  const form = readyView();
+  form.state.edits = { "p2pool.pool": "main" };
+  const viaForm = form.buildProposed();
+
+  const json = readyView();
+  json.state.mode = "json";
+  json.state.editText = JSON.stringify(viaForm.config);
+  const viaJson = json.buildProposed();
+
+  assert.deepEqual(viaJson, viaForm); // identical staged config from either mode
+});
+
+test("buildProposed: JSON mode surfaces a parse error instead of a staged config", () => {
+  const inst = readyView();
+  inst.state.mode = "json";
+  inst.state.editText = "{not json";
+  assert.match(inst.buildProposed().error, /Not valid JSON/);
+});
+
+// --- Masked-secret sentinel round-trip, both modes (#508/#440) --------------------------------
+
+test("form mode: leaving a masked secret untouched keeps the sentinel in the staged config", () => {
+  const inst = readyView();
+  const staged = inst.buildProposed(); // no edits at all
+  assert.deepEqual(staged.config.dashboard.auth.password, { __secret__: true });
+});
+
+test("JSON mode: an untouched sentinel round-trips verbatim through the textarea", () => {
+  const inst = readyView();
+  inst.state.mode = "json";
+  assert.match(inst.state.editText, /__secret__/); // still the literal sentinel shape
+  const staged = inst.buildProposed();
+  assert.deepEqual(staged.config.dashboard.auth.password, { __secret__: true });
+});
+
+// --- File-fill button (#529, mirrors #518's ~5 lines) ------------------------------------------
+
+test("the fill button reads a picked file into the JSON textarea via FileReader", () => {
+  const inst = readyView();
+  inst.state.mode = "json";
+  const content = JSON.stringify({ ...CFG, p2pool: { pool: "main", stratum_password: "" } });
+  let capturedOnLoad;
+  class FakeFileReader {
+    set onload(fn) {
+      capturedOnLoad = fn;
+    }
+    readAsText() {
+      this.result = content;
+      capturedOnLoad();
+    }
+  }
+  const realFileReader = globalThis.FileReader;
+  globalThis.FileReader = FakeFileReader;
+  try {
+    inst.onFilePick({ target: { files: [{ name: "config.json" }] } });
+  } finally {
+    globalThis.FileReader = realFileReader;
+  }
+  assert.equal(inst.state.editText, content);
+  assert.equal(inst.state.jsonError, null);
+  assert.equal(inst.buildProposed().config.p2pool.pool, "main");
+});
+
+test("the fill button is a no-op when the file picker is dismissed with no file", () => {
+  const inst = readyView();
+  inst.state.mode = "json";
+  const before = inst.state.editText;
+  inst.onFilePick({ target: { files: [] } });
+  assert.equal(inst.state.editText, before);
+});

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -190,6 +190,41 @@ class TestReferenceMerge:
         assert cfg["monero"]["node_password"] == {"__secret__": True}
 
 
+class TestCoreKeys:
+    """read_config's ``_core_keys`` field (#502/#529): the SAME config.core-keys.json file the
+    wizard reads, surfaced to the browser so the Configuration view's core group is never a second
+    hand-maintained list. Underscore-prefixed like config.reference.json's own ``_docs``, so
+    buildSections on the frontend already skips it as a config section for free."""
+
+    def test_core_keys_served_from_the_shared_file(self, spool, monkeypatch):
+        core_keys_path = spool / "config.core-keys.json"
+        core_keys_path.write_text(json.dumps(["monero.wallet_address", "p2pool.pool"]))
+        monkeypatch.setattr(control_service.config, "HOST_CORE_KEYS_PATH", str(core_keys_path))
+        cfg = control_service.read_config()
+        assert cfg["_core_keys"] == ["monero.wallet_address", "p2pool.pool"]
+
+    def test_missing_core_keys_file_degrades_to_empty_list(self, spool, monkeypatch):
+        monkeypatch.setattr(
+            control_service.config, "HOST_CORE_KEYS_PATH", str(spool / "does-not-exist.json")
+        )
+        cfg = control_service.read_config()
+        assert cfg["_core_keys"] == []
+
+    def test_malformed_core_keys_file_degrades_to_empty_list(self, spool, monkeypatch):
+        core_keys_path = spool / "config.core-keys.json"
+        core_keys_path.write_text("{not json")
+        monkeypatch.setattr(control_service.config, "HOST_CORE_KEYS_PATH", str(core_keys_path))
+        cfg = control_service.read_config()
+        assert cfg["_core_keys"] == []
+
+    def test_core_keys_file_not_a_list_degrades_to_empty_list(self, spool, monkeypatch):
+        core_keys_path = spool / "config.core-keys.json"
+        core_keys_path.write_text(json.dumps({"not": "a list"}))
+        monkeypatch.setattr(control_service.config, "HOST_CORE_KEYS_PATH", str(core_keys_path))
+        cfg = control_service.read_config()
+        assert cfg["_core_keys"] == []
+
+
 class TestWorkerApply:
     """Worker config-apply spooling + validation (#185). The intent carries only the worker name +
     writable-key changes — never a host, port, or token (those stay host-side, #440)."""

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -234,6 +234,26 @@ class TestControlRoutesEnabled:
         assert "correct horse" not in json.dumps(body)
         assert "SECRET-UUID" not in json.dumps(body)
 
+    async def test_get_config_carries_core_keys_from_the_shared_file(
+        self, control_client, control_spool, monkeypatch
+    ):
+        # #529: the Configuration view's core group reads the SAME config.core-keys.json file the
+        # wizard reads (config.HOST_CORE_KEYS_PATH), not a hand-maintained duplicate.
+        core_keys_path = control_spool / "config.core-keys.json"
+        core_keys_path.write_text(json.dumps(["p2pool.pool", "dashboard.auth.username"]))
+        monkeypatch.setattr(control_service.config, "HOST_CORE_KEYS_PATH", str(core_keys_path))
+        resp = await control_client.get("/api/config")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["_core_keys"] == ["p2pool.pool", "dashboard.auth.username"]
+
+    async def test_get_config_degrades_to_no_core_keys_when_file_is_missing(self, control_client):
+        # control_spool doesn't write config.core-keys.json, so HOST_CORE_KEYS_PATH points nowhere.
+        resp = await control_client.get("/api/config")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["_core_keys"] == []
+
     async def test_post_without_control_header_forbidden(self, control_client):
         # The custom header forces a CORS preflight cross-site, which is never granted (CSRF).
         for path in ("/api/control/preview", "/api/control/commit", "/api/control/upgrade"):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -561,6 +561,10 @@ services:
       # config.reference.json (every key with its default), read-only, so the editor form covers the
       # full schema even for keys the operator's sparse config.json omits (#33). No secrets.
       - ./config.reference.json:/host-config/config.reference.json:ro
+      # config.core-keys.json (#502/#529), read-only: the SAME core-key shortlist file the wizard
+      # reads, so the Configuration view's pinned core section is never a second hand-maintained
+      # list. No secrets — it's a list of dotted key paths, not values.
+      - ./config.core-keys.json:/host-config/config.core-keys.json:ro
     environment:
       - HOST_IP=${HOST_IP:-127.0.0.1}
       # Timezone for dashboard timestamps/charts. Set via `dashboard.timezone` in config.json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,15 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 > Only `monero.wallet_address` and `tari.wallet_address` are required. Everything below is optional
 > and has a default. Add a key only when you want to change its behavior.
 
+The table below has ~94 keys across 13 sections — most of it you'll never touch. A handful of keys
+are **core**: wallet addresses, `monero.mode`, `p2pool.pool`, the dashboard login and host, and
+`workers.list` — the ones `./pithead setup` asks about (see
+[Getting Started › Run setup](getting-started.md#3-run-setup)) and, if `dashboard.control.enabled`
+is on, the group the dashboard's [Configuration view](dashboard.md#configuration-view) pins at the
+top of its form, above the rest of the schema grouped by section and collapsed by default. Both
+read the exact same list, [`config.core-keys.json`](../config.core-keys.json) — there's only ever
+one shortlist to keep in sync with this table, not two.
+
 | Key | Default | Description |
 |---|---|---|
 | `monero.mode` | `local` | `local` runs the bundled Monero node; `remote` connects to an external node (see `monero.remote`). |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -489,14 +489,31 @@ Edit `config.json` from the dashboard. Off by default: set `dashboard.control.en
 wallet, so it refuses to run without a login), and run `./pithead apply`. A **Configuration**
 button then appears next to the Simple/Advanced toggle.
 
-The flow mirrors the CLI's `apply`:
+Two edit modes build the same candidate config and submit it through the same pipeline below
+([#529](https://github.com/p2pool-starter-stack/pithead/issues/529)):
 
-1. The form is prefilled from a pre-masked copy of `config.json` the host renders into the
-   control spool ([#440](https://github.com/p2pool-starter-stack/pithead/issues/440)), grouped by
-   section. Secrets (the dashboard password, the Telegram bot token, node RPC credentials, the
-   stratum password) show as "set — leave blank to keep"; their values never enter the dashboard
-   container, let alone the browser — leaving one untouched sends a sentinel back, and the host
-   swaps in the live value when it stages the change.
+- **Form** (the default) pins a **Core** group at the top — the same wallet-address /
+  `monero.mode` / `p2pool.pool` / dashboard-auth-and-host shortlist
+  [`./pithead setup`](getting-started.md#3-run-setup) asks, read from the one file the wizard and
+  this view share, [`config.core-keys.json`](../config.core-keys.json), so the two can't drift
+  apart. Below it, the rest of the schema is grouped by its natural top-level section (`monero`,
+  `tari`, `p2pool`, `telegram`, …), each collapsed by default, so a typical edit shows only the
+  handful of fields you're touching instead of the whole schema. `workers.list[]` (the per-rig
+  descriptors) isn't a form field here — a variable-length list has no single form control for it —
+  edit it via [Worker Inspect](#worker-inspect) or `config.json` directly.
+- **JSON** edits the whole fetched config as one text block, for operators who'd rather paste than
+  click through fields. A **Load from file** control (`FileReader`, no upload) fills it from a
+  saved `config.json`, the same pattern [Worker Inspect's JSON mode](#worker-inspect) uses. A
+  malformed edit is flagged inline before you click Save.
+
+The flow mirrors the CLI's `apply` either way:
+
+1. The form/textarea is prefilled from a pre-masked copy of `config.json` the host renders into the
+   control spool ([#440](https://github.com/p2pool-starter-stack/pithead/issues/440)). Secrets (the
+   dashboard password, the Telegram bot token, node RPC credentials, the stratum password) show as
+   "set — leave blank to keep"; their values never enter the dashboard container, let alone the
+   browser — leaving one untouched sends a sentinel back (JSON mode carries it through verbatim
+   too), and the host swaps in the live value when it stages the change.
 2. **Save & preview changes** stages the edited config on the host, which dry-runs it and returns
    the same change preview `./pithead apply` prints — one row per changed setting, disruptive rows
    (⚠) styled as warnings. A config that fails validation is rejected here with pithead's own
@@ -508,7 +525,9 @@ The flow mirrors the CLI's `apply`:
 Most settings cannot be committed from the dashboard — the host-side runner holds an explicit
 allowlist of operational settings (pool tier, XvB enable and donation level, alert toggles,
 memory limits, time zone, the energy-calculator prices, …) and default-denies a change, in any
-direction, to anything else:
+direction, to anything else. The allowlist gates BOTH edit modes identically — JSON mode is a
+different way to assemble the candidate config, not a different validation path, so it can't
+smuggle a change the form couldn't make:
 wallets, the dashboard login and onion settings, the control channel itself, the Tor egress
 firewall, clearnet toggles, node endpoints, and every credential. It likewise refuses anything
 the preview flags disruptive (⚠). Apply those from the host with `./pithead apply`; out-of-band

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -246,6 +246,8 @@ jq_assert "raw config.json never enters the dashboard container (#440)" \
     '.services.dashboard.volumes | any(.source | tostring | endswith("/config.json")) | not'
 jq_assert "dashboard config.reference.json prefill mounted read-only (#33)" \
     '.services.dashboard.volumes | any((.target == "/host-config/config.reference.json") and (.read_only == true))'
+jq_assert "dashboard config.core-keys.json shortlist mounted read-only (#529)" \
+    '.services.dashboard.volumes | any((.target == "/host-config/config.core-keys.json") and (.read_only == true))'
 jq_assert "control staged/ dir never enters the container (#33)" \
     '.services.dashboard.volumes | any(.target | contains("staged")) | not'
 jq_assert "control channel defaults off in the dashboard env (#33)" \


### PR DESCRIPTION
## Summary

Implements the RATIFIED Wave-0 decision on #529 (the two "ponytail amendments" to the original proposal):

- **Config form regroup.** The Configuration view's **Form** mode now pins a **Core** group at the top — wallet addresses, `monero.mode`, `p2pool.pool`, dashboard auth + host, `workers.list` — above the config's natural sections (`monero`, `tari`, `p2pool`, `telegram`, …), each a native `<details>` collapsed by default. `workers.list` is an array, so it was never a form field to begin with (`buildSections` already skips arrays, #172) — it stays core-in-spirit only, same as the wizard's treatment.
- **The shared core-keys artifact.** `config.core-keys.json` (landed in #502) is the ONE list — the wizard reads it from disk, the dashboard form now reads it too, via the SAME file: `control_service.read_config()` embeds it as `_core_keys` on the existing `GET /api/config` response (an underscore-prefixed metadata key, the same convention `config.reference.json`'s own `_docs` already uses — `buildSections` already skips it as a section for free). The dashboard container gets the file through a new read-only bind mount, `./config.core-keys.json:/host-config/config.core-keys.json:ro`, mirroring the existing `config.reference.json` mount exactly. No new endpoint, no duplicated hardcoded array.
- **Two modes, not three.** Form / JSON — mirrors #518's Worker Inspect editor shape exactly (down to reusing its `jsonSyntaxError` helper, moved into `configlogic.mjs` and re-exported from `workerlogic.mjs`). JSON mode edits the whole fetched config as one textarea; a **Load from file** button (`FileReader`, no upload) fills it — the fill button, not a third UI state.
- **One pipeline.** Both modes build the identical staged config object (`ConfigView.buildProposed()`) and submit it through the unchanged `/api/control/preview` → confirm → `/api/control/commit` flow. The host-side closed-schema gate is still the only validation authority — no new server validation surface.
- **Secret sentinels.** A masked value (`{__secret__: true}`) still renders as a blank password field in Form mode and round-trips verbatim in JSON mode unless the operator edits it themselves (reuses `isSecretSentinel` from `configlogic.mjs`, same as #518/#508).

## Files changed

- `build/dashboard/mining_dashboard/config/config.py` — `HOST_CORE_KEYS_PATH`
- `build/dashboard/mining_dashboard/service/control_service.py` — `_load_core_keys()` + `_core_keys` on `read_config()`
- `build/dashboard/mining_dashboard/web/static/configlogic.mjs` — `regroupCore`, `parseConfigJson`, `jsonSyntaxError` (moved here from `workerlogic.mjs`)
- `build/dashboard/mining_dashboard/web/static/configview.mjs` — Form/JSON mode toggle, core/collapsed-sections render, `buildProposed()`
- `build/dashboard/mining_dashboard/web/static/workerlogic.mjs` — re-exports `jsonSyntaxError` from `configlogic.mjs` instead of a local copy
- `build/dashboard/mining_dashboard/web/static/dashboard.css` — collapsed-section `<summary>` + core-card styling
- `docker-compose.yml` — the new read-only `config.core-keys.json` mount
- `docs/configuration.md`, `docs/dashboard.md` — core-vs-sections + the two modes, house voice
- `CHANGELOG.md` — Unreleased entry (folded under the existing `### Added` heading)
- Tests: `configlogic.test.mjs`, `configview.test.mjs`, `test_control_service.py`, `test_server.py`, `tests/stack/test_compose.sh` (new mount assertion)

## Test plan

- [x] `node --test build/dashboard/tests/frontend/*.test.mjs` — 171 passed (0 failed)
- [x] `make test-dashboard` — 1283 passed, 96.48% total coverage (control_service.py 100%)
- [x] `make test-patch-coverage` — 100% on the two changed Python files (>=90% required)
- [x] `make lint-js` / `make lint-py` / `make lint-docs-voice` / `make lint-md` — all clean
- [x] `make test-compose` — new `config.core-keys.json` mount assertion passes
- [x] `/ponytail-review` — no findings; the RATIFIED decision's two amendments already trimmed the design (one shared shortlist, two modes not three)
- [ ] Not merging — human gate per process

🤖 Generated with [Claude Code](https://claude.com/claude-code)