### PR TITLE
feat(#492): correlate per-rig hashrate to each config version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ### Added
 
+- **Worker Inspect: hashrate correlated to config version (#492).** The per-worker change
+  timeline (#185) now carries the measured hashrate (`worker_history`, #196) each version ran
+  at: a sample is attributed to the most recent *applied* config change at or before its
+  timestamp, then averaged/min/max'd per version, so an operator can compare "config #3 did
+  5.1 kH/s, config #4 did 4.8 kH/s" empirically instead of guessing. Correlation happens in
+  Python (`StateManager.get_worker_hashrate_by_config`) against the existing tables — no new
+  schema, no rig-side change needed. Surfaced as a new table in the Worker Inspect panel,
+  alongside the existing change-history table.
+
 - **Worker Inspect: a table editor and a JSON mode for the writable-config edit path (#518).**
   The raw JSON textarea is now the fallback of two modes: **Table** (the default) renders one row
   per writable key (`pools`, `DONATION`, `autotune`, `watchdog`, `watchdog_interval_min`,

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -1,3 +1,4 @@
+import bisect
 import json
 import logging
 import os
@@ -1081,24 +1082,75 @@ class StateManager:
         except sqlite3.Error as e:
             self._table_write_failed("worker_history", "Worker History Insert Error", e)
 
-    def get_worker_history(self, since: float = 0.0) -> list[dict[str, Any]]:
-        """Per-worker hashrate/share samples (every rig) at or after `since` (default: all),
-        oldest first. A per-worker filter isn't needed yet — add a WHERE name = ? when a
-        consumer (e.g. #492) actually reads one rig's series."""
+    def get_worker_history(
+        self, since: float = 0.0, name: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Per-worker hashrate/share samples at or after `since` (default: all), oldest first.
+        `name` restricts to one rig's series (#492); omit it for every rig's samples."""
         try:
             with self._db_lock:
                 if not self._conn:
                     return []
                 cursor = self._conn.cursor()
-                cursor.execute(
-                    "SELECT ts, name, h15, accepted, rejected FROM worker_history "
-                    "WHERE ts >= ? ORDER BY ts ASC",
-                    (since,),
-                )
+                if name is not None:
+                    cursor.execute(
+                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
+                        "WHERE ts >= ? AND name = ? ORDER BY ts ASC",
+                        (since, name),
+                    )
+                else:
+                    cursor.execute(
+                        "SELECT ts, name, h15, accepted, rejected FROM worker_history "
+                        "WHERE ts >= ? ORDER BY ts ASC",
+                        (since,),
+                    )
                 return [dict(row) for row in cursor.fetchall()]
         except sqlite3.Error as e:
             self.logger.error(f"Worker History Read Error: {e}")
             return []
+
+    def get_worker_hashrate_by_config(
+        self, worker: str, since: float = 0.0
+    ) -> list[dict[str, Any]]:
+        """Correlate `worker`'s measured hashrate (worker_history) to the config version active at
+        each sample's timestamp (#492 — rides #185's worker_config + #196's worker_history). Each
+        *applied* worker_config row is a version boundary; a sample belongs to the most recent
+        applied change at or before its ts, so an operator can compare "config #3 did X, config #4
+        did Y" empirically. Bucketing is in Python (bisect) — the version count is small (`limit`
+        below) and this reads far more clearly than a correlated-subquery/window-function SQL
+        version. Returns one row per version, newest first, matching get_worker_config_history:
+        `{change_id, ts, reason, sample_count, avg_h15, min_h15, max_h15}` (the h15 fields are
+        `None` for a version with zero samples). Samples that predate the first applied change have
+        no known version and are dropped — out of scope: correlate to a KNOWN version, don't guess
+        at pre-history config."""
+        versions = [
+            row
+            for row in reversed(self.get_worker_config_history(worker, limit=200))
+            if row.get("status") == "applied"
+        ]
+        if not versions:
+            return []
+        boundaries = [v["ts"] for v in versions]  # oldest first, aligned with `versions`
+        buckets: list[list[float]] = [[] for _ in versions]
+        for s in self.get_worker_history(since=since, name=worker):
+            idx = bisect.bisect_right(boundaries, s["ts"]) - 1
+            if idx >= 0:
+                buckets[idx].append(s["h15"])
+
+        out = [
+            {
+                "change_id": v["change_id"],
+                "ts": v["ts"],
+                "reason": v.get("reason"),
+                "sample_count": len(vals),
+                "avg_h15": sum(vals) / len(vals) if vals else None,
+                "min_h15": min(vals) if vals else None,
+                "max_h15": max(vals) if vals else None,
+            }
+            for v, vals in zip(versions, buckets, strict=True)
+        ]
+        out.reverse()  # newest first
+        return out
 
     def get_xvb_stats(self) -> dict[str, Any]:
         """Returns the current XvB mining statistics dictionary."""

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -82,6 +82,22 @@ function HistoryRow({ row }) {
     </tr>`;
 }
 
+// One row of the hashrate-by-config table (#492): a config version + the measured hashrate
+// (worker_history) aggregated over that version's active window, so an operator can compare
+// versions empirically ("config #3 did X, config #4 did Y"). avg/min/max are `null` — rendered
+// as "—" — for a version with no samples yet (e.g. the one just applied).
+function HashrateByConfigRow({ row }) {
+  return html`
+    <tr>
+        <td class="text-xs text-muted">${row.applied_at || ""}</td>
+        <td class="font-mono text-xs">${row.change_id || "—"}</td>
+        <td class="text-xs">${row.avg_h15 || "—"}</td>
+        <td class="text-xs text-muted">${row.min_h15 || "—"}</td>
+        <td class="text-xs text-muted">${row.max_h15 || "—"}</td>
+        <td class="text-xs text-muted">${row.sample_count}</td>
+    </tr>`;
+}
+
 // One table-editor row. `value` falls back to the field's prefilled value until the operator
 // edits it (edits is keyed like ConfigView's own `edits` state). A secret row is a masked
 // password input (#508) — never the raw sentinel JSON — so it can only be left alone or replaced.
@@ -283,6 +299,19 @@ export class WorkerInspect extends Component {
                 </table>
             </div>`
                 : html`<p class="text-muted text-small">No changes applied from the dashboard yet.</p>`
+            }
+
+            <h4 class="mt-2">Hashrate by config version</h4>
+            ${
+              (detail.hashrate_by_config || []).length
+                ? html`
+            <div class="table-scroll">
+                <table class="worker-history">
+                    <thead><tr><th>Applied</th><th>Version</th><th>Avg h15</th><th>Min</th><th>Max</th><th>Samples</th></tr></thead>
+                    <tbody>${detail.hashrate_by_config.map((row) => html`<${HashrateByConfigRow} row=${row} />`)}</tbody>
+                </table>
+            </div>`
+                : html`<p class="text-muted text-small">No applied config changes to correlate hashrate against yet.</p>`
             }
         </div>`;
   }

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1436,6 +1436,9 @@ def build_worker_detail(name, data, state_mgr):
     the dashboard last applied (the editor prefill — the rig's feed does not expose the writable
     config values, so Pithead's own last-applied record is the honest source), and the change history
     (each row's ``changes`` is a diff by construction, since we only ever record deltas we authored).
+    ``hashrate_by_config`` (#492) is that same version timeline with each version's measured
+    hashrate (worker_history) aggregated over its active window, so an operator can compare config
+    versions empirically.
 
     ``editable`` is whether the worker has an operator-set ``host`` in ``dashboard.workers[]`` — the
     precondition for the host-side write path. The rig's token is masked out of this container (#440),
@@ -1448,6 +1451,12 @@ def build_worker_detail(name, data, state_mgr):
     for row in history:
         ts = row.get("ts")
         row["applied_at"] = format_time_abs(ts) if ts else ""
+    hashrate_by_config = state_mgr.get_worker_hashrate_by_config(name)
+    for row in hashrate_by_config:
+        ts = row.get("ts")
+        row["applied_at"] = format_time_abs(ts) if ts else ""
+        for key in ("avg_h15", "min_h15", "max_h15"):
+            row[key] = format_hashrate(row[key]) if row[key] is not None else None
     return {
         "name": name,
         "found": worker is not None,
@@ -1461,6 +1470,7 @@ def build_worker_detail(name, data, state_mgr):
         "writable_keys": sorted(WORKER_WRITABLE_KEYS),
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,
+        "hashrate_by_config": hashrate_by_config,
     }
 
 

--- a/build/dashboard/tests/frontend/workerview.test.mjs
+++ b/build/dashboard/tests/frontend/workerview.test.mjs
@@ -176,3 +176,60 @@ test("the fill button is a no-op when the file picker is dismissed with no file"
   inst.onFilePick({ target: { files: [] } });
   assert.equal(inst.state.editText, before);
 });
+
+// --- Hashrate by config (#492) ----------------------------------------------------------------
+
+test("renders one row per config version with its aggregated hashrate", () => {
+  const detail = {
+    ...DETAIL,
+    hashrate_by_config: [
+      {
+        change_id: "cid2",
+        applied_at: "2026-07-16 12:00",
+        avg_h15: "4.00 kH/s",
+        min_h15: "4.00 kH/s",
+        max_h15: "4.00 kH/s",
+        sample_count: 0,
+        reason: null,
+      },
+      {
+        change_id: "cid1",
+        applied_at: "2026-07-16 10:00",
+        avg_h15: "1.50 kH/s",
+        min_h15: "1.00 kH/s",
+        max_h15: "2.00 kH/s",
+        sample_count: 2,
+        reason: null,
+      },
+    ],
+  };
+  const out = renderToString(readyInstance(detail).render());
+  assert.match(out, /cid2/);
+  assert.match(out, /cid1/);
+  assert.match(out, /1\.50 kH\/s/);
+});
+
+test("a version with no samples yet shows a dash, not a crash", () => {
+  const detail = {
+    ...DETAIL,
+    hashrate_by_config: [
+      {
+        change_id: "cid1",
+        applied_at: "2026-07-16 10:00",
+        avg_h15: null,
+        min_h15: null,
+        max_h15: null,
+        sample_count: 0,
+        reason: null,
+      },
+    ],
+  };
+  const out = renderToString(readyInstance(detail).render());
+  assert.match(out, /cid1/);
+  assert.match(out, />—</);
+});
+
+test("no applied config versions yet falls back to an explanatory message", () => {
+  const out = renderToString(readyInstance({ ...DETAIL, hashrate_by_config: [] }).render());
+  assert.match(out, /No applied config changes to correlate hashrate against yet/);
+});

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -1037,6 +1037,107 @@ class TestWorkerHistory:
             state_manager._conn.execute("DROP TABLE worker_history")
         assert state_manager.get_worker_history() == []
 
+    def test_get_name_filters_to_one_rig(self, state_manager):
+        t0 = time.time()
+        state_manager.add_worker_history(
+            [
+                {"ts": t0, "name": "rig1", "h15": 1.0, "accepted": 0, "rejected": 0},
+                {"ts": t0, "name": "rig2", "h15": 2.0, "accepted": 0, "rejected": 0},
+            ]
+        )
+        rows = state_manager.get_worker_history(name="rig1")
+        assert [r["name"] for r in rows] == ["rig1"]
+
+
+class TestWorkerHashrateByConfig:
+    """Correlates worker_history samples to the worker_config version active at each sample's
+    ts (#492, rides #185's config timeline + #196's hashrate series)."""
+
+    def test_no_applied_versions_returns_empty(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid1", "rejected", {"a": 1}, "bad", ts=100)
+        assert state_manager.get_worker_hashrate_by_config("rig1") == []
+
+    def test_samples_bucketed_by_version_boundary(self, state_manager):
+        # v1 applied at t=100, v2 applied at t=200. Samples before t=100 have no known version and
+        # are dropped; samples in [100, 200) belong to v1, samples >= 200 belong to v2.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_config_version("rig1", "cid2", "applied", {"a": 2}, None, ts=200)
+        state_manager.add_worker_history(
+            [{"ts": 50, "name": "rig1", "h15": 999.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": 120, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": 180, "name": "rig1", "h15": 2000.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": 250, "name": "rig1", "h15": 4000.0, "accepted": 0, "rejected": 0}]
+        )
+        rows = state_manager.get_worker_hashrate_by_config("rig1")
+        # Newest first, matching get_worker_config_history.
+        assert [r["change_id"] for r in rows] == ["cid2", "cid1"]
+        v2, v1 = rows
+        assert v1["sample_count"] == 2
+        assert v1["avg_h15"] == 1500.0
+        assert v1["min_h15"] == 1000.0
+        assert v1["max_h15"] == 2000.0
+        assert v2["sample_count"] == 1
+        assert v2["avg_h15"] == 4000.0
+
+    def test_version_with_no_samples_yet_has_none_aggregates(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_history(
+            [{"ts": 150, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_config_version("rig1", "cid2", "applied", {"a": 2}, None, ts=200)
+        rows = state_manager.get_worker_hashrate_by_config("rig1")
+        newest = rows[0]
+        assert newest["change_id"] == "cid2"
+        assert newest["sample_count"] == 0
+        assert newest["avg_h15"] is None
+        assert newest["min_h15"] is None
+        assert newest["max_h15"] is None
+
+    def test_non_applied_versions_are_not_boundaries(self, state_manager):
+        # A rejected/failed change never became the active config, so it must not split a segment.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_config_version("rig1", "cid2", "rejected", {"a": 2}, "bad", ts=150)
+        state_manager.add_worker_history(
+            [{"ts": 175, "name": "rig1", "h15": 5000.0, "accepted": 0, "rejected": 0}]
+        )
+        rows = state_manager.get_worker_hashrate_by_config("rig1")
+        assert len(rows) == 1
+        assert rows[0]["change_id"] == "cid1"
+        assert rows[0]["sample_count"] == 1
+
+    def test_other_workers_hashrate_is_excluded(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_history(
+            [
+                {"ts": 150, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0},
+                {"ts": 150, "name": "rig2", "h15": 9999.0, "accepted": 0, "rejected": 0},
+            ]
+        )
+        rows = state_manager.get_worker_hashrate_by_config("rig1")
+        assert rows[0]["sample_count"] == 1
+        assert rows[0]["avg_h15"] == 1000.0
+
+    def test_since_bounds_the_samples_but_not_the_version_timeline(self, state_manager):
+        # A version applied before `since` can still be the active version for samples inside the
+        # window — `since` only filters which SAMPLES are read, not which versions exist.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_history(
+            [{"ts": 120, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": 500, "name": "rig1", "h15": 3000.0, "accepted": 0, "rejected": 0}]
+        )
+        rows = state_manager.get_worker_hashrate_by_config("rig1", since=400)
+        assert rows[0]["change_id"] == "cid1"
+        assert rows[0]["sample_count"] == 1
+        assert rows[0]["avg_h15"] == 3000.0
+
 
 class TestTelemetryTableHealth:
     """Per-table 'last successful write' health signal (#196 Wave-0), mirroring db_healthy so a

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -2133,3 +2133,34 @@ class TestBuildWorkerDetail:
         assert [h["status"] for h in d["history"]] == ["rejected", "applied"]  # newest first
         assert d["history"][0]["applied_at"]  # formatted timestamp present
         assert d["last_applied"] == {"DONATION": 2}  # only the applied change prefills
+
+    def test_hashrate_by_config_correlates_samples_to_versions(self, monkeypatch):
+        # #492: worker_history samples aggregated per applied worker_config version.
+        d, sm = self._detail(
+            monkeypatch,
+            "rig1",
+            workers=[{"name": "rig1", "status": "online", "h60": 0}],
+            descriptors=[{"name": "rig1", "host": "10.0.0.9"}],
+        )
+        sm.add_worker_config_version("rig1", "cid1", "applied", {"DONATION": 2}, None, ts=100.0)
+        sm.add_worker_history(
+            [{"ts": 150.0, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0}]
+        )
+        d = build_worker_detail("rig1", {"workers": [{"name": "rig1", "status": "online"}]}, sm)
+        sm.close()
+        assert len(d["hashrate_by_config"]) == 1
+        row = d["hashrate_by_config"][0]
+        assert row["change_id"] == "cid1"
+        assert row["applied_at"]  # formatted timestamp present
+        assert row["avg_h15"] == "1.00 kH/s"  # human-formatted, matching detail["hashrate"]
+        assert row["sample_count"] == 1
+
+    def test_hashrate_by_config_empty_with_no_applied_versions(self, monkeypatch):
+        d, sm = self._detail(
+            monkeypatch,
+            "rig1",
+            workers=[{"name": "rig1", "status": "online", "h60": 0}],
+            descriptors=[{"name": "rig1", "host": "10.0.0.9"}],
+        )
+        sm.close()
+        assert d["hashrate_by_config"] == []

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -290,6 +290,15 @@ config *values*, the editor prefills from the last config the dashboard applied 
 the rig — so a change made directly on the rig (via `rigforge.sh`) won't show here until the next
 dashboard apply.
 
+Below the change history sits a **Hashrate by config version** table: each *applied* change, with the
+rig's measured hashrate (the same per-rig `worker_history` samples, taken roughly every 5 minutes)
+averaged over the window that version was active — from the moment it was applied to the moment the
+next one was, or now for the current version. A version with no samples yet (just applied) shows a
+dash rather than zero. This is a correlation over existing data, not a new measurement — no rig-side
+change was needed to add it — so use it to compare versions empirically ("config #3 did 5.1 kH/s,
+config #4 did 4.8 kH/s") rather than as a precise A/B test; a version's window can include restarts,
+sync gaps, or other noise the average doesn't separate out.
+
 ### Simple vs. Advanced view
 
 A **Simple / Advanced** toggle sits above the chart. **Simple** (the default) shows the chart, the


### PR DESCRIPTION
Closes #492

Rides #196's `worker_history` (per-rig h15 samples) + #185's `worker_config` (the config-change timeline). `get_worker_hashrate_by_config(worker)` treats each **applied** config change as a version boundary (rolled_back/rejected changes never ran, so they don't define a version), buckets the hashrate samples by which version was active at each sample's ts (bisect — small version count), and returns per-version `{change_id, ts, reason, sample_count, avg_h15, min_h15, max_h15}`. Samples predating the first applied change are dropped (correlate to a KNOWN version, don't guess). Surfaced in Worker Inspect so an operator can see "config #3 did X, #4 did Y" empirically.

Tests: pytest for the correlation query across version boundaries + zero-sample versions + pre-first-change drops; node --test for the Worker Inspect render. Dashboard 1336 passed / 96.64%; patch coverage 100%; lint-py/js clean. Ponytail: lean.

(Implementation by a delegated agent; finished, tested, and reviewed by the session lead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)