### PR TITLE
Config form v2: logical grouping, nested event groups, host-only grey-out (#611, #612, #613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   a deferred follow-up, not implemented here (fetching one is a clearnet egress this privacy-first
   stack avoids).
 
+### Changed
+
+- **Configuration view: logical section grouping, nested event groups, host-only grey-out
+  (#611/#612/#613).** The form no longer groups fields one section per top-level `config.json`
+  key — a display-layer map now groups them the way an operator thinks about them (Wallets &
+  payout, Monero node, Mining, Workers, Dashboard & access, Notifications, Energy, Alerts &
+  thresholds, System / advanced), so a grab-bag key like `dashboard` splits across the sections
+  its fields actually belong to; a path no group claims still renders, in a catch-all **Other**
+  group, and a frontend test fails if any `config.reference.json` path would ever land there
+  unclaimed (#611). Within Notifications, the 26 `telegram.events` toggles, the ntfy/webhook
+  sinks, and Healthchecks each nest one level deeper into their own collapsed sub-group instead of
+  dominating the section (#612). And a field the control-channel gate wouldn't actually commit —
+  derived from the SAME allowlist the gate enforces, surfaced to the browser as `_editable_keys` on
+  `GET /api/config` — now renders disabled with a "Host-only" tooltip up front, instead of letting
+  it be edited and rejected only at Save; a drift-guard test keeps the surfaced set in lockstep
+  with the gate's real allowlist (#613). `config.json` itself is unchanged; the staged-preview →
+  closed-schema gate → commit pipeline is unaffected. JSON mode (which edits the whole config as
+  text) is unaffected by any of this.
+
 ## [1.7.0] - 2026-07-17
 
 The **Config UX & telemetry** cycle. Config editing becomes humane — worker

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -80,6 +80,91 @@ def _deep_merge(base, override):
     return merged
 
 
+# Env-var -> config-path(s) map (#613), mirroring pithead's CONTROL_DASHBOARD_EDITABLE_KEYS
+# (pithead ~L4793) — the commit gate's ACTUAL allowlist, the single source of truth for what the
+# control channel will commit. Surfaced to the browser as ``_editable_keys`` below so the
+# Configuration view can grey out everything else up front instead of letting an operator edit a
+# host-only field and find out at Save (#613).
+#
+# Some env vars are derived from MORE than one config path — P2POOL_FLAGS folds in both
+# ``p2pool.pool`` (--mini/--nano) and ``p2pool.clearnet`` (the Tor-egress socks flags appended in
+# render_env) — so this has to mirror the actual derivation in render_env, not the prose summary
+# in pithead's own allowlist comment (which lists "clearnet toggles" as generally host-only
+# elsewhere; the gate itself works on RENDERED ENV VARS, not config paths, so a config path that
+# feeds an allowlisted var IS committable even if it sounds like it shouldn't be from the comment
+# alone).
+#
+# Drift-guarded (mirrors #515's WORKER_WRITABLE_KEYS check, see
+# test_editable_keys_have_no_intra_repo_drift below): a test regexes
+# CONTROL_DASHBOARD_EDITABLE_KEYS out of the pithead script and asserts its env-var names equal
+# this map's keys, so an allowlist edit without a matching map edit fails CI loudly instead of
+# silently drifting the greyed set out of sync with what the gate actually accepts.
+EDITABLE_ENV_KEY_PATHS = {
+    "P2POOL_FLAGS": ("p2pool.pool", "p2pool.clearnet"),
+    "P2POOL_PORT": ("p2pool.pool",),
+    "XVB_ENABLED": ("xvb.enabled",),
+    "XVB_DONATION_LEVEL": ("xvb.donation_level",),
+    "TARI_REQUIRED": ("dashboard.tari_required",),
+    "DASHBOARD_CHECK_UPDATES": ("dashboard.check_for_updates",),
+    "DASHBOARD_TZ": ("dashboard.timezone",),
+    "MONERO_MEM_LIMIT": ("monero.mem_limit",),
+    "TARI_MEM_LIMIT": ("tari.mem_limit",),
+    "MONERO_PREP_THREADS": ("monero.prep_blocks_threads",),
+    "HASHRATE_DROP_THRESHOLD_PCT": ("dashboard.hashrate_drop_threshold",),
+    "HASHRATE_DROP_MINUTES": ("dashboard.hashrate_drop_minutes",),
+    "TELEGRAM_DAILY_SUMMARY_TIME": ("telegram.daily_summary_time",),
+    # The 26 telegram.events.* toggles, minus wallet_changed / clearnet_exposed — pithead's own
+    # comment explains why those two are excluded on purpose: they're the tamper-evidence alarms
+    # on the very channel a compromised container would use to silence them, so the dashboard must
+    # never be able to turn them off. They stay in the Notifications > Telegram events nested
+    # subgroup (#612), just greyed like any other host-only field.
+    "TELEGRAM_EVENT_NODE_DOWN": ("telegram.events.node_down",),
+    "TELEGRAM_EVENT_NODE_RECOVERED": ("telegram.events.node_recovered",),
+    "TELEGRAM_EVENT_WORKER_OFFLINE": ("telegram.events.worker_offline",),
+    "TELEGRAM_EVENT_WORKER_RECOVERED": ("telegram.events.worker_recovered",),
+    "TELEGRAM_EVENT_WORKER_JOINED": ("telegram.events.worker_joined",),
+    "TELEGRAM_EVENT_WORKER_LEFT": ("telegram.events.worker_left",),
+    "TELEGRAM_EVENT_SYNC_FINISHED": ("telegram.events.sync_finished",),
+    "TELEGRAM_EVENT_DISK_SPACE": ("telegram.events.disk_space",),
+    "TELEGRAM_EVENT_DB_UNHEALTHY": ("telegram.events.db_unhealthy",),
+    "TELEGRAM_EVENT_DB_RESET": ("telegram.events.db_reset",),
+    "TELEGRAM_EVENT_XVB_NO_SHARE": ("telegram.events.xvb_no_share",),
+    "TELEGRAM_EVENT_XVB_REGISTRATION": ("telegram.events.xvb_registration",),
+    "TELEGRAM_EVENT_NEW_RELEASE": ("telegram.events.new_release",),
+    "TELEGRAM_EVENT_STACK_ONLINE": ("telegram.events.stack_online",),
+    "TELEGRAM_EVENT_DAILY_SUMMARY": ("telegram.events.daily_summary",),
+    "TELEGRAM_EVENT_HASHRATE_LOW": ("telegram.events.hashrate_low",),
+    "TELEGRAM_EVENT_HASHRATE_LOSS": ("telegram.events.hashrate_loss",),
+    "TELEGRAM_EVENT_HUGEPAGES": ("telegram.events.hugepages",),
+    "TELEGRAM_EVENT_LOW_RAM": ("telegram.events.low_ram",),
+    "TELEGRAM_EVENT_HIGH_REJECT_RATE": ("telegram.events.high_reject_rate",),
+    "TELEGRAM_EVENT_BLOCK_FOUND": ("telegram.events.block_found",),
+    "TELEGRAM_EVENT_PAYOUT_FOUND": ("telegram.events.payout_found",),
+    "TELEGRAM_EVENT_PAYOUT_CONFIRMED": ("telegram.events.payout_confirmed",),
+    "TELEGRAM_EVENT_CONTAINER_UNHEALTHY": ("telegram.events.container_unhealthy",),
+}
+
+# dashboard.energy.* is config.json-only — it never renders to .env (control_approval_gate reads
+# it straight off config.json, pithead ~L4879), so it can never appear in the map above — but the
+# gate explicitly ALLOWS it (#504). Fold it in as the map's one special-case addition. Worker
+# descriptors (workers.list[] / dashboard.workers[]) are the gate's OTHER config.json-only special
+# case, but they're REFUSED outright (per-rig hosts/tokens), so they never get an editable path —
+# and buildSections never renders them as a form field anyway (arrays, #172).
+_ENERGY_PATHS = (
+    "dashboard.energy.cost_per_kwh",
+    "dashboard.energy.currency",
+    "dashboard.energy.xmr_price",
+)
+
+
+def _editable_paths():
+    """Every config path the control gate will actually commit (#613): the env-var allowlist's
+    paths, union the dashboard.energy special-case (#504)."""
+    paths = {p for target in EDITABLE_ENV_KEY_PATHS.values() for p in target}
+    paths.update(_ENERGY_PATHS)
+    return sorted(paths)
+
+
 def _load_core_keys():
     """The wizard's core-key shortlist (#502/#529), read from the SAME file ``./pithead setup``
     reads — the one shared artifact, not a second hand-maintained list. Degrades to an empty list
@@ -102,9 +187,10 @@ def read_config():
     "set — leave blank to keep" from "not set". The copy arrives already masked (#440); the
     masking pass here is defense-in-depth and runs AFTER the merge.
 
-    The response also carries ``_core_keys`` (#529) — an underscore-prefixed metadata key, the
-    same convention ``config.reference.json``'s own ``_docs`` uses, so ``buildSections`` on the
-    frontend already skips it as a config section for free."""
+    The response also carries ``_core_keys`` (#529) and ``_editable_keys`` (#613) — both
+    underscore-prefixed metadata keys, the same convention ``config.reference.json``'s own
+    ``_docs`` uses, so ``buildSections`` on the frontend already skips them as config sections for
+    free."""
     cfg = _load_host_config()
     try:
         with open(config.HOST_REFERENCE_PATH) as f:
@@ -118,6 +204,7 @@ def read_config():
         if found and value:
             _set(cfg, path, dict(SECRET_SENTINEL))
     cfg["_core_keys"] = _load_core_keys()
+    cfg["_editable_keys"] = _editable_paths()
     return cfg
 
 

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -113,35 +113,41 @@ EDITABLE_ENV_KEY_PATHS = {
     "HASHRATE_DROP_THRESHOLD_PCT": ("dashboard.hashrate_drop_threshold",),
     "HASHRATE_DROP_MINUTES": ("dashboard.hashrate_drop_minutes",),
     "TELEGRAM_DAILY_SUMMARY_TIME": ("telegram.daily_summary_time",),
-    # The 26 telegram.events.* toggles, minus wallet_changed / clearnet_exposed — pithead's own
-    # comment explains why those two are excluded on purpose: they're the tamper-evidence alarms
-    # on the very channel a compromised container would use to silence them, so the dashboard must
-    # never be able to turn them off. They stay in the Notifications > Telegram events nested
-    # subgroup (#612), just greyed like any other host-only field.
-    "TELEGRAM_EVENT_NODE_DOWN": ("telegram.events.node_down",),
-    "TELEGRAM_EVENT_NODE_RECOVERED": ("telegram.events.node_recovered",),
-    "TELEGRAM_EVENT_WORKER_OFFLINE": ("telegram.events.worker_offline",),
-    "TELEGRAM_EVENT_WORKER_RECOVERED": ("telegram.events.worker_recovered",),
-    "TELEGRAM_EVENT_WORKER_JOINED": ("telegram.events.worker_joined",),
-    "TELEGRAM_EVENT_WORKER_LEFT": ("telegram.events.worker_left",),
-    "TELEGRAM_EVENT_SYNC_FINISHED": ("telegram.events.sync_finished",),
-    "TELEGRAM_EVENT_DISK_SPACE": ("telegram.events.disk_space",),
-    "TELEGRAM_EVENT_DB_UNHEALTHY": ("telegram.events.db_unhealthy",),
-    "TELEGRAM_EVENT_DB_RESET": ("telegram.events.db_reset",),
-    "TELEGRAM_EVENT_XVB_NO_SHARE": ("telegram.events.xvb_no_share",),
-    "TELEGRAM_EVENT_XVB_REGISTRATION": ("telegram.events.xvb_registration",),
-    "TELEGRAM_EVENT_NEW_RELEASE": ("telegram.events.new_release",),
-    "TELEGRAM_EVENT_STACK_ONLINE": ("telegram.events.stack_online",),
-    "TELEGRAM_EVENT_DAILY_SUMMARY": ("telegram.events.daily_summary",),
-    "TELEGRAM_EVENT_HASHRATE_LOW": ("telegram.events.hashrate_low",),
-    "TELEGRAM_EVENT_HASHRATE_LOSS": ("telegram.events.hashrate_loss",),
-    "TELEGRAM_EVENT_HUGEPAGES": ("telegram.events.hugepages",),
-    "TELEGRAM_EVENT_LOW_RAM": ("telegram.events.low_ram",),
-    "TELEGRAM_EVENT_HIGH_REJECT_RATE": ("telegram.events.high_reject_rate",),
-    "TELEGRAM_EVENT_BLOCK_FOUND": ("telegram.events.block_found",),
-    "TELEGRAM_EVENT_PAYOUT_FOUND": ("telegram.events.payout_found",),
-    "TELEGRAM_EVENT_PAYOUT_CONFIRMED": ("telegram.events.payout_confirmed",),
-    "TELEGRAM_EVENT_CONTAINER_UNHEALTHY": ("telegram.events.container_unhealthy",),
+    # TELEGRAM_EVENT_<NAME> -> telegram.events.<name> is a mechanical rename (pithead's tg_event()
+    # helper and render_env do the same thing per event), so it's generated below rather than
+    # hand-typed 24 times. wallet_changed / clearnet_exposed are the two events NOT in this list —
+    # deliberately excluded: they're the tamper-evidence alarms on the very channel a compromised
+    # container would use to silence them, so the dashboard must never be able to turn them off.
+    # They still render (greyed) in the Notifications > Telegram events nested subgroup (#612).
+    **{
+        f"TELEGRAM_EVENT_{name.upper()}": (f"telegram.events.{name}",)
+        for name in (
+            "node_down",
+            "node_recovered",
+            "worker_offline",
+            "worker_recovered",
+            "worker_joined",
+            "worker_left",
+            "sync_finished",
+            "disk_space",
+            "db_unhealthy",
+            "db_reset",
+            "xvb_no_share",
+            "xvb_registration",
+            "new_release",
+            "stack_online",
+            "daily_summary",
+            "hashrate_low",
+            "hashrate_loss",
+            "hugepages",
+            "low_ram",
+            "high_reject_rate",
+            "block_found",
+            "payout_found",
+            "payout_confirmed",
+            "container_unhealthy",
+        )
+    },
 }
 
 # dashboard.energy.* is config.json-only — it never renders to .env (control_approval_gate reads

--- a/build/dashboard/mining_dashboard/web/static/configlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configlogic.mjs
@@ -79,15 +79,15 @@ function walk(node, path, out) {
 // Logical section groups (#611): a display-layer map from a section name an operator recognizes
 // to the config-path PREFIXES it pulls fields from — config.json itself is unchanged, this only
 // changes which <details> a field renders under. A field matches a prefix if its dotted key
-// equals the prefix or starts with `prefix + "."`. When more than one prefix matches (e.g. both
-// "monero" and "monero.data_dir"), the LONGEST (most specific) one wins — so a narrow carve-out
-// doesn't need to be listed before a broader claim from the same or a different group; only ties
-// fall back to this array's order. Any leaf no group claims renders in the catch-all "Other"
-// group below (never silently dropped) — buildSections' own test suite asserts every
-// config.reference.json path resolves to a REAL group, so a new key can't slip into "Other"
-// unnoticed either.
+// equals the prefix or starts with `prefix + "."`. Every prefix below names a SPECIFIC leaf or
+// object, never a bare top-level key another group also reaches into (e.g. no group lists a bare
+// "dashboard", even though six different groups claim different dashboard.* leaves) — so prefixes
+// never overlap across groups and first-match is unambiguous; classifyGroup's own test asserts
+// that invariant directly. Any leaf no group claims renders in the catch-all "Other" group below
+// (never silently dropped) — buildSections' own test suite asserts every config.reference.json
+// path resolves to a REAL group, so a new key can't slip into "Other" unnoticed either.
 export const OTHER_GROUP = "Other";
-const LOGICAL_GROUPS = [
+export const LOGICAL_GROUPS = [
   {
     name: "Wallets & payout",
     prefixes: [
@@ -166,16 +166,12 @@ const LOGICAL_GROUPS = [
 ];
 
 export function classifyGroup(key) {
-  let best = null; // { name, len }
   for (const g of LOGICAL_GROUPS) {
     for (const p of g.prefixes) {
-      if (key === p || key.startsWith(`${p}.`)) {
-        const len = p.split(".").length;
-        if (!best || len > best.len) best = { name: g.name, len };
-      }
+      if (key === p || key.startsWith(`${p}.`)) return g.name;
     }
   }
-  return best ? best.name : OTHER_GROUP;
+  return OTHER_GROUP;
 }
 
 // Flatten the masked config into LOGICAL sections (#611): every leaf field, whatever top-level

--- a/build/dashboard/mining_dashboard/web/static/configlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configlogic.mjs
@@ -2,14 +2,17 @@
 //
 // GET /api/config returns the live config.json with every set secret masked to the
 // {__secret__: true} sentinel, plus _core_keys — the wizard's core-key shortlist
-// (config.core-keys.json, #502/#529), the SAME shared artifact, not a hand-maintained duplicate.
-// buildSections flattens the config into render-ready form fields; regroupCore (#529) pulls the
-// core-key fields out of their natural sections into one pinned group, mirroring the RATIFIED
-// Wave-0 decision: core shortlist at the top + the config's natural sections, collapsed by
-// default. applyEdits folds the user's edits back into a proposed config for
-// POST /api/control/preview — it takes the ORIGINAL (ungrouped) sections, so it doesn't care
-// whether a field rendered in the core group or its section. A secret left blank keeps its
-// sentinel — the server swaps it for the live value ("unchanged").
+// (config.core-keys.json, #502/#529), the SAME shared artifact, not a hand-maintained duplicate —
+// and _editable_keys (#613), the config paths the control gate will actually commit (see
+// markEditable below). buildSections groups the flattened config into LOGICAL sections (#611) —
+// display groups an operator recognizes (Wallets & payout, Monero node, …), not "one section per
+// top-level config.json key" — so a 14-key grab-bag like `dashboard.*` splits across the sections
+// it actually belongs to. regroupCore (#529) then pulls the core-key fields out of THOSE sections
+// into one pinned group on top, mirroring the RATIFIED Wave-0 decision. applyEdits folds the
+// user's edits back into a proposed config for POST /api/control/preview — it takes the flat field
+// list regardless of which display section it renders in, so config.json itself, the staged
+// preview, and the gate are all untouched by this display-only regroup. A secret left blank keeps
+// its sentinel — the server swaps it for the live value ("unchanged").
 
 export const SECRET_HINT = "set — leave blank to keep";
 
@@ -42,6 +45,12 @@ function isPlainObject(v) {
 
 function walk(node, path, out) {
   for (const [key, value] of Object.entries(node)) {
+    // Underscore-prefixed keys are metadata/docs, not config, at ANY depth — config.reference.json
+    // carries a couple nested ones (xmrig_proxy._docs, dashboard._workers_docs) alongside the
+    // top-level _docs buildSections already skipped; without this they'd render as stray text
+    // fields and, worse, fall into the catch-all "Other" logical group (#611) since no group
+    // claims a docs blob.
+    if (key.startsWith("_")) continue;
     const p = [...path, key];
     const dotted = p.join(".");
     if (isPlainObject(value) && !isSecretSentinel(value)) {
@@ -67,17 +76,127 @@ function walk(node, path, out) {
   }
 }
 
-// Flatten the masked config into sections, one per top-level object key, each field addressed
-// by its dotted path. Non-object top-level keys (e.g. a _docs string) are left out of the form
-// but survive untouched in the proposed config.
+// Logical section groups (#611): a display-layer map from a section name an operator recognizes
+// to the config-path PREFIXES it pulls fields from — config.json itself is unchanged, this only
+// changes which <details> a field renders under. A field matches a prefix if its dotted key
+// equals the prefix or starts with `prefix + "."`. When more than one prefix matches (e.g. both
+// "monero" and "monero.data_dir"), the LONGEST (most specific) one wins — so a narrow carve-out
+// doesn't need to be listed before a broader claim from the same or a different group; only ties
+// fall back to this array's order. Any leaf no group claims renders in the catch-all "Other"
+// group below (never silently dropped) — buildSections' own test suite asserts every
+// config.reference.json path resolves to a REAL group, so a new key can't slip into "Other"
+// unnoticed either.
+export const OTHER_GROUP = "Other";
+const LOGICAL_GROUPS = [
+  {
+    name: "Wallets & payout",
+    prefixes: [
+      "monero.wallet_address",
+      "monero.view_key",
+      "monero.payout_scan_height",
+      "tari.wallet_address",
+      "tari.view_key",
+      "tari.spend_public_key",
+      "tari.payout_scan_birthday",
+    ],
+  },
+  {
+    // Node-level knobs for BOTH merge-mined chains — Tari gets only two of these (mode,
+    // clearnet_initial_sync), not a whole second section for two fields.
+    name: "Monero node",
+    prefixes: [
+      "monero.mode",
+      "monero.node_username",
+      "monero.node_password",
+      "monero.prune",
+      "monero.remote",
+      "monero.rpc_lan_access",
+      "monero.clearnet_initial_sync",
+      "tari.mode",
+      "tari.clearnet_initial_sync",
+    ],
+  },
+  {
+    name: "Mining",
+    prefixes: [
+      "p2pool.pool",
+      "p2pool.stratum_bind",
+      "p2pool.stratum_port",
+      "p2pool.stratum_password",
+      "p2pool.clearnet",
+      "proxy",
+      "xvb",
+      "dashboard.tari_required",
+    ],
+  },
+  { name: "Workers", prefixes: ["workers"] },
+  {
+    name: "Dashboard & access",
+    prefixes: [
+      "dashboard.secure",
+      "dashboard.host",
+      "dashboard.timezone",
+      "dashboard.auth",
+      "dashboard.onion",
+      "dashboard.control",
+    ],
+  },
+  { name: "Notifications", prefixes: ["telegram", "notifications", "healthchecks"] },
+  { name: "Energy", prefixes: ["dashboard.energy"] },
+  {
+    name: "Alerts & thresholds",
+    prefixes: ["dashboard.hashrate_drop_threshold", "dashboard.hashrate_drop_minutes"],
+  },
+  {
+    name: "System / advanced",
+    prefixes: [
+      "monero.mem_limit",
+      "monero.data_dir",
+      "monero.prep_blocks_threads",
+      "tari.mem_limit",
+      "tari.data_dir",
+      "p2pool.data_dir",
+      "tor",
+      "dashboard.data_dir",
+      "dashboard.check_for_updates",
+      "network",
+      "xmrig_proxy",
+    ],
+  },
+];
+
+export function classifyGroup(key) {
+  let best = null; // { name, len }
+  for (const g of LOGICAL_GROUPS) {
+    for (const p of g.prefixes) {
+      if (key === p || key.startsWith(`${p}.`)) {
+        const len = p.split(".").length;
+        if (!best || len > best.len) best = { name: g.name, len };
+      }
+    }
+  }
+  return best ? best.name : OTHER_GROUP;
+}
+
+// Flatten the masked config into LOGICAL sections (#611): every leaf field, whatever top-level
+// config.json key it lives under, bucketed by classifyGroup above. Section order follows
+// LOGICAL_GROUPS, with "Other" last so an unclaimed key is visible, not hidden at the top.
+// Non-object top-level keys (e.g. a _docs string) are left out of the form but survive untouched
+// in the proposed config; underscore-prefixed keys (_core_keys, _editable_keys, #529/#613) are
+// metadata, not config, and are skipped the same way _docs always was.
 export function buildSections(cfg) {
-  const sections = [];
+  const fields = [];
   for (const [name, value] of Object.entries(cfg || {})) {
     if (name.startsWith("_") || !isPlainObject(value)) continue;
-    const fields = [];
     walk(value, [name], fields);
-    if (fields.length) sections.push({ name, fields });
   }
+  const byGroup = new Map();
+  for (const g of LOGICAL_GROUPS) byGroup.set(g.name, []);
+  byGroup.set(OTHER_GROUP, []);
+  for (const f of fields) byGroup.get(classifyGroup(f.key)).push(f);
+  const sections = [];
+  for (const [name, groupFields] of byGroup)
+    if (groupFields.length) sections.push({ name, fields: groupFields });
   return sections;
 }
 
@@ -121,6 +240,60 @@ export function regroupCore(sections, coreKeys) {
     .map((s) => ({ name: s.name, fields: s.fields.filter((f) => !coreSet.has(f.key)) }))
     .filter((s) => s.fields.length);
   return { core, sections: rest };
+}
+
+// Nested sub-groups within a logical section (#612): a noisy cluster of fields — telegram.events'
+// 26 toggles, the notification sinks, healthchecks — collapses into its own one-level-deep
+// <details>, collapsed by default, instead of dominating the section's flat field list. Keyed by
+// the OWNING SECTION's name so only sections listed here get sub-grouping; everything else's
+// fields stay flat, unchanged from before. A field matches a subgroup the same way classifyGroup
+// matches a logical group (exact key or `prefix + "."`); fields claimed by a subgroup are removed
+// from the section's own `fields` so they render exactly once.
+const SUBGROUPS = {
+  Notifications: [
+    { label: "Telegram events", prefix: "telegram.events" },
+    { label: "ntfy / webhook", prefix: "notifications" },
+    { label: "Healthchecks", prefix: "healthchecks" },
+  ],
+};
+
+export function nestSection(section) {
+  const defs = SUBGROUPS[section.name];
+  if (!defs) return { name: section.name, fields: section.fields, subgroups: [] };
+  const claimed = new Set();
+  const subgroups = defs
+    .map((d) => {
+      const fields = section.fields.filter(
+        (f) => f.key === d.prefix || f.key.startsWith(`${d.prefix}.`),
+      );
+      for (const f of fields) claimed.add(f.key);
+      return { label: d.label, fields };
+    })
+    .filter((g) => g.fields.length);
+  return {
+    name: section.name,
+    fields: section.fields.filter((f) => !claimed.has(f.key)),
+    subgroups,
+  };
+}
+
+// Editable-set membership (#613): the control gate only ever commits a fixed allowlist of config
+// paths (pithead's CONTROL_DASHBOARD_EDITABLE_KEYS, plus the dashboard.energy special-case, #504)
+// — everything else is refused at commit no matter what the form sends. Rather than let an
+// operator edit a host-only field and find out at Save, mark it non-editable up front so the view
+// can grey it out and never wire an onChange for it (belt-and-suspenders: the gate still refuses
+// regardless). `editableKeys` is `_editable_keys` on the fetched config (#613), the same
+// underscore-metadata convention `_core_keys` uses, computed server-side from the SAME allowlist
+// the gate enforces (control_service.EDITABLE_ENV_KEY_PATHS, drift-guarded against pithead's
+// CONTROL_DASHBOARD_EDITABLE_KEYS). A missing/empty set fails CLOSED — nothing is marked
+// editable — rather than defaulting to "everything editable" and silently reintroducing the
+// edit-then-reject problem this feature exists to remove.
+export function markEditable(sections, editableKeys) {
+  const editable = new Set(editableKeys || []);
+  return sections.map((s) => ({
+    name: s.name,
+    fields: s.fields.map((f) => ({ ...f, editable: editable.has(f.key) })),
+  }));
 }
 
 // JSON mode's own path (#529): the textarea holds the WHOLE candidate config (not a diff, unlike

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -7,17 +7,28 @@
 //
 // Two edit modes (#529, RATIFIED Wave-0 decision — mirrors #518's Worker Inspect shape exactly):
 // **Form** (the default) pins a `core` group — the wizard's own shortlist, `_core_keys` on the
-// fetched config, sourced from config.core-keys.json so the two never drift apart — above the
-// config's natural sections, each a native <details> collapsed by default. **JSON** is the same
-// fetched config as one editable textarea, with a Load-from-file fill button (FileReader, no
-// upload). Both modes build the SAME `proposed` config object and POST it to the SAME
-// /api/control/preview → confirm → /api/control/commit pipeline — the closed-schema gate on the
-// host is the only validation authority; neither mode adds a server-side path the other lacks.
+// fetched config, sourced from config.core-keys.json so the two never drift apart — above LOGICAL
+// sections (#611, configlogic.js buildSections) an operator recognizes (Wallets & payout, Monero
+// node, Dashboard & access, …) rather than one section per top-level config.json key, each a
+// native <details> collapsed by default. Within a section, a noisy cluster (telegram.events' 26
+// toggles, the notification sinks, healthchecks) nests one level deeper into its own collapsed
+// <details> (#612, configlogic.js nestSection). A field the control gate won't actually commit —
+// derived from `_editable_keys` on the fetched config (#613, configlogic.js markEditable) —
+// renders disabled: read-only value, a tooltip explaining why, and no onChange wired at all, so it
+// can never enter `edits`. **JSON** is the same fetched config
+// as one editable textarea, with a Load-from-file fill button (FileReader, no upload); JSON mode
+// edits the whole config and isn't affected by grouping or grey-out. Both modes build the SAME
+// `proposed` config object and POST it to the SAME /api/control/preview → confirm →
+// /api/control/commit pipeline — the closed-schema gate on the host is the only validation
+// authority; neither mode adds a server-side path the other lacks, and none of this display layer
+// changes what the gate will actually accept.
 
 import {
   applyEdits,
   buildSections,
   jsonSyntaxError,
+  markEditable,
+  nestSection,
   parseConfigJson,
   regroupCore,
   SECRET_HINT,
@@ -54,30 +65,41 @@ async function pollResult(id, skip, max = POLL_MAX) {
   );
 }
 
+const HOST_ONLY_TITLE = "Host-only — edit config.json and run ./pithead apply";
+
 // `full` (#529): the pinned Core card mixes fields from several sections, so its rows need the
 // FULL dotted key ("monero.wallet_address") to stay unambiguous; a natural section already says
 // which section it is via its own heading, so its rows keep the shorter relative label.
+//
+// `field.editable` (#613): a field the control gate would refuse at commit renders disabled, its
+// live value read-only, with a tooltip explaining why — and, critically, no onChange/onInput is
+// wired at all when disabled, so a greyed field can never add itself to `edits` (defense in
+// depth; the gate is still the real authority). Preact skips an event prop entirely when it's
+// `undefined`, so passing `undefined` rather than a no-op is what actually removes the listener.
 const Field = ({ field, edits, onEdit, full }) => {
+  const editable = field.editable !== false;
   const value = field.key in edits ? edits[field.key] : field.value;
   const label = full ? field.key : field.path.slice(1).join(".") || field.path[0];
+  const title = editable ? undefined : HOST_ONLY_TITLE;
+  const change = editable ? (e) => onEdit(field.key, e.target.value) : undefined;
   let input;
   if (field.type === "boolean") {
-    input = html`<select value=${String(value)} onChange=${(e) => onEdit(field.key, e.target.value)}>
+    input = html`<select value=${String(value)} disabled=${!editable} title=${title} onChange=${change}>
         <option value="true">true</option>
         <option value="false">false</option>
     </select>`;
   } else if (field.type === "select") {
-    input = html`<select value=${value} onChange=${(e) => onEdit(field.key, e.target.value)}>
+    input = html`<select value=${value} disabled=${!editable} title=${title} onChange=${change}>
         ${field.options.map((o) => html`<option value=${o}>${o}</option>`)}
     </select>`;
   } else if (field.type === "secret") {
     input = html`<input type="password" value=${value} placeholder=${SECRET_HINT}
-        onInput=${(e) => onEdit(field.key, e.target.value)} />`;
+        disabled=${!editable} title=${title} onInput=${change} />`;
   } else {
     input = html`<input type=${field.type === "number" ? "number" : "text"} value=${value}
-        onInput=${(e) => onEdit(field.key, e.target.value)} />`;
+        disabled=${!editable} title=${title} onInput=${change} />`;
   }
-  return html`<label class="config-field">
+  return html`<label class="config-field" title=${title}>
       <span class="config-field-name">${label}</span>
       ${input}
       ${field.warning ? html`<span class="config-field-warning">⚠ ${field.warning}</span>` : null}
@@ -133,6 +155,7 @@ export class ConfigView extends Component {
       cfg: null,
       sections: [],
       coreKeys: [],
+      editableKeys: [], // #613: config paths the control gate will actually commit
       edits: {},
       mode: "form", // form | json (#529)
       editText: "",
@@ -162,6 +185,7 @@ export class ConfigView extends Component {
         cfg,
         sections: buildSections(cfg),
         coreKeys: cfg._core_keys || [],
+        editableKeys: cfg._editable_keys || [],
         edits: {},
         editText: JSON.stringify(cfg, null, 2),
         jsonError: null,
@@ -252,10 +276,12 @@ export class ConfigView extends Component {
     }
   }
 
-  // Form mode (#529): the core group (pinned, never collapsed) above the config's natural
-  // sections, each a native <details> — collapsed by default (no `open` attribute), which gets
+  // Form mode (#529): the core group (pinned, never collapsed) above the LOGICAL sections (#611),
+  // each a native <details> — collapsed by default (no `open` attribute), which gets
   // keyboard/a11y toggling for free, the same "native platform feature over JS state" call
-  // Worker Inspect's own <dialog> made (#518).
+  // Worker Inspect's own <dialog> made (#518). Within a section, nestSection (#612) pulls a noisy
+  // cluster (telegram.events, the notification sinks, healthchecks) into its own nested <details>,
+  // one level deeper, also collapsed by default.
   renderForm(core, groups, edits) {
     const onEdit = (k, v) => this.setState({ edits: { ...edits, [k]: v } });
     const field = (f, full) =>
@@ -269,12 +295,19 @@ export class ConfigView extends Component {
             </div>`
             : null
         }
-        ${groups.map(
-          (s) => html`<details class="card config-section">
+        ${groups.map((s) => {
+          const { fields, subgroups } = nestSection(s);
+          return html`<details class="card config-section">
               <summary>${s.name}</summary>
-              ${s.fields.map((f) => field(f))}
-          </details>`,
-        )}
+              ${fields.map((f) => field(f))}
+              ${subgroups.map(
+                (g) => html`<details class="config-subsection">
+                    <summary>${g.label} (${g.fields.length})</summary>
+                    ${g.fields.map((f) => field(f))}
+                </details>`,
+              )}
+          </details>`;
+        })}
     </div>`;
   }
 
@@ -298,6 +331,7 @@ export class ConfigView extends Component {
       phase,
       sections,
       coreKeys,
+      editableKeys,
       edits,
       mode,
       editText,
@@ -341,7 +375,7 @@ export class ConfigView extends Component {
     const busy = phase === "previewing" || phase === "committing";
     const dirty = Object.keys(edits).length > 0;
     const canSave = mode === "json" ? !jsonError : dirty;
-    const { core, sections: groups } = regroupCore(sections, coreKeys);
+    const { core, sections: groups } = regroupCore(markEditable(sections, editableKeys), coreKeys);
     return html`<div class="config-view">
         ${error ? html`<div class="card"><p class="status-bad">${error}</p></div>` : null}
         <div class="toggle-group mb-1">

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -84,20 +84,20 @@ const Field = ({ field, edits, onEdit, full }) => {
   const change = editable ? (e) => onEdit(field.key, e.target.value) : undefined;
   let input;
   if (field.type === "boolean") {
-    input = html`<select value=${String(value)} disabled=${!editable} title=${title} onChange=${change}>
+    input = html`<select value=${String(value)} disabled=${!editable} onChange=${change}>
         <option value="true">true</option>
         <option value="false">false</option>
     </select>`;
   } else if (field.type === "select") {
-    input = html`<select value=${value} disabled=${!editable} title=${title} onChange=${change}>
+    input = html`<select value=${value} disabled=${!editable} onChange=${change}>
         ${field.options.map((o) => html`<option value=${o}>${o}</option>`)}
     </select>`;
   } else if (field.type === "secret") {
     input = html`<input type="password" value=${value} placeholder=${SECRET_HINT}
-        disabled=${!editable} title=${title} onInput=${change} />`;
+        disabled=${!editable} onInput=${change} />`;
   } else {
     input = html`<input type=${field.type === "number" ? "number" : "text"} value=${value}
-        disabled=${!editable} title=${title} onInput=${change} />`;
+        disabled=${!editable} onInput=${change} />`;
   }
   return html`<label class="config-field" title=${title}>
       <span class="config-field-name">${label}</span>

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -1033,6 +1033,19 @@ button.upgrade-btn {
 .config-section-core {
   border-color: var(--accent);
 }
+/* Nested sub-group within a section (#612) — telegram.events, the notification sinks,
+ * healthchecks — same collapsed-<details> pattern as .config-section, one level deeper. */
+.config-subsection {
+  margin: 10px 0 10px 4px;
+  padding-left: 10px;
+  border-left: 2px solid var(--border);
+}
+.config-subsection > summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
 .config-field {
   display: grid;
   grid-template-columns: minmax(140px, 1fr) 2fr;
@@ -1059,6 +1072,12 @@ button.upgrade-btn {
 .config-field select:focus {
   outline: none;
   border-color: var(--accent);
+}
+/* Host-only field (#613): greyed and read-only up front instead of edit-then-reject. */
+.config-field input:disabled,
+.config-field select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 .config-field-warning {
   grid-column: 1 / -1;

--- a/build/dashboard/tests/frontend/configlogic.test.mjs
+++ b/build/dashboard/tests/frontend/configlogic.test.mjs
@@ -7,11 +7,17 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { readFileSync } from "node:fs";
+
 import {
   applyEdits,
   buildSections,
+  classifyGroup,
   isSecretSentinel,
   jsonSyntaxError,
+  markEditable,
+  nestSection,
+  OTHER_GROUP,
   parseConfigJson,
   regroupCore,
 } from "../../mining_dashboard/web/static/configlogic.mjs";
@@ -39,16 +45,74 @@ test("isSecretSentinel: only the exact sentinel shape", () => {
   }
 });
 
-test("buildSections: one section per top-level object, _docs skipped, nesting flattened", () => {
+test("buildSections: LOGICAL sections (#611), not one per top-level config key; _docs skipped, nesting flattened", () => {
   const sections = buildSections(CFG);
+  // monero.wallet_address -> Wallets & payout; monero.mode/prune/node_password/remote.* -> Monero
+  // node; p2pool.pool/stratum_password -> Mining; dashboard.auth.* -> Dashboard & access;
+  // dashboard.workers is an array (skipped, #172) so it never pulls "Workers" into the list.
   assert.deepEqual(
     sections.map((s) => s.name),
-    ["monero", "p2pool", "dashboard"],
+    ["Wallets & payout", "Monero node", "Mining", "Dashboard & access"],
   );
-  const monero = sections[0];
-  const keys = monero.fields.map((f) => f.key);
+  const moneroNode = sections.find((s) => s.name === "Monero node");
+  const keys = moneroNode.fields.map((f) => f.key);
   assert.ok(keys.includes("monero.remote.rpc_port")); // nested objects walk down
   assert.ok(!keys.includes("_docs"));
+});
+
+test("buildSections: a config path split from its top-level key's other fields lands in a DIFFERENT logical section (#611)", () => {
+  // dashboard.auth.username (Dashboard & access) and a hypothetical dashboard.energy.* leaf
+  // (Energy) both live under the same top-level `dashboard` key but must not share a section —
+  // that's the whole point of #611 over "one section per top-level key".
+  const cfg = { ...CFG, dashboard: { ...CFG.dashboard, energy: { cost_per_kwh: 0.12 } } };
+  const sections = buildSections(cfg);
+  assert.ok(sections.some((s) => s.name === "Dashboard & access"));
+  assert.ok(sections.some((s) => s.name === "Energy"));
+  const energy = sections.find((s) => s.name === "Energy");
+  assert.deepEqual(
+    energy.fields.map((f) => f.key),
+    ["dashboard.energy.cost_per_kwh"],
+  );
+});
+
+test("classifyGroup: longest-prefix match — a specific carve-out beats a shorter sibling prefix", () => {
+  assert.equal(classifyGroup("monero.data_dir"), "System / advanced");
+  assert.equal(classifyGroup("monero.mode"), "Monero node"); // a different monero.* leaf, own prefix
+});
+
+test("classifyGroup + buildSections: an unclaimed path renders in the catch-all Other group, not dropped", () => {
+  assert.equal(classifyGroup("some_future_key.leaf"), OTHER_GROUP);
+  const sections = buildSections({ ...CFG, some_future_key: { leaf: "x" } });
+  const other = sections.find((s) => s.name === OTHER_GROUP);
+  assert.ok(other, "an unclaimed field must still render, in the Other group");
+  assert.deepEqual(
+    other.fields.map((f) => f.key),
+    ["some_future_key.leaf"],
+  );
+});
+
+test("buildSections: nested underscore-prefixed docs keys (any depth) are skipped, not rendered as fields", () => {
+  const cfg = { ...CFG, xmrig_proxy: { _docs: "legacy alias notes", enabled: true } };
+  const keys = buildSections(cfg)
+    .flatMap((s) => s.fields)
+    .map((f) => f.key);
+  assert.ok(!keys.includes("xmrig_proxy._docs"));
+  assert.ok(keys.includes("xmrig_proxy.enabled"));
+});
+
+// buildSections must claim EVERY leaf path in the real config.reference.json — a new config key
+// added there without a matching LOGICAL_GROUPS entry must fail this test loudly (land in Other)
+// rather than silently vanish from the editor (#611's own stated requirement). Reference values
+// are all scalars/objects/empty-arrays, so feeding the reference straight into buildSections
+// walks the exact same shape the live merged config does.
+test("buildSections: every config.reference.json leaf path resolves to a REAL logical group, not Other", () => {
+  const reference = JSON.parse(
+    readFileSync(new URL("../../../../config.reference.json", import.meta.url)),
+  );
+  const fields = buildSections(reference).flatMap((s) => s.fields);
+  assert.ok(fields.length > 50, "sanity: the reference should produce many fields");
+  const unclaimed = fields.filter((f) => classifyGroup(f.key) === OTHER_GROUP).map((f) => f.key);
+  assert.deepEqual(unclaimed, [], "these config.reference.json paths need a LOGICAL_GROUPS entry");
 });
 
 test("buildSections: field types follow the JSON value", () => {
@@ -122,26 +186,28 @@ test("applyEdits: garbage in a number field passes through for the host validato
 
 const CORE_KEYS = ["monero.wallet_address", "p2pool.pool", "dashboard.auth.username"];
 
-test("regroupCore: lifts core-key fields into one pinned group, out of their sections", () => {
+test("regroupCore: lifts core-key fields into one pinned group, out of their (logical) sections", () => {
   const { core, sections } = regroupCore(buildSections(CFG), CORE_KEYS);
   assert.deepEqual(
     core.map((f) => f.key).sort(),
     CORE_KEYS.slice().sort(),
   );
-  // The lifted fields no longer appear in their natural section...
-  const monero = sections.find((s) => s.name === "monero");
-  assert.ok(!monero.fields.some((f) => f.key === "monero.wallet_address"));
-  // ...but every OTHER field in that section is untouched.
-  assert.ok(monero.fields.some((f) => f.key === "monero.prune"));
-  const dashboard = sections.find((s) => s.name === "dashboard");
-  assert.ok(!dashboard.fields.some((f) => f.key === "dashboard.auth.username"));
-  assert.ok(dashboard.fields.some((f) => f.key === "dashboard.auth.password"));
+  // monero.wallet_address was the ONLY field "Wallets & payout" had for this fixture — lifting it
+  // empties the section, so it disappears entirely (same "no empty section" rule #529 already had).
+  assert.ok(!sections.some((s) => s.name === "Wallets & payout"));
+  // monero.prune stays behind in Monero node, untouched...
+  const moneroNode = sections.find((s) => s.name === "Monero node");
+  assert.ok(moneroNode.fields.some((f) => f.key === "monero.prune"));
+  // ...dashboard.auth.username is lifted out of Dashboard & access, dashboard.auth.password stays.
+  const dashboardAccess = sections.find((s) => s.name === "Dashboard & access");
+  assert.ok(!dashboardAccess.fields.some((f) => f.key === "dashboard.auth.username"));
+  assert.ok(dashboardAccess.fields.some((f) => f.key === "dashboard.auth.password"));
 });
 
 test("regroupCore: a section left with no remaining fields is dropped, not shown empty", () => {
-  // Every leaf of p2pool is core: the section itself should disappear from the regrouped list.
+  // Every leaf CFG.p2pool has (both Mining fields) is core: the section should disappear.
   const { sections } = regroupCore(buildSections(CFG), ["p2pool.pool", "p2pool.stratum_password"]);
-  assert.ok(!sections.some((s) => s.name === "p2pool"));
+  assert.ok(!sections.some((s) => s.name === "Mining"));
 });
 
 test("regroupCore: no core keys (missing/empty config.core-keys.json) leaves every field in its section", () => {
@@ -165,6 +231,69 @@ test("regroupCore: workers.list isn't a field to begin with (array, #172) — it
   ]);
   assert.ok(!core.some((f) => f.key === "workers.list"));
   assert.ok(!sections.some((s) => s.fields.some((f) => f.key === "workers.list")));
+});
+
+// --- Nested sub-groups within a logical section (#612) ----------------------------------------
+
+const NOTIFY_CFG = {
+  telegram: {
+    enabled: true,
+    bot_token: { __secret__: true },
+    daily_summary_time: "08:00",
+    events: { node_down: true, wallet_changed: true },
+  },
+  notifications: { ntfy: { url: "https://ntfy.sh/x" }, tor: true },
+  healthchecks: { ping_url: { __secret__: true } },
+};
+
+test("nestSection: telegram.events / notifications.* / healthchecks.* pull out into subgroups, rest stays flat", () => {
+  const notifications = buildSections(NOTIFY_CFG).find((s) => s.name === "Notifications");
+  const { fields, subgroups } = nestSection(notifications);
+  // The connection keys stay flat in the section...
+  assert.deepEqual(
+    fields.map((f) => f.key).sort(),
+    ["telegram.bot_token", "telegram.daily_summary_time", "telegram.enabled"],
+  );
+  // ...the 26-toggle wall and the sinks each get their own nested group.
+  const byLabel = Object.fromEntries(subgroups.map((g) => [g.label, g.fields.map((f) => f.key)]));
+  assert.deepEqual(byLabel["Telegram events"].sort(), ["telegram.events.node_down", "telegram.events.wallet_changed"]);
+  assert.deepEqual(byLabel["ntfy / webhook"].sort(), ["notifications.ntfy.url", "notifications.tor"]);
+  assert.deepEqual(byLabel.Healthchecks, ["healthchecks.ping_url"]);
+});
+
+test("nestSection: a section with no SUBGROUPS entry (e.g. Monero node) is returned unchanged, empty subgroups", () => {
+  const moneroNode = buildSections(CFG).find((s) => s.name === "Monero node");
+  const out = nestSection(moneroNode);
+  assert.deepEqual(out.fields, moneroNode.fields);
+  assert.deepEqual(out.subgroups, []);
+});
+
+test("nestSection: an empty subgroup (no matching fields) is omitted, not rendered blank", () => {
+  const notifications = buildSections({ telegram: { enabled: true } }).find((s) => s.name === "Notifications");
+  const { subgroups } = nestSection(notifications);
+  assert.deepEqual(subgroups, []); // no events, no notifications.*, no healthchecks in this fixture
+});
+
+// --- Editable-set membership / grey-out (#613) --------------------------------------------------
+
+test("markEditable: only fields whose dotted key is in the editable set are marked editable", () => {
+  const [marked] = markEditable(buildSections(CFG), ["monero.wallet_address"]);
+  const byKey = Object.fromEntries(marked.fields.map((f) => [f.key, f.editable]));
+  assert.equal(byKey["monero.wallet_address"], true);
+});
+
+test("markEditable: a missing/empty editable set fails CLOSED — every field non-editable", () => {
+  for (const bad of [undefined, [], null]) {
+    const sections = markEditable(buildSections(CFG), bad);
+    for (const s of sections) for (const f of s.fields) assert.equal(f.editable, false, f.key);
+  }
+});
+
+test("markEditable: host-only fields (e.g. dashboard.auth.password, a security/secret field) stay non-editable", () => {
+  const editableKeys = ["monero.wallet_address", "p2pool.pool"]; // dashboard.auth.* deliberately absent
+  const [, , , dashboardAccess] = markEditable(buildSections(CFG), editableKeys);
+  const password = dashboardAccess.fields.find((f) => f.key === "dashboard.auth.password");
+  assert.equal(password.editable, false);
 });
 
 // --- JSON mode's whole-config parse (#529) ----------------------------------------------------

--- a/build/dashboard/tests/frontend/configlogic.test.mjs
+++ b/build/dashboard/tests/frontend/configlogic.test.mjs
@@ -5,9 +5,8 @@
 // Run with Node's built-in test runner (CI runs exactly this):
 //     node --test build/dashboard/tests/frontend/
 import assert from "node:assert/strict";
-import { test } from "node:test";
-
 import { readFileSync } from "node:fs";
+import { test } from "node:test";
 
 import {
   applyEdits,
@@ -15,6 +14,7 @@ import {
   classifyGroup,
   isSecretSentinel,
   jsonSyntaxError,
+  LOGICAL_GROUPS,
   markEditable,
   nestSection,
   OTHER_GROUP,
@@ -75,9 +75,27 @@ test("buildSections: a config path split from its top-level key's other fields l
   );
 });
 
-test("classifyGroup: longest-prefix match — a specific carve-out beats a shorter sibling prefix", () => {
+test("classifyGroup: distinct monero.* leaves resolve to their own group, not a shared bare prefix", () => {
   assert.equal(classifyGroup("monero.data_dir"), "System / advanced");
-  assert.equal(classifyGroup("monero.mode"), "Monero node"); // a different monero.* leaf, own prefix
+  assert.equal(classifyGroup("monero.mode"), "Monero node");
+});
+
+// classifyGroup is first-match (no group's prefix is "more specific" than another's, by design —
+// see the comment above LOGICAL_GROUPS). This test is what actually guarantees that design holds:
+// no two groups may claim overlapping prefixes, so a real config path always resolves the same way
+// regardless of LOGICAL_GROUPS' declaration order.
+test("LOGICAL_GROUPS: no two groups claim overlapping prefixes", () => {
+  const all = LOGICAL_GROUPS.flatMap((g) => g.prefixes.map((p) => ({ group: g.name, prefix: p })));
+  const overlaps = [];
+  for (const a of all) {
+    for (const b of all) {
+      if (a.group === b.group || a.prefix === b.prefix) continue;
+      if (a.prefix === b.prefix || a.prefix.startsWith(`${b.prefix}.`)) {
+        overlaps.push(`"${a.prefix}" (${a.group}) is inside "${b.prefix}" (${b.group})`);
+      }
+    }
+  }
+  assert.deepEqual(overlaps, []);
 });
 
 test("classifyGroup + buildSections: an unclaimed path renders in the catch-all Other group, not dropped", () => {

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -235,6 +235,54 @@ test("mode toggle switches between Form and JSON rendering", () => {
   assert.doesNotMatch(out, /config-section-core/);
 });
 
+// --- Host-only fields render greyed, not edit-then-reject (#613) -----------------------------
+
+test("form mode: a field NOT in the editable set renders disabled with the host-only tooltip", () => {
+  const inst = readyView();
+  inst.state.editableKeys = ["p2pool.pool"]; // dashboard.auth.password deliberately absent
+  const out = renderToString(inst.render());
+  assert.match(out, /disabled/);
+  assert.match(out, /Host-only — edit config\.json and run \.\/pithead apply/);
+});
+
+test("form mode: a field IN the editable set renders enabled, no host-only tooltip on it", () => {
+  const inst = readyView();
+  inst.state.editableKeys = ["p2pool.pool"];
+  const out = renderToString(inst.render());
+  // p2pool.pool is core (lifted to the pinned card) and editable — its own <label> must not carry
+  // the disabled attribute or the host-only title, even though OTHER fields on the page do.
+  const poolField = out.match(/<label[^>]*>\s*<span class="config-field-name">p2pool\.pool<\/span>.*?<\/label>/s);
+  assert.ok(poolField, "expected to find the p2pool.pool field");
+  assert.doesNotMatch(poolField[0], /disabled/);
+});
+
+test("form mode: an empty editable set (host not yet reporting _editable_keys) greys out every field", () => {
+  const inst = readyView();
+  inst.state.editableKeys = [];
+  const out = renderToString(inst.render());
+  // Every field input/select carries disabled — scoped to the field's own opening tag so the
+  // unrelated Save/Discard buttons (also legitimately `disabled` when there's nothing to save)
+  // don't inflate the count.
+  const fieldTags = out.match(/<(?:input|select)[^>]*>/g) || [];
+  assert.ok(fieldTags.length > 0);
+  assert.ok(fieldTags.every((t) => /disabled/.test(t)));
+});
+
+// --- Nested sub-groups within a logical section (#612) ----------------------------------------
+
+test("form mode: telegram.events nests into its own collapsed <details>, inside the Notifications section", () => {
+  const cfg = {
+    ...CFG,
+    telegram: { enabled: true, events: { node_down: true, worker_offline: false } },
+  };
+  const inst = readyView(cfg);
+  const out = renderToString(inst.render());
+  assert.match(out, /Telegram events \(2\)/); // the nested subgroup summary, count included
+  // Nested <details> is ALSO collapsed by default — no `open` anywhere in the whole form.
+  assert.doesNotMatch(out, /<details[^>]*\bopen\b/);
+  assert.match(out, /config-subsection/);
+});
+
 // --- buildProposed(): both modes build the same staged config object -------------------------
 
 test("buildProposed: form mode folds edits back the same way applyEdits does", () => {

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -225,6 +225,71 @@ class TestCoreKeys:
         assert cfg["_core_keys"] == []
 
 
+class TestEditableKeys:
+    """read_config's ``_editable_keys`` field (#613): the config paths the control gate will
+    actually commit, derived from EDITABLE_ENV_KEY_PATHS (mirroring pithead's
+    CONTROL_DASHBOARD_EDITABLE_KEYS) plus the dashboard.energy special-case (#504). Surfaced the
+    same underscore-metadata way ``_core_keys`` is, so the Configuration view can grey out
+    everything else up front instead of edit-then-reject."""
+
+    def test_editable_keys_served_on_read_config(self, spool):
+        cfg = control_service.read_config()
+        assert "p2pool.pool" in cfg["_editable_keys"]
+        assert "xvb.donation_level" in cfg["_editable_keys"]
+        assert cfg["_editable_keys"] == sorted(cfg["_editable_keys"])  # stable, deterministic order
+
+    def test_dashboard_energy_is_the_special_case_addition(self, spool):
+        # dashboard.energy.* never renders to .env (control.approval reads it straight off
+        # config.json), so it can't come from the env-var map — it's allowed by name (#504).
+        cfg = control_service.read_config()
+        assert "dashboard.energy.cost_per_kwh" in cfg["_editable_keys"]
+        assert "dashboard.energy.currency" in cfg["_editable_keys"]
+        assert "dashboard.energy.xmr_price" in cfg["_editable_keys"]
+
+    def test_host_only_security_fields_are_not_editable(self, spool):
+        # Wallets, auth, remote-node RPC creds, and worker descriptors are exactly the class of
+        # field #613 exists to grey out — never on the list.
+        cfg = control_service.read_config()
+        for path in (
+            "monero.wallet_address",
+            "monero.view_key",
+            "dashboard.auth.password",
+            "monero.node_password",
+            "workers.api_token",
+            "workers.list",
+        ):
+            assert path not in cfg["_editable_keys"], path
+
+    def test_telegram_tamper_evidence_alarms_stay_host_only(self, spool):
+        # wallet_changed / clearnet_exposed are the alarms a compromised container must not be
+        # able to silence from the very channel it would use to do it.
+        cfg = control_service.read_config()
+        assert "telegram.events.wallet_changed" not in cfg["_editable_keys"]
+        assert "telegram.events.clearnet_exposed" not in cfg["_editable_keys"]
+        assert "telegram.events.node_down" in cfg["_editable_keys"]  # a normal event IS editable
+
+
+def test_editable_keys_have_no_intra_repo_drift():
+    """#613 (mirrors #515's WORKER_WRITABLE_KEYS check): EDITABLE_ENV_KEY_PATHS is a second copy of
+    pithead's CONTROL_DASHBOARD_EDITABLE_KEYS, kept in sync only by this test. Drift means the
+    dashboard either greys out something the gate would actually commit, or — worse — shows
+    something editable that the gate silently refuses at Save, exactly the edit-then-reject
+    experience #613 exists to remove."""
+    import re
+    from pathlib import Path
+
+    here = Path(__file__).resolve()
+    pithead_path = next((p / "pithead" for p in here.parents if (p / "pithead").is_file()), None)
+    if pithead_path is None:
+        pytest.skip("pithead CLI not present in this test context (dashboard-only image)")
+    pithead = pithead_path.read_text()
+    m = re.search(r"CONTROL_DASHBOARD_EDITABLE_KEYS='([^']*)'", pithead)
+    assert m, "could not find CONTROL_DASHBOARD_EDITABLE_KEYS in pithead"
+    pithead_keys = set(m.group(1).split())
+    assert pithead_keys, "extracted an empty allowlist — the regex likely stopped matching"
+    assert set(control_service.EDITABLE_ENV_KEY_PATHS.keys()) == pithead_keys
+
+
 class TestWorkerApply:
     """Worker config-apply spooling + validation (#185). The intent carries only the worker name +
     writable-key changes — never a host, port, or token (those stay host-side, #440)."""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,9 +68,19 @@ are **core**: wallet addresses, `monero.mode`, `p2pool.pool`, the dashboard logi
 `workers.list` — the ones `./pithead setup` asks about (see
 [Getting Started › Run setup](getting-started.md#3-run-setup)) and, if `dashboard.control.enabled`
 is on, the group the dashboard's [Configuration view](dashboard.md#configuration-view) pins at the
-top of its form, above the rest of the schema grouped by section and collapsed by default. Both
-read the exact same list, [`config.core-keys.json`](../config.core-keys.json) — there's only ever
-one shortlist to keep in sync with this table, not two.
+top of its form. Both read the exact same list, [`config.core-keys.json`](../config.core-keys.json)
+— there's only ever one shortlist to keep in sync with this table, not two.
+
+Below the core group, the Configuration view groups the rest of this table into **logical
+sections** an operator recognizes (Wallets & payout, Monero node, Mining, Workers, Dashboard &
+access, Notifications, Energy, Alerts & thresholds, System / advanced), each collapsed by default
+— not one section per top-level key like this table's own layout, so a key like `dashboard.energy`
+lands in "Energy" and `dashboard.auth` lands in "Dashboard & access" rather than sharing a section
+just because they share a JSON prefix. It also greys out any key the dashboard's control channel
+can't actually commit — most of them, including every credential and every setting listed as
+"Security-relevant" or requiring `./pithead apply` below — instead of letting you edit it and
+finding out only when Save is rejected. Both are display-only: `config.json` itself, and what the
+control channel will commit, are unaffected either way.
 
 | Key | Default | Description |
 |---|---|---|

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -510,15 +510,34 @@ Two edit modes build the same candidate config and submit it through the same pi
   `monero.mode` / `p2pool.pool` / dashboard-auth-and-host shortlist
   [`./pithead setup`](getting-started.md#3-run-setup) asks, read from the one file the wizard and
   this view share, [`config.core-keys.json`](../config.core-keys.json), so the two can't drift
-  apart. Below it, the rest of the schema is grouped by its natural top-level section (`monero`,
-  `tari`, `p2pool`, `telegram`, …), each collapsed by default, so a typical edit shows only the
-  handful of fields you're touching instead of the whole schema. `workers.list[]` (the per-rig
-  descriptors) isn't a form field here — a variable-length list has no single form control for it —
-  edit it via [Worker Inspect](#worker-inspect) or `config.json` directly.
+  apart. Below it, the rest of the schema is grouped into **logical sections**
+  ([#611](https://github.com/p2pool-starter-stack/pithead/issues/611)) an operator recognizes —
+  Wallets & payout, Monero node, Mining, Workers, Dashboard & access, Notifications, Energy, Alerts
+  & thresholds, System / advanced — instead of one section per top-level `config.json` key, so a
+  grab-bag key like `dashboard` (auth, remote access, the energy calculator, alert thresholds, …)
+  splits across the sections its fields actually belong to. Each section is a collapsed `<details>`
+  as before; within **Notifications**, the 26 `telegram.events` toggles, the ntfy/webhook sinks,
+  and Healthchecks each nest one level deeper into their own collapsed sub-group
+  ([#612](https://github.com/p2pool-starter-stack/pithead/issues/612)) instead of dominating the
+  section's field list. A config path no logical section claims still renders, in a catch-all
+  **Other** group — a new schema key can't silently vanish from the editor, and a frontend test
+  fails loudly if one ever would. `workers.list[]` (the per-rig descriptors) isn't a form field
+  here — a variable-length list has no single form control for it — edit it via
+  [Worker Inspect](#worker-inspect) or `config.json` directly.
+
+  A field the control gate wouldn't actually commit renders **greyed out**
+  ([#613](https://github.com/p2pool-starter-stack/pithead/issues/613)): disabled, its value shown
+  read-only, with a tooltip ("Host-only — edit `config.json` and run `./pithead apply`") instead of
+  letting you edit it and finding out only at Save. The editable set is derived from the same
+  allowlist the gate enforces (see below) and surfaced on `GET /api/config` as `_editable_keys`, so
+  it can't drift from what the gate actually accepts; a greyed field never enters the staged edit
+  set at all.
 - **JSON** edits the whole fetched config as one text block, for operators who'd rather paste than
   click through fields. A **Load from file** control (`FileReader`, no upload) fills it from a
   saved `config.json`, the same pattern [Worker Inspect's JSON mode](#worker-inspect) uses. A
-  malformed edit is flagged inline before you click Save.
+  malformed edit is flagged inline before you click Save. JSON mode edits the whole config as text,
+  so grouping and the host-only grey-out (both display-layer, form-mode only) don't apply to it —
+  the gate still validates and gates it identically to form mode.
 
 The flow mirrors the CLI's `apply` either way:
 
@@ -539,7 +558,9 @@ The flow mirrors the CLI's `apply` either way:
 Most settings cannot be committed from the dashboard — the host-side runner holds an explicit
 allowlist of operational settings (pool tier, XvB enable and donation level, alert toggles,
 memory limits, time zone, the energy-calculator prices, …) and default-denies a change, in any
-direction, to anything else. The allowlist gates BOTH edit modes identically — JSON mode is a
+direction, to anything else. Form mode's grey-out (above) is that SAME allowlist surfaced to the
+browser up front, not a separate approximation of it — so what renders editable is exactly what
+the gate will commit. The allowlist gates BOTH edit modes identically regardless — JSON mode is a
 different way to assemble the candidate config, not a different validation path, so it can't
 smuggle a change the form couldn't make:
 wallets, the dashboard login and onion settings, the control channel itself, the Tor egress


### PR DESCRIPTION
Closes #611
Closes #612
Closes #613

## What changed

The Configuration view's form (`configlogic.mjs` `buildSections` / `configview.mjs` `renderForm`) is display-layer only in every one of these three changes — `config.json`, the staged-preview → closed-schema gate → commit pipeline, and JSON mode are all untouched.

### #611 — logical section grouping

`buildSections` no longer groups "one section per top-level `config.json` key". A display-layer map (`LOGICAL_GROUPS` in `configlogic.mjs`) classifies every flattened field by dotted-path prefix into one of nine groups (first-match; every prefix is specific enough that no two groups ever compete for the same key — guarded by a dedicated no-overlap test):

| Section | Claims (representative) |
|---|---|
| Wallets & payout | `monero.wallet_address`, `tari.wallet_address`, `monero.view_key`, `tari.view_key`, `tari.spend_public_key`, `*.payout_scan_*` |
| Monero node | `monero.mode`/`prune`/`remote.*`/`rpc_lan_access`/`clearnet_initial_sync`/`node_username`/`node_password`, `tari.mode`/`clearnet_initial_sync` |
| Mining | `p2pool.*` (pool, stratum, clearnet), `proxy.*`, `xvb.*`, `dashboard.tari_required` |
| Workers | `workers.*` |
| Dashboard & access | `dashboard.secure`/`host`/`timezone`/`auth.*`/`onion.*`/`control.*` |
| Notifications | `telegram.*`, `notifications.*`, `healthchecks.*` |
| Energy | `dashboard.energy.*` |
| Alerts & thresholds | `dashboard.hashrate_drop_threshold`/`hashrate_drop_minutes` |
| System / advanced | mem limits, `monero.prep_blocks_threads`, `*.data_dir`, `tor.*`, `network.*`, `dashboard.check_for_updates`, `xmrig_proxy.*` (deprecated alias) |

The core shortlist (#529) still pins on top via `regroupCore`, unchanged.

**Unclaimed-path guard:** any path no group claims still renders, in a catch-all **Other** group (`classifyGroup` returns `OTHER_GROUP` instead of dropping the field). A frontend test (`configlogic.test.mjs`) loads the real `config.reference.json` and asserts `buildSections` never puts a real path in `Other` — a new schema key without a matching `LOGICAL_GROUPS` entry fails CI loudly instead of silently vanishing from the editor. As a byproduct, nested underscore-prefixed doc keys (`xmrig_proxy._docs`, `dashboard._workers_docs`) are now filtered at any depth (`walk`), not just the top level — they'd otherwise have leaked into `Other` as stray text fields.

### #612 — nested event groups

Within a logical section, `nestSection` (`configlogic.mjs`) pulls a noisy cluster into its own one-level-deeper `<details>`, collapsed by default, reusing the exact same native-`<details>` pattern the sections themselves use. Scoped to **Notifications**: `telegram.events` (26 toggles) → "Telegram events", `notifications.*` → "ntfy / webhook", `healthchecks.*` → "Healthchecks". Everything else renders flat, unchanged.

### #613 — grey out host-only fields

`_editable_keys` is a new field on `GET /api/config` (`control_service.read_config`, same underscore-metadata convention as `_core_keys`), computed from `EDITABLE_ENV_KEY_PATHS` — a Python map from each env-var name in pithead's `CONTROL_DASHBOARD_EDITABLE_KEYS` allowlist (pithead ~L4793, the gate's actual authority) to the config path(s) that render into it, via `render_env`. `dashboard.energy.*` is folded in as the one config.json-only special-case the gate allows (#504); worker descriptors (`workers.list[]`) are refused by the gate and were never a form field to begin with (arrays, #172).

One subtlety worth flagging: `P2POOL_FLAGS` is derived from **both** `p2pool.pool` and `p2pool.clearnet`, so `p2pool.clearnet` is editable even though pithead's own allowlist comment lists "clearnet toggles" as generally host-only — the gate works on rendered env vars, not config paths, so a path that feeds an allowlisted var is genuinely committable. The map mirrors the real derivation, documented inline.

`markEditable` (`configlogic.mjs`) tags each field `.editable` from the set, **failing closed** (missing/empty set → nothing editable) rather than failing open. `Field` (`configview.mjs`) renders a non-editable field disabled, read-only value, tooltip "Host-only — edit config.json and run ./pithead apply", and — critically — **no `onChange`/`onInput` handler is wired at all** (`undefined`, not a no-op), so a greyed field structurally cannot enter `edits`. Belt-and-suspenders only: the gate is still the real authority.

**Drift guard:** `test_editable_keys_have_no_intra_repo_drift` (mirrors #515's `WORKER_WRITABLE_KEYS` check) regexes `CONTROL_DASHBOARD_EDITABLE_KEYS` out of the `pithead` script and asserts its env-var names equal `EDITABLE_ENV_KEY_PATHS`'s keys — an allowlist edit without a matching map edit fails CI.

## Test evidence

- `node --test build/dashboard/tests/frontend/*.test.mjs` — 190 passed
- `make test-dashboard` — 1360 passed, 96.66% total coverage (`control_service.py` at 100%)
- `make test-patch-coverage` — 100% on the changed lines
- `make lint-js`, `make lint-py`, `make lint-md`, `make lint-docs-voice` — all clean
- `make lint-sh` / `make lint-toml` / `make lint-yaml` — clean (untouched by this PR, run for completeness)
- Passed a ponytail-review pass: simplified the editable-path map generation, dropped an unexercised longest-prefix-match mechanism in favor of first-match plus a real no-overlap invariant test, and removed a duplicate tooltip attribute

## Docs

- `docs/dashboard.md` Configuration view section — describes the logical grouping, nested sub-groups, and grey-out, and links all three issues
- `docs/configuration.md` — the reference-table intro now explains the logical grouping and grey-out sit on top of the same table
- `CHANGELOG.md` — one `### Changed` entry under the existing `## [Unreleased]` heading

## Not in scope

No `config.json`/`config.reference.json` schema change, no gate change — this is entirely display-layer, per #611's own stated constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)