### PR TITLE
test(tier1): compose-deps, audit-trim, onion-perms, worker-apply-accept, wizard

### DIFF
--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1275,6 +1275,16 @@ mkdir -p "$ac_root"
 ac_file="$ac_root/dashboard/authorized_clients/dashboard.auth"
 if [ -f "$ac_file" ]; then ok "authorized_clients/dashboard.auth is written"; else bad "authorized_clients/dashboard.auth is written" "file missing"; fi
 assert_contains "authorized_clients carries a v3 descriptor" "$(cat "$ac_file" 2>/dev/null)" "descriptor:x25519:"
+# Tor refuses a HiddenServiceDir that is group/other-accessible, so the modes provision_onion_client_auth
+# sets (pithead ~L3096-3099) are load-bearing, not a hardening nicety — a wrong mode is a silent onion
+# provisioning failure. GNU stat first (CI/Linux), BSD/macOS `-f %Lp` fallback (the repo's known gotcha:
+# `stat -f` is a VALID-but-wrong flag on Linux, so it must never run first).
+ac_dir_mode="$(stat -c '%a' "$ac_root/dashboard" 2>/dev/null || stat -f '%Lp' "$ac_root/dashboard" 2>/dev/null)"
+ac_subdir_mode="$(stat -c '%a' "$ac_root/dashboard/authorized_clients" 2>/dev/null || stat -f '%Lp' "$ac_root/dashboard/authorized_clients" 2>/dev/null)"
+ac_key_mode="$(stat -c '%a' "$ac_file" 2>/dev/null || stat -f '%Lp' "$ac_file" 2>/dev/null)"
+assert_eq "hidden-service dir is 0700" "$ac_dir_mode" "700"
+assert_eq "authorized_clients dir is 0700" "$ac_subdir_mode" "700"
+assert_eq "authorized_clients key file is 0600" "$ac_key_mode" "600"
 # With client-auth OFF, an existing authorized_clients dir is cleared (onion falls back to password-only).
 # shellcheck disable=SC1090  # STACK path is dynamic by design
 (
@@ -4949,6 +4959,15 @@ else
     bad "audit log trimmed back under the cap" "$audit_size bytes"
 fi
 assert_eq "trim keeps the newest entries (fresh entry is the last line)" "$(tail -n 1 "$AUDIT" | jq -r '.action')" "commit"
+# Pin the line count too, not just the byte size: control_audit trims to `tail -n 2000` BEFORE
+# appending the triggering entry, so the file must land at <= 2001 lines (2000 kept + the new one) —
+# the "newest ~2000 lines" behavior the byte-size check above doesn't directly prove.
+audit_lines="$(wc -l <"$AUDIT" | tr -d ' ')"
+if [ "$audit_lines" -le 2001 ]; then
+    ok "audit log trim caps the line count near the newest 2000 entries ($audit_lines lines)"
+else
+    bad "audit log trim caps the line count near the newest 2000 entries" "$audit_lines lines"
+fi
 
 echo "== black-box: spool intake cap + symlink refusal + stale sweep (#33 hardening) =="
 UUID4="44444444-4444-4444-8444-444444444444"
@@ -5647,6 +5666,56 @@ CONTROL_WA_BUDGET=0 PITHEAD_CONFIG_FILE="$WA2/config.json" run_sourced "$SANDBOX
 assert_contains "workers.list worker-apply resolves the rig (budget rejection proves pre-dial success)" \
     "$(jq -r '.error // ""' "$WA2/results/$u8.json")" "too many worker config changes"
 
+echo "== control channel: worker config apply ACCEPT path succeeds + is audited (#185) =="
+# Mirrors the reject-path setup above, but with a stub curl standing in for the rig's control API so a
+# fully-valid worker-apply actually dials, gets accepted (202 + change_id), and polls the rig's
+# /status to a terminal "applied" — proving the success leg of #185, not just the fail-closed guards
+# exercised above it.
+WA3="$SANDBOX/ctrl185-accept"
+mkdir -p "$WA3/staged" "$WA3/results" "$WA3/audit" "$WA3/bin"
+cat >"$WA3/config.json" <<'EOF'
+{ "dashboard": { "workers": [
+    { "name": "rig1", "host": "10.0.0.9", "control_port": 8082, "token": "tok-rig1" }
+] } }
+EOF
+# A minimal curl stand-in: no real network dial. Reads its own args for `-o <file>` and the trailing
+# URL (curl always puts flags/headers/data before the bare URL, so the last plain token IS the URL);
+# serves a canned 202 body for POST .../apply and a terminal "applied" 200 body for GET .../status —
+# mirroring what a real RigForge rig's control API returns (rigforge#236's status shape).
+cat >"$WA3/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+out="" url=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) url="$1"; shift ;;
+    esac
+done
+case "$url" in
+*/apply)
+    printf '{"change_id":"chg-1"}' >"$out"
+    printf '202' ;;
+*/status)
+    printf '{"change_id":"chg-1","status":"applied","changed_keys":["pools"]}' >"$out"
+    printf '200' ;;
+*) printf '000' ;;
+esac
+exit 0
+EOF
+chmod +x "$WA3/bin/curl"
+u9="12121212-1212-4212-8212-121212121212"
+printf '{"id":"%s","action":"worker-apply","actor":"admin","worker":"rig1","changes":{"pools":["pool.example:3333"]}}\n' "$u9" >"$WA3/req.json"
+PATH="$WA3/bin:$PATH" CONTROL_WA_BUDGET=1 PITHEAD_CONFIG_FILE="$WA3/config.json" \
+    run_sourced "$SANDBOX" control_process_request "$WA3/req.json" "$WA3" >/dev/null 2>&1
+assert_eq "worker-apply accept path reaches a terminal 'applied' status" \
+    "$(jq -r '.status' "$WA3/results/$u9.json" 2>/dev/null)" "applied"
+assert_eq "worker-apply accept path records the rig's change_id" \
+    "$(jq -r '.change_id' "$WA3/results/$u9.json" 2>/dev/null)" "chg-1"
+assert_eq "worker-apply accept path records the rig's changed_keys" \
+    "$(jq -rc '.changed_keys' "$WA3/results/$u9.json" 2>/dev/null)" '["pools"]'
+assert_contains "worker-apply accept is audited as applied" \
+    "$(cat "$WA3/audit/control.log")" '"action":"worker-apply","status":"applied"'
+
 # ---------------------------------------------------------------------------
 echo "== unit: config.reference.json stays a complete superset of every path pithead reads (#561) =="
 # The closed-schema control gate (#537, pithead ~L4706) relies on this invariant: every config.json
@@ -5904,6 +5973,35 @@ assert_contains "pointer mentions dashboard.energy.cost_per_kwh (#504)" "$pointe
 assert_contains "pointer mentions workers.list (per-worker overrides, #506)" "$pointer_out" "workers.list"
 assert_contains "pointer points at docs/configuration.md" "$pointer_out" "docs/configuration.md"
 assert_contains "pointer mentions the dashboard's config editor" "$pointer_out" "dashboard's config editor"
+
+echo "== black-box: 'pithead setup' completes end-to-end from a wizard-produced config (#502) =="
+# Everything above drives the wizard sub-functions directly (sourced). Nothing drives the actual
+# command an operator runs — this is the gap. ensure_config_exists refuses a piped, non-interactive
+# run OUTRIGHT when config.json is missing ([ ! -t 0 ] -> error, pithead ~L2118) — that gate is
+# deliberate (don't silently generate a config from a script with no human reading the prompts), and
+# it's exactly why the wizard functions were split out for testing (the comment above
+# ensure_config_exists says so) rather than something to fake a tty around here. So: produce
+# config.json the same piped-stdin way the wizard tests above do (proving the Q&A -> config path,
+# same as W1), THEN hand it to the real `setup` command, which skips straight past that gate
+# ([-f "$CONFIG_FILE"] short-circuit) and drives its own two remaining prompts (dashboard hostname,
+# "start now?") from stdin like any other `read -r -p`. Same docker/sudo-stubbed sandbox as the apply
+# black-box tests above; --skip-deps/--skip-optimize keep it host-safe (no apt/GRUB/sysctl edits);
+# declining "start now?" stops short of actually bringing containers up.
+SU="$SANDBOX/setup-e2e"
+mkdir -p "$SU/build/tari" "$SU/build/dashboard"
+: >"$SU/build/dashboard/Dockerfile"
+cp "$STACK" "$SU/pithead"
+cp "$ROOT/build/tari/config.toml.template" "$SU/build/tari/"
+make_stubs "$SU/bin"
+printf '%s\n%s\n\n\n\n\n\n\n\n\n' "$WALLET" "TARISETUPWALLET" | run_sourced "$SU" run_wizard >/dev/null 2>&1
+if [ -f "$SU/config.json" ]; then ok "setup e2e: wizard stage produces config.json"; else bad "setup e2e: wizard stage produces config.json" "no file at $SU/config.json"; fi
+su_out="$(cd "$SU" && printf '\nn\n' | DOCKER_LOG=/dev/null PATH="$SU/bin:$PATH" ./pithead setup --skip-deps --skip-optimize 2>&1)"
+su_rc=$?
+assert_rc "'pithead setup' exits 0 given an existing config.json" "$su_rc" "0"
+assert_contains "'pithead setup' reports completion" "$su_out" "Deployment preparation complete"
+assert_eq "'pithead setup' writes a completed .env" \
+    "$(run_sourced "$SU" env_get_file "$SU/.env" DEPLOYMENT_COMPLETED)" "true"
+unset SU su_out su_rc
 
 unset run_wizard w1_cfg w2_cfg pointer_out core_reads shape_reads
 

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -253,6 +253,34 @@ jq_assert "control staged/ dir never enters the container (#33)" \
 jq_assert "control channel defaults off in the dashboard env (#33)" \
     '.services.dashboard.environment["DASHBOARD_CONTROL_ENABLED"] == "false"'
 
+# depends_on startup ordering (#565): "wait until healthy" vs "wait until started" is a startup-
+# correctness guarantee, not decoration — e.g. p2pool must not merge-mine against a Tari node that's
+# still starting up. Render with the optional payout-confirmation profiles too
+# (payout_confirm/tari_payout_confirm, #381/#462) so the profile-gated wallet-rpc/tari-wallet edges
+# are covered, not just the always-on services. Edges enumerated from the compose file itself (6
+# depends_on stanzas total): xmrig-proxy -> p2pool is the one deliberate exception that only waits
+# for service_started, since p2pool's own healthcheck already proves what xmrig-proxy needs and
+# health-gating it too would be circular (p2pool depends on tari, not on xmrig-proxy).
+DEPS_ENV="$(mktemp)"
+sed 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=local_node,payout_confirm,tari_payout_confirm/' "$ENV_FILE" >"$DEPS_ENV"
+JSON="$(docker compose --env-file "$DEPS_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
+rm -f "$DEPS_ENV"
+for edge in "monerod=tor" "tari=tor" "p2pool=tari" "wallet-rpc=monerod" "tari-wallet=tari"; do
+    svc="${edge%%=*}" dep="${edge#*=}"
+    jq_assert "$svc waits for $dep to be service_healthy (#565)" \
+        ".services[\"$svc\"].depends_on[\"$dep\"].condition == \"service_healthy\""
+done
+jq_assert "xmrig-proxy waits for p2pool service_started only, not health-gated (#565)" \
+    '.services["xmrig-proxy"].depends_on["p2pool"].condition == "service_started"'
+# Count guard: a NEW depends_on edge (health-gated or not) added anywhere in the file must show up
+# in the enumeration above too, or this trips before it ships unasserted.
+jq_assert "exactly 5 service_healthy depends_on edges total (#565)" \
+    '[.services[] | (.depends_on // {}) | to_entries[] | select(.value.condition == "service_healthy")] | length == 5'
+jq_assert "exactly 6 depends_on edges total (#565)" \
+    '[.services[] | (.depends_on // {}) | to_entries[]] | length == 6'
+# Restore $JSON to the default-profile render for every check below this point.
+JSON="$(docker compose --env-file "$ENV_FILE" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
+
 # Configurable bridge subnet (#180): a custom network.subnet must rebase every static IP, the bridge
 # CIDR, and the dashboard's derived bridge endpoints — the host address-space-collision install fix.
 CUSTOM_ENV="$(mktemp)"


### PR DESCRIPTION
## Summary

Closes five tier-1 (CI-runnable, every PR) coverage gaps from a source-vs-tests audit:

1. **#565 compose `depends_on` ordering** — `tests/stack/test_compose.sh`: enumerated the 6 actual `depends_on` edges in `docker-compose.yml` (renders `wallet-rpc`/`tari-wallet` too, via `payout_confirm`/`tari_payout_confirm`) and asserted each dependent service keeps its expected dependency + condition — 5x `service_healthy` (`monerod->tor`, `tari->tor`, `p2pool->tari`, `wallet-rpc->monerod`, `tari-wallet->tari`), 1x `service_started` (`xmrig-proxy->p2pool`, deliberately not health-gated) — plus a total-edge-count guard so a new undocumented edge trips the test too.
2. **audit-log write-side trim** — `tests/stack/run.sh`: this was *already* covered by the existing "audit log growth is bounded (#349)" test (added with #349, not stale), but it only asserted the byte cap, not the "newest ~2000 lines" line count the trim actually implies. Added that line-count assertion (`<= 2001` = 2000 kept + 1 new) right after the existing checks — no new test scaffolding needed.
3. **Tor onion key perms 0700/0600** — `tests/stack/run.sh`: `provision_onion_client_auth` (pithead ~L3100-3101) chmods the hidden-service dir/keys but nothing verified the modes. Added `stat`-based assertions (GNU `-c %a` first, BSD `-f %Lp` fallback — the repo's known stat gotcha) on the existing client-auth fixture.
4. **control worker-apply ACCEPT path (#185)** — `tests/stack/run.sh`: only the fail-closed reject path was tested. Added a test with a stub `curl` standing in for the rig's control API: a valid pool-only worker edit dials, gets accepted (202 + `change_id`), polls to a terminal `applied`, and is audited — mirrors the existing reject-path test's fixture shape.
5. **setup wizard behavioral drive (#502)** — `tests/stack/run.sh`: no test drove the actual `setup` command (only the wizard sub-functions, sourced directly). While building this I found `ensure_config_exists` refuses a piped/non-interactive run outright when `config.json` is missing (`[ ! -t 0 ] -> error`) — deliberate, and exactly why the wizard functions were split out for testing in the first place (per the comment above that function). So: produce `config.json` the same piped-stdin way the existing wizard tests do (reusing `run_wizard`), then hand it to the real `./pithead setup --skip-deps --skip-optimize` command, which skips past that gate once `config.json` exists and drives its own two remaining prompts (hostname, "start now?") from stdin. Asserts exit 0, the completion message, and a completed `.env`.

## Evidence

- `make lint` (shellcheck --severity=warning + shfmt -d): clean on `pithead`, `tests/stack/run.sh`, `tests/stack/test_compose.sh`.
- `make test-compose`: full pass including the new `#565` assertions.
- Each new assertion (items 2-5) verified via a real excerpted slice of `tests/stack/run.sh` (exact line ranges concatenated, not a full/backgrounded run) — all green.
- **Revert-proofed**: temporarily broke each underlying behavior in `pithead`/`docker-compose.yml`, confirmed the new assertion goes red, then restored (`git diff` clean on both files afterward):
  - #565: flipped `p2pool`'s `tari` dependency from `service_healthy` to `service_started` — both the per-edge and count assertions failed as expected.
  - audit-trim: bumped the write-side trim from `tail -n 2000` to `tail -n 20000` — byte-cap and line-count assertions both failed as expected.
  - onion perms: changed `chmod 700`/`600` to `755`/`644` — all three mode assertions failed as expected.
  - worker-apply accept: dropped `applied` from the terminal-status case match — status/changed_keys/audit assertions failed as expected (result fell back to `accepted`/pending).
  - setup wizard: changed the completion log line — the completion-message assertion failed as expected.
- Rebased onto `origin/develop` (no conflicts); re-ran all of the above against the rebased tree.
- `/ponytail-review` pass: lean, nothing to cut.

## Test plan

- [x] `make lint`
- [x] `make test-compose`
- [x] Targeted slices of `tests/stack/run.sh` for each new/changed assertion
- [x] Revert-proof cycle (break -> red -> restore -> green) for every item
- [ ] Full `make test` / CI (not run locally — tier-1 suite is multi-thousand lines with real `sleep`-based waits scattered through it; slicing + targeted verification was used instead per the task's own guidance to avoid a long/parked full run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)