### PR TITLE
fix(doctor): fail loud when Tor is down while the mining stack runs

### DIFF
--- a/pithead
+++ b/pithead
@@ -1755,6 +1755,14 @@ container_is_running() { # <name>
     [ -n "$(docker ps -q --filter "name=^${1}$" --filter status=running 2>/dev/null)" ]
 }
 
+# True when a revenue container is running — i.e. the stack is UP, not cleanly `down`. Used to tell
+# "tor is down because everything is down" (fine, rules are removed at `down`) apart from "tor is
+# down while mining keeps going" (a privacy emergency: the egress backbone is dead but the stack is
+# still live). p2pool/monerod/xmrig-proxy are the revenue path; any one up means the stack is up.
+mining_stack_running() {
+    container_is_running p2pool || container_is_running monerod || container_is_running xmrig-proxy
+}
+
 # doctor (#383): verify the #270 fail-closed egress rules are ACTUALLY installed while the stack
 # runs. `down` removes them, and a host reboot silently drops them while `restart: unless-stopped`
 # brings every container back — that reboot gap is the state this catches. Read-only: `sudo -n`
@@ -1768,7 +1776,11 @@ check_egress_firewall_installed() {
         return 0
     fi
     if ! container_is_running tor; then
-        dr_info "Tor-egress firewall check skipped — the stack isn't running (rules are removed at 'down')."
+        if mining_stack_running; then
+            dr_fail "The Tor container is DOWN while the mining stack is still running — the privacy backbone is dead and clearnet dials are no longer fail-closed. Restart Tor ('./pithead restart tor'), or bring the stack down ('./pithead down')."
+        else
+            dr_info "Tor-egress firewall check skipped — the stack isn't running (rules are removed at 'down')."
+        fi
         return 0
     fi
     if ! command -v iptables >/dev/null 2>&1; then
@@ -1847,7 +1859,11 @@ check_dashboard_answers() {
 # must not fail cron health gates on a slow circuit.
 check_tor_clearnet_egress() {
     if ! container_is_running tor; then
-        dr_info "Tor clearnet-egress check skipped — the tor container isn't running."
+        if mining_stack_running; then
+            dr_fail "The Tor container is DOWN while the mining stack runs — every off-box connection (Healthchecks, Telegram, XvB, p2pool/Tari peers) has lost its Tor path. Restart Tor ('./pithead restart tor'; set tor.auto_heal:true to self-heal), or bring the stack down."
+        else
+            dr_info "Tor clearnet-egress check skipped — the tor container isn't running."
+        fi
         return 0
     fi
     if ! command -v curl >/dev/null 2>&1; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -160,7 +160,7 @@ DRBIN="$SANDBOX/drbin"
 mkdir -p "$DRBIN"
 cat >"$DRBIN/docker" <<'EOF'
 #!/usr/bin/env bash
-name=$(printf '%s' "$*" | sed -n 's/.*name=\^\([a-z-]*\)\$.*/\1/p')
+name=$(printf '%s' "$*" | sed -n 's/.*name=\^\([a-z0-9-]*\)\$.*/\1/p')
 case " ${RUNNING_CONTAINERS:-} " in *" $name "*) echo cid123 ;; esac
 exit 0
 EOF
@@ -202,6 +202,12 @@ rm -f "$SANDBOX/.env"
 # Stack down (tor not running) -> info skip: rules are legitimately absent after 'down'.
 out="$(RUNNING_CONTAINERS="" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
 assert_contains "egress check: stack down -> info" "$out" "isn't running"
+# tor DOWN while the mining stack runs -> FAIL, not a silent skip: the privacy backbone is dead but
+# revenue containers are live (tor crashed / stopped individually). doctor must not report all-clear.
+out="$(RUNNING_CONTAINERS="p2pool" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
+assert_contains "egress check: tor down + mining up -> FAIL" "$out" "Tor container is DOWN"
+out="$(RUNNING_CONTAINERS="p2pool" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_tor_clearnet_egress 2>&1)"
+assert_contains "clearnet-egress check: tor down + mining up -> FAIL" "$out" "Tor container is DOWN"
 # Running + tagged rules present -> OK.
 out="$(RUNNING_CONTAINERS="tor" IPT_TAGGED=1 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
 assert_contains "egress check: rules installed -> OK" "$out" "installed"


### PR DESCRIPTION
`pithead doctor` could report "all clear" while the entire privacy backbone was dead. Both Tor checks skipped with an info line whenever the tor container wasn't running — treating a clean `down` the same as the dangerous state where Tor crashed or was stopped individually while monerod/p2pool/xmrig-proxy keep mining. In that state clearnet dials are no longer fail-closed and off-box connections have lost their Tor path, but doctor said nothing.

Now: tor down + any revenue container up → `dr_fail` with a restart-Tor / bring-down hint. A genuinely-down stack still info-skips.

Surfaced by the #563 Tor-down tier-4 fault-injection (#618) — its "doctor fails loudly" assertion now holds. Also fixes the doctor-test docker stub's name regex (`[a-z-]`→`[a-z0-9-]`) so it matches digit names like `p2pool` (a latent stub bug the new helper exposed).

Tests: two tier-1 cases (tor-down + mining-up → FAIL); clean-down info-skip still passes. lint-sh clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)