### PR TITLE
fix(#622): one-click upgrade rides out a 502/503/504 from the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **One-click upgrade no longer shows a false "HTTP 502 — did not complete" on a
+  successful upgrade (#622).** The self-upgrade recreates the dashboard container
+  itself; while it restarts, caddy (the reverse proxy) stays up and answers
+  502/503/504 because the upstream is briefly gone. The result poller already rode
+  out a dropped connection but treated a gateway 5xx as terminal, so the modal
+  jumped to "failed" even though the upgrade landed. Gateway 502/503/504 are now
+  ridden out like a dropped connection; the durable control result is the real
+  outcome. A genuine backend 500 still fast-fails.
+
 ## [1.8.0] - 2026-07-17
 
 **Config UX round 2.** The Configuration view is regrouped around logical

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -43,8 +43,9 @@ const UPGRADE_POLL_MAX = 450; // 15 minutes — an upgrade pulls a whole release
 // Poll /api/control/result until a terminal result lands; shared by the Configuration view and
 // the Upgrade button (#59). `skip` ignores an intermediate status under the same id (the
 // still-present "previewed" result while a commit runs; "running" while an upgrade runs). Both
-// flows recreate the dashboard container itself, so a fetch here can transiently fail (connection
-// refused mid-restart) — ride it out and keep polling until the result file answers.
+// flows recreate the dashboard container itself, so a fetch here can transiently fail — either a
+// dropped connection (proxy down) or a 502/503/504 (proxy up, upstream mid-restart, #622). Ride
+// both out and keep polling until the result file answers.
 async function pollResult(id, skip, max = POLL_MAX) {
   for (let i = 0; i < max; i++) {
     await new Promise((r) => setTimeout(r, POLL_MS));
@@ -55,6 +56,11 @@ async function pollResult(id, skip, max = POLL_MAX) {
       continue;
     }
     if (res.status === 202) continue;
+    // Both flows recreate the dashboard container itself; while it restarts, the reverse proxy
+    // (caddy) stays up and answers 502/503/504 — the upstream is briefly gone, not failed. Ride
+    // these out like a dropped connection (#59/#622); the durable control result is the real
+    // outcome and `max` is the backstop. A real backend 500 (upstream up, erroring) still throws.
+    if (res.status === 502 || res.status === 503 || res.status === 504) continue;
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const out = await res.json();
     if (out.status === skip) continue;

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -94,6 +94,22 @@ test("runUpgrade posts the seen version, skips 'running', rides out the restart,
   assert.equal(posted.headers["X-Pithead-Control"], "1"); // CSRF guard rides every mutation
 });
 
+test("runUpgrade rides out a 502/503/504 from the proxy (upstream mid-restart), not just a dropped connection (#622)", async () => {
+  let polls = 0;
+  const fetchStub = async (url) => {
+    if (url === "/api/control/upgrade") {
+      return { status: 202, ok: false, json: async () => ({ id: ID, status: "pending" }) };
+    }
+    polls++;
+    // caddy stays up and answers a gateway error while the dashboard upstream is recreated —
+    // the common self-upgrade state, and the one the old poller misclassified as terminal.
+    if (polls <= 3) return { status: 502, ok: false, json: async () => ({}) };
+    return okResult({ status: "upgraded", version: "v9.9.9" });
+  };
+  const out = await withFastPoll(fetchStub, () => runUpgrade("v9.9.9"));
+  assert.equal(out.status, "upgraded"); // rode out the 502s to the durable result, no throw
+});
+
 test("runUpgrade surfaces a host-side rejection as the outcome, not a throw", async () => {
   const fetchStub = async (url) =>
     url === "/api/control/upgrade"


### PR DESCRIPTION
Closes #622.

The one-click upgrade (#59) recreates the dashboard container itself. While it restarts, caddy (the reverse proxy) stays up and answers **502/503/504** — the upstream is briefly gone, not failed. `pollResult()` already rode out a *dropped connection* (proxy down) but treated a gateway 5xx (proxy up, no upstream) as terminal → the modal jumped to "failed / HTTP 502" even though the upgrade landed and the durable control result said `upgraded`. Observed live on prod during a v1.6.3→v1.7.0 one-click.

**Fix:** ride out 502/503/504 like a dropped connection; the durable control result is the real outcome and the poll cap is the backstop. A genuine backend 500 (upstream up, erroring) still fast-fails — that signal is preserved.

**Test:** a 502 for the first N polls then the terminal `{status:"upgraded"}` must resolve to `done`, not `failed`. Frontend suite 197/197.

Ships in v1.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)