### PR TITLE
fix(dashboard): ride out proxy 502 during one-click upgrade (#622)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -55,6 +55,12 @@ async function pollResult(id, skip, max = POLL_MAX) {
       continue;
     }
     if (res.status === 202) continue;
+    // An upgrade (#59) recreates the dashboard container itself; while it restarts, the reverse
+    // proxy stays up and answers 502/503/504 — the upstream is briefly gone, not failed. Ride
+    // these out like a dropped connection (the `catch` above), otherwise the poll rejects mid-
+    // restart and a SUCCEEDED upgrade shows "did not complete" (#622). The durable control result
+    // is the real outcome; the loop's `max` is the timeout backstop. A backend 500 still fails.
+    if (res.status === 502 || res.status === 503 || res.status === 504) continue;
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const out = await res.json();
     if (out.status === skip) continue;

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -94,6 +94,30 @@ test("runUpgrade posts the seen version, skips 'running', rides out the restart,
   assert.equal(posted.headers["X-Pithead-Control"], "1"); // CSRF guard rides every mutation
 });
 
+test("runUpgrade rides out a 502 from the proxy while the dashboard restarts (#622)", async () => {
+  // The upgrade recreates the dashboard container itself while caddy stays up, so mid-restart
+  // polls get 502/503/504 (upstream gone) rather than a dropped connection. These must be
+  // tolerated, or a SUCCEEDED upgrade shows "did not complete".
+  let polls = 0;
+  const fetchStub = async (url) => {
+    if (url === "/api/control/upgrade")
+      return { status: 202, ok: false, json: async () => ({ id: ID, status: "pending" }) };
+    polls++;
+    if (polls <= 3) return { status: [502, 503, 504][polls - 1], ok: false, json: async () => ({}) };
+    return okResult({ status: "upgraded", version: "v9.9.9" });
+  };
+  const out = await withFastPoll(fetchStub, () => runUpgrade("v9.9.9"));
+  assert.equal(out.status, "upgraded");
+});
+
+test("runUpgrade still fails fast on a real backend error (500), not just times out (#622)", async () => {
+  const fetchStub = async (url) =>
+    url === "/api/control/upgrade"
+      ? { status: 202, ok: false, json: async () => ({ id: ID, status: "pending" }) }
+      : { status: 500, ok: false, json: async () => ({}) };
+  await assert.rejects(withFastPoll(fetchStub, () => runUpgrade("v9.9.9")), /HTTP 500/);
+});
+
 test("runUpgrade surfaces a host-side rejection as the outcome, not a throw", async () => {
   const fetchStub = async (url) =>
     url === "/api/control/upgrade"


### PR DESCRIPTION
## What

The one-click upgrade (#59) reports **"Upgrade did not complete — Error: HTTP 502"** even when the upgrade **succeeds**. This makes the fix in the poller, not the upgrade — the upgrade itself is fine.

Observed live on `pithead-prod` during a `v1.6.3 → v1.7.0` one-click upgrade: the UI showed the 502 "did not complete" modal, but the control-channel result was `{"status":"upgraded","version":"v1.7.0"}`, every container was on `:v1.7.0` and healthy, and p2pool was serving `8/8` miners with shares landing.

## Root cause

`pollResult()` is designed to ride out the dashboard restarting itself mid-upgrade, and already tolerates a dropped connection (`catch { continue }`) and the not-ready `202`. But the reverse proxy (caddy) stays up while the dashboard *upstream* is recreated, so mid-restart polls get a **502 Bad Gateway** — not a dropped connection. That hit `if (!res.ok) throw`, rejecting the whole poll and flipping the modal to "failed".

## Fix

Treat gateway `502/503/504` (proxy up, upstream briefly gone) like a dropped connection and keep polling. The durable host-written control result is the real outcome; the poll's `max` (15 min for upgrades) is the timeout backstop. A real backend `500` (upstream up, erroring) still fails fast.

`pollResult` is shared with the config-commit flow — the change is harmless and strictly more robust there too.

## Test

Two new `node --test` cases in `configview.test.mjs`:
- a run of `502 → 503 → 504` mid-poll is ridden out and resolves to `upgraded` (not `failed`);
- a persistent `500` still rejects with `HTTP 500` (fast-fail preserved).

`node --test` 25/25 green; biome clean.

Closes #622. Related (separate, not addressed here): #629 (one-click leaves `current ->` / dir name on the old version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)