### PR TITLE
v1.9 Wave A — upgrade hygiene: fresh version dir on one-click (#629), local frontend tests (#632), false-502 note (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **One-click upgrade keeps the versioned deploy layout honest (#629).** On the documented
+  layout (`pithead-vX.Y.Z` dirs beside a shared data root), the dashboard upgrade used to
+  extract the new release *over* the running install: the dir name and `current ->` symlink
+  kept the old version string while holding the new release, and the previous bundle — the
+  rollback copy — was destroyed. It now extracts into a fresh `pithead-v<new>/` sibling,
+  seeds `config.json`, `.env`, and the control spool, runs the new dir's `pithead upgrade`,
+  and repoints `current ->` on success, leaving the previous dir intact for rollback — the
+  same steps as a manual bundle deploy. Installs whose data directories resolve inside the
+  install dir still upgrade in place (a dir swap would strand the data) and say so in the
+  journal.
+- **`make test` now runs the frontend logic suite (#632).** The `node --test` frontend tests
+  ran only in CI; a local `make test` could pass with a frontend regression. Local and CI now
+  run the same chain.
+
+### Documentation
+
+- **The one-time false "HTTP 502 — did not complete" when upgrading from ≤ v1.7.x is
+  documented (#631).** The #622 fix rides in the release being installed, so the upgrade that
+  delivers it still polls with the old, unfixed client. The dashboard guide now says how to
+  confirm the upgrade landed (version badge, cleared release banner) and that the modal is a
+  one-time artifact.
+
 ## [1.8.1] - 2026-07-18
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
    - **test-dashboard** — the dashboard `pytest` suite (must stay ≥ the **80% total coverage gate**).
      CI also runs **`make test-patch-coverage`** (`diff-cover`): new/changed lines must be **≥ 90%**
      covered vs `origin/develop`, the ratchet that stops coverage rotting at the margin.
+   - **test-frontend** — the frontend logic tests (`node --test`); uses the same Node that the
+     lint surfaces already require.
    - **test-stack** — the `pithead` shell test suite.
    - **test-compose** — `docker-compose.yml` interpolation validation.
    - **test-integration-selftest** — the integration harness's own pure logic.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # Local test entry points (mirror the GitHub Actions CI jobs).
-.PHONY: test test-dashboard test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml release release-smoke
+.PHONY: test test-dashboard test-frontend test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml release release-smoke
 
-test: lint test-dashboard test-stack test-compose test-integration-selftest test-fakes ## Run everything that doesn't need a server/docker
+test: lint test-dashboard test-frontend test-stack test-compose test-integration-selftest test-fakes ## Run everything that doesn't need a server/docker
 
 test-dashboard: ## Dashboard unit/component tests with coverage gate (deps from uv.lock); emits coverage.xml
 	cd build/dashboard && uv run --locked --extra test python -m pytest \
 		--cov=mining_dashboard --cov-report=term-missing --cov-report=xml --cov-fail-under=80
+
+test-frontend: ## Frontend logic tests with Node's built-in runner (#632; same invocation as CI)
+	node --test build/dashboard/tests/frontend/*.test.mjs
 
 test-patch-coverage: ## diff-cover (#286): new/changed lines must be >=90% covered (run after test-dashboard)
 	cd build/dashboard && uv run --locked --extra test \

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -622,10 +622,15 @@ the host, with no SSH:
    it is newer than the running version — the container proposes, the host decides what gets
    installed. Attempts are limited to one per 10 minutes, and every one is written to the audit
    log.
-3. The runner downloads the release bundle (over Tor), extracts it over the install directory,
-   and runs the new release's `./pithead upgrade`, which re-renders the generated config and
-   pulls the new images. The page rides out its own restart and reports the outcome; reload when
-   it says the new version is up.
+3. The runner downloads the release bundle (over Tor). On the
+   [versioned deploy layout](operations.md#the-deploy-box-layout) — a `pithead-vX.Y.Z` install
+   dir with its data directories outside it — the bundle is extracted into a fresh sibling
+   `pithead-v<new>/`, `config.json`, `.env`, and the control spool are carried over, and the new
+   dir's `./pithead upgrade` runs; on success `current ->` repoints there and the previous dir
+   stays intact as the rollback copy. Any other layout (a plain `pithead/` extract, or data
+   directories living inside the install dir) gets the bundle extracted in place instead. Either
+   way, `upgrade` re-renders the generated config and pulls the new images. The page rides out
+   its own restart and reports the outcome; reload when it says the new version is up.
 
 The version the container proposes is never trusted as the target: the host independently fetches
 the latest tag from GitHub, and the bundle it downloads is for that host-derived tag. The bundle
@@ -639,6 +644,15 @@ with nothing changed, and a swapped key inside a malicious bundle cannot vouch f
 install without `cosign.pub` (older than the first signed release) still rests on TLS to GitHub
 (over Tor) plus that tag pinning, and says so in the journal — upgrading once to a signed release
 picks up the key. See [Releasing › Signed releases](releasing.md#signed-releases).
+
+**Upgrading from v1.7.x or older shows one last false failure.** Dashboard versions before
+v1.8.1 treat the reverse proxy's brief 502 — normal while the dashboard container recreates
+itself — as a hard failure, and the page polling during the upgrade is still the *old* version:
+the fix ships inside the release being installed, so it cannot protect the jump that installs
+it. If the modal reports "Error: HTTP 502" but the version badge shows the new version and the
+new-release banner is gone, the upgrade landed; reload the page to clear the modal (or confirm
+with `./pithead version` on the host). This happens once — upgrades started from v1.8.1 or
+later ride out the restart.
 
 The button never appears on a source checkout — the runner refuses the request there, since a dev
 install updates with `git pull`. If the upgrade fails, the result says so in the view: a failed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -280,7 +280,12 @@ data root:
   older. Each release lands in a fresh dir: extract the bundle, copy `config.json` and `.env`
   from the previous dir, run `./pithead upgrade`. Rollback is the same two steps from the older
   dir. The single-directory overlay under [Updating the stack](#updating-the-stack) also works;
-  the per-version layout is what a long-lived box converges to.
+  the per-version layout is what a long-lived box converges to. The dashboard's one-click
+  upgrade follows the same discipline on this layout: it extracts the new release into a fresh
+  `pithead-v<new>/` beside the running one, seeds `config.json`, `.env`, and the control spool,
+  and leaves the previous dir intact for rollback. Only when a data directory resolves *inside*
+  the install dir (the pre-shared-root default) does it extract in place instead — a dir swap
+  would strand that data — and says so in the journal.
 - **Shared data root** — point `monero.data_dir`, `tari.data_dir`, `p2pool.data_dir`, and
   `tor.data_dir` at absolute paths under one parent (here `~/mining/data`). When all four share
   a parent, the dashboard database defaults there as well (`<root>/dashboard`) instead of inside

--- a/pithead
+++ b/pithead
@@ -5245,6 +5245,87 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_fail "the $tag download actually contains version ${bundle_version:-unknown} — refusing a version-mismatched (possible rollback) release (#376). The stack keeps running v$PITHEAD_VERSION."
         return 0
     fi
+    # #629: pick the extraction target. A versioned install (pithead-vX.Y.Z dir) whose data dirs
+    # all resolve OUTSIDE the install dir gets the documented bundle-deploy layout
+    # (docs/operations.md § A recommended layout): extract into a fresh sibling pithead-<tag>/,
+    # seed the operator's config + the install-local state, and run the NEW dir's upgrade — on
+    # success its update_current_symlink repoints `current`, and this dir survives untouched as
+    # the rollback copy. Anything else falls back to the historical in-place extraction: a plain
+    # `pithead/` extract has no versioned layout to maintain, and data living under this dir
+    # (the pre-#455 default) would be stranded by a dir swap — the new render would re-derive
+    # its default paths under the NEW dir and the stack would come up beside its own data.
+    local new_dir=""
+    if [[ "$(basename "$PWD")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        new_dir="$(dirname "$PWD")/pithead-$tag"
+        local dvar dval
+        for dvar in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR TOR_DATA_DIR DASHBOARD_DATA_DIR; do
+            dval=$(env_get "$dvar")
+            [ -n "$dval" ] || continue
+            # Canonicalize: the .env value may reach the same place through the `current` symlink.
+            dval=$( (cd "$dval" 2>/dev/null && pwd -P) || printf '%s' "$dval")
+            case "$dval" in
+            "$PWD" | "$PWD"/*)
+                warn "$dvar resolves inside the install dir — upgrading in place; move the data to a shared root outside the version dir to get per-version rollback dirs (#629)."
+                new_dir=""
+                break
+                ;;
+            esac
+        done
+    fi
+    if [ -n "$new_dir" ]; then
+        # Fresh-dir deploy (#629). Plain tar throughout: nothing in $new_dir is running, and a
+        # leftover dir from an earlier failed attempt is merged over, never a reason to refuse.
+        if ! mkdir -p "$new_dir" 2>"$logf" ||
+            ! tar -xzf "$bundle" --strip-components=1 -C "$new_dir" 2>>"$logf"; then
+            rm -f "$bundle"
+            _upg_fail "could not extract the $tag bundle into $new_dir: $(tail -c 500 "$logf") — the running install is untouched; the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
+        fi
+        rm -f "$bundle"
+        # Seed what only the running install has: the operator's config, the rendered .env
+        # (preserved secrets — onions, RPC creds; cp -p keeps it 0600), and the install-local
+        # state dirs — the control spool (so the audit trail and results history carry over,
+        # and the result written below is visible to the RECREATED dashboard, which mounts the
+        # new dir's spool), the clearnet sync markers, and the caddy access log. Chain and
+        # dashboard data live outside this dir (guarded above) and carry over by path.
+        local sdir
+        if ! cp -p "$CONFIG_FILE" "$new_dir/config.json" 2>"$logf" ||
+            ! cp -p "$ENV_FILE" "$new_dir/.env" 2>>"$logf" ||
+            ! mkdir -p "$new_dir/data" 2>>"$logf"; then
+            _upg_fail "could not seed config into $new_dir: $(tail -c 500 "$logf") — the running install is untouched; the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
+        fi
+        for sdir in control clearnet-state caddy-logs; do
+            [ -d "$PWD/data/$sdir" ] || continue
+            if ! cp -a "$PWD/data/$sdir" "$new_dir/data/" 2>"$logf"; then
+                _upg_fail "could not carry data/$sdir over to $new_dir: $(tail -c 500 "$logf") — the running install is untouched; the stack keeps running v$PITHEAD_VERSION."
+                rm -f "$logf"
+                return 0
+            fi
+        done
+        # Run the NEW release's upgrade from the NEW dir: it re-renders the generated config
+        # (recomputing every $PWD-derived path, including CONTROL_DIR), re-provisions the
+        # control-runner units onto the new path, pulls the $tag images, and repoints
+        # `current ->` on success. The outcome goes to BOTH spools: the recreated dashboard
+        # mounts the new one, a failure before the recreate is read from the old one.
+        local rdir
+        if (cd "$new_dir" && ./pithead upgrade) >"$logf" 2>&1; then
+            for rdir in "$cdir" "$new_dir/data/control"; do
+                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
+                control_audit "$rdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
+            done
+        else
+            for rdir in "$cdir" "$new_dir/data/control"; do
+                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" --arg d "$new_dir" \
+                    '{status:"failed",version:$v,error:($e + " — finish the upgrade from the host: cd " + $d + " && ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+                control_audit "$rdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
+            done
+        fi
+        rm -f "$logf"
+        return 0
+    fi
     # In-place extraction over the running install, in two passes. Pass 1 lays down everything
     # EXCEPT the running script with plain tar, which MERGES existing directories — a release
     # install already carries the non-empty build/* config-template mounts — and overwrites files.

--- a/pithead
+++ b/pithead
@@ -5254,9 +5254,10 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # `pithead/` extract has no versioned layout to maintain, and data living under this dir
     # (the pre-#455 default) would be stranded by a dir swap — the new render would re-derive
     # its default paths under the NEW dir and the stack would come up beside its own data.
-    local new_dir=""
-    if [[ "$(basename "$PWD")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        new_dir="$(dirname "$PWD")/pithead-$tag"
+    local new_dir="" cwd
+    cwd=$(pwd -P) # physical path: the guard below compares canonicalized values on BOTH sides
+    if [[ "$(basename "$cwd")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        new_dir="$(dirname "$cwd")/pithead-$tag"
         local dvar dval
         for dvar in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR TOR_DATA_DIR DASHBOARD_DATA_DIR; do
             dval=$(env_get "$dvar")
@@ -5264,7 +5265,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
             # Canonicalize: the .env value may reach the same place through the `current` symlink.
             dval=$( (cd "$dval" 2>/dev/null && pwd -P) || printf '%s' "$dval")
             case "$dval" in
-            "$PWD" | "$PWD"/*)
+            "$cwd" | "$cwd"/*)
                 warn "$dvar resolves inside the install dir — upgrading in place; move the data to a shared root outside the version dir to get per-version rollback dirs (#629)."
                 new_dir=""
                 break
@@ -5272,11 +5273,17 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
             esac
         done
     fi
+    # Atomic create, no -p and no pre-check: root must never extract into (or follow a symlink
+    # planted at) a path some other local account pre-created — mkdir fails on ANY existing
+    # entry, closing the check-to-use race outright (#629 security review). A leftover dir from
+    # an earlier failed attempt therefore also lands here: fall back to in-place and say why.
+    if [ -n "$new_dir" ] && ! mkdir "$new_dir" 2>/dev/null; then
+        warn "$new_dir already exists (a previous attempt, or not ours to create) — upgrading in place. Remove it to get the fresh-dir layout back (#629)."
+        new_dir=""
+    fi
     if [ -n "$new_dir" ]; then
-        # Fresh-dir deploy (#629). Plain tar throughout: nothing in $new_dir is running, and a
-        # leftover dir from an earlier failed attempt is merged over, never a reason to refuse.
-        if ! mkdir -p "$new_dir" 2>"$logf" ||
-            ! tar -xzf "$bundle" --strip-components=1 -C "$new_dir" 2>>"$logf"; then
+        # Fresh-dir deploy (#629). Plain tar throughout: nothing in $new_dir is running.
+        if ! tar -xzf "$bundle" --strip-components=1 -C "$new_dir" 2>"$logf"; then
             rm -f "$bundle"
             _upg_fail "could not extract the $tag bundle into $new_dir: $(tail -c 500 "$logf") — the running install is untouched; the stack keeps running v$PITHEAD_VERSION."
             rm -f "$logf"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5298,6 +5298,93 @@ urun >/dev/null
 assert_contains "immediate second upgrade attempt is throttled" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "less than 10 minutes"
 reset_upgrade_state
 
+echo "== black-box: control upgrade extracts to a fresh version dir (#629) =="
+# A VERSIONED release install (deploy629/pithead-v1.3.1) whose data dirs all resolve OUTSIDE the
+# install dir — the documented bundle-deploy layout. The runner must extract v9.9.9 into a fresh
+# sibling pithead-v9.9.9/, seed config.json/.env and the install-local state dirs, run the NEW
+# dir's pithead upgrade from the new dir, write the result into BOTH spools, and leave this dir
+# intact as the rollback copy. Reuses the upgrade59 stubs ($UPG/bin) and fake bundle ($UPGB).
+VROOT="$SANDBOX/deploy629"
+VUPG="$VROOT/pithead-v1.3.1"
+VNEW="$VROOT/pithead-v9.9.9"
+mkdir -p "$VUPG/data/control/requests" "$VUPG/data/control/staged" "$VUPG/data/control/results" \
+    "$VUPG/data/control/audit" "$VUPG/data/clearnet-state" "$VROOT/data/monero"
+cp "$STACK" "$VUPG/pithead"
+printf '1.3.1' >"$VUPG/VERSION"
+printf '{}' >"$VUPG/config.json"
+printf 'clearnet-marker' >"$VUPG/data/clearnet-state/monero.synced"
+seed_v629_env() { # data dirs OUTSIDE the install dir → fresh-dir mode
+    cat >"$VUPG/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_CONTROL_ENABLED=true
+CONTROL_DIR=$VUPG/data/control
+NETWORK_PREFIX=10.9.0
+MONERO_DATA_DIR=$VROOT/data/monero
+TARI_DATA_DIR=$VROOT/data/tari
+P2POOL_DATA_DIR=$VROOT/data/p2pool
+TOR_DATA_DIR=$VROOT/data/tor
+DASHBOARD_DATA_DIR=$VROOT/data/dashboard
+EOF
+}
+seed_v629_env
+vrun() { # <extra env VAR=val...>
+    (cd "$VUPG" && PATH="$UPG/bin:$PATH" CURL_LOG="$VUPG/curl.log" \
+        CURL_API_RESPONSE="$UPGB/api.json" CURL_BUNDLE="$UPGB/bundle.tar.gz" \
+        env "$@" ./pithead control-run-pending 2>&1)
+}
+reset_v629_state() {
+    cp "$STACK" "$VUPG/pithead"
+    printf '1.3.1' >"$VUPG/VERSION"
+    rm -f "$VUPG/data/control/staged/.upgrade-stamp" "$VUPG/data/control/results/$UUPG.json"
+    rm -rf "$VNEW"
+}
+
+# Happy path: fresh sibling dir, seeded state, new pithead ran FROM the new dir, both spools
+# carry the result, and the running install — the rollback copy — is byte-for-byte untouched.
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
+vrun >/dev/null
+assert_eq "fresh-dir upgrade result status (old spool)" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "upgraded"
+assert_eq "fresh-dir upgrade result status (new spool)" "$(jq -r '.status' "$VNEW/data/control/results/$UUPG.json" 2>/dev/null)" "upgraded"
+assert_eq "new version dir holds the new release" "$(cat "$VNEW/VERSION" 2>/dev/null)" "9.9.9"
+assert_eq "old version dir still holds the old release (rollback preserved)" "$(cat "$VUPG/VERSION")" "1.3.1"
+cmp -s "$VUPG/pithead" "$STACK" && ok "old dir's pithead untouched by the extraction" ||
+    bad "old dir's pithead untouched by the extraction" "the running script was overwritten"
+assert_contains "the NEW pithead ran the upgrade from the NEW dir" "$(cat "$VNEW/upgrade-invocations.log" 2>/dev/null)" "new-pithead upgrade"
+[ -f "$VNEW/config.json" ] && ok "config.json seeded into the new dir" || bad "config.json seeded into the new dir" "missing"
+assert_contains "rendered .env seeded into the new dir" "$(cat "$VNEW/.env" 2>/dev/null)" "DEPLOYMENT_COMPLETED=true"
+assert_eq "clearnet sync markers carried over" "$(cat "$VNEW/data/clearnet-state/monero.synced" 2>/dev/null)" "clearnet-marker"
+assert_contains "fresh-dir upgrade audited in the old spool" "$(cat "$VUPG/data/control/audit/control.log" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"upgraded\""
+assert_contains "fresh-dir upgrade audited in the new spool" "$(cat "$VNEW/data/control/audit/control.log" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"upgraded\""
+
+# The new release's upgrade fails: both spools say failed, the error points at the NEW dir for
+# the host-side finish, and the old install keeps running — still intact for rollback.
+reset_v629_state
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
+vrun NEW_PITHEAD_FAIL=1 >/dev/null
+assert_eq "failed fresh-dir upgrade reports failed" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "failed fresh-dir upgrade points at the new dir" "$(jq -r '.error' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "cd $VNEW && ./pithead upgrade"
+assert_eq "failed fresh-dir upgrade leaves the old install intact" "$(cat "$VUPG/VERSION")" "1.3.1"
+assert_eq "failed fresh-dir upgrade wrote the result to the new spool too" "$(jq -r '.status' "$VNEW/data/control/results/$UUPG.json" 2>/dev/null)" "failed"
+
+# Data inside the install dir (the pre-#455 default): a dir swap would strand it — the runner
+# must fall back to the in-place path: no sibling dir, the new release lands in THIS dir.
+reset_v629_state
+cat >"$VUPG/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_CONTROL_ENABLED=true
+CONTROL_DIR=$VUPG/data/control
+NETWORK_PREFIX=10.9.0
+MONERO_DATA_DIR=$VUPG/data/monero
+EOF
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
+out="$(vrun)"
+assert_eq "data-inside-install falls back to in-place upgrade" "$(cat "$VUPG/VERSION")" "9.9.9"
+[ ! -e "$VNEW" ] && ok "data-inside-install creates no sibling version dir" ||
+    bad "data-inside-install creates no sibling version dir" "$VNEW exists"
+assert_contains "in-place fallback names the stranded data dir" "$out" "MONERO_DATA_DIR resolves inside the install dir"
+assert_eq "in-place fallback still upgrades" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "upgraded"
+seed_v629_env
+
 echo "== black-box: control upgrade verifies the bundle signature (#376) =="
 # Give the install a trust anchor (cosign.pub next to pithead — what a signed release bundle
 # ships) plus a fake cosign; the runner must fetch pithead.tar.gz.sig over the same Tor SOCKS and

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5362,13 +5362,16 @@ reset_v629_state
 printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
 vrun NEW_PITHEAD_FAIL=1 >/dev/null
 assert_eq "failed fresh-dir upgrade reports failed" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "failed"
-assert_contains "failed fresh-dir upgrade points at the new dir" "$(jq -r '.error' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "cd $VNEW && ./pithead upgrade"
+# The runner derives its paths from `pwd -P`, so on macOS the /var/folders sandbox reports as
+# /private/var/... — assert on the path's tail, not the unresolved $VNEW.
+assert_contains "failed fresh-dir upgrade points at the new dir" "$(jq -r '.error' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "/deploy629/pithead-v9.9.9 && ./pithead upgrade"
 assert_eq "failed fresh-dir upgrade leaves the old install intact" "$(cat "$VUPG/VERSION")" "1.3.1"
 assert_eq "failed fresh-dir upgrade wrote the result to the new spool too" "$(jq -r '.status' "$VNEW/data/control/results/$UUPG.json" 2>/dev/null)" "failed"
 
 # Data inside the install dir (the pre-#455 default): a dir swap would strand it — the runner
 # must fall back to the in-place path: no sibling dir, the new release lands in THIS dir.
 reset_v629_state
+mkdir -p "$VUPG/data/monero" # must exist: the guard canonicalizes via cd/pwd -P
 cat >"$VUPG/.env" <<EOF
 DEPLOYMENT_COMPLETED=true
 DASHBOARD_CONTROL_ENABLED=true
@@ -5383,6 +5386,31 @@ assert_eq "data-inside-install falls back to in-place upgrade" "$(cat "$VUPG/VER
     bad "data-inside-install creates no sibling version dir" "$VNEW exists"
 assert_contains "in-place fallback names the stranded data dir" "$out" "MONERO_DATA_DIR resolves inside the install dir"
 assert_eq "in-place fallback still upgrades" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "upgraded"
+seed_v629_env
+
+# A pre-existing entry at the target path — a leftover failed attempt, or a co-tenant's planted
+# dir/symlink (the mkdir-without--p TOCTOU guard): root must never extract into it. The runner
+# refuses the fresh-dir path and upgrades in place instead.
+reset_v629_state
+mkdir -p "$VNEW"
+printf 'not-ours' >"$VNEW/marker"
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
+out="$(vrun)"
+assert_contains "pre-existing target dir falls back to in-place" "$out" "already exists"
+assert_eq "pre-existing target dir is never written into" "$(
+    cat "$VNEW/marker" 2>/dev/null
+    ls "$VNEW" | wc -l | tr -d ' '
+)" "not-ours1"
+assert_eq "pre-existing target still upgrades in place" "$(cat "$VUPG/VERSION")" "9.9.9"
+reset_v629_state
+mkdir -p "$VROOT/plant"      # the attacker-controlled tree behind the symlink
+ln -s "$VROOT/plant" "$VNEW" # a planted symlink must fail the atomic mkdir, not be followed
+printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$UUPG" >"$VUPG/data/control/requests/$UUPG.json"
+out="$(vrun)"
+assert_contains "planted symlink at the target falls back to in-place" "$out" "already exists"
+[ -z "$(ls -A "$VROOT/plant" 2>/dev/null)" ] && ok "planted symlink is not followed (nothing extracted through it)" ||
+    bad "planted symlink is not followed (nothing extracted through it)" "files appeared behind the symlink"
+rm -f "$VNEW"
 seed_v629_env
 
 echo "== black-box: control upgrade verifies the bundle signature (#376) =="


### PR DESCRIPTION
## What

Three Wave-A items from the v1.9 roadmap (#393), landed before any further prod one-click:

### #629 — one-click upgrade extracts to a fresh version dir
On the documented deploy layout (`pithead-vX.Y.Z` dirs, data outside the install dir), `control_upgrade` now follows the same steps as a manual bundle deploy: extract the verified bundle into a fresh sibling `pithead-v<new>/`, seed `config.json` + `.env` + the install-local state dirs (control spool with results/audit history, clearnet markers, caddy log), run the **new** dir's `pithead upgrade` (which re-renders every $PWD-derived path, re-provisions the control-runner systemd units onto the new path, and repoints `current ->` on success), and write the outcome to **both** spools — the recreated dashboard mounts the new one, a failure before the recreate is read from the old one. The previous dir survives intact as the rollback copy.

Fallbacks (in-place extraction, today's behavior): non-versioned layouts, any data dir resolving inside the install dir (a swap would strand it — journal line says so), and any pre-existing entry at the target path.

**Review hardening** (verifier + security-reviewer passes done in-session):
- guard compares canonicalized paths on both sides (`pwd -P`);
- atomic `mkdir` without `-p` — root never extracts into (or through a symlink planted at) a path it didn't just create; the check-to-use race is closed by construction.

24 new stack-suite assertions pin the happy path, the failure path (error points at `cd <new_dir> && ./pithead upgrade`), both fallbacks, and both refusals.

### #632 — `make test` runs the frontend suite
`test-frontend` (`node --test build/dashboard/tests/frontend/*.test.mjs`, same invocation as CI) joins the local chain; node was already required by the lint surfaces. CONTRIBUTING.md updated.

### #631 — the one-time false 502 is documented
docs/dashboard.md explains why the upgrade *from* ≤ v1.7.x still shows one last "HTTP 502 — did not complete" (the old client polls during its own upgrade) and how to confirm success. Docs only — the old asset can't be patched retroactively.

## Testing
- `make lint` + `make test` green locally (stack suite 1426/0, frontend 197/197).
- Ponytail over-engineering pass: lean, one optional shrink declined (explicitness in a root-run path).
- Tier-4: the #629 fresh-dir path gets validated live on gouda with a real one-click before the v1.9 cut (also covers #633).

Closes #629, closes #631, closes #632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)