### PR TITLE
feat(#208): stratum auth on by default for new installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Added
+
+- **Stratum authentication is on by default for new installs (#208, #152 Phase 2).** The setup
+  wizard and `config.minimal.json` now write `p2pool.stratum_password: "auto"` into every new
+  `config.json`: the stack generates a stable secret, prints it after `setup`/`apply`, and
+  RigForge's setup prompts for it — a fresh stack plus fresh rigs authenticate end-to-end with
+  no manual edits. Existing installs are untouched: the key is written explicitly for new
+  configs, never assumed for old ones, so an upgrade flips nothing and a fleet on the open
+  `:3333` keeps mining. Set the key to `""` (or delete it) to run unauthenticated.
+
 ### Fixed
 
 - **One-click upgrade keeps the versioned deploy layout honest (#629).** On the documented

--- a/config.minimal.json
+++ b/config.minimal.json
@@ -4,5 +4,8 @@
     },
     "tari": {
         "wallet_address": "your_tari_wallet_address"
+    },
+    "p2pool": {
+        "stratum_password": "auto"
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,9 +21,18 @@ A fresh `config.json` is this (see [`config.minimal.json`](../config.minimal.jso
     },
     "tari": {
         "wallet_address": "your_tari_wallet_address"
+    },
+    "p2pool": {
+        "stratum_password": "auto"
     }
 }
 ```
+
+The `stratum_password` line turns on [stratum authentication](workers.md#authentication) for new
+installs (#208): the stack generates a stable secret, prints it after `setup`/`apply`, and rigs
+connect with it as their stratum `pass` (RigForge's setup prompts for it). It is explicit here —
+not a hidden default — so an install that predates it keeps its open-`:3333` behavior on upgrade;
+delete the line (or set `""`) to run unauthenticated on a trusted LAN.
 
 For every key and its default, see [`config.reference.json`](../config.reference.json) and copy in
 only the keys you want to override.
@@ -106,7 +115,7 @@ control channel will commit, are unaffected either way.
 | `p2pool.pool` | `mini` | Which P2Pool sidechain to mine: `main`, `mini`, or `nano`. `mini` (the default) has a lower share difficulty than `main`, so a typical home rig finds shares far more often: smoother, more frequent PPLNS payouts instead of long dry spells. Raise to `main` for high hashrate (large farms); drop to `nano` for a single low-power rig. |
 | `p2pool.stratum_bind` | `0.0.0.0` | Host bind address for the stratum port (`3333`) your rigs connect to. A single IPv4 address (maps to Docker's port-publish host IP), not a subnet/CIDR. Default `0.0.0.0` reaches the whole LAN with no setup; set a specific LAN IP (e.g. `192.168.1.10`) to limit it to one interface, or `127.0.0.1` to disable LAN access entirely. To restrict which source subnet may connect, use a firewall. See [Connecting Miners › Firewall](workers.md#firewall). |
 | `p2pool.stratum_port` | `3333` | TCP port the stratum endpoint your rigs connect to is published on. Default `3333` is the standard path — leave it unless another service already holds the port on the host. Change it and **every rig must repoint** at the new port (RigForge: `pool.port`); `apply` flags the change as destructive because rigs on the old port can't connect until updated. Only the operator-facing published port moves; p2pool's container-internal stratum stays fixed at `3333` (nothing outside the stack touches it). See [Connecting Miners › Non-standard port](workers.md#non-standard-stratum-port). |
-| `p2pool.stratum_password` | `""` _(off)_ | Optional password every rig must send to mine through the proxy. Turns the otherwise-open `3333` port into authenticated stratum. `""` (default) = no password, any rig may connect. `"auto"` = generate a random secret once and keep it stable (shown after `setup`/`apply` and stored in `.env`); set it as each rig's stratum `pass`. Any literal string = use exactly that password. Only devices that know the secret can mine, which also shrinks the worker-name [SSRF](workers.md#authentication) surface. The password is sent in cleartext over stratum, so this is access control ("who may mine"), not encryption. Pair it with `stratum_bind`/a firewall. See [Connecting Miners › Authentication](workers.md#authentication). |
+| `p2pool.stratum_password` | `""` _(off; new installs get `"auto"`)_ | Password every rig must send to mine through the proxy. Turns the otherwise-open `3333` port into authenticated stratum. `""` (the fallback for an absent key, which is what pre-#208 installs have) = no password, any rig may connect. `"auto"` = generate a random secret once and keep it stable (shown after `setup`/`apply` and stored in `.env`); set it as each rig's stratum `pass` — the wizard and `config.minimal.json` write this for every new install. Any literal string = use exactly that password. Only devices that know the secret can mine, which also shrinks the worker-name [SSRF](workers.md#authentication) surface. The password is sent in cleartext over stratum, so this is access control ("who may mine"), not encryption. Pair it with `stratum_bind`/a firewall. See [Connecting Miners › Authentication](workers.md#authentication). |
 | `p2pool.clearnet` | `false` | Privacy-relevant, default off (Tor). P2Pool's `--onion-address` only advertises an onion for inbound peers; its outbound sidechain dials need a SOCKS proxy or they go over clearnet, exposing your home IP. Default (`false`) routes those dials through the bundled Tor proxy (`--socks5 <tor>:9050 --socks5-proxy-type tor`). Set `true` to dial peers directly over clearnet for maximum yield: Tor latency raises the stale/uncle-share rate and onion-only shrinks the peer set, both worse on `--mini`/`--nano`, so a high-variance small rig may prefer clearnet (at the cost of IP exposure). Full threat model: [Privacy › P2Pool outbound peers](privacy.md#p2pool-outbound-peers-165---tor-by-default). |
 | `p2pool.data_dir` | `auto` | Where P2Pool data lives on the host. `auto` = `./data/p2pool`. |
 | `proxy.donate_level` | `0` | xmrig-proxy's built-in dev-fee donation to the xmrig developers, as a percentage of submitted hashrate. Defaults to `0`, no donation (xmrig-proxy's own compiled-in default, which the stack now renders explicitly so it's visible rather than invisible). Set an integer `1`–`99` to donate that share to the xmrig devs if you want to support them. This is not the XvB donation; that's the separate `xvb.*` mechanism the optimizer steers, never this dev fee. |

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -127,11 +127,20 @@ the internal wiring is untouched.
 
 ### Authentication
 
-By default `3333` accepts any rig that can reach it; the stratum `pass` is ignored. To require a
-shared secret, set [`p2pool.stratum_password`](configuration.md#configuration-reference). The proxy
-then rejects any rig whose stratum `pass` doesn't match, so only devices you've configured can mine.
-That also means only they can register a worker name, which shrinks the worker-name SSRF surface (a
-malicious worker name is how an untrusted device could otherwise probe the dashboard's internals).
+New installs ship with stratum authentication **on** (#208): the setup wizard and
+`config.minimal.json` both write `p2pool.stratum_password: "auto"` into the new `config.json`, the
+stack generates a stable secret and prints it after `setup`/`apply` (also shown by
+`pithead status`), and RigForge's own setup prompts for it — a fresh stack plus fresh rigs
+authenticate end-to-end with no manual config edits. The proxy rejects any rig whose stratum
+`pass` doesn't match, so only devices you've configured can mine. That also means only they can
+register a worker name, which shrinks the worker-name SSRF surface (a malicious worker name is
+how an untrusted device could otherwise probe the dashboard's internals).
+
+An install that predates this default keeps its open `:3333` on upgrade — the key is written
+explicitly into new configs, never assumed for old ones. To adopt it on an existing fleet, update
+the rigs first (set each rig's `pass`, or push it over the rigs' control API from the dashboard's
+Worker Inspect), then set the password on the stack — a rig with the wrong `pass` is rejected the
+moment the stack enforces it.
 
 ```jsonc
 // config.json — "auto" generates a stable random secret; or set your own string
@@ -159,8 +168,8 @@ Using [RigForge](https://github.com/p2pool-starter-stack/rigforge) (below)? It's
 
 NOTE: the password travels in cleartext over the LAN (plain stratum has no TLS), so this is access
 control (who may mine), not eavesdropping protection. On a trusted LAN it's enough; if you must
-expose `3333` more widely, combine it with `stratum_bind` and a firewall (above). Leaving it unset
-(`""`, the default) keeps the open, no-password behavior.
+expose `3333` more widely, combine it with `stratum_bind` and a firewall (above). Setting it to
+`""` (or deleting the key) turns authentication off and keeps the open, no-password behavior.
 
 ### Reading each worker's stats (the dashboard's worker API probe)
 

--- a/pithead
+++ b/pithead
@@ -2292,7 +2292,7 @@ wizard_write_config() {
         --arg pool "$POOL_TIER" \
         '{monero: {mode: $mode, wallet_address: $mwallet, node_username: $mu, node_password: $mp},
           tari: {wallet_address: $twallet},
-          p2pool: {pool: $pool},
+          p2pool: {pool: $pool, stratum_password: "auto"},
           dashboard: {secure: true}}')
 
     if [ "$MONERO_MODE_WIZ" == "remote" ]; then

--- a/pithead
+++ b/pithead
@@ -650,6 +650,10 @@ stack_status() {
     if onion_line=$(dashboard_onion_status); then
         log "Dashboard onion (remote access): $onion_line"
     fi
+    # #208: RigForge's setup prompt (and docs/workers.md) tell the operator the stratum
+    # access-password is "shown by 'pithead status'" — honor that contract here. No-op when
+    # auth is off; the same secret already lives in the owner-only .env.
+    announce_stratum_auth
     if [ "$problems" -eq 0 ]; then
         log "All expected services are up."
     else

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6084,6 +6084,10 @@ printf '%s\n%s\n\nmain\nopuser\nsuperSecret1\ny\ny\ny\nmybottoken123\n987654321\
 w2_cfg="$(cat "$W2/config.json" 2>/dev/null)"
 assert_eq "full path: monero.mode local (Enter-through)" "$(jq -r '.monero.mode' <<<"$w2_cfg")" "local"
 assert_eq "full path: p2pool.pool honors an explicit main" "$(jq -r '.p2pool.pool' <<<"$w2_cfg")" "main"
+assert_eq "full path: stratum auth defaults on for new installs (#208)" "$(jq -r '.p2pool.stratum_password' <<<"$w2_cfg")" "auto"
+# The other new-install path — `cp config.minimal.json config.json` (the bundle quick-start,
+# which bypasses the wizard) — must carry the same default, or only wizard users get auth.
+assert_eq "config.minimal.json ships stratum auth on (#208)" "$(jq -r '.p2pool.stratum_password' "$ROOT/config.minimal.json")" "auto"
 assert_eq "full path: dashboard.auth.username set" "$(jq -r '.dashboard.auth.username' <<<"$w2_cfg")" "opuser"
 assert_eq "full path: dashboard.auth.password set" "$(jq -r '.dashboard.auth.password' <<<"$w2_cfg")" "superSecret1"
 assert_eq "full path: clearnet-sync cluster sets BOTH chains together" \


### PR DESCRIPTION
## What

Phase 2 of #152, per the Wave 0 decisions recorded on #208. The producer — RigForge fetching the password at rig setup — already shipped (rigforge#151 closed rigforge#113), so this is the pithead half:

- **The setup wizard and `config.minimal.json` write `p2pool.stratum_password: "auto"` into every NEW `config.json`** — both new-install paths (interactive wizard, bundle quick-start `cp`). The stack generates a stable secret with the existing #152/#207 machinery, announces it after `setup`/`apply`, and RigForge setup prompts for it: fresh stack + fresh rigs authenticate end-to-end with no manual edits.
- **Existing installs flip nothing on upgrade** (the #393 no-bricked-fleets gate): the key is written explicitly into new configs; the absent-key fallback stays `""` (auth off). Verified by the existing 30+ suite configs that omit the key.
- **`pithead status` now shows the password** when auth is on — RigForge's shipped prompt and the #208 issue text both promise "shown by 'pithead status'"; it never was (security-review catch, doc/code contract fix).
- docs: workers.md#authentication rewritten (default-on scope + rigs-first adoption order for existing fleets), configuration.md minimal-config snippet + reference row.

## Reviews
- security-reviewer: **CLEAN** — announcement surface stays interactive-only commands, no path rewrites an existing config.json, 96-bit secret unchanged, no `:3333` consumer breaks or bypasses auth (healthchecks probe the listener, not stratum; worker probes use the HTTP API).
- verifier: PASS on all goals (its one CHANGELOG miss was a race with concurrent branch checkouts in the review worktree; the entry is in the diff).
- Ponytail: lean — reuses all existing machinery.
- Local: stack suite 1428/0, `make lint` green.

## Tier-4 note
The wizard→auth-on path gets exercised live in the v1.9 gouda validation (fresh-install scenario of the e2e matrix).

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)