### PR TITLE
fix(#640): full dotted labels in config sections that mix top-level keys

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -74,8 +74,11 @@ async function pollResult(id, skip, max = POLL_MAX) {
 const HOST_ONLY_TITLE = "Host-only — edit config.json and run ./pithead apply";
 
 // `full` (#529): the pinned Core card mixes fields from several sections, so its rows need the
-// FULL dotted key ("monero.wallet_address") to stay unambiguous; a natural section already says
-// which section it is via its own heading, so its rows keep the shorter relative label.
+// FULL dotted key ("monero.wallet_address") to stay unambiguous. A natural section keeps the
+// shorter relative label ONLY while all its fields share one top-level key (its heading then says
+// the rest); a logical section that mixes top-level keys (#611 — Wallets & payout spans monero.*
+// AND tari.*) gets full keys too, or monero.view_key and tari.view_key would both render as a
+// bare "view_key" (and System / advanced would show four identical "data_dir" rows).
 //
 // `field.editable` (#613): a field the control gate would refuse at commit renders disabled, its
 // live value read-only, with a tooltip explaining why — and, critically, no onChange/onInput is
@@ -303,9 +306,13 @@ export class ConfigView extends Component {
         }
         ${groups.map((s) => {
           const { fields, subgroups } = nestSection(s);
+          // Computed on the flat fields AFTER nestSection, so a section that only mixes top-level
+          // keys via its subgroups (Notifications: telegram + notifications + healthchecks, each
+          // in its own labelled <details>) keeps short labels for the flat telegram.* remainder.
+          const mixed = new Set(fields.map((f) => f.path[0])).size > 1;
           return html`<details class="card config-section">
               <summary>${s.name}</summary>
-              ${fields.map((f) => field(f))}
+              ${fields.map((f) => field(f, mixed))}
               ${subgroups.map(
                 (g) => html`<details class="config-subsection">
                     <summary>${g.label} (${g.fields.length})</summary>

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -242,6 +242,33 @@ test("form mode: a core key is lifted out of its own section (no duplicate row)"
   assert.match(out, /config-field-name">auth\.password/); // relative label inside its section
 });
 
+test("form mode: a section mixing top-level keys renders full labels — no two rows both named view_key (#611)", () => {
+  // Wallets & payout pulls from monero.* AND tari.*; with relative labels both view_keys
+  // rendered as a bare "view_key". Mixed sections must use the full dotted key.
+  const cfg = {
+    monero: { view_key: "", payout_scan_height: "auto" },
+    tari: { view_key: "", spend_public_key: "" },
+  };
+  const inst = readyView(cfg, []);
+  const out = renderToString(inst.render());
+  assert.match(out, /config-field-name">monero\.view_key/);
+  assert.match(out, /config-field-name">tari\.view_key/);
+  assert.doesNotMatch(out, /config-field-name">view_key</); // no ambiguous bare label
+});
+
+test("form mode: a section mixing top-level keys only via subgroups keeps short labels on its flat fields", () => {
+  // Notifications spans telegram + notifications + healthchecks, but the latter two live in their
+  // own labelled subgroup <details> — the flat telegram.* remainder is single-key, so the mixed
+  // check runs AFTER nestSection and the flat rows keep their relative labels.
+  const cfg = {
+    telegram: { enabled: false, bot_token: "" },
+    healthchecks: { ping_url: "" },
+  };
+  const out = renderToString(readyView(cfg, []).render());
+  assert.match(out, /config-field-name">enabled/); // relative, not telegram.enabled
+  assert.doesNotMatch(out, /config-field-name">telegram\./);
+});
+
 test("mode toggle switches between Form and JSON rendering", () => {
   const inst = readyView();
   assert.match(renderToString(inst.render()), /config-section-core/);

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -519,7 +519,10 @@ Two edit modes build the same candidate config and submit it through the same pi
   as before; within **Notifications**, the 26 `telegram.events` toggles, the ntfy/webhook sinks,
   and Healthchecks each nest one level deeper into their own collapsed sub-group
   ([#612](https://github.com/p2pool-starter-stack/pithead/issues/612)) instead of dominating the
-  section's field list. A config path no logical section claims still renders, in a catch-all
+  section's field list. Rows in a section whose fields span more than one top-level key carry their
+  full dotted path (`monero.view_key`, `tari.view_key`) so two leaves with the same name read as two
+  different keys; a single-key section keeps the shorter relative label — its heading names the rest.
+  A config path no logical section claims still renders, in a catch-all
   **Other** group — a new schema key can't silently vanish from the editor, and a frontend test
   fails loudly if one ever would. `workers.list[]` (the per-rig descriptors) isn't a form field
   here — a variable-length list has no single form control for it — edit it via


### PR DESCRIPTION
Closes #640.

## What

The Configuration form showed two rows both labelled `view_key` under **Wallets & payout** — they are `monero.view_key` and `tari.view_key`, but section rows dropped the top-level key from the label. The #611 logical regroup made that rule ambiguous: "Monero node" showed two `mode` rows and "System / advanced" four `data_dir` rows.

## Fix

One rule change in `renderForm` ([configview.mjs](build/dashboard/mining_dashboard/web/static/configview.mjs)): a section whose flat fields span more than one top-level config key renders full dotted labels (`monero.view_key`, `tari.view_key`) — the same rule the pinned Core card already uses (#529). Single-key sections keep the shorter relative label. The check runs on the flat remainder after `nestSection` (#612), so Notifications — which mixes top-level keys only via its labelled subgroups — keeps short labels for its flat `telegram.*` rows.

## Testing

- New render test: a mixed section shows both full `view_key` labels and no bare `view_key` label survives.
- New render test: a section mixing top-level keys only via subgroups keeps relative labels on its flat fields.
- Full frontend suite: 199/199 pass (`node --test build/dashboard/tests/frontend/*.test.mjs`); `make lint-js`, `lint-md`, `lint-docs-voice` clean.

## Docs

[docs/dashboard.md](docs/dashboard.md) Configuration-view section documents the labelling rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)