### PR TITLE
release: fold the rolled-in PRs into the 1.9.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,13 @@ steady-state CPU cost drops via healthcheck and peer-count tuning (#595).
 
 ### Added
 
-- **XvB raffle wins on the chart and in a log.** The dashboard reads XvB's public winners log
-  (over Tor, about every 30 minutes) and records every round your wallet won. Wins show as gold
-  stars on the hashrate chart (hover for the round type and credited hashrate), as a **Raffle
-  Wins** list in the XvB Donation Stats card, and each new win is announced once in the dashboard
-  log. Wins are stored permanently, so the history outlives the ~4-day window the winners file
-  itself keeps. Each new win also fires a Telegram/webhook alert (`raffle_win` event, on by
+- **XvB raffle wins on the chart and in a log (#644).** The dashboard reads XvB's public winners
+  log (over Tor, about every 30 minutes) and records every round your wallet won. Wins show as
+  gold stars on the hashrate chart (hover for the round type and credited hashrate), as a
+  **Raffle Wins** list in the XvB Donation Stats card, and each new win is announced once in the
+  dashboard log. Win history outlives the ~4-day window the winners file itself keeps — it is
+  kept effectively forever (bounded only far beyond any real win history, since the file is
+  remote content the stack does not control). Each new win also fires a Telegram/webhook alert (`raffle_win` event, on by
   default like the rest; opt out via `telegram.events.raffle_win: false`).
 - **Stratum authentication is on by default for new installs (#208, #152 Phase 2).** The setup
   wizard and `config.minimal.json` now write `p2pool.stratum_password: "auto"` into every new
@@ -47,6 +48,10 @@ steady-state CPU cost drops via healthcheck and peer-count tuning (#595).
 
 ### Fixed
 
+- **Configuration form: sections that mix top-level keys label rows with the full dotted path
+  (#640).** "Wallets & payout" showed two rows both named `view_key`; they are
+  `monero.view_key` and `tari.view_key` and now say so. Single-key sections keep their short
+  labels.
 - **One-click upgrade keeps the versioned deploy layout honest (#629).** On the documented
   layout (`pithead-vX.Y.Z` dirs beside a shared data root), the dashboard upgrade used to
   extract the new release *over* the running install: the dir name and `current ->` symlink


### PR DESCRIPTION
Bookkeeping so the v1.9.0 notes match what the release actually carries: #642's raffle-wins entry gains its tracking-issue ref (#644) and drops the 'stored permanently' wording its own security fix bounded; #640/#641 (config-form dotted labels) gets its Fixed line. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)