### PR TITLE
One-click upgrade names its restore point (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Added
+
+- **One-click upgrade names its restore point (#637).** Before an in-place upgrade overwrites
+  the running install, the runner copies `config.json` and the rendered `.env` to timestamped
+  `.bak-upgrade-*` siblings — and refuses to proceed if it cannot; a failure during the
+  upgrade names those copies in the result and the dashboard modal. On the versioned layout
+  the result (and the "Upgraded" modal) names the previous version dir — the rollback copy
+  #629 already kept but never pointed at.
+
 ## [1.9.0] - 2026-07-18
 
 **Stratum link security.** v1.9 locks the last cleartext link — miner ↔ stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
   `.bak-upgrade-*` siblings — and refuses to proceed if it cannot; a failure during the
   upgrade names those copies in the result and the dashboard modal. On the versioned layout
   the result (and the "Upgraded" modal) names the previous version dir — the rollback copy
-  #629 already kept but never pointed at.
+  #629 already kept but never pointed at. The copies are written symlink-safely (mktemp +
+  rename, the #629 co-tenant threat model) and pruned to the newest three pairs.
 
 ## [1.9.0] - 2026-07-18
 

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -490,6 +490,12 @@ export class UpgradeControl extends Component {
           <div class="card config-modal">
               <h3>Upgraded to ${result.version || version}</h3>
               <p class="status-ok">The stack is running the new release.</p>
+              ${
+                result.rollback
+                  ? html`<p class="text-muted">The previous release is kept at <code>${result.rollback}</code>
+                    on the host — the rollback copy if this version misbehaves.</p>`
+                  : null
+              }
               <div class="config-modal-actions">
                   <button class="btn-toggle active" onClick=${() => window.location.reload()}>Reload the dashboard</button>
               </div>
@@ -500,6 +506,12 @@ export class UpgradeControl extends Component {
           <div class="card config-modal">
               <h3>Upgrade did not complete</h3>
               <p class="status-bad">${result.error || "The host runner reported a failure."}</p>
+              ${
+                result.backup
+                  ? html`<p class="text-muted">Pre-upgrade copies of <code>config.json</code> and
+                    <code>.env</code> are kept on the host: <code>${result.backup}</code>.</p>`
+                  : null
+              }
               <div class="config-modal-actions">
                   <button class="btn-toggle" onClick=${() => this.setState({ phase: "idle", confirmText: "" })}>Close</button>
               </div>

--- a/build/dashboard/tests/frontend/configview.test.mjs
+++ b/build/dashboard/tests/frontend/configview.test.mjs
@@ -142,6 +142,31 @@ test("the confirm modal arms only on a typed UPGRADE", () => {
   assert.doesNotMatch(renderToString(inst.render()), /disabled/);
 });
 
+// #637: the host names the restore point in the result — the done modal shows the fresh-dir
+// rollback copy, the failed modal shows the in-place pre-upgrade config/.env copies. A result
+// without the field (an in-place success, an old runner) renders neither sentence.
+test("the done modal names the rollback dir when the result carries one (#637)", () => {
+  const props = { update: UPDATE, enabled: true };
+  const inst = new UpgradeControl(props);
+  inst.props = props;
+  inst.state.phase = "done";
+  inst.state.result = { status: "upgraded", version: "v9.9.9", rollback: "/srv/pithead-v1.3.1" };
+  assert.match(renderToString(inst.render()), /\/srv\/pithead-v1\.3\.1/);
+  inst.state.result = { status: "upgraded", version: "v9.9.9" };
+  assert.doesNotMatch(renderToString(inst.render()), /rollback copy/);
+});
+
+test("the failed modal names the pre-upgrade config/.env copies when the result carries them (#637)", () => {
+  const props = { update: UPDATE, enabled: true };
+  const inst = new UpgradeControl(props);
+  inst.props = props;
+  inst.state.phase = "failed";
+  inst.state.result = { status: "failed", error: "boom", backup: "/x/config.json.bak-upgrade-1 /x/.env.bak-upgrade-1" };
+  assert.match(renderToString(inst.render()), /bak-upgrade-1/);
+  inst.state.result = { status: "failed", error: "boom" };
+  assert.doesNotMatch(renderToString(inst.render()), /Pre-upgrade copies/);
+});
+
 // --- Preview modal (#504) --------------------------------------------------------------
 //
 // dashboard.energy is config.json-only, so the host runner previews an energy edit as a normal

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -645,7 +645,10 @@ the host, with no SSH:
    `pithead-v<new>/`, `config.json`, `.env`, and the control spool are carried over, and the new
    dir's `./pithead upgrade` runs; on success `current ->` repoints there and the previous dir
    stays intact as the rollback copy. Any other layout (a plain `pithead/` extract, or data
-   directories living inside the install dir) gets the bundle extracted in place instead. Either
+   directories living inside the install dir) gets the bundle extracted in place instead — and
+   because no previous dir survives there, the runner first copies `config.json` and `.env` to
+   timestamped `.bak-upgrade-*` siblings, refusing to proceed if it cannot
+   ([#637](https://github.com/p2pool-starter-stack/pithead/issues/637)). Either
    way, `upgrade` re-renders the generated config and pulls the new images. The page rides out
    its own restart and reports the outcome; reload when it says the new version is up.
 
@@ -677,7 +680,9 @@ release lookup or bundle download changes nothing; a failure during `pithead upg
 containers that were not yet recreated on the previous images, and finishing up is one
 `./pithead upgrade` on the host. There is no automatic rollback — the images of the previous
 release stay on disk, and `docker compose` state is recoverable the same way as a failed
-CLI upgrade.
+CLI upgrade. The result names the restore point ([#637](https://github.com/p2pool-starter-stack/pithead/issues/637)):
+on the versioned layout, the previous `pithead-vX.Y.Z` dir; in place, the pre-upgrade
+`config.json`/`.env` copies.
 
 ## Tips
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -647,8 +647,8 @@ the host, with no SSH:
    stays intact as the rollback copy. Any other layout (a plain `pithead/` extract, or data
    directories living inside the install dir) gets the bundle extracted in place instead — and
    because no previous dir survives there, the runner first copies `config.json` and `.env` to
-   timestamped `.bak-upgrade-*` siblings, refusing to proceed if it cannot
-   ([#637](https://github.com/p2pool-starter-stack/pithead/issues/637)). Either
+   timestamped `.bak-upgrade-*` siblings, refusing to proceed if it cannot; the newest three
+   pairs are kept ([#637](https://github.com/p2pool-starter-stack/pithead/issues/637)). Either
    way, `upgrade` re-renders the generated config and pulls the new images. The page rides out
    its own restart and reports the outcome; reload when it says the new version is up.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -306,6 +306,11 @@ State lives in the data directories (by default under `./data/`, or wherever eac
 points; see [Configuration › Data directories](configuration.md#data-directories)):
 
 - **`config.json`**: settings. `chmod 600`; keep a copy off-host.
+- **`config.json.bak-upgrade-*` / `.env.bak-upgrade-*`**: pre-upgrade copies the dashboard's
+  one-click upgrade keeps before an in-place extraction
+  ([#637](https://github.com/p2pool-starter-stack/pithead/issues/637)). The newest three pairs
+  are kept; older ones are pruned automatically. The `.env` copies carry secrets — handle them
+  like `.env` itself.
 - **`data/tor/`**: onion service keys. Back up to keep the same onion addresses across a rebuild.
 - **`data/monero/`**, **`data/tari/`**: the blockchains. Large; backing them up saves a re-sync,
   but they re-download from the network if lost.

--- a/pithead
+++ b/pithead
@@ -5414,19 +5414,35 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         # control-runner units onto the new path, pulls the $tag images, and repoints
         # `current ->` on success. The outcome goes to BOTH spools: the recreated dashboard
         # mounts the new one, a failure before the recreate is read from the old one.
+        # #637: this dir — untouched by the whole deploy — is the restore point; name it in the
+        # result so the operator learns it exists without reading docs/operations.md first.
         local rdir
         if (cd "$new_dir" && ./pithead upgrade) >"$logf" 2>&1; then
             for rdir in "$cdir" "$new_dir/data/control"; do
-                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
+                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" --arg r "$cwd" '{status:"upgraded",version:$v,rollback:$r,ts:(now|floor)}')"
                 control_audit "$rdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
             done
         else
             for rdir in "$cdir" "$new_dir/data/control"; do
-                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" --arg d "$new_dir" \
-                    '{status:"failed",version:$v,error:($e + " — finish the upgrade from the host: cd " + $d + " && ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+                control_write_result "$rdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" --arg d "$new_dir" --arg r "$cwd" \
+                    '{status:"failed",version:$v,rollback:$r,error:($e + " — finish the upgrade from the host: cd " + $d + " && ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
                 control_audit "$rdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
             done
         fi
+        rm -f "$logf"
+        return 0
+    fi
+    # #637: unlike the fresh-dir path, this one has no surviving previous dir — and the new
+    # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
+    # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
+    # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
+    # to overwrite the install without one.
+    local bak
+    bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
+    if ! cp -p "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
+        ! cp -p "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
+        rm -f "$bundle"
+        _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
         rm -f "$logf"
         return 0
     fi
@@ -5454,7 +5470,8 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
     else
         control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
-            '{status:"failed",version:$v,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+            --arg b "$PWD/$CONFIG_FILE.$bak $PWD/$ENV_FILE.$bak" \
+            '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
     fi
     rm -f "$logf"

--- a/pithead
+++ b/pithead
@@ -5436,16 +5436,41 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
     # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
     # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
-    # to overwrite the install without one.
+    # to overwrite the install without one. The destination name is predictable, so root must
+    # never write through a symlink a co-tenant planted there (the #629 mkdir guard's attack
+    # class): copy to an unpredictable mktemp name first, then rename onto the final name —
+    # rename(2) replaces a planted entry without following it.
+    _upg_snapshot() { # <src> <dst>
+        local tmp
+        tmp=$(mktemp "$PWD/.bak-upgrade.XXXXXX") || return 1
+        if ! cp -p "$1" "$tmp"; then
+            rm -f "$tmp"
+            return 1
+        fi
+        mv -f "$tmp" "$2"
+    }
     local bak
     bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
-    if ! cp -p "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
-        ! cp -p "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
+    if ! _upg_snapshot "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
+        ! _upg_snapshot "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
         rm -f "$bundle"
         _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
         rm -f "$logf"
         return 0
     fi
+    # Older snapshots hold yesterday's secrets: keep the newest three pairs, prune the rest.
+    # Lexical order IS chronological for this stamp format; `|| true` — an empty glob under
+    # pipefail must not kill the runner.
+    ls -1r "$CONFIG_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+    ls -1r "$ENV_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+    # The reported paths: CONFIG_FILE is cwd-relative unless the (test-only) override made it
+    # absolute — don't prepend $PWD onto an already-absolute path.
+    local bak_paths
+    case "$CONFIG_FILE" in
+    /*) bak_paths="$CONFIG_FILE.$bak" ;;
+    *) bak_paths="$PWD/$CONFIG_FILE.$bak" ;;
+    esac
+    bak_paths="$bak_paths $PWD/$ENV_FILE.$bak"
     # In-place extraction over the running install, in two passes. Pass 1 lays down everything
     # EXCEPT the running script with plain tar, which MERGES existing directories — a release
     # install already carries the non-empty build/* config-template mounts — and overwrites files.
@@ -5470,7 +5495,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
     else
         control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
-            --arg b "$PWD/$CONFIG_FILE.$bak $PWD/$ENV_FILE.$bak" \
+            --arg b "$bak_paths" \
             '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
         control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
     fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5120,6 +5120,7 @@ make_stubs "$UPG/bin"
 # tar; on a Mac with gnu-tar installed, route this block's tar there too so the bug reproduces.
 command -v gtar >/dev/null 2>&1 && ln -sf "$(command -v gtar)" "$UPG/bin/tar"
 printf '1.3.1' >"$UPG/VERSION"
+printf '{}' >"$UPG/config.json" # #637: the in-place path snapshots config.json before extracting
 # #544/#555: a real release install carries non-empty build/* config-template mounts (see the
 # bundle's build/* below) — pre-seed them here with STALE content from "the previous version",
 # including a file the new bundle does NOT ship, so the extraction below runs over the exact shape
@@ -5194,6 +5195,7 @@ reset_upgrade_state() { # restore between attempts: fresh runner copy, running v
     cp "$STACK" "$UPG/pithead"
     printf '1.3.1' >"$UPG/VERSION"
     rm -f "$UPG/data/control/staged/.upgrade-stamp" "$UPGRESULTS/$UUPG.json" "$UPG/upgrade-invocations.log"
+    rm -f "$UPG"/config.json.bak-upgrade-* "$UPG"/.env.bak-upgrade-* # #637 snapshots
     : >"$UPG/curl.log"
 }
 
@@ -5289,6 +5291,12 @@ upgrade_intent "$UUPG" "v9.9.9"
 assert_eq "failed upgrade run reports failed" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "failed"
 assert_contains "failed upgrade points at the host CLI" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "./pithead upgrade"
 assert_contains "failed upgrade audited" "$(cat "$UPGAUDIT" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"failed\""
+# #637: the failure result names the pre-upgrade config/.env copies, and they exist on disk.
+upg_bak="$(jq -r '.backup // ""' "$UPGRESULTS/$UUPG.json" 2>/dev/null)"
+assert_contains "failed in-place upgrade names the pre-upgrade copies (#637)" "$upg_bak" ".bak-upgrade-"
+upg_bak_cfg="${upg_bak%% *}"
+[ -n "$upg_bak_cfg" ] && [ -f "$upg_bak_cfg" ] && ok "the named config.json copy exists (#637)" ||
+    bad "the named config.json copy exists (#637)" "missing: $upg_bak_cfg"
 
 # Happy path: proposed == host-derived latest and newer than running → bundle extracted, the NEW
 # pithead's `upgrade` ran, both dials went through the stack's Tor SOCKS, everything audited.
@@ -5320,6 +5328,14 @@ if [ ! -e "$UPG/data/control/staged/.$UUPG.tar.gz" ] && [ ! -e "$UPG/data/contro
 else
     bad "no staged bundle/log residue after a successful upgrade" "leftover staging file present"
 fi
+# #637: before the extraction overwrote the install, the runner kept timestamped copies of the
+# operator's config and the rendered .env — the in-place layout's only restore point.
+upg_bak_env="$(ls "$UPG"/.env.bak-upgrade-* 2>/dev/null | head -1)"
+[ -n "$upg_bak_env" ] && ok "in-place upgrade keeps a pre-upgrade .env copy (#637)" ||
+    bad "in-place upgrade keeps a pre-upgrade .env copy (#637)" "no .env.bak-upgrade-* in $UPG"
+assert_contains "the .env copy holds the pre-upgrade content (#637)" "$(cat "$upg_bak_env" 2>/dev/null)" "DEPLOYMENT_COMPLETED=true"
+upg_bak_cfg2="$(ls "$UPG"/config.json.bak-upgrade-* 2>/dev/null | head -1)"
+assert_eq "the config.json copy holds the pre-upgrade content (#637)" "$(cat "$upg_bak_cfg2" 2>/dev/null)" "{}"
 
 # #376 rollback guard: an attacker who controls the release response serves an OLDER (genuine)
 # bundle at the v9.9.9 URL — its VERSION (1.0.0) does not match the host-derived tag, so the
@@ -5414,6 +5430,7 @@ reset_v629_state() {
     cp "$STACK" "$VUPG/pithead"
     printf '1.3.1' >"$VUPG/VERSION"
     rm -f "$VUPG/data/control/staged/.upgrade-stamp" "$VUPG/data/control/results/$UUPG.json"
+    rm -f "$VUPG"/config.json.bak-upgrade-* "$VUPG"/.env.bak-upgrade-* # #637 snapshots
     rm -rf "$VNEW"
 }
 
@@ -5433,6 +5450,12 @@ assert_contains "rendered .env seeded into the new dir" "$(cat "$VNEW/.env" 2>/d
 assert_eq "clearnet sync markers carried over" "$(cat "$VNEW/data/clearnet-state/monero.synced" 2>/dev/null)" "clearnet-marker"
 assert_contains "fresh-dir upgrade audited in the old spool" "$(cat "$VUPG/data/control/audit/control.log" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"upgraded\""
 assert_contains "fresh-dir upgrade audited in the new spool" "$(cat "$VNEW/data/control/audit/control.log" 2>/dev/null)" "\"action\":\"upgrade\",\"status\":\"upgraded\""
+# #637: the result names the old dir as the restore point (pwd -P tail, macOS /private prefix).
+assert_contains "fresh-dir result names the old dir as the rollback copy (#637)" \
+    "$(jq -r '.rollback // ""' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "/deploy629/pithead-v1.3.1"
+[ -z "$(ls "$VUPG"/.env.bak-upgrade-* 2>/dev/null)" ] &&
+    ok "fresh-dir path takes no file snapshots — the old dir IS the restore point (#637)" ||
+    bad "fresh-dir path takes no file snapshots — the old dir IS the restore point (#637)" "found .bak-upgrade-* in $VUPG"
 
 # The new release's upgrade fails: both spools say failed, the error points at the NEW dir for
 # the host-side finish, and the old install keeps running — still intact for rollback.
@@ -5445,6 +5468,8 @@ assert_eq "failed fresh-dir upgrade reports failed" "$(jq -r '.status' "$VUPG/da
 assert_contains "failed fresh-dir upgrade points at the new dir" "$(jq -r '.error' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "/deploy629/pithead-v9.9.9 && ./pithead upgrade"
 assert_eq "failed fresh-dir upgrade leaves the old install intact" "$(cat "$VUPG/VERSION")" "1.3.1"
 assert_eq "failed fresh-dir upgrade wrote the result to the new spool too" "$(jq -r '.status' "$VNEW/data/control/results/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "failed fresh-dir result still names the rollback dir (#637)" \
+    "$(jq -r '.rollback // ""' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "/deploy629/pithead-v1.3.1"
 
 # Data inside the install dir (the pre-#455 default): a dir swap would strand it — the runner
 # must fall back to the in-place path: no sibling dir, the new release lands in THIS dir.
@@ -5464,6 +5489,9 @@ assert_eq "data-inside-install falls back to in-place upgrade" "$(cat "$VUPG/VER
     bad "data-inside-install creates no sibling version dir" "$VNEW exists"
 assert_contains "in-place fallback names the stranded data dir" "$out" "MONERO_DATA_DIR resolves inside the install dir"
 assert_eq "in-place fallback still upgrades" "$(jq -r '.status' "$VUPG/data/control/results/$UUPG.json" 2>/dev/null)" "upgraded"
+[ -n "$(ls "$VUPG"/.env.bak-upgrade-* 2>/dev/null)" ] &&
+    ok "in-place fallback keeps the pre-upgrade config/.env copies (#637)" ||
+    bad "in-place fallback keeps the pre-upgrade config/.env copies (#637)" "no .bak-upgrade-* in $VUPG"
 seed_v629_env
 
 # A pre-existing entry at the target path — a leftover failed attempt, or a co-tenant's planted

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5337,6 +5337,35 @@ assert_contains "the .env copy holds the pre-upgrade content (#637)" "$(cat "$up
 upg_bak_cfg2="$(ls "$UPG"/config.json.bak-upgrade-* 2>/dev/null | head -1)"
 assert_eq "the config.json copy holds the pre-upgrade content (#637)" "$(cat "$upg_bak_cfg2" 2>/dev/null)" "{}"
 
+# #637 hardening: the snapshot destination name is predictable, so a co-tenant can plant a
+# symlink there and hope root writes through it (the #629 attack class) — the runner must
+# replace the planted entry, never follow it. And old snapshots hold yesterday's secrets, so
+# only the newest three pairs survive. Freeze `date` so the destination name is known.
+reset_upgrade_state
+cat >"$UPG/bin/date" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "+%Y%m%d-%H%M%S" ]; then echo "20990101-000000"; else exec /bin/date "$@"; fi
+EOF
+chmod +x "$UPG/bin/date"
+printf 'victim-untouched' >"$UPG/victim"
+ln -s "$UPG/victim" "$UPG/config.json.bak-upgrade-20990101-000000"
+for bakstamp in 20200101-000000 20200102-000000 20200103-000000; do
+    printf 'stale' >"$UPG/.env.bak-upgrade-$bakstamp"
+done
+upgrade_intent "$UUPG" "v9.9.9"
+urun >/dev/null
+assert_eq "planted symlink at the snapshot name is not written through (#637)" "$(cat "$UPG/victim")" "victim-untouched"
+if [ ! -L "$UPG/config.json.bak-upgrade-20990101-000000" ] && [ -f "$UPG/config.json.bak-upgrade-20990101-000000" ]; then
+    ok "the snapshot replaced the planted entry with a regular file (#637)"
+else
+    bad "the snapshot replaced the planted entry with a regular file (#637)" "still a symlink or missing"
+fi
+assert_eq "snapshots pruned to the newest three .env copies (#637)" "$(ls -1 "$UPG"/.env.bak-upgrade-* 2>/dev/null | wc -l | tr -d ' ')" "3"
+[ ! -e "$UPG/.env.bak-upgrade-20200101-000000" ] && ok "the oldest .env snapshot was pruned (#637)" ||
+    bad "the oldest .env snapshot was pruned (#637)" "still present"
+rm -f "$UPG/bin/date" "$UPG/victim"
+reset_upgrade_state
+
 # #376 rollback guard: an attacker who controls the release response serves an OLDER (genuine)
 # bundle at the v9.9.9 URL — its VERSION (1.0.0) does not match the host-derived tag, so the
 # runner refuses BEFORE extraction. A cosign signature binds bytes, not a version, so without

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5337,6 +5337,20 @@ assert_contains "the .env copy holds the pre-upgrade content (#637)" "$(cat "$up
 upg_bak_cfg2="$(ls "$UPG"/config.json.bak-upgrade-* 2>/dev/null | head -1)"
 assert_eq "the config.json copy holds the pre-upgrade content (#637)" "$(cat "$upg_bak_cfg2" 2>/dev/null)" "{}"
 
+# #637 fail-closed: no snapshot, no upgrade. With config.json unreadable the runner must refuse
+# BEFORE a byte of the bundle lands — the whole point of the restore point is that it exists
+# before the mutation does.
+reset_upgrade_state
+mv "$UPG/config.json" "$UPG/config.json.hidden"
+upgrade_intent "$UUPG" "v9.9.9"
+urun >/dev/null
+assert_eq "failed snapshot fails the upgrade (#637)" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "failed"
+assert_contains "snapshot refusal names the missing restore point (#637)" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "restore point"
+assert_eq "failed snapshot extracts nothing (#637)" "$(cat "$UPG/VERSION")" "1.3.1"
+[ -z "$(ls "$UPG"/.bak-upgrade.* 2>/dev/null)" ] && ok "failed snapshot leaves no mktemp residue (#637)" ||
+    bad "failed snapshot leaves no mktemp residue (#637)" "leftover temp file"
+mv "$UPG/config.json.hidden" "$UPG/config.json"
+
 # #637 hardening: the snapshot destination name is predictable, so a co-tenant can plant a
 # symlink there and hope root writes through it (the #629 attack class) — the runner must
 # replace the planted entry, never follow it. And old snapshots hold yesterday's secrets, so
@@ -5351,6 +5365,7 @@ printf 'victim-untouched' >"$UPG/victim"
 ln -s "$UPG/victim" "$UPG/config.json.bak-upgrade-20990101-000000"
 for bakstamp in 20200101-000000 20200102-000000 20200103-000000; do
     printf 'stale' >"$UPG/.env.bak-upgrade-$bakstamp"
+    printf 'stale' >"$UPG/config.json.bak-upgrade-$bakstamp"
 done
 upgrade_intent "$UUPG" "v9.9.9"
 urun >/dev/null
@@ -5361,6 +5376,7 @@ else
     bad "the snapshot replaced the planted entry with a regular file (#637)" "still a symlink or missing"
 fi
 assert_eq "snapshots pruned to the newest three .env copies (#637)" "$(ls -1 "$UPG"/.env.bak-upgrade-* 2>/dev/null | wc -l | tr -d ' ')" "3"
+assert_eq "snapshots pruned to the newest three config.json copies (#637)" "$(ls -1 "$UPG"/config.json.bak-upgrade-* 2>/dev/null | wc -l | tr -d ' ')" "3"
 [ ! -e "$UPG/.env.bak-upgrade-20200101-000000" ] && ok "the oldest .env snapshot was pruned (#637)" ||
     bad "the oldest .env snapshot was pruned (#637)" "still present"
 rm -f "$UPG/bin/date" "$UPG/victim"


### PR DESCRIPTION
Closes #637.

The one-click upgrade's two deploy paths get an explicit restore point:

- **In-place path** (no surviving previous dir): before the extraction overwrites the running install, the runner copies `config.json` and the rendered `.env` to timestamped `.bak-upgrade-*` siblings — and refuses to proceed if it cannot. A failure during `pithead upgrade` names those copies in the result (`backup` field) and the failed modal. Copies are written symlink-safely (mktemp + rename — the #629 co-tenant threat model; a planted symlink at the predictable destination is replaced, never followed) and pruned to the newest three pairs so old secret-bearing `.env` copies don't accumulate.
- **Fresh-dir path** (#629): the previous version dir was already kept as the rollback copy but nothing ever pointed at it. Results now carry a `rollback` field naming it, shown in the "Upgraded" modal. This path takes no file snapshots — the old dir IS the restore point (pinned by a test).

Coverage (tier 1 + frontend, per docs/testing-strategy.md):
- 13 new stack assertions: snapshot exists with pre-upgrade content, failure result names existing copies, planted-symlink not written through, prune keeps newest three, fresh-dir results name the rollback dir on success and failure, in-place fallback snapshots too.
- 2 new frontend tests: done modal shows `rollback`, failed modal shows `backup`; neither renders without the field.

Docs: `docs/dashboard.md` (upgrade flow + failure paragraph), `docs/operations.md` (Backups gains the new files), CHANGELOG under Unreleased.

Adversarially reviewed (verifier + security-reviewer); both first-cut findings — symlink-followable predictable destination, unbounded secret snapshot retention — are fixed and regression-tested in the second commit. Ponytail pass: lean, no cuts.

`make lint` and `make test` green (1465 stack, 201 frontend, full suite; re-run after rebasing onto develop past #641/#642).

🤖 Generated with [Claude Code](https://claude.com/claude-code)