### PR TITLE
release: fold #637 into the 1.9.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,6 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
-### Added
-
-- **One-click upgrade names its restore point (#637).** Before an in-place upgrade overwrites
-  the running install, the runner copies `config.json` and the rendered `.env` to timestamped
-  `.bak-upgrade-*` siblings — and refuses to proceed if it cannot; a failure during the
-  upgrade names those copies in the result and the dashboard modal. On the versioned layout
-  the result (and the "Upgraded" modal) names the previous version dir — the rollback copy
-  #629 already kept but never pointed at. The copies are written symlink-safely (mktemp +
-  rename, the #629 co-tenant threat model) and pruned to the newest three pairs.
-
 ## [1.9.0] - 2026-07-18
 
 **Stratum link security.** v1.9 locks the last cleartext link — miner ↔ stack
@@ -32,6 +22,14 @@ layout honest and preserves the rollback bundle (#629), and Tor's
 steady-state CPU cost drops via healthcheck and peer-count tuning (#595).
 
 ### Added
+
+- **One-click upgrade names its restore point (#637).** Before an in-place upgrade overwrites
+  the running install, the runner copies `config.json` and the rendered `.env` to timestamped
+  `.bak-upgrade-*` siblings — and refuses to proceed if it cannot; a failure during the
+  upgrade names those copies in the result and the dashboard modal. On the versioned layout
+  the result (and the "Upgraded" modal) names the previous version dir — the rollback copy
+  #629 already kept but never pointed at. The copies are written symlink-safely (mktemp +
+  rename, the #629 co-tenant threat model) and pruned to the newest three pairs.
 
 - **XvB raffle wins on the chart and in a log (#644).** The dashboard reads XvB's public winners
   log (over Tor, about every 30 minutes) and records every round your wallet won. Wins show as


### PR DESCRIPTION
Same bookkeeping as #645, for the last rolled-in PR (#647): the #637 entry moves from Unreleased into the section v1.9.0 actually ships. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)