### PR TITLE
Add an "All" button to the chart range presets (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The chart's default full-history range gets an "All" button (#655).** Before, no range
+  button read as selected on first load, and once a preset was clicked the full-history view
+  was unreachable without hand-editing the URL.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/static/chart.mjs
+++ b/build/dashboard/mining_dashboard/web/static/chart.mjs
@@ -24,6 +24,7 @@ const RANGES = [
   ["24h", "24 Hr"],
   ["1w", "1 Wk"],
   ["1m", "1 Mo"],
+  ["all", "All"],
 ];
 
 // Hashrate-averaging windows for the chart toggle (#168): [param key, button label]. The keys match

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -83,6 +83,15 @@ test('operational App renders the hero band and the headline cards', () => {
     assert.match(html, /Stack Topology & Egress/);
 });
 
+test('chart range buttons include All, active on the default full-history view (#655)', () => {
+    // Default UI state is range 'all' — without an All button no range reads as selected,
+    // and after picking a preset there is no way back to full history.
+    assert.match(renderApp(), /class="btn-range active"[^>]*>All</);
+    const weekly = renderApp({ ui: { ...UI, range: '1w' } });
+    assert.match(weekly, /class="btn-range active"[^>]*>1 Wk</);
+    assert.doesNotMatch(weekly, /class="btn-range active"[^>]*>All</);
+});
+
 test('operational App renders the remaining advanced cards', () => {
     const html = renderApp();
     assert.match(html, /Global P2Pool Stats/);

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -160,8 +160,8 @@ progress until it catches up and merge-mining resumes.
 
 ### Hashrate chart
 
-A time-series chart of hashrate with selectable ranges (1h / 24h / 1w / 1mo) that switch without
-reloading. Shaded bands show the P2Pool/XvB split over time.
+A time-series chart of hashrate with selectable ranges (1h / 24h / 1w / 1mo / all history) that
+switch without reloading. Shaded bands show the P2Pool/XvB split over time.
 
 Diamond markers along the top flag **hashrate events** (#99): an amber one where total hashrate
 dropped sharply and stayed down (an outage or a rig gone dark), a green one where it recovered.


### PR DESCRIPTION
Closes #655.

The chart's default range is `all` (full history), but `RANGES` offered no button for it: on first load no range button rendered active, and after clicking any preset the full-history view was unreachable without hand-editing the URL.

One line in `RANGES` fixes it — the active-state comparison, `setRange`'s URL handling (`all` clears the query param), and the server's `range=all` path all already supported the value.

## Testing

- New component test: `All` renders active on the default view; picking `1w` moves the active state and deactivates `All`.
- `make test-frontend` — 209 pass; `make lint-js` / `lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)