### PR TITLE
Show sort state on the Workers table (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Workers table shows its sort state (#656).** The sorted column now carries a direction
+  arrow and `aria-sort`, and every header names its action on hover — before, clicking sorted
+  the rows with no indication of which column or direction was active.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -774,7 +774,18 @@ function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort, onIns
         <div class="table-scroll">
             <table id="workers-table">
                 <thead>
-                    <tr>${WORKER_COLUMNS.map((c, i) => html`<th onClick=${() => onSort(i)}>${c.label}</th>`)}</tr>
+                    <tr>${WORKER_COLUMNS.map(
+                      // Sorted column carries the direction, visibly (arrow) and for AT (aria-sort);
+                      // the title makes clickability discoverable without hovering rows (#656).
+                      (c, i) => html`<th onClick=${() => onSort(i)}
+                            class=${i === ui.sortIndex ? "sorted" : null}
+                            aria-sort=${i === ui.sortIndex ? (ui.sortAsc ? "ascending" : "descending") : null}
+                            title=${"Sort by " + c.label}>${c.label}${
+                              i === ui.sortIndex
+                                ? html`<span class="sort-arrow">${ui.sortAsc ? " ▲" : " ▼"}</span>`
+                                : ""
+                            }</th>`,
+                    )}</tr>
                 </thead>
                 <tbody id="workers-tbody">
                     ${rows.map(

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -362,6 +362,12 @@ th {
   text-transform: uppercase;
   cursor: pointer;
 }
+th.sorted {
+  color: var(--text);
+}
+.sort-arrow {
+  font-size: 0.6rem;
+}
 td {
   padding: 10px;
   border-bottom: 1px solid var(--border);

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -450,6 +450,15 @@ test('WorkersTable renders headers and a row per worker with status classes', ()
     assert.match(html, /badge-ok">P2Pool/); // PoolBadge for a p2pool worker
 });
 
+test('WorkersTable marks the sorted column, visibly and via aria-sort (#656)', () => {
+    // No sort chosen (server order): no column claims a direction.
+    assert.doesNotMatch(renderApp(), /aria-sort/);
+    const asc = renderApp({ ui: { ...UI, sortIndex: 0, sortAsc: true } });
+    assert.match(asc, /<th[^>]*class="sorted"[^>]*aria-sort="ascending"[^>]*>Worker<span class="sort-arrow"> ▲<\/span>/);
+    const desc = renderApp({ ui: { ...UI, sortIndex: 0, sortAsc: false } });
+    assert.match(desc, /aria-sort="descending"[^>]*>Worker<span class="sort-arrow"> ▼<\/span>/);
+});
+
 test('WorkersTable with no workers shows the connect hint instead of a bare table (#385)', () => {
     // The fixture's host_ip is "Unknown Host" — the hint must fall back to the docs placeholder.
     const s = clone();

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -231,8 +231,8 @@ offline. Point the rig's descriptor at the enriched feed to turn this on — see
 Each rig shows accepted and rejected share counts (invalid shares folded into the rejected column as
 `3 (+2 inv)` when present). A rig whose reject rate climbs past ~5% gets a red **⚠** flag next to its
 rejected count — a rig submitting stale or bad shares (bad overclock, flaky network, clock drift)
-rather than earning. Every column is sortable; click **Rejected** to float the worst offenders to the
-top. Shares are cumulative since the proxy last started, so a brief early-run blip clears as good
+rather than earning. Every column is sortable — the sorted column shows a direction arrow; click
+**Rejected** to float the worst offenders to the top. Shares are cumulative since the proxy last started, so a brief early-run blip clears as good
 shares accumulate.
 
 Below the table, a **Proxy totals** line sums the stack's share health as reported by xmrig-proxy:


### PR DESCRIPTION
Closes #656.

Clicking a Workers-table header sorted the rows with no indication of which column or direction was active — no arrow, no styling, no `aria-sort`, and clickability was only discoverable via `cursor: pointer`.

The sorted column now renders a direction arrow (`▲`/`▼`), gets a `sorted` class (full-strength text instead of muted), and carries `aria-sort="ascending|descending"`; every header names its action in a `title`. All of it hangs off the `ui.sortIndex`/`ui.sortAsc` state `onSort` already maintains — no new state.

## Testing

- New component test: no `aria-sort` in server order; ascending and descending render the right arrow and `aria-sort` on the sorted header.
- `make test-frontend` — 209 pass; `make lint-js` / `lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)