### PR TITLE
ARIA parity for every toggle control (#657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every toggle control now announces itself like the theme switcher (#657).** The chart
+  Range row becomes real buttons in a labelled group (it was bare links), and the view
+  toggle, Form/JSON and Table/JSON editors, and the topology mesh button gain
+  `aria-pressed` and hover titles. The button resets move into `.btn-range`, which also
+  gives the Avg buttons the pointer cursor they were missing.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/static/chart.mjs
+++ b/build/dashboard/mining_dashboard/web/static/chart.mjs
@@ -385,15 +385,16 @@ export class ChartCard extends Component {
     const zoomed = !!props.window;
     return html`
         <div class="card">
-            <div class="chart-controls">
+            <div class="chart-controls" role="group" aria-label="Chart range">
                 <span class="text-muted text-small mr-1">Range:</span>
                 ${RANGES.map(
-                  ([r, label]) => html`<a href=${"?range=" + r}
+                  // Real buttons like the Avg/legend siblings (#657); the ?range= deep link
+                  // survives because setRange writes it via history.replaceState.
+                  ([r, label]) => html`<button type="button"
                     class=${"btn-range" + (!zoomed && props.range === r ? " active" : "")}
-                    onClick=${(e) => {
-                      e.preventDefault();
-                      props.onRange(r);
-                    }}>${label}</a>`,
+                    aria-pressed=${!zoomed && props.range === r}
+                    title=${"Chart range: " + label}
+                    onClick=${() => props.onRange(r)}>${label}</button>`,
                 )}
                 ${
                   zoomed

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -897,10 +897,13 @@ function DashboardView({
   return html`
     <div id="dashboard-view" class=${advanced ? "mode-advanced" : ""}>
         <div class="view-controls">
-            <div class="toggle-group">
-                <button class=${"btn-toggle" + (!advanced && !configView ? " active" : "")} onClick=${() => onView("simple")}>Simple</button>
-                <button class=${"btn-toggle" + (advanced ? " active" : "")} onClick=${() => onView("advanced")}>Advanced</button>
-                <button class=${"btn-toggle" + (configView ? " active" : "")} onClick=${() => onView("config")}>Configuration</button>
+            <div class="toggle-group" role="group" aria-label="Dashboard view">
+                <button class=${"btn-toggle" + (!advanced && !configView ? " active" : "")} aria-pressed=${!advanced && !configView}
+                    title="Chart, workers and the headline numbers" onClick=${() => onView("simple")}>Simple</button>
+                <button class=${"btn-toggle" + (advanced ? " active" : "")} aria-pressed=${advanced}
+                    title="Every stats card, calculators and diagnostics" onClick=${() => onView("advanced")}>Advanced</button>
+                <button class=${"btn-toggle" + (configView ? " active" : "")} aria-pressed=${configView}
+                    title="View or edit the stack configuration" onClick=${() => onView("config")}>Configuration</button>
             </div>
         </div>
         <${AdvancedHint} ui=${ui} onView=${onView} onDismissHint=${onDismissHint} />

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -391,9 +391,11 @@ export class ConfigView extends Component {
     const { core, sections: groups } = regroupCore(markEditable(sections, editableKeys), coreKeys);
     return html`<div class="config-view">
         ${error ? html`<div class="card"><p class="status-bad">${error}</p></div>` : null}
-        <div class="toggle-group mb-1">
-            <button class=${"btn-toggle" + (mode === "form" ? " active" : "")} onClick=${() => this.setState({ mode: "form" })}>Form</button>
-            <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setState({ mode: "json" })}>JSON</button>
+        <div class="toggle-group mb-1" role="group" aria-label="Config editor mode">
+            <button class=${"btn-toggle" + (mode === "form" ? " active" : "")} aria-pressed=${mode === "form"}
+                title="Edit settings as a form" onClick=${() => this.setState({ mode: "form" })}>Form</button>
+            <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} aria-pressed=${mode === "json"}
+                title="Edit the raw config.json" onClick=${() => this.setState({ mode: "json" })}>JSON</button>
         </div>
         ${mode === "form" ? this.renderForm(core, groups, edits) : this.renderJson(editText, jsonError, busy)}
         <div class="config-actions">

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -511,6 +511,10 @@ button.upgrade-btn {
   background-color: var(--card);
   color: var(--text-muted);
   transition: all 0.2s;
+  /* All range-look controls are <button>s now (#657) — carry the button resets here. */
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.4;
 }
 .btn-range:hover {
   border-color: var(--text-muted);
@@ -521,11 +525,7 @@ button.upgrade-btn {
   color: #fff;
   border-color: var(--ok);
 }
-/* Reset-zoom button reuses the range-button look but needs the <button> resets (Issue #47). */
 .btn-reset {
-  cursor: pointer;
-  font-family: inherit;
-  line-height: 1.4;
   margin-left: 8px;
 }
 

--- a/build/dashboard/mining_dashboard/web/static/topology.mjs
+++ b/build/dashboard/mining_dashboard/web/static/topology.mjs
@@ -83,7 +83,9 @@ export class StackTopology extends Component {
           <span class="topo-legend"><i class="topo-sw" style="background:var(--ok)"></i>Tor</span>
           <span class="topo-legend"><i class="topo-sw" style="background:var(--bad)"></i>Clearnet</span>
           <span class="topo-legend"><i class="topo-sw" style="background:var(--text-muted)"></i>Local / LAN</span>
-          <button class="topo-toggle" onClick=${() => this.setState({ internal: !internal })}>
+          <button class="topo-toggle" aria-pressed=${internal}
+            title="Container-to-container links inside the stack"
+            onClick=${() => this.setState({ internal: !internal })}>
             ${internal ? "Hide internal mesh" : "Show internal mesh"}
           </button>
         </div>

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -255,9 +255,11 @@ export class WorkerInspect extends Component {
             <p class="text-muted text-xs">Writable keys: <span class="font-mono">${(detail.writable_keys || []).join(", ")}</span>.
                Prefilled with the last config applied from the dashboard — the rig's live feed doesn't expose these values.
                The rig validates and rolls back if the miner doesn't come back live.</p>
-            <div class="toggle-group mb-1">
-                <button class=${"btn-toggle" + (mode === "table" ? " active" : "")} onClick=${() => this.setState({ mode: "table" })}>Table</button>
-                <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setState({ mode: "json" })}>JSON</button>
+            <div class="toggle-group mb-1" role="group" aria-label="Worker config mode">
+                <button class=${"btn-toggle" + (mode === "table" ? " active" : "")} aria-pressed=${mode === "table"}
+                    title="View the config as a table" onClick=${() => this.setState({ mode: "table" })}>Table</button>
+                <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} aria-pressed=${mode === "json"}
+                    title="View the raw config JSON" onClick=${() => this.setState({ mode: "json" })}>JSON</button>
             </div>
             ${
               mode === "table"

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -83,6 +83,20 @@ test('operational App renders the hero band and the headline cards', () => {
     assert.match(html, /Stack Topology & Egress/);
 });
 
+test('toggle groups carry the ARIA affordances of the theme-switcher pattern (#657)', () => {
+    // The vnode walker serializes boolean true as a bare attribute and drops false, so a bare
+    // `aria-pressed` marks the pressed control (in the browser Preact writes true/false strings).
+    const html = renderApp({ ui: { ...UI, range: '1w' } });
+    // Range row: real buttons in a labelled group; the active preset is pressed and titled.
+    assert.match(html, /aria-label="Chart range"/);
+    assert.match(html, /class="btn-range active" aria-pressed title="Chart range: 1 Wk">1 Wk</);
+    // View toggle: labelled group; the active view's button is pressed.
+    assert.match(html, /aria-label="Dashboard view"/);
+    assert.match(html, /class="btn-toggle active" aria-pressed title="[^"]+">Advanced</);
+    // Topology mesh toggle explains itself without hovering the diagram.
+    assert.match(html, /class="topo-toggle" title="Container-to-container links inside the stack"/);
+});
+
 test('operational App renders the remaining advanced cards', () => {
     const html = renderApp();
     assert.match(html, /Global P2Pool Stats/);


### PR DESCRIPTION
Closes #657.

The repo already had a gold-standard toggle pattern (theme switcher: `role="group"`, `aria-pressed`, `aria-label`, `title`; Avg buttons and chart legend close behind) — this applies it to the five control groups that lacked it:

- **Chart Range row** — the worst offender: was `<a>` tags with no group role, no `aria-pressed`, no titles. Now real `<button>`s in a labelled group, matching the Avg row directly below. The `?range=` deep link survives (`setRange` writes it via `history.replaceState`).
- **Simple / Advanced / Configuration** view toggle — `role="group"`, `aria-pressed`, per-button titles.
- **Config Form / JSON** and **Worker Inspect Table / JSON** editors — same treatment.
- **Topology "Show internal mesh"** — `aria-pressed` + title.

Since every range-look control is now a `<button>`, the `<button>` resets move from `.btn-reset` into `.btn-range` (net CSS deletion) — which also fixes the Avg buttons' missing `cursor: pointer`.

## Testing

- New component test: labelled groups render, the active range/view button carries `aria-pressed`, the mesh toggle carries its title.
- `make test-frontend` — 209 pass; `make lint-js` / `lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)