### PR TITLE
Persist the session-only UI preferences (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **UI preferences now all survive a reload (#658).** The Workers-table sort, earnings tab,
+  Form/JSON and Table/JSON editor modes, and the topology mesh toggle join the already-persisted
+  theme, view, averaging window and series toggles. A saved choice that becomes invalid (a
+  removed column, an unavailable tab) falls back to the default.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -19,9 +19,11 @@ import {
   formatXmr,
   formatXtm,
   heroKpis,
+  loadPref,
   parseHashrate,
   priceSourceLabel,
   raffleCls,
+  savePref,
   sortWorkers,
   THEME_LABELS,
   THEME_ORDER,
@@ -492,10 +494,17 @@ class EarningsCard extends Component {
   constructor(props) {
     super(props);
     // `input` (what-if hashrate) is SHARED across tabs — it lives above the tab strip so switching
-    // tabs keeps the entered value. `tab` is the active earnings tab (Monero / Tari / XvB).
-    this.state = { input: null, tab: "monero" };
+    // tabs keeps the entered value. `tab` is the active earnings tab (Monero / Tari / XvB),
+    // persisted (#658); render() already falls back to monero when the saved tab isn't available.
+    this.state = {
+      input: null,
+      tab: loadPref("dashboardEarningsTab", ["monero", "tari", "xvb", "energy"], "monero"),
+    };
     this.onInput = (e) => this.setState({ input: e.target.value });
-    this.onTab = (tab) => this.setState({ tab });
+    this.onTab = (tab) => {
+      savePref("dashboardEarningsTab", tab);
+      this.setState({ tab });
+    };
   }
 
   render() {

--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -33,6 +33,7 @@ import {
   regroupCore,
   SECRET_HINT,
 } from "./configlogic.mjs";
+import { loadPref, savePref } from "./logic.mjs";
 import { Component, html } from "./preact.mjs";
 
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
@@ -166,7 +167,7 @@ export class ConfigView extends Component {
       coreKeys: [],
       editableKeys: [], // #613: config paths the control gate will actually commit
       edits: {},
-      mode: "form", // form | json (#529)
+      mode: loadPref("dashboardConfigMode", ["form", "json"], "form"), // form | json (#529, persisted #658)
       editText: "",
       jsonError: null,
       preview: null,
@@ -178,6 +179,11 @@ export class ConfigView extends Component {
 
   componentDidMount() {
     this.load();
+  }
+
+  setMode(mode) {
+    savePref("dashboardConfigMode", mode);
+    this.setState({ mode });
   }
 
   async load() {
@@ -392,8 +398,8 @@ export class ConfigView extends Component {
     return html`<div class="config-view">
         ${error ? html`<div class="card"><p class="status-bad">${error}</p></div>` : null}
         <div class="toggle-group mb-1">
-            <button class=${"btn-toggle" + (mode === "form" ? " active" : "")} onClick=${() => this.setState({ mode: "form" })}>Form</button>
-            <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setState({ mode: "json" })}>JSON</button>
+            <button class=${"btn-toggle" + (mode === "form" ? " active" : "")} onClick=${() => this.setMode("form")}>Form</button>
+            <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setMode("json")}>JSON</button>
         </div>
         ${mode === "form" ? this.renderForm(core, groups, edits) : this.renderJson(editText, jsonError, busy)}
         <div class="config-actions">

--- a/build/dashboard/mining_dashboard/web/static/dashboard.js
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.js
@@ -6,7 +6,14 @@
 // the simple/advanced view — plus the latest data snapshot and connection status.
 
 import { App } from "./components.mjs";
-import { normalizeAvgWindow, normalizeSeries, normalizeTheme } from "./logic.mjs";
+import {
+  normalizeAvgWindow,
+  normalizeSeries,
+  normalizeSort,
+  normalizeTheme,
+  savePref,
+  WORKER_COLUMNS,
+} from "./logic.mjs";
 import { html, render } from "./preact.mjs";
 
 const root = document.getElementById("app");
@@ -44,8 +51,8 @@ const ui = {
   series: loadSeries(), // {p2pool, xvb, shares} booleans (Issue #47)
   // Hashrate-averaging window the chart plots (#168); persisted, default 10m (today's series).
   avg: normalizeAvgWindow(localStorage.getItem("dashboardAvgWindow")),
-  sortIndex: null,
-  sortAsc: true,
+  // Workers-table sort (#658); persisted like the other view preferences.
+  ...normalizeSort(localStorage.getItem("dashboardSort"), WORKER_COLUMNS.length),
   view: ["advanced", "config"].includes(localStorage.getItem("dashboardView"))
     ? localStorage.getItem("dashboardView")
     : "simple",
@@ -143,6 +150,7 @@ function resetZoom() {
 function onSort(idx) {
   ui.sortAsc = ui.sortIndex === idx ? !ui.sortAsc : true;
   ui.sortIndex = idx;
+  savePref("dashboardSort", `${idx}:${ui.sortAsc ? "asc" : "desc"}`);
   rerender(); // client-side sort only, no fetch
 }
 

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -106,6 +106,35 @@ export function normalizeSeries(obj) {
   return out;
 }
 
+// Persisted single-choice UI preferences (#658) — earnings tab, editor modes, topology mesh.
+// normalizeChoice is the pure, unit-tested core; loadPref/savePref wrap localStorage guarded,
+// so components stay importable under node --test (no localStorage → the fallback / a no-op).
+export function normalizeChoice(value, allowed, fallback) {
+  return allowed.includes(value) ? value : fallback;
+}
+export function loadPref(key, allowed, fallback) {
+  try {
+    return normalizeChoice(localStorage.getItem(key), allowed, fallback);
+  } catch {
+    return fallback;
+  }
+}
+export function savePref(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Private mode or no storage: the preference just doesn't stick.
+  }
+}
+
+// Workers-table sort preference (#658), stored as "index:asc|desc". A stale index (column
+// removed) or garbage falls back to the server order.
+export function normalizeSort(raw, colCount) {
+  const m = /^(\d+):(asc|desc)$/.exec(raw || "");
+  if (!m || Number(m[1]) >= colCount) return { sortIndex: null, sortAsc: true };
+  return { sortIndex: Number(m[1]), sortAsc: m[2] === "asc" };
+}
+
 // Human-readable span for the "Zoomed: …" label — the two coarsest units from the first
 // non-zero one (e.g. "3d 4h", "1h 20m", "45s"), trailing zero units dropped. Pure and
 // locale-independent, unlike fmtTimestamp.

--- a/build/dashboard/mining_dashboard/web/static/topology.mjs
+++ b/build/dashboard/mining_dashboard/web/static/topology.mjs
@@ -6,7 +6,7 @@
 // view stays focused on what crosses the trust boundary. Geometry is pure (boxAnchor, logic.mjs);
 // this file is presentation only — it carries no routing logic of its own (the #61 principle).
 
-import { boxAnchor } from "./logic.mjs";
+import { boxAnchor, loadPref, savePref } from "./logic.mjs";
 import { Component, html } from "./preact.mjs";
 
 // Fixed layout — the stack is a known, fixed set of components, so positions are hand-placed
@@ -67,7 +67,8 @@ export function edgePath(e, a, b) {
 export class StackTopology extends Component {
   constructor(props) {
     super(props);
-    this.state = { internal: false };
+    // Mesh visibility is a persisted preference (#658), stored as "1"/"0".
+    this.state = { internal: loadPref("dashboardTopoMesh", ["1", "0"], "0") === "1" };
   }
 
   render({ topology }, { internal }) {
@@ -83,7 +84,10 @@ export class StackTopology extends Component {
           <span class="topo-legend"><i class="topo-sw" style="background:var(--ok)"></i>Tor</span>
           <span class="topo-legend"><i class="topo-sw" style="background:var(--bad)"></i>Clearnet</span>
           <span class="topo-legend"><i class="topo-sw" style="background:var(--text-muted)"></i>Local / LAN</span>
-          <button class="topo-toggle" onClick=${() => this.setState({ internal: !internal })}>
+          <button class="topo-toggle" onClick=${() => {
+            savePref("dashboardTopoMesh", internal ? "0" : "1");
+            this.setState({ internal: !internal });
+          }}>
             ${internal ? "Hide internal mesh" : "Show internal mesh"}
           </button>
         </div>

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -14,6 +14,7 @@
 // textarea (FileReader, no upload) for pushing the same profile to several rigs.
 
 import { SECRET_HINT } from "./configlogic.mjs";
+import { loadPref, savePref } from "./logic.mjs";
 import { Component, createRef, html } from "./preact.mjs";
 import {
   buildFields,
@@ -135,7 +136,7 @@ export class WorkerInspect extends Component {
       phase: "loading",
       detail: null,
       error: null,
-      mode: "table",
+      mode: loadPref("dashboardWorkerMode", ["table", "json"], "table"), // persisted (#658)
       tableEdits: {},
       editText: "",
       jsonError: null,
@@ -148,6 +149,11 @@ export class WorkerInspect extends Component {
   componentDidMount() {
     this.load();
     this.dialogRef.current?.showModal();
+  }
+
+  setMode(mode) {
+    savePref("dashboardWorkerMode", mode);
+    this.setState({ mode });
   }
 
   async load() {
@@ -256,8 +262,8 @@ export class WorkerInspect extends Component {
                Prefilled with the last config applied from the dashboard — the rig's live feed doesn't expose these values.
                The rig validates and rolls back if the miner doesn't come back live.</p>
             <div class="toggle-group mb-1">
-                <button class=${"btn-toggle" + (mode === "table" ? " active" : "")} onClick=${() => this.setState({ mode: "table" })}>Table</button>
-                <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setState({ mode: "json" })}>JSON</button>
+                <button class=${"btn-toggle" + (mode === "table" ? " active" : "")} onClick=${() => this.setMode("table")}>Table</button>
+                <button class=${"btn-toggle" + (mode === "json" ? " active" : "")} onClick=${() => this.setMode("json")}>JSON</button>
             </div>
             ${
               mode === "table"

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -14,6 +14,7 @@ import {
     THEMES, THEME_ORDER, normalizeTheme,
     clampZoomWindow, fmtWindowDuration,
     SERIES_KEYS, normalizeSeries,
+    normalizeChoice, normalizeSort, loadPref, savePref,
     AVG_WINDOWS, DEFAULT_AVG_WINDOW, normalizeAvgWindow,
     heroKpis, raffleCls,
     parseHashrate, fmtHashrate, computeEarnings, computeXvbTier, xvbTierComparison, formatXmr, formatXtm, formatTimeToShare,
@@ -164,6 +165,31 @@ test('normalizeSeries: defaults every series to visible, only explicit false hid
     // Garbage / stray keys are ignored; output is always the full key set.
     assert.deepEqual(Object.keys(normalizeSeries({ junk: 1 })).sort(), [...SERIES_KEYS].sort());
     assert.deepEqual(normalizeSeries('nope'), { p2pool: true, xvb: true, shares: true });
+});
+
+// --- Issue #658: persisted single-choice UI preferences --------------------------------
+
+test('normalizeChoice: allowed values pass, anything else falls back', () => {
+    assert.equal(normalizeChoice('json', ['form', 'json'], 'form'), 'json');
+    assert.equal(normalizeChoice('garbage', ['form', 'json'], 'form'), 'form');
+    assert.equal(normalizeChoice(null, ['form', 'json'], 'form'), 'form');
+});
+
+test('normalizeSort: round-trips a valid choice, rejects garbage and stale columns', () => {
+    assert.deepEqual(normalizeSort('2:desc', 10), { sortIndex: 2, sortAsc: false });
+    assert.deepEqual(normalizeSort('0:asc', 10), { sortIndex: 0, sortAsc: true });
+    // A column index that no longer exists (column removed) → server order.
+    assert.deepEqual(normalizeSort('99:asc', 10), { sortIndex: null, sortAsc: true });
+    for (const bad of [null, '', 'x:asc', '1:up', '-1:asc']) {
+        assert.deepEqual(normalizeSort(bad, 10), { sortIndex: null, sortAsc: true }, `raw: ${bad}`);
+    }
+});
+
+test('loadPref/savePref: no localStorage (node) means fallback and no throw', () => {
+    // Under node --test there is no localStorage — the guards must make these safe, because
+    // components call them from constructors and the render tests import those components.
+    assert.equal(loadPref('anyKey', ['a', 'b'], 'a'), 'a');
+    assert.doesNotThrow(() => savePref('anyKey', 'b'));
 });
 
 // --- Issue #12: expected-earnings what-if --------------------------------------------

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -68,7 +68,10 @@ Once both nodes are synced, the dashboard shows the operational view.
 </picture>
 
 The page updates every 30 seconds, refreshing each panel in place rather than reloading. Scroll
-position, the worker-table sort column, and the chart stay put between updates. A poll that fails —
+position, the worker-table sort column, and the chart stay put between updates. View preferences —
+theme, Simple/Advanced view, the chart's averaging window and series toggles, the worker-table
+sort, the earnings tab, the Form/JSON editor modes, and the topology mesh toggle — are also
+remembered across reloads. A poll that fails —
 or hangs, as a dropped Tor circuit can — aborts after 25 seconds and shows a red banner naming the
 timestamp of the data still on screen ("Disconnected — showing data from …"); it clears on the next
 successful refresh.


### PR DESCRIPTION
Closes #658.

The dashboard's pattern since #47/#168 is that view preferences survive a reload — but only half did. This persists the other half, each via the smallest hook into its existing state:

| Preference | Key | Fallback behaviour |
|---|---|---|
| Workers-table sort | `dashboardSort` (`"index:asc\|desc"`) | stale column index or garbage → server order |
| Earnings tab | `dashboardEarningsTab` | unavailable tab → `render()`'s existing monero fallback |
| Config Form/JSON mode | `dashboardConfigMode` | non-value → form |
| Worker Inspect Table/JSON mode | `dashboardWorkerMode` | non-value → table |
| Topology mesh toggle | `dashboardTopoMesh` | non-value → hidden |

Mechanism: a guarded `loadPref`/`savePref` pair plus a pure `normalizeChoice` in `logic.mjs` (guarded so components stay importable under `node --test`, where `localStorage` doesn't exist), and `normalizeSort` validating the stored sort against the live column count. The what-if hashrate input and XvB tier-comparison selection stay ephemeral, as the issue scoped.

## Testing

- New unit tests: `normalizeChoice` allowed/fallback, `normalizeSort` round-trip + garbage + stale-column cases, and the no-localStorage guards (exercised for real — the render tests import these components under node).
- `make test-frontend` — 211 pass; `make lint-js` / `lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)