### PR TITLE
Overview docs match the rendered card (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Overview docs match the rendered card (#659).** The doc's field table follows the actual
+  #159 stat order, names the two wallet cards (Wallet XMR / Wallet TARI) instead of a single
+  "Wallets" row, and the stat card's label casing unifies on "Share in Window" to match the
+  hero KPI and the doc.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -45,7 +45,7 @@ const StatCard = ({ label, value, cls, span, title }) => html`
         <p class=${cls || ""}>${value}</p>
     </div>`;
 
-const SharesStat = ({ sw, label = "Share In Window" }) => html`
+const SharesStat = ({ sw, label = "Share in Window" }) => html`
     <div class="stat-card">
         <h5>${label}</h5>
         <p><span class=${sw.ok ? "status-ok" : "status-bad"}>${sw.count}</span></p>

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -81,6 +81,9 @@ test('operational App renders the hero band and the headline cards', () => {
     assert.match(html, /My P2Pool Node Stats/);
     assert.match(html, /XvB Donation Stats/);
     assert.match(html, /Stack Topology & Egress/);
+    // One casing everywhere (#659): the Overview card matches the hero KPI's lowercase "in".
+    assert.match(html, /Share in Window/);
+    assert.doesNotMatch(html, /Share In Window/);
 });
 
 test('operational App renders the remaining advanced cards', () => {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -194,18 +194,18 @@ The summary panel pulls the key numbers together:
 
 | Field | Meaning |
 |---|---|
-| **Mining Mode** | What the stack is routing hashrate to right now (e.g. P2Pool, XvB, or a split). |
 | **Total Hashrate** | Your combined hashrate across all workers. |
+| **Mining Mode** | What the stack is routing hashrate to right now (e.g. P2Pool, XvB, or a split). |
 | **Workers Alive** | How many rigs are connected and online right now. |
-| **Share in Window** | Your shares in the current P2Pool PPLNS window. |
+| **Current Tier** | The XvB tier you're currently holding, the one cleared by the **lower of your credited 1h and 24h** donation averages, so a recent hashrate drop shows up right away. |
 | **Raffle Eligible** | **Yes** only when you're set up to both *win* and *collect* an XvB payout: you're donating at least the **donor tier** (1 kH/s on XvB's *credited* 1h **and** 24h averages, the same threshold as **Current Tier**) **and** you hold a P2Pool PPLNS share (XvB's "VIP" gate; without it a win is skipped and you take a fail). Reads **No** when donating but a gate is unmet, and **N/A (XvB off)** when XvB is disabled. Intentionally stricter than XvB's bare "VIP = just a share" so a green Yes means a win is paid. |
-| **Last Share** | Time since your last accepted share. |
+| **Share in Window** | Your shares in the current P2Pool PPLNS window. |
+| **Target Tier** | The tier the engine is aiming for (from `xvb.donation_level`). If your hashrate can't sustain an explicitly chosen tier, a **⚠ Hashrate low for tier** badge appears. |
 | **P2Pool 1h / 24h (routed)** | Time-weighted average hashrate the proxy actually routed to P2Pool. |
 | **XvB 1h / 24h (routed)** | Time-weighted average hashrate the proxy actually **routed** to XvB. (The XvB-API *credited* figure, XvB's definitive record, appears in the **Advanced** view's *XvB Donation Stats* card.) |
-| **Current Tier** | The XvB tier you're currently holding, the one cleared by the **lower of your credited 1h and 24h** donation averages, so a recent hashrate drop shows up right away. |
-| **Target Tier** | The tier the engine is aiming for (from `xvb.donation_level`). If your hashrate can't sustain an explicitly chosen tier, a **⚠ Hashrate low for tier** badge appears. |
+| **Last Share** | Time since your last accepted share. |
 | **Tari Mining** | Whether merge-mining of Tari is active and healthy. |
-| **Wallets** | Your configured Monero and Tari payout addresses. |
+| **Wallet XMR / Wallet TARI** | Your configured Monero and Tari payout addresses, one card each. |
 
 ### Workers Alive
 


### PR DESCRIPTION
Closes #659.

Three drifts between `docs/dashboard.md`'s Overview section and what the UI renders — code is source of truth, so two doc fixes and one label-casing fix:

- **Field order**: the doc table predated the intentional #159 stat reorder. Reordered to the exact rendered sequence (fleet headline → raffle status → routed split → reference).
- **Wallets**: the doc described a single "Wallets" row; the UI renders separate **Wallet XMR** and **Wallet TARI** cards. The doc row now names both.
- **"Share in Window" casing**: the label was spelled three ways — doc "Share in Window", stat card "Share **In** Window", hero KPI "Shares in Window". The card unifies on the lowercase-"in" title casing the hero and doc already use (singular card vs plural hero stays — one is the stat, the other counts). A test assertion pins the casing so it can't drift a fourth time.

## Testing

- `make test-frontend` — 208 pass (assertions added to the existing headline-cards test); `make lint-js` / `lint-md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)