### PR TITLE
fix(#664): the header never advertises the release already running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ per the process in [`docs/releasing.md`](docs/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The header no longer advertises the release you are already running (#664).** Right after an
+  upgrade, the "New release vX.Y.Z available" badge and the Upgrade button could linger while the
+  version badge already showed vX.Y.Z — the pre-upgrade check result was restored from the
+  persisted snapshot and nothing was obligated to clear it promptly. Two fixes: derived update
+  state is no longer restored across a restart (the checker recomputes it), and the render seam
+  now suppresses the badge whenever the advertised release is not strictly newer than the running
+  one — the contradictory state is unrepresentable, whatever produces it. Clicking the stale
+  button was always refused host-side; this was display-truth damage only.
+
 ## [1.9.1] - 2026-07-19
 
 ### Added

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -538,6 +538,11 @@ class DataService:
         # Restore persistent state from DB to prevent empty dashboard on service restart
         loaded_snapshot = self.state_manager.load_snapshot()
         if loaded_snapshot and isinstance(loaded_snapshot, dict):
+            # Derived state must not outlive its inputs across a restart (#664): `update` is a
+            # pure function of (running version, latest tag), and the running version may have
+            # JUST changed — the very upgrade the restored badge advertised. The checker
+            # recomputes it on its own cadence; never resurrect the pre-upgrade banner.
+            loaded_snapshot.pop("update", None)
             self.latest_data.update(loaded_snapshot)
             self.workers_rejected = bool(self.latest_data.get("workers_rejected", False))
             self.miner_released = bool(self.latest_data.get("miner_released", False))

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -47,6 +47,7 @@ from mining_dashboard.service.earnings import (
 )
 from mining_dashboard.service.egress import egress_posture_from_config, topology_from_config
 from mining_dashboard.service.metrics import build_metrics, share_reject_pct
+from mining_dashboard.service.update_checker import parse_semver
 from mining_dashboard.version import resolve_version
 
 logger = logging.getLogger("WebViews")
@@ -1542,6 +1543,25 @@ def build_worker_detail(name, data, state_mgr):
     }
 
 
+def visible_update(update, running=None):
+    """The new-release badge, only when it is self-consistent (#664).
+
+    A restored snapshot can resurrect a pre-upgrade ``{available, latest, url}`` right after the
+    upgrade it advertised — and "new release X available" while *running* X is contradictory by
+    definition, whatever put it in the state. Suppress the badge whenever ``latest`` is not
+    strictly newer than the running version. A dev build (unparseable running version) keeps the
+    badge, mirroring ``compute_update``'s own semantics. Pure + unit-tested."""
+    if not update:
+        return None
+    if running is None:
+        running = (resolve_version() or {}).get("text")
+    rv = parse_semver(running)
+    lv = parse_semver(update.get("latest"))
+    if rv and lv and lv <= rv:
+        return None
+    return update
+
+
 def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASHRATE_WINDOW):
     """Assemble the full ``/api/state`` payload — the contract the client renders against.
 
@@ -1579,7 +1599,9 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         # The operator-facing stratum port (#172) — feeds the "point your rigs at host:PORT" hint.
         "stratum_port": config.STRATUM_PORT,
         "version": resolve_version(),
-        "update": data.get("update"),  # {available, latest, url} | None — new-release badge (#224)
+        # {available, latest, url} | None — new-release badge (#224), self-consistency-guarded:
+        # never advertise the version already running (#664).
+        "update": visible_update(data.get("update")),
         # Whether the control channel is on (#33) — gates the header Upgrade button (#59). The
         # routes 404 when off, so this is display gating only, not a security control. Read at
         # call time (module attribute, not from-import) so tests can flip the flag per-app.

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -488,6 +488,18 @@ class TestInit:
         assert svc.latest_data["total_live_h15"] == 5000
         assert svc.latest_data["extra"] == "kept"
 
+    def test_restored_snapshot_never_resurrects_the_update_badge(self):
+        # #664: `update` is derived state — a pre-upgrade "new release available" restored after
+        # the very upgrade it advertised must be dropped; the checker recomputes on its cadence.
+        sm = MagicMock()
+        sm.load_snapshot.return_value = {
+            "total_live_h15": 5000,
+            "update": {"available": True, "latest": "v1.9.1", "url": "u"},
+        }
+        svc = DataService(sm, MagicMock(), MagicMock())
+        assert svc.latest_data.get("update") in (None, {})  # never the restored dict
+        assert svc.latest_data["total_live_h15"] == 5000  # the rest of the snapshot survives
+
     def test_ignores_non_dict_snapshot(self):
         sm = MagicMock()
         sm.load_snapshot.return_value = None

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -51,6 +51,7 @@ from mining_dashboard.web.views import (
     host_display_addr,
     parse_window,
     recent_wallet_change,
+    visible_update,
 )
 
 # --- Metrics fixtures for the presentation builders -----------------------------------
@@ -1737,11 +1738,52 @@ class TestBuildState:
         assert isinstance(v["dev"], bool)
 
     def test_update_section_surfaced_and_defaults_none(self):
-        # The new-release badge (#224) rides on the shared payload; the checker's result passes
-        # through verbatim, and absence defaults to None (no badge).
+        # The new-release badge (#224) rides on the shared payload; a genuinely-newer result
+        # passes through, and absence defaults to None (no badge).
         upd = {"available": True, "latest": "v9.9.9", "url": "https://x/releases/tag/v9.9.9"}
         assert build_state(_data(update=upd), _state_mgr(), "all")["update"] == upd
         assert build_state(_data(), _state_mgr(), "all")["update"] is None
+
+    def test_update_badge_never_advertises_the_running_version(self, monkeypatch):
+        # #664: a restored snapshot can resurrect a pre-upgrade badge right after the upgrade it
+        # advertised — "new release X available" while RUNNING X must be unrepresentable at the
+        # render seam, whatever put it in the state.
+        monkeypatch.setattr(
+            "mining_dashboard.web.views.resolve_version",
+            lambda: {"text": "v1.9.1", "title": "Release build", "dev": False},
+        )
+        stale = {"available": True, "latest": "v1.9.1", "url": "https://x/releases/tag/v1.9.1"}
+        assert build_state(_data(update=stale), _state_mgr(), "all")["update"] is None
+        older = {"available": True, "latest": "v1.8.0", "url": "https://x/releases/tag/v1.8.0"}
+        assert build_state(_data(update=older), _state_mgr(), "all")["update"] is None
+        newer = {"available": True, "latest": "v2.0.0", "url": "https://x/releases/tag/v2.0.0"}
+        assert build_state(_data(update=newer), _state_mgr(), "all")["update"] == newer
+
+
+class TestVisibleUpdate:
+    """#664: the pure self-consistency guard on the new-release badge."""
+
+    UPD = {"available": True, "latest": "v1.9.1", "url": "https://x/releases/tag/v1.9.1"}
+
+    def test_suppressed_when_latest_equals_running(self):
+        assert visible_update(self.UPD, running="v1.9.1") is None
+        assert visible_update(self.UPD, running="1.9.1") is None  # bare VERSION form too
+
+    def test_suppressed_when_latest_is_older_than_running(self):
+        assert visible_update(self.UPD, running="v1.10.0") is None
+
+    def test_kept_when_latest_is_newer(self):
+        assert visible_update(self.UPD, running="v1.9.0") == self.UPD
+
+    def test_dev_build_keeps_the_badge(self):
+        # An unparseable running version (dev build) cannot prove the badge stale — keep it,
+        # mirroring compute_update's own semantics.
+        assert visible_update(self.UPD, running="pithead@main abc1234 (dev)") == self.UPD
+
+    def test_none_and_malformed_latest_pass_through(self):
+        assert visible_update(None, running="v1.9.1") is None
+        odd = {"available": True, "latest": "nightly", "url": "u"}
+        assert visible_update(odd, running="v1.9.1") == odd  # unprovable -> unchanged
 
     def test_is_json_serializable(self):
         json.dumps(build_state(_data(), _state_mgr(), "all"))

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -93,6 +93,9 @@ When a newer Pithead release is out, a clickable `New release vX.Y.Z available â
 to the version badge, linking to the GitHub release. The badge itself never updates anything. The
 check is on by default and routed over Tor, so it does not reveal your IP. Turn it off with
 `dashboard.check_for_updates: false` (see [Configuration](configuration.md#configuration-reference)).
+The badge can never name the version you are already running: it is suppressed whenever the
+advertised release is not strictly newer than the running one, so right after an upgrade it clears
+with the restart instead of lingering until the next hourly check (#664).
 
 With the [control channel](#configuration-view) enabled, an **Upgrade to vX.Y.Z** button appears
 beside the badge â€” see [Upgrading from the dashboard](#upgrading-from-the-dashboard). Without it,


### PR DESCRIPTION
## What

Observed live on prod right after its v1.9.1 one-click: version badge said v1.9.1, header still showed "New release v1.9.1 available" + the Upgrade button. Two-layer fix:

1. **Render seam** — `views.visible_update`: the badge is suppressed whenever the advertised release is not strictly newer than the running version. "New release X available" while running X is contradictory by definition, so it is now **unrepresentable**, whatever puts it in state. Dev builds (unparseable version text) keep the badge, mirroring `compute_update`'s own semantics. Suppressing server-side kills both surfaces — the header badge and the Upgrade button both gate on `update.available`.
2. **Root hygiene** — the persisted snapshot no longer restores `update` across a restart: derived state must not outlive its inputs, and the running version may have just changed in the very upgrade the restored badge advertised. The checker recomputes on its cadence (the assignment stays unconditional per enabled cycle, so a genuinely newer release still surfaces within one check).

Prod diagnosis before coding: no recurring poll-loop exception in the logs — snapshot-restore timing was the live suspect; both layers close it regardless of trigger. The stale button was always refused host-side (#59's semver gate): display-truth damage only, no security surface — hence verifier-only review (no new input, egress, or privilege path).

## Tests
- Tier 1: `visible_update` matrix — equal (both `v`-prefixed and bare forms), older, newer, dev-build text, None, malformed-latest.
- Tier 1 wiring: `build_state` with a stale badge naming the running version emits `update: null`.
- Tier 2: a restored snapshot carrying the pre-upgrade badge never reaches `latest_data` (rest of the snapshot survives).
- Verifier pass: PASS on all angles, incl. the alert path (`update_available` reads the recomputed value; one-restart lag is the documented existing behavior) and per-layer test independence.

## Docs
dashboard.md badge section states the invariant; CHANGELOG entry under Unreleased.

Closes #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)