### PR TITLE
docs: remind at the configuration reference that edits need ./pithead apply (#675)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,9 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 ## Configuration reference
 
 > Only `monero.wallet_address` and `tari.wallet_address` are required. Everything below is optional
-> and has a default. Add a key only when you want to change its behavior.
+> and has a default. Add a key only when you want to change its behavior. Editing `config.json`
+> changes nothing by itself — run `./pithead apply` afterward (see
+> [Changing settings later](#changing-settings-later)).
 
 The table below has ~94 keys across 13 sections — most of it you'll never touch. A handful of keys
 are **core**: wallet addresses, `monero.mode`, `p2pool.pool`, the dashboard login and host, and


### PR DESCRIPTION
Closes #675.

One line added to the callout at the top of the "Configuration reference" section: editing `config.json` changes nothing by itself — run `./pithead apply` afterward, with a link back to [Changing settings later](https://github.com/p2pool-starter-stack/pithead/blob/develop/docs/configuration.md#changing-settings-later).

The gap: the workflow is documented in the intro and "Changing settings later", but other docs deep-link straight into the ~94-key reference table, so a reader can land on a key description and never see it. No per-key repetition — key entries that already mention `apply` behavior are untouched.

Docs-only; `make lint-docs-voice` passes. The view-key docs were checked while scoping #675 and already correctly say **private** view key — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)