### PR TITLE
dashboard: workers-table sort headers are real buttons — keyboard can sort (#671)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -786,14 +786,17 @@ function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort, onIns
                     <tr>${WORKER_COLUMNS.map(
                       // Sorted column carries the direction, visibly (arrow) and for AT (aria-sort);
                       // the title makes clickability discoverable without hovering rows (#656).
-                      (c, i) => html`<th onClick=${() => onSort(i)}
+                      // The click target is a real <button> so keyboard users can sort too (#671):
+                      // native buttons are focusable and activate on Enter/Space without extra wiring.
+                      (c, i) => html`<th
                             class=${i === ui.sortIndex ? "sorted" : null}
-                            aria-sort=${i === ui.sortIndex ? (ui.sortAsc ? "ascending" : "descending") : null}
-                            title=${"Sort by " + c.label}>${c.label}${
-                              i === ui.sortIndex
-                                ? html`<span class="sort-arrow">${ui.sortAsc ? " ▲" : " ▼"}</span>`
-                                : ""
-                            }</th>`,
+                            aria-sort=${i === ui.sortIndex ? (ui.sortAsc ? "ascending" : "descending") : null}><button
+                              type="button" class="th-sort-btn" onClick=${() => onSort(i)}
+                              title=${"Sort by " + c.label}>${c.label}${
+                                i === ui.sortIndex
+                                  ? html`<span class="sort-arrow">${ui.sortAsc ? " ▲" : " ▼"}</span>`
+                                  : ""
+                              }</button></th>`,
                     )}</tr>
                 </thead>
                 <tbody id="workers-tbody">

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -360,10 +360,28 @@ th {
   padding: 10px;
   border-bottom: 1px solid var(--border);
   text-transform: uppercase;
-  cursor: pointer;
 }
 th.sorted {
   color: var(--text);
+}
+/* Sortable headers (#671): the sort control is a real <button>, so it is keyboard-operable.
+ * It absorbs the th padding and inherits the th typography — the whole cell stays the click
+ * target and the header looks unchanged. */
+th:has(.th-sort-btn) {
+  padding: 0;
+}
+.th-sort-btn {
+  display: block;
+  width: 100%;
+  padding: 10px;
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  text-transform: inherit;
+  white-space: inherit;
+  cursor: pointer;
 }
 .sort-arrow {
   font-size: 0.6rem;

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -379,8 +379,6 @@ th:has(.th-sort-btn) {
   font: inherit;
   color: inherit;
   text-align: inherit;
-  text-transform: inherit;
-  white-space: inherit;
   cursor: pointer;
 }
 .sort-arrow {

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 import { App } from '../../mining_dashboard/web/static/components.mjs';
+import { WORKER_COLUMNS } from '../../mining_dashboard/web/static/logic.mjs';
 import { StatsTable } from '../../mining_dashboard/web/static/workerview.mjs';
 import { render } from './helpers/render.mjs';
 
@@ -492,9 +493,19 @@ test('WorkersTable marks the sorted column, visibly and via aria-sort (#656)', (
     // No sort chosen (server order): no column claims a direction.
     assert.doesNotMatch(renderApp(), /aria-sort/);
     const asc = renderApp({ ui: { ...UI, sortIndex: 0, sortAsc: true } });
-    assert.match(asc, /<th[^>]*class="sorted"[^>]*aria-sort="ascending"[^>]*>Worker<span class="sort-arrow"> ▲<\/span>/);
+    assert.match(asc, /<th[^>]*class="sorted"[^>]*aria-sort="ascending"[^>]*><button[^>]*>Worker<span class="sort-arrow"> ▲<\/span>/);
     const desc = renderApp({ ui: { ...UI, sortIndex: 0, sortAsc: false } });
-    assert.match(desc, /aria-sort="descending"[^>]*>Worker<span class="sort-arrow"> ▼<\/span>/);
+    assert.match(desc, /aria-sort="descending"[^>]*><button[^>]*>Worker<span class="sort-arrow"> ▼<\/span>/);
+});
+
+test('WorkersTable sort headers are real buttons, so keyboard can sort (#671)', () => {
+    // A native <button> is focusable and activates on Enter/Space, firing the same onClick
+    // (onSort) path the mouse takes — keyboard operability rides on the element choice, so
+    // the component-tier assertion is that every header's click target IS a native button.
+    const html = renderApp();
+    const btns = html.match(/<button type="button" class="th-sort-btn" title="Sort by /g) || [];
+    assert.equal(btns.length, WORKER_COLUMNS.length);
+    assert.match(html, /<th><button type="button" class="th-sort-btn" title="Sort by Worker">Worker</);
 });
 
 test('WorkersTable with no workers shows the connect hint instead of a bare table (#385)', () => {


### PR DESCRIPTION
Closes #671.

The Workers-table header's click target moves from a bare `<th onClick>` to a native `<button>` inside the `th`, the same real-buttons pattern the #657 range/legend controls use. Native buttons are focusable and activate on Enter/Space, firing the same `onSort` path the mouse takes — no tabindex/keydown wiring to maintain.

- The button absorbs the `th` padding and inherits its typography, so the whole cell stays the click target and the header looks unchanged.
- `aria-sort`, the `sorted` class, and the arrow rendering (#656/#665) stay on the `th`, untouched.
- Dropped the global `th { cursor: pointer }` — the button carries it now, and non-sortable tables (worker history) no longer advertise a click they don't have.

Tests (component tier): the #656 sorted-column assertions updated for the new structure, plus a #671 test asserting every header's click target is a native `type="button"` — keyboard operability rides on the element choice, which is what the string renderer can honestly assert.

Verified: `make lint` clean, `make test` exit 0 (pithead 1474, selftest 132, fakes 23), frontend suite 216/216, `make test-patch-coverage` (no Python lines in diff). Ponytail review pass applied (-2 no-op CSS lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)