### PR TITLE
Disk readout switches to TB at 1 TB (#677)

### DIFF
--- a/build/dashboard/mining_dashboard/helper/utils.py
+++ b/build/dashboard/mining_dashboard/helper/utils.py
@@ -74,6 +74,26 @@ def format_hashrate(hashrate):
         return "0 H/s"
 
 
+def format_disk_size(used_gb, total_gb):
+    """Format a disk used/total pair, switching from GB to TB once the volume reaches
+    1 TB (1024 GB — the same 1024-based scale as the collector's ``BYTES_IN_GB``).
+
+    Both values switch together so the pair stays comparable; a mixed
+    ``408.6 GB / 3.6 TB`` line would not. Shared by the dashboard system card and the
+    Telegram ``/system`` reply so disk reads the same on every surface (#677).
+
+    Returns:
+        tuple: (used_str, total_str, unit) with one decimal place.
+    """
+    try:
+        used, total = float(used_gb or 0), float(total_gb or 0)
+    except (ValueError, TypeError):
+        used, total = 0.0, 0.0
+    if total >= 1024:
+        return f"{used / 1024:.1f}", f"{total / 1024:.1f}", "TB"
+    return f"{used:.1f}", f"{total:.1f}", "GB"
+
+
 def format_xmr(amount):
     """Format an XMR amount with magnitude-adaptive precision — 4 decimal places at >= 1 XMR,
     6 at >= 0.001, 8 below that — so a small daily estimate isn't truncated to zeros.

--- a/build/dashboard/mining_dashboard/service/telegram_commands.py
+++ b/build/dashboard/mining_dashboard/service/telegram_commands.py
@@ -19,6 +19,7 @@ from mining_dashboard.config.config import (
 )
 from mining_dashboard.helper.utils import (
     effective_hashrate,
+    format_disk_size,
     format_duration,
     format_hashrate,
     format_xmr,
@@ -285,13 +286,15 @@ def format_system(system, host_label=""):
     """Host resource usage — the answer to '/system'. Reads the ``system`` snapshot the dashboard
     already collects (disk / RAM / CPU / load / HugePages)."""
     disk = system.get("disk", {})
+    disk_used, disk_total, disk_unit = format_disk_size(
+        disk.get("used_gb", 0), disk.get("total_gb", 0)
+    )
     mem = system.get("memory", {})
     hp_status, _hp_class, hp_value = system.get("hugepages", ["Unknown", "", "0/0"])
     return "\n".join(
         [
             f"{_prefix(host_label)}\U0001f5a5️ System",
-            f"Disk: {disk.get('used_gb', 0):.1f}/{disk.get('total_gb', 0):.1f} GB "
-            f"({disk.get('percent_str', '0%')})",
+            f"Disk: {disk_used}/{disk_total} {disk_unit} ({disk.get('percent_str', '0%')})",
             f"RAM: {mem.get('used_gb', 0):.1f}/{mem.get('total_gb', 0):.1f} GB "
             f"({mem.get('percent_str', '0%')})",
             f"CPU: {system.get('cpu_percent', '0%')} · load {system.get('load', 'n/a')}",

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -164,7 +164,7 @@ function Header({ state }) {
                     <span class=${s.hugepages.variant === "ok" ? "status-ok" : "status-bad"}>Huge Pages: ${s.hugepages.status} (${s.hugepages.value})</span>
                 </div>
                 <div class="flex items-center">
-                    <span class=${(s.disk.level === "high" ? "status-bad" : "text-muted") + " mr-2"}>Disk: ${s.disk.used} / ${s.disk.total} GB (${s.disk.percent})</span> <${HighUsage} level=${s.disk.level} />
+                    <span class=${(s.disk.level === "high" ? "status-bad" : "text-muted") + " mr-2"}>Disk: ${s.disk.used} / ${s.disk.total} ${s.disk.unit} (${s.disk.percent})</span> <${HighUsage} level=${s.disk.level} />
                     <div class="disk-bar">
                         <div class="progress-bg">
                             <div class=${"progress-fill " + s.disk.fill} style=${{ width: s.disk.width }}></div>

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -30,6 +30,7 @@ from mining_dashboard.config.config import (
 )
 from mining_dashboard.helper.utils import (
     detect_host_ipv4,
+    format_disk_size,
     format_duration,
     format_hashrate,
     format_time_abs,
@@ -785,6 +786,9 @@ def build_system(data):
     system = data.get("system", {})
 
     disk_usage = system.get("disk", {})
+    disk_used, disk_total, disk_unit = format_disk_size(
+        disk_usage.get("used_gb", 0), disk_usage.get("total_gb", 0)
+    )
     disk_percent = disk_usage.get("percent", 0)
     disk_fill = "critical" if disk_percent > 90 else "warning" if disk_percent > 70 else ""
 
@@ -814,8 +818,9 @@ def build_system(data):
             "level": _usage_level(mem_usage.get("percent", 0)),
         },
         "disk": {
-            "used": f"{disk_usage.get('used_gb', 0):.1f}",
-            "total": f"{disk_usage.get('total_gb', 0):.1f}",
+            "used": disk_used,
+            "total": disk_total,
+            "unit": disk_unit,
             "percent": disk_usage.get("percent_str", "0%"),
             "width": f"{disk_percent}%",
             "fill": disk_fill,

--- a/build/dashboard/tests/helper/test_utils.py
+++ b/build/dashboard/tests/helper/test_utils.py
@@ -6,6 +6,7 @@ from mining_dashboard.helper.utils import (
     PPLNS_BLOCK_TIME_DEFAULT,
     PPLNS_BLOCK_TIME_NANO,
     detect_host_ipv4,
+    format_disk_size,
     format_duration,
     format_hashrate,
     format_time_abs,
@@ -118,6 +119,23 @@ class TestFormatHashrate:
         assert format_hashrate(0) == "0.00 H/s"
         assert format_hashrate("invalid") == "0 H/s"
         assert format_hashrate(None) == "0 H/s"
+
+
+class TestFormatDiskSize:
+    """#677: GB below 1 TB, TB at or above it; both values switch together."""
+
+    def test_stays_gb_below_1024(self):
+        assert format_disk_size(408.6, 931.5) == ("408.6", "931.5", "GB")
+
+    def test_switches_to_tb_at_boundary(self):
+        assert format_disk_size(512, 1024) == ("0.5", "1.0", "TB")
+
+    def test_large_volume_reads_in_tb(self):
+        assert format_disk_size(408.6, 3666.4) == ("0.4", "3.6", "TB")
+
+    def test_bad_data(self):
+        assert format_disk_size(None, None) == ("0.0", "0.0", "GB")
+        assert format_disk_size("invalid", "invalid") == ("0.0", "0.0", "GB")
 
 
 class TestFormatXmr:

--- a/build/dashboard/tests/service/test_telegram_commands.py
+++ b/build/dashboard/tests/service/test_telegram_commands.py
@@ -222,6 +222,12 @@ def test_system_reads_snapshot():
     assert "HugePages: Enabled (3072/3072)" in out
 
 
+def test_system_disk_reads_in_tb_on_large_volumes():
+    # Threshold mechanics live in test_utils.py; this proves /system wires the unit through.
+    out = tc.format_system({"disk": {"used_gb": 408.6, "total_gb": 3666.4, "percent_str": "11.1%"}})
+    assert "Disk: 0.4/3.6 TB (11.1%)" in out
+
+
 @pytest.mark.parametrize(
     "n,expected",
     [

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -785,10 +785,6 @@ class TestSystem:
         )
         assert (s["disk"]["used"], s["disk"]["total"], s["disk"]["unit"]) == ("0.4", "3.6", "TB")
 
-    def test_disk_unit_stays_gb_on_small_volumes(self):
-        s = build_system({"system": {"disk": {"used_gb": 90, "total_gb": 100}}})
-        assert (s["disk"]["total"], s["disk"]["unit"]) == ("100.0", "GB")
-
     def test_unparseable_cpu_is_ok(self):
         assert build_system({"system": {"cpu_percent": "n/a"}})["cpu"]["level"] == "ok"
 

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -778,6 +778,17 @@ class TestSystem:
     def test_warning_fill_between_70_and_90(self):
         assert build_system({"system": {"disk": {"percent": 75}}})["disk"]["fill"] == "warning"
 
+    def test_disk_unit_switches_to_tb_on_large_volumes(self):
+        # Threshold mechanics live in test_utils.py; this proves the card wires the unit through.
+        s = build_system(
+            {"system": {"disk": {"used_gb": 408.6, "total_gb": 3666.4, "percent_str": "11.1%"}}}
+        )
+        assert (s["disk"]["used"], s["disk"]["total"], s["disk"]["unit"]) == ("0.4", "3.6", "TB")
+
+    def test_disk_unit_stays_gb_on_small_volumes(self):
+        s = build_system({"system": {"disk": {"used_gb": 90, "total_gb": 100}}})
+        assert (s["disk"]["total"], s["disk"]["unit"]) == ("100.0", "GB")
+
     def test_unparseable_cpu_is_ok(self):
         assert build_system({"system": {"cpu_percent": "n/a"}})["cpu"]["level"] == "ok"
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -79,8 +79,10 @@ successful refresh.
 ### Top bar
 
 A status strip across the top shows the hostname, host telemetry (CPU, load, RAM, HugePages, disk),
-total hashrate, and 1h / 24h routed averages for both P2Pool and XvB (your split). Next to the disk
-readout, an `XMR Pruned` / `XMR Full` badge shows the Monero node's blockchain mode.
+total hashrate, and 1h / 24h routed averages for both P2Pool and XvB (your split). The disk readout
+switches from GB to TB once the volume reaches 1 TB, on the same scale in the Telegram `/system`
+reply. Next to the disk readout, an `XMR Pruned` / `XMR Full` badge shows the Monero node's
+blockchain mode.
 
 When the dashboard host is a name (not already an IP), the machine's IP shows beside it as
 `hostname @ ip` (e.g. `pithead.local @ 192.168.1.42`), a way back in when the hostname doesn't


### PR DESCRIPTION
Closes #677.

## What changed

On a 4 TB drive the system card read `Disk: 408.6 / 3666.4 GB (11.1%)`. Disk used/total now formats through a shared `format_disk_size` helper in `helper/utils.py`: below 1024 GB it stays GB with one decimal (unchanged output); at or above, both values scale to TB together — `Disk: 0.4 / 3.6 TB (11.1%)`. The threshold is 1024-based, matching the collector's `BYTES_IN_GB = 1024**3`.

Two call sites route through it, so disk reads the same on every surface:

- `web/views.py` `build_system()` — emits `used`/`total`/`unit`; `components.mjs` renders `s.disk.unit` instead of a hardcoded `GB`.
- `service/telegram_commands.py` `format_system()` — the `/system` reply.

Out of scope, per the issue: the RAM line stays GB; collector output (`used_gb`/`total_gb`), stored disk-growth telemetry, and the Prometheus endpoint are untouched.

## Tests

Threshold mechanics are covered once at tier 1 (`tests/helper/test_utils.py`: both sides, the 1024 boundary, bad data); each surface gets one wiring test (`tests/web/test_views.py`, `tests/service/test_telegram_commands.py`). Ponytail review ran; its one finding (a redundant GB-side wiring test) is dropped.

- `make test-dashboard` — 1421 passed, coverage 96.63%
- `make test-frontend` — passed
- `make test-patch-coverage` — 100%
- `make lint` (incl. `lint-docs-voice`) — clean

## Docs

`docs/dashboard.md` top-bar section notes the GB→TB switch and that the Telegram reply uses the same scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)