### PR TITLE
docs: targeted e2e is a required pre-release gate; genericize bench hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Pithead ships as **one product, one version** — the version lives in the top-l
 [`VERSION`](VERSION) file and every released image is tagged with it. Releases are cut
 per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
+## [Unreleased]
+
+### Changed
+
+- **The release process requires the targeted end-to-end run.** `docs/dev/releasing.md` now
+  states that the borrowed-rig `e2e.sh --mode targeted` pass on the release candidate is a
+  required pre-release gate — `release.sh`'s `--readiness` assessment alone is not enough — and
+  documents the post-deploy `--check` sweep and its expected parked-bench baseline. Private
+  bench hostnames in docs, comments, and one harness message are replaced with generic role
+  names; each box's specifics live in its own `~/README.md`, not the repo.
+
 ## [1.9.3] - 2026-07-19
 
 ### Fixed
@@ -1053,7 +1064,7 @@ tabbed earnings panel.
   time out, so the dead-man's-switch pings, the Telegram bot, and XvB stats all stop while mining
   (onion circuits) keeps working — the stack looks healthy as three features die. A new doctor check
   makes one request through Tor's SOCKS to a no-content endpoint and WARNs with the fix (restart the
-  tor container to pick fresh guards) when clearnet exits fail. Found live on pithead-prod after the
+  tor container to pick fresh guards) when clearnet exits fail. Found live on the production stack after the
   v1.3.0 deploy.
 - **A release-box checkout that has run the stack no longer fails `lint-toml` (#421).** taplo globs
   the filesystem, not the git index, so the generated (git-ignored) `build/tari/config.toml` left by

--- a/build/dashboard/mining_dashboard/client/tari/tari_wallet_client.py
+++ b/build/dashboard/mining_dashboard/client/tari/tari_wallet_client.py
@@ -14,7 +14,7 @@ from .generated import wallet_pb2, wallet_pb2_grpc
 # The direction/status gate is generous on purpose: p2pool's Tari coinbase is a one-sided output to
 # wallet_payment_address, and which enum a view-only wallet reports it under
 # (COINBASE_CONFIRMED vs ONE_SIDED_CONFIRMED vs a plain INBOUND) is the one item pinned to tier-4
-# (gouda). Keeping the accept-set here isolated means tightening it after that check is a one-line
+# (the live bench). Keeping the accept-set here isolated means tightening it after that check is a one-line
 # change. Enum values are the wallet.proto constants (TransactionStatus / TransactionDirection).
 _DIRECTION_INBOUND = 1  # TRANSACTION_DIRECTION_INBOUND
 _COINBASE_STATUSES = frozenset(

--- a/build/dashboard/mining_dashboard/service/tor_heal.py
+++ b/build/dashboard/mining_dashboard/service/tor_heal.py
@@ -3,7 +3,7 @@
 Tor can bootstrap to 100% yet sit on a FAILING GUARD: circuits build but clearnet exits time
 out at the 60s cutoff, so every Tor-clearnet feature (Healthchecks pings, the Telegram bot,
 XvB stats) dies at once while mining — onion / already-established circuits — keeps working
-and the stack looks healthy. Seen live on pithead-prod after the v1.3.0 deploy: ~6 hours dark
+and the stack looks healthy. Seen live in production after the v1.3.0 deploy: ~6 hours dark
 until a manual ``docker compose restart tor`` reselected guards. The doctor check (v1.3.1)
 detects this state; this monitor is the heal half.
 
@@ -32,7 +32,7 @@ Tor network is overloaded", so fresh guards may be just as bad):
   healed.
 
 The restart goes through the same start/stop-only docker-control proxy as the #31 failover.
-The manual leg is ``./pithead restart tor``. Real stuck-guard recovery is tier 4 (gouda).
+The manual leg is ``./pithead restart tor``. Real stuck-guard recovery is tier 4 (the live bench).
 """
 
 import asyncio

--- a/build/dashboard/tests/service/test_tor_heal.py
+++ b/build/dashboard/tests/service/test_tor_heal.py
@@ -3,7 +3,7 @@
 The decision core is what must be right: the healer restarts tor ONLY when egress is broken
 past the sustained threshold AND the cooldown has elapsed AND the per-outage restart budget
 isn't spent. Each guard is pinned separately, so inverting or deleting any of them fails a
-test. The actual container restart against a real stuck guard is tier 4 (gouda).
+test. The actual container restart against a real stuck guard is tier 4 (the live bench).
 """
 
 from unittest.mock import patch

--- a/build/tari-wallet/entrypoint.sh
+++ b/build/tari-wallet/entrypoint.sh
@@ -53,7 +53,7 @@ birthday="$(resolve_birthday)"
 echo "Starting view-only Tari payout wallet (birthday $birthday, base node $BASE_NODE_GRPC) (#462)..."
 
 # Point the wallet at the LOCAL base node. The exact config-override key for the base-node peer is
-# the one item pinned to tier-4 (gouda) — confirmed there against a live minotari_console_wallet
+# the one item pinned to tier-4 (the live bench) — confirmed there against a live minotari_console_wallet
 # alongside whether the merge-mine coinbase surfaces via GetCompletedTransactions. Passed via the
 # Tari config env-override convention so it is NON-secret and stays out of argv.
 export MINOTARI_WALLET__BASE_NODE__GRPC_BASE_NODE_ADDRESS="/dns4/${BASE_NODE_GRPC%%:*}/tcp/${BASE_NODE_GRPC##*:}"

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -217,20 +217,21 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 
 ## Bench allocation and the rig lock
 
-Ten boxes are shared between this repo's tier-4 harness, RigForge's release gates, and
+The bench boxes are shared between this repo's tier-4 harness, RigForge's release gates, and
 production mining. Two automations cycling the same rig's services corrupt each other's results
-(the 2026-07-10 miner-0 incident: an operator "fixed" a service an e2e run had deliberately
-stopped), so ownership is static and every run takes a kernel lock.
+(a real 2026-07 incident: an operator "fixed" a service an e2e run had deliberately stopped),
+so ownership is static and every run takes a kernel lock.
 
-Static allocation — each box states its owner in `/etc/bench-role`:
+Static allocation — each box states its owner in `/etc/bench-role`, and each box's own
+`~/README.md` carries its specifics (hostname, role, data roots):
 
-| Box | Owner | Use |
+| Box role | Owner | Use |
 |---|---|---|
-| miner-0 | RigForge | `e2e-real` / tune gates. Pithead never touches its services. |
-| miner-1, miner-2 | Pithead | Tier-4 loaner rigs: `e2e.sh` repoints one at the test bench for a run, then reverts it. Verify `systemctl is-active xmrig` after any remote restart. |
-| miner-3 … miner-7 | Production | Mining only. No test traffic. |
-| gouda | Pithead | Test bench + release box (the tier-4 target). |
-| pithead-prod | Production | Production stack; deploys only. |
+| RigForge bench rig | RigForge | `e2e-real` / tune gates. Pithead never touches its services. |
+| Loaner rigs (two) | Pithead | Tier-4: `e2e.sh` repoints one at the test bench for a run, then reverts it. Verify `systemctl is-active xmrig` after any remote restart. |
+| Fleet rigs | Production | Mining only. No test traffic. |
+| Test bench | Pithead | Test bench + release box (the tier-4 target). |
+| Production host | Production | Production stack; deploys only. |
 
 The run lock. Both harnesses take a `flock` on `/var/lock/rig-e2e.lock` before the first
 service-touching action and hold it on an inherited FD for the whole run, so the kernel releases

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -110,6 +110,31 @@ required, blocking pre-release gate. A release must not be promoted or published
 matrix is green against the real Monero + Tari nodes. This is what makes every published version
 a single, validated bundle.
 
+Two runs of the matrix are required, and the automated one is the smaller of the two:
+
+1. `release.sh` stage 2 runs the non-destructive `--readiness` assessment against the live
+   stack (via `RELEASE_INTEGRATION_ARGS`). It proves the box is fit to cut from — it does not
+   mine, restart anything, or touch a rig.
+2. Before cutting, run the targeted end-to-end matrix on the release candidate with a borrowed
+   loaner rig:
+
+   ```bash
+   BENCH_HOST=<bench> MINER_HOST=<loaner-rig> tests/integration/e2e.sh <ref> --mode targeted
+   ```
+
+   This deploys the candidate to the bench's dedicated e2e checkout, repoints the rig at it
+   (under the [rig lock](release-server.md#bench-allocation-and-the-rig-lock), with automatic
+   restore of both), and proves what `--readiness` cannot: a real miner mining through the
+   stack, the lifecycle phase (restart, apply secret-preservation, node-down failover), and
+   fail-closed auth. If the release's diff touches the worker or control-descriptor path, add
+   the `--rigforge-control` legs (needs a rig with its control API enabled). The readiness
+   gate alone does not satisfy this requirement; abort the release on any failure.
+
+After deploying the published release to the bench, run the non-destructive live sweep as the
+closing check: `tests/integration/run.sh --local --dir <stack-dir> --check`. On a bench with no
+miners connected, exactly two failures are expected — `workers online` and `stratum total
+hashes` — anything else is a regression.
+
 ## Signed releases
 
 Every promoted image digest and the install bundle carry a cosign key signature

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -304,7 +304,7 @@ rig_lock() { # rig_lock <project> <suite> [shared]
             echo "rig busy ($(cat "$hf" 2>/dev/null || echo unknown)) — waiting..." >&2
             flock $mode 9
         else
-            echo "miner-0 busy: $(cat "$hf" 2>/dev/null || echo unknown). Retry with RIG_LOCK_WAIT=1 to queue." >&2
+            echo "rig busy: $(cat "$hf" 2>/dev/null || echo unknown). Retry with RIG_LOCK_WAIT=1 to queue." >&2
             exit 75 # EX_TEMPFAIL — callers can tell "busy, retry later" from a real failure
         fi
     fi

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1957,7 +1957,7 @@ run_rigforge_control() {
 
     # The write path resolves the rig's host + token from workers.list[] (#506), or the deprecated
     # dashboard.workers[] fallback if that's what the box's baseline already carries. Use the
-    # baseline's descriptor if it already pins this rig's host (the gouda/prod case, whichever shape);
+    # baseline's descriptor if it already pins this rig's host (the live-box case, whichever shape);
     # otherwise inject one into workers.list[] from --rig-host + IT_RIG_TOKEN (local-only, so the token
     # never leaves the bench). No source for either -> skip: we won't drive an edit we can't address,
     # nor mutate what we can't restore.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5857,7 +5857,7 @@ upg455_fail=$(
 assert_not_contains "failed upgrade does NOT move the current pointer (#455)" "$upg455_fail" "symlink"
 
 echo "== black-box: deploy-box layout (#455) =="
-# A sandboxed source-checkout install whose chain data dirs share one root — the prod/gouda
+# A sandboxed source-checkout install whose chain data dirs share one root — the live deploy-box
 # layout. Proves the default resolution, the apply-time migration, and the upgrade-time
 # symlink end to end through the real CLI (docker/sudo stubbed).
 L="$SANDBOX/boxroot/pithead-v9.9.9"


### PR DESCRIPTION
Two things, per operator direction:

1. **The e2e requirement is now documented in-repo.** [docs/dev/releasing.md § Pre-release gate](docs/dev/releasing.md) states the two required matrix runs: `release.sh` stage 2's non-destructive `--readiness` assessment, and — before every cut — the borrowed-rig targeted end-to-end run on the release candidate (`e2e.sh <ref> --mode targeted`), with `--rigforge-control` added when the diff touches the worker/control-descriptor path. Also documents the post-deploy `--check` sweep and its expected parked-bench baseline (exactly two mining-liveness failures on a bench with no miners).

2. **Private bench hostnames are out of the repo.** The release-server allocation table names roles, not boxes (each box's own `~/README.md` carries its specifics); the stray box names in five source comments, one historical CHANGELOG line, and the rig-lock busy message are now generic. LICENSE/CODEOWNERS authorship and synthetic test fixtures are untouched. A repo-wide sweep for box names now returns zero hits.

Docs-only plus comment/string wording — no behavior change. `make lint` clean (docs voice included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)