### PR TITLE
security(#660): shared response-size cap for the dashboard's external API fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
   bench hostnames in docs, comments, and one harness message are replaced with generic role
   names; each box's specifics live in its own `~/README.md`, not the repo.
 
+### Security
+
+- **Every external dashboard fetch is size-capped** (#660). The GitHub release check, the three
+  XvB reads, and the CoinGecko price feed now stream their responses through a shared
+  `bounded_get` helper that cuts the body at 1 MiB, so a hostile or broken endpoint can no
+  longer make the dashboard buffer an unbounded payload. Over-cap reads follow each client's
+  existing failure contract (no result / keep the last good one).
+
 ## [1.9.3] - 2026-07-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
 ### Security
 
-- **Every external dashboard fetch is size-capped** (#660). The GitHub release check, the three
-  XvB reads, and the CoinGecko price feed now stream their responses through a shared
-  `bounded_get` helper that cuts the body at 1 MiB, so a hostile or broken endpoint can no
-  longer make the dashboard buffer an unbounded payload. Over-cap reads follow each client's
-  existing failure contract (no result / keep the last good one).
+- **The dashboard's external API fetches are size-capped** (#660). The GitHub release check, the
+  CoinGecko price feed, and the XvB client's calls (stats, reward estimates, winners, register)
+  now stream their responses through a shared `bounded_get` helper that cuts the body at 1 MiB,
+  so a hostile or broken endpoint can no longer make these clients buffer an unbounded payload.
+  Over-cap reads follow each client's existing failure contract (no result / keep the last good
+  one).
 
 ## [1.9.3] - 2026-07-19
 

--- a/build/dashboard/mining_dashboard/client/xvb_client.py
+++ b/build/dashboard/mining_dashboard/client/xvb_client.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import requests
 
 from mining_dashboard.config.config import TOR_SOCKS_PROXY, XVB_SUBMIT_URL
+from mining_dashboard.helper.http import bounded_get
 from mining_dashboard.helper.utils import parse_hashrate
 
 # The four donor tiers XvB publishes an expected per-player reward for. These are exactly the tier
@@ -159,7 +160,7 @@ class XvbClient:
         # the request carries the wallet, so a clearnet fetch would correlate IP <-> wallet (#163).
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            response = requests.get(self.url, params=params, timeout=20, proxies=proxies)
+            response = bounded_get(self.url, params=params, timeout=20, proxies=proxies)
             if response.status_code == 200:
                 return self._parse_html(response.text)
             else:
@@ -184,7 +185,7 @@ class XvbClient:
         """
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            response = requests.get(self.reward_estimate_url, timeout=20, proxies=proxies)
+            response = bounded_get(self.reward_estimate_url, timeout=20, proxies=proxies)
             if response.status_code != 200:
                 self.logger.error(
                     f"XvB reward-estimate fetch failed with status code: {response.status_code}"
@@ -221,7 +222,7 @@ class XvbClient:
 
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            response = requests.get(self.winners_url, timeout=20, proxies=proxies)
+            response = bounded_get(self.winners_url, timeout=20, proxies=proxies)
             if response.status_code != 200:
                 self.logger.error(
                     f"XvB winners fetch failed with status code: {response.status_code}"
@@ -275,7 +276,7 @@ class XvbClient:
         # wallet, so a clearnet call would correlate IP <-> wallet (#163).
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            response = requests.get(self.submit_url, params=params, timeout=20, proxies=proxies)
+            response = bounded_get(self.submit_url, params=params, timeout=20, proxies=proxies)
             body = (response.text or "").strip()
             low = body.lower()
 

--- a/build/dashboard/mining_dashboard/helper/http.py
+++ b/build/dashboard/mining_dashboard/helper/http.py
@@ -1,0 +1,56 @@
+"""Bounded reads for every external HTTP fetch (#660).
+
+Each external client (GitHub release checks #224, the three XvB reads, the CoinGecko price feed
+#651) is individually tolerant of a bad *parse*, but nothing bounded what got *read*: a hostile or
+broken endpoint could hand any of them a multi-GB body and the process would buffer it all before
+parsing. ``bounded_get`` streams the body and cuts it at a cap far above any legitimate payload;
+over-cap raises a ``requests.RequestException`` subclass, so every caller's existing failure
+contract (return ``None`` / keep the last good result) applies unchanged.
+"""
+
+import json
+
+import requests
+
+# Generous by orders of magnitude: the largest legitimate payload here (the XvB winners file) is
+# well under 100 KiB; the GitHub/CoinGecko JSON bodies are a few KiB.
+MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class ResponseTooLarge(requests.RequestException):
+    """Response body exceeded the cap. Subclasses ``RequestException`` so callers' existing
+    fail-silent handling treats it like any other transport failure."""
+
+
+class BoundedResponse:
+    """The slice of ``requests.Response`` the clients actually use: ``status_code``, ``text``,
+    ``json()`` — backed by the capped body."""
+
+    def __init__(self, status_code, content, encoding):
+        self.status_code = status_code
+        self.content = content
+        self.encoding = encoding
+
+    @property
+    def text(self):
+        return self.content.decode(self.encoding or "utf-8", errors="replace")
+
+    def json(self):
+        return json.loads(self.text)
+
+
+def bounded_get(url, max_bytes=MAX_RESPONSE_BYTES, timeout=20, **kwargs):
+    """``requests.get`` with a hard response-size cap.
+
+    Streams the body and raises ``ResponseTooLarge`` once it exceeds ``max_bytes``, instead of
+    buffering an unbounded payload. Passes ``proxies`` / ``params`` / ``headers`` through
+    unchanged; raises exactly what ``requests.get`` raises otherwise.
+    """
+    with requests.get(url, stream=True, timeout=timeout, **kwargs) as resp:
+        chunks, size = [], 0
+        for chunk in resp.iter_content(chunk_size=65536):
+            size += len(chunk)
+            if size > max_bytes:
+                raise ResponseTooLarge(f"response body exceeded {max_bytes} bytes: {url}")
+            chunks.append(chunk)
+        return BoundedResponse(resp.status_code, b"".join(chunks), resp.encoding)

--- a/build/dashboard/mining_dashboard/service/price_feed.py
+++ b/build/dashboard/mining_dashboard/service/price_feed.py
@@ -19,6 +19,8 @@ import re
 
 import requests
 
+from mining_dashboard.helper.http import bounded_get
+
 logger = logging.getLogger("PriceFeed")
 
 COINGECKO_SIMPLE_PRICE = "https://api.coingecko.com/api/v3/simple/price"
@@ -62,7 +64,7 @@ class CoinGeckoClient:
             return None
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            resp = requests.get(
+            resp = bounded_get(
                 COINGECKO_SIMPLE_PRICE,
                 params={
                     "ids": ",".join(COINGECKO_IDS.values()),

--- a/build/dashboard/mining_dashboard/service/update_checker.py
+++ b/build/dashboard/mining_dashboard/service/update_checker.py
@@ -14,6 +14,8 @@ import logging
 
 import requests
 
+from mining_dashboard.helper.http import bounded_get
+
 logger = logging.getLogger("UpdateChecker")
 
 
@@ -53,7 +55,7 @@ class GitHubReleaseClient:
         failure (network, non-200, malformed JSON). Routed through Tor when a proxy is set."""
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None
         try:
-            resp = requests.get(
+            resp = bounded_get(
                 self.api_url,
                 timeout=20,
                 proxies=proxies,

--- a/build/dashboard/tests/client/test_xvb_client.py
+++ b/build/dashboard/tests/client/test_xvb_client.py
@@ -45,7 +45,7 @@ def test_missing_wallet_returns_none():
 def test_get_stats_success_parses_html():
     client = XvbClient("49abc")
     resp = MagicMock(status_code=200, text=SAMPLE_HTML)
-    with patch.object(xvb_mod.requests, "get", return_value=resp) as mock_get:
+    with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
         stats = client.get_stats()
     assert stats == {"fail_count": 2, "avg_1h": 1500.0, "avg_24h": 3000.0}
     assert mock_get.call_args.kwargs["params"] == {"address": "49abc"}
@@ -56,7 +56,7 @@ def test_get_stats_routes_through_tor_proxy():
     # operator's home IP — the request carries the wallet, so a clearnet fetch would correlate them.
     client = XvbClient("49abc")
     resp = MagicMock(status_code=200, text=SAMPLE_HTML)
-    with patch.object(xvb_mod.requests, "get", return_value=resp) as mock_get:
+    with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
         client.get_stats()
     proxies = mock_get.call_args.kwargs["proxies"]
     assert proxies["https"].startswith("socks5h://")  # socks5h resolves the host via Tor too
@@ -66,26 +66,26 @@ def test_get_stats_routes_through_tor_proxy():
 def test_get_stats_honours_explicit_proxy():
     client = XvbClient("49abc", tor_proxy="socks5h://127.0.0.1:9999")
     resp = MagicMock(status_code=200, text=SAMPLE_HTML)
-    with patch.object(xvb_mod.requests, "get", return_value=resp) as mock_get:
+    with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
         client.get_stats()
     assert mock_get.call_args.kwargs["proxies"]["https"] == "socks5h://127.0.0.1:9999"
 
 
 def test_get_stats_non_200_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", return_value=MagicMock(status_code=503)):
+    with patch.object(xvb_mod, "bounded_get", return_value=MagicMock(status_code=503)):
         assert client.get_stats() is None
 
 
 def test_get_stats_network_error_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", side_effect=requests.RequestException("boom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=requests.RequestException("boom")):
         assert client.get_stats() is None
 
 
 def test_get_stats_unexpected_error_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", side_effect=ValueError("kaboom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=ValueError("kaboom")):
         assert client.get_stats() is None
 
 
@@ -111,7 +111,7 @@ def test_parse_reward_estimates_malformed_or_empty_is_empty_dict():
 def test_get_reward_estimates_success_routes_over_tor():
     client = XvbClient("49abc")
     resp = MagicMock(status_code=200, text=SAMPLE_REWARD_TXT)
-    with patch.object(xvb_mod.requests, "get", return_value=resp) as mock_get:
+    with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
         est = client.get_reward_estimates()
     assert est["donor_whale"] == 6.17
     proxies = mock_get.call_args.kwargs["proxies"]
@@ -120,7 +120,7 @@ def test_get_reward_estimates_success_routes_over_tor():
 
 def test_get_reward_estimates_non_200_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", return_value=MagicMock(status_code=503)):
+    with patch.object(xvb_mod, "bounded_get", return_value=MagicMock(status_code=503)):
         assert client.get_reward_estimates() is None
 
 
@@ -136,13 +136,13 @@ def test_get_reward_estimates_unparseable_body_returns_none():
 
 def test_get_reward_estimates_network_error_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", side_effect=requests.RequestException("boom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=requests.RequestException("boom")):
         assert client.get_reward_estimates() is None
 
 
 def test_get_reward_estimates_unexpected_error_returns_none():
     client = XvbClient("49abc")
-    with patch.object(xvb_mod.requests, "get", side_effect=ValueError("kaboom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=ValueError("kaboom")):
         assert client.get_reward_estimates() is None
 
 
@@ -208,7 +208,7 @@ def test_parse_winners_bounds_hostile_input():
 def test_get_recent_wins_success_routes_over_tor():
     client = XvbClient(_WIN_WALLET)
     resp = MagicMock(status_code=200, text=SAMPLE_WINNERS_TXT)
-    with patch.object(xvb_mod.requests, "get", return_value=resp) as mock_get:
+    with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
         wins = client.get_recent_wins()
     assert len(wins) == 2
     assert mock_get.call_args.args[0].endswith("winners_recent_full_pub.txt")
@@ -219,17 +219,17 @@ def test_get_recent_wins_no_wins_is_empty_list_not_none():
     # An empty list is a successful "no wins yet" read — distinct from a failed fetch (None).
     client = XvbClient("49abcSOMEOTHERWALLETxyz99")
     resp = MagicMock(status_code=200, text=SAMPLE_WINNERS_TXT)
-    with patch.object(xvb_mod.requests, "get", return_value=resp):
+    with patch.object(xvb_mod, "bounded_get", return_value=resp):
         assert client.get_recent_wins() == []
 
 
 def test_get_recent_wins_failures_return_none():
     client = XvbClient(_WIN_WALLET)
-    with patch.object(xvb_mod.requests, "get", return_value=MagicMock(status_code=503)):
+    with patch.object(xvb_mod, "bounded_get", return_value=MagicMock(status_code=503)):
         assert client.get_recent_wins() is None
-    with patch.object(xvb_mod.requests, "get", side_effect=requests.RequestException("boom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=requests.RequestException("boom")):
         assert client.get_recent_wins() is None
-    with patch.object(xvb_mod.requests, "get", side_effect=ValueError("kaboom")):
+    with patch.object(xvb_mod, "bounded_get", side_effect=ValueError("kaboom")):
         assert client.get_recent_wins() is None
 
 
@@ -253,20 +253,20 @@ class TestRegister:
     def test_disabled_when_no_endpoint(self):
         # Disable sentinel => empty submit_url => never reach out at all.
         client = XvbClient("49abc", submit_url="")
-        with patch.object(xvb_mod.requests, "get") as mock_get:
+        with patch.object(xvb_mod, "bounded_get") as mock_get:
             assert client.register() == REG_DISABLED
         mock_get.assert_not_called()
 
     def test_missing_wallet_is_invalid(self):
         client = XvbClient("", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get") as mock_get:
+        with patch.object(xvb_mod, "bounded_get") as mock_get:
             assert client.register() == REG_INVALID
         mock_get.assert_not_called()
         assert XvbClient("placeholder", submit_url=_SUBMIT).register() == REG_INVALID
 
     def test_2xx_is_registered_and_sends_full_wallet(self):
         client = XvbClient("49fullwalletaddress", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get", return_value=_resp(200, "OK")) as mock_get:
+        with patch.object(xvb_mod, "bounded_get", return_value=_resp(200, "OK")) as mock_get:
             assert client.register() == REG_OK
         # Registration takes the FULL wallet address as ?address=...
         assert mock_get.call_args.kwargs["params"] == {"address": "49fullwalletaddress"}
@@ -276,37 +276,37 @@ class TestRegister:
         # The real steady state for an entered wallet (verified live): 422 + this body.
         client = XvbClient("49abc", submit_url=_SUBMIT)
         resp = _resp(422, "ERROR: Wallet Address Already Registered")
-        with patch.object(xvb_mod.requests, "get", return_value=resp):
+        with patch.object(xvb_mod, "bounded_get", return_value=resp):
             assert client.register() == REG_OK
 
     def test_invalid_wallet_422(self):
         client = XvbClient("49abc", submit_url=_SUBMIT)
         resp = _resp(422, "ERROR: Invalid Wallet Address")
-        with patch.object(xvb_mod.requests, "get", return_value=resp):
+        with patch.object(xvb_mod, "bounded_get", return_value=resp):
             assert client.register() == REG_INVALID
 
     def test_no_share_body_is_not_eligible(self):
         # Best-effort: a body mentioning the PPLNS share => retry quietly, not a failure.
         client = XvbClient("49abc", submit_url=_SUBMIT)
         resp = _resp(422, "ERROR: No share in PPLNS window")
-        with patch.object(xvb_mod.requests, "get", return_value=resp):
+        with patch.object(xvb_mod, "bounded_get", return_value=resp):
             assert client.register() == REG_NOT_ELIGIBLE
 
     def test_5xx_is_transient_error(self):
         client = XvbClient("49abc", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get", return_value=_resp(500, "Server error!")):
+        with patch.object(xvb_mod, "bounded_get", return_value=_resp(500, "Server error!")):
             assert client.register() == REG_ERROR
 
     def test_unrecognised_body_is_error(self):
         client = XvbClient("49abc", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get", return_value=_resp(418, "teapot")):
+        with patch.object(xvb_mod, "bounded_get", return_value=_resp(418, "teapot")):
             assert client.register() == REG_ERROR
 
     def test_routes_through_configured_tor_proxy_by_default(self):
         # #163: the call carries the full wallet, so it ALWAYS rides the bridge Tor SOCKS like
         # get_stats — a default-constructed client (as main.py builds it) uses TOR_SOCKS_PROXY.
         client = XvbClient("49abc", submit_url=_SUBMIT)  # no tor_proxy => the configured default
-        with patch.object(xvb_mod.requests, "get", return_value=_resp(200, "OK")) as mock_get:
+        with patch.object(xvb_mod, "bounded_get", return_value=_resp(200, "OK")) as mock_get:
             client.register()
         proxies = mock_get.call_args.kwargs["proxies"]
         assert proxies["https"] == xvb_mod.TOR_SOCKS_PROXY
@@ -315,12 +315,12 @@ class TestRegister:
 
     def test_network_error_is_transient_error(self):
         client = XvbClient("49abc", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get", side_effect=requests.RequestException("boom")):
+        with patch.object(xvb_mod, "bounded_get", side_effect=requests.RequestException("boom")):
             assert client.register() == REG_ERROR
 
     def test_unexpected_error_is_transient_error(self):
         client = XvbClient("49abc", submit_url=_SUBMIT)
-        with patch.object(xvb_mod.requests, "get", side_effect=ValueError("kaboom")):
+        with patch.object(xvb_mod, "bounded_get", side_effect=ValueError("kaboom")):
             assert client.register() == REG_ERROR
 
 

--- a/build/dashboard/tests/helper/test_http.py
+++ b/build/dashboard/tests/helper/test_http.py
@@ -99,5 +99,7 @@ class TestWiringDriftGuard:
         for mod in external:
             src = mod.read_text()
             hit = direct_call.search(src)
-            assert hit is None, f"{mod.name}: unbounded {hit.group() if hit else ''} slipped back in"
+            assert hit is None, (
+                f"{mod.name}: unbounded {hit.group() if hit else ''} slipped back in"
+            )
             assert "bounded_get(" in src, f"{mod.name}: no bounded_get call found"

--- a/build/dashboard/tests/helper/test_http.py
+++ b/build/dashboard/tests/helper/test_http.py
@@ -1,5 +1,6 @@
 """Tier 1 — bounded_get (#660): the shared response-size cap for external HTTP fetches."""
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +30,15 @@ class TestBoundedGet:
         assert resp.json() == {"tag_name": "v1.2.3"}
         # The read is streamed, never buffered whole by requests itself.
         assert g.call_args.kwargs["stream"] is True
+
+    def test_exactly_at_cap_returns_body(self):
+        # The cap is strictly greater-than: a body of exactly max_bytes succeeds.
+        with patch(
+            "mining_dashboard.helper.http.requests.get",
+            return_value=_streaming_resp([b"x" * 1024, b"x" * 1024]),
+        ):
+            resp = bounded_get("https://example.test/x", max_bytes=2048)
+        assert resp.content == b"x" * 2048
 
     def test_over_cap_raises_request_exception(self):
         # ResponseTooLarge subclasses RequestException, so every caller's existing
@@ -78,16 +88,16 @@ class TestBoundedGet:
 
 class TestWiringDriftGuard:
     def test_external_clients_route_through_bounded_get(self):
-        """Every external fetch module GETs via bounded_get — a bare requests.get( here is drift."""
+        """Every external fetch module goes via bounded_get — any direct requests.<verb>( is drift."""
         pkg = Path(__file__).resolve().parents[2] / "mining_dashboard"
         external = [
             pkg / "service" / "update_checker.py",
             pkg / "service" / "price_feed.py",
             pkg / "client" / "xvb_client.py",
         ]
+        direct_call = re.compile(r"requests\.(get|post|put|delete|head|request)\(")
         for mod in external:
             src = mod.read_text()
-            assert "requests.get(" not in src, (
-                f"{mod.name}: unbounded requests.get( slipped back in"
-            )
+            hit = direct_call.search(src)
+            assert hit is None, f"{mod.name}: unbounded {hit.group() if hit else ''} slipped back in"
             assert "bounded_get(" in src, f"{mod.name}: no bounded_get call found"

--- a/build/dashboard/tests/helper/test_http.py
+++ b/build/dashboard/tests/helper/test_http.py
@@ -1,0 +1,93 @@
+"""Tier 1 — bounded_get (#660): the shared response-size cap for external HTTP fetches."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from mining_dashboard.helper.http import ResponseTooLarge, bounded_get
+
+
+def _streaming_resp(chunks, status_code=200, encoding="utf-8"):
+    resp = MagicMock(status_code=status_code, encoding=encoding)
+    resp.iter_content.return_value = iter(chunks)
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+class TestBoundedGet:
+    def test_under_cap_returns_body(self):
+        with patch(
+            "mining_dashboard.helper.http.requests.get",
+            return_value=_streaming_resp([b'{"tag_nam', b'e": "v1.2.3"}']),
+        ) as g:
+            resp = bounded_get("https://example.test/x", timeout=20)
+        assert resp.status_code == 200
+        assert resp.text == '{"tag_name": "v1.2.3"}'
+        assert resp.json() == {"tag_name": "v1.2.3"}
+        # The read is streamed, never buffered whole by requests itself.
+        assert g.call_args.kwargs["stream"] is True
+
+    def test_over_cap_raises_request_exception(self):
+        # ResponseTooLarge subclasses RequestException, so every caller's existing
+        # fail-silent handling (return None / keep last good) applies unchanged.
+        with patch(
+            "mining_dashboard.helper.http.requests.get",
+            return_value=_streaming_resp([b"x" * 1024] * 3),
+        ):
+            with pytest.raises(requests.RequestException):
+                bounded_get("https://example.test/x", max_bytes=2048)
+
+    def test_stops_reading_at_the_cap(self):
+        # The over-cap chunk is the last one consumed — the rest of a multi-GB body is never read.
+        chunks = iter([b"x" * 1024, b"x" * 1024, b"x" * 1024])
+        with patch(
+            "mining_dashboard.helper.http.requests.get",
+            return_value=_streaming_resp(chunks),
+        ):
+            with pytest.raises(ResponseTooLarge):
+                bounded_get("https://example.test/x", max_bytes=1024)
+        assert next(chunks, None) is not None  # at least one chunk was left unread
+
+    def test_kwargs_pass_through(self):
+        with patch(
+            "mining_dashboard.helper.http.requests.get",
+            return_value=_streaming_resp([b"ok"]),
+        ) as g:
+            bounded_get(
+                "https://example.test/x",
+                timeout=20,
+                proxies={"https": "socks5h://tor:9050"},
+                params={"a": "b"},
+                headers={"User-Agent": "pithead-dashboard"},
+            )
+        kw = g.call_args.kwargs
+        assert kw["timeout"] == 20
+        assert kw["proxies"] == {"https": "socks5h://tor:9050"}
+        assert kw["params"] == {"a": "b"}
+        assert kw["headers"] == {"User-Agent": "pithead-dashboard"}
+
+    def test_bad_encoding_degrades_not_crashes(self):
+        resp_obj = _streaming_resp([b"\xff\xfe"], encoding=None)
+        with patch("mining_dashboard.helper.http.requests.get", return_value=resp_obj):
+            resp = bounded_get("https://example.test/x")
+        assert isinstance(resp.text, str)  # errors="replace", never a decode crash
+
+
+class TestWiringDriftGuard:
+    def test_external_clients_route_through_bounded_get(self):
+        """Every external fetch module GETs via bounded_get — a bare requests.get( here is drift."""
+        pkg = Path(__file__).resolve().parents[2] / "mining_dashboard"
+        external = [
+            pkg / "service" / "update_checker.py",
+            pkg / "service" / "price_feed.py",
+            pkg / "client" / "xvb_client.py",
+        ]
+        for mod in external:
+            src = mod.read_text()
+            assert "requests.get(" not in src, (
+                f"{mod.name}: unbounded requests.get( slipped back in"
+            )
+            assert "bounded_get(" in src, f"{mod.name}: no bounded_get call found"

--- a/build/dashboard/tests/service/test_price_feed.py
+++ b/build/dashboard/tests/service/test_price_feed.py
@@ -50,7 +50,7 @@ class TestCoinGeckoClient:
         c = CoinGeckoClient("USD", tor_proxy="socks5h://t:9050")
         payload = {"monero": {"usd": 333.97}, "minotari": {"usd": 0.0004}}
         with patch(
-            "mining_dashboard.service.price_feed.requests.get",
+            "mining_dashboard.service.price_feed.bounded_get",
             return_value=self._resp(200, payload),
         ) as g:
             assert c.fetch() == {"xmr": 333.97, "tari": 0.0004}
@@ -66,15 +66,13 @@ class TestCoinGeckoClient:
 
     def test_non_200_is_silent_none(self):
         c = CoinGeckoClient("USD")
-        with patch(
-            "mining_dashboard.service.price_feed.requests.get", return_value=self._resp(429)
-        ):
+        with patch("mining_dashboard.service.price_feed.bounded_get", return_value=self._resp(429)):
             assert c.fetch() is None
 
     def test_network_error_is_silent_none(self):
         c = CoinGeckoClient("USD")
         with patch(
-            "mining_dashboard.service.price_feed.requests.get",
+            "mining_dashboard.service.price_feed.bounded_get",
             side_effect=requests.RequestException("offline"),
         ):
             assert c.fetch() is None
@@ -85,7 +83,7 @@ class TestCoinGeckoClient:
         # must mean NO request at all, not a sanitized one.
         for label in ("US Dollar$", "usd&x=exfil", "a" * 6, ""):
             c = CoinGeckoClient(label, tor_proxy="socks5h://t:9050")
-            with patch("mining_dashboard.service.price_feed.requests.get") as g:
+            with patch("mining_dashboard.service.price_feed.bounded_get") as g:
                 assert c.fetch() is None
                 g.assert_not_called()
 

--- a/build/dashboard/tests/service/test_update_checker.py
+++ b/build/dashboard/tests/service/test_update_checker.py
@@ -59,7 +59,7 @@ class TestGitHubReleaseClient:
     def test_parses_tag_and_url(self):
         c = GitHubReleaseClient("https://api/releases/latest", tor_proxy="socks5h://t:9050")
         with patch(
-            "mining_dashboard.service.update_checker.requests.get",
+            "mining_dashboard.service.update_checker.bounded_get",
             return_value=self._resp(200, {"tag_name": "v1.4.0", "html_url": "https://h/v1.4.0"}),
         ) as g:
             assert c.latest_release() == {"tag": "v1.4.0", "url": "https://h/v1.4.0"}
@@ -72,14 +72,14 @@ class TestGitHubReleaseClient:
     def test_non_200_is_silent_none(self):
         c = GitHubReleaseClient("u")
         with patch(
-            "mining_dashboard.service.update_checker.requests.get", return_value=self._resp(404)
+            "mining_dashboard.service.update_checker.bounded_get", return_value=self._resp(404)
         ):
             assert c.latest_release() is None
 
     def test_network_error_is_silent_none(self):
         c = GitHubReleaseClient("u")
         with patch(
-            "mining_dashboard.service.update_checker.requests.get",
+            "mining_dashboard.service.update_checker.bounded_get",
             side_effect=requests.RequestException("offline"),
         ):
             assert c.latest_release() is None
@@ -87,7 +87,7 @@ class TestGitHubReleaseClient:
     def test_missing_fields_is_none(self):
         c = GitHubReleaseClient("u")
         with patch(
-            "mining_dashboard.service.update_checker.requests.get",
+            "mining_dashboard.service.update_checker.bounded_get",
             return_value=self._resp(200, {"tag_name": "v1.0.0"}),
         ):  # no html_url
             assert c.latest_release() is None


### PR DESCRIPTION
Closes #660.

Every external fetch the dashboard makes — the GitHub release check (#224), the three XvB reads (stats, reward estimates, winners file), and the CoinGecko price feed (#651) — used `requests.get(..., timeout=20)` with no response-size bound: a hostile or broken endpoint could hand any of them a multi-GB body and the process would buffer it all before parsing (known residual from the #642/#646 security reviews).

## What changed

- New `mining_dashboard/helper/http.py`: `bounded_get(url, max_bytes=1 MiB, timeout=20, **kw)` — streams the body in 64 KiB chunks and raises `ResponseTooLarge` (a `requests.RequestException` subclass) once it passes the cap, so every caller's existing fail-silent contract (return `None` / keep the last good result) applies unchanged. Timeout/proxies/params/headers pass through untouched, so all five fetches still ride Tor exactly as before.
- All five call sites adopted (`update_checker.py`, `price_feed.py`, `xvb_client.py` ×3) — plus `xvb_client.register()` (#263), which has the same shape and the same exposure.
- 1 MiB cap is generous by orders of magnitude — the largest legit payload here (XvB winners file) is well under 100 KiB.

## Out of scope

The Telegram, Healthchecks, tor-heal, and Monero/Tari RPC clients keep their own `requests` calls: they talk to operator-configured or in-stack endpoints, not the public internet, and the issue scopes the cap to the five external clients.

## Tests

- Tier 1 on the helper: under-cap body round-trips (`text`/`json()`), over-cap raises into the existing `RequestException` handling, reading stops at the cap (the tail of a huge body is never consumed), kwargs pass-through, decode errors degrade instead of crashing.
- Wiring drift guard: asserts the three client modules contain no bare `requests.get(` and do call `bounded_get(`.
- `make test` green (1500 stack + dashboard suites); `make test-patch-coverage` 100%.
- Ponytail over-engineering pass: clean (lazy `json()` and the `RequestException` subclass are both load-bearing; no net lines to cut).

Part of the v1.10 worker-upgrade cycle (#598) — #596's second GitHub call site lands on top of this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)