### PR TITLE
fix: unedited dashboard config preview reports zero changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An unedited dashboard config preview reports zero changes again.** Two phantom rows crept
+  into the preview on the versioned deploy layout. First, the control runner's systemd unit
+  invokes `pithead` from the version directory while `.env` was rendered through the `current`
+  symlink, so every `$PWD`-derived path (`CLEARNET_STATE_DIR`, the control spool, default data
+  dirs) re-rendered under the other spelling and previewed as a change — and a commit rewrote
+  `.env` to the versioned spelling, breaking the repoint-`current` rollback convention. The
+  render now keeps the spelling already in `.env` whenever both resolve to the same physical
+  directory; a real move still previews (and warns) as before. Second, the editor round-trip
+  carries the `config.reference.json` default for every `dashboard.energy` key the live config
+  omits, and the raw comparison read those spelled-out defaults as an energy edit. Both sides
+  are now filled from the same reference defaults before comparing, so only a real value change
+  reports.
+
 ### Changed
 
 - **The release process requires the targeted end-to-end run.** `docs/dev/releasing.md` now

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -276,6 +276,9 @@ data root:
   names the version that last came up. It is informational — the containers mount the absolute
   paths in `.env` — but it makes the live install discoverable without `docker inspect`. Any
   other directory name (a source checkout, a plain `pithead/` extract) leaves the symlink alone.
+  Running `pithead` through `current` and from the version directory are equivalent: a re-render
+  (`apply`, or the dashboard's preview) keeps whatever spelling `.env` already uses for a path
+  that resolves to the same place, so it never rewrites `.env` from one spelling to the other.
 - **Version dirs** — keep `current`'s target plus one older dir for rollback; delete anything
   older. Each release lands in a fresh dir: extract the bundle, copy `config.json` and `.env`
   from the previous dir, run `./pithead upgrade`. Rollback is the same two steps from the older

--- a/pithead
+++ b/pithead
@@ -1526,6 +1526,37 @@ env_get_file() {
 
 env_get() { env_get_file "$ENV_FILE" "$1"; }
 
+# Canonical (symlink-resolved) form of a path, for same-physical-location comparisons. Resolves a
+# directory with `pwd -P`; a file resolves its parent and keeps its basename. Falls back to the
+# path as given when nothing resolves, so comparing against it degrades to string equality.
+physical_path() {
+    local p="$1" d
+    if d=$( (cd "$p" 2>/dev/null && pwd -P)); then
+        printf '%s' "$d"
+    elif d=$( (cd "$(dirname "$p")" 2>/dev/null && pwd -P)); then
+        printf '%s/%s' "$d" "$(basename "$p")"
+    else
+        printf '%s' "$p"
+    fi
+}
+
+# Keep the live .env's SPELLING of a path when it points at the same physical location as the
+# freshly computed one. Every $PWD-derived path changes spelling with the invocation path — the
+# `current` symlink (operator shell) vs the versioned install dir it points at (the control
+# runner's systemd unit) — and a re-render must not read that as a config change, nor rewrite
+# .env to the versioned spelling: rollback repoints `current`, and .env should keep following it.
+# A real move (a different physical location) always takes the newly computed value.
+preserve_path_spelling() { # <env-key> <computed-path> — prints the value to render
+    local old new="$2"
+    old=$(env_get "$1")
+    if [ -n "$old" ] && [ "$old" != "$new" ] &&
+        [ "$(physical_path "$old")" = "$(physical_path "$new")" ]; then
+        printf '%s' "$old"
+    else
+        printf '%s' "$new"
+    fi
+}
+
 # Normalize a config truthy value to the literal "true"/"false". Accepts 1/true/yes/on
 # (case-insensitive) as true; everything else (incl. empty/absent) is false. Matches the
 # dashboard's MONERO_PRUNE parsing so config booleans read the same on both sides (#183).
@@ -2729,6 +2760,13 @@ parse_and_validate_config() {
     TARI_DIR=$(resolve_default "$(jq -r '.tari.data_dir // empty' "$CONFIG_FILE")" "$PWD/data/tari")
     P2POOL_DIR=$(resolve_default "$(jq -r '.p2pool.data_dir // empty' "$CONFIG_FILE")" "$PWD/data/p2pool")
     TOR_DATA_DIR=$(resolve_default "$(jq -r '.tor.data_dir // empty' "$CONFIG_FILE")" "$PWD/data/tor")
+    # Two spellings of one physical directory (the `current` symlink vs the versioned install dir)
+    # must not read as a data-dir change: keep the live .env spelling (preserve_path_spelling).
+    # Done before _data_root below, so the derived defaults join the preserved spelling too.
+    MONERO_DIR=$(preserve_path_spelling MONERO_DATA_DIR "$MONERO_DIR")
+    TARI_DIR=$(preserve_path_spelling TARI_DATA_DIR "$TARI_DIR")
+    P2POOL_DIR=$(preserve_path_spelling P2POOL_DATA_DIR "$P2POOL_DIR")
+    TOR_DATA_DIR=$(preserve_path_spelling TOR_DATA_DIR "$TOR_DATA_DIR")
     # Shared data root (#455): when monero/tari/p2pool/tor all resolve under ONE parent, that
     # parent is the box's data root and the dashboard's DEFAULT joins it — before this, the
     # dashboard DB was the only data living inside the (per-version) install dir, moving with the
@@ -2745,21 +2783,22 @@ parse_and_validate_config() {
     # location — an operator-pinned dashboard.data_dir is theirs, never touched.
     DASHBOARD_DIR_IS_DEFAULT=1
     [ "$DASHBOARD_DIR" == "$_dash_cfg" ] && DASHBOARD_DIR_IS_DEFAULT=0
+    DASHBOARD_DIR=$(preserve_path_spelling DASHBOARD_DATA_DIR "$DASHBOARD_DIR")
     # Stratum TLS keypair home (#261): joins the shared data root when one exists — the cert's
     # FINGERPRINT is what every rig pins, so it must survive versioned deploys like the chain
     # data does, not move with the code. Internal (not config-driven), like CONTROL_DIR.
-    PROXY_TLS_DIR="$_data_root/proxy-tls"
+    PROXY_TLS_DIR=$(preserve_path_spelling PROXY_TLS_DIR "$_data_root/proxy-tls")
     # Internal shared state dir (#234): the dashboard (rw) drops a per-chain "clearnet sync complete"
     # marker here and the monerod/tari entrypoints (ro) read it to decide Tor-vs-clearnet. Not a
     # user-facing data dir, so it's fixed under ./data rather than config-driven.
-    CLEARNET_STATE_DIR="$PWD/data/clearnet-state"
+    CLEARNET_STATE_DIR=$(preserve_path_spelling CLEARNET_STATE_DIR "$PWD/data/clearnet-state")
     # Control-channel spool (#33): requests/ (container rw) + staged/results/audit (host-only /
     # container ro). Fixed under ./data like CLEARNET_STATE_DIR — not a user-facing data dir.
     # Deliberately NOT inside DASHBOARD_DIR, which is mounted rw wholesale into the container.
-    CONTROL_DIR="$PWD/data/control"
+    CONTROL_DIR=$(preserve_path_spelling CONTROL_DIR "$PWD/data/control")
     # Caddy access log (#349): Caddy (rw) writes access.log here, the dashboard mounts it
     # read-only. Fixed under ./data like the spool above — internal, not a user-facing data dir.
-    CADDY_LOG_DIR="$PWD/data/caddy-logs"
+    CADDY_LOG_DIR=$(preserve_path_spelling CADDY_LOG_DIR "$PWD/data/caddy-logs")
 
     # Guard every data dir against catastrophic chown -R / rm -rf targets before we touch them.
     local d
@@ -3126,7 +3165,11 @@ announce_stratum_tls() {
 # retried on the next run and the recreated dashboard always mounts the migrated directory.
 migrate_dashboard_data() {
     local old="$PWD/data/dashboard" new="${DASHBOARD_DIR:-}"
-    [ -n "$new" ] && [ "$old" != "$new" ] || return 0   # classic layout — nothing to move
+    [ -n "$new" ] && [ "$old" != "$new" ] || return 0 # classic layout — nothing to move
+    # The render prefers the live .env spelling (preserve_path_spelling), so old and new can be
+    # two spellings of ONE physical dir (`current` symlink vs versioned dir) — that is the classic
+    # layout too, and the both-locations check below would count the same data twice.
+    [ "$(physical_path "$old")" != "$(physical_path "$new")" ] || return 0
     [ -n "$(ls -A "$old" 2>/dev/null)" ] || return 0    # old default empty/absent — nothing to move
     if [ "${DASHBOARD_DIR_IS_DEFAULT:-1}" -eq 0 ]; then # operator-pinned path: their data, their call
         warn "Dashboard data found at the old default $old, but dashboard.data_dir is set explicitly ($new) — leaving both alone. Move or remove $old yourself."
@@ -3746,7 +3789,8 @@ render_env() {
     # wrapper entrypoint exports them into the wallet child process only. Kept under data/ (gitignored
     # like .env). Written for the REAL .env target only, so a dry-run render never mutates it; the
     # values are empty (harmless) when the feature is off, so the compose secret always resolves.
-    local tari_secret_file="$PWD/data/tari-wallet-secret.env"
+    local tari_secret_file
+    tari_secret_file=$(preserve_path_spelling TARI_WALLET_SECRET_FILE "$PWD/data/tari-wallet-secret.env")
     if [ "$target" != "${ENV_FILE}.dryrun" ]; then
         mkdir -p "$PWD/data"
         (
@@ -4994,6 +5038,18 @@ CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
     TELEGRAM_EVENT_HIGH_REJECT_RATE TELEGRAM_EVENT_BLOCK_FOUND
     TELEGRAM_EVENT_PAYOUT_FOUND TELEGRAM_EVENT_PAYOUT_CONFIRMED TELEGRAM_EVENT_CONTAINER_UNHEALTHY'
 
+# Effective dashboard.energy comparison for the control channel (#504). The editor's prefill
+# merges config.reference.json defaults UNDER the sparse live config (read_config, #437), so an
+# unedited round-trip comes back with every energy default spelled out. Fill BOTH sides from the
+# same reference defaults before comparing, or a live config that omits any energy key phantom-
+# reports an energy edit on every preview. Fails toward "changed" on a jq error or an unreadable
+# reference — a phantom INFO row, never a silently dropped real edit.
+energy_block_changed() { # <staged-config> — rc 0 when the effective energy settings differ
+    ! jq -e --slurpfile live "$CONFIG_FILE" --slurpfile ref "$REFERENCE_CONFIG" '
+        (($ref[0].dashboard.energy // {}) + ($live[0].dashboard.energy // {}))
+        == (($ref[0].dashboard.energy // {}) + (.dashboard.energy // {}))' "$1" >/dev/null 2>&1
+}
+
 control_approval_gate() { # <staged-file>
     local staged="$1" porcelain
     # Fail closed if we cannot re-derive the change set (the staged config was validated at
@@ -5073,7 +5129,7 @@ control_approval_gate() { # <staged-file>
     # name into the list when that block changed, else an energy-only commit would audit no key.
     local keys
     keys=$(porcelain_keys "$porcelain")
-    if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.energy // {}) == ($live[0].dashboard.energy // {})' "$staged" >/dev/null 2>&1; then
+    if energy_block_changed "$staged"; then
         keys="${keys:+$keys }DASHBOARD_ENERGY"
     fi
     printf '%s' "$keys"
@@ -5172,7 +5228,7 @@ control_preview() { # <request-file> <id> <actor> <control-dir>
         # arms Apply and the commit lands it in config.json. The approval gate allowlists exactly
         # this config.json-only block; any OTHER config.json-only delta still refuses (see
         # control_approval_gate). INFO never flips destructive, so the existing verdict stands.
-        if ! jq -e --slurpfile live "$CONFIG_FILE" '(.dashboard.energy // {}) == ($live[0].dashboard.energy // {})' "$staged" >/dev/null 2>&1; then
+        if energy_block_changed "$staged"; then
             result=$(printf '%s' "$result" | jq '.changes += [{flag:"INFO",key:"dashboard.energy",msg:"Energy calculator settings (dashboard.energy) — electricity price / currency / XMR price updated."}]')
         fi
         control_write_result "$cdir/results" "$id" "$result"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6452,6 +6452,17 @@ jq --arg d "$SPD/moved-monero" '.monero.data_dir=$d' "$SP/config.json" >"$SP/con
 out="$(cd "$SP" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply --dry-run --porcelain 2>/dev/null)"
 assert_contains "a real data-dir move still previews as a change" "$out" "MONERO_DATA_DIR"
 assert_contains "a real data-dir move is still flagged DEST" "$out" "$(printf 'DEST\tMONERO_DATA_DIR')"
+# APPLY that move with dashboard data on disk. A zero-change apply never reaches
+# migrate_dashboard_data (#455), so this apply — with a real change — is what drives it here:
+# .env spells the dashboard data dir via `current` while $PWD spells it versioned. The
+# physical-equality guard must read the two spellings as ONE dir (the classic layout), not
+# data at both locations — that check is a hard stop, and the data must not move or vanish.
+mkdir -p "$CUR/data/dashboard"
+echo "live-db" >"$CUR/data/dashboard/mining_data.db"
+out="$(cd "$SP" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "apply with dashboard data at one dir under two spellings exits 0" "$?" "0"
+assert_eq "the dashboard data stays in place — no migration, no wipe" \
+    "$(cat "$SP/data/dashboard/mining_data.db" 2>/dev/null)" "live-db"
 unset SPD SP CUR
 
 # ---------------------------------------------------------------------------

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4904,6 +4904,26 @@ assert_eq "energy cost landed in config.json" "$(jq -r '.dashboard.energy.cost_p
 assert_eq "energy currency landed in config.json" "$(jq -r '.dashboard.energy.currency' "$C/config.json")" "EUR"
 assert_contains "energy commit audits the synthetic key name (#504)" "$(grep '"action":"commit","status":"applied"' "$AUDIT" | tail -n 1)" "DASHBOARD_ENERGY"
 
+# NO PHANTOM on an unedited round-trip: the editor prefills from config.reference.json deep-merged
+# UNDER the live config (read_config, #437), so an untouched save posts back every energy default
+# the live config omits, spelled out. Effective values are identical — the preview must report
+# ZERO changes (no synthetic dashboard.energy row) and a commit must not audit DASHBOARD_ENERGY.
+UUID6="56565656-5656-4656-8656-565656565656"
+jq --slurpfile ref "$C/config.reference.json" \
+    '.dashboard.energy = ($ref[0].dashboard.energy + (.dashboard.energy // {}))' \
+    "$C/config.json" >"$C/cand.json"
+jq --arg id "$UUID6" '{id:$id,action:"preview",actor:"admin",config:.}' "$C/cand.json" >"$REQS/$UUID6.json"
+run_pending >/dev/null
+assert_eq "unedited round-trip previews cleanly" "$(jq -r '.status' "$RESULTS/$UUID6.json" 2>/dev/null)" "previewed"
+assert_eq "unedited round-trip reports zero changes" "$(jq -r '.changes | length' "$RESULTS/$UUID6.json" 2>/dev/null)" "0"
+printf '{"id":"%s","action":"commit","actor":"admin"}\n' "$UUID6" >"$REQS/$UUID6.json"
+run_pending >/dev/null
+assert_eq "unedited round-trip still commits" "$(jq -r '.status' "$RESULTS/$UUID6.json" 2>/dev/null)" "applied"
+assert_not_contains "unedited commit audits no DASHBOARD_ENERGY key" \
+    "$(grep '"action":"commit","status":"applied"' "$AUDIT" | tail -n 1)" "DASHBOARD_ENERGY"
+assert_eq "unedited commit keeps the committed energy cost" "$(jq -r '.dashboard.energy.cost_per_kwh' "$C/config.json")" "0.18"
+rm -f "$RESULTS/$UUID6.json" "$STAGED/$UUID6.json"
+
 # NEGATIVE — the #504 security teeth: an energy edit BUNDLED with a change that is NOT on the env
 # allowlist (monero.rpc_lan_access -> MONERO_RPC_BIND) must be REFUSED. The energy exemption must
 # not become a carrier for other config: the gate re-derives the env change set host-side and the
@@ -6384,6 +6404,55 @@ assert_contains "setup announces the fingerprint for rig pinning" "$sut_out" "St
 unset SUT sut_out
 
 unset run_wizard w1_cfg w2_cfg pointer_out core_reads shape_reads
+
+echo "== black-box: .env path spellings survive a symlinked re-render (versioned layout) =="
+# The versioned layout drives pithead through TWO spellings of one directory: the operator's
+# `current` symlink and the versioned install dir the control runner's systemd unit points at.
+# Every $PWD-derived path (data dirs, spool, clearnet-state, ...) must keep the spelling already
+# in .env when both resolve to the same physical location — otherwise an UNEDITED dashboard
+# preview reports phantom path changes, and a commit rewrites .env to the versioned spelling,
+# breaking the repoint-`current`-to-roll-back convention.
+SPD="$SANDBOX/spell"
+SP="$SPD/pithead-v9.9.9"
+CUR="$SPD/current"
+mkdir -p "$SP/build/tari" "$SP/build/dashboard"
+: >"$SP/build/dashboard/Dockerfile"
+cp "$STACK" "$SP/pithead"
+cp "$ROOT/config.reference.json" "$SP/config.reference.json"
+cp "$ROOT/docker-compose.yml" "$SP/docker-compose.yml"
+cp "$ROOT/build/tari/config.toml.template" "$SP/build/tari/"
+make_stubs "$SP/bin"
+ln -s "pithead-v9.9.9" "$CUR"
+printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$SP/config.json"
+cat >"$SP/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=ORIGINALTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+# Baseline apply THROUGH THE SYMLINK — .env records every default path under the `current` spelling.
+(cd "$CUR" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+assert_contains "baseline .env spells clearnet-state via the symlink" "$(cat "$SP/.env")" "CLEARNET_STATE_DIR=$CUR/data/clearnet-state"
+assert_contains "baseline .env spells the monero data dir via the symlink" "$(cat "$SP/.env")" "MONERO_DATA_DIR=$CUR/data/monero"
+# Unedited dry-run FROM THE VERSIONED DIR (the control runner's invocation shape): zero changes.
+out="$(cd "$SP" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply --dry-run --porcelain 2>/dev/null)"
+assert_rc "unedited dry-run from the versioned dir exits 0" "$?" "0"
+assert_eq "unedited dry-run from the versioned dir reports zero changes" "$out" ""
+# A real apply from the versioned dir keeps the symlink spellings — rollback stays a repoint.
+(cd "$SP" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+assert_contains "apply from the versioned dir keeps the symlink clearnet-state spelling" "$(cat "$SP/.env")" "CLEARNET_STATE_DIR=$CUR/data/clearnet-state"
+assert_contains "apply from the versioned dir keeps the symlink data-dir spelling" "$(cat "$SP/.env")" "MONERO_DATA_DIR=$CUR/data/monero"
+assert_contains "apply from the versioned dir keeps the symlink tari-secret spelling" "$(cat "$SP/.env")" "TARI_WALLET_SECRET_FILE=$CUR/data/tari-wallet-secret.env"
+# NEGATIVE: a genuinely different location is still a real change — spelling preservation must
+# never swallow an actual data-dir move.
+jq --arg d "$SPD/moved-monero" '.monero.data_dir=$d' "$SP/config.json" >"$SP/config.json.tmp" && mv "$SP/config.json.tmp" "$SP/config.json"
+out="$(cd "$SP" && DOCKER_LOG=/dev/null PATH="$SP/bin:$PATH" ./pithead apply --dry-run --porcelain 2>/dev/null)"
+assert_contains "a real data-dir move still previews as a change" "$out" "MONERO_DATA_DIR"
+assert_contains "a real data-dir move is still flagged DEST" "$out" "$(printf 'DEST\tMONERO_DATA_DIR')"
+unset SPD SP CUR
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Problem

On gouda v1.9.3, an **unedited** dashboard config preview (`POST /api/control/preview` with the config round-tripped from `/api/config`) reports two phantom INFO changes:

1. `CLEARNET_STATE_DIR: /srv/code/current/... → /srv/code/pithead-v1.9.3/...`
2. "Energy calculator settings (dashboard.energy) … updated" with nothing changed.

## Root causes

**Path spelling.** `pithead` cd's to its own directory at startup and bash keeps the *logical* path, so `$PWD` is spelled via the `current` symlink from an operator shell but via the versioned install dir from the control runner's systemd unit. Every `$PWD`-derived path re-renders under the other spelling. Only `CLEARNET_STATE_DIR` was visible (generic `describe_change` fallthrough), but `CONTROL_DIR`, `CADDY_LOG_DIR`, and `TARI_WALLET_SECRET_FILE` were silently diffing too — a commit would rewrite `.env` to the versioned spelling and break the repoint-`current` rollback convention. On an all-default install the chain data dirs would flip as DEST rows.

**Energy block.** Not the #646 price feed (it never writes config — verified). The editor's `read_config` merges `config.reference.json` defaults UNDER the sparse live config, so an untouched save posts back every energy default spelled out while `config.json` stays sparse; the raw jq equality in `control_preview` / `control_approval_gate` read that as an edit.

## Fix

- `preserve_path_spelling` (+ `physical_path`): the render keeps the spelling already in `.env` whenever old and new resolve (`pwd -P`) to the same physical location, applied to all ten path keys at the `parse_and_validate_config` / `render_env` chokepoints. A real move (different physical dir) still previews and warns exactly as before.
- `migrate_dashboard_data` gets the matching physical-equality guard, so a preserved spelling can't trip the "data exists at BOTH locations" stop on one directory counted twice.
- `energy_block_changed`: both sides filled from the same `config.reference.json` defaults before comparing, shared by the preview row and the commit gate's audit key. Fails toward "changed" on an unreadable reference — never toward hiding a real edit.

## Coverage (tier 1 per docs/dev/testing-strategy.md)

- Control-channel rig: an unedited reference-merged round-trip previews `changes: []`, still commits, and audits no `DASHBOARD_ENERGY`; the existing real-edit, bundling-refusal, and smuggling tests all still pass.
- New versioned-layout sandbox (version dir + `current` symlink): baseline apply through the symlink, then dry-run **and** apply from the versioned dir → zero porcelain rows and `.env` spellings intact (incl. the tari secret file); a genuine `monero.data_dir` move still reports `DEST`.
- Revert-proven: all six behavior assertions fail on the unfixed script.

`make lint` and `make test` pass (stack suite 1514 ✓ / 0 ✗). Changelog + `docs/operations.md` layout note updated. Ponytail review: lean, nothing to cut (`energy_block_changed` dedups a previously duplicated jq expression).

Note for the deployed fleet: gouda's systemd unit still carries the versioned `WorkingDirectory`/`ExecStart` — harmless now (either spelling renders identically); the unit self-updates on the next apply cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)