### PR TITLE
fix(#690): bound host-runner curl response sizes with --max-filesize

### DIFF
--- a/pithead
+++ b/pithead
@@ -2961,6 +2961,17 @@ readonly CONTROL_SECRET_PATHS='[
     ["p2pool","stratum_password"],
     ["healthchecks","ping_url"]]'
 
+# #690: bound every host-runner curl so a hostile/MITM'd rig or release response can't stream an
+# unbounded body into memory ($( )) or onto disk (-o) inside the --max-time window. --max-filesize
+# aborts BOTH before the transfer (when Content-Length is honest) AND mid-stream once received
+# bytes cross the cap (verified curl 8.7 → exit 63), so a lying or absent Content-Length is covered
+# too — every runner curl already treats a non-zero exit as failure and cleans its partial file.
+# Two envelopes: JSON dials + the cosign sig are tiny; the release BUNDLE is a whole-stack tarball.
+readonly CURL_CAP_SMALL=1048576 # 1 MiB — GitHub release JSON, rig control responses, cosign sig
+# ponytail: 16 MiB, ~128× today's ~126 KB bundle; bump if a real bundle ever approaches it (a
+# cap-hit surfaces as _upg_fail's "could not download over Tor", loud but network-flavoured).
+readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle (code + configs)
+
 # Render the pre-masked prefill copy (#440): the live config with every SET secret leaf replaced
 # by the {"__secret__":true} sentinel, written atomically to <control-dir>/masked/config.json.
 # The dashboard serves the Configuration form from THIS file (mounted read-only) — the raw
@@ -5333,7 +5344,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
     [ -n "$prefix" ] || prefix="172.28.0"
     socks="${prefix}.25:9050"
-    if ! rel=$(curl -fsS --max-time 60 --socks5-hostname "$socks" \
+    if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
         -H 'Accept: application/vnd.github+json' \
         "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null); then
         _upg_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
@@ -5362,7 +5373,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
     # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.
     local bundle="$cdir/staged/.$id.tar.gz" logf="$cdir/staged/.$id.log"
-    if ! curl -fsSL --max-time 900 --socks5-hostname "$socks" -o "$bundle" \
+    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$socks" -o "$bundle" \
         "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz" 2>/dev/null; then
         rm -f "$bundle"
         _upg_fail "could not download the $tag release bundle over Tor — the stack keeps running v$PITHEAD_VERSION."
@@ -5375,7 +5386,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # TLS to GitHub plus tag pinning — with one loud line in the journal.
     if [ -f cosign.pub ]; then
         local sig="$cdir/staged/.$id.tar.gz.sig"
-        if ! curl -fsSL --max-time 120 --socks5-hostname "$socks" -o "$sig" \
+        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" -o "$sig" \
             "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz.sig" 2>/dev/null; then
             rm -f "$bundle" "$sig"
             _upg_fail "the $tag release carries no bundle signature (pithead.tar.gz.sig) — refusing to install it unverified (#376); the stack keeps running v$PITHEAD_VERSION."
@@ -5693,7 +5704,7 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
     # is an operator-set host on the mining LAN, not clearnet. The token rides one header, never the
     # URL, the result, or the audit log.
     local url="http://$host:$cport/apply" bodyf="$cdir/staged/.$id.body" code
-    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 \
+    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 --max-filesize "$CURL_CAP_SMALL" \
         -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
         --data "$changes" "$url" 2>/dev/null); then
         rm -f "$bodyf"
@@ -5720,7 +5731,7 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 2
         sbody="$cdir/staged/.$id.status"
-        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 \
+        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 --max-filesize "$CURL_CAP_SMALL" \
             -H "Authorization: Bearer $token" "http://$host:$cport/status" 2>/dev/null); then
             rm -f "$sbody"
             continue
@@ -5837,7 +5848,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
         prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
         [ -n "$prefix" ] || prefix="172.28.0"
         socks="${prefix}.25:9050"
-        if ! rel=$(curl -fsS --max-time 60 --socks5-hostname "$socks" \
+        if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
             -H 'Accept: application/vnd.github+json' \
             "https://api.github.com/repos/p2pool-starter-stack/rigforge/releases/latest" 2>/dev/null); then
             _wu_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
@@ -5858,7 +5869,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
     # POST the upgrade to the rig's control API — direct LAN dial like worker-apply, NOT Tor. The
     # body carries the HOST-derived tag only; the token rides one header, never the URL or result.
     local url="http://$host:$cport/upgrade" bodyf="$cdir/staged/.$id.body" code
-    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 \
+    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 --max-filesize "$CURL_CAP_SMALL" \
         -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
         --data "$(jq -n --arg v "$tag" '{version:$v}')" "$url" 2>/dev/null); then
         rm -f "$bodyf"
@@ -5890,7 +5901,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 5
         sbody="$cdir/staged/.$id.status"
-        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 \
+        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 --max-filesize "$CURL_CAP_SMALL" \
             -H "Authorization: Bearer $token" "http://$host:$cport/status" 2>/dev/null); then
             rm -f "$sbody"
             continue

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6187,6 +6187,7 @@ wu_accept_case() { # <uuid> <status-body-json> <label> <expected-status>
     printf '%s' "v9.9.9" >"$dir/staged/.rigforge-latest-tag"
     cat >"$dir/bin/curl" <<EOF
 #!/usr/bin/env bash
+echo "\$*" >>"$dir/dials.log"
 out="" url=""
 while [ \$# -gt 0 ]; do
     case "\$1" in
@@ -6215,6 +6216,11 @@ assert_eq "applied result records the rig's change_id" \
     "$(jq -r '.change_id' "$WU_LAST_DIR/results/$w7.json" 2>/dev/null)" "chg-9"
 assert_eq "applied result records the host-derived version" \
     "$(jq -r '.version' "$WU_LAST_DIR/results/$w7.json" 2>/dev/null)" "v9.9.9"
+# #690: every runner dial (the rig POST + each /status poll) carries a response-size cap so a
+# hostile rig can't stream an unbounded body into disk/memory. Proves the flag is wired, not curl's
+# own enforcement (that needs a real curl against an oversized server — an e2e concern).
+assert_contains "worker-upgrade rig dials carry a --max-filesize cap (#690)" \
+    "$(cat "$WU_LAST_DIR/dials.log" 2>/dev/null)" "--max-filesize"
 assert_contains "upgrade applied is audited" \
     "$(cat "$WU_LAST_DIR/audit/control.log")" '"action":"worker-upgrade","status":"applied"'
 w8="23232323-2323-4232-9232-232323232323"


### PR DESCRIPTION
Closes #690.

## What

Bounds the response size of every host-runner `curl` in the control channel, so a hostile or MITM'd rig — or a hostile GitHub/release response — can't stream an arbitrarily large body into memory (`$( )`) or onto disk (`curl -o`) inside the `--max-time` window. This was the LOW residual noted in #597's security review (the same uncapped pattern was already accepted in the #33/#185 reviews); #660 capped the Python side and deliberately scoped out the bash root runner.

## How

Two `readonly` caps near the control constants, applied via `--max-filesize` to all eight runner dials across `control_upgrade`, `control_worker_apply`, and `control_worker_upgrade`:

- `CURL_CAP_SMALL` = 1 MiB — GitHub/RigForge release JSON, rig control responses, cosign sig.
- `CURL_CAP_BUNDLE` = 16 MiB — the `pithead.tar.gz` release bundle (~128× today's ~126 KB; images pull from GHCR separately, so the tarball is code + configs only).

The three remaining `curl`s in the file (localhost `/api/state` probe, two doctor probes that sink to `/dev/null`) are out of scope: not runner dials, and `/dev/null` can't exhaust anything.

### Why `--max-filesize` is sufficient (verified, not assumed)

The flag's old "no effect if size unknown" reputation doesn't hold on modern curl. Tested on curl 8.7:

- Honest `Content-Length` over the cap → aborts **before** the transfer (exit 63, zero bytes written).
- Chunked response with **no** `Content-Length` streaming past the cap → aborts **mid-stream** the moment received bytes cross the cap (exit 63, exactly cap bytes then killed).

So both the memory-capture and disk-write vectors are bounded even against a lying or absent `Content-Length`. Every runner curl already treats a non-zero exit as failure and `rm -f`s its partial file, so a truncated download is cleaned up on the existing failure path.

## Residual (named, accepted)

If a real release bundle ever grows past 16 MiB, a legit upgrade would hit the cap and surface as `_upg_fail`'s "could not download over Tor" — loud, but network-flavoured rather than size-flavoured. 128× current headroom makes that remote; bump the constant if bundles approach it. Marked with a `ponytail:` comment naming the ceiling.

## Test

Extended the existing `control_worker_upgrade` stack test to record the runner's dial args and assert every rig dial carries `--max-filesize` (`tests/stack/run.sh`). This guards the wiring — that a new or edited runner dial doesn't ship uncapped. Behavioural cap enforcement is curl's own and needs a real curl against an oversized server (an e2e concern), so it's not stubbed here.

`make lint` (shellcheck + shfmt) clean; stack suite green.
