### PR TITLE
fix(#687): don't cold-assert a pool switch that hasn't classified yet

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -478,6 +478,25 @@ wait_monero_synced() { wait_for "${1:-300}" 10 "Monero sync complete" _pred_mone
 wait_miner_running() { wait_for "${1:-180}" 5 "miner released" _pred_miner_running; }
 wait_tari_synced() { wait_for "${1:-300}" 10 "Tari sync complete" _pred_tari_synced; }
 wait_pool_ready() { wait_for "${1:-180}" 5 "pool type determinate (${2})" _pred_pool_ready "$2"; }
+# Assert a pool switch settled, WITHOUT flaking red on peer luck (#687). p2pool infers its sidechain
+# from connected peers' ports, so a freshly-switched chain (nano over Tor is the slowest to populate)
+# can read "Unknown" past the wait window. A bare assert_eq after `wait_pool_ready … || true` then
+# fires cold and fails on a timing state, not a bug. Three-way verdict, same as assert_scenario's
+# #454 handling: determinate match → pass; still Unknown/empty → peer-timing WARN; a WRONG determinate
+# type (Main when we set Mini) → fail. The 420s window is Tor-realistic; the wait polls, so a fast
+# bench that classifies in seconds pays nothing.
+assert_pool_switched() { # <label> <expected-pool-label>
+    wait_pool_ready 420 "$2" || true
+    local got
+    got="$(jq_get "$(api_state)" '.pool.type')"
+    if [ "$got" = "$2" ]; then
+        it_pass "$1 ($got)"
+    elif [ "$got" = "Unknown" ] || [ -z "$got" ]; then
+        it_warn "$1 — pool still Unknown for [$2] after 420s; peers not classified in time (nano/Tor is slow to populate), not a misclassification (#687)"
+    else
+        it_fail "$1" "got [$got], want [$2] — wrong sidechain, not a timing lag"
+    fi
+}
 wait_hashes_flowing() { wait_for "${1:-300}" 5 "stratum hashes flowing" _pred_hashes_flowing; }
 
 # --- Artifact capture -------------------------------------------------------

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1004,9 +1004,9 @@ run_lifecycle() {
             "$(rx "stat -c %u $(quote_arg "$own_probe") 2>/dev/null")" "1000"
         rx "sudo rm -f $(quote_arg "$own_probe")" >/dev/null 2>&1 || true
     fi
-    # .pool.type lags a sidechain switch until peers on the new chain connect — wait, don't assert cold (#54).
-    wait_pool_ready 180 "$(pool_label "$other")" || true
-    assert_eq "pool actually changed" "$(jq_get "$(api_state)" '.pool.type')" "$(pool_label "$other")"
+    # .pool.type lags a sidechain switch until peers on the new chain connect — wait + three-way
+    # verdict, don't assert cold on a peer-timing state (#54, #687).
+    assert_pool_switched "pool actually changed" "$(pool_label "$other")"
 
     # Node-down failover (#31): stop monerod -> status non-zero (node down), dashboard rejects
     # workers (xmrig-proxy stopped) -> start monerod -> readmitted -> status 0 again.
@@ -1044,9 +1044,9 @@ run_lifecycle() {
             pithead restore -y "$arch" >/dev/null 2>&1
             pithead up >/dev/null 2>&1
             wait_status_ok 240 || true
-            # pool.type lags peer reconnect after restore+up — wait for classification before asserting (#54).
-            wait_pool_ready 180 "$backed_pool" || true
-            assert_eq "restore reverts the pool to the backed-up value" "$(jq_get "$(api_state)" '.pool.type')" "$backed_pool"
+            # pool.type lags peer reconnect after restore+up — wait + three-way verdict, don't assert
+            # cold on a peer-timing state (#54, #687).
+            assert_pool_switched "restore reverts the pool to the backed-up value" "$backed_pool"
             assert_eq "restore preserves secrets" "$(secret_fingerprint)" "$fp_b"
             rx "rm -f $(quote_arg "$arch")" >/dev/null 2>&1 || true
         else


### PR DESCRIPTION
Closes #687.

## What

Fixes a flaky failure in the e2e lifecycle leg: after a sidechain switch (and after backup→restore), the `pool actually changed` / `restore reverts the pool` assertions could fail cold when a freshly-joined chain hadn't classified in time. In the v1.9.3 targeted run this fired as `.pool.type == Unknown` at the 180s cutoff — not a product regression (`detect_pool_type` is unchanged and the same run's restore leg classified correctly), just peer discovery on a fresh sidechain over Tor exceeding the window.

## Root cause

p2pool infers its sidechain from connected peers' ports, so a just-switched chain reads `Unknown` until peers connect (nano over Tor is the slowest to populate). The two lifecycle sites waited with `wait_pool_ready 180 … || true` and then asserted with a bare `assert_eq`, so a wait timeout re-read state cold and failed on a **timing state**, not a bug. The apply-path assertion (`assert_scenario`) already handles this correctly with a three-way verdict (#454) — the lifecycle sites just didn't share it.

## Fix

New `assert_pool_switched` helper in `tests/integration/lib.sh` folds the wait and the verdict, mirroring the apply-path semantics:

- determinate value matches expected → **pass**
- still `Unknown`/empty after the window → peer-timing **warn** (not a product bug)
- a **wrong** determinate type (Main when we set Mini) → **fail** (real misclassification)

Both lifecycle sites now call it. Window defaults to a Tor-realistic 420s (the issue's suggested value); `wait_pool_ready` polls every 5s, so a fast bench that classifies in seconds pays nothing for the higher ceiling. This is both halves of the issue's proposed fix: raise the window *and* stop cold-asserting a timeout.

## Test

`make lint` (shellcheck + shfmt) clean. This is e2e-harness code exercised on a live bench (tier-4), so it's validated on the next targeted run rather than by a unit test — the change only affects how the lifecycle leg classifies a pool read.
