### PR TITLE
v1.10.1 follow-ups: bound runner curls (#690) + fix e2e pool-switch window (#687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
 ### Changed
 
+- **The payout wallet now scans the full chain by default.** The view-only payout-confirmation
+  wallet's default restore height (`monero.payout_scan_height: auto`) is genesis (0) instead of the
+  chain tip, so it captures **every** p2pool payout this address has ever received, not only those
+  after it was set up. The initial scan is long but one-time — the wallet persists its progress.
+  Set an explicit block number to start later and skip it.
 - **Net profit now includes the XvB raffle's expected reward (#712).** The Energy tab's net figure
   adds the current XvB tier's published expected reward, valued at your XMR price, on top of P2Pool
   (and Tari, when priced). The whole net is already probabilistic, so it stays a single number — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Pithead ships as **one product, one version** — the version lives in the top-l
 [`VERSION`](VERSION) file and every released image is tagged with it. Releases are cut
 per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
+## [Unreleased]
+
+### Changed
+
+- **Net profit now includes the XvB raffle's expected reward (#712).** The Energy tab's net figure
+  adds the current XvB tier's published expected reward, valued at your XMR price, on top of P2Pool
+  (and Tari, when priced). The whole net is already probabilistic, so it stays a single number — the
+  XvB slice is labelled `(est.)` in the heading and tooltip because the raffle draw is random among
+  qualifiers. It folds in only while the fetched estimate is fresh (the same staleness rule as the
+  *XvB Donation Stats* card) and you clear a donor tier; otherwise it is left out, never guessed.
+
 ## [1.10.0] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The view-only payout wallet builds again (#714).** Setting `monero.view_key` starts a
+  view-only `wallet-rpc` that confirms p2pool payouts actually land, but it crash-looped on first
+  run — the create-from-keys JSON set an empty `"spendkey": ""`, which monero-wallet-rpc parses as
+  a secret key and rejects. The field is now omitted (the view-only form), so the wallet creates
+  and scans. A correct view key was never the problem; the entrypoint was.
+
 ### Changed
 
 - **Net profit now includes the XvB raffle's expected reward (#712).** The Energy tab's net figure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
   wallet's default restore height (`monero.payout_scan_height: auto`) is genesis (0) instead of the
   chain tip, so it captures **every** p2pool payout this address has ever received, not only those
   after it was set up. The initial scan is long but one-time — the wallet persists its progress.
-  Set an explicit block number to start later and skip it.
+  Set an explicit block number to start later and skip it. Its memory ceiling is raised to 2 GiB
+  (from 512 MiB) so the one-time full scan, which peaks above 0.5 GiB, doesn't OOM-loop.
 - **Net profit now includes the XvB raffle's expected reward (#712).** The Energy tab's net figure
   adds the current XvB tier's published expected reward, valued at your XMR price, on top of P2Pool
   (and Tari, when priced). The whole net is already probabilistic, so it stays a single number — the

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -627,21 +627,34 @@ class EarningsCard extends Component {
 // Energy & profit tab body (#260). Fleet power draw + efficiency (always, when any power is known),
 // then energy cost once an electricity price is set, then net profit once an XMR price is also set —
 // each layer appears only when its inputs exist, so the operator never sees a fabricated figure.
-// Setting a Tari price too (#520) folds the Tari merge-mining estimate into gross; the heading and
-// the Net/day tooltip say exactly what's counted so a Tari merge-miner's net is never silently
-// P2Pool-only. `est` is the earnings for the shared what-if hashrate; the client does the
-// kWh/cost/net math.
+// Setting a Tari price too (#520) folds the Tari merge-mining estimate into gross, and the current
+// XvB tier's published expected reward folds in when XvB sends a fresh one (#712); the heading and
+// the Net/day tooltip say exactly what's counted — including that XvB is an estimate — so the net
+// is never silently partial or over-confident. `est` is the earnings for the shared what-if
+// hashrate; the client does the kWh/cost/net math.
 function EnergyPanel({ energy, est }) {
   const en = computeEnergy(energy, est);
   const cur = energy.currency;
   const haveCost = energy.cost_per_kwh > 0;
   const haveNet = haveCost && energy.xmr_price > 0;
-  // Honest label (#520): say exactly what gross counts so the net figure is never silently
-  // partial. XvB never appears here — raffle status, not a clean per-day estimate.
-  const netLabel = en.includesTari ? "P2Pool + Tari, after power" : "P2Pool XMR only, after power";
-  const netTitle = en.includesTari
-    ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, minus power cost. Excludes XvB (raffle status, not a per-day income estimate)."
-    : "P2Pool XMR earnings at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it) and XvB (raffle status, not a per-day income estimate).";
+  // Honest label (#520, #712): say exactly what gross counts so the net figure is never silently
+  // partial. XvB is tagged "(est.)" — it's the current tier's published expected reward, and the
+  // raffle draw is probabilistic. When XvB isn't folded in, the strings are byte-identical to the
+  // pre-#712 label/tooltip.
+  const netLabel = en.includesXvb
+    ? en.includesTari
+      ? "P2Pool + Tari + XvB (est.), after power"
+      : "P2Pool + XvB (est.), after power"
+    : en.includesTari
+      ? "P2Pool + Tari, after power"
+      : "P2Pool XMR only, after power";
+  const netTitle = en.includesXvb
+    ? en.includesTari
+      ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, plus the current XvB tier's published expected reward valued at your XMR price, minus power cost. XvB is an estimate — the raffle draw is random among qualifiers."
+      : "P2Pool XMR earnings at your XMR price plus the current XvB tier's published expected reward valued at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it). XvB is an estimate — the raffle draw is random among qualifiers."
+    : en.includesTari
+      ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, minus power cost. Excludes XvB (raffle status, not a per-day income estimate)."
+      : "P2Pool XMR earnings at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it) and XvB (raffle status, not a per-day income estimate).";
   return html`
     <div class="stat-grid">
         <${StatCard} label="Fleet Power" value=${formatUnit(energy.total_watts, "W")}

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -239,6 +239,7 @@ export function computeEarnings(hashrateHs, earnings) {
       tariYear: null,
       tariTimeToBlockSec: null,
       tariRewardPerBlock: null,
+      xvbDay: null,
     };
   }
   const day = hashrateHs * earnings.coeff_day;
@@ -264,6 +265,9 @@ export function computeEarnings(hashrateHs, earnings) {
     tariYear: tariDay === null ? null : tariDay * DAYS_PER_YEAR,
     tariTimeToBlockSec,
     tariRewardPerBlock: earnings.tari_available ? earnings.tari_reward : null,
+    // Current-tier XvB expected reward, XMR/day (#712). A fixed published figure, NOT scaled by the
+    // what-if hashrate (unlike day/tariDay); null unless the server sent a fresh estimate.
+    xvbDay: Number.isFinite(earnings.xvb_day) ? earnings.xvb_day : null,
   };
 }
 
@@ -321,16 +325,20 @@ export function formatXtm(xtm) {
 // prices into kWh / cost / net over day·month·year for a what-if hashrate. Power draw is measured
 // (does NOT scale with the what-if hashrate — it's the real fleet), so only the earnings side
 // scales: net = gross − cost(kWh × cost_per_kwh), where
-//   gross = (what-if XMR/day × xmr_price) + (what-if Tari/day × tari_price, when priced).
+//   gross = (what-if XMR/day × xmr_price) + (what-if Tari/day × tari_price, when priced)
+//           + (current-tier XvB/day × xmr_price, when the server sent a fresh estimate).
 // `est` is the already-computed earnings for this what-if hashrate (computeEarnings; `est.tariDay`
 // is the same Tari/day estimate the Tari tab already shows — no separate estimate invented here).
-// XvB stays excluded from gross: it's a raffle status (xvbTierComparison), not a clean per-day
-// credited estimate — guessing one would fabricate a figure.
+// XvB (#712): `est.xvbDay` is the current tier's published expected reward (XMR/day), folded into
+// the single net — the whole net is already probabilistic, so one number stays coherent, and the
+// UI labels the XvB slice as an estimate (the raffle draw is random among qualifiers). It's a
+// fixed published figure, so it does NOT scale with the what-if hashrate; null (server-gated on a
+// fresh, non-stale estimate for a held donor tier) means it's simply left out — never fabricated.
 // Any figure whose inputs are missing comes back null so the card shows "—" rather than a bogus
 // number: cost needs cost_per_kwh > 0; net additionally needs xmr_price > 0 and a valid XMR
-// estimate — Tari only ever ADDS to that base (mirrors the existing xmr_price-gates-net contract,
-// #520 scope: no tari-price-only net). `includesTari` tells the UI which figure it got, so the
-// net-profit label is never silently partial (#520's honesty requirement).
+// estimate — Tari and XvB only ever ADD to that base (mirrors the existing xmr_price-gates-net
+// contract, #520 scope: no tari-price-only net). `includesTari` / `includesXvb` tell the UI which
+// figure it got, so the net-profit label is never silently partial (#520's honesty requirement).
 export function computeEnergy(energy, est) {
   const blank = {
     kwhDay: null,
@@ -343,6 +351,7 @@ export function computeEnergy(energy, est) {
     netMonth: null,
     netYear: null,
     includesTari: false,
+    includesXvb: false,
   };
   if (!energy || !energy.available || !(energy.total_watts > 0)) return blank;
   const kwhDay = (energy.total_watts / 1000) * 24;
@@ -354,8 +363,13 @@ export function computeEnergy(energy, est) {
   const haveXmr = Number.isFinite(xmrPrice) && xmrPrice > 0 && est && Number.isFinite(est.day);
   const includesTari =
     haveXmr && Number.isFinite(tariPrice) && tariPrice > 0 && Number.isFinite(est.tariDay);
+  // XvB (#712): the current tier's published expected reward (XMR/day), valued at the XMR price —
+  // an estimate blended into the single net, gated on a real XMR price like every other addend.
+  const includesXvb = haveXmr && Number.isFinite(est.xvbDay) && est.xvbDay > 0;
   const grossDay = haveXmr
-    ? est.day * xmrPrice + (includesTari ? est.tariDay * tariPrice : 0)
+    ? est.day * xmrPrice +
+      (includesTari ? est.tariDay * tariPrice : 0) +
+      (includesXvb ? est.xvbDay * xmrPrice : 0)
     : null;
   const netDay = grossDay !== null && costDay !== null ? grossDay - costDay : null;
   const span = (v, mult) => (v === null ? null : v * mult);
@@ -370,6 +384,7 @@ export function computeEnergy(energy, est) {
     netMonth: span(netDay, DAYS_PER_MONTH),
     netYear: span(netDay, DAYS_PER_YEAR),
     includesTari,
+    includesXvb,
   };
 }
 

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1351,7 +1351,43 @@ def _confirmed_payouts_summary(payouts, now=None, divisor=ATOMIC_PER_XMR, unit="
     }
 
 
-def build_earnings(data, metrics, payouts=None, tari_payouts=None):
+def xvb_current_tier_reward_day(metrics, state_mgr):
+    """XvB's published expected reward for the tier the fleet is CURRENTLY holding, as XMR/day (#712).
+
+    Feeds the net-profit calculator (``est.xvbDay``): the whole net is already probabilistic, so
+    blending the raffle's expected reward into the single figure is coherent — but it's an
+    *estimate* (the draw is random among qualifiers), so the UI labels it as one.
+
+    Uses the **current** tier (``min(xvb_1h, xvb_24h)`` — the same lower-of-two rule as
+    ``metrics.current_tier``), not the target: what the fleet is actually credited now. Returns
+    ``None`` — never a fabricated figure — unless XvB is on AND the fleet clears a donor tier AND
+    that tier has a fresh, published ``expected_reward_year`` (same staleness gate as the XvB card,
+    #311, so the two never disagree). ``expected_reward_year`` is keyed by round-type
+    (``donor``/``donor_vip``/…), exactly the ``get_tiers()`` keys."""
+    if not metrics.xvb_enabled:
+        return None
+    tiers = state_mgr.get_tiers()
+    # Round-type key of the current tier: the highest-threshold key the credited average clears —
+    # the same selection get_tier_info makes, but we need the key (not the display name) to look up
+    # the estimate. None => below the lowest donor tier (nothing published to credit).
+    hr = min(metrics.xvb_1h, metrics.xvb_24h)
+    key, best = None, 0.0
+    for k, threshold in tiers.items():
+        if threshold > 0 and hr >= threshold and threshold > best:
+            key, best = k, threshold
+    if key is None:
+        return None
+    est_state = state_mgr.get_xvb_reward_estimates()
+    estimates = (est_state or {}).get("estimates") or {}
+    if xvb_stats_are_stale(est_state) or key not in estimates:
+        return None
+    reward_year = estimates[key]
+    # 365-day year, matching logic.mjs DAYS_PER_YEAR. Guard non-positive so a zero/garbage estimate
+    # degrades to None rather than folding a bogus 0 into gross.
+    return float(reward_year) / 365 if reward_year and reward_year > 0 else None
+
+
+def build_earnings(data, metrics, payouts=None, tari_payouts=None, xvb_day=None):
     """Expected-XMR-from-P2Pool calculator inputs for the Advanced view (Issue #12).
 
     ``payouts`` (#381), when the view-only wallet feature is on, is the stored confirmed-payout
@@ -1403,6 +1439,9 @@ def build_earnings(data, metrics, payouts=None, tari_payouts=None):
         "tari_coeff_day": tari_coeff_day,  # XTM per H/s per day (long-run AVERAGE, not steady income)
         "tari_difficulty": tari_seconds_per_hs,  # seconds-to-block per H/s (client: diff / hashrate)
         "tari_reward": metrics.tari_reward,  # full XTM paid per Tari block (solo, lumpy)
+        # Current-tier XvB expected reward, XMR/day, folded into the net-profit estimate (#712).
+        # None unless XvB is on with a fresh published estimate for the tier the fleet holds now.
+        "xvb_day": xvb_day,
         "pool_difficulty": metrics.pool_difficulty,  # for expected time-to-share (diff/hr)
         "block_reward": f"{reward_atomic / 1e12:.4f} XMR",  # context, server-formatted like NetworkCard
         "disclaimer": _EARNINGS_DISCLAIMER,
@@ -1661,6 +1700,7 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
             tari_payouts=(
                 state_mgr.get_payouts("tari") if config.TARI_PAYOUT_CONFIRM_ENABLED else None
             ),
+            xvb_day=xvb_current_tier_reward_day(metrics, state_mgr),
         ),
         "xvb_calc": build_xvb_calc(metrics, state_mgr),
         "tari": build_tari(data),

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -320,6 +320,40 @@ test('EarningsCard Energy tab keeps the P2Pool-only label when tari_price is set
     assert.doesNotMatch(html, /P2Pool \+ Tari, after power/);
 });
 
+test('EarningsCard Energy tab folds the current-tier XvB estimate into net, labelled an estimate (#712)', () => {
+    const s = clone();
+    s.earnings.available = true;
+    s.earnings.coeff_day = 1e-8;
+    s.earnings.xvb_day = 0.02; // server-derived current-tier expected reward, XMR/day
+    s.energy.cost_per_kwh = 0.2;
+    s.energy.xmr_price = 150;
+    const html = renderApp({ state: s });
+    assert.match(html, /Net \/ day/);
+    assert.match(html, /P2Pool \+ XvB \(est\.\), after power/);
+    // Tooltip drops the "Excludes XvB" clause and states it's an estimate.
+    assert.match(html, /XvB is an estimate/);
+    assert.doesNotMatch(html, /Excludes XvB/);
+    assert.doesNotMatch(html, /P2Pool XMR only, after power/);
+});
+
+test('EarningsCard Energy tab: net label/tooltip byte-identical to pre-#712 when no XvB estimate', () => {
+    const s = clone();
+    s.earnings.available = true;
+    s.earnings.coeff_day = 1e-8;
+    s.earnings.xvb_day = null; // no fresh estimate → XvB not folded in
+    s.energy.cost_per_kwh = 0.2;
+    s.energy.xmr_price = 150;
+    const html = renderApp({ state: s });
+    assert.match(html, /P2Pool XMR only, after power/);
+    // The exact pre-#712 tooltip, XvB still called out as excluded.
+    assert.match(
+        html,
+        /Excludes Tari \(set dashboard\.energy\.tari_price to include it\) and XvB \(raffle status, not a per-day income estimate\)\./,
+    );
+    assert.doesNotMatch(html, /XvB \(est\.\)/);
+    assert.doesNotMatch(html, /XvB is an estimate/);
+});
+
 test('EarningsCard grows fiat rows + a price provenance line once a price is known (#520)', () => {
     const s = clone();
     s.earnings.available = true;

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -239,7 +239,7 @@ test('computeEarnings: returns nulls when unavailable or hashrate is non-positiv
     const ok = { available: true, coeff_day: 1e-7, pool_difficulty: 1 };
     const allNull = { day: null, month: null, year: null, timeToShareSec: null,
                       tariDay: null, tariMonth: null, tariYear: null,
-                      tariTimeToBlockSec: null, tariRewardPerBlock: null };
+                      tariTimeToBlockSec: null, tariRewardPerBlock: null, xvbDay: null };
     assert.deepEqual(computeEarnings(0, ok), allNull);
     assert.deepEqual(computeEarnings(null, ok), allNull);
     // available:false (network stats missing) -> graceful "—" path even with a valid hashrate.
@@ -624,6 +624,47 @@ test('computeEnergy: tari_price set but Tari not merge-mining (tariDay null) -> 
     );
     assert.ok(Math.abs(en.netDay - 10.2) < 1e-9); // same as P2Pool-only case above
     assert.equal(en.includesTari, false);
+});
+
+// --- XvB folded into net profit (#712) ---------------------------------------------------
+
+test('computeEnergy: xvbDay grows net by xvbDay*xmr_price and sets includesXvb', () => {
+    const base = computeEnergy(
+        { available: true, total_watts: 1000, cost_per_kwh: 0.2, xmr_price: 150 },
+        { day: 0.1 },
+    );
+    const en = computeEnergy(
+        { available: true, total_watts: 1000, cost_per_kwh: 0.2, xmr_price: 150 },
+        { day: 0.1, xvbDay: 0.02 }, // current-tier XvB expected reward, XMR/day
+    );
+    // gross adds 0.02*150 = 3 on top of the P2Pool-only net.
+    assert.ok(Math.abs(en.netDay - (base.netDay + 3)) < 1e-9);
+    assert.equal(en.includesXvb, true);
+    assert.equal(en.includesTari, false);
+});
+
+test('computeEnergy: null/zero xvbDay leaves net + includesXvb untouched (no fabrication)', () => {
+    const base = computeEnergy(
+        { available: true, total_watts: 1000, cost_per_kwh: 0.2, xmr_price: 150 },
+        { day: 0.1 },
+    );
+    for (const xvbDay of [null, undefined, 0]) {
+        const en = computeEnergy(
+            { available: true, total_watts: 1000, cost_per_kwh: 0.2, xmr_price: 150 },
+            { day: 0.1, xvbDay },
+        );
+        assert.ok(Math.abs(en.netDay - base.netDay) < 1e-9);
+        assert.equal(en.includesXvb, false);
+    }
+});
+
+test('computeEnergy: xvbDay set but xmr_price 0 -> not included (XvB valued at XMR price)', () => {
+    const en = computeEnergy(
+        { available: true, total_watts: 1000, cost_per_kwh: 0.2, xmr_price: 0 },
+        { day: 0.1, xvbDay: 0.02 },
+    );
+    assert.equal(en.netDay, null);        // no xmr_price -> no net at all
+    assert.equal(en.includesXvb, false);  // never fabricate a figure without a price
 });
 
 test('formatFiat: currency label, two decimals, keeps the sign', () => {

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -53,6 +53,7 @@ from mining_dashboard.web.views import (
     recent_wallet_change,
     rigforge_update_for,
     visible_update,
+    xvb_current_tier_reward_day,
 )
 
 # --- Metrics fixtures for the presentation builders -----------------------------------
@@ -1741,6 +1742,43 @@ class TestXvbCalc:
         assert out["estimates_available"] is False
         assert out["estimates_stale"] is False
         assert all(t["expected_reward_year"] is None for t in out["tiers"])
+
+    # --- current-tier reward folded into net profit (#712) ---------------------------
+
+    def test_reward_day_is_current_tier_estimate_over_365(self):
+        # Base metrics credit min(xvb_1h=2100, xvb_24h=2300)=2100 → the donor tier (>=1000, <10k);
+        # its published 0.06 XMR/year becomes 0.06/365 XMR/day. The estimate feeds est.xvbDay.
+        out = xvb_current_tier_reward_day(_metrics(), self._sm())
+        assert out == pytest.approx(0.06 / 365)
+
+    def test_reward_day_uses_lower_of_1h_24h_not_the_higher(self):
+        # The current tier is the LOWER of the two credited averages (not target): a 1h dip to the
+        # donor tier holds there even while 24h still clears whale — the honest "what you hold now".
+        out = xvb_current_tier_reward_day(_metrics(xvb_1h=2100, xvb_24h=200_000), self._sm())
+        assert out == pytest.approx(0.06 / 365)  # donor, not whale (6.17)
+
+    def test_reward_day_maps_higher_tier_to_its_own_estimate(self):
+        # min(150k, 200k)=150k clears donor_whale (100k) → its 6.17/year, proving the tier→key→
+        # estimate mapping picks the right round-type, not always the lowest.
+        out = xvb_current_tier_reward_day(_metrics(xvb_1h=150_000, xvb_24h=200_000), self._sm())
+        assert out == pytest.approx(6.17 / 365)
+
+    def test_reward_day_none_when_xvb_disabled(self):
+        assert xvb_current_tier_reward_day(_metrics(xvb_enabled=False), self._sm()) is None
+
+    def test_reward_day_none_below_lowest_donor_tier(self):
+        # min(500, 800)=500 < the 1000 donor threshold → "None" tier, nothing published to credit.
+        assert xvb_current_tier_reward_day(_metrics(xvb_1h=500, xvb_24h=800), self._sm()) is None
+
+    def test_reward_day_none_when_estimate_stale(self):
+        # Same staleness gate as the XvB card (#311): never surface a frozen number implied fresh.
+        sm = self._sm(last_update=time.time() - XVB_STATS_STALE_AFTER_S - 1)
+        assert xvb_current_tier_reward_day(_metrics(), sm) is None
+
+    def test_reward_day_none_when_estimate_absent(self):
+        # Held a tier, but XvB never published a figure for it → None, never a fabricated 0.
+        sm = self._sm(estimates={"donor_vip": 0.81}, last_update=time.time())
+        assert xvb_current_tier_reward_day(_metrics(), sm) is None
 
 
 # --- build_state integration ----------------------------------------------------------

--- a/build/monero/wallet-entrypoint.sh
+++ b/build/monero/wallet-entrypoint.sh
@@ -2,7 +2,7 @@
 # View-only payout-confirmation wallet (#381).
 #
 # Runs monero-wallet-rpc against the LOCAL monerod, scan-only: the wallet is generated from the
-# operator's PRIVATE VIEW KEY with an empty spend key, so it can see incoming payouts but CANNOT
+# operator's PRIVATE VIEW KEY with NO spend key, so it can see incoming payouts but CANNOT
 # spend. The view key is written to a JSON file on tmpfs and handed to --generate-from-json — it is
 # NEVER put on the command line, where `docker inspect` / `ps` would expose it (#90 discipline,
 # same as monerod's RPC creds). First run creates the wallet from keys at PAYOUT_SCAN_HEIGHT; later
@@ -27,6 +27,28 @@ resolve_scan_height() {
         ;;
     *) printf '%s\n' "$want" ;;
     esac
+}
+
+# Write the create-from-keys JSON for a VIEW-ONLY wallet ($1 = restore height). The spend key is
+# DELIBERATELY OMITTED, never set to "": monero-wallet-rpc (v0.18) parses an empty-string spendkey
+# as a secret key and aborts creation ("failed to parse spend key secret key"), so an empty value
+# breaks the wallet outright. An absent spendkey IS the view-only form — exactly what a payout-
+# confirmation wallet needs (#714). umask 077 so the file (it holds the view key) is owner-only.
+write_gen_json() {
+    local height="$1"
+    (
+        umask 077
+        cat >"$GEN_JSON" <<EOF
+{
+  "version": 1,
+  "filename": "$WALLET_FILE",
+  "scan_from_height": $height,
+  "password": "",
+  "address": "${MONERO_WALLET_ADDRESS:-}",
+  "viewkey": "${MONERO_VIEW_KEY:-}"
+}
+EOF
+    )
 }
 
 # When sourced by the shell test harness, expose the functions and stop — don't render or exec.
@@ -55,21 +77,8 @@ if [ ! -f "$WALLET_FILE" ]; then
     height="$(resolve_scan_height)"
     [ -n "$height" ] || height=0
     echo "Creating view-only payout wallet at restore height $height (#381)..."
-    # The view key lives ONLY in this tmpfs file, never on argv. umask 077 so it's owner-only.
-    (
-        umask 077
-        cat >"$GEN_JSON" <<EOF
-{
-  "version": 1,
-  "filename": "$WALLET_FILE",
-  "scan_from_height": $height,
-  "password": "",
-  "address": "${MONERO_WALLET_ADDRESS:-}",
-  "viewkey": "${MONERO_VIEW_KEY:-}",
-  "spendkey": ""
-}
-EOF
-    )
+    # The view key lives ONLY in this tmpfs file, never on argv.
+    write_gen_json "$height"
     # --generate-from-json creates + opens the wallet, then keeps serving the RPC.
     exec monero-wallet-rpc "$@" --generate-from-json "$GEN_JSON"
 fi

--- a/build/monero/wallet-entrypoint.sh
+++ b/build/monero/wallet-entrypoint.sh
@@ -14,17 +14,16 @@ WALLET_FILE="$WALLET_DIR/payout-wallet"
 GEN_JSON="${GEN_JSON:-/tmp/gen.json}" # tmpfs; holds the view key for the create-from-keys step only
 DAEMON_ADDRESS="${MONERO_NODE_HOST:-127.0.0.1}:${MONERO_RPC_PORT:-18081}"
 
-# Resolve the restore height: an explicit number is used verbatim; "auto"/empty means "start at the
-# daemon's current height" (fetched via get_info) so a fresh wallet doesn't rescan years of chain
-# for payout history that predates the feature. A pruned node scans fine — outputs are never pruned.
+# Resolve the restore height: an explicit number is used verbatim; "auto"/empty means genesis (0),
+# scanning the whole chain so the wallet captures the FULL payout history — every p2pool payout this
+# address ever received, not just those after the wallet was set up. The initial scan is long (years
+# of blocks) but one-time: the wallet file persists its progress, so reopens only scan new blocks. A
+# pruned node scans fine — outputs are never pruned. Set PAYOUT_SCAN_HEIGHT to a block number to
+# start later and skip the long scan.
 resolve_scan_height() {
     local want="${PAYOUT_SCAN_HEIGHT:-auto}"
     case "$want" in
-    '' | auto)
-        curl -fsS --digest -u "${MONERO_NODE_USERNAME:-}:${MONERO_NODE_PASSWORD:-}" \
-            "http://$DAEMON_ADDRESS/get_info" 2>/dev/null |
-            grep -o '"height": *[0-9]*' | grep -o '[0-9]*' | head -1
-        ;;
+    '' | auto) printf '0\n' ;;
     *) printf '%s\n' "$want" ;;
     esac
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,10 +137,12 @@ services:
     image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-monero:${STACK_VERSION:-dev}
     build: ./build/monero
     container_name: wallet-rpc
-    # Memory ceiling (#132 — see monerod). A view-only scanner is light (~0.1 GiB observed); a tight
-    # cap OOM-restarts it on a regression without touching the revenue services.
-    mem_limit: 512m
-    memswap_limit: 512m
+    # Memory ceiling (#132 — see monerod). Steady-state a view-only scanner is light (~0.1 GiB), but
+    # the one-time genesis scan (the payout_scan_height: auto default — full payout history) peaks
+    # well above 0.5 GiB and OOM-loops under a 512m cap. 2 GiB gives that scan headroom; it's a
+    # ceiling not a reservation, so idle use stays low. memswap == mem => zero swap, clean OOM-kill.
+    mem_limit: 2g
+    memswap_limit: 2g
     restart: unless-stopped
     logging: *default-logging
     # Distinct entrypoint on the shared image: creates the view-only wallet from keys on first run,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -413,7 +413,7 @@ extrapolation of the current draw). Three prices add the rest, and each is optio
 | Config | Adds |
 |---|---|
 | `dashboard.energy.cost_per_kwh` | **Power cost** per day/month/year (`kWh × price`). |
-| `dashboard.energy.xmr_price`    | **Net profit** per day/month/year, P2Pool XMR earnings × your XMR price, minus power cost. |
+| `dashboard.energy.xmr_price`    | **Net profit** per day/month/year, P2Pool XMR earnings × your XMR price, minus power cost. Also values the current-tier XvB expected reward (an estimate) into that net when XvB has a fresh figure. |
 | `dashboard.energy.tari_price`   | Folds Tari merge-mining earnings into that same net profit, at your Tari price. Requires `xmr_price` to be set too. |
 
 All three are in your `dashboard.energy.currency` label (e.g. `USD`, `EUR`) — a label only, no
@@ -423,11 +423,15 @@ what-if hashrate as the other tabs (power draw does not — it is the measured f
 when power costs more than it earns.
 
 Net profit counts **P2Pool XMR**, plus **Tari** merge-mining earnings once a Tari price is also
-known (Tari's contribution uses the same what-if Tari/day estimate the Tari tab already shows).
-With no Tari price, net profit is P2Pool XMR only — the card's heading and the Net/day tooltip say
-exactly which figure you're looking at, so it's never silently partial. **XvB stays excluded**
-either way: it's raffle status, not a clean per-day income estimate, so folding it in would mean
-guessing.
+known (Tari's contribution uses the same what-if Tari/day estimate the Tari tab already shows), plus
+the **XvB** raffle's expected reward for the tier you currently hold, valued at your XMR price. The
+whole net is already probabilistic, so it stays one figure — but the XvB slice is an **estimate**:
+it is XvB's published expected reward for your current tier (the lower of your credited 1h and 24h
+averages), and the raffle draw is random among qualifiers, so it is not a payout you are owed. The
+card's heading and the Net/day tooltip label it `XvB (est.)` and say exactly what the figure counts,
+so it is never silently partial. XvB folds in only while its published estimate is fresh (the same
+staleness rule as the *XvB Donation Stats* card) and you clear a donor tier; otherwise it is left
+out rather than guessed, and the label reverts to P2Pool (and Tari, if priced) alone.
 
 Prices come from one of two places, and the card always says which:
 

--- a/pithead
+++ b/pithead
@@ -2961,6 +2961,17 @@ readonly CONTROL_SECRET_PATHS='[
     ["p2pool","stratum_password"],
     ["healthchecks","ping_url"]]'
 
+# #690: bound every host-runner curl so a hostile/MITM'd rig or release response can't stream an
+# unbounded body into memory ($( )) or onto disk (-o) inside the --max-time window. --max-filesize
+# aborts BOTH before the transfer (when Content-Length is honest) AND mid-stream once received
+# bytes cross the cap (verified curl 8.7 → exit 63), so a lying or absent Content-Length is covered
+# too — every runner curl already treats a non-zero exit as failure and cleans its partial file.
+# Two envelopes: JSON dials + the cosign sig are tiny; the release BUNDLE is a whole-stack tarball.
+readonly CURL_CAP_SMALL=1048576 # 1 MiB — GitHub release JSON, rig control responses, cosign sig
+# ponytail: 16 MiB, ~128× today's ~126 KB bundle; bump if a real bundle ever approaches it (a
+# cap-hit surfaces as _upg_fail's "could not download over Tor", loud but network-flavoured).
+readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle (code + configs)
+
 # Render the pre-masked prefill copy (#440): the live config with every SET secret leaf replaced
 # by the {"__secret__":true} sentinel, written atomically to <control-dir>/masked/config.json.
 # The dashboard serves the Configuration form from THIS file (mounted read-only) — the raw
@@ -5333,7 +5344,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
     [ -n "$prefix" ] || prefix="172.28.0"
     socks="${prefix}.25:9050"
-    if ! rel=$(curl -fsS --max-time 60 --socks5-hostname "$socks" \
+    if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
         -H 'Accept: application/vnd.github+json' \
         "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null); then
         _upg_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
@@ -5362,7 +5373,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
     # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.
     local bundle="$cdir/staged/.$id.tar.gz" logf="$cdir/staged/.$id.log"
-    if ! curl -fsSL --max-time 900 --socks5-hostname "$socks" -o "$bundle" \
+    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$socks" -o "$bundle" \
         "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz" 2>/dev/null; then
         rm -f "$bundle"
         _upg_fail "could not download the $tag release bundle over Tor — the stack keeps running v$PITHEAD_VERSION."
@@ -5375,7 +5386,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # TLS to GitHub plus tag pinning — with one loud line in the journal.
     if [ -f cosign.pub ]; then
         local sig="$cdir/staged/.$id.tar.gz.sig"
-        if ! curl -fsSL --max-time 120 --socks5-hostname "$socks" -o "$sig" \
+        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" -o "$sig" \
             "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz.sig" 2>/dev/null; then
             rm -f "$bundle" "$sig"
             _upg_fail "the $tag release carries no bundle signature (pithead.tar.gz.sig) — refusing to install it unverified (#376); the stack keeps running v$PITHEAD_VERSION."
@@ -5693,7 +5704,7 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
     # is an operator-set host on the mining LAN, not clearnet. The token rides one header, never the
     # URL, the result, or the audit log.
     local url="http://$host:$cport/apply" bodyf="$cdir/staged/.$id.body" code
-    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 \
+    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 --max-filesize "$CURL_CAP_SMALL" \
         -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
         --data "$changes" "$url" 2>/dev/null); then
         rm -f "$bodyf"
@@ -5720,7 +5731,7 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 2
         sbody="$cdir/staged/.$id.status"
-        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 \
+        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 --max-filesize "$CURL_CAP_SMALL" \
             -H "Authorization: Bearer $token" "http://$host:$cport/status" 2>/dev/null); then
             rm -f "$sbody"
             continue
@@ -5837,7 +5848,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
         prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
         [ -n "$prefix" ] || prefix="172.28.0"
         socks="${prefix}.25:9050"
-        if ! rel=$(curl -fsS --max-time 60 --socks5-hostname "$socks" \
+        if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
             -H 'Accept: application/vnd.github+json' \
             "https://api.github.com/repos/p2pool-starter-stack/rigforge/releases/latest" 2>/dev/null); then
             _wu_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
@@ -5858,7 +5869,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
     # POST the upgrade to the rig's control API — direct LAN dial like worker-apply, NOT Tor. The
     # body carries the HOST-derived tag only; the token rides one header, never the URL or result.
     local url="http://$host:$cport/upgrade" bodyf="$cdir/staged/.$id.body" code
-    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 \
+    if ! code=$(curl -sS -o "$bodyf" -w '%{http_code}' --max-time 15 --max-filesize "$CURL_CAP_SMALL" \
         -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
         --data "$(jq -n --arg v "$tag" '{version:$v}')" "$url" 2>/dev/null); then
         rm -f "$bodyf"
@@ -5890,7 +5901,7 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 5
         sbody="$cdir/staged/.$id.status"
-        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 \
+        if ! scode=$(curl -sS -o "$sbody" -w '%{http_code}' --max-time 10 --max-filesize "$CURL_CAP_SMALL" \
             -H "Authorization: Bearer $token" "http://$host:$cport/status" 2>/dev/null); then
             rm -f "$sbody"
             continue

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -478,6 +478,25 @@ wait_monero_synced() { wait_for "${1:-300}" 10 "Monero sync complete" _pred_mone
 wait_miner_running() { wait_for "${1:-180}" 5 "miner released" _pred_miner_running; }
 wait_tari_synced() { wait_for "${1:-300}" 10 "Tari sync complete" _pred_tari_synced; }
 wait_pool_ready() { wait_for "${1:-180}" 5 "pool type determinate (${2})" _pred_pool_ready "$2"; }
+# Assert a pool switch settled, WITHOUT flaking red on peer luck (#687). p2pool infers its sidechain
+# from connected peers' ports, so a freshly-switched chain (nano over Tor is the slowest to populate)
+# can read "Unknown" past the wait window. A bare assert_eq after `wait_pool_ready … || true` then
+# fires cold and fails on a timing state, not a bug. Three-way verdict, same as assert_scenario's
+# #454 handling: determinate match → pass; still Unknown/empty → peer-timing WARN; a WRONG determinate
+# type (Main when we set Mini) → fail. The 420s window is Tor-realistic; the wait polls, so a fast
+# bench that classifies in seconds pays nothing.
+assert_pool_switched() { # <label> <expected-pool-label>
+    wait_pool_ready 420 "$2" || true
+    local got
+    got="$(jq_get "$(api_state)" '.pool.type')"
+    if [ "$got" = "$2" ]; then
+        it_pass "$1 ($got)"
+    elif [ "$got" = "Unknown" ] || [ -z "$got" ]; then
+        it_warn "$1 — pool still Unknown for [$2] after 420s; peers not classified in time (nano/Tor is slow to populate), not a misclassification (#687)"
+    else
+        it_fail "$1" "got [$got], want [$2] — wrong sidechain, not a timing lag"
+    fi
+}
 wait_hashes_flowing() { wait_for "${1:-300}" 5 "stratum hashes flowing" _pred_hashes_flowing; }
 
 # --- Artifact capture -------------------------------------------------------

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1004,9 +1004,9 @@ run_lifecycle() {
             "$(rx "stat -c %u $(quote_arg "$own_probe") 2>/dev/null")" "1000"
         rx "sudo rm -f $(quote_arg "$own_probe")" >/dev/null 2>&1 || true
     fi
-    # .pool.type lags a sidechain switch until peers on the new chain connect — wait, don't assert cold (#54).
-    wait_pool_ready 180 "$(pool_label "$other")" || true
-    assert_eq "pool actually changed" "$(jq_get "$(api_state)" '.pool.type')" "$(pool_label "$other")"
+    # .pool.type lags a sidechain switch until peers on the new chain connect — wait + three-way
+    # verdict, don't assert cold on a peer-timing state (#54, #687).
+    assert_pool_switched "pool actually changed" "$(pool_label "$other")"
 
     # Node-down failover (#31): stop monerod -> status non-zero (node down), dashboard rejects
     # workers (xmrig-proxy stopped) -> start monerod -> readmitted -> status 0 again.
@@ -1044,9 +1044,9 @@ run_lifecycle() {
             pithead restore -y "$arch" >/dev/null 2>&1
             pithead up >/dev/null 2>&1
             wait_status_ok 240 || true
-            # pool.type lags peer reconnect after restore+up — wait for classification before asserting (#54).
-            wait_pool_ready 180 "$backed_pool" || true
-            assert_eq "restore reverts the pool to the backed-up value" "$(jq_get "$(api_state)" '.pool.type')" "$backed_pool"
+            # pool.type lags peer reconnect after restore+up — wait + three-way verdict, don't assert
+            # cold on a peer-timing state (#54, #687).
+            assert_pool_switched "restore reverts the pool to the backed-up value" "$backed_pool"
             assert_eq "restore preserves secrets" "$(secret_fingerprint)" "$fp_b"
             rx "rm -f $(quote_arg "$arch")" >/dev/null 2>&1 || true
         else

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1094,6 +1094,16 @@ assert_eq "wallet gen.json carries the view key (#381)" "$(printf '%s' "$WGEN" |
 assert_eq "wallet gen.json scan_from_height verbatim (#381)" "$(printf '%s' "$WGEN" | jq -r .scan_from_height)" "3000000"
 # THE REGRESSION GUARD: a revert to "spendkey":"" crashes monero-wallet-rpc (#714). Field must be absent.
 assert_eq "wallet gen.json OMITS spendkey — monero rejects an empty one (#714)" "$(printf '%s' "$WGEN" | jq 'has("spendkey")')" "false"
+# Restore height: "auto"/empty means genesis (0) so the wallet scans the FULL payout history; an
+# explicit height is used verbatim to skip the long scan.
+rsh() { (
+    export PITHEAD_TEST_SOURCE=1 PAYOUT_SCAN_HEIGHT="$1"
+    source "$ROOT/build/monero/wallet-entrypoint.sh"
+    resolve_scan_height
+); }
+assert_eq "scan height: auto -> genesis 0 (full payout history)" "$(rsh auto)" "0"
+assert_eq "scan height: empty -> genesis 0" "$(rsh '')" "0"
+assert_eq "scan height: explicit block kept verbatim" "$(rsh 2500000)" "2500000"
 
 echo "== unit: clock_sync_status (mining is time-sensitive) =="
 # doctor's NTP check classifies timedatectl's NTPSynchronized: yes→synced, no→unsynced, else unknown.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1074,6 +1074,27 @@ assert_contains "tari entrypoint never mutates the canonical config (#234)" "$(c
 assert_contains "compose mounts clearnet-state into monerod (#234)" "$(cat "$ROOT/docker-compose.yml")" ':/clearnet-state:ro'
 assert_contains "compose wires the tari wrapper entrypoint (#234)" "$(cat "$ROOT/docker-compose.yml")" '/var/tari/config/entrypoint.sh'
 
+# --- Wallet entrypoint (#381/#714): the view-only create-from-keys JSON must OMIT the spend key.
+# monero-wallet-rpc v0.18 parses an empty-string "spendkey":"" as a secret key and aborts wallet
+# creation ("failed to parse spend key secret key"), so the field's ABSENCE — not "" — is what
+# lets the payout wallet build. This exercises the REAL entrypoint's write_gen_json.
+echo "== unit: wallet-entrypoint view-only gen.json omits spendkey (#714) =="
+# shellcheck disable=SC1090
+(
+    export PITHEAD_TEST_SOURCE=1
+    source "$ROOT/build/monero/wallet-entrypoint.sh"
+    export GEN_JSON="$SANDBOX/wallet-gen.json" WALLET_FILE="$SANDBOX/payout-wallet"
+    export MONERO_WALLET_ADDRESS="48exampleAddr" MONERO_VIEW_KEY="deadbeefdeadbeef"
+    write_gen_json 3000000
+)
+WGEN="$(cat "$SANDBOX/wallet-gen.json")"
+if printf '%s' "$WGEN" | jq -e . >/dev/null 2>&1; then ok "wallet gen.json is valid JSON (#714)"; else bad "wallet gen.json is valid JSON (#714)" "jq rejected: $WGEN"; fi
+assert_eq "wallet gen.json carries the address (#381)" "$(printf '%s' "$WGEN" | jq -r .address)" "48exampleAddr"
+assert_eq "wallet gen.json carries the view key (#381)" "$(printf '%s' "$WGEN" | jq -r .viewkey)" "deadbeefdeadbeef"
+assert_eq "wallet gen.json scan_from_height verbatim (#381)" "$(printf '%s' "$WGEN" | jq -r .scan_from_height)" "3000000"
+# THE REGRESSION GUARD: a revert to "spendkey":"" crashes monero-wallet-rpc (#714). Field must be absent.
+assert_eq "wallet gen.json OMITS spendkey — monero rejects an empty one (#714)" "$(printf '%s' "$WGEN" | jq 'has("spendkey")')" "false"
+
 echo "== unit: clock_sync_status (mining is time-sensitive) =="
 # doctor's NTP check classifies timedatectl's NTPSynchronized: yes→synced, no→unsynced, else unknown.
 CLKBIN="$SANDBOX/clk-bin"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6187,6 +6187,7 @@ wu_accept_case() { # <uuid> <status-body-json> <label> <expected-status>
     printf '%s' "v9.9.9" >"$dir/staged/.rigforge-latest-tag"
     cat >"$dir/bin/curl" <<EOF
 #!/usr/bin/env bash
+echo "\$*" >>"$dir/dials.log"
 out="" url=""
 while [ \$# -gt 0 ]; do
     case "\$1" in
@@ -6215,6 +6216,11 @@ assert_eq "applied result records the rig's change_id" \
     "$(jq -r '.change_id' "$WU_LAST_DIR/results/$w7.json" 2>/dev/null)" "chg-9"
 assert_eq "applied result records the host-derived version" \
     "$(jq -r '.version' "$WU_LAST_DIR/results/$w7.json" 2>/dev/null)" "v9.9.9"
+# #690: every runner dial (the rig POST + each /status poll) carries a response-size cap so a
+# hostile rig can't stream an unbounded body into disk/memory. Proves the flag is wired, not curl's
+# own enforcement (that needs a real curl against an oversized server — an e2e concern).
+assert_contains "worker-upgrade rig dials carry a --max-filesize cap (#690)" \
+    "$(cat "$WU_LAST_DIR/dials.log" 2>/dev/null)" "--max-filesize"
 assert_contains "upgrade applied is audited" \
     "$(cat "$WU_LAST_DIR/audit/control.log")" '"action":"worker-upgrade","status":"applied"'
 w8="23232323-2323-4232-9232-232323232323"


### PR DESCRIPTION
Bundles the v1.10.1 follow-up work for the shipped v1.10.0 milestone, to collapse into `develop` in one merge after v1.10.0 releases.

Fixes #690, #687, #714. Closes #712.

## Contents

The two fixes were reviewed and CI-green as standalone PRs; this branch merges them (`--no-ff`, disjoint files, no conflicts) so they test and land together. #712 (dashboard feature) and #714 (bug fix) were added directly on the branch.

- **#690 — bound host-runner curl response sizes** (was #704). `--max-filesize` on all eight control-channel runner curls (`control_upgrade`, `control_worker_apply`, `control_worker_upgrade`), 1 MiB for JSON/sig/rig responses, 16 MiB for the release bundle. Verified on curl 8.7 that the flag caps both before download (honest Content-Length) and mid-stream (chunked, no length), so a hostile/MITM'd rig or release response can't stream an unbounded body into memory or disk. Closes the LOW residual from #597's security review.
- **#687 — don't cold-assert an unclassified pool switch** (was #705). New `assert_pool_switched` helper mirroring the apply-path's #454 three-way verdict (match → pass, Unknown → peer-timing warn, wrong type → fail), replacing bare `assert_eq` at the two lifecycle sites; window raised to a Tor-realistic 420s. Stops the e2e lifecycle leg flaking red when a fresh sidechain hasn't found peers in time.
- **#712 — fold the current-tier XvB expected reward into net profit.** The Energy tab's net figure now adds the XvB raffle's published expected reward for the tier the fleet currently holds (the lower of the credited 1h/24h averages), valued at the operator's XMR price, on top of P2Pool and Tari. The net is already probabilistic so it stays one number, but the XvB slice is labelled `(est.)` in the heading and Net/day tooltip because the draw is random among qualifiers. Server-side (`views.py`) maps the current tier → round-type key → `expected_reward_year / 365`, gated on XvB enabled, a cleared donor tier, and a fresh (non-stale) estimate — the same staleness rule as the XvB card; `null`/left-out otherwise, never fabricated. The label/tooltip are byte-identical to before when XvB isn't folded in.
- **#714 — view-only payout wallet builds again.** `wallet-rpc` (the payout-confirmation wallet started by `monero.view_key`) crash-looped on first run: its create-from-keys JSON set an empty `"spendkey": ""`, which monero-wallet-rpc v0.18 parses as a secret key and rejects ("failed to parse spend key secret key"). Broke for anyone who set a view key — the key itself was fine. The JSON generation is extracted into `write_gen_json()` and the spendkey field is omitted (the view-only form). A tier-1 stack test sources the real entrypoint and asserts the JSON is valid with no `spendkey` key; a revert to the empty string fails it. Verified live on gouda (pre-seeded the wallet the correct way; it now opens + scans healthy).

## Verification

- #690 + #687 combined diff vs develop: +50 / −14 across `pithead`, `tests/stack/run.sh`, `tests/integration/lib.sh`, `tests/integration/run.sh`; that diff is identical to the union of #704 + #705, both of which already passed CI (15/15 and 16/16).
- #712: `make lint` (ruff + biome + shfmt + docs-voice) clean; dashboard suite **1469 passed** at 96.66% total coverage, frontend node tests green, patch coverage **100%** on the changed Python.
- #687 is e2e-harness code — the stack suite proves nothing else regressed, but the pool-switch behavior itself is validated on the next `e2e.sh --mode targeted` run against a borrowed rig.

