### PR TITLE
feat(#196): expose blocks/disk_growth/xvb_history on /api/state (Tier-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Pithead ships as **one product, one version** — the version lives in the top-l
 [`VERSION`](VERSION) file and every released image is tagged with it. Releases are cut
 per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
+## [Unreleased]
+
+### Added
+
+- **`/api/state` exposure for three of the #196 telemetry-backbone series (Tier-1).** The backbone
+  PR (#600) added five persisted SQLite tables with capture, storage, and retention, but shipped
+  without surfacing them to the client. This slice exposes three — `blocks` (pool block-found
+  events), `disk_growth` (hourly monerod-DB-size + host-disk-usage samples), and `xvb_history`
+  (~5-min XvB-credited scalar samples) — as range-filtered arrays under those same keys, bounded
+  at the existing 700-point chart cap for the two higher-cadence series. `network_history` and
+  `worker_history` are a separate (Tier-2) slice, not touched here. No chart renders any of these
+  series yet — that's a further follow-up.
+
 ## [1.10.0] - 2026-07-20
 
 ### Added

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -379,44 +379,31 @@ def build_blocks(blocks, range_arg, window=None):
     ]
 
 
+def _gauge_series(rows, range_arg, window, value_cols):
+    """Shared shape for a persisted gauge series (#196): filter to the selected range/window,
+    bucket-average past ``_MAX_CHART_POINTS`` like ``share_stats``, and key each row's own
+    ``value_cols`` under ``x`` (ms epoch). ``build_disk_growth``/``build_xvb_history`` are this
+    with their own column set — the only thing that differs between them."""
+    filtered = _downsample_gauge_rows(_filter_events(rows, range_arg, window), value_cols)
+    return [{"x": int(r["ts"] * 1000), **{c: r.get(c, 0) for c in value_cols}} for r in filtered]
+
+
 def build_disk_growth(rows, range_arg, window=None):
-    """Persisted hourly monerod-DB-size + host-disk-usage samples (#196) as chart-ready points,
-    restricted to the selected range/window and bounded at ``_MAX_CHART_POINTS`` like
-    ``share_stats`` — the table keeps every row (no retention prune), so a long-lived install can
-    otherwise pass the cap."""
-    filtered = _downsample_gauge_rows(
-        _filter_events(rows, range_arg, window),
-        ("monero_db_bytes", "disk_used_gb", "disk_total_gb"),
+    """Persisted hourly monerod-DB-size + host-disk-usage samples (#196) as chart-ready points —
+    the table keeps every row (no retention prune), so a long-lived install can otherwise pass
+    the chart-point cap ``_gauge_series`` bounds it at."""
+    return _gauge_series(
+        rows, range_arg, window, ("monero_db_bytes", "disk_used_gb", "disk_total_gb")
     )
-    return [
-        {
-            "x": int(r["ts"] * 1000),
-            "monero_db_bytes": r.get("monero_db_bytes", 0),
-            "disk_used_gb": r.get("disk_used_gb", 0),
-            "disk_total_gb": r.get("disk_total_gb", 0),
-        }
-        for r in filtered
-    ]
 
 
 def build_xvb_history(rows, range_arg, window=None):
-    """Persisted ~5-minute XvB-credited scalar samples (#196) as chart-ready points, restricted
-    to the selected range/window and bounded at ``_MAX_CHART_POINTS`` like ``share_stats`` — the
-    30-day retention at this cadence is ~8.6k rows, well past the cap."""
-    filtered = _downsample_gauge_rows(
-        _filter_events(rows, range_arg, window),
-        ("avg_1h", "avg_24h", "fail_count", "donation_fraction"),
+    """Persisted ~5-minute XvB-credited scalar samples (#196) as chart-ready points — the 30-day
+    retention at this cadence is ~8.6k rows, well past the chart-point cap ``_gauge_series``
+    bounds it at."""
+    return _gauge_series(
+        rows, range_arg, window, ("avg_1h", "avg_24h", "fail_count", "donation_fraction")
     )
-    return [
-        {
-            "x": int(r["ts"] * 1000),
-            "avg_1h": r.get("avg_1h", 0),
-            "avg_24h": r.get("avg_24h", 0),
-            "fail_count": r.get("fail_count", 0),
-            "donation_fraction": r.get("donation_fraction", 0),
-        }
-        for r in filtered
-    ]
 
 
 def _window_duration(filtered_history, range_arg, window):

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -335,6 +335,90 @@ def _window_reject_pct(rows, seconds):
     return "—" if pct is None else f"{pct:.2f}%"
 
 
+# --------------------------------------------------------------------------------------
+# #196 Tier-1 telemetry backbone: blocks / disk_growth / xvb_history surfaced on /api/state.
+# The backbone (capture + storage + retention, PR #600) shipped without this exposure step —
+# these three formatters are it. network_history and worker_history are Tier-2 (a separate
+# slice of the epic) and are not exposed here.
+# --------------------------------------------------------------------------------------
+
+
+def _downsample_gauge_rows(rows, value_cols, target=_MAX_CHART_POINTS):
+    """Bucket-average arbitrary point-in-time (gauge) columns down to ``target`` points.
+
+    Mirrors ``_downsample_share_stats``, but averages instead of summing: these rows are
+    periodic READINGS (disk size, XvB credited averages), not per-interval deltas, so summing
+    them would inflate the series instead of thinning it. A no-op when already at/under target."""
+    if len(rows) <= target:
+        return rows
+    chunk_size = len(rows) / target
+    out = []
+    for i in range(target):
+        chunk = rows[int(i * chunk_size) : int((i + 1) * chunk_size)]
+        if not chunk:
+            continue
+        bucket = {"ts": chunk[len(chunk) // 2]["ts"]}
+        for col in value_cols:
+            vals = [r.get(col, 0) or 0 for r in chunk]
+            bucket[col] = round(sum(vals) / len(vals), 2)
+        out.append(bucket)
+    return out
+
+
+def build_blocks(blocks, range_arg, window=None):
+    """Persisted P2Pool block-found events (#196) as chart-ready points, restricted to the
+    selected range/window (``_filter_events`` bounds any ts-keyed list, so this table reuses
+    it as-is). A handful of rows a week — no downsampling needed."""
+    return [
+        {
+            "x": int(b["ts"] * 1000),
+            "height": b.get("height", 0),
+            "difficulty": b.get("difficulty", 0),
+        }
+        for b in _filter_events(blocks, range_arg, window)
+    ]
+
+
+def build_disk_growth(rows, range_arg, window=None):
+    """Persisted hourly monerod-DB-size + host-disk-usage samples (#196) as chart-ready points,
+    restricted to the selected range/window and bounded at ``_MAX_CHART_POINTS`` like
+    ``share_stats`` — the table keeps every row (no retention prune), so a long-lived install can
+    otherwise pass the cap."""
+    filtered = _downsample_gauge_rows(
+        _filter_events(rows, range_arg, window),
+        ("monero_db_bytes", "disk_used_gb", "disk_total_gb"),
+    )
+    return [
+        {
+            "x": int(r["ts"] * 1000),
+            "monero_db_bytes": r.get("monero_db_bytes", 0),
+            "disk_used_gb": r.get("disk_used_gb", 0),
+            "disk_total_gb": r.get("disk_total_gb", 0),
+        }
+        for r in filtered
+    ]
+
+
+def build_xvb_history(rows, range_arg, window=None):
+    """Persisted ~5-minute XvB-credited scalar samples (#196) as chart-ready points, restricted
+    to the selected range/window and bounded at ``_MAX_CHART_POINTS`` like ``share_stats`` — the
+    30-day retention at this cadence is ~8.6k rows, well past the cap."""
+    filtered = _downsample_gauge_rows(
+        _filter_events(rows, range_arg, window),
+        ("avg_1h", "avg_24h", "fail_count", "donation_fraction"),
+    )
+    return [
+        {
+            "x": int(r["ts"] * 1000),
+            "avg_1h": r.get("avg_1h", 0),
+            "avg_24h": r.get("avg_24h", 0),
+            "fail_count": r.get("fail_count", 0),
+            "donation_fraction": r.get("donation_fraction", 0),
+        }
+        for r in filtered
+    ]
+
+
 def _window_duration(filtered_history, range_arg, window):
     """Seconds the chart currently spans — drives adaptive resolution/smoothing. From the
     window if zoomed, else the preset length, else (``all``/unknown) the actual data extent."""
@@ -1673,6 +1757,12 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         # proxy_summary so its (cumulative) shape stays unchanged for existing clients.
         "share_stats": build_share_stats(share_stats, range_arg, window),
         "reject_pct_24h": _window_reject_pct(share_stats, 24 * 3600),
+        # #196 Tier-1 telemetry backbone exposure: block-found events, hourly disk-growth
+        # samples, and ~5-min XvB-credited samples. No chart renders these yet — that's the
+        # deliberate next slice — the payload just carries the persisted series.
+        "blocks": build_blocks(state_mgr.get_blocks(), range_arg, window),
+        "disk_growth": build_disk_growth(state_mgr.get_disk_growth(), range_arg, window),
+        "xvb_history": build_xvb_history(state_mgr.get_xvb_history(), range_arg, window),
         "egress": egress,
         "topology": topology,
         "chart": build_chart(

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -30,8 +30,10 @@ from mining_dashboard.web.views import (
     _target_points,
     _window_reject_pct,
     build_badges,
+    build_blocks,
     build_cadence,
     build_chart,
+    build_disk_growth,
     build_earnings,
     build_energy,
     build_hashrate,
@@ -46,6 +48,7 @@ from mining_dashboard.web.views import (
     build_worker_detail,
     build_workers,
     build_xvb_calc,
+    build_xvb_history,
     canonical_window,
     get_shell_html,
     host_display_addr,
@@ -1393,6 +1396,137 @@ class TestShareStatsSeries:
         assert len(pts) == 3  # under the cap -> native resolution, no bucketing
 
 
+class TestBlocksDiskGrowthXvbHistorySeries:
+    """#196 Tier-1: the persisted blocks/disk_growth/xvb_history backbone surfaced on
+    /api/state. network_history and worker_history are Tier-2 and out of scope here."""
+
+    def test_build_blocks_shape_and_ms_epoch(self):
+        now = time.time()
+        rows = [{"ts": now - 60, "height": 42, "difficulty": 123.0}]
+        pts = build_blocks(rows, "all")
+        assert pts == [{"x": int((now - 60) * 1000), "height": 42, "difficulty": 123.0}]
+
+    def test_build_blocks_range_filters_old_rows(self):
+        now = time.time()
+        rows = [
+            {"ts": now - 8 * 24 * 3600, "height": 1, "difficulty": 1.0},
+            {"ts": now - 60, "height": 2, "difficulty": 2.0},
+        ]
+        assert len(build_blocks(rows, "1w")) == 1
+
+    def test_build_blocks_empty(self):
+        assert build_blocks([], "all") == []
+
+    def test_build_disk_growth_shape_and_ms_epoch(self):
+        now = time.time()
+        rows = [
+            {
+                "ts": now - 3600,
+                "monero_db_bytes": 85_000_000_000,
+                "disk_used_gb": 120.5,
+                "disk_total_gb": 500.0,
+            }
+        ]
+        pts = build_disk_growth(rows, "all")
+        assert pts == [
+            {
+                "x": int((now - 3600) * 1000),
+                "monero_db_bytes": 85_000_000_000,
+                "disk_used_gb": 120.5,
+                "disk_total_gb": 500.0,
+            }
+        ]
+
+    def test_build_disk_growth_range_filters_old_rows(self):
+        now = time.time()
+        rows = [
+            {
+                "ts": now - 8 * 24 * 3600,
+                "monero_db_bytes": 1,
+                "disk_used_gb": 1,
+                "disk_total_gb": 1,
+            },
+            {"ts": now - 60, "monero_db_bytes": 2, "disk_used_gb": 2, "disk_total_gb": 2},
+        ]
+        assert len(build_disk_growth(rows, "1w")) == 1
+
+    def test_build_disk_growth_long_series_is_bounded_and_bucket_averaged(self):
+        # Hourly, permanent (no retention prune) -> a long-lived install can pass the cap.
+        now = time.time()
+        rows = [
+            {
+                "ts": now - i * 3600,
+                "monero_db_bytes": 100,
+                "disk_used_gb": 10.0,
+                "disk_total_gb": 500.0,
+            }
+            for i in range(10_000, 0, -1)  # ascending ts, like the DB returns them
+        ]
+        pts = build_disk_growth(rows, "all")
+        assert len(pts) <= _MAX_CHART_POINTS
+        # Every source row carries the same constant values, so the bucket average is exact.
+        assert all(p["monero_db_bytes"] == 100 and p["disk_used_gb"] == 10.0 for p in pts)
+
+    def test_build_xvb_history_shape_and_ms_epoch(self):
+        now = time.time()
+        rows = [
+            {
+                "ts": now - 300,
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+                "donation_fraction": 0.5,
+            }
+        ]
+        pts = build_xvb_history(rows, "all")
+        assert pts == [
+            {
+                "x": int((now - 300) * 1000),
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+                "donation_fraction": 0.5,
+            }
+        ]
+
+    def test_build_xvb_history_range_filters_old_rows(self):
+        now = time.time()
+        rows = [
+            {
+                "ts": now - 40 * 24 * 3600,
+                "avg_1h": 1,
+                "avg_24h": 1,
+                "fail_count": 0,
+                "donation_fraction": 0,
+            },
+            {
+                "ts": now - 300,
+                "avg_1h": 2,
+                "avg_24h": 2,
+                "fail_count": 0,
+                "donation_fraction": 0,
+            },
+        ]
+        assert len(build_xvb_history(rows, "1m")) == 1
+
+    def test_build_xvb_history_long_series_is_bounded_and_bucket_averaged(self):
+        # 30 days at ~5-min cadence is ~8.6k rows, well past the chart cap.
+        now = time.time()
+        rows = [
+            {
+                "ts": now - i * 300,
+                "avg_1h": 1000.0,
+                "avg_24h": 900.0,
+                "fail_count": 0,
+                "donation_fraction": 0.5,
+            }
+            for i in range(8_640, 0, -1)  # ascending ts, like the DB returns them
+        ]
+        pts = build_xvb_history(rows, "all")
+        assert len(pts) <= _MAX_CHART_POINTS
+        assert all(p["avg_1h"] == 1000.0 for p in pts)
+
+
 # --- pool/network passthrough ---------------------------------------------------------
 
 
@@ -1749,7 +1883,14 @@ class TestXvbCalc:
 # ponytail: this _state_mgr()/_data() pair looks near-duplicated with the ones in test_metrics.py,
 # but the per-module defaults differ on purpose (e.g. tari_sync, the get_tiers/xvb shapes). A shared
 # builder would need enough params that it reads worse than the local copy — left duplicated.
-def _state_mgr(history=None, mode="P2POOL", share_stats=None):
+def _state_mgr(
+    history=None,
+    mode="P2POOL",
+    share_stats=None,
+    blocks=None,
+    disk_growth=None,
+    xvb_history=None,
+):
     sm = MagicMock()
     sm.get_history.return_value = history or []
     sm.get_xvb_stats.return_value = {"current_mode": mode}
@@ -1758,6 +1899,10 @@ def _state_mgr(history=None, mode="P2POOL", share_stats=None):
     sm.get_share_stats.return_value = share_stats or []
     sm.get_raffle_wins.return_value = []
     sm.is_db_healthy.return_value = True
+    # #196 Tier-1 telemetry backbone exposure.
+    sm.get_blocks.return_value = blocks or []
+    sm.get_disk_growth.return_value = disk_growth or []
+    sm.get_xvb_history.return_value = xvb_history or []
     return sm
 
 
@@ -1804,6 +1949,9 @@ class TestBuildState:
             "proxy_summary",
             "share_stats",
             "reject_pct_24h",
+            "blocks",
+            "disk_growth",
+            "xvb_history",
             "egress",
             "topology",
             "chart",
@@ -1880,6 +2028,33 @@ class TestVisibleUpdate:
         # No rows (fresh install / proxy idle) -> empty series and an honest dash.
         empty = build_state(_data(), _state_mgr(), "all")
         assert empty["share_stats"] == [] and empty["reject_pct_24h"] == "—"
+
+    def test_blocks_disk_growth_xvb_history_surfaced(self):
+        # #196 Tier-1: the three backbone series ride on /api/state, each sourced from its own
+        # StateManager getter.
+        now = time.time()
+        sm = _state_mgr(
+            blocks=[{"ts": now - 60, "height": 5, "difficulty": 10.0}],
+            disk_growth=[
+                {"ts": now - 60, "monero_db_bytes": 1, "disk_used_gb": 2.0, "disk_total_gb": 3.0}
+            ],
+            xvb_history=[
+                {
+                    "ts": now - 60,
+                    "avg_1h": 1,
+                    "avg_24h": 2,
+                    "fail_count": 0,
+                    "donation_fraction": 0.1,
+                }
+            ],
+        )
+        st = build_state(_data(), sm, "all")
+        assert st["blocks"][0]["height"] == 5
+        assert st["disk_growth"][0]["monero_db_bytes"] == 1
+        assert st["xvb_history"][0]["avg_1h"] == 1
+        # Fresh install -> empty series, not a crash.
+        empty = build_state(_data(), _state_mgr(), "all")
+        assert empty["blocks"] == [] and empty["disk_growth"] == [] and empty["xvb_history"] == []
 
     def test_db_unhealthy_surfaces_field_and_badge(self):
         # When persistence is broken, /api/state must carry db_healthy=False and a loud badge (#131).

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -154,6 +154,11 @@ a fresh database, and keeps running. A `db_reset` alert (Telegram and the other 
 history before that point was cleared. Payout and XvB state rebuild from the chain and the live feed;
 only the historical charts reset.
 
+The database also keeps three smaller series: pool block-found events, hourly monerod-DB-size and
+host-disk-usage samples, and XvB-credited scalar samples taken roughly every 5 minutes. `/api/state`
+serves them as `blocks`, `disk_growth`, and `xvb_history`, range-filtered the same way as
+`share_stats`. No chart reads them yet — this is persistence and API exposure only.
+
 While a node is down, the dashboard rejects workers so they fail over to the backup pools you've
 configured, rather than sitting idle on a stack that can't mine. A sustained outage stops the
 `xmrig-proxy` container (a `Workers rejected` badge shows) and a confirmed recovery restarts it.


### PR DESCRIPTION
## Summary

Partial #196 — Tier-1 persistence.

The #196 telemetry-persistence epic's backbone (PR #600, already on `develop`/`develop-v1.11`) added
five dedicated SQLite tables — `blocks`, `xvb_history`, `network_history`, `disk_growth`,
`worker_history` — each with its own capture hook, retention, and per-table write-health signal.
That PR was deliberately scoped to storage only: *"Backbone only — capture, storage, retention, and
a getter per series; charts/UI and `/api/state` exposure are deliberate follow-ups."*

This PR is that follow-up for the three series the parent task calls Tier-1:

- `blocks` — pool block-found events (permanent, event-driven)
- `disk_growth` — hourly monerod-DB-size + host-disk-usage samples (permanent)
- `xvb_history` — ~5-min XvB-credited scalar samples (30-day retention)

Each is now assembled in `build_state()` (`build/dashboard/mining_dashboard/web/views.py`) from the
existing `StateManager.get_blocks()` / `get_disk_growth()` / `get_xvb_history()` getters, range/window
-filtered the same way as the existing `share_stats` series, and bucket-averaged past the existing
700-point chart cap for `disk_growth`/`xvb_history` (both can exceed that cap over a long-lived
install; `blocks` can't — a handful of rows a week — so it isn't downsampled). A ponytail-review pass
folded the two gauge-series formatters into one shared helper (net -13 lines).

**Deferred / out of scope** (per the parent task's explicit instructions):

- `network_history` and `worker_history` (Tier-2) are **not** exposed here — separate slice of the epic.
- No chart/UI renders any of these three series yet. Storage, capture, retention, and now API
  exposure are done; charting is a further follow-up.
- Pool-wide share-health (`share_stats`) was already shipped under #116 — untouched.

Because the storage/capture/retention/counter-reset backbone (including its own tests) was already
merged in #600, this PR is scoped to exactly the missing piece: the `/api/state` formatters, their
wiring, and their tests.

Targets the v1.11 integration branch; merges to develop after v1.10 ships.

## Test plan

- [x] `make lint` — all surfaces pass except `lint-proto` (needs a Docker daemon, unavailable in
      this sandbox; unrelated to this change — the vendored Tari protos aren't touched).
- [x] `make test-dashboard` — 1472 passed, 96.66% overall coverage (gate: 80%).
- [x] `diff-cover coverage.xml --compare-branch=origin/develop-v1.11 --fail-under=90` — 96.3% patch
      coverage (1 pre-existing-pattern uncovered defensive line, matching the identical branch in
      the existing `_downsample_share_stats`/`_downsample_history`).
- [x] `bash tests/stack/run.sh` — 1541 passed, 0 failed.
- [x] `bash tests/stack/test_compose.sh` — all checks passed.
- [x] `bash tests/integration/selftest.sh` — 132 passed, 0 failed.
- [x] `uv run pytest tests/integration/fakes` — 23 passed.
- [x] `node --test build/dashboard/tests/frontend/*.test.mjs` — 222 passed.
- [x] `make lint-docs-voice` / `make lint-md` — clean on the doc/changelog edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)