### PR TITLE
feat(#530): audit out-of-band config changes, group the trail by time

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,13 @@ The stack's defaults:
   anonymous prober stored XSS against the operator. Both logs are size-bounded (Caddy's native
   rolling; a trim-before-append cap in the audit writer). Neither ever records a secret: Caddy
   redacts credential headers by default, and the audit writer logs key names only.
+- Out-of-band change detection (#530): the audit trail above only sees requests the dashboard
+  itself handled. Its poll loop separately watches for a `config.json` change with no matching
+  control-channel commit, and a worker control-API report for a change the dashboard never sent,
+  and appends both — `host-edit` / `rig-edit` — to the same trail, keys or worker names only. The
+  persisted trail (mirrored `control.log` rows plus these two out-of-band kinds) lives in the
+  dashboard's own database, not just the log tail, so the Security panel's hour/day/month grouping
+  covers more than `control.log`'s own trimmed window.
 
 ### Telegram control commands (#338)
 

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -171,6 +171,21 @@ def _editable_paths():
     return sorted(paths)
 
 
+def env_key_config_paths(env_key):
+    """The config-path prefixes a committed audit ``keys`` env-var name covers (#530).
+
+    The #33 audit log records a commit's WHAT-changed as env-var NAMES (control_approval_gate's
+    ``porcelain_keys``), while the out-of-band host-edit watcher diffs config.json PATHS — so
+    correlating "did a commit explain this changed key" needs this env->path bridge. Mirrors the
+    commit gate's own derivation: an allowlisted var maps through EDITABLE_ENV_KEY_PATHS, and the
+    synthetic ``DASHBOARD_ENERGY`` name (which the gate folds in for a dashboard.energy-only
+    commit, a config.json-only block that never renders to .env, #504) covers the whole energy
+    block by prefix. An unrecognised name maps to nothing, so it can never explain a diffed key."""
+    if env_key == "DASHBOARD_ENERGY":
+        return ("dashboard.energy",)
+    return EDITABLE_ENV_KEY_PATHS.get(env_key, ())
+
+
 def _load_core_keys():
     """The wizard's core-key shortlist (#502/#529), read from the SAME file ``./pithead setup``
     reads — the one shared artifact, not a second hand-maintained list. Degrades to an empty list

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -969,10 +969,10 @@ class DataService:
             self.state_manager.add_audit_event,
             id=event_id or f"{source}-{uuid.uuid4()}",
             ts=_iso_now(),
-            source=source,
+            source=audit_service._clean(source, 16),
             actor=audit_service._clean(actor, 64),
-            action=action,
-            status=status,
+            action=audit_service._clean(action, 16),
+            status=audit_service._clean(status, 32),
             keys=audit_service._clean(keys, 400),
         )
 

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -1,7 +1,10 @@
 import asyncio
+import json
 import logging
 import os
 import time
+import uuid
+from datetime import UTC, datetime
 
 from aiohttp import ClientSession
 
@@ -35,6 +38,7 @@ from mining_dashboard.collector.system import (
     get_load_average,
     get_memory_usage,
 )
+from mining_dashboard.config import config
 from mining_dashboard.config.config import (
     CHECK_FOR_UPDATES,
     CLEARNET_STATE_DIR,
@@ -67,8 +71,10 @@ from mining_dashboard.helper.utils import (
     pplns_block_time,
     shares_in_pplns_window,
 )
+from mining_dashboard.service import audit_service
 from mining_dashboard.service.alert_service import AlertService
 from mining_dashboard.service.clearnet_sync import ClearnetSyncSupervisor
+from mining_dashboard.service.control_service import SECRET_SENTINEL
 from mining_dashboard.service.degradation import DegradationMonitor
 from mining_dashboard.service.healthchecks import HealthchecksClient
 from mining_dashboard.service.metrics import build_metrics, share_reject_pct
@@ -344,6 +350,67 @@ def _shares_to_record(last_known_total, current_total):
     return 0, last_known_total
 
 
+def _iso_now():
+    """UTC now, formatted to match the #33 audit writer's own ``ts`` (``control_audit`` in
+    ``pithead``) — same string shape both sources write, so the audit_events table sorts and
+    groups by hour/day/month with a plain string-prefix slice, no parsing needed at read time."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _flatten_config_keys(cfg, out, prefix=""):
+    """Fill ``out`` with ``{dotted.path: leaf_value}`` for every leaf in nested dict ``cfg``. Only
+    ever used to compare/NAME keys (see ``_diff_config_keys``) — a leaf value is compared for
+    equality, never rendered; the source, ``config.HOST_CONFIG_PATH``, is already the host's
+    pre-masked copy (#440), so no secret is present to leak even here.
+
+    The masked secret sentinel (``control_service.SECRET_SENTINEL``, ``{"__secret__": True}``) is
+    treated as an opaque LEAF, not descended into — otherwise a secret being set/cleared would
+    name a synthetic ``...password.__secret__`` path instead of the real setting."""
+    if not isinstance(cfg, dict):
+        return
+    for k, v in cfg.items():
+        path = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict) and v != SECRET_SENTINEL:
+            _flatten_config_keys(v, out, path)
+        else:
+            out[path] = v
+
+
+def _diff_config_keys(old, new):
+    """Dotted config-key paths added, removed, or changed between two config snapshots (#530),
+    sorted. Names only — the values feed only an equality check and are never returned, matching
+    the #33 audit contract (key names, never values)."""
+    old_flat, new_flat = {}, {}
+    _flatten_config_keys(old, old_flat)
+    _flatten_config_keys(new, new_flat)
+    changed = set(old_flat) ^ set(new_flat)  # added or removed entirely
+    changed |= {k for k in old_flat.keys() & new_flat.keys() if old_flat[k] != new_flat[k]}
+    return sorted(changed)
+
+
+def _parse_audit_ts(ts):
+    """Parse a #33 audit-log ``ts`` string (``%Y-%m-%dT%H:%M:%SZ``) to epoch seconds, or None for
+    anything else — a malformed/garbage ts (already length-capped and charset-stripped by
+    ``audit_service._clean``) must never crash the out-of-band watcher, just fail to "explain" a
+    change (the safe direction: an unparsable commit ts causes a spurious host-edit row, not a
+    swallowed one)."""
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def _read_host_config():
+    """The masked config.json (``config.HOST_CONFIG_PATH``, #440), or None if the mount isn't
+    ready / isn't valid JSON yet. A plain blocking function — ``_watch_host_config`` runs it via
+    ``asyncio.to_thread`` rather than opening the file directly in an ``async def``."""
+    try:
+        with open(config.HOST_CONFIG_PATH) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
 class WorkerLifecycle:
     """Dashboard-side per-worker connection tracking for the "Workers Alive" table (#169 / #182).
 
@@ -447,6 +514,12 @@ class DataService:
         self._last_xvb_history_write = 0.0
         self._last_hourly_capture = 0.0
         self._last_worker_capture = 0.0
+        # Out-of-band audit watcher (#530): the last config.json snapshot this poll loop read
+        # (None until the first poll baselines it — never diff against nothing, same "re-baseline,
+        # never backfill" contract as every other watcher here) and the wall-clock of that read, so
+        # a later change can be checked against control.log entries that landed AFTER it.
+        self._last_host_config = None
+        self._last_host_check = 0.0
         # XvB raffle-winners mirror: wall-clock of the last successful winners-file read. Starts
         # at 0.0 so the first eligible poll reads it; NOT stamped on a failed fetch, so a failure
         # retries on the next 10th poll instead of waiting out the 30-min gate.
@@ -858,24 +931,129 @@ class DataService:
             )
             await self.alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])
 
-    async def _reconcile_worker_config(self, worker_results):
+    async def _record_audit_event(self, source, actor, action, status, keys):
+        """Write one out-of-band audit row (#530), through the SAME sanitizer #33's own audit
+        trail is served through (``audit_service._clean``) — defense in depth: ``actor``/``keys``
+        here are already schema-shaped (a validated worker name, dotted config-key paths), but
+        every field the Security panel serves gets the identical whitelist treatment regardless of
+        source, so a future caller can't accidentally skip it."""
+        await asyncio.to_thread(
+            self.state_manager.add_audit_event,
+            id=f"{source}-{uuid.uuid4()}",
+            ts=_iso_now(),
+            source=source,
+            actor=audit_service._clean(actor, 64),
+            action=action,
+            status=status,
+            keys=audit_service._clean(keys, 400),
+        )
+
+    async def _watch_host_config(self):
+        """Out-of-band HOST-EDIT detection (#530): config.json changed without a matching
+        control-channel commit.
+
+        Reads the same pre-masked copy the control channel itself prefills from
+        (``config.HOST_CONFIG_PATH``, #440 — already secret-free) each poll and diffs it against
+        the previous poll's snapshot. A change is "explained" — and stays quiet — only when the #33
+        audit trail shows a ``commit``/``applied`` entry stamped AFTER the last time this watcher
+        looked; anything else (a hand-edit, a `pithead apply` run outside the dashboard) is recorded
+        as a ``host-edit`` audit row naming the changed keys. First poll only baselines (no control
+        log exists yet to compare against, and every other watcher in this loop shares that
+        never-backfill contract). No-op with the control channel off — there is neither a masked
+        config mount nor an audit trail to compare against."""
+        if not config.DASHBOARD_CONTROL_ENABLED:
+            return
+        current = await asyncio.to_thread(_read_host_config)
+        if current is None:
+            return  # mount not ready yet — quiet no-op, the next poll retries
+        now = time.time()
+        if self._last_host_config is None:
+            self._last_host_config, self._last_host_check = current, now
+            return
+        changed_keys = _diff_config_keys(self._last_host_config, current)
+        if changed_keys:
+            # The audit log's ts is whole-second (_iso_now/control_audit both write
+            # "%Y-%m-%dT%H:%M:%SZ"), while `_last_host_check` is a sub-second time.time() — a
+            # commit landed in the SAME wall-clock second as the baseline poll would otherwise
+            # floor below it and be missed. One second of grace absorbs that truncation without
+            # meaningfully widening the window a genuinely stale commit could "explain" through.
+            since = self._last_host_check - 1
+            explained = any(
+                e.get("action") == "commit"
+                and e.get("status") == "applied"
+                and (ts := _parse_audit_ts(e.get("ts"))) is not None
+                and ts >= since
+                for e in audit_service.recent_changes()
+            )
+            if not explained:
+                await self._record_audit_event(
+                    "host-edit", "", "host-edit", "detected", " ".join(changed_keys)
+                )
+        self._last_host_config, self._last_host_check = current, now
+
+    async def _mirror_control_audit(self):
+        """Copy the #33 control.log's recent entries into the durable ``audit_events`` table
+        (#530), so the Security panel's time-grouped view can drill deeper than the log's own
+        trimmed tail. ``audit_service.recent_changes()`` output is already sanitized (it's the SAME
+        read the panel used before this table existed); ``add_audit_event``'s ``INSERT OR IGNORE``
+        on the log's own ``id`` makes re-mirroring the same tail every poll a no-op. Entries with no
+        id (a handful of pre-auth "invalid"/"refused" rows, #33) are skipped — they're visible only
+        while still in the log tail, same as before this feature."""
+        if not config.DASHBOARD_CONTROL_ENABLED:
+            return
+        for e in audit_service.recent_changes():
+            if not e.get("id"):
+                continue
+            await asyncio.to_thread(
+                self.state_manager.add_audit_event,
+                id=e["id"],
+                ts=e.get("ts", ""),
+                source="control",
+                actor=e.get("actor", ""),
+                action=e.get("action", ""),
+                status=e.get("status", ""),
+                keys=e.get("keys", ""),
+            )
+
+    async def _reconcile_worker_config(self, workers, worker_results):
         """Catch up any still-``accepted`` #185 worker-config history row whose change_id the rig
-        now reports terminal (#579).
+        now reports terminal (#579), and flag an out-of-band RIG-EDIT (#530).
 
         A rollback slower than the host runner's 20s status-poll deadline (#517/#543) is honestly
         recorded ``accepted`` and never revisited — this rides THIS poll's already-fetched enriched
-        bodies (``worker_results``, positionally aligned with the worker probes in ``run()``), so
-        there's no new dial and no host-runner change. A plain-xmrig rig, a rig still mid-change, or
-        an unreachable/offline rig (``{}``) all parse to ``None`` via ``parse_worker_control_status``
-        and are a quiet no-op — the row simply stays ``accepted`` until a later poll catches it."""
-        for extra_stats in worker_results:
+        bodies (``worker_results``, positionally aligned with ``workers`` and with the worker probes
+        in ``run()``), so there's no new dial and no host-runner change. A plain-xmrig rig, a rig
+        still mid-change, or an unreachable/offline rig (``{}``) all parse to ``None`` via
+        ``parse_worker_control_status`` and are a quiet no-op.
+
+        A TERMINAL report whose ``change_id`` this dashboard never spooled (``worker_config`` has no
+        row for it — checked via ``worker_config_change_known``) is a change the RIG applied on its
+        own: reconciling it would be a silent no-op anyway (the ``WHERE status='accepted'`` UPDATE
+        matches nothing), so instead it's recorded as a ``rig-edit`` audit row naming the worker.
+        RigForge's ``/status`` mirror carries only the outcome of a change, not a per-key diff, so
+        unlike host-edit's ``keys`` this can only name the change_id — a real limitation, not an
+        oversight; see the #530 PR notes."""
+        for w, extra_stats in zip(workers, worker_results, strict=False):
             ctrl = parse_worker_control_status(extra_stats) if extra_stats else None
-            if ctrl:
+            if not ctrl:
+                continue
+            known = await asyncio.to_thread(
+                self.state_manager.worker_config_change_known, ctrl["change_id"]
+            )
+            if known:
                 await asyncio.to_thread(
                     self.state_manager.reconcile_worker_config_status,
                     ctrl["change_id"],
                     ctrl["status"],
                     ctrl["reason"],
+                )
+            else:
+                await self._record_audit_event(
+                    "rig-edit",
+                    w.get("name", ""),
+                    "rig-edit",
+                    ctrl["status"],
+                    f"change_id={ctrl['change_id']}",
                 )
 
     def _on_clearnet_transition(self, name, ok):
@@ -947,8 +1125,16 @@ class DataService:
                     worker_results = await asyncio.gather(*tasks)
 
                     # 3a. Reconcile any #185 history row a slow rig rollback left stuck 'accepted'
-                    # (#579) — rides this same poll's results, no new dial.
-                    await self._reconcile_worker_config(worker_results)
+                    # (#579), and flag a rig-side out-of-band edit (#530) — rides this same poll's
+                    # results, no new dial.
+                    await self._reconcile_worker_config(proxy_workers, worker_results)
+
+                    # 3a-2. Out-of-band audit (#530): a config.json change not made through the
+                    # control channel, plus mirroring the #33 log into the durable audit_events
+                    # table so the Security panel can group by hour/day/month. Both are no-ops with
+                    # the control channel off.
+                    await self._watch_host_config()
+                    await self._mirror_control_audit()
 
                     current_mode = self.state_manager.get_xvb_stats().get("current_mode", "P2POOL")
                     # Determine active pool port for UI badges based on current Algo mode

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -74,7 +74,12 @@ from mining_dashboard.helper.utils import (
 from mining_dashboard.service import audit_service
 from mining_dashboard.service.alert_service import AlertService
 from mining_dashboard.service.clearnet_sync import ClearnetSyncSupervisor
-from mining_dashboard.service.control_service import SECRET_SENTINEL
+from mining_dashboard.service.control_service import (
+    SECRET_PATHS,
+    SECRET_SENTINEL,
+    _get,
+    _set,
+)
 from mining_dashboard.service.degradation import DegradationMonitor
 from mining_dashboard.service.healthchecks import HealthchecksClient
 from mining_dashboard.service.metrics import build_metrics, share_reject_pct
@@ -403,12 +408,24 @@ def _parse_audit_ts(ts):
 def _read_host_config():
     """The masked config.json (``config.HOST_CONFIG_PATH``, #440), or None if the mount isn't
     ready / isn't valid JSON yet. A plain blocking function — ``_watch_host_config`` runs it via
-    ``asyncio.to_thread`` rather than opening the file directly in an ``async def``."""
+    ``asyncio.to_thread`` rather than opening the file directly in an ``async def``.
+
+    The mount is the host's PRE-MASKED copy already (docker-compose bind-mounts
+    ``control/masked/config.json``; the raw config.json never enters the container). We still
+    re-apply the SECRET_PATHS mask here — exactly the defense-in-depth pass ``control_service.
+    read_config`` runs — so a host-side masking regression can never leave a raw secret VALUE
+    resident in ``self._last_host_config`` across polls. The diff only ever compares/names keys,
+    but this keeps the one long-lived config dict secret-free regardless."""
     try:
         with open(config.HOST_CONFIG_PATH) as f:
-            return json.load(f)
+            cfg = json.load(f)
     except (OSError, ValueError):
         return None
+    for path in SECRET_PATHS:
+        found, value = _get(cfg, path)
+        if found and value:
+            _set(cfg, path, dict(SECRET_SENTINEL))
+    return cfg
 
 
 class WorkerLifecycle:
@@ -520,6 +537,12 @@ class DataService:
         # a later change can be checked against control.log entries that landed AFTER it.
         self._last_host_config = None
         self._last_host_check = 0.0
+        # (worker, change_id) pairs already recorded as a rig-edit this run, so a rig that keeps
+        # reporting the same terminal change_id in its /status mirror every poll is flagged ONCE,
+        # not on every ~30s cycle. In-memory only: the deterministic audit-row id below is what
+        # actually bounds the table across restarts (INSERT OR IGNORE); this just skips the
+        # redundant DB work in the steady state. Bounded by the count of distinct real rig edits.
+        self._flagged_rig_changes = set()
         # XvB raffle-winners mirror: wall-clock of the last successful winners-file read. Starts
         # at 0.0 so the first eligible poll reads it; NOT stamped on a failed fetch, so a failure
         # retries on the next 10th poll instead of waiting out the 30-min gate.
@@ -931,15 +954,20 @@ class DataService:
             )
             await self.alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])
 
-    async def _record_audit_event(self, source, actor, action, status, keys):
+    async def _record_audit_event(self, source, actor, action, status, keys, event_id=None):
         """Write one out-of-band audit row (#530), through the SAME sanitizer #33's own audit
         trail is served through (``audit_service._clean``) — defense in depth: ``actor``/``keys``
         here are already schema-shaped (a validated worker name, dotted config-key paths), but
         every field the Security panel serves gets the identical whitelist treatment regardless of
-        source, so a future caller can't accidentally skip it."""
+        source, so a future caller can't accidentally skip it.
+
+        ``event_id`` lets a caller supply a DETERMINISTIC row id so ``INSERT OR IGNORE`` collapses
+        repeat reports of the SAME event to one row (rig-edit: a rig re-reports its last change_id
+        every poll). A host-edit passes None — each detection is a genuinely distinct event, so a
+        random id is right there."""
         await asyncio.to_thread(
             self.state_manager.add_audit_event,
-            id=f"{source}-{uuid.uuid4()}",
+            id=event_id or f"{source}-{uuid.uuid4()}",
             ts=_iso_now(),
             source=source,
             actor=audit_service._clean(actor, 64),
@@ -975,8 +1003,12 @@ class DataService:
             # The audit log's ts is whole-second (_iso_now/control_audit both write
             # "%Y-%m-%dT%H:%M:%SZ"), while `_last_host_check` is a sub-second time.time() — a
             # commit landed in the SAME wall-clock second as the baseline poll would otherwise
-            # floor below it and be missed. One second of grace absorbs that truncation without
-            # meaningfully widening the window a genuinely stale commit could "explain" through.
+            # floor below it and be missed. One second of grace absorbs that truncation.
+            # ponytail: ≤1s correlation window — a control-channel commit up to 1s before the last
+            # poll could "explain" (suppress) an unrelated hand-edit detected in this poll. The
+            # honest ceiling of a timestamp correlation; tighten to id-based ("commits seen since
+            # last poll") only if a real false-negative shows up. Pinned by
+            # test_explained_window_is_at_most_one_second.
             since = self._last_host_check - 1
             explained = any(
                 e.get("action") == "commit"
@@ -1032,7 +1064,14 @@ class DataService:
         matches nothing), so instead it's recorded as a ``rig-edit`` audit row naming the worker.
         RigForge's ``/status`` mirror carries only the outcome of a change, not a per-key diff, so
         unlike host-edit's ``keys`` this can only name the change_id — a real limitation, not an
-        oversight; see the #530 PR notes."""
+        oversight; see the #530 PR notes.
+
+        A rig keeps reporting its last terminal change_id every poll, so this fires ONCE per
+        (worker, change_id): an in-memory guard skips the redundant work in the steady state, and
+        the audit row's deterministic id makes the write itself idempotent even across a restart
+        (when the guard is empty but a repeat report must still not duplicate the row). Both matter
+        — the id is the correctness bound (a rogue rig can't flood the permanent table with repeats
+        of one bogus change_id), the guard is the optimisation."""
         for w, extra_stats in zip(workers, worker_results, strict=False):
             ctrl = parse_worker_control_status(extra_stats) if extra_stats else None
             if not ctrl:
@@ -1048,12 +1087,18 @@ class DataService:
                     ctrl["reason"],
                 )
             else:
+                worker = w.get("name", "")
+                guard_key = (worker, ctrl["change_id"])
+                if guard_key in self._flagged_rig_changes:
+                    continue
+                self._flagged_rig_changes.add(guard_key)
                 await self._record_audit_event(
                     "rig-edit",
-                    w.get("name", ""),
+                    worker,
                     "rig-edit",
                     ctrl["status"],
                     f"change_id={ctrl['change_id']}",
+                    event_id=f"rig-edit-{worker}-{ctrl['change_id']}",
                 )
 
     def _on_clearnet_transition(self, name, ok):

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -79,6 +79,7 @@ from mining_dashboard.service.control_service import (
     SECRET_SENTINEL,
     _get,
     _set,
+    env_key_config_paths,
 )
 from mining_dashboard.service.degradation import DegradationMonitor
 from mining_dashboard.service.healthchecks import HealthchecksClient
@@ -982,10 +983,14 @@ class DataService:
 
         Reads the same pre-masked copy the control channel itself prefills from
         (``config.HOST_CONFIG_PATH``, #440 — already secret-free) each poll and diffs it against
-        the previous poll's snapshot. A change is "explained" — and stays quiet — only when the #33
-        audit trail shows a ``commit``/``applied`` entry stamped AFTER the last time this watcher
-        looked; anything else (a hand-edit, a `pithead apply` run outside the dashboard) is recorded
-        as a ``host-edit`` audit row naming the changed keys. First poll only baselines (no control
+        the previous poll's snapshot. A changed key is "explained" — and stays quiet — only when
+        the #33 audit trail shows a ``commit``/``applied`` entry that both landed AFTER the last
+        time this watcher looked AND actually touched that key (the entry's env-var names are
+        bridged to config paths via ``env_key_config_paths``). Correlating by key, not merely by
+        time, is what stops a legit dashboard commit of key A from swallowing a concurrent
+        host-side hand-edit of key B. Any changed key no fresh commit covers (a hand-edit, a
+        `pithead apply` run outside the dashboard) is recorded as a ``host-edit`` audit row naming
+        the unexplained keys. First poll only baselines (no control
         log exists yet to compare against, and every other watcher in this loop shares that
         never-backfill contract). No-op with the control channel off — there is neither a masked
         config mount nor an audit trail to compare against."""
@@ -1010,16 +1015,34 @@ class DataService:
             # last poll") only if a real false-negative shows up. Pinned by
             # test_explained_window_is_at_most_one_second.
             since = self._last_host_check - 1
-            explained = any(
-                e.get("action") == "commit"
-                and e.get("status") == "applied"
-                and (ts := _parse_audit_ts(e.get("ts"))) is not None
-                and ts >= since
-                for e in audit_service.recent_changes()
-            )
-            if not explained:
+            # Correlate BY KEY, not just by time: a commit only "explains" the keys it actually
+            # touched. Fold every fresh commit's env-var names into the config paths they cover
+            # (env_key_config_paths bridges the audit log's env names to config.json paths), then
+            # record only the changed keys NO recent commit covers — the genuine out-of-band edits
+            # this watcher exists to catch. A concurrent dashboard commit of key A + a host
+            # hand-edit of key B no longer swallows B.
+            explained_paths = set()
+            for e in audit_service.recent_changes():
+                if (
+                    e.get("action") == "commit"
+                    and e.get("status") == "applied"
+                    and (ts := _parse_audit_ts(e.get("ts"))) is not None
+                    and ts >= since
+                ):
+                    for env_key in (e.get("keys") or "").split():
+                        explained_paths.update(env_key_config_paths(env_key))
+            # ponytail: env-var granularity — a var fed by >1 config path (e.g. P2POOL_FLAGS <-
+            # p2pool.pool + p2pool.clearnet) explains ALL its paths, so a commit touching one could
+            # still suppress a concurrent hand-edit of its sibling. Inherent to a name-only audit
+            # log; fix only if per-path audit keys ever land.
+            unexplained = [
+                k
+                for k in changed_keys
+                if not any(k == p or k.startswith(p + ".") for p in explained_paths)
+            ]
+            if unexplained:
                 await self._record_audit_event(
-                    "host-edit", "", "host-edit", "detected", " ".join(changed_keys)
+                    "host-edit", "", "host-edit", "detected", " ".join(unexplained)
                 )
         self._last_host_config, self._last_host_check = current, now
 

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -353,6 +353,21 @@ class StateManager:
             "CREATE TABLE IF NOT EXISTS worker_history "
             "(ts REAL, name TEXT, h15 REAL, accepted INTEGER, rejected INTEGER)"
         )
+        # audit_events (#530): the durable backing store for the Security panel's audit trail. The
+        # #33 control.log is host-owned, read-only from this container, and the writers already trim
+        # it — so it can't back a month-level drill-down on its own. This table mirrors each
+        # control.log row (source="control", `id` reused as the primary key — INSERT OR IGNORE makes
+        # the mirror idempotent) AND records the two kinds this dashboard detects itself:
+        # source="host-edit" (config.json changed without a matching control-channel commit) and
+        # source="rig-edit" (a rig's control-apply outcome carries a change_id this dashboard never
+        # issued). `keys` is names only — never a value — the same contract as control.log itself.
+        # Permanent, no pruning, like blocks/payouts/disk_growth: these are human-paced admin events,
+        # not a hot metrics series.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS audit_events "
+            "(id TEXT PRIMARY KEY, ts TEXT, source TEXT, actor TEXT, action TEXT, status TEXT, "
+            "keys TEXT)"
+        )
 
     def _create_indexes(self):
         """Creates indexes. Called after migrations so the indexed columns are guaranteed to
@@ -370,6 +385,7 @@ class StateManager:
         )
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_disk_growth_ts ON disk_growth(ts)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_worker_history_ts ON worker_history(ts)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_events_ts ON audit_events(ts)")
 
     def _migrate_db(self):
         """Handles schema migrations for existing databases."""
@@ -863,6 +879,65 @@ class StateManager:
                 self._conn.commit()
         except sqlite3.Error as e:
             self._db_error("Worker Config Reconcile Error", e)
+
+    def worker_config_change_known(self, change_id: str) -> bool:
+        """Whether ``change_id`` was ever spooled by THIS dashboard (#530): a row exists in
+        ``worker_config`` — the table only ``add_worker_config_version`` writes to, one row per
+        change the dashboard itself sent. A rig reporting a terminal outcome for a change_id NOT
+        found here is reporting something it applied on its own — an out-of-band rig edit."""
+        if not change_id:
+            return False
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return False
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT 1 FROM worker_config WHERE change_id = ? LIMIT 1", (change_id,)
+                )
+                return cursor.fetchone() is not None
+        except sqlite3.Error as e:
+            self.logger.error(f"Worker Config Lookup Error: {e}")
+            return True  # fail toward NOT flagging a false rig-edit on a DB read hiccup
+
+    def add_audit_event(
+        self, id: str, ts: str, source: str, actor: str, action: str, status: str, keys: str
+    ) -> None:
+        """Record one audit-trail row (#530) — mirrored from the #33 control.log (``source`` =
+        "control", the log's own ``id`` reused as the primary key) or detected out-of-band
+        ("host-edit" / "rig-edit"). ``INSERT OR IGNORE`` makes both idempotent: a re-mirrored
+        control.log row and a re-detected out-of-band event are no-ops. ``keys`` is names only —
+        the caller is responsible for the same no-values contract the log itself holds to."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO audit_events "
+                    "(id, ts, source, actor, action, status, keys) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (id, ts, source, actor, action, status, keys),
+                )
+                self._conn.commit()
+        except sqlite3.Error as e:
+            self._db_error("Audit Event Write Error", e)
+
+    def get_audit_events(self, limit: int = 1000) -> list[dict[str, Any]]:
+        """Every persisted audit row (#530), newest first by ``ts`` — the merged, durable
+        backing store for the Security panel's time-grouped view."""
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return []
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT id, ts, source, actor, action, status, keys FROM audit_events "
+                    "ORDER BY ts DESC LIMIT ?",
+                    (limit,),
+                )
+                return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            self.logger.error(f"Audit Event Read Error: {e}")
+            return []
 
     def get_last_applied_worker_config(self, worker: str) -> dict[str, Any]:
         """The merged writable config the dashboard last successfully applied to ``worker`` — the

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -308,11 +308,35 @@ async def handle_control_result(request):
 # charset) before it reaches the browser — log content is attacker-influenceable input.
 
 
+def _merged_audit_entries(state_mgr):
+    """The Security panel's full audit feed (#530): the #33 log's live tail (read directly, so a
+    commit that landed since the last poll cycle shows immediately — no mirror lag) UNION the
+    durable ``audit_events`` table (the mirrored log history PLUS the out-of-band host-edit/rig-edit
+    detections, which never appear in control.log at all). Deduplicated by ``id`` — a control.log
+    row already mirrored to the DB is identical either way, so the DB copy wins and the direct log
+    read is skipped for it. Entries with no ``id`` (a handful of pre-auth "invalid"/"refused" rows,
+    #33) are never mirrored and so appear only while still in the log's own tail — a disclosed, minor
+    gap, not a bug. Sorted newest first by ``ts`` (both sources share one string format, so this is a
+    plain lexical sort, no parsing)."""
+    merged = {e["id"]: e for e in state_mgr.get_audit_events() if e.get("id")}
+    for e in audit_service.recent_changes():
+        eid = e.get("id")
+        if eid and eid not in merged:
+            merged[eid] = {**e, "source": "control"}
+        elif not eid:
+            # No stable id to dedupe on — always shown live from the log tail (never mirrored).
+            merged[f"log-{id(e)}"] = {**e, "source": "control"}
+    return sorted(merged.values(), key=lambda e: e.get("ts", ""), reverse=True)
+
+
 async def handle_audit_log(request):
-    """Recent config-change audit entries, from the read-only /control/audit mount. Registered
-    only alongside the control channel — the log is a #33 artifact."""
+    """Config-change audit entries — the #33 control-channel log plus the out-of-band host-edit /
+    rig-edit detections (#530), merged and persisted so the Security panel can group by hour/day/
+    month deeper than the log's own trimmed tail. Registered only alongside the control channel —
+    the log is a #33 artifact and the out-of-band watchers only run when it's on."""
     try:
-        return web.json_response({"entries": audit_service.recent_changes()})
+        state_mgr = request.app["state_manager"]
+        return web.json_response({"entries": _merged_audit_entries(state_mgr)})
     except Exception:
         logger.exception("Error reading the control audit log")
         return web.json_response({"error": "Failed to read the audit log."}, status=500)

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -419,6 +419,27 @@ tr:last-child td {
   white-space: nowrap;
 }
 
+/* Card title + a right-aligned control, e.g. the audit trail's hour/day/month grouping select
+ * (#530). Generic — reuse wherever a card needs one control next to its heading. */
+.card-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.card-header-row h3 {
+  margin: 0;
+}
+
+/* Audit-trail time-bucket header row (#530), between groups when the operator picks
+ * hour/day/month grouping. A raised, muted divider — readable, not another data row. */
+.audit-group-header td {
+  background: var(--elevated);
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
 /* Components */
 .status-ok {
   color: var(--ok);

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -419,8 +419,7 @@ tr:last-child td {
   white-space: nowrap;
 }
 
-/* Card title + a right-aligned control, e.g. the audit trail's hour/day/month grouping select
- * (#530). Generic — reuse wherever a card needs one control next to its heading. */
+/* The audit trail's title + its hour/day/month grouping select (#530), side by side. */
 .card-header-row {
   display: flex;
   justify-content: space-between;

--- a/build/dashboard/mining_dashboard/web/static/securityview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/securityview.mjs
@@ -112,7 +112,7 @@ const AuditCard = ({ audit, group, onGroupChange }) => {
           <h3>Recent config changes</h3>
           ${
             audit.length > 0
-              ? html`<select value=${group} onChange=${(e) => onGroupChange(e.target.value)}>
+              ? html`<select aria-label="Group audit trail by" value=${group} onChange=${(e) => onGroupChange(e.target.value)}>
                   <option value="flat">All (newest first)</option>
                   <option value="hour">Group by hour</option>
                   <option value="day">Group by day</option>

--- a/build/dashboard/mining_dashboard/web/static/securityview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/securityview.mjs
@@ -1,8 +1,9 @@
 // Security panel (#349): recent dashboard accesses (Caddy's access log, read-only) and the
-// config-change audit trail (the #33 host-side audit log, read-only). Both APIs serve
-// server-sanitized fields — the backend whitelists every character before it leaves the host
-// logs — and everything here renders through Preact text nodes, never markup, so a hostile log
-// line stays inert even if the server-side filter regressed.
+// config-change audit trail (the #33 host-side audit log, read-only, plus the #530 out-of-band
+// host-edit/rig-edit detections and their persisted history). Both APIs serve server-sanitized
+// fields — the backend whitelists every character before it leaves the host logs — and everything
+// here renders through Preact text nodes, never markup, so a hostile log line stays inert even if
+// the server-side filter regressed.
 //
 // The operator story: over Tor there is no source IP, so the attack signal is the RATE of 401s.
 // A burst of failed logins shows a rotate nudge — change the password, or mint a fresh onion
@@ -11,6 +12,36 @@
 import { Component, html } from "./preact.mjs";
 
 const ACCESS_LIMIT_SHOWN = 20;
+
+// Audit entries share one ts format across every source (control.log's own writer and the #530
+// watchers both emit "YYYY-MM-DDTHH:MM:SSZ", see data_service._iso_now), so a bucket key is a
+// plain string slice — no date parsing, no timezone math.
+export function bucketKey(ts, granularity) {
+  if (typeof ts !== "string") return "";
+  if (granularity === "hour") return ts.slice(0, 13);
+  if (granularity === "month") return ts.slice(0, 7);
+  return ts.slice(0, 10); // "day"
+}
+
+// Group already newest-first ``entries`` into contiguous {bucket, entries} runs for
+// ``granularity`` ("hour"|"day"|"month"), or one ungrouped run for "flat"/anything else — the
+// drill: pick "month" to scan a year at a glance, "hour" to pin down one incident.
+export function groupAuditEntries(entries, granularity) {
+  if (granularity !== "hour" && granularity !== "day" && granularity !== "month") {
+    return [{ bucket: null, entries }];
+  }
+  const groups = [];
+  let current = null;
+  for (const e of entries) {
+    const key = bucketKey(e.ts, granularity);
+    if (!current || current.bucket !== key) {
+      current = { bucket: key, entries: [] };
+      groups.push(current);
+    }
+    current.entries.push(e);
+  }
+  return groups;
+}
 
 // Epoch seconds -> local "YYYY-MM-DD HH:MM:SS"-style string; blank for a missing/zero ts.
 export function fmtEpoch(ts) {
@@ -63,11 +94,33 @@ const AccessCard = ({ access }) => {
   </div>`;
 };
 
-const AuditCard = ({ audit }) => {
+// Outcome values a "detected" (never applied/rejected) out-of-band row never has, so it keeps its
+// own neutral styling instead of picking up the "applied" green.
+const AuditRow = (e) => html`<tr>
+    <td>${e.ts}</td>
+    <td>${e.actor}</td>
+    <td>${e.action}</td>
+    <td class=${e.status === "applied" ? "status-ok" : ""}>${e.status}</td>
+    <td class="font-mono">${e.keys}</td>
+</tr>`;
+
+const AuditCard = ({ audit, group, onGroupChange }) => {
   // null = control channel off (the /api/audit route 404s) — no card at all.
   if (!audit) return null;
   return html`<div class="card">
-      <h3>Recent config changes</h3>
+      <div class="card-header-row">
+          <h3>Recent config changes</h3>
+          ${
+            audit.length > 0
+              ? html`<select value=${group} onChange=${(e) => onGroupChange(e.target.value)}>
+                  <option value="flat">All (newest first)</option>
+                  <option value="hour">Group by hour</option>
+                  <option value="day">Group by day</option>
+                  <option value="month">Group by month</option>
+              </select>`
+              : null
+          }
+      </div>
       ${
         audit.length === 0
           ? html`<p class="text-muted">No config changes have gone through the dashboard yet.</p>`
@@ -75,15 +128,14 @@ const AuditCard = ({ audit }) => {
               <table>
                   <thead><tr><th>Time (UTC)</th><th>User</th><th>Action</th><th>Outcome</th><th>Settings</th></tr></thead>
                   <tbody>
-                      ${audit.map(
-                        (e) => html`<tr>
-                            <td>${e.ts}</td>
-                            <td>${e.actor}</td>
-                            <td>${e.action}</td>
-                            <td class=${e.status === "applied" ? "status-ok" : ""}>${e.status}</td>
-                            <td class="font-mono">${e.keys}</td>
-                        </tr>`,
-                      )}
+                      ${groupAuditEntries(audit, group).flatMap((g) => [
+                        g.bucket !== null
+                          ? html`<tr class="audit-group-header">
+                              <td colspan="5">${g.bucket} (${g.entries.length})</td>
+                          </tr>`
+                          : null,
+                        ...g.entries.map(AuditRow),
+                      ])}
                   </tbody>
               </table>
           </div>`
@@ -94,7 +146,10 @@ const AuditCard = ({ audit }) => {
 export class SecurityPanel extends Component {
   constructor(props) {
     super(props);
-    this.state = { access: null, audit: null, error: null };
+    // auditGroup: "flat" (today's plain newest-first list) is the default so existing behavior
+    // doesn't change until the operator opts into grouping (#530).
+    this.state = { access: null, audit: null, auditGroup: "flat", error: null };
+    this.setAuditGroup = (group) => this.setState({ auditGroup: group });
   }
 
   async componentDidMount() {
@@ -110,11 +165,11 @@ export class SecurityPanel extends Component {
   }
 
   render() {
-    const { access, audit, error } = this.state;
+    const { access, audit, auditGroup, error } = this.state;
     if (error) return html`<div class="card"><p class="status-bad">${error}</p></div>`;
     return html`<div class="grid">
         <${AccessCard} access=${access} />
-        <${AuditCard} audit=${audit} />
+        <${AuditCard} audit=${audit} group=${auditGroup} onGroupChange=${this.setAuditGroup} />
     </div>`;
   }
 }

--- a/build/dashboard/tests/frontend/securityview.test.mjs
+++ b/build/dashboard/tests/frontend/securityview.test.mjs
@@ -169,6 +169,10 @@ test("audit card: grouping select appears once there are entries, with the curre
   });
   assert.match(out, /<select/);
   assert.match(out, /Group by day/);
+  // Accessibility parity (#530 review): a bare <select> with no associated <label> has no
+  // accessible name for a screen reader — every other select/group control in this codebase
+  // carries one (role=group aria-label, or a <label for>, see xvb-tier-select).
+  assert.match(out, /aria-label="Group audit trail by"/);
 });
 
 test("audit card: day grouping renders one header row per distinct day, spanning the table", () => {

--- a/build/dashboard/tests/frontend/securityview.test.mjs
+++ b/build/dashboard/tests/frontend/securityview.test.mjs
@@ -11,14 +11,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { fmtEpoch, SecurityPanel } from "../../mining_dashboard/web/static/securityview.mjs";
+import {
+  bucketKey,
+  fmtEpoch,
+  groupAuditEntries,
+  SecurityPanel,
+} from "../../mining_dashboard/web/static/securityview.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 // Render the panel with its state pre-set (the render probe runs no effects, so the fetches in
 // componentDidMount never fire — state is injected directly, like the configview tests).
 function renderPanel(state) {
   const panel = new SecurityPanel({});
-  panel.state = { access: null, audit: null, error: null, ...state };
+  panel.state = { access: null, audit: null, auditGroup: "flat", error: null, ...state };
   return renderToString(panel.render());
 }
 
@@ -99,4 +104,89 @@ test("audit: empty list says so instead of an empty table", () => {
 test("fetch error surfaces as a message, not a blank panel", () => {
   const out = renderPanel({ error: "TypeError: fetch failed" });
   assert.match(out, /fetch failed/);
+});
+
+// #530: hour/day/month grouping for the audit trail.
+
+test("bucketKey: hour/day/month slice the shared ts format; unknown granularity ignored by the caller", () => {
+  const ts = "2026-07-20T14:35:00Z";
+  assert.equal(bucketKey(ts, "hour"), "2026-07-20T14");
+  assert.equal(bucketKey(ts, "day"), "2026-07-20");
+  assert.equal(bucketKey(ts, "month"), "2026-07");
+  assert.equal(bucketKey(42, "day"), ""); // non-string ts never throws
+});
+
+test("groupAuditEntries: flat/unknown granularity returns one ungrouped run", () => {
+  const entries = [{ ts: "2026-07-20T00:00:00Z" }, { ts: "2026-07-19T00:00:00Z" }];
+  assert.deepEqual(groupAuditEntries(entries, "flat"), [{ bucket: null, entries }]);
+  assert.deepEqual(groupAuditEntries(entries, undefined), [{ bucket: null, entries }]);
+});
+
+test("groupAuditEntries: contiguous same-day entries collapse into one bucket", () => {
+  const entries = [
+    { ts: "2026-07-20T14:00:00Z", actor: "a" },
+    { ts: "2026-07-20T09:00:00Z", actor: "b" },
+    { ts: "2026-07-19T23:00:00Z", actor: "c" },
+  ];
+  const groups = groupAuditEntries(entries, "day");
+  assert.equal(groups.length, 2);
+  assert.equal(groups[0].bucket, "2026-07-20");
+  assert.equal(groups[0].entries.length, 2);
+  assert.equal(groups[1].bucket, "2026-07-19");
+  assert.equal(groups[1].entries.length, 1);
+});
+
+test("groupAuditEntries: month grouping spans multiple days in one bucket", () => {
+  const entries = [
+    { ts: "2026-07-20T00:00:00Z" },
+    { ts: "2026-07-01T00:00:00Z" },
+    { ts: "2026-06-30T00:00:00Z" },
+  ];
+  const groups = groupAuditEntries(entries, "month");
+  assert.deepEqual(
+    groups.map((g) => [g.bucket, g.entries.length]),
+    [
+      ["2026-07", 2],
+      ["2026-06", 1],
+    ],
+  );
+});
+
+test("audit card: default flat grouping shows no group-header row (unchanged row output)", () => {
+  const out = renderPanel({
+    access: { available: true, entries: [] },
+    audit: [{ ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "XVB_ENABLED" }],
+  });
+  assert.doesNotMatch(out, /audit-group-header/);
+  assert.match(out, /XVB_ENABLED/);
+});
+
+test("audit card: grouping select appears once there are entries, with the current group selected", () => {
+  const out = renderPanel({
+    access: { available: true, entries: [] },
+    audit: [{ ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "XVB_ENABLED" }],
+    auditGroup: "day",
+  });
+  assert.match(out, /<select/);
+  assert.match(out, /Group by day/);
+});
+
+test("audit card: day grouping renders one header row per distinct day, spanning the table", () => {
+  const out = renderPanel({
+    access: { available: true, entries: [] },
+    auditGroup: "day",
+    audit: [
+      { ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "A" },
+      { ts: "2026-07-19T08:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "B" },
+    ],
+  });
+  assert.match(out, /class="audit-group-header"/);
+  assert.match(out, /colspan="5"/);
+  assert.match(out, /2026-07-20 \(1\)/);
+  assert.match(out, /2026-07-19 \(1\)/);
+});
+
+test("audit card: empty list shows no grouping select (nothing to group)", () => {
+  const out = renderPanel({ access: { available: true, entries: [] }, audit: [] });
+  assert.doesNotMatch(out, /<select/);
 });

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -2419,6 +2419,81 @@ class TestWatchHostConfig:
         finally:
             sm.close()
 
+    async def test_commit_of_one_key_does_not_swallow_a_concurrent_host_edit(
+        self, tmp_path, monkeypatch
+    ):
+        # #530 review MEDIUM: correlate BY KEY, not just by time. A fresh dashboard commit of key A
+        # landing in the same window as a host-side hand-edit of key B must NOT suppress B — the
+        # out-of-band change the feature exists to catch. Fails on the old time-only `explained =
+        # any(...)` logic, which swallowed the whole diff on ANY fresh commit.
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        # A: xvb.enabled (committable, maps to XVB_ENABLED). B: dashboard.tari_required (maps to
+        # TARI_REQUIRED) — hand-edited on the host, NOT named by the commit below.
+        self._write_config(cfg, {"xvb": {"enabled": True}, "dashboard": {"tari_required": True}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()  # baseline
+            # Both keys change; only A was actually committed through the dashboard.
+            self._write_config(
+                cfg, {"xvb": {"enabled": False}, "dashboard": {"tari_required": False}}
+            )
+            log.write_text(
+                json.dumps(
+                    {
+                        "ts": _iso_now(),
+                        "id": "11111111-1111-4111-8111-111111111111",
+                        "actor": "admin",
+                        "action": "commit",
+                        "status": "applied",
+                        "keys": "XVB_ENABLED",
+                    }
+                )
+                + "\n"
+            )
+            await svc._watch_host_config()
+            events = sm.get_audit_events()
+            # B is recorded out-of-band; A (explained by the commit) is NOT double-recorded.
+            assert len(events) == 1
+            assert events[0]["source"] == "host-edit"
+            assert events[0]["keys"] == "dashboard.tari_required"
+        finally:
+            sm.close()
+
+    async def test_energy_commit_explains_an_energy_subkey_by_prefix(self, tmp_path, monkeypatch):
+        # #530: dashboard.energy.* is config.json-only and audits under the synthetic
+        # DASHBOARD_ENERGY name, which env_key_config_paths maps to the whole `dashboard.energy`
+        # block by prefix — so a committed energy sub-key change stays quiet even though its dotted
+        # diff path (dashboard.energy.cost_per_kwh) isn't the literal committed name.
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        self._write_config(cfg, {"dashboard": {"energy": {"cost_per_kwh": 0.10}}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()  # baseline
+            self._write_config(cfg, {"dashboard": {"energy": {"cost_per_kwh": 0.20}}})
+            log.write_text(
+                json.dumps(
+                    {
+                        "ts": _iso_now(),
+                        "id": "11111111-1111-4111-8111-111111111111",
+                        "actor": "admin",
+                        "action": "commit",
+                        "status": "applied",
+                        "keys": "DASHBOARD_ENERGY",
+                    }
+                )
+                + "\n"
+            )
+            await svc._watch_host_config()
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()
+
     async def test_stale_commit_before_the_last_check_does_not_explain(self, tmp_path, monkeypatch):
         cfg, log = tmp_path / "config.json", tmp_path / "control.log"
         self._write_config(cfg, {"xvb": {"enabled": True}})

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -29,6 +29,7 @@ from mining_dashboard.service.data_service import (
     _parse_legacy_dict_worker,
     _parse_proxy_list_worker,
     _parse_proxy_summary,
+    _read_host_config,
     _shares_to_record,
     _summary_deltas,
 )
@@ -1987,6 +1988,39 @@ class TestRigEditDetection:
         finally:
             sm.close()
 
+    def test_same_change_id_across_polls_records_exactly_one_row(self):
+        # The flood guard (HIGH #530 review): a rig re-reports its last terminal change_id every
+        # poll. Deterministic row id + in-memory guard must collapse that to ONE audit row, not a
+        # new row per ~30s cycle for a permanent, never-pruned table.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            worker_results = [
+                {"rigforge": {"control": {"change_id": "rig-local-cid", "status": "applied"}}}
+            ]
+            for _ in range(3):  # three consecutive polls, same report
+                asyncio.run(svc._reconcile_worker_config([{"name": "rig1"}], worker_results))
+            assert len(sm.get_audit_events()) == 1
+        finally:
+            sm.close()
+
+    def test_repeat_report_after_a_restart_still_dedups_via_the_deterministic_id(self):
+        # The in-memory guard is empty on a fresh DataService (restart), but the SAME rig report
+        # must still not duplicate the row — the deterministic id + INSERT OR IGNORE is the bound.
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        try:
+            worker_results = [
+                {"rigforge": {"control": {"change_id": "rig-local-cid", "status": "applied"}}}
+            ]
+            svc1 = DataService(sm, MagicMock(), MagicMock())
+            asyncio.run(svc1._reconcile_worker_config([{"name": "rig1"}], worker_results))
+            svc2 = DataService(sm, MagicMock(), MagicMock())  # "restart": fresh empty guard set
+            asyncio.run(svc2._reconcile_worker_config([{"name": "rig1"}], worker_results))
+            assert len(sm.get_audit_events()) == 1
+        finally:
+            sm.close()
+
 
 class TestTariPayoutSync:
     """Tari on-chain payout confirmation poll (#462): persist to the shared table with chain="tari",
@@ -2426,6 +2460,96 @@ class TestWatchHostConfig:
             assert sm.get_audit_events() == []
         finally:
             sm.close()
+
+    async def test_a_raw_secret_value_never_reaches_the_audit_row(self, tmp_path, monkeypatch):
+        # Defense-in-depth (#530 review MEDIUM): even if the host masking regressed and left a RAW
+        # secret in the mounted copy, the re-mask keeps its value out of the persisted snapshot and
+        # out of any audit row. Change a non-secret key alongside the raw secret; the row names the
+        # non-secret key only, and the secret value appears nowhere.
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        self._write_config(
+            cfg, {"dashboard": {"auth": {"password": "s3cr3t-raw"}}, "xvb": {"enabled": True}}
+        )
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()  # baseline (secret already masked in the snapshot)
+            assert svc._last_host_config["dashboard"]["auth"]["password"] == {"__secret__": True}
+            self._write_config(
+                cfg,
+                {"dashboard": {"auth": {"password": "s3cr3t-changed"}}, "xvb": {"enabled": False}},
+            )
+            await svc._watch_host_config()
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["keys"] == "xvb.enabled"  # the secret masks to a sentinel both sides
+            blob = json.dumps(events) + json.dumps(svc._last_host_config)
+            assert "s3cr3t-raw" not in blob and "s3cr3t-changed" not in blob
+        finally:
+            sm.close()
+
+    async def test_explained_window_is_at_most_one_second(self, tmp_path, monkeypatch):
+        # Boundary (#530 review LOW): the "explained by a fresh commit" check floors `since` to
+        # `_last_host_check - 1` to absorb the audit log's whole-second ts truncation. That grace
+        # is exactly 1s wide — a commit 1s before the last check still explains (truncation), one
+        # 2s before does not. Pinned here so the honest ceiling can't silently widen.
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        check_epoch = _parse_audit_ts("2026-07-20T12:00:05Z")
+
+        async def _run_with_commit_ts(commit_ts):
+            svc, sm = self._svc()
+            svc._last_host_config = {"xvb": {"enabled": True}}
+            svc._last_host_check = check_epoch
+            self._write_config(cfg, {"xvb": {"enabled": False}})
+            log.write_text(
+                json.dumps(
+                    {
+                        "ts": commit_ts,
+                        "id": "11111111-1111-4111-8111-111111111111",
+                        "actor": "admin",
+                        "action": "commit",
+                        "status": "applied",
+                        "keys": "XVB_ENABLED",
+                    }
+                )
+                + "\n"
+            )
+            try:
+                await svc._watch_host_config()
+                return len(sm.get_audit_events())
+            finally:
+                sm.close()
+
+        # 1s before the last check: still explains (truncation grace) -> no host-edit row.
+        assert await _run_with_commit_ts("2026-07-20T12:00:04Z") == 0
+        # 2s before: outside the grace, correctly NOT explained -> host-edit recorded.
+        assert await _run_with_commit_ts("2026-07-20T12:00:03Z") == 1
+
+
+class TestReadHostConfig:
+    """#530 review MEDIUM: the mounted copy is pre-masked host-side, but _read_host_config
+    re-applies the SECRET_PATHS mask (like control_service.read_config) so a host masking
+    regression can't leave a raw secret resident in the long-lived config snapshot."""
+
+    def test_secret_value_is_remasked(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.json"
+        cfg.write_text(json.dumps({"dashboard": {"auth": {"password": "leaked"}}}))
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        out = _read_host_config()
+        assert out["dashboard"]["auth"]["password"] == {"__secret__": True}
+
+    def test_missing_or_bad_file_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", "/nonexistent/config.json")
+        assert _read_host_config() is None
+        bad = tmp_path / "config.json"
+        bad.write_text("{not json")
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(bad))
+        assert _read_host_config() is None
 
 
 class TestMirrorControlAudit:

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,9 +20,12 @@ from mining_dashboard.service.data_service import (
     WorkerLifecycle,
     _aggregate_hashrate,
     _aggregate_window_hashrates,
+    _diff_config_keys,
+    _iso_now,
     _merge_direct_stats,
     _merge_proxy_summary,
     _normalize_proxy_workers,
+    _parse_audit_ts,
     _parse_legacy_dict_worker,
     _parse_proxy_list_worker,
     _parse_proxy_summary,
@@ -1793,7 +1797,11 @@ class TestReconcileWorkerConfig:
     rollback left stuck 'accepted', once the rig's enriched feed mirrors a terminal outcome for
     that change_id (rigforge.control). Real StateManager (not a mock) throughout — every assertion
     reads back the actual stored row, so a reverted WHERE-clause guard or a dropped reconcile call
-    fails these tests, not just a mock's call count."""
+    fails these tests, not just a mock's call count.
+
+    #530 extends the same poll: a TERMINAL report for a change_id this dashboard never spooled is
+    a rig-side out-of-band edit, recorded to ``audit_events`` instead of silently reconciling
+    nothing."""
 
     def _svc_with_real_storage(self):
         from mining_dashboard.service.storage_service import StateManager
@@ -1809,6 +1817,9 @@ class TestReconcileWorkerConfig:
         rows = [r for r in sm.get_worker_config_history(worker) if r["change_id"] == change_id]
         assert len(rows) == 1
         return rows[0]
+
+    def _workers(self, *names):
+        return [{"name": n} for n in names]
 
     def test_terminal_report_reconciles_accepted_row(self):
         # The main revert-proof case: a real 'accepted' row becomes 'rolled_back' once the rig's
@@ -1827,10 +1838,12 @@ class TestReconcileWorkerConfig:
                     }
                 }
             ]
-            asyncio.run(svc._reconcile_worker_config(worker_results))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), worker_results))
             row = self._status_of(sm)
             assert row["status"] == "rolled_back"
             assert row["reason"] == "miner did not return to a live hashrate"
+            # A known change_id reconciles quietly — no audit row for the dashboard's own change.
+            assert sm.get_audit_events() == []
         finally:
             sm.close()
 
@@ -1841,7 +1854,7 @@ class TestReconcileWorkerConfig:
             worker_results = [
                 {"rigforge": {"control": {"change_id": "cid-1", "status": "rolled_back"}}}
             ]
-            asyncio.run(svc._reconcile_worker_config(worker_results))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), worker_results))
             assert self._status_of(sm)["status"] == "applied"
         finally:
             sm.close()
@@ -1852,7 +1865,7 @@ class TestReconcileWorkerConfig:
         svc, sm = self._svc_with_real_storage()
         try:
             self._seed(sm, "accepted")
-            asyncio.run(svc._reconcile_worker_config([{}]))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), [{}]))
             assert self._status_of(sm)["status"] == "accepted"
         finally:
             sm.close()
@@ -1862,7 +1875,7 @@ class TestReconcileWorkerConfig:
         try:
             self._seed(sm, "accepted")
             worker_results = [{"rigforge": {"control": {"status": "rolled_back"}}}]
-            asyncio.run(svc._reconcile_worker_config(worker_results))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), worker_results))
             assert self._status_of(sm)["status"] == "accepted"
         finally:
             sm.close()
@@ -1874,7 +1887,7 @@ class TestReconcileWorkerConfig:
             worker_results = [
                 {"rigforge": {"control": {"change_id": "cid-1", "status": "accepted"}}}
             ]
-            asyncio.run(svc._reconcile_worker_config(worker_results))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), worker_results))
             assert self._status_of(sm)["status"] == "accepted"
         finally:
             sm.close()
@@ -1896,11 +1909,81 @@ class TestReconcileWorkerConfig:
                     }
                 },
             ]
-            asyncio.run(svc._reconcile_worker_config(worker_results))
+            asyncio.run(svc._reconcile_worker_config(self._workers("rig1", "rig2"), worker_results))
             assert self._status_of(sm, worker="rig1", change_id="cid-1")["status"] == "applied"
             row2 = self._status_of(sm, worker="rig2", change_id="cid-2")
             assert row2["status"] == "rejected"
             assert row2["reason"] == "bad pool url"
+        finally:
+            sm.close()
+
+
+class TestRigEditDetection:
+    """#530: a rig's control-status mirror reports a TERMINAL outcome for a change_id this
+    dashboard never spooled into ``worker_config`` — the rig applied it on its own. That gets
+    recorded as a ``rig-edit`` audit row naming the worker, instead of the silent no-op a
+    ``reconcile_worker_config_status`` UPDATE would be against a change_id with no matching row."""
+
+    def _svc_with_real_storage(self):
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        svc = DataService(sm, MagicMock(), MagicMock())
+        return svc, sm
+
+    def test_unknown_change_id_records_rig_edit(self):
+        svc, sm = self._svc_with_real_storage()
+        try:
+            worker_results = [
+                {
+                    "rigforge": {
+                        "control": {
+                            "change_id": "rig-local-cid",
+                            "status": "applied",
+                            "reason": None,
+                        }
+                    }
+                }
+            ]
+            asyncio.run(svc._reconcile_worker_config([{"name": "rig1"}], worker_results))
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["source"] == "rig-edit"
+            assert events[0]["actor"] == "rig1"
+            assert events[0]["status"] == "applied"
+            assert "rig-local-cid" in events[0]["keys"]
+            # Nothing to reconcile — no #185 row existed for this change_id.
+            assert sm.get_worker_config_history("rig1") == []
+        finally:
+            sm.close()
+
+    def test_known_change_id_never_flagged(self):
+        svc, sm = self._svc_with_real_storage()
+        try:
+            sm.add_worker_config_version("rig1", "cid-1", "accepted", {"max_temp_c": 80}, None)
+            worker_results = [
+                {"rigforge": {"control": {"change_id": "cid-1", "status": "applied"}}}
+            ]
+            asyncio.run(svc._reconcile_worker_config([{"name": "rig1"}], worker_results))
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()
+
+    def test_multiple_workers_only_the_unknown_one_flagged(self):
+        svc, sm = self._svc_with_real_storage()
+        try:
+            sm.add_worker_config_version("rig1", "cid-known", "accepted", {}, None)
+            worker_results = [
+                {"rigforge": {"control": {"change_id": "cid-known", "status": "applied"}}},
+                {"rigforge": {"control": {"change_id": "cid-unknown", "status": "rejected"}}},
+            ]
+            asyncio.run(
+                svc._reconcile_worker_config([{"name": "rig1"}, {"name": "rig2"}], worker_results)
+            )
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["actor"] == "rig2"
+            assert events[0]["status"] == "rejected"
         finally:
             sm.close()
 
@@ -2160,3 +2243,262 @@ class TestSyncPrices:
         svc.price_feed.maybe_fetch.return_value = prices
         await svc._sync_prices()
         assert svc.latest_data["prices"] == prices
+
+
+class TestDiffConfigKeys:
+    """#530: dotted-path config diff — names only, the out-of-band host-edit detector's sole
+    correctness surface. A value is compared for equality but never returned."""
+
+    def test_no_change_is_empty(self):
+        cfg = {"xvb": {"enabled": True}}
+        assert _diff_config_keys(cfg, dict(cfg)) == []
+
+    def test_changed_leaf_named(self):
+        old = {"xvb": {"donation_level": "auto"}}
+        new = {"xvb": {"donation_level": "vip"}}
+        assert _diff_config_keys(old, new) == ["xvb.donation_level"]
+
+    def test_added_and_removed_keys_named(self):
+        assert _diff_config_keys({"a": 1}, {"b": 2}) == ["a", "b"]
+
+    def test_nested_paths_use_dotted_names(self):
+        old = {"telegram": {"events": {"node_down": True}}}
+        new = {"telegram": {"events": {"node_down": False}}}
+        assert _diff_config_keys(old, new) == ["telegram.events.node_down"]
+
+    def test_secret_sentinel_change_detected_without_a_value(self):
+        # The masked config's secret leaves are {"__secret__": True} sentinels (#440) — clearing or
+        # setting one changes dict-presence, detectable by equality alone; no real secret is ever
+        # compared or returned by this function.
+        old = {"dashboard": {"auth": {"password": {"__secret__": True}}}}
+        new = {"dashboard": {"auth": {}}}
+        assert _diff_config_keys(old, new) == ["dashboard.auth.password"]
+
+    def test_unrelated_keys_untouched(self):
+        assert _diff_config_keys({"a": 1, "b": 2}, {"a": 1, "b": 3}) == ["b"]
+
+    def test_non_dict_input_is_treated_as_empty(self):
+        # A malformed config.json (top-level not an object) must never crash the watcher — every
+        # key on the OTHER side just reads as added/removed.
+        assert _diff_config_keys("not-a-dict", {"a": 1}) == ["a"]
+        assert _diff_config_keys(None, None) == []
+
+
+class TestAuditTsHelpers:
+    """#530: the shared ts format between control.log's own writer and this dashboard's
+    detections — a plain string round-trips through both directions."""
+
+    def test_iso_now_round_trips_through_parse_audit_ts(self):
+        parsed = _parse_audit_ts(_iso_now())
+        assert parsed is not None
+        assert abs(parsed - time.time()) < 5
+
+    def test_parse_audit_ts_rejects_garbage(self):
+        assert _parse_audit_ts("not-a-timestamp") is None
+        assert _parse_audit_ts(None) is None
+        assert _parse_audit_ts(123) is None
+
+
+class TestWatchHostConfig:
+    """#530: config.json changed without a matching control-channel commit -> a ``host-edit``
+    audit row. Real StateManager throughout, like TestReconcileWorkerConfig — every assertion
+    reads back the persisted row."""
+
+    def _svc(self):
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        svc = DataService(sm, MagicMock(), MagicMock())
+        return svc, sm
+
+    def _write_config(self, path, doc):
+        path.write_text(json.dumps(doc))
+
+    async def test_control_disabled_is_a_noop(self, monkeypatch):
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", False)
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()
+            assert sm.get_audit_events() == []
+            assert svc._last_host_config is None
+        finally:
+            sm.close()
+
+    async def test_first_poll_only_baselines(self, tmp_path, monkeypatch):
+        cfg = tmp_path / "config.json"
+        self._write_config(cfg, {"xvb": {"enabled": True}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()
+            assert sm.get_audit_events() == []
+            assert svc._last_host_config == {"xvb": {"enabled": True}}
+        finally:
+            sm.close()
+
+    async def test_unexplained_change_is_recorded_host_edit(self, tmp_path, monkeypatch):
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        self._write_config(cfg, {"xvb": {"enabled": True}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()  # baseline
+            self._write_config(cfg, {"xvb": {"enabled": False}})  # changed out of band
+            await svc._watch_host_config()
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["source"] == "host-edit"
+            assert events[0]["keys"] == "xvb.enabled"
+            assert events[0]["status"] == "detected"
+        finally:
+            sm.close()
+
+    async def test_change_explained_by_a_fresh_commit_is_quiet(self, tmp_path, monkeypatch):
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        self._write_config(cfg, {"xvb": {"enabled": True}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()  # baseline
+            self._write_config(cfg, {"xvb": {"enabled": False}})
+            # A commit landed AFTER the baseline check — it explains the change.
+            log.write_text(
+                json.dumps(
+                    {
+                        "ts": _iso_now(),
+                        "id": "11111111-1111-4111-8111-111111111111",
+                        "actor": "admin",
+                        "action": "commit",
+                        "status": "applied",
+                        "keys": "XVB_ENABLED",
+                    }
+                )
+                + "\n"
+            )
+            await svc._watch_host_config()
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()
+
+    async def test_stale_commit_before_the_last_check_does_not_explain(self, tmp_path, monkeypatch):
+        cfg, log = tmp_path / "config.json", tmp_path / "control.log"
+        self._write_config(cfg, {"xvb": {"enabled": True}})
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", str(cfg))
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            # An old commit, already accounted for before this watcher ever ran, then a NEW
+            # out-of-band change — the stale commit must not explain it away.
+            log.write_text(
+                json.dumps(
+                    {
+                        "ts": "2020-01-01T00:00:00Z",
+                        "id": "11111111-1111-4111-8111-111111111111",
+                        "actor": "admin",
+                        "action": "commit",
+                        "status": "applied",
+                        "keys": "XVB_ENABLED",
+                    }
+                )
+                + "\n"
+            )
+            await svc._watch_host_config()  # baseline
+            self._write_config(cfg, {"xvb": {"enabled": False}})
+            await svc._watch_host_config()
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["source"] == "host-edit"
+        finally:
+            sm.close()
+
+    async def test_missing_mount_is_a_quiet_noop(self, monkeypatch):
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.config, "HOST_CONFIG_PATH", "/nonexistent/config.json")
+        svc, sm = self._svc()
+        try:
+            await svc._watch_host_config()
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()
+
+
+class TestMirrorControlAudit:
+    """#530: opportunistically copies the #33 log's recent entries into the durable
+    ``audit_events`` table so the Security panel can group deeper than the log's own trimmed
+    tail. ``audit_service.recent_changes()`` output is already sanitized — nothing new to clean
+    here, only to persist."""
+
+    def _svc(self):
+        from mining_dashboard.service.storage_service import StateManager
+
+        sm = StateManager(db_path=":memory:")
+        svc = DataService(sm, MagicMock(), MagicMock())
+        return svc, sm
+
+    def _log_line(self, **over):
+        entry = {
+            "ts": "2026-07-10T12:00:00Z",
+            "id": "11111111-1111-4111-8111-111111111111",
+            "actor": "admin",
+            "action": "commit",
+            "status": "applied",
+            "keys": "XVB_ENABLED",
+        }
+        entry.update(over)
+        return json.dumps(entry)
+
+    async def test_disabled_is_a_noop(self, monkeypatch):
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", False)
+        svc, sm = self._svc()
+        try:
+            await svc._mirror_control_audit()
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()
+
+    async def test_mirrors_log_entries(self, tmp_path, monkeypatch):
+        log = tmp_path / "control.log"
+        log.write_text(self._log_line() + "\n")
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._mirror_control_audit()
+            events = sm.get_audit_events()
+            assert len(events) == 1
+            assert events[0]["source"] == "control"
+            assert events[0]["actor"] == "admin"
+            assert events[0]["keys"] == "XVB_ENABLED"
+        finally:
+            sm.close()
+
+    async def test_re_mirroring_is_idempotent(self, tmp_path, monkeypatch):
+        log = tmp_path / "control.log"
+        log.write_text(self._log_line() + "\n")
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._mirror_control_audit()
+            await svc._mirror_control_audit()
+            assert len(sm.get_audit_events()) == 1
+        finally:
+            sm.close()
+
+    async def test_entries_without_an_id_are_skipped(self, tmp_path, monkeypatch):
+        log = tmp_path / "control.log"
+        log.write_text(self._log_line(id="") + "\n")
+        monkeypatch.setattr(ds_mod.config, "DASHBOARD_CONTROL_ENABLED", True)
+        monkeypatch.setattr(ds_mod.audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        svc, sm = self._svc()
+        try:
+            await svc._mirror_control_audit()
+            assert sm.get_audit_events() == []
+        finally:
+            sm.close()

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -1315,3 +1315,134 @@ class TestWorkerConfigReconcile:
     def test_reads_and_writes_after_close_are_safe(self, state_manager):
         state_manager.close()
         state_manager.reconcile_worker_config_status("cid-1", "rolled_back")  # must not raise
+
+
+class TestWorkerConfigChangeKnown:
+    """#530: whether a change_id was ever spooled by THIS dashboard — the rig-edit detector's
+    only question. Only ``add_worker_config_version`` (the dashboard's own worker-apply write)
+    ever populates ``worker_config``, so an unknown change_id means the RIG applied it."""
+
+    def test_known_change_id_is_true(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid-1", "accepted", {}, None)
+        assert state_manager.worker_config_change_known("cid-1") is True
+
+    def test_unknown_change_id_is_false(self, state_manager):
+        assert state_manager.worker_config_change_known("no-such-id") is False
+
+    def test_empty_change_id_is_false(self, state_manager):
+        assert state_manager.worker_config_change_known("") is False
+        assert state_manager.worker_config_change_known(None) is False
+
+    def test_after_close_is_false(self, state_manager):
+        state_manager.close()
+        assert state_manager.worker_config_change_known("cid-1") is False
+
+    def test_lookup_error_fails_open_true(self, state_manager):
+        # A DB hiccup during the lookup must not manufacture a false rig-edit report — fail toward
+        # treating the change_id as known (quiet), not toward flagging it.
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_config")
+        assert state_manager.worker_config_change_known("cid-1") is True
+
+
+class TestAuditEvents:
+    """#530: the durable audit_events table backing the Security panel — mirrored control.log
+    rows plus the out-of-band host-edit/rig-edit detections."""
+
+    def test_add_and_get_round_trips(self, state_manager):
+        state_manager.add_audit_event(
+            id="ev-1",
+            ts="2026-07-20T12:00:00Z",
+            source="host-edit",
+            actor="",
+            action="host-edit",
+            status="detected",
+            keys="xvb.enabled",
+        )
+        events = state_manager.get_audit_events()
+        assert len(events) == 1
+        assert events[0]["id"] == "ev-1"
+        assert events[0]["source"] == "host-edit"
+        assert events[0]["keys"] == "xvb.enabled"
+
+    def test_insert_or_ignore_is_idempotent_on_id(self, state_manager):
+        # Re-mirroring the same control.log row (or re-detecting the same out-of-band event)
+        # must not duplicate it.
+        for _ in range(3):
+            state_manager.add_audit_event(
+                id="dup-1",
+                ts="2026-07-20T12:00:00Z",
+                source="control",
+                actor="admin",
+                action="commit",
+                status="applied",
+                keys="XVB_ENABLED",
+            )
+        assert len(state_manager.get_audit_events()) == 1
+
+    def test_newest_first_by_ts(self, state_manager):
+        state_manager.add_audit_event(
+            id="a",
+            ts="2026-07-01T00:00:00Z",
+            source="control",
+            actor="",
+            action="commit",
+            status="applied",
+            keys="",
+        )
+        state_manager.add_audit_event(
+            id="b",
+            ts="2026-07-20T00:00:00Z",
+            source="host-edit",
+            actor="",
+            action="host-edit",
+            status="detected",
+            keys="",
+        )
+        events = state_manager.get_audit_events()
+        assert [e["id"] for e in events] == ["b", "a"]
+
+    def test_limit_applies(self, state_manager):
+        for i in range(5):
+            state_manager.add_audit_event(
+                id=f"ev-{i}",
+                ts=f"2026-07-{i + 1:02d}T00:00:00Z",
+                source="control",
+                actor="",
+                action="commit",
+                status="applied",
+                keys="",
+            )
+        assert len(state_manager.get_audit_events(limit=2)) == 2
+
+    def test_write_error_flags_db_unhealthy(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE audit_events")
+        state_manager.add_audit_event(
+            id="x",
+            ts="2026-07-20T00:00:00Z",
+            source="control",
+            actor="",
+            action="commit",
+            status="applied",
+            keys="",
+        )
+        assert state_manager.is_db_healthy() is False
+
+    def test_reads_and_writes_after_close_are_safe(self, state_manager):
+        state_manager.close()
+        state_manager.add_audit_event(
+            id="x",
+            ts="2026-07-20T00:00:00Z",
+            source="control",
+            actor="",
+            action="commit",
+            status="applied",
+            keys="",
+        )  # must not raise
+        assert state_manager.get_audit_events() == []
+
+    def test_read_error_returns_empty_list(self, state_manager):
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE audit_events")
+        assert state_manager.get_audit_events() == []

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -496,6 +496,143 @@ class TestSecurityLogRoutes:
         assert resp.status == 500
         assert "secret" not in json.dumps(await resp.json())
 
+    async def test_audit_route_merges_db_only_entries(self, control_client, monkeypatch):
+        # #530: an out-of-band host-edit/rig-edit row lives only in audit_events, never in
+        # control.log — it must still appear in the served feed.
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", "/nonexistent/control.log")
+        state_mgr = control_client.app["state_manager"]
+        state_mgr.add_audit_event(
+            id="hostedit-1",
+            ts="2026-07-20T12:00:00Z",
+            source="host-edit",
+            actor="",
+            action="host-edit",
+            status="detected",
+            keys="xvb.enabled",
+        )
+        resp = await control_client.get("/api/audit")
+        assert resp.status == 200
+        entries = (await resp.json())["entries"]
+        assert len(entries) == 1
+        assert entries[0]["source"] == "host-edit"
+        assert entries[0]["keys"] == "xvb.enabled"
+
+    async def test_audit_route_shows_a_fresh_commit_before_it_is_mirrored(
+        self, control_client, tmp_path, monkeypatch
+    ):
+        # A commit that just landed in control.log, before the next poll cycle mirrors it to the
+        # DB, must still show up immediately — no regression from #530's DB merge.
+        log = tmp_path / "control.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-07-20T12:00:00Z",
+                    "id": "11111111-1111-4111-8111-111111111111",
+                    "actor": "admin",
+                    "action": "commit",
+                    "status": "applied",
+                    "keys": "XVB_ENABLED",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        resp = await control_client.get("/api/audit")
+        entries = (await resp.json())["entries"]
+        assert len(entries) == 1
+        assert entries[0]["keys"] == "XVB_ENABLED"
+
+    async def test_audit_route_deduplicates_a_mirrored_row(
+        self, control_client, tmp_path, monkeypatch
+    ):
+        # The same control.log row, present both live (log tail) and mirrored (DB) — one row out,
+        # not two.
+        log = tmp_path / "control.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-07-20T12:00:00Z",
+                    "id": "22222222-2222-4222-8222-222222222222",
+                    "actor": "admin",
+                    "action": "commit",
+                    "status": "applied",
+                    "keys": "XVB_ENABLED",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        state_mgr = control_client.app["state_manager"]
+        state_mgr.add_audit_event(
+            id="22222222-2222-4222-8222-222222222222",
+            ts="2026-07-20T12:00:00Z",
+            source="control",
+            actor="admin",
+            action="commit",
+            status="applied",
+            keys="XVB_ENABLED",
+        )
+        resp = await control_client.get("/api/audit")
+        entries = (await resp.json())["entries"]
+        assert len(entries) == 1
+
+    async def test_audit_route_sorts_newest_first_across_sources(
+        self, control_client, tmp_path, monkeypatch
+    ):
+        log = tmp_path / "control.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-07-01T00:00:00Z",
+                    "id": "33333333-3333-4333-8333-333333333333",
+                    "actor": "admin",
+                    "action": "commit",
+                    "status": "applied",
+                    "keys": "XVB_ENABLED",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        state_mgr = control_client.app["state_manager"]
+        state_mgr.add_audit_event(
+            id="hostedit-2",
+            ts="2026-07-20T00:00:00Z",
+            source="host-edit",
+            actor="",
+            action="host-edit",
+            status="detected",
+            keys="xvb.enabled",
+        )
+        resp = await control_client.get("/api/audit")
+        entries = (await resp.json())["entries"]
+        assert [e["id"] for e in entries] == ["hostedit-2", "33333333-3333-4333-8333-333333333333"]
+
+    async def test_audit_route_shows_a_no_id_log_row_live(
+        self, control_client, tmp_path, monkeypatch
+    ):
+        # A pre-auth "invalid"/"refused" control.log row (#33) has no id — never mirrored to the
+        # DB, but still shown live from the log tail.
+        log = tmp_path / "control.log"
+        log.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-07-20T12:00:00Z",
+                    "id": "",
+                    "actor": "",
+                    "action": "invalid",
+                    "status": "refused-oversize",
+                    "keys": "",
+                }
+            )
+            + "\n"
+        )
+        monkeypatch.setattr(audit_service.config, "CONTROL_AUDIT_LOG", str(log))
+        resp = await control_client.get("/api/audit")
+        entries = (await resp.json())["entries"]
+        assert len(entries) == 1
+        assert entries[0]["status"] == "refused-oversize"
+
 
 class TestSecurityHeaders:
     async def test_security_headers_present(self, client):

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -686,6 +686,31 @@ stripped to a safe character set before it is served. See
 [Operations › Watching for intruders](operations.md#watching-for-intruders) for the log paths,
 size bounds, and rotation steps.
 
+### Catching changes made outside the dashboard
+
+The audit trail above only sees requests that went through the control channel. Two things can
+change the stack without it: a hand-edit (or a `pithead apply` run from the host CLI) to
+`config.json`, and a config change applied directly to a rig's own control API instead of through
+Worker Inspect ([#530](https://github.com/p2pool-starter-stack/pithead/issues/530)). The dashboard
+watches for both on its normal poll cycle and appends them to the SAME audit trail:
+
+- **`host-edit`** — `config.json` changed since the last poll and no control-channel commit
+  explains it. The row names the changed setting paths (e.g. `xvb.donation_level`); it never
+  records a value.
+- **`rig-edit`** — a worker's control API reports a config change this dashboard never sent. The
+  row names the worker and the rig's own change id; RigForge's status feed reports only the
+  outcome of a change, not a per-key diff, so unlike `host-edit` this can't name which setting
+  moved — inspect the rig directly to see what changed.
+
+Either kind is worth treating like a rotate-now signal in the same spirit as
+[Operations › Watching for intruders](operations.md#watching-for-intruders): if you didn't make
+the change, someone or something with host or rig access did.
+
+The audit trail is no longer only a log tail: entries — both mirrored from `control.log` and the
+two out-of-band kinds above — persist to the dashboard's own database, so the card's grouping
+selector (hour/day/month) can drill back further than the log's own trimmed window. Pick "All" for
+the flat newest-first view, or a coarser grouping to scan a longer history at a glance.
+
 ## Upgrading from the dashboard
 
 With `dashboard.control.enabled: true` (the same flag as the Configuration view) and a newer

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -116,6 +116,7 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | `doctor` runtime verdicts (#383): egress firewall, stratum listening, dashboard answers | real box | 1 ✅ (stubbed toolchain) · 4 ▶ (`--check`) |
 | Control channel (#33): `apply --dry-run` preview, runner claim/validate/commit, fail-closed flag, rw/ro spool mounts | spool files / sourced fns | 1 ✅ (shell + pytest + compose) · 4 (systemd path unit on a real box — not yet a matrix row) |
 | Audit + access logs (#349): key-names-not-values audit entries, bounded log growth, Caddyfile log block, hostile log content served inert | spool/log fixtures | 1 ✅ (shell + pytest + node) · 4 (real Caddy writes over Tor — covered by the same onion matrix row) |
+| Out-of-band audit detection + persistence (#530): a `config.json` change with no matching commit (`host-edit`) or a rig reporting a change_id the dashboard never spooled (`rig-edit`) both append to the durable `audit_events` table (mirrored `control.log` rows + these two kinds); Security panel hour/day/month grouping | poll-loop diff / real StateManager | 1 ✅ (`test_data_service.py::TestWatchHostConfig`/`TestRigEditDetection`/`TestMirrorControlAudit`, `test_storage_service.py::TestAuditEvents`, `securityview.test.mjs` grouping) · 4 (deferred — the underlying rig-side-edit-visible-in-the-enriched-feed mechanism is already proven live by the #516 row below; a real box producing a `host-edit`/`rig-edit` audit row end-to-end is not yet its own matrix leg) |
 
 ### H. Host / infrastructure (real-only)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -194,6 +194,19 @@ change staged through the dashboard and who committed it. A change you didn't ma
 rotate-now signal. Secret rotation beyond the dashboard password is tracked in
 [#378](https://github.com/p2pool-starter-stack/pithead/issues/378).
 
+`control.log` only sees requests that went through the dashboard. The dashboard's own poll loop
+additionally watches for two changes it did NOT make and appends them to the same audit trail
+([#530](https://github.com/p2pool-starter-stack/pithead/issues/530),
+[details](dashboard.md#catching-changes-made-outside-the-dashboard)): a `config.json` edit with no
+matching commit (`host-edit`), and a worker's control API reporting a change the dashboard never
+sent (`rig-edit`). Both name only what changed — settings or a worker, never a secret value — and
+both are the same rotate-now signal as an unexplained `control.log` entry.
+
+Unlike `control.log`, which the writer trims to bound its size, the audit trail served by the
+dashboard persists to its own database — mirrored `control.log` rows plus the two out-of-band
+kinds above — so the Security panel's hour/day/month grouping can look back further than the log's
+own trimmed window.
+
 ---
 
 ## Updating the stack


### PR DESCRIPTION
Closes #530

Targets the v1.11 integration branch; merges to develop after v1.10 ships.

## Summary

Extends the #349 Security panel's audit trail to catch changes it never saw, and adds time-based grouping so the trail scales past a flat tail.

**Ask 1 — out-of-band detection:**
- **`host-edit`**: the dashboard's poll loop diffs `config.json` (the same pre-masked #440 copy the control channel prefills from) against its previous snapshot. A change is "explained" — and stays quiet — only if a `commit`/`applied` entry landed in the #33 `control.log` since the last check; anything else (a hand-edit, a `pithead apply` run from the host CLI) is recorded with the changed key *names* only, never values.
- **`rig-edit`**: the existing per-rig reconcile poll (`_reconcile_worker_config`, #579) already reads each rig's terminal control-apply outcome (`change_id`/`status`/`reason`) off the enriched feed. A `change_id` this dashboard never spooled into `worker_config` (the table only its own `worker-apply` writes populate) means the rig applied it on its own — recorded naming the worker. **Known limitation, not an oversight**: RigForge's `/status` mirror reports only the outcome of a change, not a per-key diff, so unlike `host-edit` this can't name which setting moved on the rig — only that one did, and which rig.

Both reuse the existing `audit_service._clean` sanitizer (same whitelist-charset, length-capped treatment as every other audit field) before anything is persisted.

**Ask 2 — time grouping + persistence decision:**

Added an hour/day/month dropdown to the `AuditCard` (default "All", so existing behavior is unchanged until an operator opts in). Grouping needed more history than `control.log`'s own trimmed tail (the writers already cap it) can offer, and the out-of-band detections above have no log to live in at all — they're generated in the dashboard container, which only holds *write* access to the control spool's `requests/` leg (`results/`, `audit/`, `masked/` are read-only mounts, see `docker-compose.yml`). So:

- New `audit_events` SQLite table (same pattern as `worker_config`/`payouts`/`blocks`/#185): permanent, no pruning — audit events are human-paced admin actions, not a hot metrics series, matching the precedent those tables already set.
- Each poll cycle opportunistically mirrors `control.log`'s recent entries into this table (`INSERT OR IGNORE` on the log's own `id`, idempotent) alongside the two out-of-band kinds.
- `/api/audit` now merges the live log tail (so a commit that just landed shows with zero lag, no regression) with the persisted table (so grouping can look back further, and out-of-band rows — which never touch the log — show up at all), deduplicated by `id`.

## Deferred

- A live rig producing a real `rig-edit` audit row end-to-end is not its own tier-4 matrix leg — the underlying mechanism (a direct rig-side edit becoming visible in the enriched feed / masked prefill) is already proven live by the existing `#516` row in `testing-strategy.md`; this PR's detection logic on top of it is unit-tested (tier 1) with a real `StateManager`.
- `rig-edit` rows can't name the changed keys (see limitation above) — would need a RigForge-side contract change to expose a per-key diff, out of scope here.

## ponytail-review

Ran a pass for over-engineering before opening this PR. One real finding: `.card-header-row`'s comment claimed it was "generic — reuse wherever a card needs one control next to its heading" while it has exactly one caller today. Fixed (dropped the forward-looking framing, kept the one-line class since flexbox-header-row is the natural factoring either way). Nothing else worth cutting — the remaining complexity (secret-sentinel-as-opaque-leaf handling, the whole-second/sub-second timestamp grace window, fail-open on a DB read hiccup, id-based idempotent mirroring) is load-bearing correctness/security logic, not speculative flexibility.

## Test plan

- `make lint`: **green** (ruff, biome, yamllint, markdownlint, docs-voice, shellcheck/shfmt, taplo). `lint-proto` could not run — Docker daemon isn't available in this environment (unrelated to this diff; no proto files touched).
- `make test`: **green** — dashboard pytest (all tiers), frontend `node --test` (230/230), `pithead` shell suite (1541/1541), compose hardening invariants, integration harness self-test, fake-daemon contract test.
- Dashboard coverage: **96.73%** (gate: ≥80%).
- Patch coverage (`diff-cover` vs `origin/develop-v1.11`, this branch's actual base): **100%** (gate: ≥90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)