### PR TITLE
fix(#724): cap per-worker rig-edit audit rows to bound the unauth-feed flood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
   `worker_history` are a separate (Tier-2) slice, not touched here. No chart renders any of these
   series yet — that's a further follow-up.
 
+### Security
+
+- **The out-of-band audit trail is now flood-capped per worker (#724).** The `rig-edit` audit
+  source (#530) reads a worker's reported change id off the unauthenticated LAN worker feed. The
+  #530 deterministic row id collapses *repeats* of one change id to a single row, but not *distinct*
+  ones — so a malicious or compromised device presenting as a worker could report a fresh random
+  change id every poll, writing a new permanent `audit_events` row each ~30s cycle and slowly
+  filling the dashboard database (the table has no pruning). New `rig-edit` rows are now capped per
+  worker per rolling hour; beyond the cap the extra rows are dropped behind a single `rate-limited`
+  marker row and a logged warning, so the flood stays visible instead of growing the table without
+  limit. A genuine occasional rig change still records normally, and the non-attacker-controllable
+  `host-edit` and mirrored `control.log` rows are unaffected.
+
 ## [1.10.2] - 2026-07-21
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,7 +90,12 @@ The stack's defaults:
   and appends both — `host-edit` / `rig-edit` — to the same trail, keys or worker names only. The
   persisted trail (mirrored `control.log` rows plus these two out-of-band kinds) lives in the
   dashboard's own database, not just the log tail, so the Security panel's hour/day/month grouping
-  covers more than `control.log`'s own trimmed window.
+  covers more than `control.log`'s own trimmed window. The `rig-edit` source reads off the
+  unauthenticated worker feed, so it is rate-capped per worker (#724): a rig reporting distinct
+  change_ids on every poll can add at most a bounded number of rows per hour before the rest are
+  dropped behind a single `rate-limited` marker — one LAN device can't grow the database without
+  limit. The `host-edit` and mirrored `control.log` rows are not attacker-controllable and are not
+  capped.
 
 ### Telegram control commands (#338)
 

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -130,6 +130,16 @@ _WORKER_HISTORY_CAPTURE_SEC = 300  # ~5 min
 # like the capture cadences above.
 _XVB_WINNERS_SYNC_SEC = 1800
 
+# Per-worker flood cap on NEW rig-edit audit rows (#724). The enriched worker feed is
+# unauthenticated LAN input, so a rogue device presenting as a worker can report a fresh random
+# change_id every poll — each a distinct, permanent audit_events row (#530's deterministic id only
+# collapses REPEATS of one change_id, never distinct ones). At most _RIG_EDIT_CAP_PER_HOUR genuine
+# rig-edit rows per worker per rolling hour; beyond that, rows are dropped and a single
+# rate-limited marker is recorded + logged. A real fleet edits a rig a handful of times an hour at
+# most, so a legitimate cadence never trips it — only a flood does.
+_RIG_EDIT_CAP_PER_HOUR = 12
+_RIG_EDIT_WINDOW_SEC = 3600
+
 
 def _parse_proxy_list_worker(w):
     """Parse one xmrig-proxy 6.x positional row into a worker dict.
@@ -545,6 +555,15 @@ class DataService:
         # actually bounds the table across restarts (INSERT OR IGNORE); this just skips the
         # redundant DB work in the steady state. Bounded by the count of distinct real rig edits.
         self._flagged_rig_changes = set()
+        # Per-worker fixed-window flood cap on NEW rig-edit rows (#724): {worker: (window_start,
+        # count)}. Distinct change_ids clear #530's deterministic-id dedup, so a rogue rig can
+        # spam a permanent audit row every poll; this bounds them to _RIG_EDIT_CAP_PER_HOUR per
+        # worker per hour. In-memory like _flagged_rig_changes — a restart resets the window, which
+        # at worst grants one extra window's budget, still bounded per wall-hour.
+        # ponytail: a rogue device rotating the worker NAME each poll sidesteps a per-worker cap;
+        # that's the broader unauth-feed vector (#235), out of scope here — cap keyed on worker per
+        # the issue, so one rogue rig can't crowd genuine rig-edit history out.
+        self._rig_edit_window = {}
         # XvB raffle-winners mirror: wall-clock of the last successful winners-file read. Starts
         # at 0.0 so the first eligible poll reads it; NOT stamped on a failed fetch, so a failure
         # retries on the next 10th poll instead of waiting out the 30-min gate.
@@ -1133,6 +1152,19 @@ class DataService:
                 keys=e.get("keys", ""),
             )
 
+    def _rig_edit_within_cap(self, worker, now):
+        """Per-worker fixed-window cap on NEW rig-edit audit rows (#724). Counts this rig-edit
+        against the worker's current hour window and returns ``(allowed, first_over)``: ``allowed``
+        is True while the worker is under ``_RIG_EDIT_CAP_PER_HOUR`` this window; ``first_over`` is
+        True only on the single call that tips it over, so the caller logs + records the
+        rate-limited marker exactly once per window rather than every poll. A handful of real edits
+        an hour never trips it; a rig spamming distinct change_ids does."""
+        start, count = self._rig_edit_window.get(worker, (now, 0))
+        if now - start >= _RIG_EDIT_WINDOW_SEC:
+            start, count = now, 0
+        self._rig_edit_window[worker] = (start, count + 1)
+        return count < _RIG_EDIT_CAP_PER_HOUR, count == _RIG_EDIT_CAP_PER_HOUR
+
     async def _reconcile_worker_config(self, workers, worker_results):
         """Catch up any still-``accepted`` #185 worker-config history row whose change_id the rig
         now reports terminal (#579), and flag an out-of-band RIG-EDIT (#530).
@@ -1157,7 +1189,14 @@ class DataService:
         the audit row's deterministic id makes the write itself idempotent even across a restart
         (when the guard is empty but a repeat report must still not duplicate the row). Both matter
         — the id is the correctness bound (a rogue rig can't flood the permanent table with repeats
-        of one bogus change_id), the guard is the optimisation."""
+        of one bogus change_id), the guard is the optimisation.
+
+        DISTINCT change_ids each clear that dedup, though, so a rogue rig on the unauthenticated
+        feed can still write one permanent row per poll (#724). ``_rig_edit_within_cap`` bounds NEW
+        rig-edit rows to ``_RIG_EDIT_CAP_PER_HOUR`` per worker per hour; beyond that the row is
+        dropped, but never silently — a single ``rate-limited`` marker is logged and recorded so the
+        flood stays visible in the Security panel. host-edit rows are unaffected (a different,
+        non-attacker-controlled path)."""
         for w, extra_stats in zip(workers, worker_results, strict=False):
             ctrl = parse_worker_control_status(extra_stats) if extra_stats else None
             if not ctrl:
@@ -1176,6 +1215,31 @@ class DataService:
                 worker = w.get("name", "")
                 guard_key = (worker, ctrl["change_id"])
                 if guard_key in self._flagged_rig_changes:
+                    continue
+                allowed, first_over = self._rig_edit_within_cap(worker, time.time())
+                if not allowed:
+                    # Over cap this window — drop the row (don't add to the guard set, so its size
+                    # stays bounded by what we actually record, not by the flood). Surface the cap
+                    # once per window: a warning plus one marker row, its deterministic id keyed to
+                    # this worker's window start so it's idempotent even if a restart re-trips
+                    # `first_over`, and a fresh window later gets its own distinct marker.
+                    if first_over:
+                        window_start = self._rig_edit_window[worker][0]
+                        logger.warning(
+                            "Worker %s exceeded %d rig-edit audit rows this hour (#724) — a rig "
+                            "reporting distinct change_ids on the unauthenticated feed; further "
+                            "rig-edit rows are dropped until the window resets.",
+                            worker,
+                            _RIG_EDIT_CAP_PER_HOUR,
+                        )
+                        await self._record_audit_event(
+                            "rig-edit",
+                            worker,
+                            "rate-limited",
+                            "dropped",
+                            f"rig-edit rows capped at {_RIG_EDIT_CAP_PER_HOUR}/hour",
+                            event_id=f"rig-edit-ratelimited-{worker}-{int(window_start)}",
+                        )
                     continue
                 self._flagged_rig_changes.add(guard_key)
                 await self._record_audit_event(

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -2163,6 +2163,74 @@ class TestRigEditDetection:
         finally:
             sm.close()
 
+    def _flood(self, svc, worker, change_ids):
+        for cid in change_ids:
+            wr = [{"rigforge": {"control": {"change_id": cid, "status": "applied"}}}]
+            asyncio.run(svc._reconcile_worker_config([{"name": worker}], wr))
+
+    def test_distinct_change_id_flood_is_bounded_per_worker(self):
+        # #724: a rogue rig on the unauthenticated feed reports a NEW change_id every poll. Each
+        # clears #530's deterministic-id dedup, so without a cap every poll writes a permanent row.
+        # The per-worker hourly cap bounds rig-edit rows to _RIG_EDIT_CAP_PER_HOUR, plus exactly one
+        # rate-limited marker so the flood stays visible — not silently swallowed.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            cap = ds_mod._RIG_EDIT_CAP_PER_HOUR
+            self._flood(svc, "rig1", [f"cid-{i}" for i in range(cap + 8)])
+            events = sm.get_audit_events()
+            rig_edits = [e for e in events if e["action"] == "rig-edit"]
+            markers = [e for e in events if e["action"] == "rate-limited"]
+            assert len(rig_edits) == cap
+            assert len(markers) == 1
+            assert markers[0]["source"] == "rig-edit"
+            assert markers[0]["actor"] == "rig1"
+            assert markers[0]["status"] == "dropped"
+        finally:
+            sm.close()
+
+    def test_normal_cadence_is_never_rate_limited(self):
+        # A real operator edits a rig a handful of times an hour — well under the cap. Every genuine
+        # change_id records and no rate-limited marker is ever written.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            self._flood(svc, "rig1", ["real-0", "real-1", "real-2"])
+            events = sm.get_audit_events()
+            assert len(events) == 3
+            assert all(e["action"] == "rig-edit" for e in events)
+        finally:
+            sm.close()
+
+    def test_cap_is_per_worker_a_flood_does_not_starve_another_rig(self):
+        # The cap is keyed on the worker (not global), so one rogue rig flooding distinct change_ids
+        # never drops a genuine rig-edit — nor any host-edit — from a different, well-behaved source.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            self._flood(
+                svc, "rogue", [f"flood-{i}" for i in range(ds_mod._RIG_EDIT_CAP_PER_HOUR + 5)]
+            )
+            self._flood(svc, "goodrig", ["honest-cid"])
+            goodrig = [e for e in sm.get_audit_events() if e["actor"] == "goodrig"]
+            assert len(goodrig) == 1
+            assert goodrig[0]["action"] == "rig-edit"
+        finally:
+            sm.close()
+
+    def test_cap_resets_after_the_window_elapses(self, monkeypatch):
+        # Fixed in-memory window: once an hour passes the worker's budget refreshes, so a later
+        # genuine change_id records normally again — the cap throttles a flood, it doesn't ban a rig.
+        svc, sm = self._svc_with_real_storage()
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(ds_mod.time, "time", lambda: clock["t"])
+        try:
+            cap = ds_mod._RIG_EDIT_CAP_PER_HOUR
+            self._flood(svc, "rig1", [f"cid-{i}" for i in range(cap + 3)])
+            assert len([e for e in sm.get_audit_events() if e["action"] == "rig-edit"]) == cap
+            clock["t"] += ds_mod._RIG_EDIT_WINDOW_SEC + 1  # next window
+            self._flood(svc, "rig1", ["post-window"])
+            assert [e for e in sm.get_audit_events() if "post-window" in e["keys"]]
+        finally:
+            sm.close()
+
 
 class TestTariPayoutSync:
     """Tari on-chain payout confirmation poll (#462): persist to the shared table with chain="tari",

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -733,7 +733,12 @@ watches for both on its normal poll cycle and appends them to the SAME audit tra
 - **`rig-edit`** — a worker's control API reports a config change this dashboard never sent. The
   row names the worker and the rig's own change id; RigForge's status feed reports only the
   outcome of a change, not a per-key diff, so unlike `host-edit` this can't name which setting
-  moved — inspect the rig directly to see what changed.
+  moved — inspect the rig directly to see what changed. This one source reads off the
+  unauthenticated worker feed, so it is rate-capped per worker
+  ([#724](https://github.com/p2pool-starter-stack/pithead/issues/724)): a rig reporting a fresh
+  change id every poll can add only a bounded number of `rig-edit` rows per hour before the rest
+  are dropped behind a single `rate-limited` row. A real occasional rig change still records; only
+  a flood is capped.
 
 Either kind is worth treating like a rotate-now signal in the same spirit as
 [Operations › Watching for intruders](operations.md#watching-for-intruders): if you didn't make

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -205,7 +205,12 @@ both are the same rotate-now signal as an unexplained `control.log` entry.
 Unlike `control.log`, which the writer trims to bound its size, the audit trail served by the
 dashboard persists to its own database — mirrored `control.log` rows plus the two out-of-band
 kinds above — so the Security panel's hour/day/month grouping can look back further than the log's
-own trimmed window.
+own trimmed window. Because `rig-edit` reads off the unauthenticated worker feed, it is rate-capped
+per worker ([#724](https://github.com/p2pool-starter-stack/pithead/issues/724)): a rig reporting a
+fresh change_id every poll can add only a bounded number of `rig-edit` rows per hour before the
+rest are dropped behind a single `rate-limited` marker, so no one LAN device can grow the database
+without limit. A genuine occasional rig change still records normally; only a flood is capped, and
+the cap is visible — the marker names it, and the dashboard logs a warning.
 
 ---
 


### PR DESCRIPTION
## What & why

Closes #724 (security, MEDIUM).

The out-of-band audit trail (#530) writes a permanent `rig-edit-<worker>-<change_id>` row into `audit_events` whenever a worker reports a terminal `change_id` this dashboard never issued. That enriched worker feed is **unauthenticated LAN input**. #530's deterministic id correctly collapses *repeats* of one `change_id` to a single row — but does nothing to bound *distinct* ones. A malicious or compromised device presenting as a worker can report a **new random `change_id` every ~30s poll**, each clearing the `INSERT OR IGNORE` guard and creating a new permanent row in a table that has **no pruning**. A slow-burn, attacker-driven disk-fill DoS from any device on the miner LAN.

## The fix

A per-worker fixed-window cap on **new** rig-edit rows (`_RIG_EDIT_CAP_PER_HOUR = 12`, in-memory like the existing `_flagged_rig_changes`):

- Under the cap → records normally, exactly as before.
- Over the cap → the extra rows are **dropped, but never silently**: on the transition a single `rate-limited` marker row is recorded (deterministic id keyed to the worker's window start, so it's idempotent across a restart and a fresh window gets its own marker) **and** a warning is logged. The flood stays visible in the Security panel.
- A genuine occasional rig change (a handful an hour) never trips it; only a flood is capped.

Left intact, as the issue directs:
- #530's same-`change_id` dedup (`_flagged_rig_changes` + deterministic event id).
- The `host-edit` and mirrored `control.log` paths — not attacker-controllable, uncapped.

**Scope note:** a rogue device that also rotates its reported worker *name* sidesteps a per-worker cap — that's the broader unauthenticated-feed vector (#235), out of scope here and flagged in-code. The cap is keyed on the worker per the issue, so one rogue rig can't crowd genuine rig-edit history out of the trail.

## Tests (tier-1, `build/dashboard/tests/service/test_data_service.py::TestRigEditDetection`)

- `test_distinct_change_id_flood_is_bounded_per_worker` — a worker spamming distinct change_ids yields exactly `_RIG_EDIT_CAP_PER_HOUR` rig-edit rows + one `rate-limited` marker.
- `test_normal_cadence_is_never_rate_limited` — a handful of genuine distinct edits all record, no marker.
- `test_cap_is_per_worker_a_flood_does_not_starve_another_rig` — a rogue rig's flood never drops a genuine edit from a different worker (per-worker isolation; legit rows unaffected).
- `test_cap_resets_after_the_window_elapses` — after the hour passes the budget refreshes; the cap throttles a flood, it doesn't ban a rig.

Patch coverage 100%. `make lint` (Python) clean; docs-voice + markdown lint clean. Security-reviewed.

## Docs

SECURITY.md / `docs/operations.md` / `docs/dashboard.md` now qualify #530's "permanent, no pruning" note with the cap. CHANGELOG under `[Unreleased] › Security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)