### PR TITLE
feat(#728): allowlist dashboard-confirmed data-dir moves to the stack data root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
   settings, the control channel itself, the Tor egress firewall, the stratum password, node
   endpoints and credentials, and the per-rig hosts and tokens all remain refused from the dashboard,
   as does the heavier direction of a confirm-gated key (disabling pruning forces a full re-sync).
+- **Dashboard-confirmed data-directory moves are allowlisted to the stack's data root** (#728).
+  #719 made the four `*_DATA_DIR` moves confirmable from the dashboard behind a typed `APPLY`, but
+  the destination was still checked only by the host-side blocklist (`assert_safe_dir`), which
+  passes any non-catastrophic absolute path. A confirmed move from the dashboard is now further
+  held to an allowlist: the new location must sit under the stack's own data root (the install
+  dir's `data/`) or a parent the stack already keeps data in, else the move is refused even with
+  the typed confirmation and stays host-CLI only. The host `./pithead apply` path keeps the wider
+  blocklist — a shell operator already has filesystem-wide reach; only the dashboard-reachable move
+  is tightened, closing the destination trust-escalation the confirm-gate opened.
 - **Opt-in local miner** (#593). A box that runs the stack 24/7 can mine with its spare CPU by
   co-locating a RigForge worker on the stack host. `./pithead setup` now asks "Also mine on this
   machine with its spare CPU?" (off by default; also the new `local_miner.enabled` config flag),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,12 @@ The stack's defaults:
   requires Tor client authorization, and every mutation is audited host-side. Commits are default-denied against an explicit allowlist. Low-risk
   operational settings commit directly; a small set of operationally-disruptive ones — data-directory
   moves, the stratum port, enabling clearnet initial sync, and enabling pruning — commit only behind
-  a typed confirmation in the dashboard, and only in that direction. Everything else is refused in
+  a typed confirmation in the dashboard, and only in that direction. A dashboard-confirmed
+  data-directory move is further held to an **allowlist** (#728): the new location must sit under the
+  stack's own data root (the install dir's `data/`) or a parent the stack already keeps data in;
+  a move to any other absolute path is refused even with the typed confirmation and stays host-CLI
+  only. The host CLI keeps its wider blocklist check — a shell operator already has filesystem-wide
+  reach. Everything else is refused in
   every direction, as is anything the change preview flags destructive (including the heavy direction
   of a confirm-gated key, e.g. disabling pruning, which forces a full re-sync). The security
   perimeter — wallets and view keys, dashboard auth and onion exposure, the control channel itself,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -680,6 +680,18 @@ the stratum password, node endpoints and credentials, and the per-rig hosts and 
 also refuses the heavier direction of a confirm-gated key (disabling pruning forces a full re-sync,
 so it stays host-only). Apply those from the host with `./pithead apply`.
 
+A dashboard-confirmed data-directory move
+([#728](https://github.com/p2pool-starter-stack/pithead/issues/728)) is held to a tighter rule than
+the same move from the host CLI. The host guard is a blocklist — it refuses the catastrophic roots
+(`/`, `$HOME`, bare mounts) but lets a shell operator relocate data anywhere else, which is
+proportionate to shell trust. A confirmed move from the dashboard is instead held to an
+**allowlist**: the new location must sit under the stack's own data root (the install dir's
+`data/`) or a parent the stack already keeps its data in (a co-located data root, #455). A move to
+any other absolute path — another user's home, another service's volume — is refused even with the
+typed `APPLY` and stays host-CLI only. This is the one place a confirmed data-dir move differs from
+`./pithead apply`: the destination path is narrowed, because the move is now reachable at dashboard
+trust rather than shell trust.
+
 A pool switch (`p2pool.pool` main/mini/nano) carries its standing warning: p2pool re-syncs the new
 sidechain and your PPLNS window (and XvB shares) reset.
 

--- a/pithead
+++ b/pithead
@@ -5224,7 +5224,12 @@ control_approval_gate() { # <staged-file> [confirm-token]
     local ddpath dest root ok_root
     for ddpath in monero.data_dir tari.data_dir p2pool.data_dir dashboard.data_dir; do
         dest=$(jq -r --arg p "$ddpath" 'getpath($p/".") // empty' "$staged" 2>/dev/null)
-        case "$dest" in "" | auto | DYNAMIC_*) continue ;; esac # stack default → under a data root by construction
+        # Skip only values resolve_default turns into an in-root stack default — its EXACT set,
+        # not a DYNAMIC_* wildcard (which would also swallow a bogus DYNAMIC_FOO that resolve_default
+        # passes through literally). A non-absolute/traversal dest never reaches here anyway:
+        # assert_safe_dir (called in the dry-run re-derivation at the top of this gate) refuses
+        # `..`/relative paths first — keep that ordering.
+        case "$dest" in "" | auto | DYNAMIC_DATA | DYNAMIC_HOST | DYNAMIC_ID) continue ;; esac
         ok_root=0
         # Trailing slash on both sides so a root prefix can't false-match a sibling (/data vs
         # /database); an exact-root dest matches too (harmless — still the stack's own dir).

--- a/pithead
+++ b/pithead
@@ -5200,6 +5200,42 @@ control_approval_gate() { # <staged-file> [confirm-token]
         printf 'this change is destructive and cannot be committed from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
         return 1
     fi
+    # Data-dir destination allowlist (#728). #719 made the four *_DATA_DIR moves confirm-gated, so a
+    # dashboard operator who types APPLY can now RELOCATE a service's data dir. assert_safe_dir — the
+    # host-shell guard — is a BLOCKLIST: it refuses the catastrophic roots (/, $HOME, bare mounts, …)
+    # but passes any OTHER absolute path. At host-shell trust that is proportionate (a shell already
+    # has filesystem-wide reach); at dashboard trust it would let a confirmed move target another
+    # user's home or another service's data volume and have pithead mkdir/chown -R it and bind-mount
+    # it into a recreated container — a destination trust-escalation. This gate runs ONLY for
+    # dashboard commits (the host `apply` path never calls control_approval_gate), so it is exactly
+    # where the tighter, control-only rule belongs: for a control-channel move, narrow the
+    # DESTINATION from a blocklist to an ALLOWLIST — permit only a path under the stack's own data
+    # root ($PWD/data, the install dir's data/) or a parent the stack ALREADY keeps data in (each
+    # live *_DATA_DIR's parent — a root a host operator already opted into, which covers a co-located
+    # shared data root, #455). Anything else is refused EVEN with the APPLY token: that move stays
+    # host-CLI-only. Only EXPLICIT absolute paths are checked — "auto"/empty resolves to a stack
+    # default that is under a data root by construction. assert_safe_dir still runs at apply time.
+    local -a allowed_roots=("$PWD/data")
+    local dvar cur
+    for dvar in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DASHBOARD_DATA_DIR; do
+        cur=$(env_get "$dvar")
+        [ -n "$cur" ] && allowed_roots+=("$(dirname "$cur")")
+    done
+    local ddpath dest root ok_root
+    for ddpath in monero.data_dir tari.data_dir p2pool.data_dir dashboard.data_dir; do
+        dest=$(jq -r --arg p "$ddpath" 'getpath($p/".") // empty' "$staged" 2>/dev/null)
+        case "$dest" in "" | auto | DYNAMIC_*) continue ;; esac # stack default → under a data root by construction
+        ok_root=0
+        # Trailing slash on both sides so a root prefix can't false-match a sibling (/data vs
+        # /database); an exact-root dest matches too (harmless — still the stack's own dir).
+        for root in "${allowed_roots[@]}"; do
+            case "$dest/" in "$root"/*) ok_root=1 && break ;; esac
+        done
+        if [ "$ok_root" -eq 0 ]; then
+            printf 'this move sends %s to %s, which is outside the stack data root(s) — a dashboard-confirmed data-dir move must stay under the stack data directory (%s) or a parent it already uses. Apply it from the host with `%s apply`.' "$ddpath" "$dest" "$PWD/data" "$0"
+            return 1
+        fi
+    done
     # Confirm-gate (#719): an in-scope CONFIRM row PROCEEDS only with the operator's typed
     # confirmation. The token is a fixed literal ("APPLY"), orthogonal to the value being set — it
     # is friction that forces the operator to acknowledge an expensive/disruptive op, NOT a security

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4952,6 +4952,48 @@ assert_contains "prune-disable refusal names the host apply path, not stale #338
 assert_eq "prune stays enabled after the refusal" "$(jq -r '.monero.prune' "$C/config.json")" "true"
 [ ! -f "$STAGED/$UUID3.json" ] && ok "refused destructive intent cleared from staged" || bad "refused destructive intent cleared from staged" "still staged"
 
+echo "== black-box: a dashboard-confirmed data-dir move is allowlisted to the stack data root (#728) =="
+# #719 made the four *_DATA_DIR moves confirm-gated. assert_safe_dir is a BLOCKLIST, so a
+# confirmed move could target any non-blocklisted absolute path (another user's home, another
+# service's volume). control_approval_gate now narrows the DESTINATION to an allowlist for
+# control-channel moves: only under the stack data root ($C/data) or a parent it already uses.
+# The host `apply` path keeps the blocklist — a shell operator is already trusted.
+UUID7="77777777-7777-4777-8777-777777777777"
+control_config mini
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+EVIL_DIR="$SANDBOX/other-service-vol/monero" # absolute, NOT blocklisted, NOT under $C/data
+preview_move() {                             # <monero.data_dir>
+    jq -n --arg w "$WALLET" --arg id "$UUID7" --arg dd "$1" '{id:$id,action:"preview",actor:"admin",config:{
+        monero:{mode:"local",wallet_address:$w,node_username:"u",node_password:"p",data_dir:$dd},
+        tari:{wallet_address:"T"}, p2pool:{pool:"mini"},
+        dashboard:{secure:true,host:"box.lan",auth:{username:"admin",password:"a control passphrase"},control:{enabled:true}}}}' >"$REQS/$UUID7.json"
+    run_pending >/dev/null
+}
+# (1) A move UNDER the stack data root, confirmed with APPLY, is allowed and lands.
+preview_move "$C/data/monero-v2"
+assert_contains "in-root data-dir move previews a CONFIRM row" "$(jq -r '.changes[].flag' "$RESULTS/$UUID7.json" 2>/dev/null)" "CONFIRM"
+printf '{"id":"%s","action":"commit","actor":"admin","confirm":"APPLY"}\n' "$UUID7" >"$REQS/$UUID7.json"
+run_pending >/dev/null
+assert_eq "in-root data-dir move with APPLY applies" "$(jq -r '.status' "$RESULTS/$UUID7.json" 2>/dev/null)" "applied"
+assert_eq "in-root move landed in .env" "$(run_sourced "$C" env_get_file "$C/.env" MONERO_DATA_DIR)" "$C/data/monero-v2"
+# (2) A move to an arbitrary non-blocklisted, non-allowed path is refused EVEN with APPLY.
+preview_move "$EVIL_DIR"
+printf '{"id":"%s","action":"commit","actor":"admin","confirm":"APPLY"}\n' "$UUID7" >"$REQS/$UUID7.json"
+run_pending >/dev/null
+assert_eq "out-of-root data-dir move is refused despite the APPLY token" "$(jq -r '.status' "$RESULTS/$UUID7.json" 2>/dev/null)" "rejected"
+assert_contains "refusal names the data-root allowlist" "$(jq -r '.error' "$RESULTS/$UUID7.json" 2>/dev/null)" "outside the stack data root"
+# The refusal left config.json untouched — it still carries the previously-committed in-root value
+# (test 1), never the refused out-of-root path.
+assert_eq "refused move did not touch config.json" "$(jq -r '.monero.data_dir // empty' "$C/config.json")" "$C/data/monero-v2"
+[ ! -f "$STAGED/$UUID7.json" ] && ok "refused out-of-root move cleared from staged" || bad "refused out-of-root move cleared from staged" "still staged"
+# (3) The SAME path from the HOST shell still applies — the tighter rule is control-only.
+jq -n --arg w "$WALLET" --arg dd "$EVIL_DIR" '{monero:{mode:"local",wallet_address:$w,node_username:"u",node_password:"p",data_dir:$dd},
+    tari:{wallet_address:"T"}, p2pool:{pool:"mini"},
+    dashboard:{secure:true,host:"box.lan",auth:{username:"admin",password:"a control passphrase"},control:{enabled:true}}}' >"$C/config.json"
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+assert_rc "host-shell apply to the same out-of-root path succeeds" "$?" "0"
+assert_eq "host-shell apply rendered the out-of-root path (blocklist, not allowlist)" "$(run_sourced "$C" env_get_file "$C/.env" MONERO_DATA_DIR)" "$EVIL_DIR"
+
 echo "== black-box: a NON-destructive commit still proceeds with no token (#33) =="
 # Restore a clean baseline (prune off, clearnet off) then a pool switch mini -> nano is INFO, not
 # DEST/CONFIRM — it commits with no confirmation at all.


### PR DESCRIPTION
## What

Closes #728. #719 made the four `*_DATA_DIR` moves confirm-gated, so a dashboard operator who types `APPLY` can now relocate a service's data dir. The destination was still checked only by `assert_safe_dir` — a **blocklist** that refuses the catastrophic roots (`/`, `$HOME`, bare mounts) but passes any other absolute path. At host-shell trust that is proportionate; at dashboard trust it lets a confirmed move target another user's home or another service's volume and have pithead `mkdir`/`chown -R` it and bind-mount it into a recreated container — a destination trust-escalation.

## Control-vs-host split

`control_approval_gate` runs **only** for dashboard commits — it is called solely from `control_commit` (the control runner's commit path); the host `./pithead apply` path never calls it and keeps rendering through `parse_and_validate_config` → `assert_safe_dir`. So the gate itself *is* the control-channel signal; no new env var or flag is needed. The allowlist lives inside the gate, scoping it to control-originated moves automatically.

## The allowlist

For a control-channel move, the destination is narrowed from a blocklist to an **allowlist**: permit only a path under

- the stack's own data root (`$PWD/data`, the install dir's `data/`), or
- a parent the stack already keeps data in — each live `*_DATA_DIR`'s parent from `.env` (covers an operator-established, co-located data root, #455).

Anything else is refused **even with the `APPLY` token** and stays host-CLI only. Only explicit absolute paths are checked; `auto`/empty resolves to a stack default that is under a data root by construction. `assert_safe_dir` still runs at apply time.

## Tests (tier-1 stack, `tests/stack/run.sh`)

- A control-confirmed move **under** the data root (`$C/data/monero-v2`) applies with `APPLY`.
- A move to an arbitrary non-blocklisted-but-non-allowed path (`$SANDBOX/other-service-vol/monero`) is **refused even with `APPLY`**, cleared from staged, config.json untouched.
- The **same path from the host shell** still applies — the tighter rule is control-only.

## Docs

`SECURITY.md`, `docs/dashboard.md`, `CHANGELOG.md`.

## Note

This is a security change to the control gate — a security-reviewer pass is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
