### PR TITLE
chore: migrate biome linter config to the 2.x preset key

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": { "useTemplate": "off" },
       "complexity": { "useOptionalChain": "off", "noImportantStyles": "off" }
     }


### PR DESCRIPTION
`biome migrate` — `rules.recommended: true` → `rules.preset: "recommended"`. Silences the deprecation warning biome 2.5 prints on every `biome check`/CI lint run. No lint-behavior change (`biome check` clean).