### PR TITLE
feat(caddy): configurable dashboard host port (#740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1025,6 +1025,15 @@ its published artifacts were removed. 1.6.1 carries every 1.6.0 change plus the 
 
 ### Added
 
+- **Configurable Caddy host port (#740).** Caddy binds the host's 80/443 by default; on a machine
+  already running another reverse proxy (Nginx Proxy Manager, Traefik, a separate Caddy) those
+  ports are taken and the stack fails to start. `dashboard.port` moves the LAN vhost off them —
+  `"auto"` (default) keeps the scheme's standard port (443 with `dashboard.secure`, 80 without);
+  a number (e.g. `8443`) binds that instead, so an existing proxy keeps 80/443 and fronts the
+  stack. In HTTPS mode a custom port also drops Caddy's automatic HTTP→HTTPS redirect (which would
+  otherwise hold port 80), leaving that to the fronting proxy. Caddy stays in the path, so the
+  `dashboard.auth` login is unaffected. Split from the co-hosting umbrella (#181). See
+  [Configuration › Co-hosting on a shared server](docs/configuration.md#co-hosting-on-a-shared-server).
 - **Tor guard self-heal (#424).** Tor can bootstrap to 100% and then sit on a failing guard:
   circuits time out, so every Tor-clearnet feature — Healthchecks pings, the Telegram bot, XvB
   stats — breaks at once while mining (established onion circuits) keeps working. v1.3.1 added

--- a/build/dashboard/mining_dashboard/web/static/configlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configlogic.mjs
@@ -138,6 +138,7 @@ export const LOGICAL_GROUPS = [
     prefixes: [
       "dashboard.secure",
       "dashboard.host",
+      "dashboard.port",
       "dashboard.timezone",
       "dashboard.auth",
       "dashboard.onion",

--- a/config.reference.json
+++ b/config.reference.json
@@ -79,6 +79,7 @@
     "dashboard": {
         "secure": true,
         "host": "auto",
+        "port": "auto",
         "timezone": "auto",
         "data_dir": "auto",
         "tari_required": true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,7 @@ control channel will commit, are unaffected either way.
 | `tor.auto_heal` | `false` _(off)_ | Privacy-relevant, default off. Tor can bootstrap fully and then sit on a **failing guard**: circuits time out, so everything that exits Tor to the clearnet (Healthchecks pings, the Telegram bot, XvB stats) breaks at once while mining keeps working (#424). `true` lets the dashboard probe Tor clearnet egress every 5 minutes and restart the tor container once egress has been broken for 15 minutes, so Tor reselects guards — bounded to 3 restarts per outage, 30 minutes apart, each logged; if egress stays broken (Tor network overload) it stops restarting and keeps warning. Off by default because each restart drops **every** Tor circuit, mining onions included (they rebuild in minutes). The manual equivalent is `./pithead restart tor`. See [Operations › Troubleshooting](operations.md#troubleshooting). |
 | `dashboard.secure` | `true` | `true` serves the dashboard over HTTPS (Caddy `tls internal`); `false` uses plain HTTP. |
 | `dashboard.host` | `auto` | Hostname you use to reach the dashboard. `auto` = this machine's hostname. |
+| `dashboard.port` | `auto` | Host port Caddy binds the dashboard on. `auto` = the scheme default (443 with `dashboard.secure: true`, 80 without). Set a number (e.g. `8443`) to move it — for a host already running another reverse proxy on 80/443, so that proxy can front the stack. In HTTPS mode a custom port also drops Caddy's automatic HTTP→HTTPS redirect (which would otherwise hold port 80), so the fronting proxy owns any redirect. See [Co-hosting on a shared server](#co-hosting-on-a-shared-server). |
 | `dashboard.auth.username` | `admin` | Login name for the dashboard when a password is set (see below). Letters, digits, and `. _ @ -`, 1–64 chars. Ignored while `dashboard.auth.password` is empty. |
 | `dashboard.auth.password` | `""` _(off)_ | Optional password to open the dashboard. Turns on a Caddy [HTTP basic-auth](https://caddyserver.com/docs/caddyfile/directives/basic_auth) prompt in front of every page. `""` (default) = no login, anyone who can reach the dashboard sees it (fine for a private LAN appliance). Any 8–128-character string (no double-quotes) turns the prompt on. The plaintext lives only in your owner-only `config.json`; pithead bcrypt-hashes it with the pinned Caddy image and stores only the hash in `.env`, so the password itself is never persisted in rendered state. Basic-auth credentials travel in cleartext over HTTP, so keep `dashboard.secure: true` (the default); pithead warns if you set a password with `secure: false`. See [Exposing the dashboard safely](#exposing-the-dashboard-safely). |
 | `dashboard.onion.enabled` | `false` _(off)_ | Privacy-relevant, default off. `true` publishes the dashboard as a Tor v3 onion service so you can reach it remotely over Tor — no port-forward, no VPN, no public IP. It fronts the authenticated Caddy login on the internal bridge, never the LAN. pithead **fails closed**: if no `dashboard.auth.password` is set it generates a strong one (saved to `config.json`, login `admin`); a password you set yourself must be at least 16 characters. See [Remote access over Tor](#remote-access-over-tor-onion-service). |
@@ -270,6 +271,34 @@ How it works and what to keep in mind:
 
 To remove the login again, clear the password (`"password": ""`) and `apply`. pithead drops the
 `basic_auth` block and the dashboard is open on the LAN as before.
+
+### Co-hosting on a shared server
+
+By default Caddy binds the host's ports 80 and 443. On a machine that already runs another reverse
+proxy (Nginx Proxy Manager, Traefik, a separate Caddy) those ports are taken, and the stack fails to
+start. Move Caddy off them with `dashboard.port`:
+
+```json
+"dashboard": {
+    "secure": true,
+    "port": 8443,
+    "auth": { "username": "admin", "password": "a-long-passphrase" }
+}
+```
+
+Caddy now serves the dashboard on `:8443` and leaves 80/443 for your existing proxy, which you point
+at `https://<host>:8443` as its upstream. With `dashboard.secure: false` the same knob sets the plain
+HTTP port instead (e.g. `"port": 8080`) — use that when your proxy terminates TLS and wants an HTTP
+upstream.
+
+A couple of things to know:
+
+- **No built-in redirect on a custom port.** In HTTPS mode the default setup also answers on port 80
+  and redirects to HTTPS. On a custom port that redirect is switched off (it would otherwise keep
+  holding port 80, defeating the point). Your fronting proxy owns the http→https bounce.
+- **This does not remove Caddy or its login.** `dashboard.port` only moves the port. The dashboard
+  itself still binds `127.0.0.1:8000` with no authentication of its own — the `dashboard.auth` login
+  lives in Caddy — so keep Caddy in the path and set a password before your proxy exposes it.
 
 ### Remote access over Tor (onion service)
 

--- a/pithead
+++ b/pithead
@@ -1949,6 +1949,13 @@ is_valid_host() {
     [[ "$1" =~ ^[A-Za-z0-9.:_-]{1,253}$ ]]
 }
 
+# A bare TCP port, 1–65535. Used to validate dashboard.port (#740) before it is rendered into the
+# Caddyfile site address — the digits-only shape also guarantees no space/newline/`{` can slip in
+# and break the Caddyfile or inject a directive, the same threat is_valid_host guards for the host.
+is_valid_port() {
+    [[ "$1" =~ ^[0-9]{1,5}$ ]] && [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
 # Best-effort detection of the host's IANA timezone (Linux + macOS), used as the dashboard
 # default when dashboard.timezone is "auto"/unset. Falls back to Etc/UTC if it can't tell.
 detect_host_timezone() {
@@ -2822,6 +2829,14 @@ parse_and_validate_config() {
     # the Caddyfile (or inject directives). Mirrors the stratum_bind validation above (#130).
     if [ -n "$DASHBOARD_HOST" ] && ! is_valid_host "$DASHBOARD_HOST"; then
         error "dashboard.host must be a hostname or IP address — only letters, digits, dots, hyphens, and colons (got \"$DASHBOARD_HOST\")."
+    fi
+    # Caddy LAN listen port (#740). "auto"/empty keeps the scheme default (443 secure / 80 plain) —
+    # today's behavior. An explicit port moves the LAN vhost so an existing reverse proxy on the host
+    # can keep 80/443 (co-hosting, #181). Rendered into the Caddyfile site address (generate_caddyfile),
+    # so validate it is a bare 1–65535 port before it lands there.
+    HOST_PORT=$(resolve_default "$(jq -r '.dashboard.port // empty' "$CONFIG_FILE")" "")
+    if [ -n "$HOST_PORT" ] && ! is_valid_port "$HOST_PORT"; then
+        error "dashboard.port must be a whole number between 1 and 65535, or \"auto\" (got \"$HOST_PORT\")."
     fi
     # Ensure a strict true/false string is returned, defaulting to true
     DASHBOARD_SECURE=$(jq -r 'if .dashboard.secure != null then .dashboard.secure | tostring else "true" end' "$CONFIG_FILE")
@@ -3963,6 +3978,7 @@ DASHBOARD_CONTROL_ENABLED=$DASHBOARD_CONTROL_ENABLED
 CONTROL_DIR=$CONTROL_DIR
 CADDY_LOG_DIR=$CADDY_LOG_DIR
 HOST_IP=$HOST_IP
+HOST_PORT=$HOST_PORT
 DEPLOYMENT_COMPLETED=${DEPLOYMENT_COMPLETED:-false}
 EOF
     )
@@ -4046,10 +4062,34 @@ generate_caddyfile() {
         }
         format json
     }'
+    # Caddy LAN listen port (#740). An empty HOST_PORT — or a value that equals the scheme's own
+    # default (443 for HTTPS, 80 for HTTP) — keeps the standard port and renders today's Caddyfile
+    # verbatim. A custom port is appended to the site address so an existing reverse proxy on the
+    # host can keep 80/443 (co-hosting, #181). In HTTPS mode a custom port also disables Caddy's
+    # automatic :80 -> HTTPS redirect (a global option emitted once at the top of the file) so port
+    # 80 is left free for that proxy; the fronting proxy owns any http->https bounce instead.
+    local dport="${HOST_PORT:-}" port_suffix="" global_block=""
     if [ "$DASHBOARD_SECURE" == "true" ]; then
-        log "Generating Caddyfile for automatic HTTPS ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
-        cat <<EOF >"Caddyfile"
-https://$HOST_IP {
+        [ "$dport" == "443" ] && dport=""
+        if [ -n "$dport" ]; then
+            port_suffix=":$dport"
+            global_block='{
+    auto_https disable_redirects
+}
+
+'
+        fi
+    else
+        [ "$dport" == "80" ] && dport=""
+        [ -n "$dport" ] && port_suffix=":$dport"
+    fi
+
+    : >"Caddyfile"
+    [ -n "$global_block" ] && printf '%s' "$global_block" >>"Caddyfile"
+    if [ "$DASHBOARD_SECURE" == "true" ]; then
+        log "Generating Caddyfile for automatic HTTPS ($HOST_IP$port_suffix)$([ -n "$auth" ] && echo ' with login')..."
+        cat <<EOF >>"Caddyfile"
+https://$HOST_IP$port_suffix {
     tls internal
 $auth
 $logblk
@@ -4059,9 +4099,9 @@ $logblk
 }
 EOF
     else
-        log "Generating Caddyfile for HTTP ($HOST_IP)$([ -n "$auth" ] && echo ' with login')..."
-        cat <<EOF >"Caddyfile"
-http://$HOST_IP {
+        log "Generating Caddyfile for HTTP ($HOST_IP$port_suffix)$([ -n "$auth" ] && echo ' with login')..."
+        cat <<EOF >>"Caddyfile"
+http://$HOST_IP$port_suffix {
 $auth
 $logblk
     reverse_proxy 127.0.0.1:8000 {
@@ -4600,6 +4640,16 @@ describe_change() {
     HOST_IP)
         msg="Dashboard hostname: $old → $new."
         ;;
+    HOST_PORT)
+        # #740: Caddy's LAN listen port. Empty means the scheme default (443/80). Stay silent when
+        # both sides are empty — a fresh binary just adds the key with no value on the first apply
+        # (comm flags the added line); that is not a real change worth previewing.
+        if [ -z "$old" ] && [ -z "$new" ]; then
+            msg=""
+        else
+            msg="Dashboard Caddy port: ${old:-default (443/80)} → ${new:-default (443/80)} — the caddy container is recreated."
+        fi
+        ;;
     MONERO_PREP_THREADS)
         msg="Monero block-prep threads: $old → $new."
         ;;
@@ -4873,7 +4923,7 @@ apply() {
             # DASHBOARD_CONTROL_ENABLED rides along (#33): the Caddyfile always renders the
             # X-Auth-User header_up now, but a pre-upgrade caddy may still run without it —
             # restart caddy at the moment the audit actor starts to matter.
-            case "$key" in HOST_IP | DASHBOARD_SECURE | DASHBOARD_AUTH_USER | DASHBOARD_AUTH_HASH_B64 | DASHBOARD_ONION_ENABLED | DASHBOARD_CONTROL_ENABLED) caddy_changed=1 ;; esac
+            case "$key" in HOST_IP | HOST_PORT | DASHBOARD_SECURE | DASHBOARD_AUTH_USER | DASHBOARD_AUTH_HASH_B64 | DASHBOARD_ONION_ENABLED | DASHBOARD_CONTROL_ENABLED) caddy_changed=1 ;; esac
             # Payout-wallet change (#375): remember WHICH wallet keys change for the typed
             # confirmation below — one prompt per key, so a Monero+Tari double change can't
             # ride through on a single typed prefix.

--- a/pithead
+++ b/pithead
@@ -1949,11 +1949,13 @@ is_valid_host() {
     [[ "$1" =~ ^[A-Za-z0-9.:_-]{1,253}$ ]]
 }
 
-# A bare TCP port, 1–65535. Used to validate dashboard.port (#740) before it is rendered into the
-# Caddyfile site address — the digits-only shape also guarantees no space/newline/`{` can slip in
-# and break the Caddyfile or inject a directive, the same threat is_valid_host guards for the host.
+# A bare TCP port, 1–65535, no leading zero. Used to validate dashboard.port (#740) before it is
+# rendered into the Caddyfile site address — the digits-only shape also guarantees no space/newline/`{`
+# can slip in and break the Caddyfile or inject a directive, the same threat is_valid_host guards for
+# the host. The `[1-9]` lead rejects a leading zero (e.g. `0899`), which would otherwise reach `-le`
+# as an invalid octal literal and error instead of cleanly failing.
 is_valid_port() {
-    [[ "$1" =~ ^[0-9]{1,5}$ ]] && [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+    [[ "$1" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$1" -le 65535 ]
 }
 
 # Best-effort detection of the host's IANA timezone (Linux + macOS), used as the dashboard

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -600,6 +600,9 @@ assert_running_state() {
     [ "$rpc_lan" = "true" ] && want_bind="0.0.0.0" || want_bind="127.0.0.1"
     assert_eq "MONERO_RPC_BIND matches rpc_lan_access" "$(env_on_box MONERO_RPC_BIND)" "$want_bind"
     assert_eq "DASHBOARD_SECURE matches config" "$(env_on_box DASHBOARD_SECURE)" "${secure:-true}"
+    # #740: dashboard.port flows config -> .env. Unset in every scenario, so HOST_PORT must render
+    # empty (the scheme-default path); a scenario that sets dash_port would assert the custom value.
+    assert_eq "HOST_PORT matches config (empty = scheme default)" "$(env_on_box HOST_PORT)" "${dash_port:-}"
     assert_eq "XVB_ENABLED matches config" "$(env_on_box XVB_ENABLED)" "${xvb:-true}"
 
     # 8b. Resource + privacy posture (LOCAL only). These regress silently and would otherwise only
@@ -759,10 +762,15 @@ assert_metrics_via_caddy() {
         return 0
     fi
     secure="$(env_on_box DASHBOARD_SECURE)"
+    # #740: Caddy binds HOST_PORT when set, else the scheme default (80/443). Read it so the operator
+    # path is curled on the port Caddy actually listens on, not a hardcoded 80/443.
+    port="$(env_on_box HOST_PORT)"
     if [ "$secure" = "false" ]; then
-        scheme="http" port=80
+        scheme="http"
+        [ -n "$port" ] || port=80
     else
-        scheme="https" port=443
+        scheme="https"
+        [ -n "$port" ] || port=443
     fi
     if [ -n "$(env_on_box DASHBOARD_AUTH_HASH_B64)" ]; then
         if [ -z "${IT_DASHBOARD_PASSWORD:-}" ]; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -310,6 +310,24 @@ assert_rc "rejects hostname" "$?" "1"
 run_sourced "$SANDBOX" is_ipv4 "" >/dev/null 2>&1
 assert_rc "rejects empty" "$?" "1"
 
+echo "== unit: is_valid_port (#740 — dashboard.port / Caddyfile injection guard) =="
+run_sourced "$SANDBOX" is_valid_port "8443" >/dev/null 2>&1
+assert_rc "accepts 8443" "$?" "0"
+run_sourced "$SANDBOX" is_valid_port "1" >/dev/null 2>&1
+assert_rc "accepts 1 (low bound)" "$?" "0"
+run_sourced "$SANDBOX" is_valid_port "65535" >/dev/null 2>&1
+assert_rc "accepts 65535 (high bound)" "$?" "0"
+run_sourced "$SANDBOX" is_valid_port "0" >/dev/null 2>&1
+assert_rc "rejects 0" "$?" "1"
+run_sourced "$SANDBOX" is_valid_port "65536" >/dev/null 2>&1
+assert_rc "rejects 65536 (over range)" "$?" "1"
+run_sourced "$SANDBOX" is_valid_port "80x" >/dev/null 2>&1
+assert_rc "rejects non-numeric" "$?" "1"
+run_sourced "$SANDBOX" is_valid_port "8080 {" >/dev/null 2>&1
+assert_rc "rejects a Caddyfile-injection attempt" "$?" "1"
+run_sourced "$SANDBOX" is_valid_port "" >/dev/null 2>&1
+assert_rc "rejects empty" "$?" "1"
+
 echo "== unit: semver_newer (#59 — the upgrade downgrade guard) =="
 # The comparison gates the upgrade button: a lexical bug would let 1.9.0 look "newer" than 1.10.0
 # and could be leveraged to force an older, vulnerable release.
@@ -1256,6 +1274,46 @@ assert_contains "caddyfile insecure uses http" "$caddy_http" "http://box.lan"
 case "$caddy_http" in
 *"tls internal"*) bad "caddyfile insecure has no TLS" "'tls internal' present on a plain-HTTP site" ;;
 *) ok "caddyfile insecure has no TLS" ;;
+esac
+
+echo "== unit: generate_caddyfile custom port (#740) =="
+# A custom HOST_PORT moves the LAN vhost off the scheme default so a co-hosted reverse proxy keeps
+# 80/443. In HTTPS mode it also emits the global `auto_https disable_redirects` so nothing holds :80.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_port_https="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan HOST_PORT=8443 DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "custom https port binds the site" "$caddy_port_https" "https://box.lan:8443 {"
+assert_contains "custom https port disables the :80 redirect" "$caddy_port_https" "auto_https disable_redirects"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_port_http="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=false HOST_IP=box.lan HOST_PORT=8080 DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "custom http port binds the site" "$caddy_port_http" "http://box.lan:8080 {"
+case "$caddy_port_http" in
+*"disable_redirects"*) bad "plain-HTTP custom port has no redirect global" "'disable_redirects' present on a plain-HTTP site" ;;
+*) ok "plain-HTTP custom port has no redirect global" ;;
+esac
+# A port that equals the scheme default (443 secure / unset) renders today's Caddyfile verbatim —
+# no port suffix, no redirect global. Guards the byte-identical default path.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_port_default="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan HOST_PORT=443 DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "explicit default port keeps the bare site address" "$caddy_port_default" "https://box.lan {"
+case "$caddy_port_default" in
+*"disable_redirects"*) bad "default port emits no redirect global" "'disable_redirects' present at the scheme default" ;;
+*":443"*) bad "default port emits no explicit suffix" "':443' suffix present at the scheme default" ;;
+*) ok "default port renders the bare site address" ;;
 esac
 
 echo "== unit: generate_caddyfile onion vhost (#343) =="

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -327,6 +327,8 @@ run_sourced "$SANDBOX" is_valid_port "8080 {" >/dev/null 2>&1
 assert_rc "rejects a Caddyfile-injection attempt" "$?" "1"
 run_sourced "$SANDBOX" is_valid_port "" >/dev/null 2>&1
 assert_rc "rejects empty" "$?" "1"
+run_sourced "$SANDBOX" is_valid_port "0899" >/dev/null 2>&1
+assert_rc "rejects a leading zero (no octal-parse error)" "$?" "1"
 
 echo "== unit: semver_newer (#59 — the upgrade downgrade guard) =="
 # The comparison gates the upgrade button: a lexical bug would let 1.9.0 look "newer" than 1.10.0
@@ -420,6 +422,14 @@ assert_contains "stratum lan is INFO" "$(run_sourced "$SANDBOX" describe_change 
 assert_contains "stratum port change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change STRATUM_PORT 3333 4444)" "CONFIRM"
 assert_contains "stratum port change says repoint" "$(run_sourced "$SANDBOX" describe_change STRATUM_PORT 3333 4444)" "repoint"
 assert_contains "stratum port first render is INFO" "$(run_sourced "$SANDBOX" describe_change STRATUM_PORT '' 3333)" "INFO"
+# Caddy LAN port (#740): a real change previews the port; the default->default no-op (the key is
+# added empty on the first apply after an upgrade) stays silent so it isn't a scary row.
+assert_contains "caddy port change previews the port" "$(run_sourced "$SANDBOX" describe_change HOST_PORT '' 8443)" "Caddy port"
+hp_silent="$(run_sourced "$SANDBOX" describe_change HOST_PORT '' '')"
+case "$hp_silent" in
+*"Caddy port"*) bad "caddy port default->default stays silent" "empty-both HOST_PORT emitted a preview line" ;;
+*) ok "caddy port default->default stays silent" ;;
+esac
 # Stratum access-password (#152): enabling/changing is DEST (rigs need the new pass), disabling is
 # INFO — and the secret value must NEVER appear in the change preview.
 assert_contains "stratum pw enable is DEST" "$(run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD '' s3cr3t)" "DEST"
@@ -1314,6 +1324,25 @@ case "$caddy_port_default" in
 *"disable_redirects"*) bad "default port emits no redirect global" "'disable_redirects' present at the scheme default" ;;
 *":443"*) bad "default port emits no explicit suffix" "':443' suffix present at the scheme default" ;;
 *) ok "default port renders the bare site address" ;;
+esac
+# Onion + custom LAN port together (#740 × #343): the LAN vhost moves to the custom port and the
+# `disable_redirects` global is emitted, but the onion vhost MUST stay on the bridge gateway's bare
+# :80 — Tor's HiddenServicePort maps 80 -> NETWORK_PREFIX.1:80, so a custom LAN port must not leak
+# onto it. Also confirms the global-options block is still valid Caddyfile with onion vhosts appended.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_port_onion="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan HOST_PORT=8443 DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
+        DASHBOARD_ONION_ENABLED=true NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "onion+custom-port: LAN vhost moves to the custom port" "$caddy_port_onion" "https://box.lan:8443 {"
+assert_contains "onion+custom-port: redirect global still emitted" "$caddy_port_onion" "auto_https disable_redirects"
+assert_contains "onion+custom-port: onion vhost stays on the bridge's bare :80" "$caddy_port_onion" "http://172.28.0.1 {"
+case "$caddy_port_onion" in
+*"172.28.0.1:8443"* | *"172.28.0.1:80 "*) bad "onion vhost keeps its bare bridge port" "custom LAN port leaked onto the onion vhost" ;;
+*) ok "onion vhost keeps its bare bridge port (no custom-port leak)" ;;
 esac
 
 echo "== unit: generate_caddyfile onion vhost (#343) =="


### PR DESCRIPTION
Closes #740. Split from the co-hosting umbrella #181.

## What
Adds a `dashboard.port` config knob so Caddy's LAN vhost can bind a host port other than 80/443. On a shared host already running another reverse proxy (Nginx Proxy Manager, Traefik, a separate Caddy), 80/443 are taken and the stack fails to start today. `dashboard.port: 8443` moves Caddy off them; the existing proxy keeps 80/443 and fronts the stack.

```json
"dashboard": { "secure": true, "port": 8443, "auth": { "password": "…" } }
```

- `"auto"` (default) → the scheme's standard port (443 secure / 80 plain). **Renders today's Caddyfile verbatim** — no behavior change for existing installs.
- a number → the LAN vhost binds that port instead.
- In HTTPS mode a custom port also emits `auto_https disable_redirects`, so Caddy doesn't hold `:80` for the HTTP→HTTPS redirect — the fronting proxy owns that bounce.

## Design notes
- **One knob, not two.** With `network_mode: host` there's a single listen port that matters per scheme (HTTPS in secure mode, HTTP in plain mode). #181 asked for "8081:80 and 8443:443" in compose-mapping terms; a single `dashboard.port` covers the collision.
- **Onion untouched.** The onion vhost stays on the bridge gateway at 80/443 because Tor's `HiddenServicePort 80/443 → <bridge>:80/443` mapping is fixed. It isn't on the LAN, so it never collides with the operator's proxy. (Niche: onion + co-host + a proxy on `0.0.0.0:80` would still contend for the bridge `:80` — documented.)
- **Caddy stays in the path.** This only moves the port; the dashboard still binds `127.0.0.1:8000` with no auth of its own — the `dashboard.auth` login lives in Caddy — so the login is unaffected. Disabling Caddy entirely (the other half of #181) stays out of scope: it removes the only place auth lives and needs a fail-closed design + security review.
- **Not dashboard-editable.** `dashboard.port` is host-config like `network.subnet`; set it in `config.json` + `apply`. Not added to the control-channel editable allowlist, so a compromised dashboard can't move the port (the host gate fail-closed-rejects it).

## Injection guard
The value is rendered into the Caddyfile site address, so it's validated by a new `is_valid_port` (bare 1–65535). The digits-only shape guarantees no space / newline / `{` can slip in and break the Caddyfile or inject a directive — the same threat `is_valid_host` guards for `dashboard.host`.

## Tests
- `is_valid_port` unit tests incl. a `"8080 {"` injection attempt (rejected).
- `generate_caddyfile` custom-port rendering: HTTPS custom port binds `:8443` + emits `disable_redirects`; plain custom port binds `:8080` with no redirect global; explicit-default (443) renders the bare site address (guards the byte-identical default path).
- Full suite green against current develop: `1615 passed, 0 failed`; `make lint-sh` / `lint-docs-voice` clean; dashboard `test_control_service` + `test_server` green (reference-merge shows the new field, no exact-key coupling).

## Docs
- `docs/configuration.md`: new `dashboard.port` row + a **Co-hosting on a shared server** section.
- CHANGELOG under `[Unreleased] › Added`.

## Not verified here
No live co-host run (two proxies on one box) — the change is covered at the unit tier (Caddyfile text + validator). Worth a manual smoke on a real shared host before the release that ships it.
