### PR TITLE
docs(configuration): flag the remote-node ZMQ requirement at Option B

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -378,8 +378,10 @@ A few things to keep in mind:
 
 ### Option B — Connect to a remote node
 
-If your existing Monero node runs on another machine, or you want to use a node you don't host,
-switch to remote mode and the stack won't run its own `monerod` at all. See
+If your existing Monero node runs on another machine, switch to remote mode and the stack won't run
+its own `monerod` at all. The node must be one you run yourself with **ZMQ publishing enabled** and
+its RPC reachable by P2Pool — a general-purpose public "open node" won't work, because P2Pool needs
+the ZMQ feed that those don't expose. See
 [Connecting to a remote Monero node](#connecting-to-a-remote-monero-node) below.
 
 > Tari uses the same mechanism: point `tari.data_dir` at an existing Minotari node directory


### PR DESCRIPTION
Small doc clarification split from the #181 co-hosting/migration discussion.

**Problem.** The "Reusing an existing node → Option B — Connect to a remote node" section said *"or you want to use a node you don't host"*, which sets the wrong expectation. A remote node only works if it exposes **ZMQ** (P2Pool needs the ZMQ feed), so a general-purpose public "open node" won't work. That constraint was already documented — but one click away, in the "Connecting to a remote Monero node" section a migrating reader reaches *after* Option B.

**Change.** One paragraph in Option B now states the requirement up front: the node must be one you run yourself with ZMQ publishing enabled and RPC reachable, and public open nodes won't work. No behavior change; docs only.

Verified: `make lint-docs-voice` clean.