### PR TITLE
feat(tari): remote Tari base-node mode (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
 
 ### Added
 
+- **Remote Tari node (#103).** `tari.mode: remote` merge-mines against a Tari base node running
+  elsewhere instead of the bundled one: set `tari.remote.host` (required) and
+  `tari.remote.grpc_port` (default `18142`). Remote mode skips the bundled `tari` container, its
+  memory cap, and payout confirmation. The remote node's mining-template
+  RPC is request-scoped, so one node can serve several pithead stacks at once, each with its own
+  wallet — a shared node for a fleet or household is the intended pattern. The gRPC link stays
+  plaintext and unauthenticated (p2pool has no way to speak TLS or auth to it), so use a node you
+  trust: its operator, or anyone on the network path, can silently redirect Tari rewards. Monero
+  mining is unaffected either way. LAN/trusted-network only for now — a `.onion` remote is a
+  follow-up. See [Configuration › Remote Tari node](docs/configuration.md#remote-tari-node).
 - Dual-distribution plan (#77/#78): the architecture decision record for shipping Pithead as a
   curl-installed Compose stack, a flashable immutable appliance (Debian 13 + Rugix A/B, Podman
   Quadlet), and a git clone — one release manifest across all three. Dev doc only, no behaviour

--- a/build/dashboard/mining_dashboard/web/static/configlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configlogic.mjs
@@ -23,6 +23,7 @@ export function isSecretSentinel(v) {
 // Fixed-choice fields; everything else renders from its JSON type.
 const FIELD_OPTIONS = {
   "monero.mode": ["local", "remote"],
+  "tari.mode": ["local", "remote"],
   "p2pool.pool": ["main", "mini", "nano"],
   "workers.api_auth": ["none", "name", "token"],
   "xvb.donation_level": ["auto", "donor", "vip", "whale", "mega"],
@@ -113,6 +114,7 @@ export const LOGICAL_GROUPS = [
       "monero.rpc_lan_access",
       "monero.clearnet_initial_sync",
       "tari.mode",
+      "tari.remote",
       "tari.clearnet_initial_sync",
     ],
   },

--- a/config.reference.json
+++ b/config.reference.json
@@ -32,7 +32,12 @@
         "payout_scan_birthday": "auto",
         "clearnet_initial_sync": false,
         "data_dir": "auto",
-        "mem_limit": "auto"
+        "mem_limit": "auto",
+
+        "remote": {
+            "host": "tari-node.lan",
+            "grpc_port": 18142
+        }
     },
 
     "p2pool": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,7 +195,9 @@ services:
       start_period: 120s
 
   # --- Tari Base Node ---
+  # Only starts if "local_tari" profile is active (#103, mirrors monerod's "local_node" above).
   tari:
+    profiles: ["local_tari"]
     # Pinned by digest (#135) so the v5.3.1-mainnet tag can't be silently re-pointed.
     image: quay.io/tarilabs/minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0
     container_name: tari
@@ -309,7 +311,11 @@ services:
     environment:
       # NON-SECRET config only — the three MINOTARI_WALLET_* secrets are delivered via `secrets:`
       # below, NOT here (an `environment:` value shows in `docker inspect`, the acceptance criterion).
-      - TARI_BASE_NODE_GRPC_ADDRESS=${NETWORK_PREFIX:-172.28.0}.27:18142
+      # Tari base-node gRPC endpoint (#103): pithead renders TARI_GRPC_ADDRESS for both local (the
+      # bundled node's fixed bridge IP) and remote (a third-party/fleet-shared node's host:port);
+      # the fallback here is the stock local default for a bare `docker compose up` bypassing
+      # pithead. Harmless either way — this service never runs in remote mode (the gate above).
+      - TARI_BASE_NODE_GRPC_ADDRESS=${TARI_GRPC_ADDRESS:-172.28.0.27:18142}
       - TARI_WALLET_BIRTHDAY=${TARI_WALLET_BIRTHDAY:-auto}
       - TARI_WALLET_GRPC_BIND=/ip4/0.0.0.0/tcp/18143
       - WALLET_DIR=/home/ubuntu/wallet
@@ -384,7 +390,9 @@ services:
       - --wallet
       - ${MONERO_WALLET_ADDRESS}
       - --merge-mine
-      - tari://${NETWORK_PREFIX:-172.28.0}.27:18142
+      # Tari base-node gRPC endpoint (#103): local or remote, driven by pithead's rendered
+      # TARI_GRPC_ADDRESS (the fallback is the stock local default, for a bare `docker compose up`).
+      - tari://${TARI_GRPC_ADDRESS:-172.28.0.27:18142}
       - ${TARI_WALLET_ADDRESS}
       - --onion-address
       - ${P2POOL_ONION_ADDRESS}
@@ -403,10 +411,10 @@ services:
     networks:
       mining_net:
         ipv4_address: ${NETWORK_PREFIX:-172.28.0}.28
-    depends_on:
-      # monerod dependency removed to allow remote node operation
-      tari:
-        condition: service_healthy
+    # No depends_on: both monerod (local_node) and tari (local_tari, #103) are profile-gated and
+    # OFF in remote mode — a depends_on edge to a service that profiles have excluded fails
+    # `compose up` outright, not just at startup. p2pool retries its own RPC/gRPC dials, so it
+    # comes up fine without a startup-order guarantee against either node.
     healthcheck:
       # Liveness for the core revenue service (#90). Probe the stratum listener directly: a TCP
       # connect to :3333 proves p2pool is up and accepting miners, which is the failure miners
@@ -653,7 +661,9 @@ services:
       # the host-networked dashboard reaches them here — mining containers cannot.
       - DOCKER_PROXY_URL=tcp://127.0.0.1:12375
       - DOCKER_CONTROL_URL=tcp://127.0.0.1:12376
-      - TARI_GRPC_ADDRESS=${NETWORK_PREFIX:-172.28.0}.27:18142
+      # Tari base-node gRPC endpoint (#103): local or remote, driven by pithead's rendered
+      # TARI_GRPC_ADDRESS (the fallback is the stock local default).
+      - TARI_GRPC_ADDRESS=${TARI_GRPC_ADDRESS:-172.28.0.27:18142}
       # Local monerod bridge IP (local-vs-remote detection), the internal SSRF-guard CIDR, and the
       # Tor SOCKS endpoint all track the configured subnet prefix (#180).
       - LOCAL_MONERO_HOST=${NETWORK_PREFIX:-172.28.0}.26

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,11 +108,13 @@ control channel will commit, are unaffected either way.
 | `monero.remote.host` / `rpc_port` / `zmq_port` | — / `18081` / `18083` | Remote node connection details (used when `mode` is `remote`). |
 | `monero.data_dir` | `auto` | Where the Monero blockchain lives on the host. `auto` = `./data/monero`. Point this at an existing `.bitmonero` directory to reuse a synced node. See [Reusing an existing node](#reusing-an-existing-node). |
 | `monero.mem_limit` | `auto` | Upper limit on the monerod container's memory, so a leak/runaway OOM-restarts monerod alone instead of the host's OOM-killer picking a victim. `auto` is a generous ceiling (6 GB) that won't trip during normal operation or initial sync. monerod's OOM-triggering memory is small (~0.1 GiB at rest, ~1–3 GiB during sync) while its multi-GB blockchain DB is reclaimable, memory-mapped page cache that the kernel evicts under pressure rather than OOM-killing. Lower it only to free RAM. Raise it for a full (unpruned) node doing a heavy initial sync on a fast disk, or if a low-RAM host ever OOMs monerod during IBD (it restarts and resumes; the on-disk chain is transactional, no data loss). Accepts any Docker memory value, e.g. `"8g"`. (Tari has its own `tari.mem_limit`; the dashboard, P2Pool, Tor, and the proxies are small and carry fixed conservative ceilings in `docker-compose.yml`.) |
+| `tari.mode` | `local` | `local` runs the bundled Tari base node; `remote` merge-mines against an external one (see `tari.remote` and [Remote Tari node](#remote-tari-node)). |
 | `tari.wallet_address` | _required_ | Your Tari (Minotari) payout address. |
 | `tari.view_key` | _empty_ | The private **view** key for the Tari payout address, to confirm merge-mine payouts on-chain (#462, the Tari sibling of `monero.view_key`). When set, the stack runs a view-only `minotari_console_wallet` against your local Tari node and the dashboard shows confirmed Tari payouts beside the time-to-block estimate (see [Dashboard › Payout confirmation](dashboard.md#payout-confirmation)). Requires `tari.spend_public_key` too. **Security:** a view key can scan but never spend — yet it reveals every incoming amount and its timing to anyone who can read `config.json`/`.env`, so it is handled like `node_password` (never logged or echoed, kept in the owner-only `.env`, and delivered to the container via a tmpfs secret, never `docker inspect`). Local Tari node only. Empty (the default) leaves the feature off. |
 | `tari.spend_public_key` | _empty_ | The **public** spend key for the Tari payout address, exported alongside the view key (`minotari_console_wallet ... export-view-key-and-spend-key`; see [Dashboard › Exporting your keys](dashboard.md#exporting-your-keys)). Required whenever `tari.view_key` is set — a view-only Tari wallet is built from the private view key plus this public spend key. Public, not a secret. |
 | `tari.payout_scan_birthday` | `auto` | Where the view-only Tari wallet starts scanning on first creation (#462). Unlike Monero's block-height restore point, a Tari birthday is **days since the Unix epoch** (a u16, 0–65535). `auto` = today when the wallet is first made, so it tracks payouts forward without rescanning from genesis. Set an earlier day to backfill older payouts (slower first scan). Only affects the first wallet creation; ignored once the wallet exists. |
 | `tari.clearnet_initial_sync` | `false` | Privacy-relevant, default off. `true` makes the Tari base node sync over clearnet instead of Tor: it switches the P2P transport to TCP, re-enables the `seeds.tari.com` DNS seed (the bundled onion `peer_seeds` are unreachable without Tor), and stops advertising its onion. Your node's IP becomes visible to the Tari P2P network while it's on, plus one DNS lookup of `seeds.tari.com`. `pithead` warns loudly (apply/status/doctor/up). The dashboard switches Tari back to Tor automatically once it's synced (#234), so you can leave this `true`. Full threat model: [Privacy › Optional clearnet initial sync](privacy.md#optional-clearnet-initial-sync-off-by-default). |
+| `tari.remote.host` / `grpc_port` | — / `18142` | Remote Tari base node connection details (used when `tari.mode` is `remote`). See [Remote Tari node](#remote-tari-node). |
 | `tari.data_dir` | `auto` | Where the Tari node data lives on the host. `auto` = `./data/tari`. |
 | `tari.mem_limit` | `auto` | Upper limit on the Tari container's memory, so a runaway Tari restarts cleanly on its own instead of dragging down the whole host. `auto` picks a safe size for your machine. Leave it unless you want to give Tari less RAM (to free it for other apps) or more (if it ever restarts too often). Accepts any Docker memory value, e.g. `"8g"`. |
 | `p2pool.pool` | `mini` | Which P2Pool sidechain to mine: `main`, `mini`, or `nano`. `mini` (the default) has a lower share difficulty than `main`, so a typical home rig finds shares far more often: smoother, more frequent PPLNS payouts instead of long dry spells. Raise to `main` for high hashrate (large farms); drop to `nano` for a single low-power rig. |
@@ -446,6 +448,68 @@ To connect to an external Monero node instead of running one locally, set `moner
 
 Switching between `local` and `remote` is a disruptive change, so `apply` will confirm before
 applying it.
+
+---
+
+## Remote Tari node
+
+To merge-mine against a Tari base node running elsewhere instead of the bundled one, set
+`tari.mode` to `remote` and fill in `tari.remote`:
+
+```json
+{
+    "tari": {
+        "mode": "remote",
+        "wallet_address": "...",
+        "remote": {
+            "host": "tari-node.lan",
+            "grpc_port": 18142
+        }
+    }
+}
+```
+
+- The bundled `tari` container does not start in remote mode, and neither does `tari-wallet`
+  (payout confirmation is unsupported in remote mode — see below).
+- `tari.remote.host` is required; `grpc_port` defaults to `18142`, the base node's standard gRPC
+  port.
+- The remote node must rebind its gRPC listener off the stock `grpc_address` (`127.0.0.1`), so it
+  accepts connections from off-box, and enable the mining allowlist preset upstream ships for
+  exactly this
+  (`c_base_node_b_mining_allow_methods.toml`) so `get_new_block_template_with_coinbases` and
+  `submit_block` are reachable.
+- Leave `grpc_authentication` and `grpc_tls_enabled` off on the remote node. p2pool's Tari
+  merge-mine client dials plaintext, unauthenticated gRPC and has no way to speak either — turning
+  them on there just breaks the connection.
+- Remote mode turns off: the bundled `tari` container, the Tari container memory cap
+  (`tari.mem_limit` — nothing local left to cap), and payout confirmation (`tari.view_key` is
+  rejected with `tari.mode: remote`, same as `monero.view_key` with `monero.mode: remote`). Tor
+  still publishes the Tari inbound onion address, but with no local node behind it, connections to
+  it go nowhere — the same inert leftover a remote Monero node leaves.
+- The base node's mining-template RPC is request-scoped: every `get_new_block_template_with_coinbases`
+  call carries its own caller's coinbase address, and the node holds no per-caller state between
+  calls. One Tari node can serve several pithead stacks this way, each with its own
+  `tari.wallet_address` — pointing a fleet's or household's stacks at one shared node is the
+  intended pattern, not a workaround.
+
+Switching between `local` and `remote` is a disruptive change, so `apply` will confirm before
+applying it.
+
+### Trust boundary
+
+The gRPC link to a remote Tari node is plaintext and unauthenticated end to end. p2pool cannot
+verify that the block template it gets back actually pays `tari.wallet_address` — the node
+operator, or anyone else on the network path, can substitute a different payout and there is
+nothing in pithead that would catch it; the dashboard has no way to distinguish a redirected
+reward from one that never arrived. Only Tari yield is exposed this way: Monero mining runs on a
+separate path and is unaffected even if the Tari leg is compromised or down.
+
+Use a node you run yourself, or one run by someone you trust, on your LAN or reachable over
+WireGuard. A `.onion` remote isn't supported yet: the Tor default bridges this gRPC leg onto a
+direct connection before it would reach Tor (see [Privacy › Runtime egress](privacy.md#runtime-egress)),
+so an onion host doesn't resolve — tracked as a follow-up. Upstream Tari guidance is not to expose
+base-node gRPC to the public internet; an open third-party node still works, but its operator (or
+anyone on-path) holds your Tari rewards.
 
 ---
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -71,6 +71,7 @@ What the running stack sends to the internet, connection by connection.
 | **monerod RPC to a remote node** (only if `monero.mode: remote`) | the node you configured | **your real home IP**, to that node's operator | ❌ clearnet | **off** — the bundled local node is the default and has no remote-RPC egress | use a node you run/trust, or one reachable as a `.onion` over Tor |
 | **Tari** P2P | Tari network | — | ✅ Tor (`type = "tor"`) | on | Tor by default; can opt into clearnet (TCP) for the initial sync only ([#183](#optional-clearnet-initial-sync-off-by-default)) |
 | **Tari** DNS seeds + Pulse (`seeds.tari.com`, `checkpoints.tari.com`) | DNS resolvers | "this IP runs Tari" | ✅ **closed** — `dns_seeds = []`, onion `peer_seeds`, resolver pointed at a dead address (#162) | n/a | clearnet sync ([#183](#optional-clearnet-initial-sync-off-by-default)) re-enables the `seeds.tari.com` DNS seed for the sync window |
+| **P2Pool** merge-mine gRPC to a remote Tari node (only if `tari.mode: remote`) | the node you configured | **your real IP**, to that node's operator | ❌ clearnet — same posture as monerod's own remote-node RPC above | **off** — the bundled local Tari node is the default and this leg only exists in remote mode | use a node on your LAN or reachable over WireGuard; a `.onion` remote isn't supported yet (see [Configuration › Remote Tari node](configuration.md#remote-tari-node)) |
 | **P2Pool** inbound peers | reach you via onion | — | ✅ onion hidden service | on | — |
 | **P2Pool** outbound sidechain peers | P2Pool sidechain peers, via Tor | — | ✅ **Tor** (`--socks5`, proxy-type `tor`) by default (#165) | on | opt out with `p2pool.clearnet: true` (exposes your IP for max yield) → [below](#p2pool-outbound-peers-165---tor-by-default) |
 | Dashboard **XvB stats** fetch | `xmrvsbeast.com` | your Monero **wallet** (no longer your IP) | ✅ Tor (`socks5h`, #163) | on, only if XvB enabled | `XVB_ENABLED=false` stops it |
@@ -87,6 +88,12 @@ What the running stack sends to the internet, connection by connection.
 `socks5h` (used for the XvB stats fetch) routes DNS resolution through Tor too, so the hostname isn't
 resolved on the clearnet either. The host-networked dashboard reaches the bridge's Tor SOCKS at
 `172.28.0.25:9050`.
+
+A remote node given as a hostname (`monero.remote.host` or `tari.remote.host`) is the exception:
+p2pool's socat bridge (above) only moves the TCP connection itself off the SOCKS5 proxy, so the
+DNS lookup that turns that hostname into an IP still happens on the clearnet, via the container's
+own resolver — same exposure as any of the closed clearnet DNS lookups above, but this one has no
+toggle. Use an IP literal instead if that lookup itself is a concern.
 
 The dashboard's egress panel classifies the alert-sink carve-out by what it can prove from the
 config alone: with `notifications.tor: false`, the sinks show as **local** — not a counted leak —

--- a/pithead
+++ b/pithead
@@ -1691,6 +1691,13 @@ assert_safe_dir() {
     case "$d" in
     *..*) error "Refusing data directory '$d' — '..' path traversal is not allowed." ;;
     esac
+    # 3) A ':' would split the compose bind-mount short syntax it renders into
+    #    (`${MONERO_DATA_DIR}:/dest`) — e.g. a dir ending ':ro' forges a third MODE field, turning a
+    #    read-write data mount read-only or breaking `compose up`. It's operator-set but, since #728,
+    #    also dashboard-committable, so charset-guard it here. No legitimate data-dir path needs a colon.
+    case "$d" in
+    *:*) error "Refusing data directory '$d' — ':' is not allowed (it would corrupt the container's volume mount)." ;;
+    esac
 }
 
 safe_sed() {
@@ -2599,6 +2606,20 @@ parse_and_validate_config() {
     if [ -z "$MONERO_WALLET" ] || [ -z "$TARI_WALLET" ]; then
         error "Missing required wallet addresses in $CONFIG_FILE."
     fi
+    # tari.wallet_address gets no exact-format gate like monero's below: Tari addresses come in
+    # base58 AND emoji forms, single/dual, with optional payment IDs — length and charset both vary
+    # (RFC-0155), and p2pool passes the string straight to the Tari node, which accepts either form,
+    # so a strict regex would false-reject valid addresses. But two mistakes are unambiguous and cause
+    # the same silent mining-to-nowhere monero guards against (#250): the untouched placeholder, and
+    # embedded whitespace (no Tari address of either form contains an ASCII space, and a space isn't a
+    # control char so the central guard above doesn't catch it). Reject both; a subtler typo is the
+    # node's to reject at merge-mine time. [TODO: verify upstream — exact accepted form, to gate fully.]
+    if [ "$TARI_WALLET" = "your_tari_wallet_address" ]; then
+        error "tari.wallet_address is still the placeholder in $CONFIG_FILE — set your real Tari (Minotari) payout address, or mining earns Tari that goes nowhere."
+    fi
+    case "$TARI_WALLET" in
+    *[[:space:]]*) error "tari.wallet_address contains whitespace — a Tari address (base58 or emoji) has none. Check for a stray space or line break in $CONFIG_FILE." ;;
+    esac
     if [ "$MONERO_WALLET" == "your_monero_wallet_address" ] || [ "$TARI_WALLET" == "your_tari_wallet_address" ]; then
         error "Wallet addresses in $CONFIG_FILE are still the template placeholders. Set your real addresses."
     fi
@@ -2716,26 +2737,26 @@ parse_and_validate_config() {
     # bridge command `TCP:$_mmhost:$_mmport` (build/p2pool/entrypoint.sh), where a comma is read as a
     # socat address-option separator (`TCP:host,fork,…`). So charset-guard both with the same
     # is_valid_host/is_valid_port used for dashboard.host/.port — no comma/space/`{` reaches a sink.
+    # These resolve once here and are reused verbatim by render_env (globals, like MONERO_MODE above),
+    # so the value that passes validation is exactly the value rendered — no second jq read, no drift.
     if [ "$MONERO_MODE" == "remote" ]; then
-        local remote_host remote_rpc_port remote_zmq_port
-        remote_host=$(jq -r '.monero.remote.host // empty' "$CONFIG_FILE")
-        [ -n "$remote_host" ] || error "monero.mode is \"remote\" but monero.remote.host is not set in $CONFIG_FILE."
-        is_valid_host "$remote_host" || error "monero.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$remote_host\"."
-        remote_rpc_port=$(jq -r '.monero.remote.rpc_port // 18081' "$CONFIG_FILE")
-        is_valid_port "$remote_rpc_port" || error "monero.remote.rpc_port must be a TCP port 1–65535. Got \"$remote_rpc_port\"."
-        remote_zmq_port=$(jq -r '.monero.remote.zmq_port // 18083' "$CONFIG_FILE")
-        is_valid_port "$remote_zmq_port" || error "monero.remote.zmq_port must be a TCP port 1–65535. Got \"$remote_zmq_port\"."
+        MONERO_REMOTE_HOST=$(jq -r '.monero.remote.host // empty' "$CONFIG_FILE")
+        [ -n "$MONERO_REMOTE_HOST" ] || error "monero.mode is \"remote\" but monero.remote.host is not set in $CONFIG_FILE."
+        is_valid_host "$MONERO_REMOTE_HOST" || error "monero.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$MONERO_REMOTE_HOST\"."
+        MONERO_REMOTE_RPC_PORT=$(jq -r '.monero.remote.rpc_port // 18081' "$CONFIG_FILE")
+        is_valid_port "$MONERO_REMOTE_RPC_PORT" || error "monero.remote.rpc_port must be a TCP port 1–65535. Got \"$MONERO_REMOTE_RPC_PORT\"."
+        MONERO_REMOTE_ZMQ_PORT=$(jq -r '.monero.remote.zmq_port // 18083' "$CONFIG_FILE")
+        is_valid_port "$MONERO_REMOTE_ZMQ_PORT" || error "monero.remote.zmq_port must be a TCP port 1–65535. Got \"$MONERO_REMOTE_ZMQ_PORT\"."
     fi
     # tari.mode remote (#103), mirroring monero.mode above: a third-party (or fleet-shared) Tari
     # base node needs a host — an empty one would render an empty TARI_GRPC_ADDRESS and mining can't
     # merge-mine, so abort at validation rather than let that reach the containers silently.
     if [ "$TARI_MODE" == "remote" ]; then
-        local tari_remote_host tari_remote_port
-        tari_remote_host=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
-        [ -n "$tari_remote_host" ] || error "tari.mode is \"remote\" but tari.remote.host is not set in $CONFIG_FILE."
-        is_valid_host "$tari_remote_host" || error "tari.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$tari_remote_host\"."
-        tari_remote_port=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
-        is_valid_port "$tari_remote_port" || error "tari.remote.grpc_port must be a TCP port 1–65535. Got \"$tari_remote_port\"."
+        TARI_REMOTE_HOST=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
+        [ -n "$TARI_REMOTE_HOST" ] || error "tari.mode is \"remote\" but tari.remote.host is not set in $CONFIG_FILE."
+        is_valid_host "$TARI_REMOTE_HOST" || error "tari.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$TARI_REMOTE_HOST\"."
+        TARI_REMOTE_PORT=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
+        is_valid_port "$TARI_REMOTE_PORT" || error "tari.remote.grpc_port must be a TCP port 1–65535. Got \"$TARI_REMOTE_PORT\"."
     fi
 
     POOL_TYPE=$(jq -r '.p2pool.pool // "mini"' "$CONFIG_FILE")
@@ -3608,9 +3629,10 @@ render_env() {
         zmq_port="18083"
         profiles="local_node"
     else
-        mono_host=$(jq -r '.monero.remote.host // empty' "$CONFIG_FILE")
-        rpc_port=$(jq -r '.monero.remote.rpc_port // 18081' "$CONFIG_FILE")
-        zmq_port=$(jq -r '.monero.remote.zmq_port // 18083' "$CONFIG_FILE")
+        # Reuse the parse-time validated globals — the validated value IS the rendered value.
+        mono_host="$MONERO_REMOTE_HOST"
+        rpc_port="$MONERO_REMOTE_RPC_PORT"
+        zmq_port="$MONERO_REMOTE_ZMQ_PORT"
         profiles="" # Empty profile disables local monerod
     fi
 
@@ -3624,10 +3646,8 @@ render_env() {
         tari_grpc_addr="${NETWORK_PREFIX}.27:18142"
         profiles="${profiles:+$profiles,}local_tari"
     else
-        local tari_remote_host tari_remote_port
-        tari_remote_host=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
-        tari_remote_port=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
-        tari_grpc_addr="${tari_remote_host}:${tari_remote_port}"
+        # Reuse the parse-time validated globals (see Monero above) — single source of truth.
+        tari_grpc_addr="${TARI_REMOTE_HOST}:${TARI_REMOTE_PORT}"
     fi
 
     # On-chain payout confirmation (#381): the view-only wallet-rpc service only starts when its

--- a/pithead
+++ b/pithead
@@ -2609,14 +2609,11 @@ parse_and_validate_config() {
     # tari.wallet_address gets no exact-format gate like monero's below: Tari addresses come in
     # base58 AND emoji forms, single/dual, with optional payment IDs — length and charset both vary
     # (RFC-0155), and p2pool passes the string straight to the Tari node, which accepts either form,
-    # so a strict regex would false-reject valid addresses. But two mistakes are unambiguous and cause
-    # the same silent mining-to-nowhere monero guards against (#250): the untouched placeholder, and
-    # embedded whitespace (no Tari address of either form contains an ASCII space, and a space isn't a
-    # control char so the central guard above doesn't catch it). Reject both; a subtler typo is the
-    # node's to reject at merge-mine time. [TODO: verify upstream — exact accepted form, to gate fully.]
-    if [ "$TARI_WALLET" = "your_tari_wallet_address" ]; then
-        error "tari.wallet_address is still the placeholder in $CONFIG_FILE — set your real Tari (Minotari) payout address, or mining earns Tari that goes nowhere."
-    fi
+    # so a strict regex would false-reject valid addresses. The untouched placeholder is caught by the
+    # combined check just below; also reject embedded whitespace here — no Tari address of either form
+    # has an ASCII space, and a space isn't a control char so the central guard above misses it, yet it
+    # would silently mine to a wrong address (the #250 failure mode). A subtler typo is the node's to
+    # reject at merge-mine time. [TODO: verify upstream — exact accepted form, to gate fully.]
     case "$TARI_WALLET" in
     *[[:space:]]*) error "tari.wallet_address contains whitespace — a Tari address (base58 or emoji) has none. Check for a stray space or line break in $CONFIG_FILE." ;;
     esac
@@ -2690,7 +2687,7 @@ parse_and_validate_config() {
     TARI_PAYOUT_CONFIRM_ENABLED=false
     if [ -n "$TARI_VIEW_KEY" ]; then
         if [ "$TARI_MODE" != "local" ]; then
-            error "tari.view_key is set but tari.mode is \"$TARI_MODE\". Payout confirmation needs the LOCAL Tari node — unsupported with tari.mode: remote (#103), since scanning through a third-party node changes the trust story. Unset tari.view_key, or use a local Tari node."
+            error "tari.view_key is set but tari.mode is \"$TARI_MODE\". Payout confirmation needs the LOCAL Tari node — unsupported with tari.mode: remote, since scanning through a third-party node changes the trust story. Unset tari.view_key, or use a local Tari node."
         fi
         # Tari view / public-spend keys are 64 lowercase hex chars (32-byte Ristretto scalar / point).
         if ! printf '%s' "$TARI_VIEW_KEY" | grep -qE '^[0-9a-f]{64}$'; then
@@ -2739,6 +2736,12 @@ parse_and_validate_config() {
     # is_valid_host/is_valid_port used for dashboard.host/.port — no comma/space/`{` reaches a sink.
     # These resolve once here and are reused verbatim by render_env (globals, like MONERO_MODE above),
     # so the value that passes validation is exactly the value rendered — no second jq read, no drift.
+    # Cleared to empty first (defensive): each real `apply` is a fresh process so these start unset,
+    # but clearing them keeps the invariant "globals reflect only the current config" true even if a
+    # future caller ever parses twice in one process — a stale remote host must never survive into a
+    # later local-mode render.
+    MONERO_REMOTE_HOST="" MONERO_REMOTE_RPC_PORT="" MONERO_REMOTE_ZMQ_PORT=""
+    TARI_REMOTE_HOST="" TARI_REMOTE_GRPC_PORT=""
     if [ "$MONERO_MODE" == "remote" ]; then
         MONERO_REMOTE_HOST=$(jq -r '.monero.remote.host // empty' "$CONFIG_FILE")
         [ -n "$MONERO_REMOTE_HOST" ] || error "monero.mode is \"remote\" but monero.remote.host is not set in $CONFIG_FILE."
@@ -2755,8 +2758,8 @@ parse_and_validate_config() {
         TARI_REMOTE_HOST=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
         [ -n "$TARI_REMOTE_HOST" ] || error "tari.mode is \"remote\" but tari.remote.host is not set in $CONFIG_FILE."
         is_valid_host "$TARI_REMOTE_HOST" || error "tari.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$TARI_REMOTE_HOST\"."
-        TARI_REMOTE_PORT=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
-        is_valid_port "$TARI_REMOTE_PORT" || error "tari.remote.grpc_port must be a TCP port 1–65535. Got \"$TARI_REMOTE_PORT\"."
+        TARI_REMOTE_GRPC_PORT=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
+        is_valid_port "$TARI_REMOTE_GRPC_PORT" || error "tari.remote.grpc_port must be a TCP port 1–65535. Got \"$TARI_REMOTE_GRPC_PORT\"."
     fi
 
     POOL_TYPE=$(jq -r '.p2pool.pool // "mini"' "$CONFIG_FILE")
@@ -3647,7 +3650,7 @@ render_env() {
         profiles="${profiles:+$profiles,}local_tari"
     else
         # Reuse the parse-time validated globals (see Monero above) — single source of truth.
-        tari_grpc_addr="${TARI_REMOTE_HOST}:${TARI_REMOTE_PORT}"
+        tari_grpc_addr="${TARI_REMOTE_HOST}:${TARI_REMOTE_GRPC_PORT}"
     fi
 
     # On-chain payout confirmation (#381): the view-only wallet-rpc service only starts when its
@@ -4574,10 +4577,10 @@ describe_change() {
             msg="Switching to a REMOTE Monero node — the local monerod container will be STOPPED and removed (its on-disk data is kept)."
         elif [ "$old_tari_local" = false ] && [ "$new_tari_local" = true ]; then
             flag=DEST
-            msg="Switching to a LOCAL Tari node (#103) — the tari container will start and SYNC the chain (large download / disk use)."
+            msg="Switching to a LOCAL Tari node — the tari container will start and SYNC the chain (large download / disk use)."
         elif [ "$old_tari_local" = true ] && [ "$new_tari_local" = false ]; then
             flag=DEST
-            msg="Switching to a REMOTE Tari node (#103) — the local tari container will be STOPPED and removed (its on-disk data is kept)."
+            msg="Switching to a REMOTE Tari node — the local tari container will be STOPPED and removed (its on-disk data is kept)."
         else
             msg="Payout confirmation profile changed ($old → $new)."
         fi

--- a/pithead
+++ b/pithead
@@ -572,6 +572,11 @@ stack_status() {
         if [ "$s" = "monerod" ] && [[ ",$profiles," != *",local_node,"* ]]; then
             continue
         fi
+        # Same for the bundled Tari node under local_tari (#103): tari.mode remote means it's
+        # never expected to be running, so don't flag it missing either.
+        if [ "$s" = "tari" ] && [[ ",$profiles," != *",local_tari,"* ]]; then
+            continue
+        fi
 
         cid=$(docker compose ps -aq "$s" 2>/dev/null | head -n1 || true)
         if [ -z "$cid" ]; then
@@ -924,6 +929,20 @@ doctor() {
         # .env renders MONERO_PRUNE as 1 (pruning on) / 0 (off); default to pruned if unset.
         doctor_prune=$(env_get MONERO_PRUNE)
         [ -n "$doctor_prune" ] || doctor_prune=1
+        # A remote node (#103) keeps its chain elsewhere, so its dir must not count toward THIS
+        # host's disk budget — otherwise doctor demands ~120 GiB (Monero) / ~170 GiB (Tari) for a
+        # container that never runs, on exactly the small-disk hosts remote mode exists for. Read
+        # the mode from the profile tokens like the container checks above; a pre-#103 .env has no
+        # local_tari token yet, so require a rendered TARI_GRPC_ADDRESS (also new in #103) before
+        # trusting its absence — old installs keep the local budget until the next apply re-renders.
+        local doctor_profiles
+        doctor_profiles=$(env_get COMPOSE_PROFILES)
+        if [[ ",$doctor_profiles," != *",local_node,"* ]]; then
+            mono_dir=""
+        fi
+        if [ -n "$(env_get TARI_GRPC_ADDRESS)" ] && [[ ",$doctor_profiles," != *",local_tari,"* ]]; then
+            tari_dir=""
+        fi
     else
         mono_dir="$PWD/data/monero"
         tari_dir="$PWD/data/tari"
@@ -2599,6 +2618,15 @@ parse_and_validate_config() {
     *) error "monero.mode must be \"local\" or \"remote\" (got \"$MONERO_MODE\")." ;;
     esac
 
+    # tari.mode (#103), the same explicit local/remote switch as monero.mode above. Read here (not
+    # only inside the view-key gate below) so an invalid value fails validation regardless of
+    # whether a view key is even set.
+    TARI_MODE=$(jq -r '.tari.mode // "local"' "$CONFIG_FILE")
+    case "$TARI_MODE" in
+    local | remote) ;;
+    *) error "tari.mode must be \"local\" or \"remote\" (got \"$TARI_MODE\")." ;;
+    esac
+
     # On-chain payout confirmation (#381). The operator supplies the PRIVATE VIEW KEY for
     # monero.wallet_address; the stack runs a view-only monero-wallet-rpc against the LOCAL node to
     # confirm payouts actually landed. The view key is a SECRET (it reveals all incoming amounts and
@@ -2630,17 +2658,18 @@ parse_and_validate_config() {
     # merge-mine coinbase actually landed. The view key is a SECRET (reveals all incoming amounts and
     # timing) — handled like node_password: never logged or echoed, delivered to the container via a
     # tmpfs-mounted compose secret, never the command line or `docker inspect`. Empty (the default) =
-    # feature off. Phase 1 is LOCAL NODE ONLY: a view key with a remote Tari node (#103, v1.6) is
-    # refused, mirroring monero.mode. tari.payout_scan_birthday is Tari's restore point: DAYS SINCE
-    # THE UNIX EPOCH (a u16, not a block height), so a fresh wallet doesn't rescan from genesis.
+    # feature off. Phase 1 is LOCAL NODE ONLY: a view key with a remote Tari node (#103) is refused,
+    # mirroring monero.mode — scanning through a third-party node changes the trust story.
+    # tari.payout_scan_birthday is Tari's restore point: DAYS SINCE THE UNIX EPOCH (a u16, not a
+    # block height), so a fresh wallet doesn't rescan from genesis. TARI_MODE was already parsed and
+    # validated above.
     TARI_VIEW_KEY=$(jq -r '.tari.view_key // empty' "$CONFIG_FILE")
     TARI_SPEND_PUBLIC_KEY=$(jq -r '.tari.spend_public_key // empty' "$CONFIG_FILE")
     TARI_WALLET_BIRTHDAY=$(jq -r '.tari.payout_scan_birthday // "auto"' "$CONFIG_FILE")
-    TARI_MODE=$(jq -r '.tari.mode // "local"' "$CONFIG_FILE")
     TARI_PAYOUT_CONFIRM_ENABLED=false
     if [ -n "$TARI_VIEW_KEY" ]; then
         if [ "$TARI_MODE" != "local" ]; then
-            error "tari.view_key is set but tari.mode is \"$TARI_MODE\". Tari payout confirmation (#462) scans against the LOCAL Tari node only — remote Tari (#103) is v1.6 and changes the trust story. Unset tari.view_key, or use a local Tari node."
+            error "tari.view_key is set but tari.mode is \"$TARI_MODE\". Payout confirmation needs the LOCAL Tari node — unsupported with tari.mode: remote (#103), since scanning through a third-party node changes the trust story. Unset tari.view_key, or use a local Tari node."
         fi
         # Tari view / public-spend keys are 64 lowercase hex chars (32-byte Ristretto scalar / point).
         if ! printf '%s' "$TARI_VIEW_KEY" | grep -qE '^[0-9a-f]{64}$'; then
@@ -2681,10 +2710,32 @@ parse_and_validate_config() {
     TOR_AUTO_HEAL=$(normalize_bool "$(config_bool '.tor.auto_heal' false)")
     # Surfaced for the dashboard's egress-posture panel (#170); mirrors what p2pool_outbound_flags reads.
     P2POOL_CLEARNET=$(normalize_bool "$(config_bool '.p2pool.clearnet' false)")
+    # Remote-node host/port validation (#103). The central control-char guard above already stops a
+    # newline forging an .env line, but a remote.host also flows into shell/URL sinks it doesn't
+    # cover: monero's into the p2pool `--host` arg, tari's into `--merge-mine tari://…` AND the socat
+    # bridge command `TCP:$_mmhost:$_mmport` (build/p2pool/entrypoint.sh), where a comma is read as a
+    # socat address-option separator (`TCP:host,fork,…`). So charset-guard both with the same
+    # is_valid_host/is_valid_port used for dashboard.host/.port — no comma/space/`{` reaches a sink.
     if [ "$MONERO_MODE" == "remote" ]; then
-        local remote_host
+        local remote_host remote_rpc_port remote_zmq_port
         remote_host=$(jq -r '.monero.remote.host // empty' "$CONFIG_FILE")
         [ -n "$remote_host" ] || error "monero.mode is \"remote\" but monero.remote.host is not set in $CONFIG_FILE."
+        is_valid_host "$remote_host" || error "monero.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$remote_host\"."
+        remote_rpc_port=$(jq -r '.monero.remote.rpc_port // 18081' "$CONFIG_FILE")
+        is_valid_port "$remote_rpc_port" || error "monero.remote.rpc_port must be a TCP port 1–65535. Got \"$remote_rpc_port\"."
+        remote_zmq_port=$(jq -r '.monero.remote.zmq_port // 18083' "$CONFIG_FILE")
+        is_valid_port "$remote_zmq_port" || error "monero.remote.zmq_port must be a TCP port 1–65535. Got \"$remote_zmq_port\"."
+    fi
+    # tari.mode remote (#103), mirroring monero.mode above: a third-party (or fleet-shared) Tari
+    # base node needs a host — an empty one would render an empty TARI_GRPC_ADDRESS and mining can't
+    # merge-mine, so abort at validation rather than let that reach the containers silently.
+    if [ "$TARI_MODE" == "remote" ]; then
+        local tari_remote_host tari_remote_port
+        tari_remote_host=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
+        [ -n "$tari_remote_host" ] || error "tari.mode is \"remote\" but tari.remote.host is not set in $CONFIG_FILE."
+        is_valid_host "$tari_remote_host" || error "tari.remote.host must be a hostname or IP literal (letters, digits, and . : _ - only, ≤253 chars). Got \"$tari_remote_host\"."
+        tari_remote_port=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
+        is_valid_port "$tari_remote_port" || error "tari.remote.grpc_port must be a TCP port 1–65535. Got \"$tari_remote_port\"."
     fi
 
     POOL_TYPE=$(jq -r '.p2pool.pool // "mini"' "$CONFIG_FILE")
@@ -3563,6 +3614,22 @@ render_env() {
         profiles="" # Empty profile disables local monerod
     fi
 
+    # Tari mode → gRPC address / compose profile (#103), mirroring Monero above. local -> the
+    # bundled Tari node at its fixed bridge IP, plus the local_tari profile so compose starts it.
+    # remote -> a third-party (or fleet-shared) node's host:port; local_tari stays out of $profiles
+    # so the bundled node never starts (parse_and_validate_config already required
+    # tari.remote.host to be set).
+    local tari_grpc_addr
+    if [ "$TARI_MODE" == "local" ]; then
+        tari_grpc_addr="${NETWORK_PREFIX}.27:18142"
+        profiles="${profiles:+$profiles,}local_tari"
+    else
+        local tari_remote_host tari_remote_port
+        tari_remote_host=$(jq -r '.tari.remote.host // empty' "$CONFIG_FILE")
+        tari_remote_port=$(jq -r '.tari.remote.grpc_port // 18142' "$CONFIG_FILE")
+        tari_grpc_addr="${tari_remote_host}:${tari_remote_port}"
+    fi
+
     # On-chain payout confirmation (#381): the view-only wallet-rpc service only starts when its
     # compose profile is active, which is only when a view key is set on a local node. Off = no
     # container, dashboard unchanged. PAYOUT_CONFIRM_ENABLED is set by parse_and_validate_config
@@ -3802,28 +3869,36 @@ render_env() {
     # Net: with HugePages on, ~7.5 GB on a 16 GB host, ~19 GB on 32 GB; with HugePages off
     # (--skip-optimize) it's ~75% of RAM. Override with tari.mem_limit (any Docker value, e.g. "8g").
     local tari_mem_limit ram_mb huge_mb avail_mb reserve_mb monero_mem_limit
-    tari_mem_limit=$(jq -r '.tari.mem_limit // "auto"' "$CONFIG_FILE")
-    case "$tari_mem_limit" in
-    "" | auto)
-        huge_mb=0
-        if [ "$OS_TYPE" == "Darwin" ]; then
-            ram_mb=$(($(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576))
-        else
-            ram_mb=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 0)
-            # HugePages_Total (pages) * Hugepagesize (kB) -> MiB reserved out of RAM.
-            huge_mb=$(awk '/HugePages_Total/{t=$2} /Hugepagesize/{s=$2} END{print int(t*s/1024)}' /proc/meminfo 2>/dev/null || echo 0)
-        fi
-        [ "${ram_mb:-0}" -gt 0 ] 2>/dev/null || ram_mb=16384 # unknown host => assume 16 GB
-        [ "${huge_mb:-0}" -ge 0 ] 2>/dev/null || huge_mb=0
-        avail_mb=$((ram_mb - huge_mb)) # RAM left after HugePages
-        [ "$avail_mb" -lt 2048 ] && avail_mb=2048
-        reserve_mb=$((avail_mb / 4)) # rest of the stack + OS + cache
-        [ "$reserve_mb" -lt 2048 ] && reserve_mb=2048
-        tari_mem_limit=$((avail_mb - reserve_mb))
-        [ "$tari_mem_limit" -lt 2048 ] && tari_mem_limit=2048 # never starve Tari below 2 GB
-        tari_mem_limit="${tari_mem_limit}m"
-        ;;
-    esac
+    if [ "$TARI_MODE" == "remote" ]; then
+        # No local Tari container to cap in remote mode (#103) — the RAM-sniffing auto-calc below is
+        # about THIS host's memory, irrelevant to a third-party node, so skip it entirely. Render a
+        # fixed placeholder so the (profiled-off) tari service's compose interpolation still
+        # resolves; it is never applied to a running container.
+        tari_mem_limit="0m"
+    else
+        tari_mem_limit=$(jq -r '.tari.mem_limit // "auto"' "$CONFIG_FILE")
+        case "$tari_mem_limit" in
+        "" | auto)
+            huge_mb=0
+            if [ "$OS_TYPE" == "Darwin" ]; then
+                ram_mb=$(($(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576))
+            else
+                ram_mb=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 0)
+                # HugePages_Total (pages) * Hugepagesize (kB) -> MiB reserved out of RAM.
+                huge_mb=$(awk '/HugePages_Total/{t=$2} /Hugepagesize/{s=$2} END{print int(t*s/1024)}' /proc/meminfo 2>/dev/null || echo 0)
+            fi
+            [ "${ram_mb:-0}" -gt 0 ] 2>/dev/null || ram_mb=16384 # unknown host => assume 16 GB
+            [ "${huge_mb:-0}" -ge 0 ] 2>/dev/null || huge_mb=0
+            avail_mb=$((ram_mb - huge_mb)) # RAM left after HugePages
+            [ "$avail_mb" -lt 2048 ] && avail_mb=2048
+            reserve_mb=$((avail_mb / 4)) # rest of the stack + OS + cache
+            [ "$reserve_mb" -lt 2048 ] && reserve_mb=2048
+            tari_mem_limit=$((avail_mb - reserve_mb))
+            [ "$tari_mem_limit" -lt 2048 ] && tari_mem_limit=2048 # never starve Tari below 2 GB
+            tari_mem_limit="${tari_mem_limit}m"
+            ;;
+        esac
+    fi
 
     # monerod memory ceiling (#132): a generous default so heavy initial-sync verification never trips
     # it (monerod's LMDB is reclaimable page cache, so its capped RSS stays low). Tunable for low-RAM
@@ -3968,6 +4043,7 @@ MONERO_RPC_BIND=$rpc_bind
 MONERO_NODE_HOST=$mono_host
 MONERO_RPC_PORT=$rpc_port
 MONERO_ZMQ_PORT=$zmq_port
+TARI_GRPC_ADDRESS=$tari_grpc_addr
 COMPOSE_PROFILES=$profiles
 DASHBOARD_SECURE=$DASHBOARD_SECURE
 DASHBOARD_ONION_ENABLED=$DASHBOARD_ONION_ENABLED
@@ -4373,8 +4449,14 @@ preflight_resources() {
     # Treat the stack as one unit: group all five data dirs by the filesystem they live on and warn
     # once per volume that can't hold the combined requirement of the components sharing it (so dirs
     # on the same disk produce a single line, not one per dir). check_disk_grouped is WARN-only here.
+    # A remote node (#103) keeps its chain elsewhere: blank its dir so the ~120 GiB (Monero) /
+    # ~170 GiB (Tari) budget isn't demanded of THIS host — small disks are exactly why an operator
+    # goes remote. check_disk_grouped skips empty dirs.
+    local pre_mono_dir="${MONERO_DIR:-}" pre_tari_dir="${TARI_DIR:-}"
+    [ "$MONERO_MODE" == "remote" ] && pre_mono_dir=""
+    [ "$TARI_MODE" == "remote" ] && pre_tari_dir=""
     check_disk_grouped preflight "$prune" \
-        "${MONERO_DIR:-}" "${TARI_DIR:-}" "${P2POOL_DIR:-}" "${DASHBOARD_DIR:-}" "${TOR_DATA_DIR:-}"
+        "$pre_mono_dir" "$pre_tari_dir" "${P2POOL_DIR:-}" "${DASHBOARD_DIR:-}" "${TOR_DATA_DIR:-}"
 
     # --- RAM: total memory (Linux only — /proc/meminfo isn't available on macOS dev hosts) ---
     if [ "$OS_TYPE" == "Linux" ]; then
@@ -4454,18 +4536,28 @@ describe_change() {
         esac
         ;;
     COMPOSE_PROFILES)
-        # #552: COMPOSE_PROFILES also carries payout_confirm/tari_payout_confirm (#381/#462), so an
-        # empty-vs-non-empty check misreads those toggles as a node switch. Decide by presence of the
-        # local_node token instead — only a real flip of that token is a node switch (DEST).
-        local old_local=false new_local=false
+        # #552: COMPOSE_PROFILES also carries payout_confirm/tari_payout_confirm (#381/#462) and
+        # local_tari (#103), so an empty-vs-non-empty check misreads those toggles as a node switch.
+        # Decide by presence of the local_node / local_tari tokens instead — only a real flip of
+        # either token is a node switch (DEST). Monero is checked first; a same-apply flip of BOTH
+        # nodes is rare and either message alone is enough to make the change obvious.
+        local old_local=false new_local=false old_tari_local=false new_tari_local=false
         case ",$old," in *,local_node,*) old_local=true ;; esac
         case ",$new," in *,local_node,*) new_local=true ;; esac
+        case ",$old," in *,local_tari,*) old_tari_local=true ;; esac
+        case ",$new," in *,local_tari,*) new_tari_local=true ;; esac
         if [ "$old_local" = false ] && [ "$new_local" = true ]; then
             flag=DEST
             msg="Switching to a LOCAL Monero node — monerod will start and SYNC the blockchain (large download / disk use)."
         elif [ "$old_local" = true ] && [ "$new_local" = false ]; then
             flag=DEST
             msg="Switching to a REMOTE Monero node — the local monerod container will be STOPPED and removed (its on-disk data is kept)."
+        elif [ "$old_tari_local" = false ] && [ "$new_tari_local" = true ]; then
+            flag=DEST
+            msg="Switching to a LOCAL Tari node (#103) — the tari container will start and SYNC the chain (large download / disk use)."
+        elif [ "$old_tari_local" = true ] && [ "$new_tari_local" = false ]; then
+            flag=DEST
+            msg="Switching to a REMOTE Tari node (#103) — the local tari container will be STOPPED and removed (its on-disk data is kept)."
         else
             msg="Payout confirmation profile changed ($old → $new)."
         fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2472,6 +2472,14 @@ assert_eq "two fs -> two lines" "$(printf '%s\n' "$out" | grep -c 'Data on')" "2
 assert_contains "/big groups monero+tari (~290 GB)" "$out" "/big (monero, tari): 600G free — needs ~290 GB"
 assert_contains "/small groups the small three (~8 GB)" "$out" "/small (p2pool, dashboard, tor): 600G free — needs ~8 GB"
 
+# Remote node modes (#103): doctor/preflight blank the remote component's dir (its chain lives on
+# the OTHER host), and an empty dir arg must drop that component from the budget entirely — here
+# tari remote drops the ~170 GB Tari share, leaving monero+the small three (120+5+2+1 = 128 GB).
+out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
+    run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "" "$pd" "$dd" "$rd" 2>&1)"
+assert_contains "remote tari drops tari from the budget" "$out" "(monero, p2pool, dashboard, tor)"
+assert_contains "remote tari budget excludes the 170 GB" "$out" "needs ~128 GB"
+
 # Preflight mode is WARN-only and silent when there's enough room.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped preflight 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
@@ -3050,6 +3058,15 @@ rc=$?
 assert_rc "remote mode without a host rejected" "$rc" "1"
 assert_contains "remote-host message" "$out" "monero.remote.host"
 
+# monero.remote.host with a comma is rejected by is_valid_host (#103): monero's remote host renders
+# into the p2pool `--host` arg the same way tari's does, and the comma vector slips past the central
+# control-char guard, so the field-specific guard must catch it here too.
+seed_env
+printf '{ "monero": {"mode":"remote","remote":{"host":"1.2.3.4,fork"},"wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "monero.remote.host with a comma rejected" "$?" "1"
+assert_contains "monero comma-host message names the field" "$out" "monero.remote.host"
+
 # A malformed network.subnet (#180): anything but an X.Y.Z.0/24 block renders a broken NETWORK_PREFIX
 # into every service IP and the #270 firewall rules — reject before it can.
 seed_env
@@ -3248,6 +3265,94 @@ printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","n
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_rc "valid birthday accepted" "$?" "0"
 assert_eq "valid birthday reflected into .env" "$(run_sourced "$V" env_get_file "$V/.env" TARI_WALLET_BIRTHDAY)" "1000"
+
+echo "== black-box: tari.mode remote (#103) =="
+# The Tari sibling of monero.mode remote: mirrors the Monero pattern above (host:port render,
+# missing-host error, mode/view-key gating), so a third-party or fleet-shared Tari base node works
+# the same way an operator already expects from Monero.
+
+# (1) local (default): TARI_GRPC_ADDRESS renders the bundled node's fixed bridge IP, and local_tari
+# is added to COMPOSE_PROFILES so compose actually starts it.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "local tari mode applies cleanly" "$?" "0"
+assert_eq "local tari renders the bundled node's gRPC address" "$(run_sourced "$V" env_get_file "$V/.env" TARI_GRPC_ADDRESS)" "172.28.0.27:18142"
+assert_contains "local_tari profile added" "$(run_sourced "$V" env_get_file "$V/.env" COMPOSE_PROFILES)" "local_tari"
+
+# (2) remote: TARI_GRPC_ADDRESS renders host:port from tari.remote, and local_tari is OMITTED from
+# COMPOSE_PROFILES so the bundled node stays off. Port defaults to 18142 when unset.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"tari.example.com"}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "remote tari mode applies cleanly" "$?" "0"
+assert_eq "remote tari renders host:port with the default gRPC port" "$(run_sourced "$V" env_get_file "$V/.env" TARI_GRPC_ADDRESS)" "tari.example.com:18142"
+case "$(run_sourced "$V" env_get_file "$V/.env" COMPOSE_PROFILES)" in
+*local_tari*) bad "no local_tari profile in remote tari mode" "local_tari leaked into COMPOSE_PROFILES" ;;
+*) ok "no local_tari profile in remote tari mode" ;;
+esac
+# A remote node still renders SOME TARI_MEM_LIMIT placeholder (compose interpolation must resolve
+# even though the profiled-off tari service never uses it) rather than an empty value.
+[ -n "$(run_sourced "$V" env_get_file "$V/.env" TARI_MEM_LIMIT)" ] && ok "remote tari still renders a TARI_MEM_LIMIT placeholder" || bad "remote tari still renders a TARI_MEM_LIMIT placeholder" "empty"
+
+# (3) remote with a custom grpc_port reflects verbatim.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"tari.example.com","grpc_port":28142}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_eq "remote tari custom grpc_port reflected" "$(run_sourced "$V" env_get_file "$V/.env" TARI_GRPC_ADDRESS)" "tari.example.com:28142"
+
+# (4) remote mode with no host: renders an empty TARI_GRPC_ADDRESS -> p2pool/dashboard dial nothing,
+# merge-mining can't start. Must abort at validation, not silently proceed.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+rc=$?
+assert_rc "remote tari mode without a host rejected" "$rc" "1"
+assert_contains "tari remote-host message" "$out" "tari.remote.host"
+
+# (5) remote Tari node + tari.view_key -> refused loudly (Phase 1 is local-only for the same reason
+# as Monero's #381 gate: scanning through a third-party node changes the trust story).
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"tari.example.com"},"view_key":"%s","spend_public_key":"%s"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" "$TVIEW" "$TSPEND" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "tari view key on a remote node rejected" "$?" "1"
+assert_contains "remote tari view-key message names the field" "$out" "tari.view_key"
+
+# (6a) tari.remote.host carrying a newline is rejected. Defence-in-depth: the central control-char
+# guard catches it first (a newline in ANY value would forge a second .env line), before the
+# per-field is_valid_host check below even runs — so assert rejection + no forged line, not a
+# field-specific message.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"1.2.3.4\\nEVIL=pwned"}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "tari.remote.host with a newline rejected" "$?" "1"
+case "$(cat "$V/.env" 2>/dev/null)" in
+*EVIL=pwned*) bad "no forged .env line from a crafted host" "EVIL=pwned leaked into .env" ;;
+*) ok "no forged .env line from a crafted host" ;;
+esac
+
+# (6b) A comma in tari.remote.host is rejected by is_valid_host — a comma is NOT a control char, so
+# it slips past the central guard above, but it would inject socat address options in the p2pool
+# entrypoint's bridge command (TCP:$_mmhost:$_mmport). This is the field-specific guard's own case.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"1.2.3.4,fork,reuseaddr"}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "tari.remote.host with a comma rejected" "$?" "1"
+assert_contains "comma-host message names the field" "$out" "tari.remote.host"
+
+# (6c) A non-numeric tari.remote.grpc_port is rejected.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"remote","remote":{"host":"tari.example.com","grpc_port":"18142; rm -rf"}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "non-numeric tari.remote.grpc_port rejected" "$?" "1"
+assert_contains "bad grpc_port message names the field" "$out" "tari.remote.grpc_port"
+
+# (7) An invalid tari.mode value is rejected before it ever reaches render_env.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T","mode":"bogus"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "invalid tari.mode rejected" "$?" "1"
+assert_contains "invalid tari.mode message" "$out" "tari.mode must be"
 
 echo "== black-box: monero.rpc_lan_access + prep_blocks_threads reflect into .env (#523) =="
 # The rendered .env must match the config input. rpc_lan_access gates the monerod RPC bind: default
@@ -3892,7 +3997,7 @@ ST="$SANDBOX/status"
 mkdir -p "$ST/bin"
 cp "$STACK" "$ST/pithead"
 make_status_stub "$ST/bin"
-printf 'DEPLOYMENT_COMPLETED=true\nCOMPOSE_PROFILES=local_node\nHOST_IP=box.lan\n' >"$ST/.env"
+printf 'DEPLOYMENT_COMPLETED=true\nCOMPOSE_PROFILES=local_node,local_tari\nHOST_IP=box.lan\n' >"$ST/.env"
 ALL_UP="tor=running:healthy monerod=running:healthy p2pool=running:none tari=running:healthy xmrig-proxy=running:none dashboard=running:none docker-proxy=running:none docker-control=running:none caddy=running:none"
 
 # All services up -> success, friendly summary.
@@ -3930,6 +4035,14 @@ REMOTE="tor=running:healthy monerod=missing p2pool=running:none tari=running:hea
 out="$(cd "$ST" && FAKE_STATES="$REMOTE" PATH="$ST/bin:$PATH" ./pithead status 2>&1)"
 rc=$?
 assert_rc "status: remote mode ignores monerod" "$rc" "0"
+
+# Remote Tari mode (#103): the bundled tari container is not expected even if absent, mirroring
+# monerod above — COMPOSE_PROFILES carries local_node (Monero local) but no local_tari.
+printf 'DEPLOYMENT_COMPLETED=true\nCOMPOSE_PROFILES=local_node\nHOST_IP=box.lan\n' >"$ST/.env"
+REMOTE_TARI="tor=running:healthy monerod=running:healthy p2pool=running:none tari=missing xmrig-proxy=running:none dashboard=running:none docker-proxy=running:none docker-control=running:none caddy=running:none"
+out="$(cd "$ST" && FAKE_STATES="$REMOTE_TARI" PATH="$ST/bin:$PATH" ./pithead status 2>&1)"
+rc=$?
+assert_rc "status: remote tari mode ignores tari" "$rc" "0"
 
 echo "== black-box: doctor exit code (#127) =="
 # doctor must EXIT NON-ZERO when a critical check fails, so it's usable as a cron/CI health gate

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3052,14 +3052,14 @@ rc=$?
 assert_rc "integrated payout rejected (would never be paid)" "$rc" "1"
 assert_contains "integrated message names the type" "$out" "INTEGRATED"
 
-# tari.wallet_address left at the placeholder -> rejected (else mining earns Tari that goes nowhere,
-# the #250 failure mode). No exact-format gate (base58/emoji both valid), but the placeholder and any
-# whitespace are unambiguous.
+# tari.wallet_address left at the placeholder -> rejected by the shared template-placeholder guard
+# (else mining earns Tari that goes nowhere, the #250 failure mode). No exact-format gate
+# (base58/emoji both valid), but the placeholder and any whitespace are unambiguous.
 seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"your_tari_wallet_address"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_rc "placeholder tari.wallet_address rejected" "$?" "1"
-assert_contains "placeholder message names the field" "$out" "tari.wallet_address"
+assert_contains "placeholder message names the template placeholders" "$out" "template placeholders"
 # A stray space in the Tari address (not a control char, so the central guard misses it) -> rejected.
 seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"12ab cd34"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -98,6 +98,9 @@ run_sourced "$SANDBOX" assert_safe_dir "relative/data" >/dev/null 2>&1
 assert_rc "rejects relative path" "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/srv/../etc/data" >/dev/null 2>&1
 assert_rc "rejects .. traversal" "$?" "1"
+# A ':' would forge an extra field in the compose bind-mount short syntax (SOURCE:TARGET:MODE).
+run_sourced "$SANDBOX" assert_safe_dir "/srv/pithead/data:ro" >/dev/null 2>&1
+assert_rc "rejects ':' (compose volume-mount injection)" "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/mnt/disk/monero" >/dev/null 2>&1
 assert_rc "allows mount subfolder" "$?" "0"
 
@@ -3048,6 +3051,21 @@ out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 rc=$?
 assert_rc "integrated payout rejected (would never be paid)" "$rc" "1"
 assert_contains "integrated message names the type" "$out" "INTEGRATED"
+
+# tari.wallet_address left at the placeholder -> rejected (else mining earns Tari that goes nowhere,
+# the #250 failure mode). No exact-format gate (base58/emoji both valid), but the placeholder and any
+# whitespace are unambiguous.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"your_tari_wallet_address"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "placeholder tari.wallet_address rejected" "$?" "1"
+assert_contains "placeholder message names the field" "$out" "tari.wallet_address"
+# A stray space in the Tari address (not a control char, so the central guard misses it) -> rejected.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"12ab cd34"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "whitespace in tari.wallet_address rejected" "$?" "1"
+assert_contains "whitespace message names the field" "$out" "tari.wallet_address"
 
 # Remote mode with no host (#*): renders an empty MONERO_NODE_HOST -> p2pool/dashboard dial nothing,
 # mining can't start. Must abort at validation, not silently proceed.

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -50,7 +50,8 @@ MONERO_RPC_BIND=127.0.0.1
 MONERO_NODE_HOST=172.28.0.26
 MONERO_RPC_PORT=18081
 MONERO_ZMQ_PORT=18083
-COMPOSE_PROFILES=local_node
+TARI_GRPC_ADDRESS=172.28.0.27:18142
+COMPOSE_PROFILES=local_node,local_tari
 DASHBOARD_SECURE=true
 HOST_IP=box.lan
 EOF
@@ -254,32 +255,57 @@ jq_assert "control channel defaults off in the dashboard env (#33)" \
     '.services.dashboard.environment["DASHBOARD_CONTROL_ENABLED"] == "false"'
 
 # depends_on startup ordering (#565): "wait until healthy" vs "wait until started" is a startup-
-# correctness guarantee, not decoration — e.g. p2pool must not merge-mine against a Tari node that's
-# still starting up. Render with the optional payout-confirmation profiles too
+# correctness guarantee, not decoration. Render with the optional payout-confirmation profiles too
 # (payout_confirm/tari_payout_confirm, #381/#462) so the profile-gated wallet-rpc/tari-wallet edges
-# are covered, not just the always-on services. Edges enumerated from the compose file itself (6
+# are covered, not just the always-on services. Edges enumerated from the compose file itself (5
 # depends_on stanzas total): xmrig-proxy -> p2pool is the one deliberate exception that only waits
-# for service_started, since p2pool's own healthcheck already proves what xmrig-proxy needs and
-# health-gating it too would be circular (p2pool depends on tari, not on xmrig-proxy).
+# for service_started, since p2pool's own healthcheck already proves what xmrig-proxy needs.
+# p2pool itself has NO depends_on (#103/#565): both monerod and tari are profile-gated and can be
+# off in remote mode, so p2pool retries its own RPC/gRPC dials instead of waiting on either.
 DEPS_ENV="$(mktemp)"
-sed 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=local_node,payout_confirm,tari_payout_confirm/' "$ENV_FILE" >"$DEPS_ENV"
+sed 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=local_node,local_tari,payout_confirm,tari_payout_confirm/' "$ENV_FILE" >"$DEPS_ENV"
 JSON="$(docker compose --env-file "$DEPS_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
 rm -f "$DEPS_ENV"
-for edge in "monerod=tor" "tari=tor" "p2pool=tari" "wallet-rpc=monerod" "tari-wallet=tari"; do
+for edge in "monerod=tor" "tari=tor" "wallet-rpc=monerod" "tari-wallet=tari"; do
     svc="${edge%%=*}" dep="${edge#*=}"
     jq_assert "$svc waits for $dep to be service_healthy (#565)" \
         ".services[\"$svc\"].depends_on[\"$dep\"].condition == \"service_healthy\""
 done
 jq_assert "xmrig-proxy waits for p2pool service_started only, not health-gated (#565)" \
     '.services["xmrig-proxy"].depends_on["p2pool"].condition == "service_started"'
+jq_assert "p2pool has no depends_on — both monerod and tari can be profiled off (#103/#565)" \
+    '(.services["p2pool"].depends_on // {}) == {}'
 # Count guard: a NEW depends_on edge (health-gated or not) added anywhere in the file must show up
 # in the enumeration above too, or this trips before it ships unasserted.
-jq_assert "exactly 5 service_healthy depends_on edges total (#565)" \
-    '[.services[] | (.depends_on // {}) | to_entries[] | select(.value.condition == "service_healthy")] | length == 5'
-jq_assert "exactly 6 depends_on edges total (#565)" \
-    '[.services[] | (.depends_on // {}) | to_entries[]] | length == 6'
+jq_assert "exactly 4 service_healthy depends_on edges total (#565)" \
+    '[.services[] | (.depends_on // {}) | to_entries[] | select(.value.condition == "service_healthy")] | length == 4'
+jq_assert "exactly 5 depends_on edges total (#565)" \
+    '[.services[] | (.depends_on // {}) | to_entries[]] | length == 5'
 # Restore $JSON to the default-profile render for every check below this point.
 JSON="$(docker compose --env-file "$ENV_FILE" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
+
+# Tari profile gating (#103, mirrors monerod's local_node above): local_tari present/absent from
+# COMPOSE_PROFILES must add/omit the tari service itself, and compose must resolve cleanly either
+# way — a depends_on edge onto a profiled-off service would otherwise fail `compose config`/`up`
+# outright, not just at startup.
+jq_assert "tari service present when local_tari is active (#103)" \
+    '.services | has("tari")'
+REMOTE_TARI_ENV="$(mktemp)"
+sed 's/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=local_node/' "$ENV_FILE" >"$REMOTE_TARI_ENV"
+if docker compose --env-file "$REMOTE_TARI_ENV" -f "$ROOT/docker-compose.yml" config -q; then
+    echo "  ✓ compose config resolves with local_tari OMITTED (remote tari, #103)"
+else
+    echo "  ✗ compose config failed to resolve with local_tari omitted (remote tari, #103)"
+    fails=$((fails + 1))
+fi
+REMOTE_TARI_JSON="$(docker compose --env-file "$REMOTE_TARI_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
+rm -f "$REMOTE_TARI_ENV"
+if printf '%s' "$REMOTE_TARI_JSON" | jq -e '.services | has("tari") | not' >/dev/null 2>&1; then
+    echo "  ✓ tari service absent when local_tari is omitted (remote tari, #103)"
+else
+    echo "  ✗ tari service still present with local_tari omitted (remote tari, #103)"
+    fails=$((fails + 1))
+fi
 
 # Configurable bridge subnet (#180): a custom network.subnet must rebase every static IP, the bridge
 # CIDR, and the dashboard's derived bridge endpoints — the host address-space-collision install fix.


### PR DESCRIPTION
Closes #103.

Adds `tari.mode: remote` — merge-mine against an external Tari base node instead of the bundled container, mirroring the existing Monero remote-node mode. Offloads Tari's RAM and ~170 GiB of disk, and (because the base node's mining-template gRPC is request-scoped — each call carries its own wallet) one node can serve several stacks: a shared fleet/household node is the intended pattern.

Feasibility was confirmed against p2pool and Tari upstream source before any code — verdict recorded on the issue. The core question ("does p2pool's `--merge-mine` work against a non-local Tari gRPC") is yes: the stack already runs that path non-colocated in production via the #313/#314 socat bridge.

## What's in the change

- **Config:** `tari.remote.host` (required in remote mode) + `tari.remote.grpc_port` (default 18142); explicit `tari.mode` local/remote validation. Config editor (`configlogic.mjs`) exposes them exactly as `monero.remote.*`.
- **Render (`pithead`):** `TARI_GRPC_ADDRESS` rendered for both modes; a `local_tari` compose profile gates the bundled `tari` container (mirrors monerod's `local_node`). Remote mode skips the Tari mem-limit calc, refuses `tari.view_key` (payout confirmation stays local-only), and drops the Tari **and** Monero disk budget from doctor/preflight.
- **Compose:** p2pool `--merge-mine`, the dashboard, and the profile-gated payout wallet all read `TARI_GRPC_ADDRESS`; p2pool's `depends_on` is removed since both nodes can be profiled off in remote mode (a `depends_on` edge to an excluded service fails `compose up` outright).
- **Docs:** a "Remote Tari node" section + trust-boundary subsection, privacy.md egress/DNS rows, CHANGELOG.

## Trust model (documented, deliberate)

p2pool's Tari client speaks **plaintext, unauthenticated gRPC** (hardcoded `InsecureChannelCredentials`, no auth metadata — Tari's `grpc_authentication`/`grpc_tls_enabled` exist but p2pool can't use them). A malicious remote node or on-path attacker can silently redirect Tari rewards; **only Tari yield is at risk — Monero mining runs on a separate path.** So: use a node you or someone you trust runs, on LAN or over WireGuard. `.onion` remote isn't supported yet (the Tor default bridges this leg onto a direct connection before Tor) — tracked as a follow-up.

## Review findings addressed

This branch was put through verifier + security-reviewer passes:

- **Disk budget (fixed):** doctor/preflight demanded the remote node's full chain budget (~170 GiB Tari, ~120 GiB Monero) on exactly the small-disk hosts remote mode is for. Both call sites now blank a remote component's dir; the Monero side was a **pre-existing sibling bug** fixed in the same pass. Unit test added.
- **socat option-injection (fixed, MEDIUM):** `remote.host` (both monero + tari) flowed unvalidated into the p2pool `--host`/`--merge-mine` args and the socat bridge, where a comma is read as a socat address-option separator. Closed with `is_valid_host`/`is_valid_port` at parse time (reusing the existing dashboard.host guards), covering the pre-existing Monero exposure too.
- **`.env` newline injection (already defended):** the reviewer's HIGH reproduced against a raw heredoc in isolation, but pithead's central control-char guard (#33 hardening) rejects any newline/control char in any config value before it reaches a render sink. Not exploitable via config.json or the control channel. `is_valid_host` is kept as defence-in-depth.
- **Onion leftover (docs fixed):** remote mode doesn't stop Tor from publishing the (now-inert) Tari inbound onion — docs corrected to call it an inert leftover, matching Monero remote; a follow-up will gate the dead hidden services off.
- **Repoint-without-confirm (accepted parity):** changing an already-remote host via the control channel gets an INFO preview, not a DEST confirm — identical to Monero's `MONERO_NODE_HOST`. The local↔remote mode flip **is** DEST-gated.

## Testing

- `make lint` (all diff-relevant surfaces), `make test-stack` (1647 passed), `make test-compose` (72 passed), `make test-frontend` (263 passed), `make test-dashboard` (1605 passed, 96.9% cov). Patch-coverage gate is vacuous — the diff changes no Python; the shell logic is covered at tier 1, the correct tier per `docs/dev/testing-strategy.md`.
- Live different-machine e2e (a second box running minotari with `grpc_address` rebound + the upstream mining allowlist preset) folds into the release e2e per the feasibility verdict, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
