### PR TITLE
docs(cli): upgrade help text covers the bundle path

### DIFF
--- a/pithead
+++ b/pithead
@@ -1478,7 +1478,9 @@ Lifecycle:
   restart [tor]             Restart the stack — or only the tor container, which picks
                             fresh guards when Tor clearnet egress is stuck (drops
                             and rebuilds all Tor circuits).
-  upgrade                   Rebuild and restart the stack (after a 'git pull').
+  upgrade                   Re-render generated config and rebuild/restart the stack after
+                            an update — a 'git pull' on source installs, or an extracted
+                            release bundle (the dashboard's one-click upgrade runs this).
 
 Inspection:
   logs [service]            Follow logs for all containers, or a single service.


### PR DESCRIPTION
One help line in `pithead`: `upgrade` said "after a 'git pull'", dating from when source checkouts were the only install. It is also the verb the extracted release bundle and the dashboard's one-click upgrade run. The line now names both paths and the re-render step upgrade performs before rebuilding.

Help-text only — no behaviour change. `shfmt` + `shellcheck` pass. Spotted during the CLI-interface review on the dual-distribution work (`docs/dev/dual-distribution-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)