### PR TITLE
fix(tor): publish a node's inbound onion only while that node is local (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ per the process in [`docs/dev/releasing.md`](docs/dev/releasing.md).
   Quadlet), and a git clone — one release manifest across all three. Dev doc only, no behaviour
   change. See [`docs/dev/dual-distribution-plan.md`](docs/dev/dual-distribution-plan.md).
 
+### Fixed
+
+- **No onion for a node that isn't here (#103).** With `monero.mode` or `tari.mode: remote`, Tor
+  kept publishing that node's inbound hidden service even though the container never starts, so the
+  stack advertised an onion address that accepted connections into nothing. Each node's hidden
+  service is now published only while that node runs locally; P2Pool's is unchanged, since p2pool
+  always runs. Switching a node back to `local` republishes it at the same address — the key never
+  left `tor.data_dir` — and a stack first set up in remote mode mints the address on the apply that
+  makes the node local.
+
 ## [1.13.0] - 2026-07-22
 
 ### Added

--- a/build/tor/entrypoint.sh
+++ b/build/tor/entrypoint.sh
@@ -12,6 +12,32 @@ set -eu
 
 sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
 
+# Node inbound hidden services (#103): the bundled monerod and Tari containers only start under
+# their compose profiles, so publish each node's onion only then — in remote mode the onion would
+# be an address with nothing behind it. The gate is the profile list itself (passed through from
+# pithead's rendered .env by docker-compose.yml), so it cannot drift from which nodes actually run.
+# Unset (a bare `docker compose` with no .env) means no profiles, so no bundled node and no onion.
+case ",${COMPOSE_PROFILES:-}," in
+*,local_node,*)
+    cat >>/tmp/torrc <<EOF
+
+# Monero P2P Hidden Service
+HiddenServiceDir /var/lib/tor/monero/
+HiddenServicePort 18080 ${NETWORK_PREFIX}.26:18084
+EOF
+    ;;
+esac
+case ",${COMPOSE_PROFILES:-}," in
+*,local_tari,*)
+    cat >>/tmp/torrc <<EOF
+
+# Tari Base Node Hidden Service
+HiddenServiceDir /var/lib/tor/tari/
+HiddenServicePort 18189 ${NETWORK_PREFIX}.27:18189
+EOF
+    ;;
+esac
+
 # Dashboard hidden service (#343): opt-in, default off. Appended only when pithead sets the flag, so
 # the default stack publishes exactly the three mining onions and nothing else. The target is the
 # bridge gateway (NETWORK_PREFIX.1), where host-networked Caddy binds the auth-gated onion vhost —

--- a/build/tor/torrc.template
+++ b/build/tor/torrc.template
@@ -18,14 +18,10 @@ ControlPort 127.0.0.1:9051
 
 # --- Hidden Services (Onion Routing) ---
 # Note: Target IPs (__NETWORK_PREFIX__.x) correspond to static assignments in docker-compose.yml
-
-# Monero P2P Hidden Service
-HiddenServiceDir /var/lib/tor/monero/
-HiddenServicePort 18080  __NETWORK_PREFIX__.26:18084
-
-# Tari Base Node Hidden Service
-HiddenServiceDir /var/lib/tor/tari/
-HiddenServicePort 18189  __NETWORK_PREFIX__.27:18189
+#
+# Only P2Pool's onion is unconditional — p2pool always runs. The monerod and Tari inbound onions
+# belong to containers that only start in local mode, so the entrypoint appends those two blocks
+# when their compose profile is active (#103); the dashboard onion (#343) is appended there too.
 
 # P2Pool Hidden Service
 HiddenServiceDir /var/lib/tor/p2pool/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,12 @@ services:
     environment:
       # Subnet prefix (#180): the entrypoint envsubst's it into the rendered torrc's bridge IPs.
       - NETWORK_PREFIX=${NETWORK_PREFIX:-172.28.0}
+      # Node onions (#103): the entrypoint publishes the monerod / Tari inbound hidden services only
+      # when their profile is active, so a remote node leaves no onion pointing at nothing. Passing
+      # the profile list itself (rather than a parallel flag) keeps the gate and the containers that
+      # actually start reading from one value; a change here also recreates tor, which is required
+      # for the new torrc to take effect.
+      - COMPOSE_PROFILES=${COMPOSE_PROFILES:-}
       # Dashboard onion (#343): opt-in, default off. When true the entrypoint appends a hidden
       # service for the dashboard (fronting Caddy on the bridge gateway, never the LAN).
       - DASHBOARD_ONION_ENABLED=${DASHBOARD_ONION_ENABLED:-false}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,7 +439,10 @@ To connect to an external Monero node instead of running one locally, set `moner
 }
 ```
 
-- The bundled `monerod` container is not started in remote mode.
+- The bundled `monerod` container is not started in remote mode, and Tor stops publishing the
+  Monero inbound onion with it — a node running elsewhere accepts its own peers. Switch back to
+  `local` and the next `apply` publishes it again, at the same address (the key stays in
+  `tor.data_dir`).
 - The remote node must be set up for P2Pool mining, with ZMQ publishing enabled (`zmq-pub`, port
   `18083` by default) and its RPC reachable by P2Pool. In practice that means a node you run and
   control; general-purpose public "open node" endpoints do not work, since they don't expose ZMQ.
@@ -484,8 +487,8 @@ To merge-mine against a Tari base node running elsewhere instead of the bundled 
 - Remote mode turns off: the bundled `tari` container, the Tari container memory cap
   (`tari.mem_limit` — nothing local left to cap), and payout confirmation (`tari.view_key` is
   rejected with `tari.mode: remote`, same as `monero.view_key` with `monero.mode: remote`). Tor
-  still publishes the Tari inbound onion address, but with no local node behind it, connections to
-  it go nowhere — the same inert leftover a remote Monero node leaves.
+  stops publishing the Tari inbound onion too — the same as a remote Monero node — so no onion
+  address is left pointing at a container that isn't running.
 - The base node's mining-template RPC is request-scoped: every `get_new_block_template_with_coinbases`
   call carries its own caller's coinbase address, and the node holds no per-caller state between
   calls. One Tari node can serve several pithead stacks this way, each with its own

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -43,7 +43,9 @@ fails closed instead of leaking your IP.
 
 Your home IP is never advertised to an inbound peer, and you never touch your router's port-forward
 settings. Every service that accepts inbound connections does so through a Tor hidden service (onion
-address): monerod, Tari, and P2Pool each get one from the built-in Tor daemon. So:
+address): monerod, Tari, and P2Pool each get one from the built-in Tor daemon. A node you run
+elsewhere (`monero.mode` / `tari.mode: remote`) accepts its own peers, so Tor publishes no onion for
+it — only services that actually run here get an address. So:
 
 - No public IPv4 port forwarding is required, and your IP is not advertised to inbound peers.
 - The only LAN-facing port is the stratum endpoint `:3333` that your own rigs connect to. It is

--- a/pithead
+++ b/pithead
@@ -984,26 +984,21 @@ doctor() {
         # --- Tor onion addresses ---
         echo ""
         echo "Tor onion addresses:"
-        local k onion onion_profiles
+        local k onion onion_profiles needs
         onion_profiles=",$(env_get COMPOSE_PROFILES),"
         for k in MONERO_ONION_ADDRESS TARI_ONION_ADDRESS P2POOL_ONION_ADDRESS; do
             # A node's inbound onion only exists while that node is local (#103) — key off the same
             # profile tokens as the container checks above, so remote mode reports "not needed"
-            # instead of an address that was never meant to be provisioned.
+            # instead of an address that was never meant to be provisioned. P2Pool always runs.
             case "$k" in
-            MONERO_ONION_ADDRESS)
-                if [[ "$onion_profiles" != *",local_node,"* ]]; then
-                    dr_ok "$k not needed — remote Monero node, so no inbound hidden service."
-                    continue
-                fi
-                ;;
-            TARI_ONION_ADDRESS)
-                if [[ "$onion_profiles" != *",local_tari,"* ]]; then
-                    dr_ok "$k not needed — remote Tari node, so no inbound hidden service."
-                    continue
-                fi
-                ;;
+            MONERO_ONION_ADDRESS) needs="local_node" ;;
+            TARI_ONION_ADDRESS) needs="local_tari" ;;
+            *) needs="" ;;
             esac
+            if [ -n "$needs" ] && [[ "$onion_profiles" != *",$needs,"* ]]; then
+                dr_ok "$k not needed — that node runs elsewhere, so it has no inbound hidden service."
+                continue
+            fi
             onion=$(env_get "$k")
             if [ -z "$onion" ] || [ "$onion" == "placeholder" ]; then
                 dr_warn "$k is not provisioned (value: '${onion:-empty}') — re-run './pithead setup' to generate Tor hidden services."

--- a/pithead
+++ b/pithead
@@ -415,6 +415,7 @@ stack_upgrade() {
     DEPLOYMENT_COMPLETED=true
     render_env "${ENV_FILE}.new"
     mv "${ENV_FILE}.new" "$ENV_FILE"
+    provision_node_onions # #103: as in apply — a node switched to local needs its onion first
     inject_service_configs
     generate_caddyfile
     provision_control_runner # #33: converge the control-runner units on the current toggle
@@ -983,8 +984,26 @@ doctor() {
         # --- Tor onion addresses ---
         echo ""
         echo "Tor onion addresses:"
-        local k onion
+        local k onion onion_profiles
+        onion_profiles=",$(env_get COMPOSE_PROFILES),"
         for k in MONERO_ONION_ADDRESS TARI_ONION_ADDRESS P2POOL_ONION_ADDRESS; do
+            # A node's inbound onion only exists while that node is local (#103) — key off the same
+            # profile tokens as the container checks above, so remote mode reports "not needed"
+            # instead of an address that was never meant to be provisioned.
+            case "$k" in
+            MONERO_ONION_ADDRESS)
+                if [[ "$onion_profiles" != *",local_node,"* ]]; then
+                    dr_ok "$k not needed — remote Monero node, so no inbound hidden service."
+                    continue
+                fi
+                ;;
+            TARI_ONION_ADDRESS)
+                if [[ "$onion_profiles" != *",local_tari,"* ]]; then
+                    dr_ok "$k not needed — remote Tari node, so no inbound hidden service."
+                    continue
+                fi
+                ;;
+            esac
             onion=$(env_get "$k")
             if [ -z "$onion" ] || [ "$onion" == "placeholder" ]; then
                 dr_warn "$k is not provisioned (value: '${onion:-empty}') — re-run './pithead setup' to generate Tor hidden services."
@@ -3346,29 +3365,73 @@ resolve_dashboard_host() {
     fi
 }
 
+# Poll the running tor container for one hidden service's hostname file and echo the address.
+# $1 = the HiddenServiceDir name under /var/lib/tor. Polls instead of sleeping a fixed 15s — Tor
+# can take more or less than that to publish, especially on first run. Returns 1 on timeout so the
+# caller decides whether a missing address is fatal.
+wait_for_onion() {
+    local svc="$1" elapsed=0 timeout="${2:-60}"
+    until docker exec tor test -f "/var/lib/tor/$svc/hostname"; do
+        if [ "$elapsed" -ge "$timeout" ]; then
+            return 1
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    docker exec tor cat "/var/lib/tor/$svc/hostname"
+}
+
 provision_tor() {
     log "Initializing Tor service to generate onion addresses..."
     # Client-auth keys must be in place before tor starts, since it reads authorized_clients then (#343).
     provision_onion_client_auth
     docker compose up --pull "$(resolve_pull_policy)" -d tor
-    # Poll for the three hidden-service hostname files instead of a fixed sleep — Tor can take
-    # more or less than 15s to publish them, especially on first run.
     log "Waiting for Tor hidden services to be generated..."
-    local elapsed=0 timeout=60
-    until docker exec tor test -f /var/lib/tor/monero/hostname &&
-        docker exec tor test -f /var/lib/tor/tari/hostname &&
-        docker exec tor test -f /var/lib/tor/p2pool/hostname; do
-        if [ "$elapsed" -ge "$timeout" ]; then
-            error "Timed out after ${timeout}s waiting for Tor hidden-service hostnames."
-        fi
-        sleep 2
-        elapsed=$((elapsed + 2))
-    done
-
-    MONERO_ONION=$(docker exec tor cat /var/lib/tor/monero/hostname)
-    TARI_ONION=$(docker exec tor cat /var/lib/tor/tari/hostname)
-    P2POOL_ONION=$(docker exec tor cat /var/lib/tor/p2pool/hostname)
+    P2POOL_ONION=$(wait_for_onion p2pool) ||
+        error "Timed out waiting for the P2Pool Tor hidden-service hostname."
+    # A node's inbound onion is only published while that node is local (build/tor/entrypoint.sh
+    # gates each block on its compose profile), so in remote mode there is nothing to wait for and
+    # the address stays a placeholder — provision_node_onions mints it if the node ever goes local.
+    if [ "$MONERO_MODE" == "local" ]; then
+        MONERO_ONION=$(wait_for_onion monero) ||
+            error "Timed out waiting for the Monero Tor hidden-service hostname."
+    fi
+    if [ "$TARI_MODE" == "local" ]; then
+        TARI_ONION=$(wait_for_onion tari) ||
+            error "Timed out waiting for the Tari Tor hidden-service hostname."
+    fi
     provision_dashboard_onion # #343: reads the dashboard onion too, but only when it's enabled
+}
+
+# Mint and capture a node's inbound onion when that node has just switched remote → local (#103).
+# Its hidden service exists only while the node is local, so a stack first set up in remote mode
+# has no address for it yet. Recreating tor against the freshly committed .env publishes the
+# service; the address must then be in .env BEFORE the node container starts, because monerod
+# templates `anonymous-inbound` from it and the Tari config takes the onion at render time.
+# No-op — and no docker call — whenever both nodes' addresses are already in hand.
+provision_node_onions() {
+    local want_monero=false want_tari=false
+    if [ "${MONERO_MODE:-}" == "local" ] && onion_missing "${MONERO_ONION:-}"; then want_monero=true; fi
+    if [ "${TARI_MODE:-}" == "local" ] && onion_missing "${TARI_ONION:-}"; then want_tari=true; fi
+    [ "$want_monero" == "true" ] || [ "$want_tari" == "true" ] || return 0
+
+    log "Publishing the Tor hidden service for the node that just became local..."
+    docker compose up -d tor
+    if [ "$want_monero" == "true" ]; then
+        MONERO_ONION=$(wait_for_onion monero) ||
+            error "Timed out waiting for the Monero Tor hidden-service hostname."
+    fi
+    if [ "$want_tari" == "true" ]; then
+        TARI_ONION=$(wait_for_onion tari) ||
+            error "Timed out waiting for the Tari Tor hidden-service hostname."
+    fi
+    render_env # commit the new address before the node container is (re)created against it
+}
+
+# An onion address that was never provisioned: empty, or the placeholder render_env writes until
+# the real hostname is captured.
+onion_missing() {
+    [ -z "${1:-}" ] || [ "${1:-}" == "placeholder" ]
 }
 
 # Prepare Tor v3 client authorization for the dashboard onion (#343). Generates the client keypair
@@ -4948,7 +5011,8 @@ apply_dry_run() {
         # the candidate config. A dry run must only read; an invalid candidate fails validation.
         parse_and_validate_config
         load_preserved_state
-        if [ "$MONERO_ONION" == "placeholder" ] || ! is_deployed; then
+        # P2Pool's onion is the provisioning marker (see apply) — a node's may be a placeholder.
+        if onion_missing "$P2POOL_ONION" || ! is_deployed; then
             error "Stack is not fully provisioned. Run '$0 setup' first."
         fi
         resolve_dashboard_host # non-interactive
@@ -5005,7 +5069,9 @@ apply() {
     ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one
     parse_and_validate_config
     load_preserved_state
-    if [ "$MONERO_ONION" == "placeholder" ] || ! is_deployed; then
+    # P2Pool's onion is the provisioning marker, not Monero's: p2pool always runs, while a node's
+    # onion is legitimately a placeholder in remote mode (#103).
+    if onion_missing "$P2POOL_ONION" || ! is_deployed; then
         error "Stack is not fully provisioned. Run '$0 setup' first."
     fi
 
@@ -5092,6 +5158,7 @@ apply() {
         fi
 
         mv "$newenv" "$ENV_FILE"
+        provision_node_onions # #103: a node that just went local needs its onion before it starts
         inject_service_configs
         generate_caddyfile
     else

--- a/pithead
+++ b/pithead
@@ -3365,7 +3365,7 @@ resolve_dashboard_host() {
 # can take more or less than that to publish, especially on first run. Returns 1 on timeout so the
 # caller decides whether a missing address is fatal.
 wait_for_onion() {
-    local svc="$1" elapsed=0 timeout="${2:-60}"
+    local svc="$1" elapsed=0 timeout=60
     until docker exec tor test -f "/var/lib/tor/$svc/hostname"; do
         if [ "$elapsed" -ge "$timeout" ]; then
             return 1

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -512,6 +512,19 @@ assert_running_state() {
         *) it_pass "monerod absent in remote mode" ;;
         esac
     fi
+    # 1b. A node's inbound onion follows the node (#103): the LIVE torrc must carry the Monero
+    #     hidden service only in local mode, or the stack advertises an onion address that accepts
+    #     connections into a container that never started. Tier-1 proves the rendering; only here
+    #     can we prove the running container actually got the gate through compose. Read the torrc
+    #     rather than the hostname file — a key minted during an earlier local scenario stays on
+    #     disk, so its presence proves nothing; what tor publishes is what the torrc lists.
+    local hs_monero
+    hs_monero="$(rx "docker exec tor grep -c -F 'HiddenServiceDir /var/lib/tor/monero/' /tmp/torrc 2>/dev/null")"
+    if [ "$mode" = "remote" ]; then
+        assert_eq "no Monero inbound onion in remote mode (#103)" "${hs_monero:-0}" "0"
+    else
+        assert_num_ge "Monero inbound onion published in local mode (#103)" "${hs_monero:-0}" 1
+    fi
 
     # 2. pithead status is green for a healthy config.
     pithead status >/dev/null 2>&1

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -910,7 +910,7 @@ apply_order=$(
     source "$STACK"
     set +e
     # shellcheck disable=SC2034  # read by the sourced apply()'s "not provisioned" guard, unseen here
-    MONERO_ONION=onion
+    P2POOL_ONION=onion
     require_env() { :; }
     parse_and_validate_config() { :; }
     load_preserved_state() { :; }
@@ -1658,7 +1658,7 @@ caddy_apply_capture=$(
     # The shadowed capture: the address is unknown until the recreated tor container publishes it
     # post-up, exactly like the real provision_dashboard_onion.
     provision_dashboard_onion() { DASHBOARD_ONION="captured1234abcd.onion"; }
-    MONERO_ONION=mona.onion HOST_IP=box.lan DASHBOARD_SECURE=true DASHBOARD_AUTH_USER=admin \
+    P2POOL_ONION=p2pa.onion HOST_IP=box.lan DASHBOARD_SECURE=true DASHBOARD_AUTH_USER=admin \
         DASHBOARD_AUTH_HASH_B64="$auth_hb64" NETWORK_PREFIX=172.28.0 DASHBOARD_ONION_ENABLED=true \
         DASHBOARD_ONION=placeholder apply -y >/dev/null 2>&1
     cat Caddyfile
@@ -4649,12 +4649,12 @@ rm -rf "$XPTLS"
 # covered above; this exercises the real container entrypoint's branch + the .1 substitution with a
 # stub `tor` on PATH and the repo torrc.template (via the TORRC_TEMPLATE seam).
 TOR_ENTRY="$ROOT/build/tor/entrypoint.sh"
-tor_torrc() { # <DASHBOARD_ONION_ENABLED> -> the torrc the entrypoint would hand to `tor -f`
+tor_torrc() { # <DASHBOARD_ONION_ENABLED> [COMPOSE_PROFILES] -> the torrc the entrypoint would hand to `tor -f`
     local d
     d="$(mktemp -d)"
     printf '#!/bin/sh\ncat /tmp/torrc\n' >"$d/tor" # stub tor: ignore -f, just print the rendered file
     chmod +x "$d/tor"
-    PATH="$d:$PATH" DASHBOARD_ONION_ENABLED="$1" NETWORK_PREFIX=10.9.0 \
+    PATH="$d:$PATH" DASHBOARD_ONION_ENABLED="$1" COMPOSE_PROFILES="${2-local_node,local_tari}" NETWORK_PREFIX=10.9.0 \
         TORRC_TEMPLATE="$ROOT/build/tor/torrc.template" sh "$TOR_ENTRY"
     rm -rf "$d"
 }
@@ -4667,6 +4667,144 @@ assert_contains "tor entrypoint: onion also exposes :443 for the Tor-Browser htt
     "$tor_onion_on" "HiddenServicePort 443 10.9.0.1:443"
 assert_not_contains "tor entrypoint: no dashboard onion when disabled (default off) (#343)" \
     "$(tor_torrc false)" "Dashboard Hidden Service"
+
+# Node inbound onions (#103): each is published only while its node is local, so a remote node
+# leaves no onion pointing at a container that never starts. The gate is the compose profile list,
+# passed through from the rendered .env — same tokens that decide whether the node runs at all.
+tor_both_local="$(tor_torrc false local_node,local_tari)"
+assert_contains "tor entrypoint: Monero HS present when local_node is active (#103)" \
+    "$tor_both_local" "HiddenServiceDir /var/lib/tor/monero/"
+assert_contains "tor entrypoint: Monero HS targets the node on the moved prefix (#103/#180)" \
+    "$tor_both_local" "HiddenServicePort 18080 10.9.0.26:18084"
+assert_contains "tor entrypoint: Tari HS present when local_tari is active (#103)" \
+    "$tor_both_local" "HiddenServiceDir /var/lib/tor/tari/"
+assert_contains "tor entrypoint: Tari HS targets the node on the moved prefix (#103/#180)" \
+    "$tor_both_local" "HiddenServicePort 18189 10.9.0.27:18189"
+tor_remote_tari="$(tor_torrc false local_node)"
+assert_contains "tor entrypoint: Monero HS still present with only local_node (#103)" \
+    "$tor_remote_tari" "HiddenServiceDir /var/lib/tor/monero/"
+assert_not_contains "tor entrypoint: no Tari HS when local_tari is omitted (remote tari, #103)" \
+    "$tor_remote_tari" "/var/lib/tor/tari/"
+tor_both_remote="$(tor_torrc false "")"
+assert_not_contains "tor entrypoint: no Monero HS with no profiles (remote monero, #103)" \
+    "$tor_both_remote" "/var/lib/tor/monero/"
+assert_not_contains "tor entrypoint: no Tari HS with no profiles (remote tari, #103)" \
+    "$tor_both_remote" "/var/lib/tor/tari/"
+assert_contains "tor entrypoint: P2Pool HS is unconditional — p2pool always runs (#103)" \
+    "$tor_both_remote" "HiddenServiceDir /var/lib/tor/p2pool/"
+unset tor_both_local tor_remote_tari tor_both_remote
+
+echo "== unit: onion provisioning follows node mode (#103) =="
+# pithead's half of the same gate: a hidden service that is never published has no hostname to wait
+# for, so provision_tor must not block on a remote node's onion (a 60s timeout, then a fatal error),
+# and the address stays a placeholder. wait_for_onion is stubbed — the polling itself is the docker
+# layer, and it runs in a command substitution, so the probe records asks in a file.
+ONP="$SANDBOX/onion-prov"
+mkdir -p "$ONP"
+prov_probe() { # <MONERO_MODE> <TARI_MODE> -> "<onions asked for>|<MONERO_ONION>|<TARI_ONION>|<P2POOL_ONION>"
+    (
+        cd "$ONP" || exit
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        : >asked
+        log() { :; }
+        docker() { :; }
+        resolve_pull_policy() { echo missing; }
+        provision_onion_client_auth() { :; }
+        provision_dashboard_onion() { :; }
+        wait_for_onion() {
+            printf '%s,' "$1" >>asked
+            echo "$1.onion"
+        }
+        MONERO_MODE="$1"
+        TARI_MODE="$2"
+        MONERO_ONION=placeholder
+        TARI_ONION=placeholder
+        P2POOL_ONION=placeholder
+        provision_tor
+        printf '%s|%s|%s|%s' "$(cat asked)" "$MONERO_ONION" "$TARI_ONION" "$P2POOL_ONION"
+    )
+}
+assert_eq "provision_tor waits for both node onions when both nodes are local (#103)" \
+    "$(prov_probe local local)" "p2pool,monero,tari,|monero.onion|tari.onion|p2pool.onion"
+assert_eq "provision_tor skips a remote node's onion and leaves it a placeholder (#103)" \
+    "$(prov_probe remote remote)" "p2pool,|placeholder|placeholder|p2pool.onion"
+assert_eq "provision_tor waits for the local node only in a mixed setup (#103)" \
+    "$(prov_probe local remote)" "p2pool,monero,|monero.onion|placeholder|p2pool.onion"
+
+# provision_node_onions: the remote → local switch. A stack first set up in remote mode has no
+# address for that node, so apply/upgrade recreate tor against the committed profiles, capture the
+# freshly minted hostname, and re-render .env BEFORE the node container starts against it. It must
+# cost nothing (no docker, no render) once every local node's address is in hand.
+node_onion_probe() { # <MONERO_MODE> <MONERO_ONION> <TARI_MODE> <TARI_ONION> -> "<docker calls>|<asked>|<MONERO_ONION>|<TARI_ONION>|<renders>"
+    (
+        cd "$ONP" || exit
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        : >asked
+        : >dockerlog
+        : >renders
+        log() { :; }
+        docker() { printf '%s ' "$*" >>dockerlog; }
+        render_env() { printf 'x' >>renders; }
+        wait_for_onion() {
+            printf '%s,' "$1" >>asked
+            echo "$1.onion"
+        }
+        # shellcheck disable=SC2034  # read by the sourced provision_node_onions, unseen here
+        MONERO_MODE="$1"
+        MONERO_ONION="$2"
+        # shellcheck disable=SC2034  # read by the sourced provision_node_onions, unseen here
+        TARI_MODE="$3"
+        TARI_ONION="$4"
+        provision_node_onions
+        printf '%s|%s|%s|%s|%s' "$(cat dockerlog)" "$(cat asked)" "$MONERO_ONION" "$TARI_ONION" "$(cat renders)"
+    )
+}
+assert_eq "provision_node_onions is a free no-op once every local node has its onion (#103)" \
+    "$(node_onion_probe local mona.onion local taria.onion)" "||mona.onion|taria.onion|"
+assert_eq "provision_node_onions ignores a remote node with no onion (#103)" \
+    "$(node_onion_probe remote placeholder remote placeholder)" "||placeholder|placeholder|"
+assert_eq "provision_node_onions mints + captures the onion of a node that just went local (#103)" \
+    "$(node_onion_probe local placeholder remote placeholder)" "compose up -d tor |monero,|monero.onion|placeholder|x"
+assert_eq "provision_node_onions treats an empty address as missing, and re-renders once (#103)" \
+    "$(node_onion_probe local '' local '')" "compose up -d tor |monero,tari,|monero.onion|tari.onion|x"
+unset ONP prov_probe node_onion_probe
+
+echo "== black-box: doctor's onion report follows node mode (#103) =="
+# A node running elsewhere has no hidden service to provision, so its placeholder address is the
+# correct state — doctor must not send the operator back to `setup` over it. A LOCAL node with no
+# address is still a real problem and must keep warning.
+DOC="$SANDBOX/doctor-onion"
+mkdir -p "$DOC/build/tari" "$DOC/build/dashboard"
+: >"$DOC/build/dashboard/Dockerfile"
+cp "$STACK" "$DOC/pithead"
+cp "$ROOT/build/tari/config.toml.template" "$DOC/build/tari/"
+make_stubs "$DOC/bin"
+printf '{"monero":{"mode":"remote","wallet_address":"%s","remote":{"host":"10.0.0.8"}},"tari":{"mode":"remote","wallet_address":"T","remote":{"host":"10.0.0.9"}}}\n' "$WALLET" >"$DOC/config.json"
+doctor_onions() { # <COMPOSE_PROFILES> -> doctor's "Tor onion addresses" section
+    {
+        printf 'MONERO_ONION_ADDRESS=placeholder\nTARI_ONION_ADDRESS=placeholder\nP2POOL_ONION_ADDRESS=p2pa.onion\n'
+        printf 'TARI_GRPC_ADDRESS=10.0.0.9:18142\nDEPLOYMENT_COMPLETED=true\nHOST_IP=box.lan\n'
+        printf 'COMPOSE_PROFILES=%s\n' "$1"
+    } >"$DOC/.env"
+    (cd "$DOC" && PATH="$DOC/bin:$PATH" ./pithead doctor 2>&1 | sed -n '/Tor onion addresses/,/^$/p')
+}
+doc_remote="$(doctor_onions "")"
+assert_contains "doctor: a remote Monero node's missing onion is expected, not a warning (#103)" \
+    "$doc_remote" "MONERO_ONION_ADDRESS not needed"
+assert_contains "doctor: a remote Tari node's missing onion is expected, not a warning (#103)" \
+    "$doc_remote" "TARI_ONION_ADDRESS not needed"
+assert_contains "doctor: P2Pool's onion is still reported either way (#103)" \
+    "$doc_remote" "P2POOL_ONION_ADDRESS set"
+doc_local="$(doctor_onions "local_node,local_tari")"
+assert_contains "doctor: a LOCAL Monero node with no onion still warns (#103)" \
+    "$doc_local" "MONERO_ONION_ADDRESS is not provisioned"
+assert_contains "doctor: a LOCAL Tari node with no onion still warns (#103)" \
+    "$doc_local" "TARI_ONION_ADDRESS is not provisioned"
+unset DOC doc_remote doc_local doctor_onions
 
 # ---------------------------------------------------------------------------
 echo "== black-box: dashboard control channel (#33) =="

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -306,6 +306,14 @@ else
     echo "  ✗ tari service still present with local_tari omitted (remote tari, #103)"
     fails=$((fails + 1))
 fi
+# The same profile list must reach the tor container, which gates each node's inbound hidden service
+# on it (#103) — without this wiring tor would keep publishing an onion for a node that never starts.
+if printf '%s' "$REMOTE_TARI_JSON" | jq -e '.services.tor.environment.COMPOSE_PROFILES == "local_node"' >/dev/null 2>&1; then
+    echo "  ✓ tor receives the active profile list, so its onion gate matches the running nodes (#103)"
+else
+    echo "  ✗ tor did not receive the active profile list (#103)"
+    fails=$((fails + 1))
+fi
 
 # Configurable bridge subnet (#180): a custom network.subnet must rebase every static IP, the bridge
 # CIDR, and the dashboard's derived bridge endpoints — the host address-space-collision install fix.


### PR DESCRIPTION
## What

With `monero.mode` or `tari.mode` set to `remote`, the bundled node container never starts — but `build/tor/torrc.template` still defined that node's inbound hidden service, so Tor published an onion address that accepted connections into nothing.

Each node's `HiddenService` block moves out of the template and into `build/tor/entrypoint.sh`, appended only when that node's compose profile is active. The gate is the profile list itself, passed to the tor container from pithead's rendered `.env`, so it cannot drift from which nodes actually run. P2Pool's onion stays unconditional — p2pool always runs.

## pithead side

- `provision_tor` waits only for the onions that will exist (a remote node's hostname would never appear — 60s timeout, then a fatal error).
- `doctor` reports a remote node's missing address as expected, not a warning telling the operator to re-run `setup`.
- The "Stack is not fully provisioned" guard keys off P2Pool's onion instead of Monero's — a placeholder Monero address is now legitimate.
- `provision_node_onions` covers the remote → local switch: a stack first set up in remote mode has no address for that node, so apply/upgrade recreate tor against the committed profiles, capture the freshly minted hostname, and re-render `.env` **before** the node container starts against it (monerod templates `anonymous-inbound` from that value).

## Testing

- **Tier 1** (`tests/stack/run.sh`): torrc gating on/off via the `TORRC_TEMPLATE` seam; `provision_tor` / `provision_node_onions` by node mode; doctor's onion report in both modes. 1674 pass, 0 fail.
- **Tier 2** (`tests/stack/test_compose.sh`): the active profile list reaches the tor service, so the gate matches the running nodes. 73 pass.
- **Tier 3** (`tests/integration/run.sh`): the **live** torrc carries the Monero hidden service only in local mode — reads the torrc, not the hostname file, since a key minted by an earlier local scenario stays on disk.

## Docs

`docs/configuration.md` (both remote-node sections — the "inert leftover" sentence is gone, since it isn't one any more), `docs/privacy.md` inbound section, CHANGELOG.

`make lint` green (`lint-proto` needs a Docker daemon, unavailable locally — CI covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)