### PR TITLE
feat(os): phase-0 Quadlet fixtures + spike-proven renderer rules

### DIFF
--- a/docs/dev/dual-distribution-plan.md
+++ b/docs/dev/dual-distribution-plan.md
@@ -75,10 +75,21 @@ the DIY channel changes nothing.
   a systemd-only knob, the escape hatch is a native drop-in
   (`<service>.container.d/override.conf`) beside the generated unit — no
   service-model abstraction layer until a second real divergence exists.
-- Compose-semantics mapping: `depends_on: service_healthy` → `Notify=healthy` +
-  `After=`/`Requires=` (set `TimeoutStartSec` above the longest `HealthStartPeriod` —
-  known Podman interaction); healthchecks → `HealthCmd=`/`HealthInterval=`;
-  `--remove-orphans` → obsolete, systemd owns lifecycle.
+- Compose-semantics mapping — **spike-proven rules** (each bought with an actual
+  failure; evidence on #78, fixtures in `os/quadlet/`):
+  1. `depends_on: service_healthy` → `Notify=healthy` + `After=` + `Requires=` +
+     `TimeoutStartSec=infinity`. A finite start timeout KILLS a not-yet-healthy
+     service and restarts it — compose's `start_period` never kills; p2pool's first
+     sidechain sync hit exactly that kill/restart loop.
+  2. Plain `depends_on` → `After=` + `Wants=`, never `Requires=` — differential
+     proven: after `systemctl stop p2pool`, xmrig-proxy stays running (compose
+     parity); `Requires=` would stop-couple them.
+  3. Compose tmpfs `uid=`/`gid=` options are rejected by podman's `Tmpfs=` —
+     map to `mode=1777` (or `Mount=` with chown).
+  4. Healthchecks → `HealthCmd=`/`HealthInterval=`/`HealthRetries=`/
+     `HealthStartPeriod=`; `--remove-orphans` → obsolete, systemd owns lifecycle.
+  5. Tooling uses stop-then-start: `systemctl restart` racing an in-flight start job
+     fails spuriously.
 - Docker-API consumers (dashboard start/stop/logs via the two socket proxies) point at
   Podman's Docker-compat socket on the appliance; the four endpoints used
   (`GET containers/json`, `GET logs`, `POST start`, `POST stop`) are spike-verified.
@@ -208,7 +219,13 @@ cut, and the installer smoke rides the same checklist.
   reset — delete `config.json` + secrets, re-enter the first-boot wizard, chain data
   kept; (2) factory reset — `rugix-ctrl state reset`, everything wiped. Reflash keeps
   data; the wizard offers tier 1 before tier 2.
-- Perf baked in: hugepages kargs, CPU governor, sysctls; hardware + systemd watchdog.
+- Hugepage reservation baked in at boot — **load-bearing, not perf polish** (spike
+  finding): the RandomX dataset (~2.1 GiB) lives in hugetlbfs outside the memory
+  cgroup only when pages are reserved; unreserved, it falls to anon memory and
+  p2pool OOM-loops at any cap ≤ 2g ("Dataset init invoked oom-killer"). Every memory
+  cap in the stack assumes the reservation, so the image reserves before containers
+  start, and `doctor`'s hugepages check is a hard prerequisite on the appliance.
+  Plus CPU governor, sysctls; hardware + systemd watchdog.
 - Rugix bus-factor-1 risk stands, with the v2 mitigations: updater-agnostic rootfs
   recipe (Docker-exported tarball) keeping RAUC as escape hatch; ask Silitics/Umbrel
   before phase 2 investment.
@@ -234,6 +251,16 @@ Exit: #78 closed with outcome (A) + spike notes, with binding go/no-go consequen
 | `Notify=healthy` ordering diverges in a way that breaks the dashboard | redesign the mapping before phase 1; no renderer until resolved |
 | socket-proxy endpoint gaps | each gap documented as a degraded appliance feature — accepted explicitly or fixed, never discovered later |
 | all four verified | proceed to phase 1 |
+
+**Outcome (2026-07-24): all four verified — #78 closed as (A).** The firewall port is
+an independent `inet pithead_egress` nftables table at forward priority −5 (no chain
+ownership shared with netavark; survives its reprogramming). The unmodified tecnativa
+proxies serve all four endpoints from the Podman compat socket, and the read proxy
+still refuses writes (403). The ordering matrix confirmed `tor < p2pool <
+xmrig-proxy` on `ActiveEnterTimestampMonotonic` with each edge gated on health. The
+full seven-unit stack ran end-to-end against remote nodes, including the dashboard's
+sync-gate driving containers through the control proxy. The degraded-features list is
+empty. Fixtures: `os/quadlet/`; evidence trail: the three verdict comments on #78.
 
 ### Phase 1 — curl installer + Quadlet renderer
 

--- a/os/README.md
+++ b/os/README.md
@@ -1,0 +1,17 @@
+# Appliance runtime units
+
+The hand-written Quadlet unit set that ran the full stack under rootful Podman in
+the #78 runtime spike (2026-07-24): seven `.container` units and two `.network` units,
+brought up on a Debian 13 VM with both nodes remote. Preserved in `quadlet/` as the
+reference output the phase-1 `pithead render-quadlet` renderer must reproduce.
+
+Secrets, wallets, and the onion address are replaced with `rendered-*` /
+`your_*_wallet_address` placeholders; everything else is exactly what ran, including
+the fixes the spike forced (`TimeoutStartSec=infinity`, tmpfs `mode=` instead of
+`uid=`/`gid=`, the 1g p2pool cap that holds once hugepages are reserved).
+
+These files are fixtures, not deployable configuration. Nothing consumes them yet, and
+the appliance never hand-edits units — `pithead` renders them from `config.json`. The
+translation rules the spike established, with evidence, live in
+[`docs/dev/dual-distribution-plan.md`](../docs/dev/dual-distribution-plan.md)
+(Runtime architecture) and on issue #78.

--- a/os/quadlet/caddy.container
+++ b/os/quadlet/caddy.container
@@ -1,0 +1,20 @@
+[Unit]
+Description=pithead caddy (spike)
+[Container]
+ContainerName=caddy
+Image=docker.io/library/caddy:2.11.4
+Network=host
+Volume=/opt/pithead/Caddyfile:/etc/caddy/Caddyfile:ro
+Volume=pithead-caddy-data:/data
+Volume=/opt/pithead/data/caddy-logs:/var/log/caddy
+Tmpfs=/tmp
+Tmpfs=/config
+ReadOnly=true
+DropCapability=all
+AddCapability=NET_BIND_SERVICE
+NoNewPrivileges=true
+PodmanArgs=--memory 128m --memory-swap 128m
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/dashboard.container
+++ b/os/quadlet/dashboard.container
@@ -1,0 +1,26 @@
+[Unit]
+Description=pithead dashboard (spike)
+[Container]
+ContainerName=dashboard
+Image=ghcr.io/p2pool-starter-stack/pithead-dashboard:v1.14.0
+Network=host
+Environment=HOST_IP=127.0.0.1 TZ=Etc/UTC MONERO_NODE_HOST=192.168.1.243 MONERO_NODE_USERNAME=rendered-node-user MONERO_NODE_PASSWORD=rendered-node-password MONERO_PRUNE=true MONERO_CLEARNET_SYNC=false TARI_CLEARNET_SYNC=false CLEARNET_STATE_DIR=/clearnet-state TOR_EGRESS_FIREWALL=false TOR_AUTO_HEAL=false P2POOL_CLEARNET=true P2POOL_URL=172.28.0.28:3333 MONERO_WALLET_ADDRESS=your_monero_wallet_address STRATUM_PORT=3333 TARI_REQUIRED=true TARI_GRPC_ADDRESS=192.168.1.243:18142 XVB_ENABLED=false XVB_TOR_ENABLED=true XVB_DONATION_LEVEL=auto PROXY_HOST=172.28.0.29 PROXY_API_PORT=3344 PROXY_AUTH_TOKEN=rendered-proxy-token DOCKER_PROXY_URL=tcp://127.0.0.1:12375 DOCKER_CONTROL_URL=tcp://127.0.0.1:12376 LOCAL_MONERO_HOST=172.28.0.26 MINING_NET_CIDR=172.28.0.0/24 TOR_SOCKS_PROXY=socks5h://172.28.0.25:9050 DASHBOARD_CHECK_UPDATES=false DASHBOARD_CONTROL_ENABLED=false DASHBOARD_FAIL_CLOSED=false TELEGRAM_ENABLED=false
+Volume=/opt/pithead/data/p2pool/stats:/app/stats:ro
+Volume=/opt/pithead/data/dashboard:/data
+Volume=/opt/pithead/data/clearnet-state:/clearnet-state
+Volume=/opt/pithead/data/control/requests:/control/requests
+Volume=/opt/pithead/data/control/results:/control/results:ro
+Volume=/opt/pithead/data/control/audit:/control/audit:ro
+Volume=/opt/pithead/data/control/masked:/control/masked:ro
+Volume=/opt/pithead/data/caddy-logs:/access-log:ro
+Volume=/home/vijit/pithead/config.reference.json:/host-config/config.reference.json:ro
+Volume=/home/vijit/pithead/config.core-keys.json:/host-config/config.core-keys.json:ro
+Tmpfs=/tmp:size=64m,mode=1777
+ReadOnly=true
+DropCapability=all
+NoNewPrivileges=true
+PodmanArgs=--memory 512m --memory-swap 512m
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/docker-control.container
+++ b/os/quadlet/docker-control.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=pithead control socket proxy (spike)
+[Container]
+ContainerName=docker-control
+Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Network=proxy.network
+Environment=CONTAINERS=1 POST=1 ALLOW_START=1 ALLOW_STOP=1
+Volume=/run/podman/podman.sock:/var/run/docker.sock:ro
+Tmpfs=/run
+Tmpfs=/tmp
+PublishPort=127.0.0.1:12376:2375
+ReadOnly=true
+DropCapability=all
+NoNewPrivileges=true
+PodmanArgs=--memory 128m --memory-swap 128m
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/docker-proxy.container
+++ b/os/quadlet/docker-proxy.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=pithead read socket proxy (spike)
+[Container]
+ContainerName=docker-proxy
+Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Network=proxy.network
+Environment=CONTAINERS=1 LOGS=1
+Volume=/run/podman/podman.sock:/var/run/docker.sock:ro
+Tmpfs=/run
+Tmpfs=/tmp
+PublishPort=127.0.0.1:12375:2375
+ReadOnly=true
+DropCapability=all
+NoNewPrivileges=true
+PodmanArgs=--memory 128m --memory-swap 128m
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/mining.network
+++ b/os/quadlet/mining.network
@@ -1,0 +1,3 @@
+[Network]
+NetworkName=mining_net
+Subnet=172.28.0.0/24

--- a/os/quadlet/p2pool.container
+++ b/os/quadlet/p2pool.container
@@ -1,0 +1,32 @@
+[Unit]
+Description=pithead p2pool (spike)
+After=tor.service
+Requires=tor.service
+[Container]
+ContainerName=p2pool
+Image=ghcr.io/p2pool-starter-stack/pithead-p2pool:v1.14.0
+Network=mining.network
+IP=172.28.0.28
+Environment=P2POOL_FLAGS=--mini
+Exec=--host 192.168.1.243 --rpc-port 18081 --rpc-login rendered-node-user:rendered-node-password --zmq-port 18083 --wallet your_monero_wallet_address --merge-mine tari://192.168.1.243:18142 your_tari_wallet_address --onion-address rendered-p2pool-onion.onion --local-api --stratum 0.0.0.0:3333 --p2p 0.0.0.0:37888 --data-api /stats
+Volume=/opt/pithead/data/p2pool:/home/ubuntu
+Volume=/opt/pithead/data/p2pool/stats:/stats
+Volume=/dev/hugepages:/dev/hugepages
+Tmpfs=/tmp:size=64m,mode=1777
+ReadOnly=true
+DropCapability=all
+AddCapability=IPC_LOCK SYS_NICE
+NoNewPrivileges=true
+Ulimit=memlock=-1:-1
+PodmanArgs=--memory 1g --memory-swap 1g
+HealthCmd=/usr/local/bin/p2pool-healthcheck.sh
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+HealthStartPeriod=60s
+Notify=healthy
+[Service]
+Restart=always
+TimeoutStartSec=infinity
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/proxy.network
+++ b/os/quadlet/proxy.network
@@ -1,0 +1,2 @@
+[Network]
+NetworkName=proxy_net

--- a/os/quadlet/tor.container
+++ b/os/quadlet/tor.container
@@ -1,0 +1,22 @@
+[Unit]
+Description=pithead tor (spike)
+[Container]
+ContainerName=tor
+Image=ghcr.io/p2pool-starter-stack/pithead-tor:v1.14.0
+Network=mining.network
+IP=172.28.0.25
+Environment=NETWORK_PREFIX=172.28.0 COMPOSE_PROFILES= DASHBOARD_ONION_ENABLED=false DASHBOARD_ONION_CLIENT_AUTH=false
+Volume=/opt/pithead/data/tor:/var/lib/tor
+Tmpfs=/tmp:size=64m,mode=1777
+ReadOnly=true
+HealthCmd=/usr/local/bin/tor-healthcheck.sh
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=5
+HealthStartPeriod=90s
+Notify=healthy
+[Service]
+Restart=always
+TimeoutStartSec=infinity
+[Install]
+WantedBy=multi-user.target

--- a/os/quadlet/xmrig-proxy.container
+++ b/os/quadlet/xmrig-proxy.container
@@ -1,0 +1,23 @@
+[Unit]
+Description=pithead xmrig-proxy (spike)
+After=p2pool.service
+Wants=p2pool.service
+[Container]
+ContainerName=xmrig-proxy
+Image=ghcr.io/p2pool-starter-stack/pithead-xmrig-proxy:v1.14.0
+Network=mining.network
+IP=172.28.0.29
+Environment=PROXY_API_PORT=3344 PROXY_AUTH_TOKEN=rendered-proxy-token PROXY_STRATUM_PASSWORD= PROXY_STRATUM_TLS=false PROXY_DONATE_LEVEL=0
+Exec=-o 172.28.0.28:3333 -u your_monero_wallet_address -b 0.0.0.0:3333 -m simple --coin monero --verbose --http-host 0.0.0.0 --http-port 3344 --http-access-token rendered-proxy-token --http-no-restricted --donate-level 0
+Volume=/opt/pithead/data/proxy-tls:/tls:ro
+Tmpfs=/tmp:size=64m,mode=1777
+Tmpfs=/home/ubuntu:size=64m,mode=1777
+PublishPort=0.0.0.0:3333:3333
+ReadOnly=true
+DropCapability=all
+NoNewPrivileges=true
+PodmanArgs=--memory 512m --memory-swap 512m
+[Service]
+Restart=always
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
First PR into **`develop-v2`** — the v2-appliance integration branch (the develop-v1.5/v1.11 pattern): feature PRs land here, and the whole v2 line collapses into `develop` in one PR at the end.

## What

- **`os/quadlet/`** — the hand-written unit set that ran the full stack under rootful Podman in the #78 spike (7 `.container` + 2 `.network`), preserved as the reference output `pithead render-quadlet` (phase 1) must reproduce. Secrets/wallets/onion replaced with `rendered-*` placeholders; everything else as-run, including the spike-forced fixes.
- **`os/README.md`** — what the fixtures are, what they are not (deployable config), where the rules live.
- **Plan updates** (`docs/dev/dual-distribution-plan.md`):
  - The provisional compose→Quadlet mapping is replaced by the five spike-proven rules — `TimeoutStartSec=infinity` for `Notify=healthy` services (a finite timeout kills what compose's `start_period` never would), `Wants=` not `Requires=` for ungated `depends_on` (differential-proven), tmpfs `uid=/gid=` → `mode=`, healthcheck key mapping, stop-then-start tooling.
  - Phase-0 outcome recorded: **all four go/no-go items verified, #78 closed as outcome (A)** — firewall via an independent nft table at priority −5, unmodified proxies serving the four endpoints (read proxy still 403s writes), health-gated ordering confirmed on monotonic timestamps, full stack live against remote nodes with the #35 sync-gate driving containers through the control proxy.
  - Hugepage reservation upgraded from perf note to **load-bearing prerequisite**: unreserved, the RandomX dataset falls into the memory cgroup and p2pool OOM-loops at any cap ≤ 2g.

Evidence trail: the three verdict comments on #78. `lint-docs-voice` + `markdownlint` pass; fixtures scanned clean of secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)