### PR TITLE
feat(cli): doctor --json + support-bundle

### DIFF
--- a/pithead
+++ b/pithead
@@ -689,18 +689,28 @@ DR_FAIL=0
 
 dr_ok() {
     DR_OK=$((DR_OK + 1))
+    dr_record ok "$1"
     printf '  %b✓ OK%b   %s\n' "$C_GREEN" "$C_RESET" "$1"
 }
 dr_warn() {
     DR_WARN=$((DR_WARN + 1))
+    dr_record warn "$1"
     printf '  %b⚠ WARN%b %s\n' "$C_YELLOW" "$C_RESET" "$1"
 }
 dr_fail() {
     DR_FAIL=$((DR_FAIL + 1))
+    dr_record fail "$1"
     printf '  %b✗ FAIL%b %s\n' "$C_RED" "$C_RESET" "$1"
 }
 # Neutral note for context lines that aren't pass/fail (e.g. a skipped Linux-only check).
-dr_info() { printf '  %b•%b      %s\n' "$C_YELLOW" "$C_RESET" "$1"; }
+dr_info() {
+    dr_record info "$1"
+    printf '  %b•%b      %s\n' "$C_YELLOW" "$C_RESET" "$1"
+}
+# `doctor --json` capture (#77 phase 1): every check verdict lands as a status<TAB>message line in
+# DR_JSON_FILE when set; doctor assembles the machine report from it. TSV keeps this a plain
+# append — messages are prose and never carry tabs.
+dr_record() { [ -n "${DR_JSON_FILE:-}" ] && printf '%s\t%s\n' "$1" "$2" >>"$DR_JSON_FILE" || true; }
 
 # Best-effort system-clock sync status. Mining is time-sensitive — P2Pool/Monero stamp shares and
 # blocks, so a skewed clock gets shares/blocks rejected ("strongly recommended to synchronize your
@@ -1054,6 +1064,87 @@ doctor() {
     # gate in cron/CI/monitoring (mirrors `status`). Warnings alone still exit 0 (#127).
     [ "$DR_FAIL" -gt 0 ] && return 1
     return 0
+}
+
+# `doctor --json` (#77 phase 1): the machine-readable doctor — same checks, same exit semantics.
+# JSON on stdout, the human report on stderr, so `pithead doctor --json | jq` works while a
+# watching operator still sees progress. This is the appliance commit gate's input (phase 2) and
+# rides inside every support bundle; the appliance's engine-aware check variants land behind the
+# same shape (plan § phase 2).
+doctor_json() {
+    local rc=0
+    DR_JSON_FILE=$(mktemp)
+    doctor >&2 || rc=$?
+    jq -Rs --arg version "$PITHEAD_VERSION" --argjson rc "$rc" \
+        'split("\n") | map(select(length > 0) | split("\t") | {status: .[0], message: .[1]})
+         | {version: $version, exit: $rc,
+            summary: {ok: map(select(.status == "ok")) | length,
+                      warn: map(select(.status == "warn")) | length,
+                      fail: map(select(.status == "fail")) | length},
+            checks: .}' "$DR_JSON_FILE"
+    rm -f "$DR_JSON_FILE"
+    unset DR_JSON_FILE
+    return "$rc"
+}
+
+# `support-bundle` (#77 phase 1): most support is log collection — one command gathers what a
+# report needs into a chmod-600 tarball the operator reviews before sharing. Read-only; nothing
+# leaves the box. Secrets are redacted at the source: config via the control channel's masking
+# (render_masked_config), .env by key pattern, container logs by argv pattern — p2pool echoes its
+# --rpc-login on launch, the exact leak class this exists to stop.
+stack_support_bundle() {
+    _reject_options support-bundle "$@"
+    local ts out tmp rc=0
+    ts=$(date -u +%Y%m%dT%H%M%SZ)
+    out="$PWD/support-bundle-$ts.tar.gz"
+    tmp=$(mktemp -d)
+    mkdir -p "$tmp/bundle/logs"
+
+    log "Collecting diagnostics (read-only)..."
+    {
+        echo "pithead ${PITHEAD_VERSION:-unknown}"
+        uname -a
+        echo
+        df -h 2>/dev/null || true
+        echo
+        free -h 2>/dev/null || true
+    } >"$tmp/bundle/host.txt" 2>&1
+    doctor_json >"$tmp/bundle/doctor.json" 2>"$tmp/bundle/doctor.txt" || rc=$?
+    [ "$rc" -gt 0 ] && log "doctor reported failures — included in the bundle."
+
+    # Masked config: the same jq walk the dashboard prefill uses; every set secret leaf becomes
+    # {"__secret__": true}. Rendered into the scratch dir, never into the live control spool.
+    if [ -f "$CONFIG_FILE" ]; then
+        render_masked_config "$tmp/scratch" 2>/dev/null || true
+        [ -f "$tmp/scratch/masked/config.json" ] &&
+            cp "$tmp/scratch/masked/config.json" "$tmp/bundle/config.masked.json"
+    fi
+    # .env with secret-bearing values stripped by key pattern; structure (ports, dirs, modes)
+    # stays — that is what support actually needs.
+    if [ -f .env ]; then
+        awk -F= '/^[A-Z0-9_]+=/ {
+            if ($1 ~ /(PASSWORD|TOKEN|SECRET|KEY|WALLET|ONION|AUTH|PING_URL|CHAT_ID)/) print $1 "=[redacted]";
+            else print; next } { print }' .env >"$tmp/bundle/env.redacted" 2>/dev/null || true
+    fi
+
+    # Container state + recent logs, when an engine is reachable. Argv-pattern redaction guards
+    # the launch lines services echo (p2pool: --rpc-login; xmrig-proxy: --http-access-token).
+    if docker compose ps >"$tmp/bundle/compose-ps.txt" 2>/dev/null; then
+        local svc
+        for svc in $(docker compose ps --all --format '{{.Service}}' 2>/dev/null); do
+            docker compose logs --no-color --tail 200 "$svc" 2>/dev/null |
+                sed -E 's/(--rpc-login|--http-access-token|--tls-fingerprint)[= ][^ ]+/\1 [redacted]/g' \
+                    >"$tmp/bundle/logs/$svc.log" || true
+        done
+    else
+        echo "container engine not reachable — no container state collected" >"$tmp/bundle/compose-ps.txt"
+    fi
+
+    tar -czf "$out" -C "$tmp" bundle
+    chmod 600 "$out"
+    rm -rf "$tmp"
+    log "Support bundle written: $out"
+    log "Secrets are redacted at collection, but REVIEW the contents before sharing: tar -tzf $(basename "$out")"
 }
 
 announce_dashboard_url() {
@@ -1500,8 +1591,15 @@ Inspection:
   logs [service]            Follow logs for all containers, or a single service.
   status                    Show container status + health-check every expected service
                             (warns about anything down; non-zero exit if so).
-  doctor                    Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk,
+  doctor [--json]           Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk,
                             .env/onion state, and container status — a paste-able health report.
+                              --json           machine-readable report on stdout (the human
+                                               report moves to stderr); same checks, same
+                                               non-zero exit on critical failures.
+  support-bundle            Collect a chmod-600 diagnostics tarball for a bug report: host
+                            facts, doctor (prose + JSON), masked config, redacted .env, and
+                            the last 200 log lines per container (launch-line credentials
+                            scrubbed). Read-only; nothing leaves the box — review, then share.
   version, -V, --version    Print the installed stack version (offline; no update check).
 
 Maintenance:
@@ -5491,7 +5589,7 @@ apply() {
 # Every dispatchable subcommand, in help order. main's dispatch, the chain validator, and the
 # tab-completion script (pithead-completion.bash) key off this one list; tests/stack/run.sh fails
 # if any of the three drift apart.
-readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 # The subset allowed in a chain: commands that take no positional argument and terminate on their
 # own. Excluded: setup (interactive first-run), logs (follows until Ctrl+C), restore (needs an
 # archive path), reset-dashboard (destructive — run it deliberately, alone), and the one-shot
@@ -6915,9 +7013,16 @@ main() {
         stack_status || exit 1
         ;;
     doctor)
-        _reject_options doctor "$@"
-        doctor || exit 1
+        case "${1:-}" in
+        "") doctor || exit 1 ;;
+        --json)
+            [ "$#" -eq 1 ] || error "doctor --json takes no further options. Run '$0 help'."
+            doctor_json || exit 1
+            ;;
+        *) error "Unknown option for doctor: '$1'. Run '$0 help'." ;;
+        esac
         ;;
+    support-bundle) stack_support_bundle "$@" ;;
     reset-dashboard)
         require_deployed
         reset_dashboard "$@"

--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -13,7 +13,7 @@
 
 # Keep in sync with PITHEAD_COMMANDS in the pithead script — tests/stack/run.sh fails if the
 # two lists drift.
-_pithead_commands="setup apply up down restart upgrade logs status doctor reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+_pithead_commands="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 
 # Service names = the top-level keys under `services:` in the docker-compose.yml next to the
 # pithead being completed. $1 = path to that compose file.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3426,6 +3426,30 @@ assert_eq "refused render writes no units" "$(find "$SANDBOX/quadlet-prof-out" -
 out=$(run_sourced "$SANDBOX" render_quadlet_units "$SANDBOX/no-such.env" "$SANDBOX/quadlet-none" 2>&1)
 assert_contains "render-quadlet missing env errors" "$out" "env file not found"
 
+echo "== black-box: doctor --json + support-bundle (#77 phase 1) =="
+# doctor --json: valid JSON on stdout, the human report on stderr, counters consistent with the
+# check list (info lines are context, not verdicts).
+dj_out="$SANDBOX/doctor.json"
+dj_err="$SANDBOX/doctor.err"
+(cd "$V" && PATH="$V/bin:$PATH" ./pithead doctor --json >"$dj_out" 2>"$dj_err") || true
+assert_eq "doctor --json has checks + summary" "$(jq -r 'has("checks") and has("summary")' "$dj_out" 2>/dev/null)" "true"
+assert_eq "doctor --json counters match verdict lines" \
+    "$(jq -r '(.summary.ok + .summary.warn + .summary.fail) == ([.checks[] | select(.status != "info")] | length)' "$dj_out" 2>/dev/null)" "true"
+assert_contains "doctor --json human report on stderr" "$(cat "$dj_err")" "Diagnostics summary"
+out=$(cd "$V" && PATH="$V/bin:$PATH" ./pithead doctor --bogus 2>&1 || true)
+assert_contains "doctor rejects unknown options" "$out" "Unknown option"
+# support-bundle: chmod-600 tarball; doctor.json inside; .env secrets redacted by key pattern —
+# seed_env's PROXY_AUTH_TOKEN must never appear in the bundle.
+(cd "$V" && PATH="$V/bin:$PATH" ./pithead support-bundle >/dev/null 2>&1) || true
+sb_tar=$(find "$V" -maxdepth 1 -name 'support-bundle-*.tar.gz' | head -1)
+assert_contains "support bundle written" "$sb_tar" "support-bundle-"
+assert_eq "support bundle is chmod 600" "$(stat -c '%a' "$sb_tar" 2>/dev/null || stat -f '%Lp' "$sb_tar" 2>/dev/null)" "600"
+mkdir -p "$SANDBOX/sb-extract"
+tar -xzf "$sb_tar" -C "$SANDBOX/sb-extract"
+assert_eq "bundle carries doctor.json" "$(jq -r 'has("summary")' "$SANDBOX/sb-extract/bundle/doctor.json" 2>/dev/null)" "true"
+assert_contains "bundle .env redacts token keys" "$(cat "$SANDBOX/sb-extract/bundle/env.redacted")" "PROXY_AUTH_TOKEN=[redacted]"
+assert_eq "no raw secret value anywhere in the bundle" "$(grep -rc "ORIGINALTOKEN" "$SANDBOX/sb-extract" | grep -vc ":0")" "0"
+
 echo "== black-box: monero.out_peers renders to .env, bounds enforced (#595) =="
 # Default 48 when unset (the Tor-IBD bandwidth default); an explicit value lands verbatim in
 # MONERO_OUT_PEERS (each outbound peer ≈ one Tor circuit — the steady-state Tor CPU lever);


### PR DESCRIPTION
Phase 1 of the dual-distribution plan, into `develop-v2`.

## What

- **`pithead doctor --json`** — same checks, same non-zero exit on critical failures; JSON on stdout, human report on stderr (`| jq` and watching both work). Captured at the source: every `dr_ok/warn/fail/info` verdict lands in a TSV that one jq call assembles into `{version, exit, summary{ok,warn,fail}, checks[{status,message}]}`. This is the appliance commit gate's input (phase 2), whose engine-aware check variants land behind the same shape.
- **`pithead support-bundle`** — one read-only command, chmod-600 tarball: host facts, doctor prose + JSON, masked config (reusing the control channel's `render_masked_config`), `.env` redacted by key pattern, last 200 log lines per container with launch-line credentials scrubbed — p2pool echoes `--rpc-login` at start, the exact leak class the #78 spike hit. Nothing leaves the box; the closing message says review before sharing.
- Both registered in `PITHEAD_COMMANDS` + completion; the dispatch-order drift-guard caught the list ordering on first run.

## Coverage (tier 1)

JSON shape, counter-vs-checks consistency, stderr split, unknown-option rejection; bundle exists chmod 600 with `doctor.json` inside, token keys redacted, and the seeded secret value greps to zero across the extracted bundle. `make test-stack` **1703 passed / 0 failed**; shellcheck + shfmt clean.

CHANGELOG deferred to the v2 collapse PR, as with the rest of the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)