### PR TITLE
feat(install): curl installer + pithead uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-proto lint-toml ## Lint/format-check every surface
 
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh
 	shfmt -i 4 -d pithead pithead-completion.bash $(shell git ls-files '*.sh')
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Pithead curl installer (#77 phase 1) — thin by design: check the host, fetch and verify the
+# release bundle, delegate to `pithead setup`. All provisioning logic stays in the bundle, so
+# what this script does is auditable in one screen:
+#
+#   curl -fsSL https://raw.githubusercontent.com/p2pool-starter-stack/pithead/main/install.sh | bash
+#
+# Env overrides: PITHEAD_VERSION=vX.Y.Z (default: latest release), PITHEAD_DIR=<install dir>
+# (default: ./pithead-<version>), PITHEAD_ALLOW_ANY_DISTRO=1 to skip the apt-family check.
+set -euo pipefail
+
+REPO="p2pool-starter-stack/pithead"
+fail() {
+    echo "[install] ERROR: $*" >&2
+    exit 1
+}
+note() { echo "[install] $*"; }
+
+# --- Host checks. amd64 + AVX2 are hard requirements (xmrig-proxy has no arm64 build; RandomX
+# prep needs AVX2) — fail here, not hours into a sync.
+[ "$(uname -s)" = "Linux" ] || fail "Pithead runs on Linux (found $(uname -s)). See docs/getting-started.md."
+[ "$(uname -m)" = "x86_64" ] || fail "Pithead is x86_64-only (found $(uname -m)) — xmrig-proxy has no arm64 build."
+grep -qw avx2 /proc/cpuinfo || fail "This CPU lacks AVX2, which RandomX block verification requires."
+if [ "${PITHEAD_ALLOW_ANY_DISTRO:-0}" != "1" ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release 2>/dev/null || fail "Cannot read /etc/os-release. Set PITHEAD_ALLOW_ANY_DISTRO=1 to proceed anyway."
+    case "${ID:-} ${ID_LIKE:-}" in
+    *debian* | *ubuntu*) ;;
+    *) fail "'./pithead setup' installs dependencies with apt (found ${PRETTY_NAME:-unknown}). Set PITHEAD_ALLOW_ANY_DISTRO=1 and install docker/jq/openssl yourself." ;;
+    esac
+fi
+for dep in curl tar sha256sum; do
+    command -v "$dep" >/dev/null 2>&1 || fail "'$dep' is required to install. apt install $dep, then re-run."
+done
+
+# --- Resolve the release tag. No jq yet (setup installs it) — grep the API response.
+TAG="${PITHEAD_VERSION:-}"
+if [ -z "$TAG" ]; then
+    TAG=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+        grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    [ -n "$TAG" ] || fail "Could not resolve the latest release tag from the GitHub API."
+fi
+DIR="${PITHEAD_DIR:-$PWD/pithead-$TAG}"
+[ -e "$DIR" ] && fail "$DIR already exists — pick another PITHEAD_DIR or remove it."
+note "Installing Pithead $TAG into $DIR"
+
+# --- Fetch bundle + manifest; verify the bundle against the manifest's sha256 line when the
+# release carries one (releases newer than v1.14.0 do; for older ones HTTPS is the trust anchor,
+# same as cloning the repo). Image digests are pinned inside the bundle's compose file, and
+# `pithead up`/`upgrade` verify cosign signatures when cosign.pub + cosign are present.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+curl -fsSL -o "$TMP/pithead.tar.gz" "https://github.com/$REPO/releases/download/$TAG/pithead.tar.gz" ||
+    fail "Bundle download failed for $TAG."
+if curl -fsSL -o "$TMP/ingredients.md" "https://github.com/$REPO/releases/download/$TAG/ingredients-$TAG.md" 2>/dev/null; then
+    WANT=$(grep -m1 -oE 'bundle sha256: `[a-f0-9]{64}`' "$TMP/ingredients.md" | grep -oE '[a-f0-9]{64}' || true)
+    if [ -n "$WANT" ]; then
+        GOT=$(sha256sum "$TMP/pithead.tar.gz" | cut -d' ' -f1)
+        [ "$GOT" = "$WANT" ] || fail "Bundle sha256 mismatch: manifest $WANT, downloaded $GOT. Refusing to install."
+        note "Bundle sha256 verified against the release manifest."
+    else
+        note "Release manifest carries no bundle sha256 (pre-v1.15 release) — trusting the HTTPS download."
+    fi
+else
+    note "No release manifest found — trusting the HTTPS download."
+fi
+
+mkdir -p "$DIR"
+tar -xzf "$TMP/pithead.tar.gz" --strip-components=1 -C "$DIR"
+[ -x "$DIR/pithead" ] || fail "Extracted bundle has no pithead executable — corrupt download?"
+note "Extracted. Handing off to './pithead setup' (interactive)."
+cd "$DIR"
+exec ./pithead setup "$@"

--- a/pithead
+++ b/pithead
@@ -1147,6 +1147,48 @@ stack_support_bundle() {
     log "Secrets are redacted at collection, but REVIEW the contents before sharing: tar -tzf $(basename "$out")"
 }
 
+# `uninstall` (#77 phase 1): the clean exit for the DIY channel — stop and remove what pithead
+# created on this host, keep what the operator owns. Kept: config.json, the data dirs (chains,
+# Tor onion keys, dashboard DB), backups/. Removed: containers, the stack's images, the rendered
+# .env and Caddyfile, this checkout's control-runner units, the egress firewall rules. The
+# appliance has no uninstall — its equivalents are the reset tiers.
+stack_uninstall() {
+    local yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+        -y | --yes) yes=1 ;;
+        *) error "Unknown option for uninstall: $arg. Run '$0 help'." ;;
+        esac
+    done
+    [ -f .env ] || error "No .env here — nothing deployed to uninstall. A never-deployed checkout is just a directory: remove it."
+    detect_os
+    # The keep-list is read from .env BEFORE it is removed.
+    local data_dirs
+    data_dirs=$(grep -E '^(MONERO|TARI|P2POOL|DASHBOARD|TOR)_DATA_DIR=' .env | cut -d= -f2- | sort -u | tr '\n' ' ')
+    warn "DESTRUCTIVE: stops the stack, removes its containers and images, and deletes the rendered .env and Caddyfile."
+    log "Kept (yours): config.json, backups/, and the data dirs: ${data_dirs:-none recorded}"
+    if [ "$yes" -ne 1 ]; then
+        printf "Type 'uninstall' to continue: "
+        read -r arg
+        [ "$arg" == "uninstall" ] || {
+            log "Aborted — nothing changed."
+            return 1
+        }
+    fi
+    remove_tor_egress_firewall 2>/dev/null || true
+    docker compose down --remove-orphans 2>/dev/null ||
+        warn "compose down failed (engine not running?) — continuing with cleanup."
+    # Exact image refs from the compose config; failures (image shared/in use) are non-fatal.
+    docker compose config --images 2>/dev/null | sort -u | while read -r img; do
+        [ -n "$img" ] && docker rmi "$img" >/dev/null 2>&1 || true
+    done
+    # Removes only THIS checkout's pithead-control units (the ownership check inside).
+    DASHBOARD_CONTROL_ENABLED=false provision_control_runner 2>/dev/null || true
+    rm -f .env Caddyfile
+    log "Uninstalled. Still on disk: config.json, backups/, data dirs (${data_dirs:-none}) — remove them yourself for a full wipe."
+    log "Kernel HugePages/GRUB tuning from setup persists; revert in GRUB config if you want it gone."
+}
+
 announce_dashboard_url() {
     local display_host
     display_host=$(env_get HOST_IP)
@@ -1629,6 +1671,14 @@ Maintenance:
                             Asks for the passphrase (or reads PITHEAD_BACKUP_PASSPHRASE) and
                             fails before touching anything if it's wrong.
                               -y, --yes        restore without the confirmation prompt.
+
+  uninstall [-y|--yes]      DESTRUCTIVE: the clean exit. Stops the stack, removes its
+                            containers and images, deletes the rendered .env and Caddyfile,
+                            this checkout's control-runner units, and the egress firewall
+                            rules. Keeps what is yours: config.json, backups/, and the data
+                            dirs (chains, Tor onion keys, dashboard DB) — the closing message
+                            lists them for manual removal. Type-to-confirm unless -y.
+                              -y, --yes        skip the confirmation prompt.
 
   onion-client-key          Print the Tor client-auth line for the dashboard onion —
                             the client PRIVATE key, kept out of 'status'. Add it to your Tor
@@ -5589,7 +5639,7 @@ apply() {
 # Every dispatchable subcommand, in help order. main's dispatch, the chain validator, and the
 # tab-completion script (pithead-completion.bash) key off this one list; tests/stack/run.sh fails
 # if any of the three drift apart.
-readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 # The subset allowed in a chain: commands that take no positional argument and terminate on their
 # own. Excluded: setup (interactive first-run), logs (follows until Ctrl+C), restore (needs an
 # archive path), reset-dashboard (destructive — run it deliberately, alone), and the one-shot
@@ -7029,6 +7079,7 @@ main() {
         ;;
     backup) stack_backup "$@" ;;
     restore) stack_restore "$@" ;;
+    uninstall) stack_uninstall "$@" ;;
     control-run-pending)
         _reject_options control-run-pending "$@"
         require_deployed

--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -13,7 +13,7 @@
 
 # Keep in sync with PITHEAD_COMMANDS in the pithead script — tests/stack/run.sh fails if the
 # two lists drift.
-_pithead_commands="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+_pithead_commands="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 
 # Service names = the top-level keys under `services:` in the docker-compose.yml next to the
 # pithead being completed. $1 = path to that compose file.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -503,6 +503,9 @@ publish() {
     write_manifest "$manifest"
     local bundle="$WORKDIR/pithead.tar.gz" # versionless name → stable /releases/latest/download/ URL
     make_bundle "$bundle"
+    # Bundle checksum into the manifest (#77 phase 1): install.sh verifies its download against
+    # this line. Appended here because write_manifest runs before the bundle exists.
+    printf -- '- bundle sha256: `%s`\n' "$(sha256sum "$bundle" | cut -d' ' -f1)" >>"$manifest"
     local bundle_sig="" # pithead.tar.gz.sig — only when signing is on (#376 opt-in)
     if [ "${COSIGN_ENABLED:-0}" -eq 1 ]; then
         bundle_sig="$bundle.sig" # the #59 upgrade runner fetches it by name

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3450,6 +3450,37 @@ assert_eq "bundle carries doctor.json" "$(jq -r 'has("summary")' "$SANDBOX/sb-ex
 assert_contains "bundle .env redacts token keys" "$(cat "$SANDBOX/sb-extract/bundle/env.redacted")" "PROXY_AUTH_TOKEN=[redacted]"
 assert_eq "no raw secret value anywhere in the bundle" "$(grep -rc "ORIGINALTOKEN" "$SANDBOX/sb-extract" | grep -vc ":0")" "0"
 
+echo "== black-box: uninstall keeps the operator's files (#77 phase 1) =="
+# Without confirmation: aborts, changes nothing.
+touch "$V/Caddyfile"
+out=$(cd "$V" && printf 'no\n' | PATH="$V/bin:$PATH" ./pithead uninstall 2>&1) || true
+assert_contains "uninstall aborts without the confirm word" "$out" "Aborted"
+assert_eq "aborted uninstall keeps .env" "$([ -f "$V/.env" ] && echo yes)" "yes"
+# With -y: rendered files go, the operator's files stay.
+out=$(cd "$V" && PATH="$V/bin:$PATH" ./pithead uninstall -y 2>&1)
+assert_contains "uninstall names the kept files" "$out" "config.json"
+assert_eq "uninstall removes .env" "$([ -f "$V/.env" ] || echo gone)" "gone"
+assert_eq "uninstall removes Caddyfile" "$([ -f "$V/Caddyfile" ] || echo gone)" "gone"
+assert_eq "uninstall keeps config.json" "$([ -f "$V/config.json" ] && echo yes)" "yes"
+out=$(cd "$V" && PATH="$V/bin:$PATH" ./pithead uninstall --bogus 2>&1) || true
+assert_contains "uninstall rejects unknown options" "$out" "Unknown option"
+# Re-render the sandbox .env for the sections below — uninstall just deleted it.
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+
+echo "== unit: install.sh host gate (#77 phase 1) =="
+# The installer hard-fails on the platforms the stack cannot run on, before any download.
+IBIN="$SANDBOX/install-stub-bin"
+mkdir -p "$IBIN"
+printf '#!/bin/bash\ncase "$1" in -s) echo Linux ;; -m) echo aarch64 ;; esac\n' >"$IBIN/uname"
+chmod +x "$IBIN/uname"
+out=$(PATH="$IBIN:$PATH" bash "$ROOT/install.sh" 2>&1) || true
+assert_contains "install.sh refuses non-amd64" "$out" "x86_64-only"
+printf '#!/bin/bash\ncase "$1" in -s) echo Darwin ;; -m) echo x86_64 ;; esac\n' >"$IBIN/uname"
+out=$(PATH="$IBIN:$PATH" bash "$ROOT/install.sh" 2>&1) || true
+assert_contains "install.sh refuses non-Linux" "$out" "runs on Linux"
+
 echo "== black-box: monero.out_peers renders to .env, bounds enforced (#595) =="
 # Default 48 when unset (the Tor-IBD bandwidth default); an explicit value lands verbatim in
 # MONERO_OUT_PEERS (each outbound peer ≈ one Tor circuit — the steady-state Tor CPU lever);


### PR DESCRIPTION
Phase 1 of the dual-distribution plan, into `develop-v2` — the DIY channel's front door and clean exit.

## What

- **`install.sh`** (repo root) — the curl channel, thin and auditable in one screen: hard host gates first (Linux, x86_64, AVX2 — fail before any download, not hours into a sync; apt-family check with `PITHEAD_ALLOW_ANY_DISTRO=1` as the escape hatch), resolve latest release (or `PITHEAD_VERSION`), fetch the bundle, **verify sha256 against the release manifest** when the line exists, extract, `exec ./pithead setup`. All provisioning logic stays in the bundle.
- **`release.sh`**: appends `bundle sha256` to the ingredients manifest — future releases are checksum-verifiable by the installer; for older releases the installer prints that it is trusting HTTPS.
- **`pithead uninstall [-y]`** — the clean exit: stops the stack, removes containers + stack images, deletes rendered `.env`/`Caddyfile`, this checkout's control-runner units (reusing `provision_control_runner`'s ownership check), and the egress firewall rules. Keeps and names the operator's files: `config.json`, `backups/`, data dirs. Type-to-confirm unless `-y`. DIY-only — the appliance's equivalents are the reset tiers.

## Coverage (tier 1)

Uninstall: abort keeps everything; `-y` removes rendered files, keeps `config.json`; unknown options rejected. Installer: platform gates proven via stubbed `uname` (non-amd64, non-Linux). `make test-stack` **1712 / 0**; `install.sh` joins `lint-sh`; shellcheck + shfmt clean.

Runtime proof of the full install path is a clean-VM smoke on the release checklist (per the plan's testing section) — not fakeable at tier 1.

CHANGELOG deferred to the v2 collapse PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)