### PR TITLE
feat(cli): engine-aware doctor host checks

### DIFF
--- a/pithead
+++ b/pithead
@@ -728,10 +728,35 @@ clock_sync_status() {
     esac
 }
 
+# Container engine for doctor's host checks (#77 phase 2): docker on the DIY channel, podman on
+# the appliance. PITHEAD_ENGINE overrides (the appliance image sets it); auto-detect otherwise —
+# docker wins when both are present, matching the DIY default.
+container_engine() {
+    case "${PITHEAD_ENGINE:-}" in
+    docker | podman)
+        printf '%s' "$PITHEAD_ENGINE"
+        return
+        ;;
+    esac
+    if command -v docker >/dev/null 2>&1; then
+        printf 'docker'
+    elif command -v podman >/dev/null 2>&1; then
+        printf 'podman'
+    else
+        printf 'docker'
+    fi
+}
+
 # True if Docker is set to start at boot (docker.service OR docker.socket enabled). systemd only —
 # the caller checks that systemctl exists. Checking docker.socket too covers socket-activated
 # installs where docker.service is "static" but Docker still comes up at boot.
 docker_boot_enabled() {
+    if [ "$(container_engine)" = "podman" ]; then
+        # Rootful podman has no daemon; boot persistence = the socket-activated API (the proxies
+        # mount it) plus systemd starting the Quadlet units, which [Install] handles per-unit.
+        systemctl is-enabled podman.socket >/dev/null 2>&1
+        return
+    fi
     systemctl is-enabled docker.service >/dev/null 2>&1 || systemctl is-enabled docker.socket >/dev/null 2>&1
 }
 
@@ -792,7 +817,13 @@ doctor() {
     # --- Docker daemon ---
     echo ""
     echo "Docker daemon:"
-    if ! command -v docker >/dev/null 2>&1; then
+    if [ "$(container_engine)" = "podman" ]; then
+        if podman info >/dev/null 2>&1; then
+            dr_ok "Container engine (podman) is reachable."
+        else
+            dr_fail "Container engine (podman) is not reachable — check 'systemctl status podman.socket' (rootful podman has no daemon; the socket serves the API)."
+        fi
+    elif ! command -v docker >/dev/null 2>&1; then
         dr_info "Skipped — docker is not installed."
     elif docker info >/dev/null 2>&1; then
         dr_ok "Docker daemon is reachable."
@@ -811,7 +842,7 @@ doctor() {
         if docker_boot_enabled; then
             dr_ok "Docker is enabled to start at boot — the stack will come back after a reboot."
         else
-            dr_warn "Docker is NOT enabled to start at boot — after a power loss/reboot the stack won't restart. Fix: 'sudo systemctl enable --now docker'."
+            dr_warn "The container engine is NOT enabled to start at boot — after a power loss/reboot the stack won't restart. Fix: 'sudo systemctl enable --now docker' (docker) or 'sudo systemctl enable --now podman.socket' (podman)."
         fi
     fi
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3432,6 +3432,20 @@ for f in mining.network proxy.network tor.container monerod.container tari.conta
     assert_eq "quadlet payout parity: $f" "$(diff -u "$ROOT/os/quadlet/payout/$f" "$QPAY/$f" 2>&1 | head -c 300)" ""
 done
 assert_eq "local render emits no wallet units" "$(find "$QLOCAL" -name 'wallet-rpc.container' -o -name 'tari-wallet.container' | wc -l | tr -d ' ')" "0"
+
+echo "== unit: engine-aware doctor checks (#77 phase 2) =="
+# Same check names and verdict semantics on both engines; PITHEAD_ENGINE pins the appliance.
+assert_eq "engine override wins" "$(PITHEAD_ENGINE=podman run_sourced "$SANDBOX" container_engine)" "podman"
+assert_eq "engine defaults to docker" "$(run_sourced "$SANDBOX" container_engine)" "docker"
+# podman boot persistence = podman.socket enabled (stubbed systemctl says yes for it only).
+EBIN="$SANDBOX/engine-stub-bin"
+mkdir -p "$EBIN"
+printf '#!/bin/bash\n[ "$1" = is-enabled ] && [ "$2" = podman.socket ] && exit 0\nexit 1\n' >"$EBIN/systemctl"
+chmod +x "$EBIN/systemctl"
+out=$(PITHEAD_ENGINE=podman PATH="$EBIN:$PATH" run_sourced "$SANDBOX" docker_boot_enabled && echo enabled || echo disabled)
+assert_eq "podman boot persistence reads podman.socket" "$out" "enabled"
+out=$(PITHEAD_ENGINE=docker PATH="$EBIN:$PATH" run_sourced "$SANDBOX" docker_boot_enabled && echo enabled || echo disabled)
+assert_eq "docker boot persistence ignores podman.socket" "$out" "disabled"
 # A missing env file is a hard error, not an empty render.
 out=$(run_sourced "$SANDBOX" render_quadlet_units "$SANDBOX/no-such.env" "$SANDBOX/quadlet-none" 2>&1)
 assert_contains "render-quadlet missing env errors" "$out" "env file not found"


### PR DESCRIPTION
Phase 2 on `develop-v2`. The appliance commit gate consumes `doctor --json`, but three host checks were Docker-shaped and would misreport under Podman/systemd — the gap the plan flagged in its phase-2 section.

- `container_engine()`: `PITHEAD_ENGINE` override (the appliance image sets it), auto-detect fallback, docker wins when both exist (the DIY default).
- **Engine reachable**: `podman info` via the socket-activated API, with a `podman.socket` hint instead of the docker-daemon one.
- **Boot persistence**: `podman.socket` enabled — rootful podman has no daemon, and Quadlet `[Install]` covers unit startup per-unit. The not-enabled warning names both engines' fixes.
- Same check names, verdict semantics, and `--json` shape on both engines — the commit gate and support bundle read identically everywhere.

Deliberately **not** an engine abstraction over pithead's docker call sites — doctor-only, per the plan's port-surface doctrine (the appliance path doesn't call compose at all).

Tier 1: override wins; default is docker; podman persistence reads `podman.socket` while docker mode ignores it (stubbed systemctl). `make test-stack` **1740 / 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)