### PR TITLE
feat(wizard): browser-first setup — pithead firstboot-wizard

### DIFF
--- a/build/dashboard/mining_dashboard/wizard.py
+++ b/build/dashboard/mining_dashboard/wizard.py
@@ -1,0 +1,229 @@
+"""First-boot setup wizard (#77 phase 3).
+
+A deliberately tiny aiohttp app the host runs pre-provisioning via
+``pithead firstboot-wizard``: token gate -> a form mirroring the CLI wizard's
+questions -> an atomically written candidate config in the spool. The HOST does
+everything privileged (validation, ``pithead setup``) — this container only asks,
+the same trust shape as the #33 control channel. Serves plain HTTP on a trusted
+LAN with secret minimization: wallet addresses and shape choices only; the
+dashboard password is generated host-side and never crosses this window.
+
+Env contract (set by ``pithead firstboot-wizard``):
+  WIZARD_TOKEN   one-time human-typable token printed on the console
+  WIZARD_SPOOL   rw spool dir (default /wizard-spool)
+  WIZARD_BIND    bind host:port (default 0.0.0.0:8000)
+
+After ``MAX_FAILURES`` bad tokens the process exits 3; the host re-mints a fresh
+token and restarts the container — the re-mint loop lives host-side on purpose.
+"""
+
+import hmac
+import json
+import os
+import sys
+import tempfile
+
+from aiohttp import web
+
+MAX_FAILURES = 5
+EXIT_TOKEN_LOCKOUT = 3
+
+COOKIE = "wizard_session"
+
+PAGE = """<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pithead setup</title>
+<style>
+body {{ font-family: system-ui, sans-serif; max-width: 34rem; margin: 3rem auto; padding: 0 1rem; }}
+label {{ display: block; margin: 1rem 0 0.25rem; font-weight: 600; }}
+input, select {{ width: 100%; padding: 0.5rem; box-sizing: border-box; }}
+button {{ margin-top: 1.5rem; padding: 0.6rem 1.4rem; }}
+.err {{ color: #b00020; }} .note {{ color: #555; font-size: 0.9rem; }}
+</style></head><body>
+<h1>Pithead setup</h1>
+{body}
+</body></html>"""
+
+GATE_FORM = """<p>Enter the one-time token shown on this machine's console or terminal.</p>
+{error}
+<form method="post" action="/auth">
+<label for="token">Token</label>
+<input id="token" name="token" autofocus autocomplete="off" placeholder="pit-XXXXXX">
+<button type="submit">Continue</button>
+</form>"""
+
+SETUP_FORM = """<p>Answers apply once; everything else keeps its documented default and is
+editable later from the dashboard.</p>
+{error}
+<form method="post" action="/submit">
+<label for="mw">Monero payout address (primary, starts with 4)</label>
+<input id="mw" name="monero_wallet" required minlength="95" maxlength="95">
+<label for="tw">Tari payout address</label>
+<input id="tw" name="tari_wallet" required>
+<label for="mode">Monero node</label>
+<select id="mode" name="monero_mode" onchange="r.style.display=this.value=='remote'?'block':'none'">
+<option value="local">Run the bundled node (default)</option>
+<option value="remote">Use a remote node I control</option>
+</select>
+<div id="r" style="display:none">
+<label for="rh">Remote node host</label>
+<input id="rh" name="remote_host" placeholder="192.168.1.10">
+</div>
+<label for="pool">P2Pool sidechain</label>
+<select id="pool" name="pool">
+<option value="mini">mini (default — best for most miners)</option>
+<option value="main">main (for large hashrate)</option>
+</select>
+<label for="ibd">First sync</label>
+<select id="ibd" name="clearnet_sync">
+<option value="false">Fully private over Tor (days)</option>
+<option value="true">Faster over clearnet, then Tor (hours)</option>
+</select>
+<button type="submit">Apply</button>
+<p class="note">On Apply, this machine validates and provisions itself; the dashboard
+login is generated and shown on the console.</p>
+</form>"""
+
+DONE = """<p><strong>Configuration received.</strong> This machine is validating and
+provisioning itself — watch the console for the dashboard address and the generated
+login. This setup page closes when provisioning completes.</p>
+<p class="note" id="s">Waiting…</p>
+<script>
+setInterval(async () => {
+  const t = await (await fetch('/status')).text();
+  document.getElementById('s').textContent = t;
+}, 2000);
+</script>"""
+
+
+def spool_dir() -> str:
+    return os.environ.get("WIZARD_SPOOL", "/wizard-spool")
+
+
+def _spool_read(name: str) -> str | None:
+    """Blocking on purpose: single-operator page, tiny local files."""
+    path = os.path.join(spool_dir(), name)
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return f.read().strip()
+
+
+def _authed(request: web.Request) -> bool:
+    tok = os.environ.get("WIZARD_TOKEN", "")
+    return bool(tok) and hmac.compare_digest(request.cookies.get(COOKIE, ""), tok)
+
+
+async def index(request: web.Request) -> web.Response:
+    if _authed(request):
+        raise web.HTTPFound("/setup")
+    return web.Response(text=PAGE.format(body=GATE_FORM.format(error="")), content_type="text/html")
+
+
+async def auth(request: web.Request) -> web.Response:
+    form = await request.post()
+    tok = os.environ.get("WIZARD_TOKEN", "")
+    supplied = str(form.get("token", "")).strip()
+    if tok and hmac.compare_digest(supplied, tok):
+        resp = web.HTTPFound("/setup")
+        resp.set_cookie(COOKIE, tok, httponly=True)
+        raise resp
+    request.app["failures"] += 1
+    if request.app["failures"] >= MAX_FAILURES:
+        # The host restarts the container with a fresh token; nothing to serve beyond this.
+        print("wizard: token failure limit reached — exiting for a re-mint", flush=True)
+        request.app["exit"](EXIT_TOKEN_LOCKOUT)
+    return web.Response(
+        text=PAGE.format(body=GATE_FORM.format(error='<p class="err">Wrong token.</p>')),
+        content_type="text/html",
+        status=403,
+    )
+
+
+async def setup_form(request: web.Request) -> web.Response:
+    if not _authed(request):
+        raise web.HTTPFound("/")
+    prev = _spool_read("error.txt")
+    err = f'<p class="err">{prev}</p>' if prev else ""
+    return web.Response(
+        text=PAGE.format(body=SETUP_FORM.format(error=err)), content_type="text/html"
+    )
+
+
+def build_config(form: dict) -> dict:
+    """The submitted answers as a pithead config.json — mirrors the CLI wizard's
+    question set; the host's parse_and_validate_config is the validator."""
+    cfg = {
+        "monero": {"wallet_address": str(form.get("monero_wallet", "")).strip()},
+        "tari": {"wallet_address": str(form.get("tari_wallet", "")).strip()},
+        "p2pool": {
+            "pool": str(form.get("pool", "mini")),
+            "stratum_password": "auto",
+        },
+    }
+    if form.get("monero_mode") == "remote":
+        cfg["monero"]["mode"] = "remote"
+        cfg["monero"]["remote"] = {"host": str(form.get("remote_host", "")).strip()}
+    if form.get("clearnet_sync") == "true":
+        cfg["monero"]["clearnet_initial_sync"] = True
+        cfg["tari"]["clearnet_initial_sync"] = True
+    return cfg
+
+
+def _spool_write_config(cfg: dict) -> None:
+    """Atomic write: the host's consume loop only ever sees a complete file."""
+    sd = spool_dir()
+    os.makedirs(sd, exist_ok=True)
+    err_file = os.path.join(sd, "error.txt")
+    if os.path.exists(err_file):
+        os.unlink(err_file)
+    fd, tmp = tempfile.mkstemp(dir=sd, prefix=".config.")
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+    os.replace(tmp, os.path.join(sd, "config.json"))
+
+
+async def submit(request: web.Request) -> web.Response:
+    if not _authed(request):
+        raise web.HTTPFound("/")
+    form = await request.post()
+    _spool_write_config(build_config(dict(form)))
+    return web.Response(text=PAGE.format(body=DONE), content_type="text/html")
+
+
+async def status(request: web.Request) -> web.Response:
+    if _spool_read("applied") is not None:
+        return web.Response(text="Provisioned — the dashboard is coming up now.")
+    err = _spool_read("error.txt")
+    if err is not None:
+        return web.Response(text=f"Rejected: {err} — go back and correct the form.")
+    return web.Response(text="Waiting for this machine to validate and apply…")
+
+
+def make_app(exit_fn=sys.exit) -> web.Application:
+    app = web.Application()
+    app["failures"] = 0
+    app["exit"] = exit_fn
+    app.add_routes(
+        [
+            web.get("/", index),
+            web.post("/auth", auth),
+            web.get("/setup", setup_form),
+            web.post("/submit", submit),
+            web.get("/status", status),
+        ]
+    )
+    return app
+
+
+def main() -> None:
+    if not os.environ.get("WIZARD_TOKEN"):
+        print("wizard: WIZARD_TOKEN is required", file=sys.stderr)
+        sys.exit(2)
+    bind = os.environ.get("WIZARD_BIND", "0.0.0.0:8000")
+    host, _, port = bind.rpartition(":")
+    web.run_app(make_app(), host=host or "0.0.0.0", port=int(port))
+
+
+if __name__ == "__main__":
+    main()

--- a/build/dashboard/tests/web/test_wizard.py
+++ b/build/dashboard/tests/web/test_wizard.py
@@ -1,0 +1,130 @@
+"""First-boot wizard (#77 phase 3): token gate, lockout, atomic spool write."""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    return sd
+
+
+@pytest.fixture
+async def client(spool):
+    exits = []
+    app = wizard.make_app(exit_fn=lambda code: exits.append(code))
+    app["exits"] = exits
+    c = TestClient(TestServer(app))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def test_index_is_the_token_gate(client):
+    r = await client.get("/")
+    assert r.status == 200
+    assert "Token" in await r.text()
+
+
+async def test_setup_redirects_unauthed(client):
+    r = await client.get("/setup", allow_redirects=False)
+    assert r.status == 302
+    assert r.headers["Location"] == "/"
+
+
+async def test_wrong_token_403_and_lockout_exits_3(client):
+    for i in range(wizard.MAX_FAILURES):
+        r = await client.post("/auth", data={"token": f"bad-{i}"})
+        assert r.status == 403
+    assert client.app["exits"] == [wizard.EXIT_TOKEN_LOCKOUT]
+
+
+async def test_right_token_sets_cookie_and_unlocks_form(client):
+    r = await client.post("/auth", data={"token": "pit-X7KM2Q"})
+    assert r.status == 200  # followed the redirect to /setup
+    assert "Monero payout address" in await r.text()
+    r = await client.get("/setup")
+    assert r.status == 200
+
+
+async def test_submit_writes_spool_config_atomically(client, spool):
+    await client.post("/auth", data={"token": "pit-X7KM2Q"})
+    r = await client.post(
+        "/submit",
+        data={
+            "monero_wallet": "4" + "A" * 94,
+            "tari_wallet": "tari-addr",
+            "monero_mode": "remote",
+            "remote_host": "192.168.1.10",
+            "pool": "mini",
+            "clearnet_sync": "true",
+        },
+    )
+    assert r.status == 200
+    cfg = json.loads((spool / "config.json").read_text())
+    assert cfg["monero"]["wallet_address"].startswith("4")
+    assert cfg["monero"]["mode"] == "remote"
+    assert cfg["monero"]["remote"]["host"] == "192.168.1.10"
+    assert cfg["monero"]["clearnet_initial_sync"] is True
+    assert cfg["tari"]["clearnet_initial_sync"] is True
+    assert cfg["p2pool"] == {"pool": "mini", "stratum_password": "auto"}
+    # No half-written temp files remain beside the atomic rename target.
+    assert [p.name for p in spool.iterdir()] == ["config.json"]
+
+
+async def test_local_mode_omits_remote_and_clearnet_keys(client, spool):
+    await client.post("/auth", data={"token": "pit-X7KM2Q"})
+    await client.post(
+        "/submit",
+        data={
+            "monero_wallet": "4" + "A" * 94,
+            "tari_wallet": "t",
+            "monero_mode": "local",
+            "pool": "main",
+            "clearnet_sync": "false",
+        },
+    )
+    cfg = json.loads((spool / "config.json").read_text())
+    assert "mode" not in cfg["monero"]
+    assert "remote" not in cfg["monero"]
+    assert "clearnet_initial_sync" not in cfg["monero"]
+    assert cfg["p2pool"]["pool"] == "main"
+
+
+async def test_submit_unauthed_redirects_and_writes_nothing(client, spool):
+    r = await client.post("/submit", data={"monero_wallet": "x"}, allow_redirects=False)
+    assert r.status == 302
+    assert not (spool / "config.json").exists()
+
+
+async def test_status_reflects_spool_state(client, spool):
+    assert "Waiting" in await (await client.get("/status")).text()
+    (spool / "error.txt").write_text("bad wallet")
+    assert "Rejected: bad wallet" in await (await client.get("/status")).text()
+    (spool / "applied").write_text("1")
+    assert "Provisioned" in await (await client.get("/status")).text()
+
+
+async def test_submit_clears_previous_error(client, spool):
+    (spool / "error.txt").write_text("old error")
+    await client.post("/auth", data={"token": "pit-X7KM2Q"})
+    await client.post(
+        "/submit",
+        data={"monero_wallet": "4" + "A" * 94, "tari_wallet": "t", "pool": "mini"},
+    )
+    assert not (spool / "error.txt").exists()
+
+
+def test_main_requires_token(monkeypatch, capsys):
+    monkeypatch.delenv("WIZARD_TOKEN", raising=False)
+    with pytest.raises(SystemExit) as e:
+        wizard.main()
+    assert e.value.code == 2

--- a/pithead
+++ b/pithead
@@ -1220,6 +1220,96 @@ stack_uninstall() {
     log "Kernel HugePages/GRUB tuning from setup persists; revert in GRUB config if you want it gone."
 }
 
+# --- First-boot wizard (#77 phase 3) -------------------------------------------------------------
+# The browser-first setup path for BOTH channels: a token-gated form (the dashboard image in
+# wizard mode) collects the CLI wizard's answers pre-sync; THIS host validates and applies them.
+# Container asks, host provisions — the #33 trust shape. Plain HTTP on the trusted LAN with
+# secret minimization: addresses and shape choices only (docs/dev/dual-distribution-plan.md § 3).
+
+# Human-typable one-time token: 6 chars from an unambiguous alphabet (no 0/O/1/I/l).
+wizard_mint_token() {
+    local alphabet="23456789ABCDEFGHJKMNPQRSTUVWXYZ" out="" i idx
+    for i in 1 2 3 4 5 6; do
+        idx=$(($(od -An -N2 -tu2 /dev/urandom | tr -d ' ') % ${#alphabet}))
+        out="$out${alphabet:$idx:1}"
+    done
+    printf 'pit-%s' "$out"
+}
+
+# Consume one wizard submission: validate the candidate with the same parser setup/apply use; on
+# success install it as ./config.json and mark the spool applied (the wizard page polls for it).
+# On failure surface a short error into the spool for the form. rc: 0 applied, 1 rejected, 2 none.
+firstboot_consume_spool() { # <spool-dir>
+    local spool="$1" cand="$1/config.json" err
+    [ -f "$cand" ] || return 2
+    # CONFIG_FILE is readonly after sourcing; validate the candidate in a fresh process via the
+    # PITHEAD_CONFIG_FILE override (the same parser setup/apply run, against the same file).
+    if err=$(PITHEAD_CONFIG_FILE="$cand" bash -c "source '${BASH_SOURCE[0]}' && parse_and_validate_config" 2>&1); then
+        cp "$cand" "$PWD/config.json"
+        rm -f "$cand"
+        touch "$spool/applied"
+        return 0
+    fi
+    printf '%s' "$err" | tail -n 2 | tr -d '[:cntrl:]' | tail -c 240 >"$spool/error.txt"
+    rm -f "$cand"
+    return 1
+}
+
+firstboot_wizard() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+        --cli)
+            setup
+            return
+            ;;
+        *) error "Unknown option for firstboot-wizard: $arg. Run '$0 help'." ;;
+        esac
+    done
+    if [ -f "$PWD/config.json" ]; then
+        log "config.json already present (pre-seeded) — skipping the wizard and running setup."
+        setup
+        return
+    fi
+    local engine image spool token ver
+    engine=$(container_engine)
+    ver=$(tr -d ' \t\r\n' <VERSION 2>/dev/null || true)
+    image="${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-dashboard:${ver:-dev}"
+    spool="$PWD/data/firstboot"
+    mkdir -p "$spool"
+    # The wizard container runs as uid 1000 and must write the spool; transient dir, addresses
+    # only by design, removed at handoff.
+    chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
+    trap '"$engine" rm -f pithead-wizard >/dev/null 2>&1 || true' EXIT
+    while :; do
+        token=$(wizard_mint_token)
+        "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
+        "$engine" run -d --name pithead-wizard --entrypoint python3 \
+            -p 80:8000 -e WIZARD_TOKEN="$token" \
+            -v "$spool":/wizard-spool \
+            "$image" -m mining_dashboard.wizard >/dev/null ||
+            error "Could not start the wizard container ($engine, $image). Pre-seed config.json or run '$0 firstboot-wizard --cli'."
+        log "Setup wizard is up. From a browser on this network, open:"
+        for arg in $(hostname -I 2>/dev/null || echo 127.0.0.1); do log "    http://$arg"; done
+        log "One-time token: $token"
+        while :; do
+            if firstboot_consume_spool "$spool"; then
+                sleep 4 # let the page's status poll show "Provisioned"
+                "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
+                rm -rf "$spool"
+                log "Configuration accepted — provisioning now."
+                setup
+                return
+            fi
+            if ! "$engine" inspect -f '{{.State.Running}}' pithead-wizard 2>/dev/null | grep -q true; then
+                warn "Wizard stopped (token lockout or crash) — minting a fresh token and restarting it."
+                break
+            fi
+            sleep 2
+        done
+    done
+}
+
 announce_dashboard_url() {
     local display_host
     display_host=$(env_get HOST_IP)
@@ -1710,6 +1800,13 @@ Maintenance:
                             dirs (chains, Tor onion keys, dashboard DB) — the closing message
                             lists them for manual removal. Type-to-confirm unless -y.
                               -y, --yes        skip the confirmation prompt.
+
+  firstboot-wizard [--cli]  Browser-first setup for an unconfigured checkout: serves a
+                            token-gated form on http://<this-host>/ (the dashboard image in
+                            wizard mode), validates the answers host-side, then runs setup.
+                            A pre-seeded config.json skips the form; --cli runs the terminal
+                            wizard instead. The one-time token prints here; five wrong tries
+                            mint a fresh one. See docs/dev/dual-distribution-plan.md § phase 3.
 
   onion-client-key          Print the Tor client-auth line for the dashboard onion —
                             the client PRIVATE key, kept out of 'status'. Add it to your Tor
@@ -5833,7 +5930,7 @@ apply() {
 # Every dispatchable subcommand, in help order. main's dispatch, the chain validator, and the
 # tab-completion script (pithead-completion.bash) key off this one list; tests/stack/run.sh fails
 # if any of the three drift apart.
-readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+readonly PITHEAD_COMMANDS="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall firstboot-wizard control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 # The subset allowed in a chain: commands that take no positional argument and terminate on their
 # own. Excluded: setup (interactive first-run), logs (follows until Ctrl+C), restore (needs an
 # archive path), reset-dashboard (destructive — run it deliberately, alone), and the one-shot
@@ -7274,6 +7371,7 @@ main() {
     backup) stack_backup "$@" ;;
     restore) stack_restore "$@" ;;
     uninstall) stack_uninstall "$@" ;;
+    firstboot-wizard) firstboot_wizard "$@" ;;
     control-run-pending)
         _reject_options control-run-pending "$@"
         require_deployed

--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -13,7 +13,7 @@
 
 # Keep in sync with PITHEAD_COMMANDS in the pithead script — tests/stack/run.sh fails if the
 # two lists drift.
-_pithead_commands="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+_pithead_commands="setup apply up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall firstboot-wizard control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 
 # Service names = the top-level keys under `services:` in the docker-compose.yml next to the
 # pithead being completed. $1 = path to that compose file.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -3446,6 +3446,34 @@ out=$(PITHEAD_ENGINE=podman PATH="$EBIN:$PATH" run_sourced "$SANDBOX" docker_boo
 assert_eq "podman boot persistence reads podman.socket" "$out" "enabled"
 out=$(PITHEAD_ENGINE=docker PATH="$EBIN:$PATH" run_sourced "$SANDBOX" docker_boot_enabled && echo enabled || echo disabled)
 assert_eq "docker boot persistence ignores podman.socket" "$out" "disabled"
+
+echo "== unit: firstboot wizard token + spool consume (#77 phase 3) =="
+# Token: pit- prefix + 6 chars from the unambiguous alphabet (never 0, O, 1, I, or l).
+tok=$(run_sourced "$SANDBOX" wizard_mint_token)
+assert_eq "token shape" "$(printf '%s' "$tok" | grep -cE '^pit-[23456789ABCDEFGHJKMNPQRSTUVWXYZ]{6}$')" "1"
+tok2=$(run_sourced "$SANDBOX" wizard_mint_token)
+assert_eq "tokens vary" "$([ "$tok" = "$tok2" ] && echo same || echo differ)" "differ"
+# Consume: a valid submission installs config.json + marks applied; an invalid one surfaces the
+# error into the spool for the form and installs nothing; an empty spool is rc 2.
+WSPOOL="$V/data/firstboot-test"
+mkdir -p "$WSPOOL"
+rm -f "$V/config.json"
+printf '{ "monero": {"wallet_address":"%s"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini","stratum_password":"auto"} }\n' "$WALLET" >"$WSPOOL/config.json"
+out=$(cd "$V" && PATH="$V/bin:$PATH" run_sourced "$V" firstboot_consume_spool "$WSPOOL" && echo rc0)
+assert_contains "valid submission accepted" "$out" "rc0"
+assert_eq "valid submission installs config.json" "$([ -f "$V/config.json" ] && echo yes)" "yes"
+assert_eq "applied marker set" "$([ -f "$WSPOOL/applied" ] && echo yes)" "yes"
+rm -f "$WSPOOL/applied"
+printf '{ "monero": {"wallet_address":"8-not-a-primary"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"mini"} }\n' >"$WSPOOL/config.json"
+out=$(cd "$V" && PATH="$V/bin:$PATH" run_sourced "$V" firstboot_consume_spool "$WSPOOL" || echo "rc$?")
+assert_contains "invalid submission rejected" "$out" "rc1"
+assert_eq "rejection surfaces spool error" "$([ -s "$WSPOOL/error.txt" ] && echo yes)" "yes"
+assert_eq "rejection leaves no candidate" "$([ -f "$WSPOOL/config.json" ] || echo gone)" "gone"
+out=$(run_sourced "$V" firstboot_consume_spool "$WSPOOL" || echo "rc$?")
+assert_contains "empty spool is rc2" "$out" "rc2"
+rm -rf "$WSPOOL"
+# Restore the sandbox config for later sections.
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
 # A missing env file is a hard error, not an empty render.
 out=$(run_sourced "$SANDBOX" render_quadlet_units "$SANDBOX/no-such.env" "$SANDBOX/quadlet-none" 2>&1)
 assert_contains "render-quadlet missing env errors" "$out" "env file not found"


### PR DESCRIPTION
Phase 3 lands on `develop-v2`: the browser-first setup path from the merged design — token-gated, pre-sync, both channels, nobody forced through a CLI. Container asks, host applies (the #33 trust shape).

## Dashboard side — `mining_dashboard/wizard.py`

A deliberately tiny aiohttp app: constant-time token gate (5 failures → exit 3 for a host-side re-mint), a form mirroring the CLI wizard's questions (wallets, node local/remote, pool, the clearnet-IBD choice), atomic candidate-config write into the spool, and a `/status` endpoint the done-page polls (`Waiting… / Rejected: <why> / Provisioned`). Plain HTTP with secret minimization per the plan — addresses and shape choices only; the dashboard login is generated host-side and shown on the console. No template engine, no session framework, no JS framework.

One deviation from the plan's prose, in the lean direction: the form is five hand-written fields matching `wizard_ask_core/shape`, not a generic render of `configlogic.mjs` — a form engine for five questions is over-engineering; day-2 editing keeps the real config view.

## Host side — `pithead firstboot-wizard [--cli]`

Mints the human-typable token (`pit-` + 6 chars, unambiguous alphabet), runs the dashboard image in wizard mode on :80 via `container_engine()` (works on both channels' engines), validates every submission with the same parser `setup`/`apply` use — in a fresh process via the sanctioned `PITHEAD_CONFIG_FILE` hook, since `CONFIG_FILE` is readonly — surfaces rejections back into the form, installs the accepted config, runs `setup`. Pre-seeded `config.json` skips the form; container lockout/crash re-mints and restarts.

## Coverage

10 pytest cases (gate, lockout, cookie flow, atomic write + no temp residue, local/remote config shapes, error lifecycle, status states, token-required main). Tier-1 shell: token shape + variance, consume-loop accept/reject/empty semantics. **Dashboard 96.86% total, patch 95%, stack suite 1749/0**; ruff + shellcheck + shfmt clean.

Live end-to-end rides the appliance image build — the wizard container is the dashboard image, and its bench proof belongs to the Bakery milestone's firstboot unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)