### PR TITLE
fix(ci): allowlist the wizard handoff-password test fixture in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,4 +11,8 @@ regexTarget = "line"
 # is still caught.
 regexes = [
   '''-u "\$\{[A-Z_]+:-[^}]*\}:\$\{[A-Z_]+:-[^}]*\}"''',
+  # Fixture password in the wizard handoff-card frontend test — a made-up literal the test
+  # asserts is RENDERED, so it can't be replaced with an env var. CI scans every pushed ref,
+  # so this must be allowlisted even while the branch that carries it is still in flight.
+  '''rX6d2A4sGBHFEcQT4TVQQJRQg7xtbDMg''',
 ]


### PR DESCRIPTION
## What & why

The secret scan (gitleaks) fails on **every** open PR — including a docs-free dependabot bump — with `leaks found: 1`. The finding is not in any PR: CI's scan reads every pushed ref, and `build/dashboard/tests/frontend/wizard.test.mjs` on the in-flight `feat/phase2-bakery-image` branch asserts a made-up handoff password literal is rendered on the card. `generic-api-key` flags it.

The literal can't be swapped for an env var — the test's whole point is that the credential string appears in the rendered HTML. History on the pushed branch would keep the string anyway, so the allowlist is the only fix that doesn't rewrite an active branch.

One regex added to the existing `[allowlist]` in `.gitleaks.toml`, pinned to the exact fixture string.

**Verified** with the exact CI invocation (`ghcr.io/gitleaks/gitleaks:v8.30.1` by digest, full history including the bakery branch): `602 commits scanned … no leaks found`. Before the change the same scan reports the single wizard-fixture finding.

## Related issue

None — CI unblocking fix; the fixture lives on an unmerged branch.

## Checklist

- [x] `make test` passes locally (config-only change; gitleaks re-run against full history verified above)
- [x] This PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)