### PR TITLE
feat(os): one-flag debug builds — build-image.sh --ssh; updater defaults to rauc

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -37,6 +37,19 @@ bench is `gouda`; a laptop cannot run this (`/dev/kvm` is required).
 os/build-image.sh && sudo os/rauc/mkimage.sh
 ```
 
+Two build variants, chosen by one flag:
+
+- **Release** (the artifact that ships): no flag. Shell-less — sshd stays disabled and no key
+  is baked; `tests/os/verify-image.sh` refuses test material in this variant.
+- **Debug/bench** (`--ssh [PUBKEY_FILE]`): bakes the given public key (default: the builder's
+  own `~/.ssh/id_ed25519.pub`) as root's authorized key and enables sshd, for benches driven
+  over SSH. Verify with `tests/os/verify-image.sh IMAGE --test`. A bench that takes an A/B
+  update to a *release* bundle loses SSH — deliberate, and worth remembering before pressing
+  install.
+
+The updater defaults to RAUC; an image built without it cannot take another update, and the
+only way to get one now is to set `PITHEAD_UPDATER` to something else on purpose.
+
 Then the tiered battery, lowest tier first — the same rule as
 [`testing-strategy.md`](testing-strategy.md):
 

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -2,9 +2,44 @@
 # Build the pithead-os appliance rootfs (#77 phase 2): the OS as a container build, exported to a
 # tarball. os/rauc/mkimage.sh turns that tarball into a bootable image and os/rauc/mkbundle.sh
 # turns it into an update bundle. Run from the repo root on a box with docker.
-#   os/build-image.sh   -> os/build/pithead-root.tar
+#   os/build-image.sh [--ssh [PUBKEY_FILE]]   -> os/build/pithead-root.tar
+#
+#   --ssh [FILE]   debug/bench variant: bake FILE (default: the builder's ~/.ssh/id_ed25519.pub,
+#                  falling back to id_rsa.pub) as root's authorized key and enable sshd. Release
+#                  builds omit it and stay shell-less. Sets the same PITHEAD_TEST_SSH_PUBKEY the
+#                  env path always honored — the flag exists so the bench recipe is one word,
+#                  not a rediscovered env var.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --ssh)
+        keyfile=""
+        # An optional value: `--ssh path/to/key.pub` or bare `--ssh` for the builder's own key.
+        if [ $# -gt 1 ] && [ "${2#--}" = "$2" ]; then
+            keyfile="$2"
+            shift
+        else
+            for k in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do
+                [ -s "$k" ] && keyfile="$k" && break
+            done
+        fi
+        [ -s "${keyfile:-}" ] || {
+            echo "--ssh: no public key found (looked for ~/.ssh/id_ed25519.pub, ~/.ssh/id_rsa.pub); pass one explicitly" >&2
+            exit 1
+        }
+        PITHEAD_TEST_SSH_PUBKEY="$(head -n1 "$keyfile")"
+        export PITHEAD_TEST_SSH_PUBKEY
+        echo "==> debug build: sshd enabled, key from $keyfile"
+        ;;
+    *)
+        echo "unknown argument: $1 (usage: os/build-image.sh [--ssh [PUBKEY_FILE]])" >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
 
 # Bake the wizard's container image into the appliance: first boot must reach the setup page
 # without a registry (the operator may have no working network config yet, and the plan's
@@ -58,7 +93,7 @@ echo "==> rootfs: container build + export"
 docker build -f os/rootfs/Containerfile -t "$ROOTFS_TAG" \
     --build-arg PITHEAD_TEST_SSH_PUBKEY="${PITHEAD_TEST_SSH_PUBKEY:-}" \
     --build-arg PITHEAD_TEST_MARKER="${PITHEAD_TEST_MARKER:-}" \
-    --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-}" .
+    --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" .
 cid=$(docker create "$ROOTFS_TAG")
 mkdir -p os/build
 docker export --output os/build/pithead-root.tar "$cid"


### PR DESCRIPTION
## What

The bench recipe kept getting reinvented from env vars. Now:

- `os/build-image.sh --ssh [PUBKEY_FILE]` = the debug/bench variant: bakes the key (default: the builder's own `~/.ssh/id_ed25519.pub`, then `id_rsa.pub`) as root's authorized key and enables sshd. No flag = the shell-less release variant, unchanged.
- `PITHEAD_UPDATER` defaults to `rauc` — the first R2 RC build ran without it and produced an image that could never take another A/B update; verify-image caught it (52/53), but the silent-empty default was the only wrong option. Closes #815.
- `docs/dev/appliance-release.md` documents the two variants and the take-a-release-update-lose-SSH consequence observed live on the bench today.

## Verified

shellcheck clean, `make lint` green; the same key-bake path (`PITHEAD_TEST_SSH_PUBKEY`) just built the bench debug image on bench-host and passed `verify-image --test` 51/0 — the flag is a front door on a proven path, not new mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)