### PR TITLE
test(e2e): bounded wait before the stratum-hashes assertion

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -473,7 +473,20 @@ _pred_share_stats_nonempty() {
     [ -n "$n" ] && [ "$n" -gt 0 ] 2>/dev/null
 }
 
+# Predicate: the proxy's stratum counters show hashes accumulating — proof a rig is actually
+# submitting work, not merely listed. A REAL borrowed rig fails over to its secondary pool when
+# the bench stratum bounces between scenarios and returns on xmrig's own retry clock (~60-90s),
+# so a single early sample legitimately reads 0 on a rig that is mining a minute later (#831).
+_pred_stratum_hashes() {
+    local st h
+    st="$(api_state)"
+    [ -n "$st" ] || return 1
+    h="$(jq_get "$st" '.stratum.total_hashes')"
+    [ -n "$h" ] && [ "$h" -gt 0 ] 2>/dev/null
+}
+
 wait_status_ok() { wait_for "${1:-180}" 5 "pithead status OK" _pred_status_ok; }
+wait_stratum_hashes() { wait_for "${1:-180}" 10 "stratum hashes accumulating" _pred_stratum_hashes; }
 wait_monero_synced() { wait_for "${1:-300}" 10 "Monero sync complete" _pred_monero_synced; }
 wait_miner_running() { wait_for "${1:-180}" 5 "miner released" _pred_miner_running; }
 wait_tari_synced() { wait_for "${1:-300}" 10 "Tari sync complete" _pred_tari_synced; }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -569,8 +569,16 @@ assert_running_state() {
     assert_pool_type "pool type" "$(jq_get "$st" '.pool.type')" "$(pool_label "$pool")"
 
     # 6. End-to-end mining: workers online + hashes accumulating (#28). proxy_workers is the
-    #    reliable liveness signal; stratum.conns is reported but informational (can be 0).
+    #    reliable liveness signal; stratum.conns is reported but informational (can be 0). The
+    #    hashes figure gets a bounded wait first (#831): between scenarios the bench stratum
+    #    bounces, a REAL rig fails over to its secondary pool and returns on xmrig's own retry
+    #    clock (~60-90s) — a single early sample reads 0 while the rig is genuinely mining a
+    #    minute later, and which scenario loses that race moves run to run. The re-fetched
+    #    assertion below stays the arbiter: a rig that never returns still fails after the
+    #    timeout.
     local workers conns hashes
+    wait_stratum_hashes 180 || true
+    st="$(api_state)" # re-fetch so this step and everything after read post-wait state
     workers="$(jq_get "$st" '.proxy_workers')"
     conns="$(jq_get "$st" '.stratum.conns')"
     hashes="$(jq_get "$st" '.stratum.total_hashes')"


### PR DESCRIPTION
Two consecutive rc/v1.16.1 targeted runs failed `stratum total hashes > 0` in a *different* scenario each time (377/1 then 376/1) — miner-1's journal shows the mechanism: the bench stratum bounces between scenarios, xmrig fails over to its secondary (prod) pool, and returns on its own ~60–90s retry clock; a single early sample lands in the failover dwell and reads 0 on a rig genuinely mining a minute later. Documented Tor-timing flake class; previous clean runs were phase luck.

Fix at the harness tier, in the harness's own idiom: `wait_stratum_hashes` (`wait_for` 180s/10s over a `_pred_stratum_hashes` mirror of the sibling predicates), then a state re-fetch so the assertion and the steps after it read post-wait figures. A rig that never returns still fails after the timeout — the assertion stops racing the retry clock, it does not stop asserting.

Integration selftest 148/0; shellcheck/shfmt clean.

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)