### PR TITLE
ci: weekly CVE sweep + Dependabot coverage of compose-pinned images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,20 @@ updates:
       # migrations, not security updates — keep Dependabot to digest + patch within the pinned tag.
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Third-party image digests pinned directly in docker-compose.yml (Tari node + wallet,
+  # docker-socket-proxy, caddy) — outside build/*, so the `docker` entry above never sees them,
+  # and they feed both channels: pulled on the DIY stack, baked into the appliance image (#833).
+  # The pithead-* image lines interpolate env vars and carry no digest; Dependabot skips them.
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      compose:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the docker entry: digest + patch within the pinned tag. A Tari or Caddy
+      # major/minor is a deliberate migration (compose flags, config compatibility), not a CVE fix.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main, develop]
   pull_request:
+  # Weekly CVE sweep (#833): rebuild + Trivy-scan every image even when no PR is open, so a CVE
+  # disclosed during a quiet week — or fixed in the apt archive without a new base digest, which
+  # Dependabot never sees — surfaces here instead of reddening the next unrelated PR. Only
+  # `build-images` runs on the schedule (every other job gates on the event); the run going red
+  # in the Actions tab is the alert, the lychee.yml posture. Scheduled runs use the default
+  # branch (develop).
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC
 
 # Least privilege (#282): every job here only reads the repo — none push commits, comment, or
 # publish packages. Narrowing the default GITHUB_TOKEN limits the blast radius of a compromised step.
@@ -19,6 +27,7 @@ concurrency:
 jobs:
   dashboard:
     name: Dashboard tests (pytest + coverage)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -50,6 +59,7 @@ jobs:
 
   frontend:
     name: Frontend logic tests (node --test)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -67,6 +77,7 @@ jobs:
 
   dashboard-image:
     name: Dashboard image (Docker test stage)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -109,6 +120,7 @@ jobs:
 
   hadolint:
     name: Dockerfile lint (hadolint)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -126,6 +138,7 @@ jobs:
 
   python-lint:
     name: Python lint + format (ruff)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -149,6 +162,7 @@ jobs:
 
   gitleaks:
     name: Secret scan (gitleaks)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -166,6 +180,7 @@ jobs:
 
   zizmor:
     name: Workflow audit (zizmor)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -187,6 +202,7 @@ jobs:
 
   shell:
     name: Shell tests (shellcheck + pithead suite)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -224,6 +240,7 @@ jobs:
 
   compose:
     name: Compose config + security hardening
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -235,6 +252,7 @@ jobs:
 
   lint-surfaces:
     name: Lint per-surface (biome, yaml, markdown, proto, toml)
+    if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## What & why

Two proactive-update gaps from the appliance update-strategy plan (#833), items 3 and 6 — the pieces that live on `develop`:

- **`dependabot.yml`**: a new `docker-compose` ecosystem entry (the ecosystem that actually parses compose files — the existing `docker` entry only reads Dockerfiles), so the third-party digests pinned directly in `docker-compose.yml` (Tari node + wallet, `docker-socket-proxy`, `caddy`) get the same weekly digest/patch tracking as the `build/*` base images. Same major/minor ignore policy: those are deliberate migrations, not CVE fixes.
- **`ci.yml`**: a weekly `schedule` trigger (Mondays 05:00 UTC) that rebuilds and Trivy-scans every `build/*` image on `develop`, so a CVE disclosed between PRs — or fixed in the apt archive without a new base digest, which Dependabot never sees — surfaces in the Actions tab instead of reddening the next unrelated PR. Only `build-images` runs on the schedule; the other ten jobs gate on the event, so the scan job with its `.trivyignore` wiring stays the single source of truth (no duplicated workflow to drift).

The remaining #833 items (rootfs digest pin + scan, pinned-binary watch, cadence docs) target the appliance tree and ship separately against `develop-v2`.

## Related issue

Part of #833 — implements items 3 and 6; the issue stays open for the appliance-side items.

## Checklist

- [x] `make test` passes locally (lint + dashboard pytest ≥ coverage gate + `pithead` shell suite + compose validation) — dashboard 1641 passed / 96.91% coverage, shell suite 1696 passed, yamllint + zizmor clean; the Docker-daemon-dependent steps (`lint-proto`, compose validation) can't run in this sandbox and are covered by CI on this PR
- [x] `pithead` and test scripts are shellcheck-clean (no new warnings) — no shell touched
- [x] Docs in `docs/` (and the README, if relevant) are updated for any user-facing change, in the house voice (`docs/dev/STYLE.md`) — no user-facing change; no doc describes the Dependabot/CI internals
- [x] New/changed behaviour is tested at the right tier (`docs/dev/testing-strategy.md`); patch coverage clears the gate — YAML-only CI/tooling config, validated by yamllint + zizmor (the tier that covers workflows)
- [x] This PR is focused on a single logical change
- [x] A linked issue exists for non-trivial changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFc4Z74jLpMoJMX3L3DaGP)_