### PR TITLE
feat(dashboard): log pager — match count, rows-per-page, prev/next; grouping dropdown retired

### DIFF
--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -383,8 +383,8 @@ def _log_filters(request):
 
 async def handle_audit_log(request):
     """Config-change audit entries — the #33 control-channel log plus the out-of-band host-edit /
-    rig-edit detections (#530), merged and persisted so the Security panel can group by hour/day/
-    month deeper than the log's own trimmed tail. Registered only alongside the control channel —
+    rig-edit detections (#530), merged and persisted so the Security panel can filter and page
+    deeper than the log's own trimmed tail. Registered only alongside the control channel —
     the log is a #33 artifact and the out-of-band watchers only run when it's on.
     Accepts the #823 navigation params (``from``/``to`` epoch seconds, ``q`` substring)."""
     try:

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -610,12 +610,21 @@ tr:last-child td {
   margin: 0;
 }
 
-/* Audit-trail time-bucket header row (#530), between groups when the operator picks
- * hour/day/month grouping. A raised, muted divider — readable, not another data row. */
-.audit-group-header td {
-  background: var(--elevated);
-  color: var(--text-muted);
-  font-weight: 600;
+/* Log pager (#823 follow-up): match count, rows-per-page select, prev/next — the grouping
+ * dropdown's replacement now that presets/dates/search own the time navigation. */
+.log-pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.log-pager select {
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-size: 0.8rem;
 }
 
 /* Components */

--- a/build/dashboard/mining_dashboard/web/static/securityview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/securityview.mjs
@@ -78,10 +78,13 @@ const isFiltering = (f) => f.preset !== "all" || !!f.fromDate || !!f.toDate || !
 export const PAGE_SIZES = [5, 10, 20, 50, 100];
 
 export function pageFor(entries, page, size) {
+  // Guarded, not trusted: size comes from a fixed select in practice, but a 0/NaN reaching the
+  // division would render "page NaN of Infinity" — fall back to the default page size instead.
+  const s = Number.isFinite(size) && size >= 1 ? Math.floor(size) : 20;
   const total = entries.length;
-  const pages = Math.max(1, Math.ceil(total / size));
-  const p = Math.min(Math.max(0, page), pages - 1);
-  return { slice: entries.slice(p * size, (p + 1) * size), page: p, pages, total };
+  const pages = Math.max(1, Math.ceil(total / s));
+  const p = Math.min(Math.max(0, Number.isFinite(page) ? page : 0), pages - 1);
+  return { slice: entries.slice(p * s, (p + 1) * s), page: p, pages, total };
 }
 
 const Pager = ({ label, total, page, pages, size, onPage, onSize }) => html`<div class="log-pager">

--- a/build/dashboard/mining_dashboard/web/static/securityview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/securityview.mjs
@@ -11,8 +11,6 @@
 
 import { Component, html } from "./preact.mjs";
 
-const ACCESS_LIMIT_SHOWN = 20;
-
 // --- Log navigation (#823) -------------------------------------------------------------
 //
 // Both cards share one control row: the chart's preset idiom (24 Hr / 1 Wk / 1 Mo / All) for
@@ -73,35 +71,30 @@ const LogControls = ({ label, filters, onChange }) => {
 const EMPTY_FILTERS = { preset: "all", fromDate: "", toDate: "", q: "" };
 const isFiltering = (f) => f.preset !== "all" || !!f.fromDate || !!f.toDate || !!f.q.trim();
 
-// Audit entries share one ts format across every source (control.log's own writer and the #530
-// watchers both emit "YYYY-MM-DDTHH:MM:SSZ", see data_service._iso_now), so a bucket key is a
-// plain string slice — no date parsing, no timezone math.
-export function bucketKey(ts, granularity) {
-  if (typeof ts !== "string") return "";
-  if (granularity === "hour") return ts.slice(0, 13);
-  if (granularity === "month") return ts.slice(0, 7);
-  return ts.slice(0, 10); // "day"
+// Pagination (#823 follow-up): the grouping dropdown became a page-size control — with range
+// presets, date jumps and search doing the time navigation, bucketed grouping answered a
+// strictly weaker question. Paging is CLIENT-side over the (server-filtered, bounded) result
+// set; pageFor clamps so a shrinking result set never strands the view on a page past the end.
+export const PAGE_SIZES = [5, 10, 20, 50, 100];
+
+export function pageFor(entries, page, size) {
+  const total = entries.length;
+  const pages = Math.max(1, Math.ceil(total / size));
+  const p = Math.min(Math.max(0, page), pages - 1);
+  return { slice: entries.slice(p * size, (p + 1) * size), page: p, pages, total };
 }
 
-// Group already newest-first ``entries`` into contiguous {bucket, entries} runs for
-// ``granularity`` ("hour"|"day"|"month"), or one ungrouped run for "flat"/anything else — the
-// drill: pick "month" to scan a year at a glance, "hour" to pin down one incident.
-export function groupAuditEntries(entries, granularity) {
-  if (granularity !== "hour" && granularity !== "day" && granularity !== "month") {
-    return [{ bucket: null, entries }];
-  }
-  const groups = [];
-  let current = null;
-  for (const e of entries) {
-    const key = bucketKey(e.ts, granularity);
-    if (!current || current.bucket !== key) {
-      current = { bucket: key, entries: [] };
-      groups.push(current);
-    }
-    current.entries.push(e);
-  }
-  return groups;
-}
+const Pager = ({ label, total, page, pages, size, onPage, onSize }) => html`<div class="log-pager">
+    <span class="text-muted text-xs">${total} entr${total === 1 ? "y" : "ies"}${pages > 1 ? html` · page ${page + 1} of ${pages}` : ""}</span>
+    <select aria-label=${label + ": rows per page"} value=${String(size)}
+            onChange=${(e) => onSize(Number(e.target.value))}>
+        ${PAGE_SIZES.map((n) => html`<option value=${String(n)}>${n} rows</option>`)}
+    </select>
+    <button type="button" class="btn-range" disabled=${page <= 0} aria-label=${label + ": previous page"}
+            onClick=${() => onPage(page - 1)}>‹ Prev</button>
+    <button type="button" class="btn-range" disabled=${page >= pages - 1} aria-label=${label + ": next page"}
+            onClick=${() => onPage(page + 1)}>Next ›</button>
+</div>`;
 
 // Epoch seconds -> local "YYYY-MM-DD HH:MM:SS"-style string; blank for a missing/zero ts.
 export function fmtEpoch(ts) {
@@ -109,7 +102,7 @@ export function fmtEpoch(ts) {
   return new Date(ts * 1000).toLocaleString();
 }
 
-const AccessCard = ({ access, filters, onFilters }) => {
+const AccessCard = ({ access, filters, onFilters, pager, onPager }) => {
   if (!access) return null;
   if (!access.available) {
     return html`<div class="card">
@@ -119,11 +112,7 @@ const AccessCard = ({ access, filters, onFilters }) => {
     </div>`;
   }
   const failures = access.failures_24h || 0;
-  // A filtered view shows every match the server returned (its read is already bounded); only
-  // the unfiltered glance keeps the short tail so the card stays a glance.
-  const shown = isFiltering(filters)
-    ? access.entries || []
-    : (access.entries || []).slice(0, ACCESS_LIMIT_SHOWN);
+  const pg = pageFor(access.entries || [], pager.page, pager.size);
   return html`<div class="card">
       <h3>Access log</h3>
       <${LogControls} label="Access log filter" filters=${filters} onChange=${onFilters} />
@@ -142,13 +131,19 @@ const AccessCard = ({ access, filters, onFilters }) => {
           : null
       }
       ${
-        shown.length === 0 && isFiltering(filters)
-          ? html`<p class="text-muted">No entries match this filter.</p>`
-          : html`<div class="table-scroll">
+        pg.total === 0
+          ? html`<p class="text-muted">${
+              isFiltering(filters) ? "No entries match this filter." : "No requests logged yet."
+            }</p>`
+          : html`<div>
+          <${Pager} label="Access log" total=${pg.total} page=${pg.page} pages=${pg.pages}
+                    size=${pager.size} onPage=${(page) => onPager({ ...pager, page })}
+                    onSize=${(size) => onPager({ size, page: 0 })} />
+          <div class="table-scroll">
           <table>
               <thead><tr><th>Time</th><th>Status</th><th>Method</th><th>Path</th><th>User</th></tr></thead>
               <tbody>
-                  ${shown.map(
+                  ${pg.slice.map(
                     (e) => html`<tr>
                         <td>${fmtEpoch(e.ts)}</td>
                         <td class=${e.status === 401 ? "status-bad" : ""}>${e.status || "?"}</td>
@@ -159,6 +154,7 @@ const AccessCard = ({ access, filters, onFilters }) => {
                   )}
               </tbody>
           </table>
+          </div>
       </div>`
       }
   </div>`;
@@ -174,45 +170,32 @@ const AuditRow = (e) => html`<tr>
     <td class="font-mono">${e.keys}</td>
 </tr>`;
 
-const AuditCard = ({ audit, group, onGroupChange, filters, onFilters }) => {
+const AuditCard = ({ audit, filters, onFilters, pager, onPager }) => {
   // null = control channel off (the /api/audit route 404s) — no card at all.
   if (!audit) return null;
+  const pg = pageFor(audit, pager.page, pager.size);
   return html`<div class="card">
-      <div class="card-header-row">
-          <h3>Recent config changes</h3>
-          ${
-            audit.length > 0 || isFiltering(filters)
-              ? html`<select aria-label="Group audit trail by" value=${group} onChange=${(e) => onGroupChange(e.target.value)}>
-                  <option value="flat">All (newest first)</option>
-                  <option value="hour">Group by hour</option>
-                  <option value="day">Group by day</option>
-                  <option value="month">Group by month</option>
-              </select>`
-              : null
-          }
-      </div>
+      <h3>Recent config changes</h3>
       <${LogControls} label="Config-change filter" filters=${filters} onChange=${onFilters} />
       ${
-        audit.length === 0
+        pg.total === 0
           ? html`<p class="text-muted">${
               isFiltering(filters)
                 ? "No entries match this filter."
                 : "No config changes have gone through the dashboard yet."
             }</p>`
-          : html`<div class="table-scroll">
+          : html`<div>
+              <${Pager} label="Config changes" total=${pg.total} page=${pg.page} pages=${pg.pages}
+                        size=${pager.size} onPage=${(page) => onPager({ ...pager, page })}
+                        onSize=${(size) => onPager({ size, page: 0 })} />
+              <div class="table-scroll">
               <table>
                   <thead><tr><th>Time (UTC)</th><th>User</th><th>Action</th><th>Outcome</th><th>Settings</th></tr></thead>
                   <tbody>
-                      ${groupAuditEntries(audit, group).flatMap((g) => [
-                        g.bucket !== null
-                          ? html`<tr class="audit-group-header">
-                              <td colspan="5">${g.bucket} (${g.entries.length})</td>
-                          </tr>`
-                          : null,
-                        ...g.entries.map(AuditRow),
-                      ])}
+                      ${pg.slice.map(AuditRow)}
                   </tbody>
               </table>
+              </div>
           </div>`
       }
   </div>`;
@@ -221,28 +204,30 @@ const AuditCard = ({ audit, group, onGroupChange, filters, onFilters }) => {
 export class SecurityPanel extends Component {
   constructor(props) {
     super(props);
-    // auditGroup: "flat" (today's plain newest-first list) is the default so existing behavior
-    // doesn't change until the operator opts into grouping (#530). Each card carries its own
-    // #823 filter state — following the access log and pinning down one config change are
-    // different investigations.
+    // Each card carries its own #823 filter state — following the access log and pinning down
+    // one config change are different investigations — plus its own pager (page resets to 0
+    // whenever the filter changes; a new question starts at its first page).
     this.state = {
       access: null,
       audit: null,
-      auditGroup: "flat",
       accessFilters: { ...EMPTY_FILTERS },
       auditFilters: { ...EMPTY_FILTERS },
+      accessPager: { page: 0, size: 20 },
+      auditPager: { page: 0, size: 20 },
       error: null,
     };
-    this.setAuditGroup = (group) => this.setState({ auditGroup: group });
     // Search keystrokes debounce (300 ms) so each letter doesn't hit the endpoint; preset and
     // date changes apply immediately — they are single deliberate clicks.
     this.setAccessFilters = (f) => this.applyFilters("access", "accessFilters", f);
     this.setAuditFilters = (f) => this.applyFilters("audit", "auditFilters", f);
+    this.setAccessPager = (pager) => this.setState({ accessPager: pager });
+    this.setAuditPager = (pager) => this.setState({ auditPager: pager });
   }
 
   applyFilters(which, key, filters) {
     const prev = this.state[key];
-    this.setState({ [key]: filters });
+    const pagerKey = which === "access" ? "accessPager" : "auditPager";
+    this.setState({ [key]: filters, [pagerKey]: { ...this.state[pagerKey], page: 0 } });
     clearTimeout(this._debounce?.[which]);
     const run = () => this.refetch(which, filters);
     if (filters.q !== prev.q) {
@@ -294,12 +279,14 @@ export class SecurityPanel extends Component {
   }
 
   render() {
-    const { access, audit, auditGroup, accessFilters, auditFilters, error } = this.state;
+    const { access, audit, accessFilters, auditFilters, accessPager, auditPager, error } =
+      this.state;
     if (error) return html`<div class="card"><p class="status-bad">${error}</p></div>`;
     return html`<div class="grid">
-        <${AccessCard} access=${access} filters=${accessFilters} onFilters=${this.setAccessFilters} />
-        <${AuditCard} audit=${audit} group=${auditGroup} onGroupChange=${this.setAuditGroup}
-                      filters=${auditFilters} onFilters=${this.setAuditFilters} />
+        <${AccessCard} access=${access} filters=${accessFilters} onFilters=${this.setAccessFilters}
+                       pager=${accessPager} onPager=${this.setAccessPager} />
+        <${AuditCard} audit=${audit} filters=${auditFilters} onFilters=${this.setAuditFilters}
+                      pager=${auditPager} onPager=${this.setAuditPager} />
     </div>`;
   }
 }

--- a/build/dashboard/tests/frontend/securityview.test.mjs
+++ b/build/dashboard/tests/frontend/securityview.test.mjs
@@ -12,10 +12,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  bucketKey,
   buildLogQuery,
   fmtEpoch,
-  groupAuditEntries,
+  pageFor,
   SecurityPanel,
 } from "../../mining_dashboard/web/static/securityview.mjs";
 import { renderToString } from "./helpers/render.mjs";
@@ -25,9 +24,11 @@ import { renderToString } from "./helpers/render.mjs";
 function renderPanel(state) {
   const panel = new SecurityPanel({});
   panel.state = {
-    access: null, audit: null, auditGroup: "flat", error: null,
+    access: null, audit: null, error: null,
     accessFilters: { preset: "all", fromDate: "", toDate: "", q: "" },
     auditFilters: { preset: "all", fromDate: "", toDate: "", q: "" },
+    accessPager: { page: 0, size: 20 },
+    auditPager: { page: 0, size: 20 },
     ...state,
   };
   return renderToString(panel.render());
@@ -112,93 +113,53 @@ test("fetch error surfaces as a message, not a blank panel", () => {
   assert.match(out, /fetch failed/);
 });
 
-// #530: hour/day/month grouping for the audit trail.
+// Pagination (#823 follow-up): the grouping dropdown became a rows-per-page control.
 
-test("bucketKey: hour/day/month slice the shared ts format; unknown granularity ignored by the caller", () => {
-  const ts = "2026-07-20T14:35:00Z";
-  assert.equal(bucketKey(ts, "hour"), "2026-07-20T14");
-  assert.equal(bucketKey(ts, "day"), "2026-07-20");
-  assert.equal(bucketKey(ts, "month"), "2026-07");
-  assert.equal(bucketKey(42, "day"), ""); // non-string ts never throws
+test("pageFor: slices, clamps past-the-end pages, and reports totals", () => {
+  const entries = Array.from({ length: 23 }, (_, i) => ({ n: i }));
+  const p0 = pageFor(entries, 0, 10);
+  assert.deepEqual([p0.page, p0.pages, p0.total, p0.slice.length], [0, 3, 23, 10]);
+  const last = pageFor(entries, 2, 10);
+  assert.equal(last.slice.length, 3); // the short final page
+  // A page past the end (result set shrank under a filter) clamps to the last real page.
+  const clamped = pageFor(entries, 9, 10);
+  assert.equal(clamped.page, 2);
+  // Empty set: one empty page, never NaN/negative.
+  const empty = pageFor([], 0, 10);
+  assert.deepEqual([empty.page, empty.pages, empty.total], [0, 1, 0]);
 });
 
-test("groupAuditEntries: flat/unknown granularity returns one ungrouped run", () => {
-  const entries = [{ ts: "2026-07-20T00:00:00Z" }, { ts: "2026-07-19T00:00:00Z" }];
-  assert.deepEqual(groupAuditEntries(entries, "flat"), [{ bucket: null, entries }]);
-  assert.deepEqual(groupAuditEntries(entries, undefined), [{ bucket: null, entries }]);
-});
-
-test("groupAuditEntries: contiguous same-day entries collapse into one bucket", () => {
-  const entries = [
-    { ts: "2026-07-20T14:00:00Z", actor: "a" },
-    { ts: "2026-07-20T09:00:00Z", actor: "b" },
-    { ts: "2026-07-19T23:00:00Z", actor: "c" },
-  ];
-  const groups = groupAuditEntries(entries, "day");
-  assert.equal(groups.length, 2);
-  assert.equal(groups[0].bucket, "2026-07-20");
-  assert.equal(groups[0].entries.length, 2);
-  assert.equal(groups[1].bucket, "2026-07-19");
-  assert.equal(groups[1].entries.length, 1);
-});
-
-test("groupAuditEntries: month grouping spans multiple days in one bucket", () => {
-  const entries = [
-    { ts: "2026-07-20T00:00:00Z" },
-    { ts: "2026-07-01T00:00:00Z" },
-    { ts: "2026-06-30T00:00:00Z" },
-  ];
-  const groups = groupAuditEntries(entries, "month");
-  assert.deepEqual(
-    groups.map((g) => [g.bucket, g.entries.length]),
-    [
-      ["2026-07", 2],
-      ["2026-06", 1],
-    ],
-  );
-});
-
-test("audit card: default flat grouping shows no group-header row (unchanged row output)", () => {
+test("cards render the pager: count, rows-per-page select, prev/next with edge disabling", () => {
   const out = renderPanel({
-    access: { available: true, entries: [] },
+    access: { available: true, entries: Array.from({ length: 23 }, (_, i) => ({
+      ts: 1000 + i, status: 200, method: "GET", uri: `/p/${i}`, user: "u" })) },
     audit: [{ ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "XVB_ENABLED" }],
+    accessPager: { page: 1, size: 10 },
   });
-  assert.doesNotMatch(out, /audit-group-header/);
-  assert.match(out, /XVB_ENABLED/);
+  assert.match(out, /23 entries · page 2 of 3/);
+  assert.match(out, /aria-label="Access log: rows per page"/);
+  assert.match(out, /‹ Prev/);
+  assert.match(out, /Next ›/);
+  // Middle page: neither edge disabled on the access pager; the single-page audit pager
+  // disables both (vnode walker serializes boolean true as a bare attribute).
+  assert.match(out, /1 entry(?! · page)/); // audit count, no page suffix on one page
+  // Page 2 of 3 shows rows 10-19.
+  assert.match(out, /\/p\/10/);
+  assert.doesNotMatch(out, /\/p\/9</);
+  assert.doesNotMatch(out, /\/p\/20/);
 });
 
-test("audit card: grouping select appears once there are entries, with the current group selected", () => {
+test("audit card renders flat rows only — grouping artifacts are gone", () => {
   const out = renderPanel({
     access: { available: true, entries: [] },
-    audit: [{ ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "XVB_ENABLED" }],
-    auditGroup: "day",
-  });
-  assert.match(out, /<select/);
-  assert.match(out, /Group by day/);
-  // Accessibility parity (#530 review): a bare <select> with no associated <label> has no
-  // accessible name for a screen reader — every other select/group control in this codebase
-  // carries one (role=group aria-label, or a <label for>, see xvb-tier-select).
-  assert.match(out, /aria-label="Group audit trail by"/);
-});
-
-test("audit card: day grouping renders one header row per distinct day, spanning the table", () => {
-  const out = renderPanel({
-    access: { available: true, entries: [] },
-    auditGroup: "day",
     audit: [
       { ts: "2026-07-20T12:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "A" },
       { ts: "2026-07-19T08:00:00Z", actor: "admin", action: "commit", status: "applied", keys: "B" },
     ],
   });
-  assert.match(out, /class="audit-group-header"/);
-  assert.match(out, /colspan="5"/);
-  assert.match(out, /2026-07-20 \(1\)/);
-  assert.match(out, /2026-07-19 \(1\)/);
-});
-
-test("audit card: empty list shows no grouping select (nothing to group)", () => {
-  const out = renderPanel({ access: { available: true, entries: [] }, audit: [] });
-  assert.doesNotMatch(out, /<select/);
+  assert.doesNotMatch(out, /audit-group-header/);
+  assert.doesNotMatch(out, /Group audit trail by/);
+  assert.match(out, /XVB|A/);
 });
 
 // --- Log navigation (#823) -------------------------------------------------------------
@@ -235,17 +196,17 @@ test('both cards render the shared filter controls with the active preset marked
   assert.match(html, /type="search"/);
 });
 
-test('a filtered view shows every match and an honest empty message (#823)', () => {
-  // Filtered: the 20-row glance cap is lifted (server already bounded the read).
+test('filtered results page like everything else, with honest empty messages (#823)', () => {
+  // 30 matches at 20/page: page 1 shows rows 0-19, the pager owns the rest — no silent cap.
   const many = access({ entries: Array.from({ length: 30 }, (_, i) => ({
     ts: 1000 + i, status: 200, method: 'GET', uri: `/p/${i}`, user: 'u' })) });
   const filtered = renderPanel({
     access: many,
     accessFilters: { preset: '7d', fromDate: '', toDate: '', q: '' },
   });
-  assert.match(filtered, /\/p\/29/); // the 30th row renders under a filter
-  const glance = renderPanel({ access: many });
-  assert.doesNotMatch(glance, /\/p\/29/); // unfiltered keeps the glance cap
+  assert.match(filtered, /30 entries · page 1 of 2/);
+  assert.match(filtered, /\/p\/19/);
+  assert.doesNotMatch(filtered, /\/p\/29/); // page 2's rows wait behind Next
   // No matches under a filter says so, instead of the no-changes-yet copy.
   const empty = renderPanel({
     access: access({ entries: [] }),

--- a/build/dashboard/tests/frontend/securityview.test.mjs
+++ b/build/dashboard/tests/frontend/securityview.test.mjs
@@ -127,6 +127,16 @@ test("pageFor: slices, clamps past-the-end pages, and reports totals", () => {
   // Empty set: one empty page, never NaN/negative.
   const empty = pageFor([], 0, 10);
   assert.deepEqual([empty.page, empty.pages, empty.total], [0, 1, 0]);
+  // Hostile size/page inputs fall back instead of dividing into NaN/Infinity.
+  for (const badSize of [0, -5, NaN, undefined]) {
+    const g = pageFor(entries, 0, badSize);
+    assert.deepEqual([g.pages, g.slice.length], [2, 20], `size=${badSize} must fall back to 20`);
+  }
+  assert.equal(pageFor(entries, NaN, 10).page, 0);
+  assert.equal(pageFor(entries, -999, 10).page, 0);
+  // The clamp is the safety net behind every pager callback: a stale page (result set shrank,
+  // size grew, a reset that never fired) lands on the last REAL page, never off the end.
+  assert.equal(pageFor(entries, 5, 100).page, 0);
 });
 
 test("cards render the pager: count, rows-per-page select, prev/next with edge disabling", () => {
@@ -140,13 +150,27 @@ test("cards render the pager: count, rows-per-page select, prev/next with edge d
   assert.match(out, /aria-label="Access log: rows per page"/);
   assert.match(out, /‹ Prev/);
   assert.match(out, /Next ›/);
-  // Middle page: neither edge disabled on the access pager; the single-page audit pager
-  // disables both (vnode walker serializes boolean true as a bare attribute).
+  // Edge disabling, actually asserted (vnode walker serializes boolean true as a bare
+  // attribute and DROPS false), scoped per pager via its aria-label: the middle-page access
+  // pager disables neither button, the single-page audit pager disables both.
+  assert.doesNotMatch(out, /disabled aria-label="Access log: previous page"/);
+  assert.doesNotMatch(out, /disabled aria-label="Access log: next page"/);
+  assert.match(out, /disabled aria-label="Config changes: previous page"/);
+  assert.match(out, /disabled aria-label="Config changes: next page"/);
   assert.match(out, /1 entry(?! · page)/); // audit count, no page suffix on one page
   // Page 2 of 3 shows rows 10-19.
   assert.match(out, /\/p\/10/);
   assert.doesNotMatch(out, /\/p\/9</);
   assert.doesNotMatch(out, /\/p\/20/);
+  // ...and on the last page, Next is disabled while Prev stays live.
+  const lastPage = renderPanel({
+    access: { available: true, entries: Array.from({ length: 23 }, (_, i) => ({
+      ts: 1000 + i, status: 200, method: "GET", uri: `/p/${i}`, user: "u" })) },
+    audit: null,
+    accessPager: { page: 2, size: 10 },
+  });
+  assert.match(lastPage, /disabled aria-label="Access log: next page"/);
+  assert.doesNotMatch(lastPage, /disabled aria-label="Access log: previous page"/);
 });
 
 test("audit card renders flat rows only — grouping artifacts are gone", () => {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -817,8 +817,9 @@ the "to" date covers that whole day — and a search box that matches any field:
 a path fragment, a status, a settings name. Filters compose (a search inside a range searches only
 that range), the search narrows as you type, and filtering happens on the server, so a match
 deeper than the on-screen tail is still found — the access log's read stays size-bounded either
-way. A filter with no matches says so; the failed-login counter always describes the whole log,
-never the filtered slice.
+way. Below the row, a pager reports how many entries matched and walks them a page at a time —
+pick 5 to 100 rows per page, step with Prev/Next. A filter with no matches says so; the
+failed-login counter always describes the whole log, never the filtered slice.
 
 Both panels read host-written files through read-only mounts, and the dashboard treats every
 field in them as hostile input — a request path is attacker-chosen bytes — so each string is


### PR DESCRIPTION
Follow-up to #838, per operator direction: with range presets, date jumps and search owning the time navigation, the hour/day/month grouping dropdown answered a strictly weaker question — it becomes a **pager**.

- Each log card now shows **"N entries · page X of Y"** (the match-feedback line), a **5/10/20/50/100 rows-per-page** select, and **Prev/Next** buttons with edge disabling.
- Paging is client-side over the server-filtered, bounded result set. `pageFor` clamps so a shrinking result set never strands the view past the end; the page resets to 0 on any filter change.
- Both cards page identically — the access card's filtered-vs-glance cap split dies along with the grouping machinery (`bucketKey`, `groupAuditEntries`, the group-header rows and their CSS). Net: the diff deletes more logic than it adds.
- The audit handler docstring and `docs/dashboard.md` updated to match; deep history stays a documented pointer to the host files rather than dashboard scope.

Coverage: `pageFor` unit tests (slicing, clamping, empty-set), pager render tests (count line, per-page select, edge disabling, page-2 slice boundaries), flat-audit-rendering regression, and the #838 filter tests updated to the paging model. Frontend suite green (14/14 securityview + full run), dashboard 1649 pass, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)