### PR TITLE
ci(appliance): rootfs CVE scan, Dependabot base-digest tracking, pinned-binary watch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,12 @@ updates:
       - dependency-name: "grpcio"
         update-types: ["version-update:semver-major"]
 
-  # Base-image digests across every build/* Dockerfile (incl. the uv build image). This is the
-  # mechanism that clears base-distro CVEs — e.g. the openssl point-release accepted in .trivyignore.
+  # Base-image digests across every build/* Dockerfile (incl. the uv build image) and the
+  # appliance rootfs (#833). This is the mechanism that clears base-distro CVEs — e.g. the
+  # openssl point-release accepted in .trivyignore. For the appliance the stakes are higher:
+  # its Debian userland has no apt at runtime, so the digest bump + rebake IS its patch channel.
+  # Dependabot reads this file on the default branch only, so os/rootfs coverage starts when
+  # the appliance tree merges; until then os-rootfs.yml's scan on os/** PRs is the eye on it.
   - package-ecosystem: "docker"
     directories:
       - "/build/dashboard"
@@ -37,6 +41,7 @@ updates:
       - "/build/p2pool"
       - "/build/tor"
       - "/build/xmrig-proxy"
+      - "/os/rootfs"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -1,0 +1,70 @@
+name: OS rootfs scan
+
+# Build the appliance rootfs (os/rootfs/Dockerfile) and Trivy-scan it (#833). The appliance's
+# Debian userland — podman, netavark, openssl, the kernel — is frozen at bake time and has no
+# apt at runtime, so this scan is the eye on the base OS between releases. Runs on PRs that
+# touch os/ and weekly on a schedule; a red scheduled run in the Actions tab is the alert, the
+# lychee.yml posture. It is its own workflow (not a build-images matrix entry in ci.yml)
+# because the xmrig prebuild makes this the slowest image in the repo — the paths filter keeps
+# it off stack-only PRs.
+on:
+  pull_request:
+    paths:
+      - "os/**"
+      - ".github/workflows/os-rootfs.yml"
+      - ".trivyignore"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC, after ci.yml's 05:00 image sweep
+  workflow_dispatch:
+
+# Least privilege (#282): read-only, same as ci.yml.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  rootfs-image:
+    name: Build + scan the appliance rootfs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check the appliance tree exists
+        # Scheduled runs use the default branch; until the appliance tree merges there, skip
+        # quietly instead of going red every Monday for a directory that cannot exist yet.
+        id: tree
+        run: |
+          if [ -f os/rootfs/Dockerfile ]; then
+            echo "present=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "present=false" >>"$GITHUB_OUTPUT"
+            echo "os/rootfs/Dockerfile not on this branch; nothing to scan"
+          fi
+      - name: docker build os/rootfs
+        if: steps.tree.outputs.present == 'true'
+        # BUILD_COMMIT is a build artifact (os/build-image.sh stamps it; the Dockerfile COPYs
+        # it), so stamp it here too. PITHEAD_UPDATER=rauc matches build-image.sh's default so
+        # the scan covers the updater packages; the test args stay empty — release variant.
+        # images/ holds only .keep here: the staged wizard image is a separate scan target
+        # (ci.yml builds and scans the dashboard image directly).
+        run: |
+          git rev-parse HEAD > os/rootfs/BUILD_COMMIT
+          docker build -f os/rootfs/Dockerfile -t pithead-os-rootfs:ci \
+            --build-arg PITHEAD_UPDATER=rauc .
+      - name: Scan rootfs for CVEs (Trivy)
+        if: steps.tree.outputs.present == 'true'
+        # Same gate as ci.yml's image scan: actionable (fixable) HIGH/CRITICAL only; accepted
+        # findings live in .trivyignore with a rationale and how they clear.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: pithead-os-rootfs:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -1,0 +1,63 @@
+name: Pinned binary watch
+
+# The rootfs pins two binaries Dependabot has no ecosystem for (#833): docker-compose (the
+# compose provider podman delegates to) and cosign. Weekly, compare each pin in
+# os/rootfs/Dockerfile against the upstream latest release and open one issue per stale pin —
+# skipping when an open issue for that binary already exists, so a pin we are deliberately
+# sitting on nags exactly once. RigForge's pin is excluded on purpose: moving it to a tagged
+# release is #821. Runs on the default branch only (schedules always do); until the appliance
+# tree merges there, the guard below makes every run a quiet no-op.
+on:
+  schedule:
+    - cron: "30 6 * * 1" # Mondays 06:30 UTC, after the image sweeps
+  workflow_dispatch:
+
+# Least privilege (#282): issues.write is the job's one output — it never pushes or publishes.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  pin-watch:
+    name: Compare rootfs binary pins against upstream releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check pins against latest upstream releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ ! -f os/rootfs/Dockerfile ]; then
+            echo "os/rootfs/Dockerfile not on this branch; nothing to watch"
+            exit 0
+          fi
+
+          check() {
+            name="$1" upstream="$2" pinned="$3"
+            latest=$(gh api "repos/${upstream}/releases/latest" --jq .tag_name)
+            if [ "$latest" = "$pinned" ]; then
+              echo "${name}: ${pinned} is current"
+              return 0
+            fi
+            open=$(gh issue list --state open --search "in:title \"${name}: pinned\"" \
+              --json number --jq length)
+            if [ "$open" -gt 0 ]; then
+              echo "${name}: stale (${pinned} -> ${latest}) — an issue is already open"
+              return 0
+            fi
+            gh issue create \
+              --title "${name}: pinned ${pinned}, upstream released ${latest}" \
+              --label appliance --label infra \
+              --body "Weekly pin-watch (#833): \`os/rootfs/Dockerfile\` pins ${name} at \`${pinned}\`; upstream's latest release is \`${latest}\` (https://github.com/${upstream}/releases). Bumping means updating both the version ARG and its sha256 ARG in the Dockerfile. If the pin is being held back on purpose, say why here and leave this open — the watcher will not file a duplicate while it is."
+            echo "${name}: stale (${pinned} -> ${latest}) — issue filed"
+          }
+
+          compose_pin=$(sed -n 's/^ARG COMPOSE_VERSION=//p' os/rootfs/Dockerfile)
+          cosign_pin=$(sed -n 's/^ARG COSIGN_VERSION=//p' os/rootfs/Dockerfile)
+          test -n "$compose_pin" && test -n "$cosign_pin"
+          check docker-compose docker/compose "$compose_pin"
+          check cosign sigstore/cosign "$cosign_pin"

--- a/.trivyignore
+++ b/.trivyignore
@@ -12,3 +12,15 @@ CVE-2026-45447
 # /app/.venv and never invoked at runtime (the entrypoint runs the venv's python). Cleared by a base bump.
 CVE-2026-23949
 CVE-2026-24049
+
+# Appliance rootfs pinned binaries (docker-compose v5.3.1, cosign v3.1.2 — BOTH already the
+# latest upstream releases, byte-verified): these three sit in Go modules VENDORED inside those
+# binaries, so no pin bump can clear them until upstream cuts releases on the fixed modules.
+# Cleared when pin-watch flags the next compose/cosign releases — bump the pins, drop these.
+# golang.org/x/text norm.Iter infinite loop (both binaries):
+CVE-2026-56852
+# github.com/docker/docker authz bypass, vendored in compose (server-side moby code, and the
+# appliance talks to podman's compat socket, not dockerd — no exposed authz plugin path here):
+CVE-2026-34040
+# Go stdlib (both binaries built with go1.26.4; clears with upstream rebuilds):
+CVE-2026-39822

--- a/.trivyignore
+++ b/.trivyignore
@@ -24,3 +24,6 @@ CVE-2026-56852
 CVE-2026-34040
 # Go stdlib (both binaries built with go1.26.4; clears with upstream rebuilds):
 CVE-2026-39822
+# google.golang.org/grpc vendored in both pinned binaries (GHSA id — Trivy gates on it like a
+# CVE; same clearing condition as the three above: upstream rebuilds on the fixed module):
+GHSA-hrxh-6v49-42gf

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -246,6 +246,15 @@ kind of update.
 Your data is never part of an update. Wallets, settings and the chain live on a separate
 partition that updates and rollbacks do not touch.
 
+Security fixes travel the same road. There is no package manager on the machine and
+nothing for you to patch by hand: every piece of the operating system — Debian itself,
+the container engine, the mining programs — is fixed at the moment the image is built,
+and a security fix reaches your machine as the next image, with the same
+install-then-fall-back protection as any other update. The practical consequence:
+**taking updates when they are offered is the security maintenance.** A machine left on
+an old image keeps running fine, but it keeps the old image's known holes too. The base
+system is Debian 13, which receives security support upstream into 2030.
+
 ## If something goes wrong
 
 **The machine will not boot from the stick.** Almost always Secure Boot — disable it in

--- a/docs/dev/dual-distribution-plan.md
+++ b/docs/dev/dual-distribution-plan.md
@@ -403,6 +403,14 @@ image per cut on the #54 matrix, same mandate as the targeted e2e.
 - Upgrade path: N→N+1 always; skip-version best-effort.
 - Two channels (stable/beta); appliance supported on the #54-validated matrix,
   best-effort elsewhere.
+- Security cadence (#833): the appliance's Debian userland has no apt at runtime, so
+  **bake cadence is patch cadence** — a merged fix does nothing for a fleet until an
+  os-image release ships it. The watchers: Dependabot tracks every base digest
+  (`build/*`, `docker-compose.yml`, `os/rootfs`), the weekly CI sweeps rebuild and
+  Trivy-scan the stack images (ci.yml) and the rootfs (os-rootfs.yml), and
+  pin-watch.yml files an issue when a hand-pinned binary (docker-compose, cosign)
+  falls behind upstream. A security-relevant bump landing on the integration branch
+  is a release trigger, not just a green check.
 
 ## Repo outline (target state)
 
@@ -723,7 +731,7 @@ not by argument. Rugix booting first is an accident of order, not a decision: it
 no default status, and no further updater-specific work lands until this runs.
 
 **Why a bake-off is affordable at all:** the rootfs is updater-agnostic by design
-(`os/rootfs/Containerfile` contains zero updater knowledge), so each candidate consumes
+(`os/rootfs/Dockerfile` contains zero updater knowledge), so each candidate consumes
 the *same* exported tarball. The candidate-specific surface is small — Rugix is ~150
 lines of TOML in `os/bakery/` plus ~30 lines of harness commands.
 

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -90,7 +90,7 @@ echo "==> building from commit ${BUILD_COMMIT}${BUILD_DIRTY}"
 ROOTFS_TAG="${PITHEAD_ROOTFS_TAG:-pithead-os-rootfs}"
 
 echo "==> rootfs: container build + export"
-docker build -f os/rootfs/Containerfile -t "$ROOTFS_TAG" \
+docker build -f os/rootfs/Dockerfile -t "$ROOTFS_TAG" \
     --build-arg PITHEAD_TEST_SSH_PUBKEY="${PITHEAD_TEST_SSH_PUBKEY:-}" \
     --build-arg PITHEAD_TEST_MARKER="${PITHEAD_TEST_MARKER:-}" \
     --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" .

--- a/os/rauc/populate-slot.sh
+++ b/os/rauc/populate-slot.sh
@@ -27,7 +27,7 @@ populate_slot() { # $1 = mounted rootfs
     } >"$root/etc/hosts"
     ln -sf ../run/systemd/resolve/stub-resolv.conf "$root/etc/resolv.conf"
     # /etc/hostname is the FOURTH bind-mount artefact: docker overlays it per container, so the
-    # Containerfile's write never left the build. The machine then calls itself "localhost",
+    # rootfs Dockerfile's write never left the build. The machine then calls itself "localhost",
     # avahi publishes localhost.local, and caddy renders a site nobody can reach.
     echo 'pithead' >"$root/etc/hostname"
 

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -3,7 +3,14 @@
 # Debian 13 + systemd + rootful Podman; pithead is the provisioning brain, Quadlet the runtime.
 # Deliberately updater-agnostic: nothing in here knows about Rugix — the RAUC escape hatch
 # stays open (docs/dev/dual-distribution-plan.md § appliance architecture).
-FROM debian:trixie-slim
+#
+# This file is named Dockerfile, not Containerfile, so Dependabot's docker ecosystem tracks the
+# base digest below (it only reads Dockerfile-named files — dependabot-core#6067); nothing else
+# cares about the name, build-image.sh passes the path with -f.
+# Pinned by digest (#135) so the debian:trixie-slim tag can't be silently re-pointed. The digest
+# bump is how base-distro CVE fixes reach the appliance (#833): there is no apt on the running
+# box — every Debian package here is frozen until the next bake.
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## What & why

The appliance-side items of the update strategy (#833). The appliance's Debian userland has no apt at runtime — every package is frozen until the next bake — so its update story needs watchers on the supply chain, not `unattended-upgrades`:

- **`os/rootfs/Containerfile` → `os/rootfs/Dockerfile`**: Dependabot's docker ecosystem only reads `Dockerfile`-named files ([dependabot-core#6067](https://github.com/dependabot/dependabot-core/issues/6067)); `build-image.sh` passes the path with `-f`, so nothing else cares about the name. All references updated.
- **Digest-pinned the base**: `debian:trixie-slim` is now pinned by digest like every `build/*` image (#135), and `/os/rootfs` joins the `docker` ecosystem in `dependabot.yml` — the digest bump is how base-distro CVE fixes reach the appliance. Coverage starts when this tree reaches the default branch (Dependabot reads the config there); until then the new scan below is the eye on it.
- **`os-rootfs.yml` (new)**: builds the rootfs and Trivy-scans it with `ci.yml`'s exact gate (fixable HIGH/CRITICAL, `--ignore-unfixed`, `.trivyignore`), on `os/**` PRs and weekly. Its own workflow rather than a `build-images` matrix entry: the xmrig prebuild makes it the slowest image in the repo, and the paths filter keeps it off stack-only PRs. Scheduled runs skip quietly until the appliance tree merges to the default branch.
- **`pin-watch.yml` (new)**: weekly compare of the `docker-compose` and `cosign` pins in the rootfs Dockerfile against upstream's latest release; files one `appliance`+`infra`-labeled issue per stale pin, and never a duplicate while one is open. RigForge's pin is excluded on purpose — repinning it to a tagged release is #821.
- **Docs**: `appliance.md`'s Updates section now tells operators that taking updates *is* the security maintenance (there is no package manager on the box); the dual-distribution plan's support policy records the maintainer side — bake cadence is patch cadence, and a security-relevant bump is a release trigger.

This PR itself triggers the new rootfs scan (the paths filter matches), so the workflow validates against the real build. If Trivy flags fixable HIGH/CRITICALs in current trixie packages, they need `.trivyignore` entries with rationale — visible in this PR's checks.

## Related issue

Part of #833 — the appliance-side items (1, 2, 5, 7, and the item-4 policy as documentation). Items 3 and 6 landed on `develop` via #837.

## Checklist

- [x] `make test` passes locally (lint + dashboard pytest ≥ coverage gate + `pithead` shell suite + compose validation) — shell suite 1907 passed / 0 failed on this branch, yamllint (incl. both new workflows) + markdownlint + docs-voice + shellcheck/shfmt + zizmor all clean; the Docker-daemon-dependent steps (`lint-proto`, compose validation, image builds) can't run in this sandbox and are covered by CI on this PR
- [x] `pithead` and test scripts are shellcheck-clean (no new warnings) — `make lint-sh` covers the touched `os/` scripts
- [x] Docs in `docs/` (and the README, if relevant) are updated for any user-facing change, in the house voice (`docs/dev/STYLE.md`) — `appliance.md` + `dual-distribution-plan.md`; `make lint-docs-voice` passes
- [x] New/changed behaviour is tested at the right tier (`docs/dev/testing-strategy.md`); patch coverage clears the gate — workflow YAML is validated by yamllint + zizmor, and the rootfs scan exercises itself on this PR; no Python/dashboard lines touched
- [x] This PR is focused on a single logical change
- [x] A linked issue exists for non-trivial changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFc4Z74jLpMoJMX3L3DaGP)_