### PR TITLE
fix(appliance): enforce Tor-only egress under podman/netavark, not just Docker

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -25,11 +25,25 @@ sync, then returns to Tor. It is off by default, loudly warned, and covered in f
 
 Every per-app Tor setting below is backed by a host firewall, so "behind Tor" is a property the
 stack enforces, not one it merely hopes each daemon is configured for. At `up`/`apply`, `pithead`
-installs rules in Docker's `DOCKER-USER` chain: the mining bridge (monerod, p2pool, tari,
+installs a fail-closed rule set on the mining subnet: the mining bridge (monerod, p2pool, tari,
 xmrig-proxy) may reach the LAN, the other containers, and the Tor SOCKS, but any direct dial to the
 public internet is DROPPED. Only the `tor` container reaches the internet. So if a daemon is
 misconfigured, buggy, or learns a clearnet peer address (as Tari's comms layer does), the connection
 fails closed instead of leaking your IP.
+
+The rules land where the running container engine actually filters forwarded traffic, which differs
+by channel:
+
+- **Docker (DIY channel):** the rules go in Docker's `DOCKER-USER` chain. Docker adds the
+  `FORWARD → DOCKER-USER` jump when it creates the network, so the chain is traversed on egress.
+- **podman + netavark (appliance):** netavark serves the forward hook from its own nftables table and
+  never adds a `DOCKER-USER` jump, so the same iptables rules would sit in a chain no packet reaches.
+  `pithead` instead installs an independent `inet pithead_egress` nftables table hooked at forward
+  priority −5 — ahead of netavark's blanket accept, owning no chain shared with netavark so it
+  survives netavark reprogramming its own table.
+
+`pithead doctor` reads whichever mechanism the running engine uses and checks the drop is in a chain
+that is actually hooked at forward, so it cannot report enforced while the rules are orphaned.
 
 - Needs root (the firewall rules), like the GRUB/HugePages steps; removed at `pithead down`.
 - Opt out with `network.tor_egress_firewall: false` (then routing falls back to per-app config only).

--- a/pithead
+++ b/pithead
@@ -291,7 +291,16 @@ stack_restart() { # [tor]
 # root (sudo), like the GRUB/HugePages steps; IPv4-only (mining_net is IPv4). Opt out with
 # network.tor_egress_firewall=false. Proven by tests/integration/benchmarks/bench-verify-egress.sh.
 # See docs/privacy.md.
+#
+# Two enforcement backends, one allow-set. Docker adds a `FORWARD -> DOCKER-USER` jump when it
+# creates a network, so on the DIY/Docker channel the rules live in DOCKER-USER (iptables). The
+# appliance runs podman + netavark, which never adds that jump — DOCKER-USER is orphaned there and
+# the DROP never fires. On the podman path we instead install an independent `inet pithead_egress`
+# nftables table hooked at forward priority -5 (ahead of netavark's priority-0 accept), owning no
+# chain shared with netavark so it survives netavark reprogramming its own table. apply/remove/doctor
+# all branch on container_engine.
 TOR_EGRESS_TAG="pithead-tor-egress"
+TOR_EGRESS_NFT_TABLE="pithead_egress"
 
 # Ordered iptables rule bodies (no chain/comment) for <subnet> <tor_ip>. Pure (args only) so it
 # unit-tests; ACCEPTs first, DROP last — the order is load-bearing.
@@ -307,8 +316,39 @@ tor_egress_rules() { # <subnet> <tor_ip>
         "-s $subnet -j DROP"
 }
 
-# Remove every rule we previously installed (matched by the comment tag) — idempotent, config-agnostic.
+# Full `nft -f` ruleset for the appliance/netavark path — same allow-set as tor_egress_rules, in
+# native nftables. Pure (args only) so it unit-tests. `add`+`delete` before the table body is the
+# canonical atomic idempotent-replace: `add table` no-ops if it already exists, `delete` then clears
+# it, and the block recreates it fresh — the whole file loads as one transaction. The base chain is
+# hooked at forward priority -5 so it evaluates before netavark's priority-0 blanket accept; a `drop`
+# there is terminal across the ruleset. accepts come first so LAN/Tor/established traffic skips the
+# final subnet-wide drop, mirroring the iptables order.
+render_tor_egress_nft() { # <subnet> <tor_ip>
+    local subnet="$1" tor_ip="$2"
+    printf '%s\n' \
+        "add table inet $TOR_EGRESS_NFT_TABLE" \
+        "delete table inet $TOR_EGRESS_NFT_TABLE" \
+        "table inet $TOR_EGRESS_NFT_TABLE {" \
+        "  chain forward {" \
+        "    type filter hook forward priority -5; policy accept;" \
+        "    ct state established,related accept" \
+        "    ip saddr $tor_ip accept" \
+        "    ip saddr $subnet ip daddr 10.0.0.0/8 accept" \
+        "    ip saddr $subnet ip daddr 172.16.0.0/12 accept" \
+        "    ip saddr $subnet ip daddr 192.168.0.0/16 accept" \
+        "    ip saddr $subnet ip daddr 100.64.0.0/10 accept" \
+        "    ip saddr $subnet drop" \
+        "  }" \
+        "}"
+}
+
+# Remove every rule we previously installed — idempotent, config-agnostic, engine-agnostic. Clears
+# BOTH backends so a re-apply (or an engine change) can't leave a stale set behind: drop the nft
+# table if present, then delete the tagged DOCKER-USER rules if present.
 remove_tor_egress_firewall() {
+    if command -v nft >/dev/null 2>&1; then
+        sudo nft delete table inet "$TOR_EGRESS_NFT_TABLE" 2>/dev/null || true
+    fi
     command -v iptables >/dev/null 2>&1 || return 0
     local saved match line
     saved=$(sudo iptables-save 2>/dev/null) || return 0
@@ -325,9 +365,10 @@ remove_tor_egress_firewall() {
 }
 
 # Install (or re-install, idempotently) the fail-closed Tor-only egress rules. Reads the toggle +
-# subnet from .env so it works in the `up` path (where config.json isn't re-parsed).
+# subnet from .env so it works in the `up` path (where config.json isn't re-parsed). Branches to the
+# engine's forward-hook mechanism: nftables under podman/netavark, DOCKER-USER under Docker.
 apply_tor_egress_firewall() {
-    local enabled subnet tor_ip pos=1 rule
+    local enabled subnet tor_ip
     enabled=$(env_get TOR_EGRESS_FIREWALL 2>/dev/null)
     [ -n "$enabled" ] || enabled=true
     remove_tor_egress_firewall # clear stale rules so a re-apply is idempotent
@@ -335,15 +376,39 @@ apply_tor_egress_firewall() {
         warn "Tor-only egress firewall is OFF (network.tor_egress_firewall=false) — a misconfigured app could reach clearnet."
         return 0
     fi
-    if ! command -v iptables >/dev/null 2>&1; then
-        warn "iptables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
-        return 0
-    fi
     subnet=$(env_get NETWORK_SUBNET 2>/dev/null)
     [ -n "$subnet" ] || subnet="172.28.0.0/24"
     tor_ip=$(env_get NETWORK_PREFIX 2>/dev/null)
     [ -n "$tor_ip" ] || tor_ip="172.28.0"
     tor_ip="${tor_ip}.25"
+    if [ "$(container_engine)" = "podman" ]; then
+        apply_tor_egress_nft "$subnet" "$tor_ip"
+    else
+        apply_tor_egress_iptables "$subnet" "$tor_ip"
+    fi
+}
+
+# Appliance/netavark path: load the independent nft table (atomic, idempotent-replace).
+apply_tor_egress_nft() { # <subnet> <tor_ip>
+    local subnet="$1" tor_ip="$2"
+    if ! command -v nft >/dev/null 2>&1; then
+        warn "nftables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
+        return 0
+    fi
+    if ! render_tor_egress_nft "$subnet" "$tor_ip" | sudo nft -f - 2>/dev/null; then
+        warn "Could not install the Tor-egress firewall (needs root + nftables). Stack runs, but clearnet egress is NOT fail-closed."
+        return 0
+    fi
+    log "Tor-only egress enforced: clearnet dials from $subnet dropped except via Tor ($tor_ip)."
+}
+
+# DIY/Docker path: insert the tagged rules into DOCKER-USER, which Docker jumps to from FORWARD.
+apply_tor_egress_iptables() { # <subnet> <tor_ip>
+    local subnet="$1" tor_ip="$2" pos=1 rule
+    if ! command -v iptables >/dev/null 2>&1; then
+        warn "iptables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
+        return 0
+    fi
     # DOCKER-USER may not exist yet on a first-ever `up` (Docker creates it with its first network).
     # Pre-create it so installing here — before compose runs — succeeds; Docker adopts the existing
     # chain and adds the FORWARD jump. Harmless (-N fails with rc 1) once the chain is already there.
@@ -3062,7 +3127,7 @@ check_tor_running() {
 # brings every container back — that reboot gap is the state this catches. Read-only: `sudo -n`
 # never prompts; every can't-check path degrades to an info line, only a confirmed absence FAILs.
 check_egress_firewall_installed() {
-    local enabled rules
+    local enabled
     enabled=$(env_get TOR_EGRESS_FIREWALL 2>/dev/null)
     [ -n "$enabled" ] || enabled=true
     if [ "$(normalize_bool "$enabled")" != "true" ]; then
@@ -3076,6 +3141,42 @@ check_egress_firewall_installed() {
         dr_info "Tor-egress firewall check skipped — the tor container isn't running."
         return 0
     fi
+    if [ "$(container_engine)" = "podman" ]; then
+        check_egress_firewall_nft
+    else
+        check_egress_firewall_iptables
+    fi
+    return 0
+}
+
+# Appliance/netavark probe. The failure this whole fix is about — a DROP that exists in a chain no
+# packet traverses — is exactly what a base chain hooked at forward CANNOT be: if the table carries a
+# `hook forward` chain with a `drop`, forwarded packets DO pass through it. So we assert the hook and
+# the drop, not merely that some rule exists somewhere.
+check_egress_firewall_nft() {
+    local ruleset
+    if ! command -v nft >/dev/null 2>&1; then
+        dr_info "Tor-egress firewall check skipped — no nftables."
+        return 0
+    fi
+    # `nft list table` returns rc 1 both when the table is missing AND when sudo -n is refused; a
+    # cheap `list tables` probe (succeeds whether or not our table exists) tells the two apart, so a
+    # sudo refusal can't masquerade as a missing firewall (a false FAIL).
+    if ! sudo -n nft list tables >/dev/null 2>&1; then
+        dr_info "Tor-egress firewall check skipped — reading nftables needs passwordless sudo. Verify manually: 'sudo nft list table inet $TOR_EGRESS_NFT_TABLE'."
+        return 0
+    fi
+    ruleset=$(sudo -n nft list table inet "$TOR_EGRESS_NFT_TABLE" 2>/dev/null) || ruleset=""
+    if printf '%s\n' "$ruleset" | grep -q 'hook forward' && printf '%s\n' "$ruleset" | grep -qw drop; then
+        dr_ok "Tor-only egress firewall is installed (#270) — clearnet dials from the stack are fail-closed via nftables (inet $TOR_EGRESS_NFT_TABLE)."
+    else
+        dr_fail "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them (#270)."
+    fi
+}
+
+# DIY/Docker probe: the tagged rules in DOCKER-USER, which Docker's FORWARD jump traverses.
+check_egress_firewall_iptables() {
+    local rules
     if ! command -v iptables >/dev/null 2>&1; then
         dr_info "Tor-egress firewall check skipped — no iptables."
         return 0
@@ -3089,7 +3190,6 @@ check_egress_firewall_installed() {
     else
         dr_fail "Tor-only egress firewall rules are MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them (#270)."
     fi
-    return 0
 }
 
 # doctor (#383): something must actually LISTEN on the stratum port while xmrig-proxy runs — the

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1189,6 +1189,34 @@ phase_provision() {
         return
     fi
 
+    # ---- Tor-only egress backstop (#855): the fail-closed firewall must actually DROP -------
+    # The whole product is Tor-first; the guarantee is that nothing CAN bypass Tor even if an app
+    # is misconfigured, compromised, or dials a raw public IP. On the appliance the engine is
+    # podman+netavark, and the old DOCKER-USER rules land in a chain no forwarded packet traverses
+    # — the firewall was fail-OPEN while doctor and the boot log called it enforced. This leg dials
+    # clearnet FROM a mining-net container by raw IP and asserts the drop. It is the check whose
+    # absence let a leaking appliance ship green: it FAILS against the orphaned-chain code and
+    # PASSES once the nft table is installed. monerod sits on mining_net (172.28.0.x) and syncs
+    # regardless of the mining hold, so it is the honest origin for the dial.
+    if _ssh "podman exec monerod sh -c 'command -v curl' >/dev/null 2>&1"; then
+        # NEGATIVE — a direct clearnet dial by IP must be DROPPED (curl times out, non-zero).
+        if _ssh "podman exec monerod curl -s -o /dev/null -m 8 http://1.1.1.1/" 2>/dev/null; then
+            bad "clearnet egress is FAIL-OPEN — monerod reached 1.1.1.1 directly, bypassing Tor (the firewall is not enforced)"
+        else
+            ok "direct clearnet dial from a mining container is dropped — Tor-only egress is enforced"
+        fi
+        # POSITIVE — the SAME container still reaches clearnet THROUGH Tor's SOCKS, proving the
+        # drop spares Tor and intra-subnet traffic (real mining keeps working). Tor's default
+        # SOCKS is 172.28.0.25:9050 on the appliance's mining_net.
+        if _ssh "podman exec monerod curl -s -o /dev/null -m 30 --socks5-hostname 172.28.0.25:9050 http://1.1.1.1/" 2>/dev/null; then
+            ok "egress through Tor's SOCKS still works — the drop did not break real mining"
+        else
+            bad "the mining container can no longer reach clearnet even through Tor — the firewall is too tight"
+        fi
+    else
+        bad "monerod lacks curl — cannot assert the Tor-only egress drop (the #855 backstop is unverified)"
+    fi
+
     # ---- local-miner leg (#796): enable -> xmrig up -> wired to the machine's own stratum ---
     # The submit above asked to mine on the box itself, so the built-in RigForge worker must
     # come up without any hands: setup renders its config, runs its appliance-mode setup, and

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -198,6 +198,21 @@ cat >"$DRBIN/curl" <<'EOF'
 #!/usr/bin/env bash
 exit "${CURL_RC:-0}"
 EOF
+# nft for the podman/netavark doctor path: `list tables` always answers (the sudo-readable probe);
+# `list table inet pithead_egress` emits a forward-hooked, dropping ruleset only when NFT_HOOK=1,
+# else exits 1 (table absent). Lets a test distinguish "installed & traversed" from "missing".
+cat >"$DRBIN/nft" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+"list tables") echo "table inet netavark" ;;
+"list table inet pithead_egress")
+    [ "${NFT_HOOK:-0}" = "1" ] || exit 1
+    printf '%s\n' 'table inet pithead_egress {' '  chain forward {' \
+        '    type filter hook forward priority -5; policy accept;' \
+        '    ip saddr 172.28.0.0/24 drop' '  }' '}' ;;
+esac
+exit 0
+EOF
 chmod +x "$DRBIN"/*
 
 # container_is_running: filter answered vs not.
@@ -234,6 +249,20 @@ assert_contains "egress check: rules missing -> FAIL" "$out" "MISSING"
 # sudo -n denied -> info skip with the manual command, never a prompt or a false FAIL.
 out="$(RUNNING_CONTAINERS="tor" SUDO_DENY=1 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
 assert_contains "egress check: no passwordless sudo -> info" "$out" "passwordless sudo"
+
+# Podman/netavark doctor path (#855): the check must read the nft table it actually installs, and
+# probe the HOOK — the orphaned-chain failure (a DROP no packet reaches) is exactly what a
+# forward-hooked base chain can't be, so hook presence is the honest signal, not "a rule exists".
+out="$(PITHEAD_ENGINE=podman RUNNING_CONTAINERS="tor" NFT_HOOK=1 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
+assert_contains "egress check (podman): forward-hooked drop present -> OK" "$out" "installed"
+assert_contains "egress check (podman): OK verdict names nftables" "$out" "nftables"
+# Table absent (post-reboot on the appliance, or the old fail-open build) -> FAIL, not a false pass.
+out="$(PITHEAD_ENGINE=podman RUNNING_CONTAINERS="tor" NFT_HOOK=0 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
+assert_contains "egress check (podman): no nft table -> FAIL" "$out" "MISSING"
+# sudo -n denied on the podman path -> info skip (the `list tables` probe tells a sudo refusal apart
+# from a genuinely missing table, so it never false-FAILs).
+out="$(PITHEAD_ENGINE=podman RUNNING_CONTAINERS="tor" SUDO_DENY=1 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_egress_firewall_installed 2>&1)"
+assert_contains "egress check (podman): no passwordless sudo -> info" "$out" "passwordless sudo"
 
 # Stratum listening: proxy not running -> info (a sync hold must not FAIL).
 out="$(RUNNING_CONTAINERS="" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_stratum_listening 2>&1)"
@@ -605,16 +634,65 @@ assert_contains "192.168/16 LAN allowed" "$TER" "-s 172.28.0.0/24 -d 192.168.0.0
 assert_eq "the clearnet DROP is the FINAL rule (fail-closed)" "$(printf '%s\n' "$TER" | tail -1)" "-s 172.28.0.0/24 -j DROP"
 assert_contains "honours a custom subnet/prefix (#180)" "$(run_sourced "$SANDBOX" tor_egress_rules 172.30.5.0/24 172.30.5.25)" "-s 172.30.5.0/24 -j DROP"
 
-echo "== black-box: apply/remove_tor_egress_firewall via stubbed iptables (#270) =="
+echo "== unit: render_tor_egress_nft — same allow-set as nftables for the netavark path (#855) =="
+# The appliance runs podman+netavark, whose FORWARD hook is served by `table inet netavark`; nothing
+# jumps to the iptables DOCKER-USER chain, so the Docker-path rules install into a chain no packet
+# traverses (the fail-open bug). This backend puts the DROP in an independent nft table hooked at
+# forward, which forwarded packets DO pass through.
+NFTR=$(run_sourced "$SANDBOX" render_tor_egress_nft 172.28.0.0/24 172.28.0.25)
+assert_contains "hooks the chain at forward so packets actually traverse it" "$NFTR" "hook forward"
+assert_contains "priority -5 runs ahead of netavark's priority-0 blanket accept" "$NFTR" "priority -5"
+assert_contains "ESTABLISHED/RELATED accepted (return + ongoing flows)" "$NFTR" "ct state established,related accept"
+assert_contains "only Tor (.25) may egress to the internet" "$NFTR" "ip saddr 172.28.0.25 accept"
+assert_contains "inter-container + 172.16/12 LAN allowed" "$NFTR" "ip saddr 172.28.0.0/24 ip daddr 172.16.0.0/12 accept"
+assert_contains "100.64/10 CGNAT LAN allowed" "$NFTR" "ip saddr 172.28.0.0/24 ip daddr 100.64.0.0/10 accept"
+assert_eq "the clearnet DROP is the FINAL rule before the chain closes (fail-closed)" "$(printf '%s\n' "$NFTR" | grep -E 'accept|drop' | tail -1)" "    ip saddr 172.28.0.0/24 drop"
+# add+delete before the body is the atomic idempotent-replace — a re-apply can't stack duplicates.
+assert_contains "idempotent-replace: add table first" "$NFTR" "add table inet pithead_egress"
+assert_contains "idempotent-replace: delete before recreating" "$NFTR" "delete table inet pithead_egress"
+assert_contains "honours a custom subnet/prefix (#180)" "$(run_sourced "$SANDBOX" render_tor_egress_nft 172.30.5.0/24 172.30.5.25)" "ip saddr 172.30.5.0/24 drop"
+
+echo "== black-box: apply_tor_egress_firewall routes to nftables under podman (#855) =="
+# PITHEAD_ENGINE=podman must send apply down the nft path (loaded via `nft -f -`), NOT the orphaned
+# DOCKER-USER path. Capture what gets piped to nft and assert the fail-closed ruleset landed.
+NFW="$SANDBOX/nfw"
+mkdir -p "$NFW/bin"
+printf '#!/usr/bin/env bash\nexec "$@"\n' >"$NFW/bin/sudo"
+# nft -f -: record stdin (the ruleset). Any other invocation (e.g. remove's delete) just logs args.
+cat >"$NFW/bin/nft" <<NFT
+#!/usr/bin/env bash
+if [ "\$1" = "-f" ]; then cat >>"$NFW/nft.ruleset"; else printf '%s\n' "\$*" >>"$NFW/nft.log"; fi
+exit 0
+NFT
+# an iptables that FAILS loudly if apply ever calls it under podman — proves we took the nft branch.
+printf '#!/usr/bin/env bash\necho "ILLEGAL iptables call on podman path: $*" >>"%s/nft.log"\nexit 1\n' "$NFW" >"$NFW/bin/iptables"
+chmod +x "$NFW/bin/sudo" "$NFW/bin/nft" "$NFW/bin/iptables"
+printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$NFW/.env"
+: >"$NFW/nft.ruleset"
+: >"$NFW/nft.log"
+PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall >/dev/null 2>&1
+assert_contains "podman path loads the nft table with the fail-closed DROP" "$(cat "$NFW/nft.ruleset")" "ip saddr 172.28.0.0/24 drop"
+assert_contains "podman path hooks the chain at forward" "$(cat "$NFW/nft.ruleset")" "hook forward"
+assert_not_contains "podman path never touches the orphaned DOCKER-USER chain" "$(cat "$NFW/nft.log")" "ILLEGAL iptables"
+# opt-out on the podman path installs no table either.
+printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=false\n' >"$NFW/.env"
+: >"$NFW/nft.ruleset"
+PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall >/dev/null 2>&1
+assert_eq "opt-out on the podman path loads no nft ruleset" "$(cat "$NFW/nft.ruleset")" ""
+
+echo "== black-box: apply/remove_tor_egress_firewall via stubbed iptables (Docker path, #270) =="
 FW="$SANDBOX/fw"
 mkdir -p "$FW/bin"
 printf '#!/usr/bin/env bash\nexec "$@"\n' >"$FW/bin/sudo"
 printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/ipt.log"\n' "$FW" >"$FW/bin/iptables"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$FW/bin/iptables-save" # no pre-existing rules
-chmod +x "$FW/bin/sudo" "$FW/bin/iptables" "$FW/bin/iptables-save"
+# remove_tor_egress_firewall probes nft on every path (it clears BOTH backends); stub it inert so the
+# Docker-path black-box stays hermetic and never touches the host's real nftables.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$FW/bin/nft"
+chmod +x "$FW/bin/sudo" "$FW/bin/iptables" "$FW/bin/iptables-save" "$FW/bin/nft"
 printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$FW/.env"
 : >"$FW/ipt.log"
-PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
+PITHEAD_ENGINE=docker PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
 iptlog="$(cat "$FW/ipt.log" 2>/dev/null)"
 assert_contains "installs the fail-closed clearnet DROP, tagged" "$iptlog" "-I DOCKER-USER 7 -m comment --comment pithead-tor-egress -s 172.28.0.0/24 -j DROP"
 assert_contains "exempts the Tor container" "$iptlog" "-m comment --comment pithead-tor-egress -s 172.28.0.25 -j ACCEPT"
@@ -624,7 +702,7 @@ assert_contains "pre-creates the DOCKER-USER chain (idempotently)" "$iptlog" "-N
 # opt-out: TOR_EGRESS_FIREWALL=false installs nothing
 printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=false\n' >"$FW/.env"
 : >"$FW/ipt.log"
-PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
+PITHEAD_ENGINE=docker PATH="$FW/bin:$PATH" run_sourced "$FW" apply_tor_egress_firewall >/dev/null 2>&1
 assert_eq "opt-out (network.tor_egress_firewall=false) installs no DROP" "$(grep -c 'DROP' "$FW/ipt.log" 2>/dev/null)" "0"
 # install-failure rollback (#270): if an `iptables -I` insert fails partway, apply must NOT leave a
 # half-open firewall it believes is fail-closed — it warns and rolls back via remove_tor_egress_firewall.
@@ -640,10 +718,11 @@ case "$1" in -I) exit 1 ;; esac # every insert fails midway
 exit 0
 IPT
 printf '#!/usr/bin/env bash\nprintf "save\\n" >>"$IPT_LOG"\nexit 0\n' >"$FF/bin/iptables-save"
-chmod +x "$FF/bin/sudo" "$FF/bin/iptables" "$FF/bin/iptables-save"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$FF/bin/nft" # inert: remove probes nft on the Docker path too
+chmod +x "$FF/bin/sudo" "$FF/bin/iptables" "$FF/bin/iptables-save" "$FF/bin/nft"
 printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$FF/.env"
 : >"$FF/ipt.log"
-fwfail_out="$(PATH="$FF/bin:$PATH" IPT_LOG="$FF/ipt.log" run_sourced "$FF" apply_tor_egress_firewall 2>&1)"
+fwfail_out="$(PITHEAD_ENGINE=docker PATH="$FF/bin:$PATH" IPT_LOG="$FF/ipt.log" run_sourced "$FF" apply_tor_egress_firewall 2>&1)"
 fwfail_rc=$?
 assert_rc "insert failure degrades gracefully (stack still runs, rc 0)" "$fwfail_rc" "0"
 assert_contains "insert failure warns clearnet is NOT fail-closed" "$fwfail_out" "NOT fail-closed"
@@ -663,13 +742,18 @@ cat <<'RULES'
 -A DOCKER-USER -j RETURN
 RULES
 SAVE
-chmod +x "$RM/bin/sudo" "$RM/bin/iptables" "$RM/bin/iptables-save"
+# remove is engine-agnostic: it drops the nft table AND strips the iptables tags, so a stale set can't
+# survive a re-apply or an engine change. Log nft calls to prove it tears down the netavark backend too.
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s/nft.log"\nexit 0\n' "$RM" >"$RM/bin/nft"
+chmod +x "$RM/bin/sudo" "$RM/bin/iptables" "$RM/bin/iptables-save" "$RM/bin/nft"
 : >"$RM/ipt.log"
+: >"$RM/nft.log"
 PATH="$RM/bin:$PATH" run_sourced "$RM" remove_tor_egress_firewall >/dev/null 2>&1
 rmlog="$(cat "$RM/ipt.log" 2>/dev/null)"
 assert_contains "down removes the tagged clearnet DROP" "$rmlog" "-D DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.0/24 -j DROP"
 assert_contains "down removes the tagged Tor-exempt ACCEPT" "$rmlog" "-D DOCKER-USER -m comment --comment pithead-tor-egress -s 172.28.0.25 -j ACCEPT"
 assert_not_contains "down leaves foreign DOCKER-USER rules untouched" "$rmlog" "RETURN"
+assert_contains "down also drops the nft egress table (netavark backend)" "$(cat "$RM/nft.log" 2>/dev/null)" "delete table inet pithead_egress"
 
 echo "== regression: every command installs the Tor-egress firewall BEFORE compose (#291) =="
 # The firewall must go in BEFORE any clearnet-capable container starts, on EVERY path that brings one


### PR DESCRIPTION
Closes #855

## The bug

On the appliance the Tor-only egress firewall was **fail-open** while `doctor` and the boot log reported it enforced. `apply_tor_egress_firewall` installs the fail-closed DROP into the iptables `DOCKER-USER` chain — a Docker convention. Docker adds the `FORWARD → DOCKER-USER` jump when it creates a network; podman + netavark (the appliance engine) never does. The rules sat in an orphaned chain no forwarded packet traversed, so any mining container reached clearnet directly, defeating the Tor-first backstop.

Confirmed live on the bench (`develop-v2` tip `03751f3`):

```
# iptables -S FORWARD | grep DOCKER-USER      → (nothing; FORWARD never jumps there)
# podman exec monerod curl -m5 http://1.1.1.1/ → HTTP 301   (leak)
```

## The fix

Enforcement now follows the running engine (`container_engine`):

- **Docker (DIY):** unchanged — rules in `DOCKER-USER`.
- **podman + netavark (appliance):** an independent `inet pithead_egress` nftables table, base chain hooked at `forward priority -5` — ahead of netavark's priority-0 blanket accept, owning no chain shared with netavark so it survives netavark reprogramming its own table. Same allow-set (ESTABLISHED/RELATED, the tor container IP, RFC1918 + CGNAT LAN, DROP the rest of the mining subnet). This is the phase-0 spike design finally landed.

`remove_tor_egress_firewall` clears **both** backends so a re-apply or engine change can't strand a stale set. `apply`/`remove`/`doctor` all branch on the engine.

**doctor now reports the true state:** `check_egress_firewall_nft` reads the nft table the appliance actually installs and asserts the chain is **hooked at forward** — the orphaned-chain condition (a DROP no packet reaches) is exactly what a forward-hooked base chain cannot be, so hook presence is the honest signal, not "a rule exists somewhere." A `list tables` probe distinguishes a sudo refusal from a genuinely missing table, so it never false-FAILs.

The appliance boot path (`pithead-boot` → `./pithead up` → `stack_up` → `apply_tor_egress_firewall`) picks up the correct backend with no other change.

## Coverage

- **Stack tier** (`tests/stack/run.sh`): `render_tor_egress_nft` rendering (hook, priority, allow-set, fail-closed final drop, idempotent-replace); `apply_tor_egress_firewall` routes to nft under `PITHEAD_ENGINE=podman` and never touches `DOCKER-USER`; `remove` tears down the nft table too; the doctor nft branch (OK on a forward-hooked drop, FAIL when the table is absent, info-skip on no-sudo/no-nft). Existing Docker-path tests pinned to `PITHEAD_ENGINE=docker` and made hermetic against the new nft probe.
- **KVM battery** (`tests/os/run.sh`, provision phase): from inside `monerod` on the mining net, a direct clearnet dial by raw IP must be DROPPED, while the same container still reaches clearnet through Tor's SOCKS — the assertion whose absence let this ship green. It FAILS against the orphaned-chain code and PASSES with the fix.

## Live bench proof

Rendered the fixed nft table by hand on `pithead.local` and loaded it (bench restored to its code-managed state afterward — it's mid-soak):

| | direct clearnet `1.1.1.1` | via Tor SOCKS |
|---|---|---|
| before (orphaned iptables) | **HTTP 301 (leak)** | HTTP 301 |
| after (`inet pithead_egress` loaded) | **DROPPED (curl rc 28 timeout)** | HTTP 301 |
| after restore | HTTP 301 | — |

The DROP blocks the direct dial while Tor-routed egress (real mining) keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
