### PR TITLE
Bake systemd watchdog + performance CPU governor into the appliance

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -28,6 +28,28 @@ The image also carries no installer payload. `pithead-install` rebuilds the layo
 target and copies the running slot, so the artifact never contains a compressed copy of
 itself.
 
+### Host tuning baked in
+
+An unattended headless box has to heal itself, and two of the guards live below the container
+layer where `restart:` policies and `panic=60` cannot reach:
+
+- **systemd watchdog.** `/etc/systemd/system.conf.d/pithead-watchdog.conf` sets
+  `RuntimeWatchdogSec=20s`, so systemd feeds `/dev/watchdog` and the platform watchdog
+  hard-resets the machine if PID 1 stops pinging — the soft-hang case, where nothing panicked and
+  no container died but the box is wedged. `RebootWatchdogSec=2min` keeps the watchdog armed
+  through shutdown, so a reboot that itself hangs still resets. 20 s is chosen to survive a
+  RandomX-loaded stall without a false reset while still self-healing in under a minute. On
+  hardware with no watchdog device — a KVM guest, most bench boxes — the setting is a safe no-op;
+  real appliance boards expose one and this is where it earns its keep.
+- **CPU governor.** `pithead-cpu-governor.service` sets the `performance` governor every boot, so
+  the node, wallet, and any built-in miner run at full clock. A co-located RigForge miner sets the
+  same `performance` value from its own service; the two agree, and this only establishes the
+  baseline earlier and covers the miner-disabled box. It is a no-op where there is no cpufreq to
+  steer.
+
+Both are asserted by `tests/os/verify-image.sh` — the config is checked into the built rootfs, not
+the runtime effect (CI has no real watchdog device to trip).
+
 ## Build variants and the variant stamp
 
 Every build is one of two variants, decided by whether the rootfs bakes an SSH key

--- a/os/overlay/pithead-cpu-governor.service
+++ b/os/overlay/pithead-cpu-governor.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Set CPU frequency governor to performance (appliance tuning)
+# Skip cleanly where there is no cpufreq to steer — a KVM guest or a bench box with no
+# scaling driver has no scaling_governor node, and the appliance should boot the same there.
+ConditionPathExists=/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+After=sysinit.target
+Before=pithead-boot.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# The baseline for a mining appliance: hold the cores at full clock so the node, the wallet,
+# and any built-in miner are not scheduled onto a throttled-down CPU. A co-located RigForge
+# miner sets the same performance governor from its own service; both write the identical
+# value, so this only establishes the baseline earlier and covers the miner-disabled box.
+ExecStart=/usr/bin/cpupower frequency-set -g performance
+
+[Install]
+WantedBy=multi-user.target

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -125,6 +125,19 @@ RUN printf 'PITHEAD_ENGINE=podman\n' >> /etc/environment \
     && mkdir -p /etc/systemd/journald.conf.d \
     && printf '[Journal]\nStorage=persistent\nSystemMaxUse=200M\n' > /etc/systemd/journald.conf.d/pithead.conf
 
+# Hardware/systemd watchdog: catch a soft-hung kernel or wedged init on an unattended headless
+# box — the case panic=60 (grub.cfg) and container restart policies cannot see, because nothing
+# panicked and PID 1 is the thing that stopped pinging. systemd feeds /dev/watchdog every
+# RuntimeWatchdogSec/2; miss the full interval and the platform watchdog hard-resets the machine.
+# 20s is the balance point: long enough that a RandomX-loaded box under a GC or IO stall is not
+# falsely reset, short enough that a real hang self-heals in well under a minute. RebootWatchdogSec
+# arms the watchdog across a shutdown too, so a reboot that itself wedges still resets rather than
+# hanging forever. No /dev/watchdog (a KVM guest or bench box with no virtual watchdog device) is a
+# safe no-op — systemd logs the missing device and carries on; real appliance hardware exposes one
+# (iTCO_wdt and friends auto-probe), which is where this earns its keep.
+RUN mkdir -p /etc/systemd/system.conf.d \
+    && printf '[Manager]\nRuntimeWatchdogSec=20s\nRebootWatchdogSec=2min\n' > /etc/systemd/system.conf.d/pithead-watchdog.conf
+
 # Container storage lives on the DATA partition, never on the root overlay. Two reasons, both
 # load-bearing: podman's overlay driver cannot stack on Rugix's overlayfs root ("'overlay' is not
 # supported over overlayfs"), and images/containers must survive A/B updates and reboots — the
@@ -159,6 +172,9 @@ COPY os/overlay/pithead-sync /usr/local/sbin/pithead-sync
 COPY os/overlay/pithead-mount-generator /usr/lib/systemd/system-generators/pithead-mount-generator
 COPY os/overlay/pithead-boot.service /etc/systemd/system/pithead-boot.service
 COPY os/overlay/pithead-boot /usr/local/sbin/pithead-boot
+# CPU governor: hold the cores at performance every boot (mining appliance tuning). Oneshot, and
+# a no-op on a box with no cpufreq — see the unit for the RigForge co-location note.
+COPY os/overlay/pithead-cpu-governor.service /etc/systemd/system/pithead-cpu-governor.service
 RUN chmod +x /usr/local/sbin/pithead-sync /usr/local/sbin/pithead-boot /usr/lib/systemd/system-generators/pithead-mount-generator
 # The updater is chosen per image (bake-off candidates). rugix-ctrl arrives via the bakery layer's
 # core recipe; RAUC is a Debian package, so it is installed here when selected.
@@ -189,7 +205,8 @@ COPY os/rootfs/repart.d/ /usr/lib/repart.d/
 # on ERR_ADDRESS_UNREACHABLE before falling back — pithead.local "took forever" on a healthy
 # LAN. The console prints the v4 address; the name should resolve to the same thing.
 RUN sed -i 's/^#\?use-ipv6=.*/use-ipv6=no/' /etc/avahi/avahi-daemon.conf
-RUN systemctl enable podman.socket pithead-boot.service avahi-daemon systemd-timesyncd systemd-resolved \
+RUN systemctl enable podman.socket pithead-boot.service pithead-cpu-governor.service avahi-daemon \
+        systemd-timesyncd systemd-resolved \
         systemd-networkd systemd-networkd-wait-online pithead-sync.service pithead-firstboot.service \
     && systemctl disable ssh
 # systemd-repart.service is static — it is pulled in by sysinit.target, and `systemctl enable` on a

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -97,6 +97,18 @@ chk "pithead-boot script present and executable" 'test -x "$ROOT/usr/local/sbin/
 chk "podman-restart retired (it killed the stack it started)" '[ ! -e "$ROOT/etc/systemd/system/multi-user.target.wants/podman-restart.service" ] && [ ! -e "$ROOT/etc/systemd/system/podman-restart.service.d" ]'
 chk "kernel + initrd in the slot" '[ -s "$ROOT/vmlinuz" ] || [ -L "$ROOT/vmlinuz" ]'
 
+echo "==> unattended auto-heal (soft hang the container/panic paths cannot catch)"
+# systemd watchdog: a wedged kernel/init on a headless box is what /dev/watchdog exists for. We
+# assert the CONFIG is baked, not that a hang reboots — no CI/KVM watchdog device to prove that.
+chk "watchdog drop-in baked" '[ -s "$ROOT/etc/systemd/system.conf.d/pithead-watchdog.conf" ]'
+chk "RuntimeWatchdogSec set" 'grep -q "^RuntimeWatchdogSec=" "$ROOT/etc/systemd/system.conf.d/pithead-watchdog.conf"'
+chk "RebootWatchdogSec set (reboot itself is watched)" 'grep -q "^RebootWatchdogSec=" "$ROOT/etc/systemd/system.conf.d/pithead-watchdog.conf"'
+# CPU governor: performance held every boot; a no-op where there is no cpufreq, so this asserts
+# the unit is present and enabled, not the runtime governor value.
+chk "cpu-governor unit present" '[ -s "$ROOT/etc/systemd/system/pithead-cpu-governor.service" ]'
+chk "cpu-governor unit enabled" 'test -L "$ROOT/etc/systemd/system/multi-user.target.wants/pithead-cpu-governor.service"'
+chk "cpu-governor asks for performance" 'grep -q "frequency-set -g performance" "$ROOT/etc/systemd/system/pithead-cpu-governor.service"'
+
 echo "==> docker-export artefacts (all six members)"
 chk "no /.dockerenv" '[ ! -e "$ROOT/.dockerenv" ]'
 chk "pseudo-fs mount points exist" '[ -d "$ROOT/proc" ] && [ -d "$ROOT/sys" ] && [ -d "$ROOT/dev" ] && [ -d "$ROOT/run" ]'


### PR DESCRIPTION
## What

Bakes the two auto-heal/tuning guards the dual-distribution plan called for but the image never carried (`docs/dev/dual-distribution-plan.md` L228, L296).

An unattended headless appliance has no recovery for a **soft-hung kernel or wedged init**: `panic=60` only catches a panic, and `restart:` policies only catch a dead container. Both new guards sit below the container layer.

### systemd/hardware watchdog
`/etc/systemd/system.conf.d/pithead-watchdog.conf`:
- `RuntimeWatchdogSec=20s` — systemd feeds `/dev/watchdog` every 10 s; miss the full interval and the platform watchdog hard-resets the box. 20 s survives a RandomX-loaded stall without a false reset, still self-heals in under a minute.
- `RebootWatchdogSec=2min` — keeps the watchdog armed across shutdown, so a reboot that itself wedges still resets.

Degrades gracefully: no `/dev/watchdog` (KVM guest / bench box with no virtual watchdog device) is a safe systemd no-op. Real appliance boards expose one (`iTCO_wdt` and friends auto-probe). No `softdog` force-load — that would mask the real hardware device as `watchdog1`.

### CPU governor
`pithead-cpu-governor.service` — oneshot, sets `performance` every boot via the already-installed `cpupower`. `ConditionPathExists` on `scaling_governor` makes it a clean no-op where there is no cpufreq. A co-located RigForge miner sets the same `performance` value from its own `ExecStartPre`; the two agree, so this only establishes the baseline earlier and covers the miner-disabled box.

## Coverage
`tests/os/verify-image.sh` gains an "unattended auto-heal" section asserting both **configs** are in the built rootfs (drop-in present, `RuntimeWatchdogSec`/`RebootWatchdogSec` set, governor unit present + enabled + asks for performance). The runtime effect is not asserted — CI/KVM has no real watchdog device to trip.

## Docs
`docs/dev/appliance-release.md` § "Host tuning baked in" documents the interval and why, the reboot-watched rationale, and the RigForge co-location.

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)