### PR TITLE
fix(appliance): fail-closed IPv6 coverage for the Tor egress firewall

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -45,6 +45,14 @@ by channel:
 `pithead doctor` reads whichever mechanism the running engine uses and checks the drop is in a chain
 that is actually hooked at forward, so it cannot report enforced while the rules are orphaned.
 
+The allow-set matches on IPv4 addresses because the mining bridge is IPv4-only by design. On the
+appliance path the firewall also fences IPv6: if the mining network ever gains an IPv6 subnet, an
+address match has nothing to key on (there is no assigned v6 range), so the drop is scoped to the
+mining bridge interface instead — the v6 LAN (ULA `fc00::/7` and link-local `fe80::/10`) is allowed
+and everything else the bridge originates is dropped, leaving the host's own IPv6 forwarding on every
+other interface untouched. If a v6 subnet is present but the bridge interface can't be resolved,
+`pithead` refuses to install a v4-only firewall it would otherwise report as fail-closed.
+
 - Needs root (the firewall rules), like the GRUB/HugePages steps; removed at `pithead down`.
 - Opt out with `network.tor_egress_firewall: false` (then routing falls back to per-app config only).
 - The host-networked dashboard and caddy aren't on the bridge; the dashboard's only external calls

--- a/pithead
+++ b/pithead
@@ -288,7 +288,9 @@ stack_restart() { # [tor]
 # Docker's DOCKER-USER chain (preserved across Docker restarts), installed BEFORE containers start on
 # every path that brings a clearnet-capable app up — `up`, `upgrade`, `apply`, `reset-dashboard` (so
 # there is no startup window to grandfather a leak past) — and removed at `down`. Needs
-# root (sudo), like the GRUB/HugePages steps; IPv4-only (mining_net is IPv4). Opt out with
+# root (sudo), like the GRUB/HugePages steps. The allow-set is IPv4 (mining_net is IPv4-only by
+# design); the nft backend also fences IPv6 off the mining bridge if mining_net ever gains a v6
+# subnet, so the backstop can't silently fail open. Opt out with
 # network.tor_egress_firewall=false. Proven by tests/integration/benchmarks/bench-verify-egress.sh.
 # See docs/privacy.md.
 #
@@ -323,8 +325,14 @@ tor_egress_rules() { # <subnet> <tor_ip>
 # hooked at forward priority -5 so it evaluates before netavark's priority-0 blanket accept; a `drop`
 # there is terminal across the ruleset. accepts come first so LAN/Tor/established traffic skips the
 # final subnet-wide drop, mirroring the iptables order.
-render_tor_egress_nft() { # <subnet> <tor_ip>
-    local subnet="$1" tor_ip="$2"
+#
+# The optional third arg is the mining bridge interface. mining_net is IPv4-only by design, so it is
+# empty on every normal apply and the ruleset stays v4-only. If mining_net ever gains an IPv6 subnet
+# the caller resolves the bridge and passes it here, which appends the v6 fail-closed backstop: there
+# is no assigned v6 range to source-match, so the drop is keyed on the mining bridge INTERFACE — the
+# host's own IPv6 forwarding on every other interface is left untouched.
+render_tor_egress_nft() { # <subnet> <tor_ip> [<mining_bridge>]
+    local subnet="$1" tor_ip="$2" br="${3:-}"
     printf '%s\n' \
         "add table inet $TOR_EGRESS_NFT_TABLE" \
         "delete table inet $TOR_EGRESS_NFT_TABLE" \
@@ -337,9 +345,36 @@ render_tor_egress_nft() { # <subnet> <tor_ip>
         "    ip saddr $subnet ip daddr 172.16.0.0/12 accept" \
         "    ip saddr $subnet ip daddr 192.168.0.0/16 accept" \
         "    ip saddr $subnet ip daddr 100.64.0.0/10 accept" \
-        "    ip saddr $subnet drop" \
+        "    ip saddr $subnet drop"
+    # IPv6 backstop, only when mining_net actually has v6 (br set). ct established,related above is
+    # family-agnostic and already spares return traffic; here we allow the v6 LAN (ULA fc00::/7 +
+    # link-local fe80::/10) off the mining bridge and drop everything else it originates. Scoped to
+    # iifname so it can never touch v6 forwarded from any other interface.
+    if [ -n "$br" ]; then
+        printf '%s\n' \
+            "    iifname \"$br\" ip6 daddr fc00::/7 accept" \
+            "    iifname \"$br\" ip6 daddr fe80::/10 accept" \
+            "    iifname \"$br\" meta nfproto ipv6 drop"
+    fi
+    printf '%s\n' \
         "  }" \
         "}"
+}
+
+# Resolve the mining bridge interface IFF mining_net carries an IPv6 subnet — both come from the same
+# `podman network inspect`, so whenever v6 is present the interface name is too. Prints the bridge
+# name for the v6 backstop; prints nothing when mining_net is IPv4-only (the normal case) or absent
+# (a first-ever `up`, where the firewall installs before compose creates the network). Sole tricky
+# case — a v6 subnet present but no resolvable interface — is signalled by rc 3 so the caller can
+# refuse rather than install a v4-only firewall it would wrongly call fail-closed.
+mining_net_ipv6_bridge() {
+    local inspect v6 br
+    inspect=$(podman network inspect mining_net 2>/dev/null) || return 0
+    v6=$(printf '%s' "$inspect" | jq -r '[.[0].subnets[]?.subnet | select(test(":"))][0] // empty' 2>/dev/null)
+    [ -n "$v6" ] || return 0
+    br=$(printf '%s' "$inspect" | jq -r '.[0].network_interface // empty' 2>/dev/null)
+    [ -n "$br" ] || return 3
+    printf '%s' "$br"
 }
 
 # Remove every rule we previously installed — idempotent, config-agnostic, engine-agnostic. Clears
@@ -390,16 +425,26 @@ apply_tor_egress_firewall() {
 
 # Appliance/netavark path: load the independent nft table (atomic, idempotent-replace).
 apply_tor_egress_nft() { # <subnet> <tor_ip>
-    local subnet="$1" tor_ip="$2"
+    local subnet="$1" tor_ip="$2" br rc
     if ! command -v nft >/dev/null 2>&1; then
         warn "nftables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
         return 0
     fi
-    if ! render_tor_egress_nft "$subnet" "$tor_ip" | sudo nft -f - 2>/dev/null; then
+    # mining_net is IPv4-only by design, so br is empty and the ruleset stays v4-only. If it ever
+    # gains an IPv6 subnet we key a v6 fail-closed drop on its bridge interface. rc 3 means v6 is
+    # present but the bridge couldn't be resolved — refuse rather than load a v4-only firewall we'd
+    # then wrongly report as fail-closed (a v6 clearnet leak would fall through policy accept).
+    br=$(mining_net_ipv6_bridge)
+    rc=$?
+    if [ "$rc" -eq 3 ]; then
+        warn "mining_net has an IPv6 subnet but its bridge interface could not be resolved — REFUSING to install a v4-only egress firewall that would leave IPv6 clearnet un-fenced. Recreate mining_net or set network.tor_egress_firewall=false to acknowledge."
+        return 0
+    fi
+    if ! render_tor_egress_nft "$subnet" "$tor_ip" "$br" | sudo nft -f - 2>/dev/null; then
         warn "Could not install the Tor-egress firewall (needs root + nftables). Stack runs, but clearnet egress is NOT fail-closed."
         return 0
     fi
-    log "Tor-only egress enforced: clearnet dials from $subnet dropped except via Tor ($tor_ip)."
+    log "Tor-only egress enforced: clearnet dials from $subnet${br:+ (IPv4) and via $br (IPv6)} dropped except via Tor ($tor_ip)."
 }
 
 # DIY/Docker path: insert the tagged rules into DOCKER-USER, which Docker jumps to from FORWARD.

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1213,6 +1213,19 @@ phase_provision() {
         else
             bad "the mining container can no longer reach clearnet even through Tor — the firewall is too tight"
         fi
+        # IPv6 backstop (#858): mining_net is IPv4-only by design, so monerod has no global v6 and
+        # this leg self-skips on the stock appliance. If mining_net ever gains a v6 subnet, the
+        # container CAN originate v6 clearnet — assert that dial is DROPPED too (the fail-open the
+        # v4-only rules left behind). Guarded on the container actually holding a global v6 address.
+        if _ssh "podman exec monerod sh -c 'ip -6 addr show scope global 2>/dev/null | grep -q inet6'" 2>/dev/null; then
+            if _ssh "podman exec monerod curl -s -o /dev/null -m 8 -g 'http://[2606:4700:4700::1111]/'" 2>/dev/null; then
+                bad "IPv6 clearnet egress is FAIL-OPEN — monerod reached a v6 address directly, bypassing Tor"
+            else
+                ok "direct IPv6 clearnet dial from a mining container is dropped — the v6 backstop holds"
+            fi
+        else
+            ok "mining_net is IPv4-only (no global v6 in the container) — v6 clearnet dial not possible, backstop not exercised"
+        fi
     else
         bad "monerod lacks curl — cannot assert the Tor-only egress drop (the #855 backstop is unverified)"
     fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -652,6 +652,51 @@ assert_contains "idempotent-replace: add table first" "$NFTR" "add table inet pi
 assert_contains "idempotent-replace: delete before recreating" "$NFTR" "delete table inet pithead_egress"
 assert_contains "honours a custom subnet/prefix (#180)" "$(run_sourced "$SANDBOX" render_tor_egress_nft 172.30.5.0/24 172.30.5.25)" "ip saddr 172.30.5.0/24 drop"
 
+echo "== unit: render_tor_egress_nft — IPv6 backstop only when the mining bridge is passed (#858) =="
+# mining_net is IPv4-only by design, so a bare render (no bridge arg) must stay v4-only — no ip6
+# rule can appear, or it would fence traffic that doesn't exist and risk the host's own v6.
+assert_not_contains "no bridge arg → no IPv6 rule at all (v4-only, the normal case)" "$NFTR" "ip6"
+# When mining_net gains v6 the caller resolves the bridge and passes it; the v6 fail-closed drop is
+# keyed on that interface (there's no v6 range to source-match) and mirrors the v4 LAN allow-set.
+NFTR6=$(run_sourced "$SANDBOX" render_tor_egress_nft 172.28.0.0/24 172.28.0.25 podman1)
+assert_contains "v6 drop is scoped to the mining bridge, never the whole forward path" "$NFTR6" 'iifname "podman1" meta nfproto ipv6 drop'
+assert_contains "v6 LAN ULA (fc00::/7) allowed off the bridge" "$NFTR6" 'iifname "podman1" ip6 daddr fc00::/7 accept'
+assert_contains "v6 link-local (fe80::/10) allowed off the bridge" "$NFTR6" 'iifname "podman1" ip6 daddr fe80::/10 accept'
+assert_eq "the IPv6 drop is the FINAL rule before the chain closes (fail-closed)" "$(printf '%s\n' "$NFTR6" | grep -E 'accept|drop' | tail -1)" '    iifname "podman1" meta nfproto ipv6 drop'
+assert_contains "the v4 allow-set is unchanged when v6 is added" "$NFTR6" "ip saddr 172.28.0.0/24 drop"
+
+echo "== unit: mining_net_ipv6_bridge — resolve bridge only when mining_net has a v6 subnet (#858) =="
+# Both the v6 subnet and the interface name come from the SAME `podman network inspect`, so whenever
+# v6 is present the bridge is too. Stub podman to answer network inspect; jq is real.
+NB="$SANDBOX/netbr"
+mkdir -p "$NB/bin"
+# v4-only mining_net → no bridge emitted, rc 0 (the normal appliance state).
+cat >"$NB/bin/podman" <<'PM'
+#!/usr/bin/env bash
+[ "$1" = "network" ] && [ "$2" = "inspect" ] || { echo "[]"; exit 0; }
+echo '[{"name":"mining_net","network_interface":"podman1","subnets":[{"subnet":"172.28.0.0/24"}]}]'
+PM
+chmod +x "$NB/bin/podman"
+assert_eq "v4-only mining_net → no bridge (stays v4-only), rc 0" "$(
+    PATH="$NB/bin:$PATH" run_sourced "$NB" mining_net_ipv6_bridge
+    echo " rc=$?"
+)" " rc=0"
+# dual-stack mining_net → the bridge name is emitted for the v6 backstop.
+cat >"$NB/bin/podman" <<'PM'
+#!/usr/bin/env bash
+echo '[{"name":"mining_net","network_interface":"podman4","subnets":[{"subnet":"172.28.0.0/24"},{"subnet":"fd00:dead:beef::/64"}]}]'
+PM
+assert_eq "dual-stack mining_net → emits the resolved bridge name" "$(PATH="$NB/bin:$PATH" run_sourced "$NB" mining_net_ipv6_bridge)" "podman4"
+# pathological: v6 subnet present but no resolvable interface → rc 3, so apply refuses (fail-closed).
+cat >"$NB/bin/podman" <<'PM'
+#!/usr/bin/env bash
+echo '[{"name":"mining_net","subnets":[{"subnet":"fd00:dead:beef::/64"}]}]'
+PM
+assert_eq "v6 present but no interface → rc 3 (caller refuses, never installs a v4-only firewall)" "$(
+    PATH="$NB/bin:$PATH" run_sourced "$NB" mining_net_ipv6_bridge >/dev/null
+    echo $?
+)" "3"
+
 echo "== black-box: apply_tor_egress_firewall routes to nftables under podman (#855) =="
 # PITHEAD_ENGINE=podman must send apply down the nft path (loaded via `nft -f -`), NOT the orphaned
 # DOCKER-USER path. Capture what gets piped to nft and assert the fail-closed ruleset landed.
@@ -679,6 +724,36 @@ printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWA
 : >"$NFW/nft.ruleset"
 PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall >/dev/null 2>&1
 assert_eq "opt-out on the podman path loads no nft ruleset" "$(cat "$NFW/nft.ruleset")" ""
+# The two blocks above never stub podman, so mining_net_ipv6_bridge finds no v6 → the loaded ruleset
+# stays strictly v4 (no over-block of IPv6 that doesn't exist yet).
+assert_not_contains "v4-only mining_net → the loaded ruleset carries no IPv6 rule" "$(
+    printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$NFW/.env"
+    : >"$NFW/nft.ruleset"
+    PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall >/dev/null 2>&1
+    cat "$NFW/nft.ruleset"
+)" "ip6"
+
+echo "== black-box: apply on a dual-stack mining_net loads the IPv6 backstop (#858) =="
+# Same harness, now with a podman that reports mining_net carrying a v6 subnet. apply must resolve
+# the bridge and pipe an interface-scoped v6 drop into nft alongside the v4 rules.
+printf '#!/usr/bin/env bash\necho '"'"'[{"name":"mining_net","network_interface":"podman4","subnets":[{"subnet":"172.28.0.0/24"},{"subnet":"fd00:dead:beef::/64"}]}]'"'"'\n' >"$NFW/bin/podman"
+chmod +x "$NFW/bin/podman"
+printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$NFW/.env"
+: >"$NFW/nft.ruleset"
+PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall >/dev/null 2>&1
+dsrules="$(cat "$NFW/nft.ruleset")"
+assert_contains "dual-stack apply keeps the v4 fail-closed DROP" "$dsrules" "ip saddr 172.28.0.0/24 drop"
+assert_contains "dual-stack apply adds the bridge-scoped IPv6 DROP" "$dsrules" 'iifname "podman4" meta nfproto ipv6 drop'
+
+echo "== black-box: apply REFUSES a v4-only firewall when mining_net has un-resolvable v6 (#858) =="
+# v6 subnet present but no interface name → mining_net_ipv6_bridge returns rc 3. apply must warn and
+# load NOTHING rather than install a v4-only table it would wrongly report as fail-closed.
+printf '#!/usr/bin/env bash\necho '"'"'[{"name":"mining_net","subnets":[{"subnet":"fd00:dead:beef::/64"}]}]'"'"'\n' >"$NFW/bin/podman"
+: >"$NFW/nft.ruleset"
+refuse_out="$(PITHEAD_ENGINE=podman PATH="$NFW/bin:$PATH" run_sourced "$NFW" apply_tor_egress_firewall 2>&1)"
+assert_contains "warns loudly that it is REFUSING (fail-closed by refusal)" "$refuse_out" "REFUSING"
+assert_eq "refusal loads no nft ruleset at all (no half-open v4-only firewall)" "$(cat "$NFW/nft.ruleset")" ""
+rm -f "$NFW/bin/podman" # restore the v4-only harness for anything downstream
 
 echo "== black-box: apply/remove_tor_egress_firewall via stubbed iptables (Docker path, #270) =="
 FW="$SANDBOX/fw"


### PR DESCRIPTION
Closes #855

## The bug

On the appliance the Tor-only egress firewall was **fail-open** while `doctor` and the boot log reported it enforced. `apply_tor_egress_firewall` installs the fail-closed DROP into the iptables `DOCKER-USER` chain — a Docker convention. Docker adds the `FORWARD → DOCKER-USER` jump when it creates a network; podman + netavark (the appliance engine) never does. The rules sat in an orphaned chain no forwarded packet traversed, so any mining container reached clearnet directly, defeating the Tor-first backstop.

Confirmed live on the bench (`develop-v2` tip `03751f3`):

```
# iptables -S FORWARD | grep DOCKER-USER      → (nothing; FORWARD never jumps there)
# podman exec monerod curl -m5 http://1.1.1.1/ → HTTP 301   (leak)
```

## The fix

Enforcement now follows the running engine (`container_engine`):

- **Docker (DIY):** unchanged — rules in `DOCKER-USER`.
- **podman + netavark (appliance):** an independent `inet pithead_egress` nftables table, base chain hooked at `forward priority -5` — ahead of netavark's priority-0 blanket accept, owning no chain shared with netavark so it survives netavark reprogramming its own table. Same allow-set (ESTABLISHED/RELATED, the tor container IP, RFC1918 + CGNAT LAN, DROP the rest of the mining subnet). This is the phase-0 spike design finally landed.

`remove_tor_egress_firewall` clears **both** backends so a re-apply or engine change can't strand a stale set. `apply`/`remove`/`doctor` all branch on the engine.

**doctor now reports the true state:** `check_egress_firewall_nft` reads the nft table the appliance actually installs and asserts the chain is **hooked at forward** — the orphaned-chain condition (a DROP no packet reaches) is exactly what a forward-hooked base chain cannot be, so hook presence is the honest signal, not "a rule exists somewhere." A `list tables` probe distinguishes a sudo refusal from a genuinely missing table, so it never false-FAILs.

The appliance boot path (`pithead-boot` → `./pithead up` → `stack_up` → `apply_tor_egress_firewall`) picks up the correct backend with no other change.

## Coverage

- **Stack tier** (`tests/stack/run.sh`): `render_tor_egress_nft` rendering (hook, priority, allow-set, fail-closed final drop, idempotent-replace); `apply_tor_egress_firewall` routes to nft under `PITHEAD_ENGINE=podman` and never touches `DOCKER-USER`; `remove` tears down the nft table too; the doctor nft branch (OK on a forward-hooked drop, FAIL when the table is absent, info-skip on no-sudo/no-nft). Existing Docker-path tests pinned to `PITHEAD_ENGINE=docker` and made hermetic against the new nft probe.
- **KVM battery** (`tests/os/run.sh`, provision phase): from inside `monerod` on the mining net, a direct clearnet dial by raw IP must be DROPPED, while the same container still reaches clearnet through Tor's SOCKS — the assertion whose absence let this ship green. It FAILS against the orphaned-chain code and PASSES with the fix.

## Live bench proof

Rendered the fixed nft table by hand on `pithead.local` and loaded it (bench restored to its code-managed state afterward — it's mid-soak):

| | direct clearnet `1.1.1.1` | via Tor SOCKS |
|---|---|---|
| before (orphaned iptables) | **HTTP 301 (leak)** | HTTP 301 |
| after (`inet pithead_egress` loaded) | **DROPPED (curl rc 28 timeout)** | HTTP 301 |
| after restore | HTTP 301 | — |

The DROP blocks the direct dial while Tor-routed egress (real mining) keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
