### PR TITLE
feat(appliance): two-tier reset + wedged-/data recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-st
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
 	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh \
-		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot tests/os/run.sh tests/os/verify-image.sh
+		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot os/overlay/pithead-data-reset tests/os/run.sh tests/os/verify-image.sh
 	shfmt -i 4 -d pithead pithead-completion.bash os/installer/pithead-install $(shell git ls-files '*.sh')
 
 lint-py: ## ruff lint + format check on all repo Python (ruff runs via uv from the locked dev extra)

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -255,6 +255,34 @@ install-then-fall-back protection as any other update. The practical consequence
 an old image keeps running fine, but it keeps the old image's known holes too. The base
 system is Debian 13, which receives security support upstream into 2030.
 
+## Starting over: the two resets
+
+There are two ways to reset the machine, and the difference between them is days of your
+time. Both run from a shell — log in at the console as `root` with the dashboard password
+(the appliance has no uninstall; these resets are its equivalents).
+
+**Config reset** clears your settings and reopens the setup wizard, and keeps everything
+else. The synced chain, your wallet, the Tor onion keys and your dashboard history all
+stay on the machine, so the wizard opens on a box that is still fully synced — you re-enter
+your answers and it is running again in minutes, at the same onion address. Reach for this
+when you want to change a setting the wizard owns, or hand the machine to someone else
+without a resync.
+
+```
+pithead config-reset
+```
+
+**Factory reset** erases the whole data area — chain, wallet, Tor keys, settings, all of
+it — and reboots to a blank setup wizard, exactly as the machine shipped. The resync that
+follows takes days, so use config reset first unless you truly want nothing kept.
+
+```
+pithead factory-reset
+```
+
+Both ask you to type the reset name before they do anything. The machine reboots itself
+into setup when the reset is done.
+
 ## If something goes wrong
 
 **The machine will not boot from the stick.** Almost always Secure Boot — disable it in

--- a/os/overlay/pithead-data-reset
+++ b/os/overlay/pithead-data-reset
@@ -22,7 +22,11 @@ MARKER_NAME="pithead-reset"
 # /var. Keep this list in lockstep with 40-data.conf.
 SEED_DIRS="/overlay/var /overlay/var-work /pithead"
 
-log() { echo "pithead-data-reset: $*"; }
+# stderr, not stdout: data_reset_decision's STDOUT is its verdict and the caller captures it with
+# $(...). A progress line on stdout would ride along inside the captured value, match no `case`
+# branch, and silently skip the recovery reformat — the wedged box would stay wedged. The journal
+# gets stderr from a unit exactly as it gets stdout, so nothing is lost by moving it.
+log() { echo "pithead-data-reset: $*" >&2; }
 
 # The data and ESP partitions on the disk the system booted from — the same derivation
 # pithead-mount-generator uses (never by label: every pithead disk carries the same labels, so a

--- a/os/overlay/pithead-data-reset
+++ b/os/overlay/pithead-data-reset
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Reformat /data BEFORE it mounts — the executor for `pithead factory-reset` and the recovery path
+# for a wedged data partition. Runs one layer under the running system precisely because a mounted
+# /data (holding the container store and the /var overlay's upper/work dirs) cannot be reformatted.
+#
+# Two triggers, both fail-safe:
+#   1. Factory reset requested — a `pithead-reset` marker sits on the ESP. The host CLI writes it
+#      (the marker lives on the ESP, not /data, so it survives the wipe) and reboots here.
+#   2. Wedged /data — the partition exists but will not mount even after an fsck. A shell-less
+#      release image with root locked has no other way back; the alternative is a bricked box.
+#
+# The guard that matters: a data partition that mounts cleanly and carries no marker is NEVER
+# touched. We only ever reformat on an explicit request or a genuinely unmountable partition, and
+# a fsck pass runs first so a transient/dirty filesystem is repaired rather than erased. Fail safe
+# — never wipe a recoverable /data.
+set -uo pipefail
+
+MARKER_NAME="pithead-reset"
+# The dirs systemd-repart seeds at format time (os/rootfs/repart.d/40-data.conf). repart only runs
+# MakeDirectories when IT formats a partition, so when we reformat we reseed them ourselves — the
+# /var overlay's upperdir/workdir must exist before /var mounts, or the box boots with no writable
+# /var. Keep this list in lockstep with 40-data.conf.
+SEED_DIRS="/overlay/var /overlay/var-work /pithead"
+
+log() { echo "pithead-data-reset: $*"; }
+
+# The data and ESP partitions on the disk the system booted from — the same derivation
+# pithead-mount-generator uses (never by label: every pithead disk carries the same labels, so a
+# stick + an installed disk present together make LABEL=data ambiguous). Partition numbers are
+# fixed by the layout: 1 = ESP, 4 = data.
+boot_disk_part() { # $1: partition number -> prints /dev/node, or nothing
+    local rootsrc disk sep
+    rootsrc=$(findmnt -no SOURCE / 2>/dev/null) || return 1
+    case "$rootsrc" in /dev/*) ;; *) return 1 ;; esac
+    disk=$(printf '%s' "$rootsrc" | sed -E 's/[0-9]+$//; s/(^.*[0-9])p$/\1/')
+    case "$disk" in *[0-9]) sep="p" ;; *) sep="" ;; esac
+    printf '%s%s%s' "$disk" "$sep" "$1"
+}
+
+# Read-only probe mount (so it never dirties the fs), cleaned up either way. rc mirrors the mount.
+try_mount_ro() { # $1: partition
+    local mnt
+    mnt=$(mktemp -d) || return 1
+    if mount -o ro "$1" "$mnt" 2>/dev/null; then
+        umount "$mnt" 2>/dev/null || true
+        rmdir "$mnt" 2>/dev/null || true
+        return 0
+    fi
+    rmdir "$mnt" 2>/dev/null || true
+    return 1
+}
+
+# Can the data partition be mounted? Tries once, runs a non-interactive fsck repair, tries again.
+# rc 0 = mountable (healthy or repaired), rc 1 = wedged.
+data_mountable() { # $1: data partition
+    try_mount_ro "$1" && return 0
+    log "$1 did not mount — attempting fsck repair before deciding anything"
+    fsck -p -t ext4 "$1" >/dev/null 2>&1 || true
+    try_mount_ro "$1"
+}
+
+# The whole decision, isolated so it is testable with stubbed mount/fsck. Echoes exactly one of:
+#   skip                 healthy partition, no request — touch nothing (the fail-safe default)
+#   reformat-requested   the factory-reset marker is present
+#   reformat-wedged      the partition will not mount even after fsck
+data_reset_decision() { # $1: data partition, $2: marker file path
+    if [ -f "$2" ]; then
+        echo reformat-requested
+        return 0
+    fi
+    if data_mountable "$1"; then
+        echo skip
+        return 0
+    fi
+    echo reformat-wedged
+}
+
+# Reformat the data partition and reseed the dirs repart would have. DESTRUCTIVE — only ever
+# reached from data_reset_decision's reformat verdicts.
+reformat_data() { # $1: data partition
+    local part="$1" mnt d
+    log "reformatting $part (ext4, label 'data')"
+    mkfs.ext4 -q -F -L data "$part" || {
+        log "mkfs failed on $part — leaving it as-is"
+        return 1
+    }
+    mnt=$(mktemp -d) || return 1
+    if mount "$part" "$mnt" 2>/dev/null; then
+        for d in $SEED_DIRS; do mkdir -p "$mnt$d"; done
+        umount "$mnt" 2>/dev/null || true
+    fi
+    rmdir "$mnt" 2>/dev/null || true
+}
+
+main() {
+    local data_part esp_part esp_mnt marker verdict
+    data_part=$(boot_disk_part 4) || {
+        log "could not resolve the data partition from the boot disk — doing nothing"
+        return 0
+    }
+    [ -b "$data_part" ] || {
+        log "$data_part is not a block device yet (first boot?) — doing nothing"
+        return 0
+    }
+
+    # Read (and later clear) the factory-reset marker on the ESP. The ESP is not mounted this early,
+    # so mount it ourselves; if it will not mount we simply have no marker to act on.
+    esp_part=$(boot_disk_part 1) || esp_part=""
+    esp_mnt=$(mktemp -d)
+    marker=""
+    if [ -n "$esp_part" ] && [ -b "$esp_part" ] && mount "$esp_part" "$esp_mnt" 2>/dev/null; then
+        marker="$esp_mnt/$MARKER_NAME"
+    fi
+
+    verdict=$(data_reset_decision "$data_part" "${marker:-/nonexistent}")
+    case "$verdict" in
+    skip)
+        log "$data_part is healthy and no reset was requested — leaving it untouched"
+        ;;
+    reformat-requested)
+        log "factory-reset requested — wiping $data_part"
+        reformat_data "$data_part"
+        # Consume the marker so the wipe is one-shot, never a reboot loop.
+        [ -n "$marker" ] && rm -f "$marker" 2>/dev/null || true
+        ;;
+    reformat-wedged)
+        log "$data_part is unmountable even after fsck — reinitializing it so the box can recover"
+        reformat_data "$data_part"
+        ;;
+    esac
+
+    if mountpoint -q "$esp_mnt" 2>/dev/null; then umount "$esp_mnt" 2>/dev/null || true; fi
+    rmdir "$esp_mnt" 2>/dev/null || true
+    return 0
+}
+
+# Sourceable for the test suite (functions only); runs main only when executed directly.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then main "$@"; fi

--- a/os/overlay/pithead-data-reset.service
+++ b/os/overlay/pithead-data-reset.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Reformat /data on factory-reset request or when it is wedged — before it mounts
+# Runs in the early-boot local-fs transaction, with no default ordering, so it can act on the data
+# partition BEFORE anything mounts it: a mounted /data (container store + the /var overlay's
+# upper/work dirs) cannot be reformatted. systemd-repart creates the partition on first boot, so we
+# wait for it; then we go strictly before /data (and therefore before the /var overlay, which has
+# x-systemd.requires-mounts-for=/data) so a reformat + reseed lands before any consumer.
+DefaultDependencies=no
+After=systemd-repart.service
+Before=data.mount local-fs.target
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/pithead-data-reset
+
+[Install]
+# Pulled into the same transaction that mounts /data, so it is scheduled (and ordered before) it.
+WantedBy=local-fs.target

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -159,7 +159,13 @@ COPY os/overlay/pithead-sync /usr/local/sbin/pithead-sync
 COPY os/overlay/pithead-mount-generator /usr/lib/systemd/system-generators/pithead-mount-generator
 COPY os/overlay/pithead-boot.service /etc/systemd/system/pithead-boot.service
 COPY os/overlay/pithead-boot /usr/local/sbin/pithead-boot
-RUN chmod +x /usr/local/sbin/pithead-sync /usr/local/sbin/pithead-boot /usr/lib/systemd/system-generators/pithead-mount-generator
+# The two-tier reset's deep tier and the wedged-/data recovery path: reformats /data before it
+# mounts, either on a `pithead factory-reset` request (ESP marker) or when the partition is
+# genuinely unmountable. Ordered before data.mount by its unit — the wipe cannot run once /data is
+# in use — and fail-safe: a healthy, unmarked partition is never touched.
+COPY os/overlay/pithead-data-reset.service /etc/systemd/system/pithead-data-reset.service
+COPY os/overlay/pithead-data-reset /usr/local/sbin/pithead-data-reset
+RUN chmod +x /usr/local/sbin/pithead-sync /usr/local/sbin/pithead-boot /usr/local/sbin/pithead-data-reset /usr/lib/systemd/system-generators/pithead-mount-generator
 # The updater is chosen per image (bake-off candidates). rugix-ctrl arrives via the bakery layer's
 # core recipe; RAUC is a Debian package, so it is installed here when selected.
 ARG PITHEAD_UPDATER=""
@@ -191,6 +197,7 @@ COPY os/rootfs/repart.d/ /usr/lib/repart.d/
 RUN sed -i 's/^#\?use-ipv6=.*/use-ipv6=no/' /etc/avahi/avahi-daemon.conf
 RUN systemctl enable podman.socket pithead-boot.service avahi-daemon systemd-timesyncd systemd-resolved \
         systemd-networkd systemd-networkd-wait-online pithead-sync.service pithead-firstboot.service \
+        pithead-data-reset.service \
     && systemctl disable ssh
 # systemd-repart.service is static — it is pulled in by sysinit.target, and `systemctl enable` on a
 # static unit is an error that would fail the build. Assert it is present instead.

--- a/pithead
+++ b/pithead
@@ -2381,6 +2381,98 @@ reset_dashboard() {
     fi
 }
 
+# --- Two-tier reset (config / factory) -----------------------------------------------------------
+# The appliance has no uninstall — its equivalents are these two reset tiers. A full wipe costs
+# days of chain resync, so config-reset is the cheap tier: clear the configuration, keep every
+# data directory. factory-reset is the deep one: wipe /data back to a blank machine.
+
+# On the appliance, reboot into the first-boot path; elsewhere, just say what to run by hand. The
+# reboot command is overridable so the test suite can assert it fires without rebooting the runner.
+reset_reboot_or_hint() {
+    if is_appliance; then
+        _console "Rebooting into first-boot setup..."
+        ${PITHEAD_REBOOT_CMD:-systemctl reboot} ||
+            warn "Reboot command failed — reboot the machine by hand to reach the setup wizard."
+    else
+        log "Reconfigure with '$0 firstboot-wizard' (or '$0 setup') when you're ready."
+    fi
+}
+
+# config-reset: back to unprovisioned, chains kept. Removing config.json is the whole mechanism —
+# pithead-firstboot's ConditionPathExists=!config.json re-arms the wizard, and pithead-boot's
+# opposite condition stands down. Every data directory (chains, Tor onion keys, wallets, dashboard
+# history) stays: only config.json and the files rendered from it go, so reconfiguring costs no
+# resync and the onion address survives.
+config_reset() {
+    local assume_yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        *) error "Unknown option for config-reset: $arg. Run '$0 help'." ;;
+        esac
+    done
+    [ -f "$CONFIG_FILE" ] ||
+        error "No $CONFIG_FILE here — already unprovisioned. The setup wizard opens on its own when config.json is absent."
+
+    echo -e "${C_RED}[WARNING] This is a DESTRUCTIVE action.${C_RESET}"
+    echo "It clears your configuration and reopens the setup wizard."
+    log "Kept: chains, wallets, Tor onion keys, dashboard history — every data directory stays. Only config.json and the files rendered from it go."
+    if [ "$assume_yes" -eq 0 ]; then
+        printf "Type 'config-reset' to continue: "
+        read -r arg || true
+        [ "$arg" = "config-reset" ] || {
+            log "Aborted — nothing changed."
+            return 1
+        }
+    fi
+
+    detect_os 2>/dev/null || true
+    docker compose down --remove-orphans 2>/dev/null ||
+        warn "compose down failed (engine not running?) — continuing with the config wipe."
+    remove_tor_egress_firewall 2>/dev/null || true
+    rm -f "$CONFIG_FILE" "$ENV_FILE" Caddyfile
+    log "Configuration cleared — the first-boot wizard owns the next boot."
+    reset_reboot_or_hint
+}
+
+# factory-reset: the deep wipe. /data cannot be reformatted while it is mounted and holding the
+# container store and the /var overlay, so the wipe runs one layer down: a marker on the ESP (which
+# survives the wipe) arms pithead-data-reset, which reformats /data before it mounts on the next
+# boot, then the box comes up blank into the wizard. Appliance-only — a normal install's clean exit
+# is 'uninstall', where the operator owns the data dirs and can remove them deliberately.
+factory_reset() {
+    local assume_yes=0 arg
+    for arg in "$@"; do
+        case "$arg" in
+        -y | --yes) assume_yes=1 ;;
+        *) error "Unknown option for factory-reset: $arg. Run '$0 help'." ;;
+        esac
+    done
+    is_appliance ||
+        error "factory-reset wipes the appliance data partition and only runs on the appliance. On a normal install, 'uninstall' is the clean exit — it keeps your data dirs for you to remove yourself."
+
+    echo -e "${C_RED}[WARNING] This ERASES EVERYTHING on the data partition.${C_RESET}"
+    echo "Chains, wallets, Tor onion keys, dashboard history, and all settings go. The box reboots"
+    echo "to a blank setup wizard, and the chain resync that follows costs days."
+    if [ "$assume_yes" -eq 0 ]; then
+        printf "Type 'factory-reset' to continue: "
+        read -r arg || true
+        [ "$arg" = "factory-reset" ] || {
+            log "Aborted — nothing changed."
+            return 1
+        }
+    fi
+
+    # Arm the boot-time wipe. The marker lives on the ESP, not /data, precisely because /data is
+    # what gets erased. If the ESP is not writable the wipe cannot be armed, so refuse loudly
+    # rather than reboot into a box that quietly did nothing.
+    local marker="$PRESEED_DIR/pithead-reset"
+    : >"$marker" 2>/dev/null ||
+        error "Could not arm the reset marker at $marker (ESP not mounted?) — nothing was wiped."
+    log "Reset armed. Rebooting to reformat /data and reopen the wizard..."
+    reset_reboot_or_hint
+}
+
 # --- Backup / Restore ---
 # Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, and the Tor
 # data dir (onion service keys). The blockchains and dashboard DB re-sync, so they're excluded
@@ -2724,6 +2816,18 @@ Inspection:
 Maintenance:
   reset-dashboard [-y|--yes]
                             DESTRUCTIVE: wipe and recreate dashboard/p2pool data.
+                              -y, --yes        skip the confirmation prompt.
+  config-reset [-y|--yes]   DESTRUCTIVE: clear the configuration and reopen the setup wizard,
+                            keeping every data directory — chains, wallets, Tor onion keys, and
+                            dashboard history all stay, so reconfiguring costs no resync. Removes
+                            config.json and the files rendered from it, then (on the appliance)
+                            reboots into first-boot setup. Type-to-confirm unless -y.
+                              -y, --yes        skip the confirmation prompt.
+  factory-reset [-y|--yes]  DESTRUCTIVE (appliance only): erase the whole data partition back to
+                            a blank machine — chains, wallets, Tor keys, and settings all go — then
+                            reboot into the setup wizard. The chain resync that follows costs days;
+                            reach for config-reset first. On a normal install, 'uninstall' is the
+                            clean exit instead. Type-to-confirm unless -y.
                               -y, --yes        skip the confirmation prompt.
   backup [--with-chains] [--no-encrypt] [-y|--yes]
                             Write a timestamped, chmod-600 archive under backups/ holding the
@@ -7377,7 +7481,7 @@ apply() {
 # Every dispatchable subcommand, in help order. main's dispatch, the chain validator, and the
 # tab-completion script (pithead-completion.bash) key off this one list; tests/stack/run.sh fails
 # if any of the three drift apart.
-readonly PITHEAD_COMMANDS="setup apply render up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall firstboot-wizard load-images local-miner os-update control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+readonly PITHEAD_COMMANDS="setup apply render up down restart upgrade logs status doctor support-bundle reset-dashboard config-reset factory-reset backup restore uninstall firstboot-wizard load-images local-miner os-update control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 # The subset allowed in a chain: commands that take no positional argument and terminate on their
 # own. Excluded: setup (interactive first-run), logs (follows until Ctrl+C), restore (needs an
 # archive path), reset-dashboard (destructive — run it deliberately, alone), and the one-shot
@@ -8831,6 +8935,8 @@ main() {
         require_deployed
         reset_dashboard "$@"
         ;;
+    config-reset) config_reset "$@" ;;
+    factory-reset) factory_reset "$@" ;;
     backup) stack_backup "$@" ;;
     restore) stack_restore "$@" ;;
     uninstall) stack_uninstall "$@" ;;

--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -13,7 +13,7 @@
 
 # Keep in sync with PITHEAD_COMMANDS in the pithead script — tests/stack/run.sh fails if the
 # two lists drift.
-_pithead_commands="setup apply render up down restart upgrade logs status doctor support-bundle reset-dashboard backup restore uninstall firstboot-wizard load-images local-miner os-update control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
+_pithead_commands="setup apply render up down restart upgrade logs status doctor support-bundle reset-dashboard config-reset factory-reset backup restore uninstall firstboot-wizard load-images local-miner os-update control-run-pending onion-client-key rotate-dashboard-onion rotate-secrets render-quadlet version help"
 
 # Service names = the top-level keys under `services:` in the docker-compose.yml next to the
 # pithead being completed. $1 = path to that compose file.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8690,6 +8690,117 @@ rm -rf "$RSMTMP"
 unset RSM RSMTMP
 unset -f rsm rsm_field
 
+echo "== black-box: config-reset clears config, keeps the chains (appliance two-tier reset) =="
+# A throwaway deployment: config.json + rendered files + data dirs. docker is a noop; the reboot is
+# a stub that just records that it fired, so we assert the reboot without rebooting the runner.
+CR="$SANDBOX/config-reset"
+mkdir -p "$CR/bin" "$CR/data/monero" "$CR/data/tor"
+cp "$STACK" "$CR/pithead"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$CR/bin/docker"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$CR/bin/sudo"
+chmod +x "$CR/bin/docker" "$CR/bin/sudo"
+seed_cr() {
+    printf '{ "monero":{"mode":"local","wallet_address":"%s"}, "tari":{"wallet_address":"T"} }\n' "$WALLET" >"$CR/config.json"
+    printf 'DEPLOYMENT_COMPLETED=true\nHOST_IP=box.lan\n' >"$CR/.env"
+    : >"$CR/Caddyfile"
+    : >"$CR/data/monero/blockchain" # stand-in for the synced chain
+    : >"$CR/data/tor/hostname"      # stand-in for the onion key material
+}
+# Wrong confirmation word: aborts, changes nothing.
+seed_cr
+out=$(cd "$CR" && printf 'nope\n' | PITHEAD_APPLIANCE=0 PATH="$CR/bin:$PATH" ./pithead config-reset 2>&1) || true
+assert_contains "config-reset aborts on the wrong confirm word" "$out" "Aborted"
+assert_eq "aborted config-reset keeps config.json" "$([ -f "$CR/config.json" ] && echo yes)" "yes"
+# -y off the appliance: config + rendered files go, data dirs stay, no reboot — just the hint.
+seed_cr
+rebooted="$CR/.rebooted"
+rm -f "$rebooted"
+out=$(cd "$CR" && PITHEAD_APPLIANCE=0 PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$CR/bin:$PATH" ./pithead config-reset -y 2>&1)
+assert_rc "config-reset succeeds" "$?" "0"
+assert_eq "config-reset removes config.json" "$([ -f "$CR/config.json" ] || echo gone)" "gone"
+assert_eq "config-reset removes .env" "$([ -f "$CR/.env" ] || echo gone)" "gone"
+assert_eq "config-reset removes Caddyfile" "$([ -f "$CR/Caddyfile" ] || echo gone)" "gone"
+assert_eq "config-reset KEEPS the monero chain" "$([ -f "$CR/data/monero/blockchain" ] && echo kept)" "kept"
+assert_eq "config-reset KEEPS the Tor onion key" "$([ -f "$CR/data/tor/hostname" ] && echo kept)" "kept"
+assert_eq "config-reset off the appliance does not reboot" "$([ -f "$rebooted" ] || echo no)" "no"
+assert_contains "config-reset hints how to reconfigure" "$out" "firstboot-wizard"
+# On the appliance: same wipe, but it reboots into first-boot setup.
+seed_cr
+rm -f "$rebooted"
+out=$(cd "$CR" && PITHEAD_APPLIANCE=1 PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$CR/bin:$PATH" ./pithead config-reset -y 2>&1)
+assert_eq "config-reset on the appliance reboots into firstboot" "$([ -f "$rebooted" ] && echo yes)" "yes"
+# Already unprovisioned: nothing to reset.
+out=$(cd "$CR" && PITHEAD_APPLIANCE=1 PATH="$CR/bin:$PATH" ./pithead config-reset -y 2>&1) || true
+assert_contains "config-reset refuses when config.json is absent" "$out" "already unprovisioned"
+out=$(cd "$CR" && PATH="$CR/bin:$PATH" ./pithead config-reset --bogus 2>&1) || true
+assert_contains "config-reset rejects unknown options" "$out" "Unknown option"
+
+echo "== black-box: factory-reset arms the boot-time wipe, appliance-only (two-tier reset) =="
+FR="$SANDBOX/factory-reset"
+mkdir -p "$FR/bin" "$FR/esp"
+cp "$STACK" "$FR/pithead"
+marker="$FR/esp/pithead-reset"
+rebooted="$FR/.rebooted"
+# Off the appliance: refuse, arm nothing, point at uninstall.
+rm -f "$marker" "$rebooted"
+out=$(cd "$FR" && PITHEAD_APPLIANCE=0 PITHEAD_PRESEED_DIR="$FR/esp" PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$FR/bin:$PATH" ./pithead factory-reset -y 2>&1) || true
+assert_contains "factory-reset off the appliance refuses" "$out" "only runs on the appliance"
+assert_eq "refused factory-reset arms no marker" "$([ -f "$marker" ] || echo none)" "none"
+# Wrong confirmation word on the appliance: aborts, arms nothing.
+out=$(cd "$FR" && printf 'nope\n' | PITHEAD_APPLIANCE=1 PITHEAD_PRESEED_DIR="$FR/esp" PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$FR/bin:$PATH" ./pithead factory-reset 2>&1) || true
+assert_contains "factory-reset aborts on the wrong confirm word" "$out" "Aborted"
+assert_eq "aborted factory-reset arms no marker" "$([ -f "$marker" ] || echo none)" "none"
+# -y on the appliance: BATTERY — the marker is written AND the reboot fires (both, or the wipe
+# either never runs or never reaches the boot that runs it).
+rm -f "$marker" "$rebooted"
+out=$(cd "$FR" && PITHEAD_APPLIANCE=1 PITHEAD_PRESEED_DIR="$FR/esp" PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$FR/bin:$PATH" ./pithead factory-reset -y 2>&1)
+assert_rc "factory-reset succeeds" "$?" "0"
+assert_eq "factory-reset arms the ESP marker AND reboots" \
+    "$([ -f "$marker" ] && [ -f "$rebooted" ] && echo armed-and-rebooting)" "armed-and-rebooting"
+# ESP not writable: refuse loudly, reboot nothing (a box that quietly did nothing is the trap).
+rm -f "$rebooted"
+out=$(cd "$FR" && PITHEAD_APPLIANCE=1 PITHEAD_PRESEED_DIR="$FR/no-such-esp" PITHEAD_REBOOT_CMD="touch $rebooted" PATH="$FR/bin:$PATH" ./pithead factory-reset -y 2>&1) || true
+assert_contains "factory-reset refuses when the ESP marker cannot be written" "$out" "Could not arm"
+assert_eq "unarmable factory-reset does not reboot" "$([ -f "$rebooted" ] || echo no)" "no"
+
+echo "== unit: pithead-data-reset decides reformat-vs-skip fail-safe (wedged-/data recovery) =="
+# Source the boot script (functions only — its main is guarded) and drive data_reset_decision with
+# a stubbed mount/fsck, in a subshell so its set -u / defs never leak into the suite.
+DR="$SANDBOX/data-reset"
+mkdir -p "$DR/bin"
+# mount: MOUNT_MODE=ok always mounts; fail never; repair fails the first call then mounts (fsck fixed
+# it). A counter file makes 'repair' stateful across the two calls in data_mountable.
+cat >"$DR/bin/mount" <<'EOF'
+#!/usr/bin/env bash
+case "${MOUNT_MODE:-ok}" in
+  ok) exit 0 ;;
+  fail) exit 1 ;;
+  repair)
+    n=$(cat "${MOUNT_COUNTER:-/dev/null}" 2>/dev/null || echo 0)
+    echo $((n + 1)) >"${MOUNT_COUNTER:-/dev/null}" 2>/dev/null || true
+    [ "$n" -ge 1 ] && exit 0 || exit 1 ;;
+esac
+EOF
+printf '#!/usr/bin/env bash\nexit 0\n' >"$DR/bin/umount"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$DR/bin/fsck"
+chmod +x "$DR/bin/mount" "$DR/bin/umount" "$DR/bin/fsck"
+decide() { # $1 marker-file, $2 mount-mode
+    (
+        export PATH="$DR/bin:$PATH"
+        export MOUNT_MODE="$2" # exported: the stubbed mount runs as a child process
+        export MOUNT_COUNTER="$DR/counter"
+        : >"$MOUNT_COUNTER"
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-data-reset"
+        data_reset_decision "/dev/fake-data" "$1"
+    )
+}
+touch "$DR/marker-present"
+assert_eq "marker present -> reformat-requested (even if /data would mount)" "$(decide "$DR/marker-present" ok)" "reformat-requested"
+assert_eq "no marker + /data mounts clean -> skip (fail-safe: never touch a healthy partition)" "$(decide "$DR/no-marker" ok)" "skip"
+assert_eq "no marker + /data wedged after fsck -> reformat-wedged (recovery)" "$(decide "$DR/no-marker" fail)" "reformat-wedged"
+assert_eq "no marker + fsck repairs the mount -> skip (recoverable /data is never wiped)" "$(decide "$DR/no-marker" repair)" "skip"
+
 # ---------------------------------------------------------------------------
 echo ""
 printf 'pithead tests: \033[1;32m%d passed\033[0m, ' "$PASS"


### PR DESCRIPTION
## Two-tier reset + wedged-/data recovery

Closes #849. The appliance had neither reset tier and no way back from a corrupt `/data` on a shell-less release image (root login locked). This adds both tiers as host-CLI commands plus a boot-time recovery path.

### The two commands
- **`pithead config-reset [-y]`** — the cheap tier. Removes `config.json` and the files rendered from it (`.env`, `Caddyfile`), which re-arms the first-boot wizard (`pithead-firstboot`'s `ConditionPathExists=!config.json`) and stands `pithead-boot` down. Every data directory stays — chains, wallets, Tor onion keys, dashboard history — so reconfiguring costs no resync and the onion address survives. On the appliance it reboots into setup; elsewhere it prints how to reconfigure.
- **`pithead factory-reset [-y]`** — the deep tier, **appliance-only** (a normal install's clean exit stays `uninstall`). `/data` can't be reformatted while it's mounted (it holds the container store and the `/var` overlay's upper/work dirs), so the wipe runs one layer down: it arms a marker on the **ESP** (which survives the wipe) and reboots.

Both are type-to-confirm unless `-y`.

### Wedged-/data recovery
New early-boot unit **`pithead-data-reset.service`** + script, ordered before `data.mount`. It's both the factory-reset executor and the recovery path. It reformats `/data` (and reseeds the dirs `systemd-repart` would — the `/var` overlay's upper/work) in exactly two cases:
1. the factory-reset marker is present on the ESP, or
2. the partition is unmountable **even after an `fsck -p` repair**.

**Fail-safe guards (the load-bearing part):**
- A partition that mounts cleanly with **no marker is never touched** — the default verdict is `skip`.
- Unmountable is not enough on its own: `fsck -p` runs first and we retry, so a merely dirty/transient fs is repaired, not erased. Only a genuinely unrecoverable partition is reformatted — and the alternative there is a bricked, shell-less box.
- If the boot disk's data partition can't be resolved, or isn't a block device yet (first boot), it does nothing.

### Appliance surface
Console is the surfaced path today (root login at the console with the dashboard password — the resets are the appliance's `uninstall` equivalent). A dashboard-button / removable-media trigger depends on the shell-less-parity work in #786 and is out of scope here.

### Tests
Stack-tier (`tests/stack/run.sh`, docker/sudo/reboot stubbed):
- config-reset: preserves the chain + onion key, removes config/`.env`/`Caddyfile`, reboots only on the appliance, refuses when already unprovisioned, type-to-confirm.
- factory-reset: appliance-only refusal, **battery assertion** that it arms the ESP marker *and* reboots, refuses when the ESP marker can't be written (and then does not reboot), type-to-confirm.
- `data_reset_decision` unit: healthy→skip, wedged→reformat, fsck-repaired→skip, marker→reformat-requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
