### PR TITLE
fix(os-update): version floor + data-migration rollback guard

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -56,6 +56,57 @@ warns before making that transition, requiring a y/N confirmation (or `--yes`). 
 `rauc install` bypasses the guard; use it only when you have already decided the SSH loss
 is acceptable.
 
+## Compatibility metadata and the data-migration floor
+
+The bundle manifest's `[meta.pithead]` section carries the compatibility contract the
+update path reads back before it installs:
+
+| Field | Meaning |
+|---|---|
+| `version` | the OS version this bundle carries (from `VERSION`) |
+| `data_migration` | `true` if this release runs a forward-only `/data` (lmdb) migration |
+| `minimum_os_version` | the lowest OS version that can still read `/data` once it has migrated |
+
+Two guards consume them, because a correctly-signed bundle is not automatically a safe one:
+
+- **No signed downgrade.** `os-update` installs without confirmation only a clean `X.Y.Z`
+  release whose `version` is at or newer than the running OS. It fails **closed**: an older
+  bundle, a pre-release/`-prep` version, garbage, or an absent stamp is not proof of safety
+  (an older image re-introduces the holes the newer one fixed, carrying our own valid
+  signature), so any of them is refused unless `--allow-downgrade` is passed on purpose.
+  The check is skipped only when the box cannot read its *own* version — a source checkout,
+  never a provisioned appliance. (Deliberate A/B rollback is unaffected — `rauc status
+  mark-bad booted` boots the spare slot already present; it does not re-install an old bundle.)
+- **No rollback below the migration floor.** When a `data_migration` bundle installs,
+  `os-update` records its `minimum_os_version` as a floor on `/data` (`.os-data-floor`). Once
+  a floor file exists it is authoritative and fails **closed**: an OS below it, a bundle whose
+  version can't be parsed, *or a corrupt floor file itself* is refused **outright** —
+  `--allow-downgrade` does not override any of these, because the migrated chain data is
+  unreadable there and the failure is silent data loss, not a policy preference. The escape is
+  a factory reset (loses the chain) or restoring a backup taken on a version at or above the
+  floor.
+
+**The data-migration contract for release authors:** a release that ships a forward-only
+schema bump MUST declare it, or a later rollback silently strands the migrated chain data.
+Build the bundle with both fields set:
+
+```bash
+PITHEAD_DATA_MIGRATION=true PITHEAD_MIN_OS_VERSION=X.Y.Z os/rauc/mkbundle.sh ...
+```
+
+`X.Y.Z` is the lowest OS version whose monerod/tari can still read `/data` after the
+migration — normally this release's own version. `mkbundle.sh` refuses to build a
+migrating bundle without it.
+
+**Scoped follow-up — the migration runner.** Recording and enforcing the floor is done;
+*executing* the forward-only migration is not. The remaining half of the deadlock rule
+(`dual-distribution-plan.md` risk #6) is `pithead-boot` withholding the chain services
+(monerod/tari) until the slot commits on a `data_migration` update, so automatic A/B
+fallback stays pre-migration. Until that lands, the floor guard above prevents the *manual*
+rollback path from stranding data; the automatic-fallback ordering is bench (tier-4) work,
+asserted by `tests/os/run.sh --phase update`. The `db_schema` field the plan also lists
+lands with that runner — nothing reads it yet.
+
 ## Development loop
 
 Everything runs from the repo root on a Linux box with docker, KVM and libvirt. The

--- a/docs/dev/appliance-wizard.md
+++ b/docs/dev/appliance-wizard.md
@@ -189,6 +189,16 @@ a hardware-validated failure:
    `hugepages_reserve_extra_mb` — RigForge's grow-only sysctl then sizes the shared pool as
    the single writer, and pithead's own HugePages write never shrinks a grown pool back.
 
+**Known gap at step 4 — forward-only data migrations.** Today `up` (step 3) starts the whole
+stack, monerod and tari included, *before* the commit at step 4. A release that runs a
+forward-only lmdb migration would therefore migrate `/data` before the slot commits, so a
+failed health check could leave the box unable to commit *or* fall back cleanly. The
+migration-deadlock rule (`dual-distribution-plan.md` risk #6) closes this by withholding the
+chain services until the slot commits on a `data_migration`-flagged update; that boot-path
+change is scoped follow-up. Until it lands, `pithead os-update` already refuses a *manual*
+rollback below the `/data` migration floor — see
+[`appliance-release.md`](appliance-release.md#compatibility-metadata-and-the-data-migration-floor).
+
 **Rule for changes:** anything generated from `config.json` or the program is derived and must
 be rebuilt by `render` — adding one anywhere else recreates the staleness bug. The container
 images are derived in the same sense: functions of the running slot, converged every boot by

--- a/os/rauc/mkbundle.sh
+++ b/os/rauc/mkbundle.sh
@@ -21,6 +21,31 @@ for arg in "$@"; do
 done
 OUT="${OUT:-os/rauc/build/update.raucb}"
 TARBALL="os/build/pithead-root.tar"
+
+# Compatibility metadata — the channel contract the update path reads back (docs/dev/appliance-release.md).
+# Validated up front so a bad release input fails before the multi-minute image build, not after.
+#   PITHEAD_DATA_MIGRATION=true  — this release runs a forward-only /data (lmdb) migration.
+#   PITHEAD_MIN_OS_VERSION=X.Y.Z — the lowest OS version that can still read /data once it has.
+# A migrating release MUST name that floor: without it a later rollback silently strands the
+# migrated chain data (os-update reads the floor back to refuse exactly that).
+OS_VERSION=$(tr -d ' \t\r\n' <VERSION)
+DATA_MIGRATION=${PITHEAD_DATA_MIGRATION:-false}
+case "$DATA_MIGRATION" in
+true | false) ;;
+*)
+    echo "PITHEAD_DATA_MIGRATION must be 'true' or 'false', got '$DATA_MIGRATION'" >&2
+    exit 2
+    ;;
+esac
+MIN_OS_VERSION=${PITHEAD_MIN_OS_VERSION:-}
+if [ -n "$MIN_OS_VERSION" ] && ! printf '%s' "$MIN_OS_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "PITHEAD_MIN_OS_VERSION must be X.Y.Z, got '$MIN_OS_VERSION'" >&2
+    exit 2
+fi
+if [ "$DATA_MIGRATION" = true ] && [ -z "$MIN_OS_VERSION" ]; then
+    echo "PITHEAD_DATA_MIGRATION=true needs PITHEAD_MIN_OS_VERSION=X.Y.Z — the floor below which the migrated /data cannot be read" >&2
+    exit 2
+fi
 # shellcheck source=os/rauc/populate-slot.sh
 . os/rauc/populate-slot.sh
 WORK=$(mktemp -d)
@@ -54,10 +79,13 @@ mv "$WORK/rootfs.ext4" "$WORK/bundle/rootfs.ext4"
 cat >"$WORK/bundle/manifest.raucm" <<EOF
 [update]
 compatible=pithead-amd64
-version=$(tr -d ' \t\r\n' <VERSION)
+version=$OS_VERSION
 
 [meta.pithead]
 variant=$VARIANT
+version=$OS_VERSION
+data_migration=$DATA_MIGRATION
+minimum_os_version=$MIN_OS_VERSION
 
 [image.rootfs]
 filename=rootfs.ext4

--- a/pithead
+++ b/pithead
@@ -2259,16 +2259,47 @@ os_running_variant() { # echoes debug|release|unknown
     case "$v" in debug | release) echo "$v" ;; *) echo unknown ;; esac
 }
 
+os_bundle_meta() { # $1: bundle, $2: [meta.pithead] key — echoes its value or empty, never fails
+    # `rauc info --output-format=json` exposes the manifest meta. Parsed defensively: find any
+    # object carrying a `pithead` child (so a RAUC that nests the manifest differently still
+    # resolves) and read the key out of it. Anything unparseable degrades to empty.
+    rauc info --output-format=json "$1" 2>/dev/null |
+        jq -r --arg k "$2" '[.. | objects | select(has("pithead")) | .pithead | objects | .[$k]? // empty] | map(select(. != "")) | first // empty' 2>/dev/null
+}
+
 os_bundle_variant() { # $1: bundle path — echoes debug|release|unknown, never fails
-    # The stamp lives under [meta.pithead] in the bundle manifest; `rauc info` exposes manifest
-    # meta in its JSON output. Parsed defensively (any object carrying a `variant` key), so a
-    # RAUC that nests the manifest differently still yields the stamp rather than a false
-    # "unknown" — and anything unparseable degrades to unknown, which the gate treats as
-    # shell-less.
+    # Unknown covers both an unstamped bundle and any garbage: the gate treats unknown as
+    # shell-less, so a debug box is warned before an install that might drop SSH.
     local v
-    v=$(rauc info --output-format=json "$1" 2>/dev/null |
-        jq -r '[.. | objects | .variant? // empty] | map(select(. == "debug" or . == "release")) | first // empty' 2>/dev/null)
+    v=$(os_bundle_meta "$1" variant)
     case "$v" in debug | release) echo "$v" ;; *) echo unknown ;; esac
+}
+
+os_semver_ok() { printf '%s' "${1:-}" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+$'; }
+
+os_running_version() { # the OS version this checkout/slot IS — PITHEAD_VERSION, else the VERSION file
+    printf '%s' "${PITHEAD_VERSION:-$(tr -d ' \t\r\n' <VERSION 2>/dev/null || true)}"
+}
+
+# The /data-resident floor: the lowest OS version that can still read the current on-disk chain
+# data. Raised when a data_migration bundle installs; read back to refuse an unsafe rollback below
+# it. Overridable for tests; absent means no migration has raised a floor yet (today's reality).
+os_data_floor_file() { printf '%s' "${PITHEAD_DATA_FLOOR_FILE:-/data/pithead/.os-data-floor}"; }
+
+os_data_floor() { # echoes the floor version, or empty
+    local f
+    f=$(os_data_floor_file)
+    [ -f "$f" ] && tr -d ' \t\r\n' <"$f" 2>/dev/null || true
+}
+
+os_raise_data_floor() { # $1: new floor — raise it, never lower (a migration only ever tightens)
+    local f cur
+    f=$(os_data_floor_file)
+    cur=$(os_data_floor)
+    if [ -z "$cur" ] || { os_semver_ok "$cur" && semver_newer "$1" "$cur"; }; then
+        mkdir -p "$(dirname "$f")" 2>/dev/null || true
+        printf '%s\n' "$1" >"$f"
+    fi
 }
 
 os_update_needs_confirmation() { # $1: running variant, $2: bundle variant — rc 0 = confirm first
@@ -2278,10 +2309,11 @@ os_update_needs_confirmation() { # $1: running variant, $2: bundle variant — r
 }
 
 os_update() {
-    local bundle="" assume_yes=0 arg
+    local bundle="" assume_yes=0 allow_downgrade=0 arg
     for arg in "$@"; do
         case "$arg" in
         -y | --yes) assume_yes=1 ;;
+        --allow-downgrade) allow_downgrade=1 ;;
         -*) error "Unknown option for os-update: $arg. Run '$0 help'." ;;
         *)
             [ -z "$bundle" ] || error "os-update takes exactly one bundle path. Run '$0 help'."
@@ -2293,6 +2325,46 @@ os_update() {
     command -v rauc >/dev/null 2>&1 ||
         error "rauc is not available here — OS updates apply to the appliance image, not a checkout install."
     [ -f "$bundle" ] || error "No such bundle: $bundle"
+
+    # Version floor + data-migration guards. A correctly-signed bundle is not automatically a safe
+    # one: an OLDER image re-introduces the holes the newer one fixed under our own signature, and
+    # an image below the /data migration floor cannot read the chain data a newer release migrated.
+    # Both guards fail CLOSED: a version the comparator cannot parse (a pre-release/-prep suffix,
+    # garbage, or an absent stamp) is not proof of safety, so it refuses rather than skips.
+    # semver_newer only understands clean X.Y.Z, so os_semver_ok gates every comparison.
+    local bundle_version bundle_min bundle_migrates running_version floor_file floor
+    bundle_version=$(os_bundle_meta "$bundle" version)
+    bundle_min=$(os_bundle_meta "$bundle" minimum_os_version)
+    bundle_migrates=$(os_bundle_meta "$bundle" data_migration)
+    running_version=$(os_running_version)
+
+    # The data floor is not a policy knob — installing below it strands the migrated chain data, so
+    # it hard-refuses with no --allow-downgrade override. A floor FILE that exists is authoritative:
+    # a corrupt/unparseable floor, or a bundle we cannot prove is at or above it, refuses. The escape
+    # is a factory reset or restoring a matching backup.
+    floor_file=$(os_data_floor_file)
+    if [ -f "$floor_file" ]; then
+        floor=$(os_data_floor)
+        if ! os_semver_ok "$floor"; then
+            error "Refusing: the /data migration floor is unreadable ('${floor:-empty}'). A corrupt floor is not permission to install over migrated chain data — restore it, or recover with a factory reset (loses the chain) or a matching backup."
+        fi
+        if ! os_semver_ok "$bundle_version" || semver_newer "$floor" "$bundle_version"; then
+            error "Refusing: /data was migrated forward and now needs OS >= $floor to read; this bundle is '${bundle_version:-unstamped}'. Installing it would strand the chain data. Recover with a factory reset (loses the chain) or by restoring a backup taken on $floor or newer."
+        fi
+    fi
+
+    # Downgrade guard: install without --allow-downgrade ONLY when the bundle is a clean release
+    # semver provably newer than or equal to the running one. An older, pre-release, or unstamped
+    # bundle re-opens fixed holes under a valid signature — it needs the explicit flag. Skipped only
+    # when we cannot read our OWN version (a source checkout; os-update is appliance-only in practice,
+    # where the running version is always the baked release stamp).
+    if os_semver_ok "$running_version" &&
+        { ! os_semver_ok "$bundle_version" || semver_newer "$running_version" "$bundle_version"; }; then
+        if [ "$allow_downgrade" -eq 0 ]; then
+            error "Refusing a possible downgrade: bundle version '${bundle_version:-unstamped}', running $running_version. Only a clean X.Y.Z release at or newer than the running one installs without confirmation. Pass --allow-downgrade to install an older, pre-release, or unstamped bundle on purpose."
+        fi
+        warn "Installing a bundle that is not a verified upgrade (version '${bundle_version:-unstamped}', running $running_version) — downgrade explicitly allowed."
+    fi
 
     local running target
     running=$(os_running_variant)
@@ -2314,6 +2386,16 @@ os_update() {
     fi
     log "Installing OS update bundle: $bundle (running: $running, bundle: $target)"
     rauc install "$bundle"
+
+    # A data_migration bundle raises the /data floor so a later rollback below it is refused. Armed
+    # at install (conservative: before the migration actually runs on the new slot's next boot) —
+    # the safe direction, and the only floor pithead can guarantee without executing the migration
+    # itself. Executing the forward-only migration + withholding chain services until the slot
+    # commits is the remaining half of the deadlock rule, tracked as follow-up (see appliance-release.md).
+    if [ "$bundle_migrates" = "true" ] && os_semver_ok "$bundle_min"; then
+        os_raise_data_floor "$bundle_min"
+        log "Recorded /data migration floor: OS >= $bundle_min required to read chain data after this update commits."
+    fi
 }
 
 reset_dashboard() {
@@ -2775,12 +2857,16 @@ Maintenance:
                             stop the miner when it is off. The boot path runs this after the
                             stack is up; a no-op outside the appliance.
 
-  os-update BUNDLE [-y|--yes]
+  os-update BUNDLE [-y|--yes] [--allow-downgrade]
                             Install an OS update bundle into the spare A/B slot (appliance
-                            only — runs 'rauc install'). When this system is a debug build
-                            (SSH baked in) and the bundle is not, it warns and asks first:
-                            that install removes the SSH channel driving it.
-                              -y, --yes        skip the confirmation prompt.
+                            only — runs 'rauc install'). Refuses a bundle older than the
+                            running OS (a signed downgrade re-opens fixed holes), and refuses
+                            one below the /data migration floor outright. When this system is a
+                            debug build (SSH baked in) and the bundle is not, it warns and asks
+                            first: that install removes the SSH channel driving it.
+                              -y, --yes          skip the confirmation prompt.
+                              --allow-downgrade  install an older bundle on purpose (does not
+                                                 override the /data migration floor).
 
   onion-client-key          Print the Tor client-auth line for the dashboard onion —
                             the client PRIVATE key, kept out of 'status'. Add it to your Tor

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8606,10 +8606,118 @@ assert_rc "release -> release installs with no prompt" "$?" "0"
 assert_contains "rauc install ran unprompted" "$(cat "$RAUC_LOG")" "install bundle.raucb"
 out=$(ourun "$OUSB/variant-debug" "$OUSB/info-release.json" 2>&1)
 assert_rc "a missing bundle path is an error, not an install" "$?" "1"
+
+# --- os-update version floor + data-migration guards (#856 downgrade, #851 migration deadlock) ---
+# A correctly-signed bundle is not automatically a safe one: an OLDER image re-opens fixed holes,
+# and an image below the /data migration floor cannot read the chain data a newer release migrated.
+printf '{"manifest":{"meta":{"pithead":{"variant":"release","version":"1.17.0","data_migration":"false","minimum_os_version":""}}}}\n' >"$OUSB/info-1170.json"
+printf '{"manifest":{"meta":{"pithead":{"variant":"release","version":"1.10.0","data_migration":"false","minimum_os_version":""}}}}\n' >"$OUSB/info-1100.json"
+printf '{"manifest":{"meta":{"pithead":{"variant":"release","version":"1.17.0","data_migration":"true","minimum_os_version":"1.17.0"}}}}\n' >"$OUSB/info-mig.json"
+
+# os_bundle_meta: the manifest fields read back out of `rauc info` JSON.
+ometa() { cd "$OUSB" && PATH="$OUSB/bin:$PATH" RAUC_INFO_JSON="$1" run_sourced "$OUSB" os_bundle_meta bundle.raucb "$2"; }
+assert_eq "os_bundle_meta reads version" "$(ometa "$OUSB/info-mig.json" version)" "1.17.0"
+assert_eq "os_bundle_meta reads data_migration" "$(ometa "$OUSB/info-mig.json" data_migration)" "true"
+assert_eq "os_bundle_meta reads minimum_os_version" "$(ometa "$OUSB/info-mig.json" minimum_os_version)" "1.17.0"
+assert_eq "an absent meta key is empty, not an error" "$(ometa "$OUSB/info-mig.json" db_schema)" ""
+unset -f ometa
+
+# ourun_v: os_update with a set running version + a data-floor file, variant pinned to release
+# (the SSH gate is covered above; here we isolate the version/floor guards).
+ourun_v() { # <running-version> <floor-file> <info-json> [os-update args...]
+    local rv="$1" ff="$2" ij="$3"
+    shift 3
+    (
+        cd "$OUSB" || exit
+        PATH="$OUSB/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        PITHEAD_VERSION="$rv" PITHEAD_DATA_FLOOR_FILE="$ff" \
+            RAUC_INFO_JSON="$ij" PITHEAD_VARIANT_FILE="$OUSB/variant-release" os_update "$@" </dev/null
+    )
+}
+
+# #856: an older bundle is refused, and rauc install is never reached.
+: >"$RAUC_LOG"
+out=$(ourun_v "1.17.0" "" "$OUSB/info-1100.json" bundle.raucb 2>&1)
+assert_rc "a bundle older than running is refused" "$?" "1"
+assert_contains "the refusal names the downgrade" "$out" "possible downgrade"
+assert_not_contains "rauc install was NOT reached on a refused downgrade" "$(cat "$RAUC_LOG")" "install"
+# ...unless --allow-downgrade is passed on purpose.
+: >"$RAUC_LOG"
+ourun_v "1.17.0" "" "$OUSB/info-1100.json" bundle.raucb --allow-downgrade >/dev/null 2>&1
+assert_rc "--allow-downgrade installs the older bundle" "$?" "0"
+assert_contains "rauc install ran under --allow-downgrade" "$(cat "$RAUC_LOG")" "install bundle.raucb"
+# A newer bundle installs with no ceremony.
+: >"$RAUC_LOG"
+ourun_v "1.10.0" "" "$OUSB/info-1170.json" bundle.raucb >/dev/null 2>&1
+assert_rc "a newer bundle installs" "$?" "0"
+assert_contains "rauc install ran for the newer bundle" "$(cat "$RAUC_LOG")" "install bundle.raucb"
+
+# #851: below the /data migration floor is refused OUTRIGHT — --allow-downgrade does not override it.
+printf '2.0.0\n' >"$OUSB/floor-2"
+: >"$RAUC_LOG"
+out=$(ourun_v "1.17.0" "$OUSB/floor-2" "$OUSB/info-1170.json" bundle.raucb --allow-downgrade 2>&1)
+assert_rc "a bundle below the /data floor is refused even with --allow-downgrade" "$?" "1"
+assert_contains "the floor refusal warns about the chain data" "$out" "strand the chain data"
+assert_not_contains "rauc install was NOT reached below the floor" "$(cat "$RAUC_LOG")" "install"
+# A bundle at or above the floor installs.
+printf '1.17.0\n' >"$OUSB/floor-at"
+: >"$RAUC_LOG"
+ourun_v "1.17.0" "$OUSB/floor-at" "$OUSB/info-1170.json" bundle.raucb >/dev/null 2>&1
+assert_rc "a bundle at the /data floor installs" "$?" "0"
+
+# #851: installing a data_migration bundle RECORDS the floor; a plain bundle does not.
+FW="$OUSB/floor-written"
+rm -f "$FW"
+: >"$RAUC_LOG"
+ourun_v "1.17.0" "$FW" "$OUSB/info-mig.json" bundle.raucb >/dev/null 2>&1
+assert_rc "a data_migration bundle installs" "$?" "0"
+assert_eq "installing a data_migration bundle records the /data floor" "$(tr -d ' \n' <"$FW" 2>/dev/null)" "1.17.0"
+FN="$OUSB/floor-none"
+rm -f "$FN"
+ourun_v "1.10.0" "$FN" "$OUSB/info-1170.json" bundle.raucb >/dev/null 2>&1
+assert_eq "a non-migration bundle records no floor" "$([ -f "$FN" ] && echo present || echo absent)" "absent"
+
+# Fail-closed: a version the comparator can't parse is NOT proof of safety. Releases DO use -prep
+# tags, so a pre-release bundle must not silently bypass the downgrade guard by parsing as "0".
+printf '{"manifest":{"meta":{"pithead":{"variant":"release","version":"1.17.0-prep","data_migration":"false","minimum_os_version":""}}}}\n' >"$OUSB/info-prep.json"
+: >"$RAUC_LOG"
+out=$(ourun_v "1.17.0" "" "$OUSB/info-prep.json" bundle.raucb 2>&1)
+assert_rc "a pre-release (-prep) bundle is refused fail-closed" "$?" "1"
+assert_contains "the refusal names it a possible downgrade" "$out" "possible downgrade"
+assert_not_contains "rauc install was NOT reached for the pre-release bundle" "$(cat "$RAUC_LOG")" "install"
+: >"$RAUC_LOG"
+ourun_v "1.17.0" "" "$OUSB/info-prep.json" bundle.raucb --allow-downgrade >/dev/null 2>&1
+assert_rc "--allow-downgrade installs the pre-release bundle on purpose" "$?" "0"
+assert_contains "rauc install ran for the pre-release under --allow-downgrade" "$(cat "$RAUC_LOG")" "install bundle.raucb"
+
+# Fail-closed: a corrupt floor file is NOT permission to downgrade past a migration.
+printf 'not-a-version\n' >"$OUSB/floor-corrupt"
+: >"$RAUC_LOG"
+out=$(ourun_v "1.17.0" "$OUSB/floor-corrupt" "$OUSB/info-1170.json" bundle.raucb --allow-downgrade 2>&1)
+assert_rc "a corrupt /data floor is refused fail-closed, even with --allow-downgrade" "$?" "1"
+assert_contains "the corrupt-floor refusal says the floor is unreadable" "$out" "floor is unreadable"
+assert_not_contains "rauc install was NOT reached with a corrupt floor" "$(cat "$RAUC_LOG")" "install"
+unset -f ourun_v
+
 unset RAUC_LOG
 unset -f ourun
 rm -rf "$OUSB"
 unset OUSB
+
+# --- mkbundle metadata validation (fails fast, before the multi-minute image build) ---
+echo "== unit: mkbundle compatibility-metadata validation =="
+out=$(cd "$ROOT" && PITHEAD_DATA_MIGRATION=maybe bash os/rauc/mkbundle.sh /dev/null 2>&1)
+assert_rc "PITHEAD_DATA_MIGRATION must be true/false" "$?" "2"
+assert_contains "the message names the field" "$out" "PITHEAD_DATA_MIGRATION"
+out=$(cd "$ROOT" && PITHEAD_DATA_MIGRATION=true bash os/rauc/mkbundle.sh /dev/null 2>&1)
+assert_rc "data_migration=true without a floor is refused" "$?" "2"
+assert_contains "the message asks for the migration floor" "$out" "PITHEAD_MIN_OS_VERSION"
+out=$(cd "$ROOT" && PITHEAD_MIN_OS_VERSION=1.2 bash os/rauc/mkbundle.sh /dev/null 2>&1)
+assert_rc "a non-semver floor is refused" "$?" "2"
+assert_contains "the message names the floor field" "$out" "PITHEAD_MIN_OS_VERSION"
 
 # ---------------------------------------------------------------------------
 # os/rauc signing-material guard (resolve_signing_material in populate-slot.sh). A release build


### PR DESCRIPTION
## What

Two related update-safety gaps, one shared manifest mechanism.

**#856 — signed downgrade.** `pithead os-update` had no version floor: any
correctly-signed *older* bundle installed, health-passed, and committed — a
signed downgrade that re-opens the holes the newer image fixed, under our own
valid signature, so no signature check catches it.

**#851 — migration-deadlock rule.** The `data_migration` / `minimum_os_version`
manifest compatibility fields were unimplemented (`dual-distribution-plan.md`
risk #6). A forward-only `/data` (lmdb) migration left no record, so a later
rollback could strand the migrated chain data on an OS that can no longer read it.

## Change

The bundle manifest's `[meta.pithead]` section grows the channel contract,
validated up front in `mkbundle.sh` (before the multi-minute image build):

| field | meaning |
|---|---|
| `version` | the OS version this bundle carries (from `VERSION`) |
| `data_migration` | `true` if this release runs a forward-only `/data` migration |
| `minimum_os_version` | lowest OS version that can still read `/data` once it has migrated |

`os-update` reads them back and:

- refuses a bundle older than the running OS unless `--allow-downgrade` (#856);
- records a `/data` migration floor when a `data_migration` bundle installs, and
  refuses any later rollback below it **outright** — `--allow-downgrade` does not
  override it, because the migrated chain data is unreadable there (#851).

Deliberate A/B rollback (`rauc status mark-bad booted`) is unaffected — it boots
the spare slot already present, it does not re-install an old bundle.

## Scoped follow-up (explicit)

Recording and *enforcing* the floor is done and tested. **Executing** the
forward-only migration, and withholding chain services (monerod/tari) until the
slot commits — the automatic-fallback half of the deadlock rule — remain scoped
follow-up, documented in `appliance-release.md` and `appliance-wizard.md`. Until
that boot-path change lands, the guard here prevents the *manual* rollback path
from stranding data; the automatic-fallback ordering is bench/tier-4 work
(`tests/os/run.sh --phase update`). The plan's `db_schema` field lands with that
runner — nothing reads it yet.

## Tests

`tests/stack/run.sh`: `os_bundle_meta` parsing of all three fields; the downgrade
refusal + `--allow-downgrade` override; the below-floor hard refusal (no
override); the floor being recorded on a `data_migration` install and *not* on a
plain one; `mkbundle.sh`'s fail-fast metadata validation. Full suite: 1996
passed, 0 failed. `make lint` green (shellcheck, shfmt, docs-voice, operator-strings).

Closes #856
Refs #851 — the safety guard + manifest fields are done and tested here; the
migration runner and the automatic-fallback boot ordering are scoped follow-up,
so this deliberately does not auto-close #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
