### PR TITLE
docs(appliance): correct the appliance docs against the shipped code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-st
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
 	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh \
-		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot os/overlay/pithead-data-reset tests/os/run.sh tests/os/verify-image.sh
+		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot \
+		os/overlay/pithead-data-reset os/overlay/pithead-mount-generator tests/os/run.sh tests/os/verify-image.sh
 	shfmt -i 4 -d pithead pithead-completion.bash os/installer/pithead-install $(shell git ls-files '*.sh')
 
 lint-py: ## ruff lint + format check on all repo Python (ruff runs via uv from the locked dev extra)

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -227,6 +227,21 @@ survive.
 Keys still at their default are not written to disk, so this machine keeps picking up improved
 defaults from future updates. The configuration it runs is identical either way.
 
+## What the machine does on its own
+
+Two things the appliance sets for itself, that a machine you installed the stack on yourself
+would not:
+
+- **It resets itself if it hangs.** The image arms the hardware watchdog built into the
+  motherboard: systemd pets it every 10 seconds, and if the kernel stops answering for 20
+  seconds the board cuts power and the machine reboots. An appliance in a cupboard has nobody
+  to press the button, so a hang that would otherwise cost you days of downtime costs a reboot.
+  A shutdown that stalls is bounded the same way, at two minutes.
+- **It holds the CPU at full clock.** The governor is set to `performance` at every boot, so the
+  node, the wallet and any built-in miner are never scheduled onto a CPU that has clocked itself
+  down. This applies whether or not you mine on the machine — a dedicated appliance has no other
+  workload to save power for. On hardware with no frequency scaling the step is skipped.
+
 ## Updates
 
 The appliance keeps **two copies of the system**, and only one runs at a time. An update

--- a/docs/dev/dual-distribution-plan.md
+++ b/docs/dev/dual-distribution-plan.md
@@ -11,7 +11,7 @@ the #394 tracker; decision comments are on #77 and #78.
 
 | Question | Decision |
 |---|---|
-| Appliance foundation | **Debian 13 + Rugix A/B images** (v2 decision, stands). Peer-proven pattern: umbrelOS (Debian + Rugix, crypto-node appliance), HAOS (Buildroot + RAUC). bootc + CentOS Stream rejected — no third-party shipping appliance found on it, rolling base, manual rollback + greenboot bolt-on; full evidence table in the v2 section below. |
+| Appliance foundation | **Debian 13 + A/B images, updater RAUC** (bake-off verdict 2026-07-25 — see [Verdict](#verdict-2026-07-25-rauc-on-stability-grounds--conditional-on-fault-injection); the v2 decision named Rugix, and the bake-off replaced it on stability grounds). Peer-proven pattern: umbrelOS (Debian + Rugix, crypto-node appliance), HAOS (Buildroot + RAUC). bootc + CentOS Stream rejected — no third-party shipping appliance found on it, rolling base, manual rollback + greenboot bolt-on; full evidence table in the v2 section below. |
 | Container runtime | **Quadlet on the appliance, Compose on the DIY channel — #78 outcome (A)** (operator decision, v4; supersedes v3's Podman-everywhere). Appliance: daemonless, each container a systemd service supervised and restarted independently — the idiomatic fit where we own the OS (Debian 13, Podman 5.4.2). DIY: Compose stays — the reach argument is concrete: Quadlet's `Notify=healthy` needs Podman ≥ 5.0, and Ubuntu 24.04 LTS ships 4.9, so Podman-everywhere would exclude the largest current LTS until 2029. Compose runs wherever Docker runs; existing deployments (gouda, prod) never migrate. Cost accepted: two runtime renders, mitigated by generation + parity (below). |
 | Runtime definitions | `docker-compose.yml` stays the maintained reference (as today, `.env`-rendered by `pithead`). The appliance adds `pithead render-quadlet`: units generated from `config.json`, never hand-maintained. A parity test derives expectations from the compose file itself and **fails on any compose key it does not recognize** — new compose features cannot silently skip the appliance. |
 | Distribution channels | **(1) curl installer (Docker/Compose), (2) flashable appliance image (Podman/Quadlet), (3) git clone (developers).** Package-manager/apt-repo channel dropped. |
@@ -27,7 +27,7 @@ infrastructure.
 | Channel | Artifact | Runtime | Audience |
 |---|---|---|---|
 | **curl installer** | `curl -fsSL <url>/install.sh \| bash` — installs/uses Docker CE, fetches the signed release bundle, runs `pithead setup` | Docker Compose (today's stack, unchanged) | homelabs, VPS, existing Docker users |
-| **Appliance image** | `pithead-os-vX.Y.Z.img` + Rugix delta update bundles | Podman/Quadlet | zero-Linux-setup users, fleets |
+| **Appliance image** | `pithead-os-vX.Y.Z.img` + RAUC update bundles | Podman/Quadlet | zero-Linux-setup users, fleets |
 | **git clone** | the repo | Docker Compose | developers, contributors |
 
 Flash target: the image is written to the machine's **internal SSD/NVMe** — running
@@ -35,7 +35,7 @@ the stack host from a USB stick is not supported (250+ GB chain, constant writes
 USB flash is too slow and wears out). Two supported paths: write the raw image
 directly to the target disk, or boot a USB installer that copies it to an internal
 disk after an explicit, destructive disk-selection confirmation (the installer flow is
-our tooling — Rugix produces the raw image only). Raw writes are for factory-new
+our tooling — the image build produces the raw image only). Raw writes are for factory-new
 drives only and the docs say so loudly: `dd` replaces the partition table and
 destroys an existing `/data` (250+ GB of synced chain). Reinstall on an existing box
 goes through the installer, which detects the labeled `/data` partition, preserves
@@ -173,7 +173,7 @@ cut, and the installer smoke rides the same checklist.
 ## Appliance architecture (unchanged from v2, runtime swapped)
 
 - Minimal Debian 13, read-only root, overlay discarded each boot.
-- Rugix A/B slots; new slot boots provisionally; **the commit gate is a `localhost` curl plus
+- RAUC A/B slots; new slot boots provisionally; **the commit gate is a `localhost` curl plus
   `pithead doctor --json`** (`os/overlay/pithead-boot`). The curl proves the derived-config →
   caddy → dashboard chain answers; doctor exits non-zero on critical failures and checks the
   revenue containers (monerod/p2pool/tari), Tor, and the egress firewall. Both must pass before
@@ -218,8 +218,13 @@ cut, and the installer smoke rides the same checklist.
   against shared state); images kept, units re-rendered.
 - **Two-tier reset**, because a full wipe costs days of chain resync: (1) config
   reset — delete `config.json` + secrets, re-enter the first-boot wizard, chain data
-  kept; (2) factory reset — `rugix-ctrl state reset`, everything wiped. Reflash keeps
-  data; the wizard offers tier 1 before tier 2.
+  kept; (2) factory reset — everything wiped. RAUC has no integrated state reset, so both
+  tiers are ours: `pithead config-reset` and `pithead factory-reset`. The deep tier cannot
+  run against a mounted `/data`, so it drops a marker on the ESP (which survives the wipe)
+  and reboots into `os/overlay/pithead-data-reset`, which reformats the partition one layer
+  under the running system. That executor doubles as the recovery path for a `/data` that
+  will not mount — the only way back on a shell-less release image. Reflash keeps data; the
+  wizard offers tier 1 before tier 2.
 - Hugepage reservation baked in at boot — **load-bearing, not perf polish** (spike
   finding): the RandomX dataset (~2.1 GiB) lives in hugetlbfs outside the memory
   cgroup only when pages are reserved; unreserved, it falls to anon memory and
@@ -420,17 +425,20 @@ pithead/
 ├── pithead                     # brain for all channels
 │                               #   + render-quadlet (phase 1)
 │                               #   + unprovisioned mode (phase 3)
-│                               #   + support-bundle, rugix commit glue (phase 2)
+│                               #   + support-bundle, rauc commit glue (phase 2)
 ├── docker-compose.yml          # DIY runtime definition + the parity reference (stays)
 ├── build/                      # service images — unchanged
 │   └── dashboard/              #   + first-boot wizard mode for the #33 form (phase 3)
 ├── install.sh                  # NEW — the curl channel (phase 1)
 ├── os/                         # NEW — the appliance (phases 0, 2, 3)
-│   ├── bakery/                 # Rugix Bakery project: layers, recipes, x86 EFI target
+│   ├── build-image.sh          # exports the OS rootfs tarball from os/rootfs
 │   ├── rootfs/                 # Dockerfile assembling the OS rootfs tarball
-│   │                           #   (updater-agnostic — the RAUC escape hatch)
+│   │                           #   (updater-agnostic — the updater sits on top)
+│   │   └── repart.d/           # systemd-repart: slot B + /data built on the target disk
+│   ├── rauc/                   # image + bundle build, slot population, GRUB boot state
+│   ├── installer/              # pithead-install: copy the running system to a disk
 │   ├── quadlet/                # phase 0 hand-written reference units → renderer fixtures
-│   ├── overlay/                # fstab, mount guards, watchdog, firstboot units
+│   ├── overlay/                # mount generator, watchdog, governor, boot/sync/firstboot units
 │   └── README.md
 ├── scripts/
 │   └── release.sh              # + os-image lane, cosign mandatory

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -2,8 +2,11 @@
 
 ## Status: RAUC appliance, installs to disk, all batteries green (2026-07-25)
 
-`tests/os/run.sh` passes boot 3/3, update 11/11 and fault 11/11 on the RAUC appliance,
-with no brick in any run. The image ships the ESP and slot A only (636 MB);
+`tests/os/run.sh` passes all five phases on the RAUC appliance — boot 3/3, update 13/13,
+provision 21/21, install 33/33 and fault 11/11 — with no brick in any run. The per-phase
+assertion list is in
+[the release doc's battery table](../docs/dev/appliance-release.md#the-automated-battery).
+The image ships the ESP and slot A only (636 MB);
 systemd-repart builds slot B and /data on the target's own disk, and `/data` measured
 24 GiB of a 40 GiB disk while the system slot stayed at 8.
 
@@ -194,14 +197,6 @@ dashboard answers through caddy (#793). On the read-only root, host units render
   time, so the plan's "first boot works offline" property is partial: the setup page
   works without a network, provisioning does not. Baking the full set roughly triples
   the image and inflates every update bundle — sized deliberately, not forgotten.
-- **The stick and an installed disk carry identical partition labels.** The DANGEROUS half
-  is fixed: the kernel root is the PARTUUID of the partition GRUB actually chose (`probe
-  --part-uuid` at boot), so the machine can no longer boot one disk's kernel against the
-  other disk's system. What remains is `/data` and the ESP, mounted by LABEL from a static
-  fstab — with both disks present, which `data` wins is udev's choice. The installer powers
-  the machine off after installing (remove the stick while it is off) and the docs say
-  never to boot with both; the residual exposure is a confusing but non-destructive mount,
-  not a wrong system.
 - **Every direct-flashed stick shares the image's identity material.** `/etc/machine-id`
   and the SSH host keys are baked at image build, so two sticks flashed from one release
   are identical until something regenerates them. The installer resets machine-id for

--- a/os/overlay/pithead-sync.service
+++ b/os/overlay/pithead-sync.service
@@ -4,7 +4,7 @@ Description=Sync the pithead program tree onto the data partition
 # slot, all state lives on /data. pithead itself assumes both share a directory — it cd's to
 # its own location and writes config.json/.env there — so the program is copied onto /data and
 # run from there. Without this, an A/B update destroys the operator's configuration: RAUC
-# replaces the whole slot, and Rugix's root overlay is discarded.
+# replaces the whole slot, and the root overlay is discarded on every boot.
 ConditionPathIsMountPoint=/data
 After=local-fs.target
 Before=pithead-firstboot.service

--- a/os/rauc/mkimage.sh
+++ b/os/rauc/mkimage.sh
@@ -107,9 +107,10 @@ install -m 644 os/rauc/grub.cfg /mnt/rauc-esp/grub/grub.cfg
 grub-editenv /mnt/rauc-esp/grub/grubenv create
 grub-editenv /mnt/rauc-esp/grub/grubenv set ORDER="A B" A_OK=1 A_TRY=0 B_OK=0 B_TRY=0
 
-# The /var overlay directories cannot be seeded here any more — /data does not exist until
-# systemd-repart creates it. pithead-dataprep.service makes them on first boot, before anything
-# that needs a writable /var.
+# The /var overlay directories cannot be seeded here — /data does not exist until systemd-repart
+# creates it on the target machine's real disk. repart makes them itself at format time, via the
+# MakeDirectories lines in os/rootfs/repart.d/40-data.conf, so they exist before anything mounts
+# the overlay that needs a writable /var.
 
 sync
 echo "==> image: $OUT ($(du -h "$OUT" | cut -f1))"

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -1,8 +1,10 @@
 # pithead-os rootfs (#77 phase 2) — the appliance operating system as a container build,
-# exported to a tarball and fed to Rugix Bakery (the Umbrel pattern; os/build-image.sh).
+# exported to a tarball by os/build-image.sh (the Umbrel pattern) and turned into a bootable
+# image or an update bundle by os/rauc/mkimage.sh / os/rauc/mkbundle.sh.
 # Debian 13 + systemd + rootful Podman; pithead is the provisioning brain, Quadlet the runtime.
-# Deliberately updater-agnostic: nothing in here knows about Rugix — the RAUC escape hatch
-# stays open (docs/dev/dual-distribution-plan.md § appliance architecture).
+# Deliberately updater-agnostic: the updater sits on top and is selected by PITHEAD_UPDATER
+# below, so swapping it does not touch this file (docs/dev/dual-distribution-plan.md
+# § appliance architecture).
 #
 # This file is named Dockerfile, not Containerfile, so Dependabot's docker ecosystem tracks the
 # base digest below (it only reads Dockerfile-named files — dependabot-core#6067); nothing else
@@ -139,7 +141,7 @@ RUN mkdir -p /etc/systemd/system.conf.d \
     && printf '[Manager]\nRuntimeWatchdogSec=20s\nRebootWatchdogSec=2min\n' > /etc/systemd/system.conf.d/pithead-watchdog.conf
 
 # Container storage lives on the DATA partition, never on the root overlay. Two reasons, both
-# load-bearing: podman's overlay driver cannot stack on Rugix's overlayfs root ("'overlay' is not
+# load-bearing: podman's overlay driver cannot stack on the appliance's overlayfs root ("'overlay' is not
 # supported over overlayfs"), and images/containers must survive A/B updates and reboots — the
 # root overlay is discarded. This is the plan's "/var/lib/containers on the labeled data
 # partition" rule; the mount guard lives on the units that use it.
@@ -182,8 +184,8 @@ COPY os/overlay/pithead-data-reset /usr/local/sbin/pithead-data-reset
 # a no-op on a box with no cpufreq — see the unit for the RigForge co-location note.
 COPY os/overlay/pithead-cpu-governor.service /etc/systemd/system/pithead-cpu-governor.service
 RUN chmod +x /usr/local/sbin/pithead-sync /usr/local/sbin/pithead-boot /usr/local/sbin/pithead-data-reset /usr/lib/systemd/system-generators/pithead-mount-generator
-# The updater is chosen per image (bake-off candidates). rugix-ctrl arrives via the bakery layer's
-# core recipe; RAUC is a Debian package, so it is installed here when selected.
+# The updater is chosen per image. RAUC is a Debian package, so it is installed here when
+# selected; leaving PITHEAD_UPDATER empty builds the same rootfs with no updater at all.
 ARG PITHEAD_UPDATER=""
 # NB: `rauc` is the CLI ONLY. Debian splits the D-Bus daemon into `rauc-service`, which is not even
 # a Recommends of `rauc` — so --no-install-recommends is not what drops it, the package simply has
@@ -221,7 +223,7 @@ RUN systemctl enable podman.socket pithead-boot.service pithead-cpu-governor.ser
 RUN test -f /usr/lib/systemd/system/systemd-repart.service
 
 # TEST-ONLY hooks (tests/os/run.sh --phase update): both default EMPTY and change nothing in a
-# release build. A pubkey enables root-key SSH so the harness can drive rugix-ctrl in the guest;
+# release build. A pubkey enables root-key SSH so the harness can drive `rauc` in the guest;
 # the marker distinguishes v1/v2 slots across the A/B cycle.
 #
 # The SSH bake is also what DEFINES the build variant, so it is stamped here (#819): a baked key
@@ -243,5 +245,3 @@ RUN if [ -n "$PITHEAD_TEST_SSH_PUBKEY" ]; then \
     && if [ -n "$PITHEAD_TEST_MARKER" ]; then \
         printf '%s\n' "$PITHEAD_TEST_MARKER" > /etc/pithead-test-marker; \
     fi
-
-# Rugix Ctrl lands via the bakery layer's core recipes, not here — rootfs stays updater-agnostic.

--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -40,7 +40,8 @@ runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).
   disqualifying. Opt-in: `all` runs the four phases above, not this one.
 
 `--keep` leaves the VM and disks for inspection; `--phase boot|update|install|provision|fault|all`
-scopes the run. The run exits non-zero on the first failed assertion.
+scopes the run. A failed assertion is recorded and the run carries on, so one bench boot collects
+the whole battery; the run exits non-zero if anything failed.
 
 ## Static verification
 

--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -3,33 +3,52 @@
 Tier-4 tests for the `pithead-os` appliance image (#77 phase 2): the properties only real
 firmware and a real A/B updater can prove. The compose/CLI stack is covered by the other
 tiers ([`docs/dev/testing-strategy.md`](../../docs/dev/testing-strategy.md)); this harness
-covers what the flashed image adds — EFI boot, the first-boot wizard window, and the
-update → commit → rollback cycle that is the phase-2 exit criterion.
+covers what the flashed image adds — EFI boot, the first-boot wizard window, install-to-disk,
+and the update → commit → rollback cycle that is the phase-2 exit criterion.
 
-It needs a Linux host with KVM, libvirt, and qemu (the bench, not CI):
+It needs a Linux host with KVM, libvirt and qemu, and root (the bench, not CI):
 
 ```bash
-os/build-image.sh                              # produce os/bakery/build/pithead-os-amd64/system.img
-tests/os/run.sh --image os/bakery/build/pithead-os-amd64/system.img
+os/build-image.sh --ssh                       # rootfs tarball -> os/build/pithead-root.tar
+os/rauc/mkimage.sh --dev                      # bootable image -> os/rauc/build/system.img
+sudo tests/os/run.sh --image os/rauc/build/system.img
 ```
+
+The harness builds its own update bundles from the same tarball (`os/rauc/mkbundle.sh --dev`),
+signed with a throwaway development key. A release build names its key instead — see the custody
+runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).
 
 ## Phases
 
 - **boot** — flash the image to a scratch disk, boot it under OVMF, assert the kernel/systemd
   banner reaches the serial console, the first-boot wizard announces its URL + one-time token,
-  and the token gate answers on `:80`.
-- **update** — `bake bundle` a v2 update, install it with `rugix-ctrl update install`, and assert
-  commit-on-healthy (the gate is `pithead doctor --json`); then install a deliberately broken
-  bundle and assert automatic rollback to the previous slot. This is the plan's
-  "apply a good update (commits), apply a deliberately broken one (falls back)" exit bar.
+  and the token gate answers.
+- **update** — build a v2 bundle, `rauc install` it, boot the spare slot, and assert the whole
+  A/B contract: an uncommitted slot auto-rolls-back, a healthy one commits (the gate is
+  `pithead doctor --json`), and a committed version can still be rolled off. Also asserts `/data`
+  grew to fill the disk.
+- **install** — boot the image as removable media beside a blank disk, run the disk installer,
+  then boot the target and prove the copied system is COMPLETE — the `/var` overlay made an
+  incomplete copy easy to produce and invisible to every other phase. Then the reinstall leg:
+  `/data` must survive a second install over the same disk, and the three-way wipe choice
+  (`keep`/`data`/`all`) is asserted on the raw partition.
+- **provision** — submit a config through the wizard's real HTTP flow and require the STACK to
+  come up: wizard accepted, setup ran, images pulled and verified, containers running, dashboard
+  served, Tor-only egress actually enforced, built-in miner up. This is the phase that catches an
+  appliance whose engine cannot run the product.
+- **fault** — power cuts mid-write and mid-commit, plus a corrupt bundle. A brick is
+  disqualifying. Opt-in: `all` runs the four phases above, not this one.
 
-`--keep` leaves the VM and disks for inspection; `--phase boot|update|all` scopes the run.
+`--keep` leaves the VM and disks for inspection; `--phase boot|update|install|provision|fault|all`
+scopes the run. The run exits non-zero on the first failed assertion.
 
-## Status
+## Static verification
 
-The boot phase is wired and runs against a built image. The update phase builds the bundle;
-driving `rugix-ctrl` install/commit/rollback inside the running guest is the open leg (the
-guest exposes no SSH by default — the harness drives it over the serial console, or an
-opt-in test-only SSH key baked by a build arg). Until that lands, the update phase fails
-loudly rather than reporting a green it did not earn — a silent skip would read as coverage
-that does not exist.
+`tests/os/verify-image.sh` is the cheapest gate and runs without KVM — it mounts a built image
+read-only and checks that no test material shipped, that every baked fix is in the artifact, and
+that the boot path's files sit where the firmware and GRUB will look.
+
+```bash
+sudo tests/os/verify-image.sh os/rauc/build/system.img          # release: test artifacts REFUSED
+sudo tests/os/verify-image.sh os/rauc/build/system.img --test   # harness build: SSH key expected
+```

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -141,26 +141,6 @@ _build_bundle() {
     find os/rauc/build -name '*.raucb' | head -1
 }
 
-# Dev signing material, shared by both candidates so the comparison stays updater-only.
-CERT_DIR="os/certs-test"
-# A ROOT + LEAF chain, not a single self-signed cert. Rugix enforces proper X.509 semantics and
-# rejects a CA certificate used as the end entity ("CaUsedAsEndEntity"); RAUC accepts the same
-# certificate as both root and signer. The stricter reading is the right one, and it is also what
-# production wants: the root that devices trust should not be the key that signs day to day.
-_gen_certs() {
-    [ -s "$CERT_DIR/cert.pem" ] && return 0
-    mkdir -p "$CERT_DIR"
-    openssl req -x509 -newkey rsa:4096 -nodes -keyout "$CERT_DIR/ca.key" \
-        -out "$CERT_DIR/ca.pem" -days 3650 -subj "/CN=pithead-os-test-ca" \
-        -addext "basicConstraints=critical,CA:TRUE" 2>/dev/null || return 1
-    openssl req -newkey rsa:4096 -nodes -keyout "$CERT_DIR/key.pem" \
-        -out "$CERT_DIR/leaf.csr" -subj "/CN=pithead-os-test-signer" 2>/dev/null || return 1
-    openssl x509 -req -in "$CERT_DIR/leaf.csr" -CA "$CERT_DIR/ca.pem" -CAkey "$CERT_DIR/ca.key" \
-        -CAcreateserial -out "$CERT_DIR/cert.pem" -days 3650 \
-        -extfile <(printf 'basicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\n') \
-        2>/dev/null || return 1
-}
-
 # Bundles are signed with the dev chain and RAUC verifies them against the keyring baked into the
 # slot, so nothing but the bundle itself needs staging.
 _stage_bundle() { # $1 bundle path

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -23,7 +23,9 @@
 #   fault   power cuts mid-write and mid-commit, plus a corrupt bundle. A brick is disqualifying.
 #   all     all four (default)
 #
-# Exit non-zero on the first failed assertion. --keep leaves the VM + disks for inspection.
+# A failed assertion is recorded and the run continues, so one bench boot collects the whole
+# battery rather than stopping at the first fault; the run exits non-zero if any assertion failed.
+# --keep leaves the VM + disks for inspection.
 set -uo pipefail
 
 IMAGE=""


### PR DESCRIPTION
Quality pass over the appliance work merged to `develop-v2` in the last day, across three axes: testing, documentation accuracy, and concise code. This PR carries **only the safe mechanical fixes**. Everything needing judgment is in the report / filed as issues.

## What this fixes

**Docs that disagree with the code** (repo rule: fix the doc)

- `tests/os/README.md` — documented `rugix-ctrl`, an image path `os/build-image.sh` does not produce (it claimed `os/bakery/build/…/system.img`; the script emits `os/build/pithead-root.tar`, and the bootable image comes from `os/rauc/mkimage.sh`), and two of the harness's five phases. Its Status section still said the update phase was an open leg that "fails loudly" — `os/KNOWN-ISSUES.md` records it green. Rewritten against `run.sh` as it stands, plus the `verify-image.sh` gate it never mentioned.
- `os/KNOWN-ISSUES.md:5` — battery counts said "boot 3/3, update 11/11 and fault 11/11": the wrong update figure and three of five phases. Now matches the maintained per-phase table in `appliance-release.md`, and links to it rather than re-stating it.
- `os/KNOWN-ISSUES.md` — the stick/disk label-collision bullet claimed `/data` and the ESP are still mounted by LABEL from a static fstab. `os/overlay/pithead-mount-generator` supersedes that: it resolves both mounts from the booted disk's partition numbers. Every sibling bullet in that file is genuinely open, so the resolved one is dropped; the invariant it protected is already the generator's own header comment.
- `docs/dev/dual-distribution-plan.md` — the decision table, channel table, appliance-architecture bullet, reset tiers and repo tree still named **Rugix**, which the 2026-07-25 bake-off in that same document replaced with RAUC. Only current-state claims moved; the bake-off appendix is a historical record and keeps its Rugix prose. The repo tree also showed an `os/bakery/` that never shipped.
- `os/rauc/mkimage.sh:110` — pointed at `pithead-dataprep.service`, which does not exist anywhere in `os/`. The `/var` overlay directories are seeded by systemd-repart at format time via `os/rootfs/repart.d/40-data.conf`.
- `docs/appliance.md` — the appliance arms the hardware watchdog (`RuntimeWatchdogSec=20s`) and pins the `performance` CPU governor on every boot, whether or not you mine. Both are operator-visible and were undocumented; the only governor mentions in the docs were RigForge's miner tuning.

**Dead code**

- `tests/os/run.sh` — `_gen_certs` and `CERT_DIR`, zero call sites. Vestigial since signing moved into `mkbundle.sh` / `populate-slot.sh` with the explicit-key custody rule. A sweep of every shell function defined across `pithead`, `os/**` and `tests/os/**` found this as the only dead one, and no dead Python or JS.

**Lint gap**

- `os/overlay/pithead-mount-generator` is a shipped `/bin/sh` script that no lint target covered. Added to `lint-sh`; it was already clean.

## Not in this PR

No behavior was refactored and no test was restructured. Filed separately: the untested fail-closed paths in `install.sh`, and the appliance's absence from the four-tier map in `docs/dev/testing-strategy.md`.

## Verification

`make lint-sh`, `make lint-md`, `make lint-docs-voice`, `make lint-operator-strings` pass. `make test-stack` is 2016 passed / 0 failed. `tests/os/run.sh` needs KVM and was not run; it is syntax-checked and the deletion has no callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)