### PR TITLE
fix(os): omit the migration floor when empty — rauc refused every plain bundle build

### DIFF
--- a/os/rauc/mkbundle.sh
+++ b/os/rauc/mkbundle.sh
@@ -76,20 +76,8 @@ VARIANT=$(tr -d ' \t\r\n' 2>/dev/null <"$WORK/mnt/etc/pithead-variant" || echo r
 umount "$WORK/mnt"
 mv "$WORK/rootfs.ext4" "$WORK/bundle/rootfs.ext4"
 
-cat >"$WORK/bundle/manifest.raucm" <<EOF
-[update]
-compatible=pithead-amd64
-version=$OS_VERSION
-
-[meta.pithead]
-variant=$VARIANT
-version=$OS_VERSION
-data_migration=$DATA_MIGRATION
-minimum_os_version=$MIN_OS_VERSION
-
-[image.rootfs]
-filename=rootfs.ext4
-EOF
+render_bundle_manifest "$OS_VERSION" "$VARIANT" "$DATA_MIGRATION" "$MIN_OS_VERSION" \
+    >"$WORK/bundle/manifest.raucm"
 
 echo "==> signing the bundle"
 rm -f "$OUT"

--- a/os/rauc/populate-slot.sh
+++ b/os/rauc/populate-slot.sh
@@ -70,6 +70,17 @@ resolve_signing_material() { # $1 = dev(1/0); sets RAUC_CERT, RAUC_KEY, RAUC_KEY
     return 0
 }
 
+# The bundle manifest, rendered from the compatibility inputs so it can be tested without a
+# multi-minute image build. RAUC refuses a key with an empty value ("Missing value for key
+# 'minimum_os_version'"), so the migration floor is emitted ONLY when the release declares one —
+# emitting it unconditionally broke every ordinary, non-migrating build.
+render_bundle_manifest() { # $1 os_version, $2 variant, $3 data_migration, $4 minimum_os_version
+    printf '[update]\ncompatible=pithead-amd64\nversion=%s\n\n' "$1"
+    printf '[meta.pithead]\nvariant=%s\nversion=%s\ndata_migration=%s\n' "$2" "$1" "$3"
+    [ -n "$4" ] && printf 'minimum_os_version=%s\n' "$4"
+    printf '\n[image.rootfs]\nfilename=rootfs.ext4\n'
+}
+
 populate_slot() { # $1 = mounted rootfs
     local root="$1"
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8777,6 +8777,25 @@ printf '{"manifest":{"meta":{"pithead":{"variant":"release","version":"1.17.0","
 
 # os_bundle_meta: the manifest fields read back out of `rauc info` JSON.
 ometa() { cd "$OUSB" && PATH="$OUSB/bin:$PATH" RAUC_INFO_JSON="$1" run_sourced "$OUSB" os_bundle_meta bundle.raucb "$2"; }
+# render_bundle_manifest: the WRITE side of the manifest (the read side is os_bundle_meta below).
+# RAUC refuses a key with an empty value, so an ordinary non-migrating build must omit the floor
+# entirely — emitting `minimum_os_version=` unconditionally broke every plain bundle build, and
+# the stubbed rauc in these tests never saw it. Assert the rendered text directly.
+plain_manifest="$(cd "$ROOT" && . os/rauc/populate-slot.sh && render_bundle_manifest 1.17.0 release false "")"
+assert_not_contains "plain build omits the migration floor entirely (no empty-valued key)" \
+    "$plain_manifest" "minimum_os_version"
+assert_contains "plain build still carries the version" "$plain_manifest" "version=1.17.0"
+assert_contains "plain build still carries the variant" "$plain_manifest" "variant=release"
+assert_contains "plain build declares no migration" "$plain_manifest" "data_migration=false"
+mig_manifest="$(cd "$ROOT" && . os/rauc/populate-slot.sh && render_bundle_manifest 1.18.0 release true 1.18.0)"
+assert_contains "a migrating build names its floor" "$mig_manifest" "minimum_os_version=1.18.0"
+# No key may ever render with an empty value — that is the exact shape rauc rejects.
+if printf '%s\n' "$plain_manifest" "$mig_manifest" | grep -qE '^[a-z_]+=$'; then
+    bad "no manifest key renders with an empty value" "found one"
+else
+    ok "no manifest key renders with an empty value"
+fi
+
 assert_eq "os_bundle_meta reads version" "$(ometa "$OUSB/info-mig.json" version)" "1.17.0"
 assert_eq "os_bundle_meta reads data_migration" "$(ometa "$OUSB/info-mig.json" data_migration)" "true"
 assert_eq "os_bundle_meta reads minimum_os_version" "$(ometa "$OUSB/info-mig.json" minimum_os_version)" "1.17.0"


### PR DESCRIPTION
## The bug

`mkbundle.sh` wrote `minimum_os_version=$MIN_OS_VERSION` unconditionally. RAUC rejects a manifest key with an empty value:

```
Failed to create bundle: Missing value for key 'minimum_os_version'
```

So **every ordinary (non-migrating) bundle build failed at the signing step** — the normal case. Introduced with the migration-manifest work in #863; CI never saw it because the stack tests stub `rauc bundle`. A real bench build caught it minutes after merge.

## The fix

The floor key is emitted only when the release declares one. The manifest render moves into `render_bundle_manifest` beside `populate_slot`, so the **write** side is testable without a multi-minute image build (the read side, `os_bundle_meta`, was already covered). Net: mkbundle.sh gets 14 lines shorter.

## Tests — the ones that would have caught it

- a plain build omits the floor entirely (no empty-valued key)
- a migrating build names its floor
- **no manifest key ever renders with an empty value** — the exact shape RAUC refuses

Stack suite 2079/0, shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)