### PR TITLE
Honest XvB economics: measured realization + win odds on both earnings surfaces

### DIFF
--- a/build/dashboard/mining_dashboard/client/xvb_client.py
+++ b/build/dashboard/mining_dashboard/client/xvb_client.py
@@ -101,6 +101,47 @@ def parse_winners(text, wallet_address):
     return wins
 
 
+def parse_round_stats(text):
+    """Aggregate EVERY round in ``winners_recent_full_pub.txt`` — not just ours (#866/#872).
+
+    The file's ``players`` column is the qualifier count for each round, which makes two honest
+    figures computable that XvB's published estimates gloss over: how often a tier is drawn
+    (rounds of that type per day) and against how many qualifiers (players average). Returns
+    ``{"types": {round_type: {"rounds": n, "players_avg": x}}, "span_days": d}`` — an empty
+    ``types`` dict for a garbage/empty file, never a raise (same tolerance and input bounds as
+    ``parse_winners``; the two parse the SAME fetched body, one request)."""
+    types = {}
+    first_ts = last_ts = None
+    for line in (text or "").splitlines()[:_WINNERS_MAX_LINES]:
+        fields = line.split()
+        if len(fields) != _WINNERS_FIELD_COUNT:
+            continue
+        try:
+            ts = (
+                datetime.strptime(f"{fields[1]} {fields[2]}", "%Y-%m-%d %H:%M:%S")
+                .replace(tzinfo=UTC)
+                .timestamp()
+            )
+            players = int(fields[7])
+        except ValueError:
+            continue
+        if players <= 0:
+            continue
+        first_ts = ts if first_ts is None else max(first_ts, ts)
+        last_ts = ts if last_ts is None else min(last_ts, ts)
+        agg = types.setdefault(fields[8], {"rounds": 0, "players_sum": 0})
+        agg["rounds"] += 1
+        agg["players_sum"] += players
+    span_days = (first_ts - last_ts) / 86400.0 if first_ts is not None else 0.0
+    return {
+        "types": {
+            t: {"rounds": a["rounds"], "players_avg": a["players_sum"] / a["rounds"]}
+            for t, a in types.items()
+        },
+        "span_days": span_days,
+    }
+
+
 # register() outcomes (#263). The endpoint returns plaintext "ERROR: ..." with a 422 for the error
 # cases (not a 200/JSON contract), so success/failure is classified from status + body, not status
 # alone. The caller maps these to dashboard state + retry behaviour.
@@ -206,10 +247,11 @@ class XvbClient:
             return None
 
     def get_recent_wins(self):
-        """Fetch XvB's public raffle-winners log over Tor and return THIS wallet's wins,
-        oldest first.
+        """Fetch XvB's public raffle-winners log over Tor — ONE request, both parses.
 
-        An empty list is a normal, successful read (no wins in the file's ~4-day window);
+        Returns ``{"wins": [...], "round_stats": {...}}``: ``wins`` is THIS wallet's wins oldest
+        first (``parse_winners``; an empty list is a normal read — no wins in the file's ~4-day
+        window), ``round_stats`` the all-rounds aggregate (``parse_round_stats``, #866/#872).
         ``None`` means the fetch failed — same "None means keep what you have" contract as
         ``get_stats``, so the caller writes nothing and retries later. The file carries only
         masked wallets and the request carries none, so there's no IP<->wallet correlation
@@ -228,7 +270,10 @@ class XvbClient:
                     f"XvB winners fetch failed with status code: {response.status_code}"
                 )
                 return None
-            return parse_winners(response.text, self.wallet_address)
+            return {
+                "wins": parse_winners(response.text, self.wallet_address),
+                "round_stats": parse_round_stats(response.text),
+            }
         except requests.RequestException as e:
             self.logger.error(f"Network error while fetching XvB winners: {e}")
             return None

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -888,11 +888,16 @@ class DataService:
         now = time.time()
         if now - self._last_xvb_winners_sync < _XVB_WINNERS_SYNC_SEC:
             return
-        wins = await asyncio.to_thread(self.xvb_client.get_recent_wins)
-        if wins is None:
+        result = await asyncio.to_thread(self.xvb_client.get_recent_wins)
+        if result is None:
             return  # fetch failed — retry next eligible poll; don't stamp the gate
         self._last_xvb_winners_sync = now
-        new_wins = await asyncio.to_thread(self.state_manager.add_raffle_wins, wins)
+        # Same fetched body, second parse (#866/#872): the all-rounds aggregate that makes win
+        # odds and realized-reward figures computable. Written only when it parsed to something,
+        # so a format change degrades to stale (detectable) rather than an empty-implied-fresh.
+        if (result.get("round_stats") or {}).get("types"):
+            await asyncio.to_thread(self.state_manager.set_xvb_round_stats, result["round_stats"])
+        new_wins = await asyncio.to_thread(self.state_manager.add_raffle_wins, result["wins"])
         for win in new_wins:
             logger.info(
                 f"XvB raffle WIN: {win['tier']} round won at "

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -105,6 +105,9 @@ class StateManager:
         # losing it on restart just costs one refetch. ``last_update`` bumps only on a genuine fetch,
         # so the same staleness check as the stats (``xvb_stats_are_stale``) applies to it (#311).
         self._xvb_rewards = {"estimates": {}, "last_update": 0.0}
+        # All-rounds aggregate from the same winners file (#866/#872): round-type frequencies +
+        # qualifier counts. Same memory-only, refetch-on-restart, staleness-by-last_update rules.
+        self._xvb_round_stats = {"stats": {}, "last_update": 0.0}
 
         # Initialize persistent DB connection
         # check_same_thread=False allows the connection to be used by multiple threads
@@ -1373,6 +1376,20 @@ class StateManager:
         """Replace the cached reward estimates and stamp ``last_update`` (only on a genuine fetch, #118)."""
         with self._lock:
             self._xvb_rewards = {"estimates": dict(estimates or {}), "last_update": time.time()}
+
+    def get_xvb_round_stats(self) -> dict[str, Any]:
+        """The cached all-rounds raffle aggregate (#866/#872):
+        ``{"stats": {"types": {...}, "span_days": d}, "last_update": ts}``."""
+        with self._lock:
+            return {
+                "stats": dict(self._xvb_round_stats["stats"]),
+                "last_update": self._xvb_round_stats["last_update"],
+            }
+
+    def set_xvb_round_stats(self, stats: dict[str, Any]):
+        """Replace the cached round aggregate and stamp ``last_update`` (only on a genuine fetch)."""
+        with self._lock:
+            self._xvb_round_stats = {"stats": dict(stats or {}), "last_update": time.time()}
 
     def update_xvb_stats(
         self,

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -491,6 +491,9 @@ class XvbComparison extends Component {
       tiers.find((t) => t.name === calc.target_tier) ||
       tiers[0];
     const cmp = xvbTierComparison(sel, coeffDay);
+    // The actionable net: measured realization when the wallet has one, face value otherwise —
+    // the label always says which (#872: the face-value net once had the wrong SIGN).
+    const netShown = cmp.realizedNet !== null ? cmp.realizedNet : cmp.net;
     // The same sustains rule the tier block states: donating the threshold must fit inside the
     // donateable share of the what-if hashrate. An unsustainable tier's Net is "—" — showing,
     // say, Mega's +56 XMR/yr to a 269 kH/s fleet would imply an unreachable payout.
@@ -510,14 +513,32 @@ class XvbComparison extends Component {
                              title="XvB's own published expected reward for this tier per year (their reward_calc figures, fetched over Tor). This is the raffle expectation across all qualifiers — donating above the tier threshold does NOT raise it." />
                 <${StatCard} label="Cost / yr" value=${cmp.cost !== null ? formatXmr(cmp.cost) : "—"}
                              title="P2Pool earnings foregone by donating the tier threshold for a year (threshold × the P2Pool daily rate × 365)." />
-                <${StatCard} label="Net / yr" value=${sustainable && cmp.net !== null ? formatXmr(cmp.net) : "—"}
-                             cls=${sustainable && cmp.net !== null ? netCls(cmp.net) : ""}
+                <${StatCard} label=${cmp.realizedNet !== null ? "Net / yr (measured)" : "Net / yr (face value)"}
+                             value=${sustainable && netShown !== null ? formatXmr(netShown) : "—"}
+                             cls=${sustainable && netShown !== null ? netCls(netShown) : ""}
                              title=${
-                               sustainable
-                                 ? "Expected XvB reward minus the P2Pool earnings given up. Shown only when XvB's estimate is available."
-                                 : "Not shown — this tier isn't sustainable at your hashrate, so its payout isn't reachable."
+                               !sustainable
+                                 ? "Not shown — this tier isn't sustainable at your hashrate, so its payout isn't reachable."
+                                 : cmp.realizedNet !== null
+                                   ? `XvB's published reward scaled to what this wallet's wins actually paid — ` +
+                                     `${calc.realization_pct}% of face value over the last ${calc.realization_wins} wins — ` +
+                                     `minus the P2Pool earnings given up.`
+                                   : "XvB's published FACE-VALUE reward minus the P2Pool earnings given up. The face " +
+                                     "value prices every bonus hash at full block reward and assumes every won round " +
+                                     "runs to completion — wallets collect less; this net is an upper bound. Once " +
+                                     "enough wins land, this figure switches to your measured payout realization."
 } />
             </div>
+            ${
+              // The draw behind the XMR figure (#872): how often this round type comes up and
+              // against how many qualifiers — which also makes a single-qualifier tier (whose
+              // headline reward evaporates the moment a second donor qualifies) self-evident.
+              sel.win_odds_day > 0
+                ? html`<p class="text-muted text-xs mt-1" id="xvb-draw-line">
+                    Draw: ≈ ${Number((sel.win_odds_day * 30).toPrecision(2))} wins / 30d
+                    among ~${Number(sel.players_avg.toPrecision(2))} qualifiers</p>`
+                : null
+            }
             ${
               // Fiat mirror of the XMR/yr figures (#520): same visibility guards as the cards
               // above (never a fiat number whose XMR figure is hidden), at the XMR price in use.
@@ -525,7 +546,7 @@ class XvbComparison extends Component {
                 ? html`<p class="text-muted text-xs mt-1" id="xvb-fiat-line">
                     ≈ ${calc.estimates_available ? formatFiat(coinFiat(cmp.expected, energy.xmr_price), energy.currency) : "—"} expected ·
                     ${formatFiat(coinFiat(cmp.cost, energy.xmr_price), energy.currency)} cost ·
-                    ${sustainable ? formatFiat(coinFiat(cmp.net, energy.xmr_price), energy.currency) : "—"} net, per year
+                    ${sustainable ? formatFiat(coinFiat(netShown, energy.xmr_price), energy.currency) : "—"} net, per year
                 </p>`
                 : null
             }
@@ -548,9 +569,10 @@ class XvbComparison extends Component {
 // XvB tier / raffle block (#118), inside the earnings card and driven by the same what-if
 // hashrate: the highest XMRvsBeast tier that hashrate sustains (computeXvbTier — the server's
 // own auto rule), what holding it costs, and the current vs target tier for context. Labelled
-// raffle status, never a payout; deliberately no entry counts or win odds — the draw is random
-// above the threshold. Hidden entirely while XvB is disabled. `coeffDay` (earnings.coeff_day)
-// feeds the per-tier payout comparison dropdown below.
+// raffle status, never a payout. The draw is random above the threshold — donating more within
+// a tier buys nothing — but the odds themselves ARE knowable (#872: qualifier counts from XvB's
+// winners file), so the comparison dropdown shows them. Hidden entirely while XvB is disabled.
+// `coeffDay` (earnings.coeff_day) feeds the per-tier payout comparison dropdown below.
 function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
   if (!calc || !calc.enabled) return null;
   const t = computeXvbTier(hr, calc);
@@ -615,10 +637,17 @@ function ExpectedVsActualCard({ summary }) {
     dim: !xmr.enabled,
     title: xmr.includes_xvb
       ? "Confirmed on-chain payouts over the trailing 30 days vs the P2Pool linear expectation " +
-        "at your 30-day average hashrate PLUS XvB's published estimate for your tier — combined " +
+        "at your 30-day average hashrate PLUS XvB's estimate for your tier — combined " +
         "on both sides, because an XvB win pays out through ordinary payouts that cannot be " +
-        "told apart from P2Pool payouts. Payouts swing with luck; a sustained gap is the " +
-        "signal worth checking, not one window."
+        "told apart from P2Pool payouts. " +
+        (xmr.xvb_realization_pct !== null
+          ? `The XvB share is tempered to this wallet's measured win payouts — ` +
+            `${xmr.xvb_realization_pct}% of XvB's published face value over the last ` +
+            `${xmr.xvb_wins_measured} wins. `
+          : "The XvB share is XvB's published face-value estimate — an upper bound: it prices " +
+            "every bonus hash at full block reward and assumes every won round runs to " +
+            "completion. ") +
+        "Payouts swing with luck; a sustained gap is the signal worth checking, not one window."
       : "Confirmed on-chain payouts over the trailing 30 days vs the linear expectation at " +
         "your 30-day average P2Pool hashrate. Any XvB win payouts land in the actual too — " +
         "they cannot be told apart from P2Pool payouts. Payouts swing with luck; a sustained " +
@@ -645,15 +674,22 @@ function ExpectedVsActualCard({ summary }) {
   if (xvb.enabled) {
     rows.push({
       label: "XvB wins (30d)",
-      expected: "—",
+      // Forecast from XvB's own winners file (#866): round-type frequency ÷ qualifier count for
+      // the held tier. Two significant digits, same honesty rule as the Tari row. "—" while the
+      // aggregate is missing or stale — never a guess.
+      expected:
+        xvb.expected_wins_30d !== null && xvb.expected_wins_30d !== undefined
+          ? `≈ ${Number(xvb.expected_wins_30d.toPrecision(2))} wins`
+          : "—",
       actual:
         `${xvb.wins_30d} win${xvb.wins_30d === 1 ? "" : "s"}` +
         (xvb.last_win_ts ? ` · last ${formatAgo(xvb.last_win_ts)}` : ""),
       dim: false,
       title:
         "Raffle wins recorded in the last 30 days (last-win recency can predate the window). " +
-        "A win's XMR arrives through ordinary payouts, so its value is counted in the " +
-        "Monero + XvB row above — this row tracks only that wins keep landing.",
+        "Expected is computed from XvB's public winners file: how often your tier's rounds are " +
+        "drawn ÷ how many qualifiers they have. A win's XMR arrives through ordinary payouts, " +
+        "so its value is counted in the Monero + XvB row above — this row tracks the draw.",
     });
   }
   return html`

--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -678,7 +678,7 @@ function ExpectedVsActualCard({ summary }) {
       // the held tier. Two significant digits, same honesty rule as the Tari row. "—" while the
       // aggregate is missing or stale — never a guess.
       expected:
-        xvb.expected_wins_30d !== null && xvb.expected_wins_30d !== undefined
+        xvb.expected_wins_30d != null
           ? `≈ ${Number(xvb.expected_wins_30d.toPrecision(2))} wins`
           : "—",
       actual:

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -302,19 +302,26 @@ export function computeXvbTier(hashrateHs, calc) {
   return best && { tier: best.name, threshold: best.threshold, cost: best.threshold };
 }
 
-// XvB per-tier payout comparison (#118). Weighs XvB's own published expected reward for a tier
-// (`expected_reward_year`, XMR/year, fetched server-side over Tor) against what donating that tier
-// costs in foregone P2Pool earnings: cost = threshold H/s × the daily P2Pool rate (`coeffDay`,
-// same `earnings.coeff_day` the card already uses) × 365. Net = expected − cost. `expected` is null
-// when the estimate is unavailable/stale — cost still stands, but net is null: we never fabricate
-// the reward. This is a raffle-tier comparison, NOT a claim that donating more within a tier helps.
+// XvB per-tier payout comparison (#118, made honest by #872). Weighs XvB's expected reward for a
+// tier against what donating that tier costs in foregone P2Pool earnings: cost = threshold H/s ×
+// the daily P2Pool rate (`coeffDay`, same `earnings.coeff_day` the card already uses) × 365.
+// TWO reward figures: `expected` is XvB's published face value (prices every bonus hash at full
+// block reward — measured wallets collect a fraction), `realized` is that figure × the wallet's
+// own measured win realization (server-computed, null until enough wins measure it). The
+// actionable net prefers realized — the published face value once flipped the net's SIGN on a
+// production box (+2.97 shown, −1.8 measured, #872). Either figure null (unavailable/stale/
+// unmeasured) => its net is null: we never fabricate the reward. This is a raffle-tier
+// comparison, NOT a claim that donating more within a tier helps.
 export function xvbTierComparison(tier, coeffDay) {
   const cost =
     tier && tier.threshold > 0 && coeffDay > 0 ? tier.threshold * coeffDay * DAYS_PER_YEAR : null;
   const expected =
     tier && Number.isFinite(tier.expected_reward_year) ? tier.expected_reward_year : null;
+  const realized =
+    tier && Number.isFinite(tier.realized_reward_year) ? tier.realized_reward_year : null;
   const net = expected !== null && cost !== null ? expected - cost : null;
-  return { expected, cost, net };
+  const realizedNet = realized !== null && cost !== null ? realized - cost : null;
+  return { expected, cost, net, realized, realizedNet };
 }
 
 // Decimal places for a coin amount: more for small amounts (a day's earnings can be a tiny

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1555,9 +1555,8 @@ def xvb_realization(payouts, raffle_wins, xvb_day, expected_wins_day, now=None):
     average rode the round minimum; the published figures assume 1.0. Returns
     ``(fraction clamped to [0, 1], wins measured)``, or None (callers fall back to the published
     number, labeled face value) when either side is missing or fewer than
-    ``_XVB_REALIZATION_MIN_WINS`` wins are measurable.
+    ``_XVB_REALIZATION_MIN_WINS`` wins are measurable."""
     # ponytail: one factor across tiers and eras — per-tier factors if a tier change muddies it.
-    """
     if not payouts or not raffle_wins or not xvb_day or not expected_wins_day:
         return None
     now = now if now is not None else time.time()

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1482,14 +1482,7 @@ def xvb_current_tier_reward_day(metrics, state_mgr):
     if not metrics.xvb_enabled:
         return None
     tiers = state_mgr.get_tiers()
-    # Round-type key of the current tier: the highest-threshold key the credited average clears —
-    # the same selection get_tier_info makes, but we need the key (not the display name) to look up
-    # the estimate. None => below the lowest donor tier (nothing published to credit).
-    hr = min(metrics.xvb_1h, metrics.xvb_24h)
-    key, best = None, 0.0
-    for k, threshold in tiers.items():
-        if threshold > 0 and hr >= threshold and threshold > best:
-            key, best = k, threshold
+    key = xvb_current_tier_key(metrics, tiers)
     if key is None:
         return None
     est_state = state_mgr.get_xvb_reward_estimates()
@@ -1500,6 +1493,94 @@ def xvb_current_tier_reward_day(metrics, state_mgr):
     # 365-day year, matching logic.mjs DAYS_PER_YEAR. Guard non-positive so a zero/garbage estimate
     # degrades to None rather than folding a bogus 0 into gross.
     return float(reward_year) / 365 if reward_year and reward_year > 0 else None
+
+
+def xvb_current_tier_key(metrics, tiers):
+    """Round-type key of the tier the fleet is CURRENTLY credited for, or None below the lowest.
+
+    The highest-threshold key that ``min(xvb_1h, xvb_24h)`` clears — the same lower-of-two rule as
+    ``metrics.current_tier``, but yielding the KEY (``donor``/``donor_vip``/…) the estimate and
+    round-stats tables are indexed by."""
+    hr = min(metrics.xvb_1h, metrics.xvb_24h)
+    key, best = None, 0.0
+    for k, threshold in tiers.items():
+        if threshold > 0 and hr >= threshold and threshold > best:
+            key, best = k, threshold
+    return key
+
+
+# Measuring what a raffle win actually pays (#866/#872). A win's bonus round mines for up to an
+# hour and lands as ordinary small P2Pool payouts shortly after; production measurement put the
+# attributable payout mass inside 2h of the win timestamp. A win younger than the settle window
+# may still have payouts in flight, so it is left out of the sample rather than dragging the
+# factor down. Below the minimum sample the factor is noise — callers fall back to the published
+# figure and the UI labels it face value.
+_XVB_WIN_PAYOUT_WINDOW_S = 2 * 3600
+_XVB_WIN_SETTLE_S = 12 * 3600
+_XVB_REALIZATION_MIN_WINS = 5
+_XVB_REALIZATION_WINDOW_S = 45 * SECONDS_PER_DAY
+
+
+def xvb_expected_wins_day(round_stats_state, tier_key, tiers):
+    """Expected raffle wins per day for the held tier (#866), from XvB's own winners file.
+
+    The file's players column is the qualifier count per round, so the honest forecast is
+    mechanical: for each donor round type the fleet qualifies for (threshold at or under the held
+    tier's), rounds-per-day ÷ average qualifiers, summed. Verified against production: predicted
+    0.84 whale wins/day, measured 0.84/day over the same stretch. None when the aggregate is
+    missing, stale (#311 rule), or spans no measurable time — the card shows "—", never a guess."""
+    if not tier_key:
+        return None
+    stats = (round_stats_state or {}).get("stats") or {}
+    types = stats.get("types") or {}
+    span_days = stats.get("span_days") or 0.0
+    if xvb_stats_are_stale(round_stats_state) or not types or span_days <= 0:
+        return None
+    held = tiers.get(tier_key, 0.0)
+    total = 0.0
+    for key, threshold in tiers.items():
+        if 0 < threshold <= held:
+            agg = types.get(key)
+            if agg and agg.get("players_avg", 0) > 0 and agg.get("rounds", 0) > 0:
+                total += (agg["rounds"] / span_days) / agg["players_avg"]
+    return total if total > 0 else None
+
+
+def xvb_realization(payouts, raffle_wins, xvb_day, expected_wins_day, now=None):
+    """Measured fraction of XvB's published expectation this wallet actually collects (#866/#872).
+
+    Numerator: mean confirmed XMR landing within the attribution window after each settled win in
+    the trailing measurement window. Denominator: face value per win — the published per-day figure
+    spread over the expected win rate. Production measured ~0.19 on a Whale-tier box whose credited
+    average rode the round minimum; the published figures assume 1.0. Returns
+    ``(fraction clamped to [0, 1], wins measured)``, or None (callers fall back to the published
+    number, labeled face value) when either side is missing or fewer than
+    ``_XVB_REALIZATION_MIN_WINS`` wins are measurable.
+    # ponytail: one factor across tiers and eras — per-tier factors if a tier change muddies it.
+    """
+    if not payouts or not raffle_wins or not xvb_day or not expected_wins_day:
+        return None
+    now = now if now is not None else time.time()
+    lo = now - _XVB_REALIZATION_WINDOW_S
+    stamps = [
+        t for t in ((w.get("ts") or 0) for w in raffle_wins) if lo <= t <= now - _XVB_WIN_SETTLE_S
+    ]
+    if len(stamps) < _XVB_REALIZATION_MIN_WINS:
+        return None
+    face_per_win = xvb_day / expected_wins_day
+    if face_per_win <= 0:
+        return None
+    # Each payout counts once even when two win windows overlap (back-to-back wins).
+    realized = (
+        sum(
+            (p.get("amount_atomic") or 0)
+            for p in payouts
+            if any(0 <= (p.get("ts") or 0) - t <= _XVB_WIN_PAYOUT_WINDOW_S for t in stamps)
+        )
+        / ATOMIC_PER_XMR
+    )
+    frac = (realized / len(stamps)) / face_per_win
+    return (max(0.0, min(1.0, frac)), len(stamps))
 
 
 def build_earnings(data, metrics, payouts=None, tari_payouts=None, xvb_day=None):
@@ -1571,7 +1652,9 @@ def build_earnings(data, metrics, payouts=None, tari_payouts=None, xvb_day=None)
     }
 
 
-def build_earnings_vs_actual(metrics, earnings, raffle_wins, now=None):
+def build_earnings_vs_actual(
+    metrics, earnings, raffle_wins, now=None, expected_wins_day=None, realization=None
+):
     """Expected-vs-actual summary — one row per income stream, for both views (#808).
 
     The comparison the operator otherwise assembles by hand across the Earnings tabs: the linear
@@ -1588,7 +1671,9 @@ def build_earnings_vs_actual(metrics, earnings, raffle_wins, now=None):
     expected = the P2Pool linear model + XvB's published per-day estimate × 30 (folded only when
     fresh; ``includes_xvb`` tells the client which label to draw), actual = every confirmed
     payout; ``pct`` compares like with like, and ``partial`` carries the confirmed window's
-    may-be-incomplete flag. **Tari** compares BLOCK COUNTS: solo merge-mining pays whole blocks,
+    may-be-incomplete flag. The XvB addend is TEMPERED by this wallet's measured win realization
+    when enough wins exist to measure it (#866 — see ``xvb_realization``); the published face
+    value stays in the tooltip via ``xvb_realization_pct``/``xvb_wins_measured``. **Tari** compares BLOCK COUNTS: solo merge-mining pays whole blocks,
     so the honest unit is blocks (expected = hashrate × window ÷ aux difficulty; actual =
     confirmed payout count, each payout being a found block), with the XTM sum alongside — no
     percent, a count that small is luck either way. **XvB** keeps only its win count and last-win
@@ -1605,6 +1690,16 @@ def build_earnings_vs_actual(metrics, earnings, raffle_wins, now=None):
     # the combined expectation to <= 0 while `available` stays True — an inverted pct at best, a
     # zero denominator at worst. A negative estimate is meaningless, so it folds as 0.
     expected_xvb = max(0.0, earnings["xvb_day"] or 0.0) * 30 if metrics.xvb_enabled else 0.0
+    # Temper the XvB leg by what THIS wallet's wins measurably paid (#866): the published figure
+    # prices bonus hashes at face value, which a production wallet realized ~19% of — folding it
+    # untempered made the combined pct blame the P2Pool leg for XvB's optimism. With enough
+    # measured wins (``realization``, computed once in build_state via ``xvb_realization``) the
+    # leg scales down to the measured fraction; without them the published figure stands and the
+    # client labels it face value.
+    if realization and expected_xvb > 0:
+        expected_xvb *= realization[0]
+    else:
+        realization = None
     xmr = {
         "available": expected_p2pool > 0,
         "expected_30d": expected_p2pool + expected_xvb,
@@ -1612,6 +1707,10 @@ def build_earnings_vs_actual(metrics, earnings, raffle_wins, now=None):
         # actual ALWAYS contains any win payouts; when XvB is on but the published figure is
         # stale, the tooltip owns the asymmetry rather than a fabricated estimate filling it.
         "includes_xvb": expected_xvb > 0,
+        # Tempering context for the tooltip: the measured fraction and its sample size, or None
+        # when the leg is the untempered published figure (or XvB is off).
+        "xvb_realization_pct": round(realization[0] * 100) if realization else None,
+        "xvb_wins_measured": realization[1] if realization else None,
         "enabled": bool(conf.get("enabled")),
         "actual_30d": conf.get("xmr_30d") if conf.get("enabled") else None,
         "partial": bool((conf.get("partial") or {}).get("30d")),
@@ -1639,6 +1738,10 @@ def build_earnings_vs_actual(metrics, earnings, raffle_wins, now=None):
         "enabled": metrics.xvb_enabled,
         "wins_30d": sum(1 for t in stamps if t >= now - 30 * SECONDS_PER_DAY),
         "last_win_ts": max(stamps, default=0),
+        # The forecast the "—" used to stand in for (#866): win odds are computable from XvB's
+        # own winners file (round-type frequency ÷ qualifier count), so publish them. None while
+        # the aggregate is missing/stale — the client keeps the dash.
+        "expected_wins_30d": expected_wins_day * 30 if expected_wins_day else None,
     }
     return {"xmr": xmr, "tari": tari, "xvb": xvb}
 
@@ -1659,7 +1762,7 @@ _XVB_SIDECHAIN_NOTE = (
 )
 
 
-def build_xvb_calc(metrics, state_mgr):
+def build_xvb_calc(metrics, state_mgr, realization=None):
     """XvB tier/raffle calculator inputs for the Advanced view (Issue #118).
 
     Same pattern as ``build_earnings``'s ``coeff_day``: the server publishes the tier table and
@@ -1669,12 +1772,31 @@ def build_xvb_calc(metrics, state_mgr):
     ``resolve_target_threshold``'s auto rule). Current/target tier state comes straight off
     ``Metrics`` — no tier math is re-derived here.
 
-    Deliberately carries NO raffle-entry or win-probability figures: the raffle draw is random
-    among qualifiers, so tier + threshold + cost is everything the operator can act on. Returns
-    ``{"enabled": False}`` alone when XvB is off — there is no tier to calculate."""
+    The draw is random among qualifiers, but the winners file publishes the qualifier count per
+    round (#872), so each tier carries its measurable draw context: ``win_odds_day`` (that round
+    type's frequency ÷ its average qualifiers — per-round-type, unlike the earnings card's
+    cumulative forecast) and ``players_avg`` (which also makes a single-qualifier artifact like
+    Mega's self-evident). ``realized_reward_year`` scales the published figure by this wallet's
+    measured win realization (``realization``, from ``xvb_realization``) — None when unmeasured,
+    so the client falls back to face value and says so. Returns ``{"enabled": False}`` alone when
+    XvB is off — there is no tier to calculate."""
     if not metrics.xvb_enabled:
         return {"enabled": False}
     tiers = state_mgr.get_tiers()
+    round_state = state_mgr.get_xvb_round_stats()
+    round_types = (
+        {}
+        if xvb_stats_are_stale(round_state)
+        else ((round_state.get("stats") or {}).get("types") or {})
+    )
+    span_days = ((round_state.get("stats") or {}).get("span_days") or 0.0) if round_types else 0.0
+
+    def _odds_day(key):
+        agg = round_types.get(key)
+        if not agg or span_days <= 0 or agg.get("players_avg", 0) <= 0:
+            return None
+        return (agg["rounds"] / span_days) / agg["players_avg"]
+
     # XvB's published per-tier expected reward (XMR/year), fetched over Tor and cached (#118). The
     # tier KEY is exactly the round-type in the file (donor / donor_vip / donor_whale / donor_mega),
     # so a tier maps to its estimate by key. A stale or empty cache degrades to None per tier +
@@ -1697,6 +1819,15 @@ def build_xvb_calc(metrics, state_mgr):
                     "expected_reward_year": (
                         float(estimates[key]) if estimates_available and key in estimates else None
                     ),
+                    # Published figure × measured realization (#872) — the net the panel can
+                    # honestly act on. None until enough wins measure the factor.
+                    "realized_reward_year": (
+                        float(estimates[key]) * realization[0]
+                        if estimates_available and key in estimates and realization
+                        else None
+                    ),
+                    "win_odds_day": _odds_day(key),
+                    "players_avg": (round_types.get(key) or {}).get("players_avg"),
                 }
                 for key, t in tiers.items()
                 if t > 0
@@ -1705,6 +1836,10 @@ def build_xvb_calc(metrics, state_mgr):
         ),
         "estimates_available": estimates_available,
         "estimates_stale": estimates_stale,
+        # Measurement context for the realized figures: the factor and its sample size, or None
+        # while unmeasured (the client then labels the published number face value).
+        "realization_pct": round(realization[0] * 100) if realization else None,
+        "realization_wins": realization[1] if realization else None,
         "max_fraction": XVB_MAX_DONATION_FRACTION,  # donation headroom rule (sustainability)
         "current_tier": metrics.current_tier,
         "target_tier": metrics.target_tier,
@@ -1847,6 +1982,19 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         xvb_day=xvb_current_tier_reward_day(metrics, state_mgr),
     )
 
+    # XvB honesty figures (#866/#872), computed once and shared by the earnings summary and the
+    # tier calculator so the two can never disagree: the forecast win rate from XvB's own winners
+    # file, and the measured fraction of the published reward this wallet's wins actually paid.
+    xvb_wins_day = xvb_realized = None
+    if metrics.xvb_enabled:
+        xvb_tiers = state_mgr.get_tiers()
+        xvb_wins_day = xvb_expected_wins_day(
+            state_mgr.get_xvb_round_stats(), xvb_current_tier_key(metrics, xvb_tiers), xvb_tiers
+        )
+        xvb_realized = xvb_realization(
+            monero_payouts, raffle_wins, earnings["xvb_day"], xvb_wins_day
+        )
+
     egress = egress_posture_from_config()  # per-component egress route + privacy roll-up (#170)
     topology = (
         topology_from_config()
@@ -1898,8 +2046,14 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         # (feature off → earnings shows only the estimate). Built above, before the payload.
         "earnings": earnings,
         # Expected vs actual, one row per stream (#808) — the Simple view's earnings figure.
-        "earnings_summary": build_earnings_vs_actual(metrics, earnings, raffle_wins),
-        "xvb_calc": build_xvb_calc(metrics, state_mgr),
+        "earnings_summary": build_earnings_vs_actual(
+            metrics,
+            earnings,
+            raffle_wins,
+            expected_wins_day=xvb_wins_day,
+            realization=xvb_realized,
+        ),
+        "xvb_calc": build_xvb_calc(metrics, state_mgr, realization=xvb_realized),
         # On a backup stack, the XvB controller state last pulled from the primary (#249) — held as
         # standby, adopted only at failover. None on a single stack (nothing pulls). Inspectable so
         # an operator can confirm the backup is warm before it takes over.

--- a/build/dashboard/tests/client/test_xvb_client.py
+++ b/build/dashboard/tests/client/test_xvb_client.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 import mining_dashboard.client.xvb_client as xvb_mod
@@ -12,6 +13,7 @@ from mining_dashboard.client.xvb_client import (
     XvbClient,
     mask_wallet,
     parse_reward_estimates,
+    parse_round_stats,
     parse_winners,
 )
 
@@ -205,12 +207,43 @@ def test_parse_winners_bounds_hostile_input():
     assert parse_winners(tail, _WIN_WALLET) == []
 
 
+def test_parse_round_stats_aggregates_every_round():
+    stats = parse_round_stats(SAMPLE_WINNERS_TXT)
+    # ALL valid rows count — other wallets included (that is the point: the aggregate is the
+    # raffle's shape, not ours). Garbage and bad-date rows are skipped like parse_winners.
+    assert stats["types"] == {
+        "donor_mega": {"rounds": 1, "players_avg": 1.0},
+        "donor_vip": {"rounds": 1, "players_avg": 27.0},
+        "donor_whale": {"rounds": 1, "players_avg": 10.0},
+    }
+    # Span: newest (20:41:38) minus oldest (15:40:26) of the valid rows, in days.
+    assert stats["span_days"] == pytest.approx((1784407298.0 - 1784389226.0) / 86400.0)
+
+
+def test_parse_round_stats_garbage_or_empty_yields_no_types():
+    assert parse_round_stats("")["types"] == {}
+    assert parse_round_stats(None)["types"] == {}
+    assert parse_round_stats("no\ttabs here\n\n???")["types"] == {}
+    # A zero/negative players column is meaningless for odds — the row is skipped.
+    bad = "48M2j8Gj...d8KgGBwa\t2026-07-18 20:41:38\t1kH/s\t1\t\tb1\t1/1\t0\tdonor\n"
+    assert parse_round_stats(bad)["types"] == {}
+
+
+def test_parse_round_stats_bounds_hostile_input():
+    # Same line cap as parse_winners: rows beyond it are never scanned.
+    row = "48M2j8Gj...d8KgGBwa 2026-07-18 15:40:26 1kH/s 1 blk 1/1 5 donor"
+    tail = ("junk\n" * 9_999) + row
+    assert parse_round_stats(tail)["types"] == {}
+
+
 def test_get_recent_wins_success_routes_over_tor():
     client = XvbClient(_WIN_WALLET)
     resp = MagicMock(status_code=200, text=SAMPLE_WINNERS_TXT)
     with patch.object(xvb_mod, "bounded_get", return_value=resp) as mock_get:
-        wins = client.get_recent_wins()
-    assert len(wins) == 2
+        result = client.get_recent_wins()
+    assert len(result["wins"]) == 2
+    # The SAME fetched body yields the all-rounds aggregate (#866) — one request, two parses.
+    assert result["round_stats"]["types"]["donor_vip"]["rounds"] == 1
     assert mock_get.call_args.args[0].endswith("winners_recent_full_pub.txt")
     assert mock_get.call_args.kwargs["proxies"]["https"].startswith("socks5h://")
 
@@ -220,7 +253,7 @@ def test_get_recent_wins_no_wins_is_empty_list_not_none():
     client = XvbClient("49abcSOMEOTHERWALLETxyz99")
     resp = MagicMock(status_code=200, text=SAMPLE_WINNERS_TXT)
     with patch.object(xvb_mod, "bounded_get", return_value=resp):
-        assert client.get_recent_wins() == []
+        assert client.get_recent_wins()["wins"] == []
 
 
 def test_get_recent_wins_failures_return_none():

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -662,6 +662,51 @@ test('XvB comparison dropdown shows Expected/Cost/Net per tier, degrades on a st
     assert.doesNotMatch(uHtml, /2\.5200 XMR/); // but no reachable-looking Net
 });
 
+test('XvB tier comparison prefers the measured net and shows the draw behind it (#872)', () => {
+    const base = clone();
+    base.earnings.available = true;
+    base.earnings.coeff_day = 1e-7;
+    base.earnings.p2pool_hr = 200000; // what-if default: Whale sustainable (200k × 0.85 > 100k)
+    base.xvb_calc = {
+        enabled: true,
+        estimates_available: true,
+        estimates_stale: false,
+        max_fraction: 0.85,
+        current_tier: 'Whale (100.00 kH/s+)',
+        target_tier: 'Whale (100.00 kH/s+)',
+        target_threshold: 100000,
+        sustainable: true,
+        note: 'An XvB tier is raffle status, not an XMR payout.',
+        mode_note: null,
+        realization_pct: 19,
+        realization_wins: 15,
+        tiers: [
+            { name: 'Whale (100.00 kH/s+)', threshold: 100000, expected_reward_year: 6.17,
+              realized_reward_year: 6.17 * 0.19, win_odds_day: 0.84, players_avg: 8.2 },
+        ],
+    };
+    const up = renderApp({ state: base });
+    // Measured: the label says so, the value is realized − cost (1.1723 − 3.65 = −2.4777) —
+    // the face-value +2.52 must NOT render as the net (#872: it had the wrong sign).
+    assert.match(up, /Net \/ yr \(measured\)/);
+    assert.match(up, /-2\.4777\d* XMR/);
+    assert.doesNotMatch(up, /2\.5200 XMR/);
+    assert.match(up, /19% of face value over the last 15 wins/);
+    // The draw line: odds over 30d and the qualifier count.
+    assert.match(up, /≈ 25 wins \/ 30d/);
+    assert.match(up, /~8\.2 qualifiers/);
+
+    // Unmeasured: face value stands but is LABELED face value, and no draw line without odds.
+    base.xvb_calc.realization_pct = null;
+    base.xvb_calc.realization_wins = null;
+    base.xvb_calc.tiers[0].realized_reward_year = null;
+    base.xvb_calc.tiers[0].win_odds_day = null;
+    const fv = renderApp({ state: base });
+    assert.match(fv, /Net \/ yr \(face value\)/);
+    assert.match(fv, /2\.5200 XMR/);
+    assert.doesNotMatch(fv, /id="xvb-draw-line"/);
+});
+
 test('CadenceCard shows the — placeholders on a cold stack, real figures when available (#84)', () => {
     // The base fixture has no pool difficulty → cadence.available === false → server-sent dashes.
     const cold = renderApp();
@@ -1056,4 +1101,26 @@ test('ExpectedVsActualCard counts Tari blocks and windows XvB wins (#808)', () =
     // XvB off → the row disappears (no invented raffle framing on a non-XvB box).
     s.earnings_summary.xvb = { enabled: false, wins_30d: 0, last_win_ts: 0 };
     assert.doesNotMatch(renderApp({ state: s }), /XvB wins \(30d\)/);
+});
+
+test('ExpectedVsActualCard forecasts XvB wins from the winners feed, dash when unmeasured (#866)', () => {
+    const s = clone();
+    s.earnings_summary.xvb = {
+        enabled: true, wins_30d: 13, last_win_ts: 1735689000, expected_wins_30d: 25.2,
+    };
+    assert.match(renderApp({ state: s }), /≈ 25 wins/); // two significant digits
+    // No aggregate (missing/stale) → the dash, never a guess.
+    s.earnings_summary.xvb.expected_wins_30d = null;
+    assert.doesNotMatch(renderApp({ state: s }), /≈ .* wins<\/td>/);
+});
+
+test('ExpectedVsActualCard tooltip owns the tempered vs face-value XvB share (#866)', () => {
+    const s = clone();
+    s.earnings_summary.xmr.includes_xvb = true;
+    s.earnings_summary.xmr.xvb_realization_pct = 19;
+    s.earnings_summary.xmr.xvb_wins_measured = 15;
+    assert.match(renderApp({ state: s }), /19% of XvB(?:'|&#39;)s published face value/);
+    s.earnings_summary.xmr.xvb_realization_pct = null;
+    s.earnings_summary.xmr.xvb_wins_measured = null;
+    assert.match(renderApp({ state: s }), /face-value estimate — an upper bound/);
 });

--- a/build/dashboard/tests/frontend/fixtures/_gen_state.py
+++ b/build/dashboard/tests/frontend/fixtures/_gen_state.py
@@ -80,6 +80,19 @@ def _state_mgr():
         "estimates": {"donor": 0.06, "donor_vip": 0.81, "donor_whale": 6.17, "donor_mega": 56.9},
         "last_update": NOW,
     }
+    # All-rounds raffle aggregate (#866/#872): enough for draw odds + the expected-wins cell.
+    sm.get_xvb_round_stats.return_value = {
+        "stats": {
+            "types": {
+                "donor": {"rounds": 7, "players_avg": 70.0},
+                "donor_vip": {"rounds": 28, "players_avg": 28.0},
+                "donor_whale": {"rounds": 56, "players_avg": 8.0},
+                "donor_mega": {"rounds": 63, "players_avg": 1.0},
+            },
+            "span_days": 7.0,
+        },
+        "last_update": NOW,
+    }
     # One recorded XvB raffle win (inside the chart window) so the fixture carries both the
     # chart's gold-star marker and the XvB card's wins-log row.
     sm.get_raffle_wins.return_value = [

--- a/build/dashboard/tests/frontend/fixtures/state.json
+++ b/build/dashboard/tests/frontend/fixtures/state.json
@@ -115,10 +115,13 @@
       "expected_30d": 0.0,
       "includes_xvb": false,
       "partial": false,
-      "pct": null
+      "pct": null,
+      "xvb_realization_pct": null,
+      "xvb_wins_measured": null
     },
     "xvb": {
       "enabled": true,
+      "expected_wins_30d": null,
       "last_win_ts": 1735689000,
       "wins_30d": 1
     }
@@ -746,6 +749,8 @@
     "max_fraction": 0.85,
     "mode_note": null,
     "note": "An XvB tier is raffle status, not an XMR payout. Donated hashrate earns no P2Pool shares; holding a tier costs about its threshold in continuous donation (XvB qualifies a tier on both the 1h and 24h credited averages), and donating above the threshold adds nothing \u2014 the raffle winner is drawn at random among qualifiers.",
+    "realization_pct": null,
+    "realization_wins": null,
     "sustainable": true,
     "target_threshold": 1000.0,
     "target_tier": "Donor (1.00 kH/s+)",
@@ -753,22 +758,34 @@
       {
         "expected_reward_year": 0.06,
         "name": "Donor (1.00 kH/s+)",
-        "threshold": 1000.0
+        "players_avg": 70.0,
+        "realized_reward_year": null,
+        "threshold": 1000.0,
+        "win_odds_day": 0.014285714285714285
       },
       {
         "expected_reward_year": 0.81,
         "name": "Vip (10.00 kH/s+)",
-        "threshold": 10000.0
+        "players_avg": 28.0,
+        "realized_reward_year": null,
+        "threshold": 10000.0,
+        "win_odds_day": 0.14285714285714285
       },
       {
         "expected_reward_year": 6.17,
         "name": "Whale (100.00 kH/s+)",
-        "threshold": 100000.0
+        "players_avg": 8.0,
+        "realized_reward_year": null,
+        "threshold": 100000.0,
+        "win_odds_day": 1.0
       },
       {
         "expected_reward_year": 56.9,
         "name": "Mega (1.00 MH/s+)",
-        "threshold": 1000000.0
+        "players_avg": 1.0,
+        "realized_reward_year": null,
+        "threshold": 1000000.0,
+        "win_odds_day": 9.0
       }
     ]
   },

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -373,6 +373,27 @@ test('xvbTierComparison: no coeff_day (network stats down) → cost and net null
     assert.equal(c.expected, 6.17);
 });
 
+test('xvbTierComparison: measured realization yields realizedNet — the sign the face value got wrong (#872)', () => {
+    // Face value nets positive (6.17 − 3.65) while the measured figure nets NEGATIVE — the
+    // production case that motivated #872. Both are returned; the panel prefers realized.
+    const tier = {
+        name: 'Whale', threshold: 100_000,
+        expected_reward_year: 6.17, realized_reward_year: 6.17 * 0.19,
+    };
+    const c = xvbTierComparison(tier, 1e-7);
+    assert.ok(c.net > 0);
+    assert.ok(Math.abs(c.realized - 1.1723) < 1e-9);
+    assert.ok(c.realizedNet < 0);
+});
+
+test('xvbTierComparison: unmeasured realization stays null — never fabricated (#872)', () => {
+    const tier = { name: 'Whale', threshold: 100_000, expected_reward_year: 6.17, realized_reward_year: null };
+    const c = xvbTierComparison(tier, 1e-7);
+    assert.equal(c.realized, null);
+    assert.equal(c.realizedNet, null);
+    assert.ok(c.net !== null); // face-value net still stands, labeled as such by the panel
+});
+
 test('formatXmr: precision scales with magnitude; "—" for null/invalid', () => {
     assert.equal(formatXmr(2.5), '2.5000 XMR');        // >= 1 -> 4 dp
     assert.equal(formatXmr(0.1234567), '0.123457 XMR'); // >= 0.001 -> 6 dp

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -1727,6 +1727,11 @@ class TestXvbWinnersSync:
     — and additionally does NOT stamp the gate, so a failure retries on the next eligible poll."""
 
     _WIN = {"ts": 1000.0, "hashrate": 4.2e6, "height": 100, "block_id": "aa11", "tier": "donor"}
+    # get_recent_wins' one-fetch-two-parses shape (#866): wins + the all-rounds aggregate.
+    _STATS = {"types": {"donor": {"rounds": 4, "players_avg": 70.0}}, "span_days": 4.0}
+
+    def _fetch(self, wins, stats=None):
+        return {"wins": wins, "round_stats": stats if stats is not None else self._STATS}
 
     def _svc(self):
         sm = MagicMock()
@@ -1736,29 +1741,43 @@ class TestXvbWinnersSync:
 
     async def test_successful_fetch_persists_wins(self):
         svc, sm, xvb = self._svc()
-        xvb.get_recent_wins.return_value = [self._WIN]
+        xvb.get_recent_wins.return_value = self._fetch([self._WIN])
         await svc._sync_xvb_winners()
         sm.add_raffle_wins.assert_called_once_with([self._WIN])
+        # The same fetched body also refreshes the all-rounds aggregate (#866).
+        sm.set_xvb_round_stats.assert_called_once_with(self._STATS)
         assert svc._last_xvb_winners_sync > 0  # gate stamped on success
+
+    async def test_unparseable_round_stats_do_not_overwrite_the_cached_aggregate(self):
+        # A file that yields wins but no round aggregate (format drift) must not blank the
+        # cache — the stale-by-last_update rule owns degradation, never an empty-implied-fresh.
+        svc, sm, xvb = self._svc()
+        xvb.get_recent_wins.return_value = self._fetch(
+            [self._WIN], stats={"types": {}, "span_days": 0.0}
+        )
+        await svc._sync_xvb_winners()
+        sm.set_xvb_round_stats.assert_not_called()
+        sm.add_raffle_wins.assert_called_once_with([self._WIN])
 
     async def test_failed_fetch_writes_nothing_and_leaves_the_gate_open(self):
         svc, sm, xvb = self._svc()
         xvb.get_recent_wins.return_value = None
         await svc._sync_xvb_winners()
         sm.add_raffle_wins.assert_not_called()
+        sm.set_xvb_round_stats.assert_not_called()
         # Gate NOT stamped: the next eligible poll retries instead of waiting out 30 min.
         assert svc._last_xvb_winners_sync == 0.0
 
     async def test_wallclock_gate_suppresses_a_too_soon_second_fetch(self):
         svc, sm, xvb = self._svc()
-        xvb.get_recent_wins.return_value = []
+        xvb.get_recent_wins.return_value = self._fetch([])
         await svc._sync_xvb_winners()
         await svc._sync_xvb_winners()
         assert xvb.get_recent_wins.call_count == 1
 
     async def test_gate_reopens_once_the_cadence_elapses(self):
         svc, sm, xvb = self._svc()
-        xvb.get_recent_wins.return_value = []
+        xvb.get_recent_wins.return_value = self._fetch([])
         await svc._sync_xvb_winners()
         svc._last_xvb_winners_sync -= 1801  # simulate 30+ minutes having passed
         await svc._sync_xvb_winners()
@@ -1774,7 +1793,7 @@ class TestXvbWinnersSync:
         svc = DataService(sm, MagicMock(), MagicMock())
         svc.alert_service = AsyncMock()
         try:
-            svc.xvb_client.get_recent_wins.return_value = [self._WIN]
+            svc.xvb_client.get_recent_wins.return_value = self._fetch([self._WIN])
             await svc._sync_xvb_winners()
             rows = sm.get_raffle_wins()
             assert len(rows) == 1

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -117,6 +117,17 @@ class TestXvbStats:
         got["estimates"]["donor"] = 99
         assert state_manager.get_xvb_reward_estimates()["estimates"]["donor"] == 0.06
 
+    def test_round_stats_default_empty_then_set_stamps_and_copies(self, state_manager):
+        # #866: same memory-only, stamp-on-genuine-fetch, copy-out contract as the estimates.
+        assert state_manager.get_xvb_round_stats() == {"stats": {}, "last_update": 0.0}
+        stats = {"types": {"donor_whale": {"rounds": 62, "players_avg": 9.8}}, "span_days": 7.0}
+        state_manager.set_xvb_round_stats(stats)
+        got = state_manager.get_xvb_round_stats()
+        assert got["stats"] == stats
+        assert got["last_update"] > 0.0
+        got["stats"]["span_days"] = 99
+        assert state_manager.get_xvb_round_stats()["stats"]["span_days"] == 7.0
+
     def test_local_only_writes_do_not_set_last_update(self, state_manager):
         # The algo controller writes mode / donation_fraction / fail_count every cycle; none is an
         # xmrvsbeast.com fetch, so the "Updated" freshness timestamp must NOT bump on them (#136) —

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -1949,6 +1949,8 @@ class TestXvbRealization:
         assert xvb_realization(self._payouts(1), self.WINS, None, 1.0, now=self.NOW) is None
         assert xvb_realization(self._payouts(1), self.WINS, 0.016, None, now=self.NOW) is None
         assert xvb_realization(self._payouts(1), self.WINS, 0.016, 0.0, now=self.NOW) is None
+        # A hostile/corrupt negative published figure gives a negative face value — no factor.
+        assert xvb_realization(self._payouts(1), self.WINS, -0.016, 1.0, now=self.NOW) is None
 
 
 class TestEarningsVsActualTempering:

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -59,6 +59,8 @@ from mining_dashboard.web.views import (
     rigforge_update_for,
     visible_update,
     xvb_current_tier_reward_day,
+    xvb_expected_wins_day,
+    xvb_realization,
 )
 
 # --- Metrics fixtures for the presentation builders -----------------------------------
@@ -1858,6 +1860,145 @@ class TestEarningsVsActual:
         )
 
 
+# --- XvB honest economics: forecast win rate + measured realization (#866/#872) -------
+
+
+_WINS_TIERS = {"donor": 1_000.0, "donor_vip": 10_000.0, "donor_whale": 100_000.0}
+_WINS_STATS = {
+    "stats": {
+        "types": {
+            "donor": {"rounds": 7, "players_avg": 70.0},
+            "donor_vip": {"rounds": 28, "players_avg": 28.0},
+            "donor_whale": {"rounds": 56, "players_avg": 8.0},
+        },
+        "span_days": 7.0,
+    },
+    "last_update": None,  # set fresh per test
+}
+
+
+def _round_state(stale=False):
+    ts = time.time() - (XVB_STATS_STALE_AFTER_S + 1 if stale else 0)
+    return {**_WINS_STATS, "last_update": ts}
+
+
+class TestXvbExpectedWinsDay:
+    def test_sums_every_donor_round_type_the_held_tier_qualifies_for(self):
+        # A whale qualifier also plays the vip and donor rounds beneath it: the forecast is the
+        # sum of each round type's frequency ÷ its qualifier count, not the whale rounds alone.
+        out = xvb_expected_wins_day(_round_state(), "donor_whale", _WINS_TIERS)
+        assert out == pytest.approx((56 / 7.0) / 8.0 + (28 / 7.0) / 28.0 + (7 / 7.0) / 70.0)
+        # A donor-tier fleet only plays the donor rounds.
+        assert xvb_expected_wins_day(_round_state(), "donor", _WINS_TIERS) == pytest.approx(
+            (7 / 7.0) / 70.0
+        )
+
+    def test_missing_stale_or_empty_aggregate_yields_none(self):
+        assert xvb_expected_wins_day(None, "donor_whale", _WINS_TIERS) is None
+        assert xvb_expected_wins_day(_round_state(stale=True), "donor_whale", _WINS_TIERS) is None
+        empty = {"stats": {"types": {}, "span_days": 0.0}, "last_update": time.time()}
+        assert xvb_expected_wins_day(empty, "donor_whale", _WINS_TIERS) is None
+        assert xvb_expected_wins_day(_round_state(), None, _WINS_TIERS) is None
+
+
+_REALIZATION_NOW = 1_760_000_000
+
+
+class TestXvbRealization:
+    NOW = _REALIZATION_NOW
+    # 6 settled wins, hourly; face value 0.016 XMR/day at 1 expected win/day => 16 mXMR face/win.
+    WINS = [{"ts": _REALIZATION_NOW - 86_400 - i * 3_600} for i in range(6)]
+
+    def _payouts(self, per_win_atomic):
+        # One payout landing 30 min after each win — squarely inside the attribution window.
+        return [{"ts": w["ts"] + 1_800, "amount_atomic": per_win_atomic} for w in self.WINS]
+
+    def test_measures_the_fraction_of_face_value_wins_actually_paid(self):
+        # 3.2 mXMR realized per win against a 16 mXMR face => 0.2, with the sample size.
+        out = xvb_realization(self._payouts(3_200_000_000), self.WINS, 0.016, 1.0, now=self.NOW)
+        assert out == (pytest.approx(0.2), 6)
+
+    def test_clamps_at_face_value_and_floors_at_zero(self):
+        # A lucky window can overshoot face value — the factor is a discount, never a bonus.
+        out = xvb_realization(self._payouts(32_000_000_000), self.WINS, 0.016, 1.0, now=self.NOW)
+        assert out[0] == 1.0
+
+    def test_too_few_wins_is_none_not_noise(self):
+        out = xvb_realization(self._payouts(3_200_000_000), self.WINS[:4], 0.016, 1.0, now=self.NOW)
+        assert out is None
+
+    def test_unsettled_wins_are_left_out_of_the_sample(self):
+        # A win still inside the settle window has payouts in flight — counting it would drag
+        # the factor down for no reason. With it excluded the sample drops below the minimum.
+        fresh = [{"ts": self.NOW - 600}] + self.WINS[:4]
+        assert (
+            xvb_realization(self._payouts(3_200_000_000), fresh, 0.016, 1.0, now=self.NOW) is None
+        )
+
+    def test_a_payout_in_two_overlapping_windows_counts_once(self):
+        # Back-to-back wins share attribution windows; the payout sum iterates payouts, not
+        # windows, so an overlapped payout cannot double-count.
+        payout = {"ts": self.WINS[0]["ts"] + 900, "amount_atomic": 3_200_000_000}
+        out = xvb_realization([payout], self.WINS, 0.016, 1.0, now=self.NOW)
+        assert out == (pytest.approx(3.2e-3 / 6 / 0.016), 6)
+
+    def test_missing_inputs_yield_none(self):
+        assert xvb_realization(None, self.WINS, 0.016, 1.0, now=self.NOW) is None
+        assert xvb_realization([], self.WINS, 0.016, 1.0, now=self.NOW) is None
+        assert xvb_realization(self._payouts(1), None, 0.016, 1.0, now=self.NOW) is None
+        assert xvb_realization(self._payouts(1), self.WINS, None, 1.0, now=self.NOW) is None
+        assert xvb_realization(self._payouts(1), self.WINS, 0.016, None, now=self.NOW) is None
+        assert xvb_realization(self._payouts(1), self.WINS, 0.016, 0.0, now=self.NOW) is None
+
+
+class TestEarningsVsActualTempering:
+    NOW = 1_760_000_000
+
+    def _e(self):
+        return _summary_earnings(
+            coeff_day=1e-8,
+            xvb_day=0.016,
+            confirmed={"enabled": True, "xmr_30d": 0.28, "partial": {"30d": False}},
+        )
+
+    def test_measured_realization_tempers_the_xvb_leg(self):
+        # The published leg (0.016 × 30 = 0.48) scales to the measured fraction; the factor and
+        # its sample ride along for the tooltip. The P2Pool leg is untouched.
+        s = build_earnings_vs_actual(
+            _metrics(p2pool_30d=8000.0), self._e(), [], now=self.NOW, realization=(0.19, 15)
+        )
+        assert s["xmr"]["expected_30d"] == pytest.approx(1e-8 * 8000.0 * 30 + 0.016 * 30 * 0.19)
+        assert s["xmr"]["xvb_realization_pct"] == 19
+        assert s["xmr"]["xvb_wins_measured"] == 15
+        assert s["xmr"]["includes_xvb"] is True
+
+    def test_without_a_measured_factor_the_published_figure_stands(self):
+        s = build_earnings_vs_actual(_metrics(p2pool_30d=8000.0), self._e(), [], now=self.NOW)
+        assert s["xmr"]["expected_30d"] == pytest.approx(1e-8 * 8000.0 * 30 + 0.016 * 30)
+        assert s["xmr"]["xvb_realization_pct"] is None
+        assert s["xmr"]["xvb_wins_measured"] is None
+
+    def test_realization_without_an_xvb_leg_is_ignored(self):
+        # XvB off (or no fresh estimate): there is no leg to temper — the factor must not leak
+        # into the payload as if one existed.
+        s = build_earnings_vs_actual(
+            _metrics(p2pool_30d=8000.0, xvb_enabled=False),
+            self._e(),
+            [],
+            now=self.NOW,
+            realization=(0.19, 15),
+        )
+        assert s["xmr"]["xvb_realization_pct"] is None
+
+    def test_expected_wins_fill_the_xvb_row(self):
+        s = build_earnings_vs_actual(
+            _metrics(p2pool_30d=8000.0), self._e(), [], now=self.NOW, expected_wins_day=0.84
+        )
+        assert s["xvb"]["expected_wins_30d"] == pytest.approx(25.2)
+        s = build_earnings_vs_actual(_metrics(p2pool_30d=8000.0), self._e(), [], now=self.NOW)
+        assert s["xvb"]["expected_wins_30d"] is None
+
+
 # --- Host address beside the hostname (Issue #119) ------------------------------------
 
 
@@ -2038,12 +2179,29 @@ class TestXvbCalc:
     # XvB's published per-tier expected rewards, keyed by round-type == tier key (#118).
     _ESTIMATES = {"donor": 0.06, "donor_vip": 0.81, "donor_whale": 6.17, "donor_mega": 56.9}
 
-    def _sm(self, estimates=None, last_update=None):
+    # All-rounds aggregate from the winners file (#872): frequencies + qualifier counts over
+    # a one-week span, shaped like parse_round_stats' output.
+    _ROUND_STATS = {
+        "types": {
+            "donor": {"rounds": 7, "players_avg": 70.0},
+            "donor_vip": {"rounds": 28, "players_avg": 28.0},
+            "donor_whale": {"rounds": 56, "players_avg": 8.0},
+            "donor_mega": {"rounds": 63, "players_avg": 1.0},
+        },
+        "span_days": 7.0,
+    }
+
+    def _sm(self, estimates=None, last_update=None, round_stats=None, round_ts=None):
         sm = MagicMock()
         sm.get_tiers.return_value = self._TIERS
         est = self._ESTIMATES if estimates is None else estimates
         ts = time.time() if last_update is None else last_update
         sm.get_xvb_reward_estimates.return_value = {"estimates": est, "last_update": ts}
+        stats = self._ROUND_STATS if round_stats is None else round_stats
+        sm.get_xvb_round_stats.return_value = {
+            "stats": stats,
+            "last_update": time.time() if round_ts is None else round_ts,
+        }
         return sm
 
     def test_disabled_returns_enabled_false_only(self):
@@ -2101,6 +2259,43 @@ class TestXvbCalc:
         assert out["estimates_available"] is False
         assert out["estimates_stale"] is True
         assert all(t["expected_reward_year"] is None for t in out["tiers"])
+
+    def test_round_stats_expose_per_tier_draw_odds(self):
+        # #872: the winners file's players column makes the draw knowable — each tier carries its
+        # OWN round type's frequency ÷ qualifiers (the earnings card's forecast, by contrast,
+        # sums the lower tiers a qualifier also plays in).
+        out = build_xvb_calc(_metrics(), self._sm())
+        by_threshold = {t["threshold"]: t for t in out["tiers"]}
+        assert by_threshold[100_000]["win_odds_day"] == pytest.approx((56 / 7.0) / 8.0)
+        assert by_threshold[100_000]["players_avg"] == 8.0
+        # The single-qualifier artifact is self-evident: one Mega player, one win per draw.
+        assert by_threshold[1_000_000]["players_avg"] == 1.0
+
+    def test_stale_or_missing_round_stats_null_the_odds(self):
+        stale = self._sm(round_ts=time.time() - XVB_STATS_STALE_AFTER_S - 1)
+        assert all(t["win_odds_day"] is None for t in build_xvb_calc(_metrics(), stale)["tiers"])
+        empty = self._sm(round_stats={"types": {}, "span_days": 0.0}, round_ts=0.0)
+        assert all(t["win_odds_day"] is None for t in build_xvb_calc(_metrics(), empty)["tiers"])
+
+    def test_realization_scales_published_rewards_into_realized(self):
+        # #872: with a measured factor, every tier carries published × factor — the figure whose
+        # net can honestly be acted on — plus the factor and its sample size for the label.
+        out = build_xvb_calc(_metrics(), self._sm(), realization=(0.19, 15))
+        by_threshold = {t["threshold"]: t for t in out["tiers"]}
+        assert by_threshold[100_000]["realized_reward_year"] == pytest.approx(6.17 * 0.19)
+        assert out["realization_pct"] == 19
+        assert out["realization_wins"] == 15
+
+    def test_no_realization_leaves_realized_none(self):
+        # Unmeasured (too few wins / payout confirmation off): realized stays None so the client
+        # falls back to face value AND says so — never a fabricated factor.
+        out = build_xvb_calc(_metrics(), self._sm())
+        assert all(t["realized_reward_year"] is None for t in out["tiers"])
+        assert out["realization_pct"] is None
+        # Stale estimates null realized too — a factor cannot resurrect a stale face value.
+        sm = self._sm(last_update=time.time() - XVB_STATS_STALE_AFTER_S - 1)
+        out = build_xvb_calc(_metrics(), sm, realization=(0.5, 9))
+        assert all(t["realized_reward_year"] is None for t in out["tiers"])
 
     def test_empty_estimates_available_false_no_crash(self):
         # Never fetched / unparseable cache: available False, not "stale" (last_update 0), rewards None.
@@ -2167,6 +2362,7 @@ def _state_mgr(
     sm.get_xvb_stats.return_value = {"current_mode": mode}
     sm.get_tiers.return_value = {}
     sm.get_xvb_reward_estimates.return_value = {"estimates": {}, "last_update": 0.0}
+    sm.get_xvb_round_stats.return_value = {"stats": {}, "last_update": 0.0}
     sm.get_share_stats.return_value = share_stats or []
     sm.get_raffle_wins.return_value = []
     sm.get_xvb_standby.return_value = None  # no backup standby held (#249)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -267,9 +267,9 @@ trailing **30-day** window:
 
 | Row | Expected | Actual |
 |---|---|---|
-| **Monero + XvB (30d)** | The P2Pool linear estimate at your **30-day average** routed hashrate — the hashrate that actually ran the window — **plus** XvB's published per-day estimate for your current tier, when XvB is on and the estimate is fresh (the label drops "+ XvB" otherwise). | All confirmed on-chain payouts over the window ([payout confirmation](#payout-confirmation)), with a percent-of-expected. |
+| **Monero + XvB (30d)** | The P2Pool linear estimate at your **30-day average** routed hashrate — the hashrate that actually ran the window — **plus** the XvB share for your current tier, when XvB is on and the estimate is fresh (the label drops "+ XvB" otherwise). Once enough of your wins have confirmed payouts to measure, the XvB share is XvB's published figure **scaled to what your wins actually paid** — the tooltip names the measured percentage and sample. Until then the published face value stands, and the tooltip says it is an upper bound. | All confirmed on-chain payouts over the window ([payout confirmation](#payout-confirmation)), with a percent-of-expected. |
 | **Tari (30d)** | Expected **blocks** (hashrate × window ÷ Tari difficulty). Tari is merge-mined solo, so blocks are the honest unit — at fractions of a block per month, zero found is the normal case, not a fault. | Blocks found (each confirmed Tari payout is one solo-found block) and the XTM they paid. |
-| **XvB wins (30d)** | — | Raffle wins recorded in the window, and how long ago the most recent win on record landed (which can predate the window). |
+| **XvB wins (30d)** | Forecast wins for your tier, from XvB's own winners file: how often your tier's rounds are drawn ÷ how many qualifiers they have (summed with the lower donor rounds you also qualify for). `—` while the file hasn't been read or has gone stale. | Raffle wins recorded in the window, and how long ago the most recent win on record landed (which can predate the window). |
 
 Monero and XvB share one row **on both sides** deliberately: an XvB win pays out through ordinary
 small payouts that can't be told apart from P2Pool payouts, so the confirmed actual always
@@ -619,9 +619,10 @@ Set the keys in `config.json` and run `./pithead apply`. Key reference: the `mon
 
 A block inside the earnings card, driven by the same what-if hashrate input, that answers "which
 XMRvsBeast tier could this hashrate hold, and what would it cost?". Hidden entirely while XvB is
-disabled (`xvb.enabled: false`). It shows tier status only — deliberately no raffle entries or win
-odds, because there are none to show: the raffle winner is drawn at random among everyone above
-the threshold, so donating more than the threshold buys zero extra win chance.
+disabled (`xvb.enabled: false`). The raffle winner is drawn at random among everyone above the
+threshold, so donating more than the threshold buys zero extra win chance — but the odds
+themselves are knowable: XvB's winners file publishes the qualifier count for every round, and
+the comparison below shows them.
 
 | Field | Meaning |
 |---|---|
@@ -634,13 +635,19 @@ Below the tier figures, a **per-tier payout comparison** dropdown weighs each do
 
 | Field | Meaning |
 |---|---|
-| **Expected (XvB)** | XvB's own published expected reward for the tier, in XMR per year. This is XvB's pre-computed `reward_calc` figure for the tier's donor round, fetched over Tor from `reward_estimate_pub.txt` — the dashboard does not re-derive it. It is the raffle expectation across all qualifiers, so donating **above** the tier threshold does not raise it. `estimate unavailable` when the fetch is stale or failed — never a stale figure implied fresh. |
+| **Expected (XvB)** | XvB's own published expected reward for the tier, in XMR per year. This is XvB's pre-computed `reward_calc` figure for the tier's donor round, fetched over Tor from `reward_estimate_pub.txt` — the dashboard does not re-derive it. It is the raffle expectation across all qualifiers, so donating **above** the tier threshold does not raise it. It is also **face value**: it prices every bonus hash at full block reward and assumes every won round runs to completion — wallets collect less. `estimate unavailable` when the fetch is stale or failed — never a stale figure implied fresh. |
 | **Cost / yr** | The P2Pool earnings given up by donating the tier threshold for a year: `threshold × the P2Pool daily rate × 365`, using the same rate the Monero tab shows. |
-| **Net / yr** | Expected minus Cost. Shown only when XvB's estimate is available; otherwise the cost stands alone. |
+| **Net / yr** | The reward minus the P2Pool earnings given up — the number to act on. Labeled **(measured)** when enough of your wins have confirmed payouts to measure what they actually paid: the published reward is scaled to that measured fraction first, because the face-value net can carry the wrong **sign** (a production Whale box showed +2.97 XMR/yr while the measured net was about −1.8). Labeled **(face value)** until then — read it as an upper bound. |
 
-The estimate is fetched over Tor on the same cadence and staleness rules as the XvB stats card, so
-a quiet feed degrades to `estimate unavailable` rather than showing an old number. Pick a tier to
-compare, e.g. Whale against VIP Donor, at a glance.
+Below the figures, a **draw line** shows the selected tier's raffle odds from the winners file:
+about how many wins per 30 days its rounds pay out and among how many qualifiers the draw runs. A
+tier with one qualifier (it happens) is winner-take-all: its headline reward assumes that one
+donor stays alone, and evaporates the moment a second qualifies.
+
+The estimate and the winners file are fetched over Tor on the same cadence and staleness rules as
+the XvB stats card, so a quiet feed degrades to `estimate unavailable` (and the draw line
+disappears) rather than showing an old number. Pick a tier to compare, e.g. Whale against VIP
+Donor, at a glance.
 
 Raffle mechanics, flat: the winner of a donor round is drawn at random among wallets above the
 tier threshold on both credited averages; a win terminates if the 1h average then drops below the


### PR DESCRIPTION
## What

The expected-vs-actual card and the XvB tier calculator both priced XvB's published per-tier estimate as income. Measured on production (30d ending 2026-08-02): wins paid ~19% of that face value, making the card read 54% while the P2Pool leg ran at 120% — and the calculator's Net/yr showed **+2.97 XMR/yr for a tier measured at about −1.8**.

The winners file we already mirror over Tor publishes the qualifier count per round, so both surfaces become honest with no new egress and no re-derivation of XvB's reward_calc:

- **`parse_round_stats`** — second parse of the same fetched body: round-type frequencies, qualifier averages, span. Cached beside the reward estimates with the same #311 staleness rule.
- **Expected wins** — the card's "—" becomes a forecast: rounds-per-day ÷ qualifiers for the held tier (verified against production: predicted 0.84 whale wins/day, measured 0.84/day).
- **Measured realization** — confirmed payouts within 2h of each settled win ÷ face value per win, ≥5 wins required. The earnings card's XvB leg and the calculator's Net/yr scale by it and label themselves **(measured)**; until measurable, face value stands, labeled **(face value)** and described as an upper bound.
- **Draw line** — each tier's win odds + qualifier count in the calculator, which also makes a single-qualifier tier (Mega, currently one donor winning 42% of rounds) self-evident.

## Testing

Tier 1/2 per docs/dev/testing-strategy.md: parser bounds + aggregation, storage contract, forecast/realization/tempering unit tests, calculator payload tests, frontend logic + component render tests (271 node tests). Full suite + docs voice lint green; patch coverage 98%.

Docs: docs/dashboard.md updated for all three surfaces in house voice.

Closes #866. Closes #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)