### PR TITLE
XvB follow-ups: target-tier win forecast, stand-down when disabled, wins-log height cap

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -255,7 +255,13 @@ function Header({ state }) {
         <div class="text-right">
             <div class="text-muted text-xs">Last Update: ${state.last_update}</div>
             <div class=${"text-xs mt-1 " + cVar(hr.p2p_variant)}>P2Pool (routed): ${hr.p2p_1h} (1h) / ${hr.p2p_24h} (24h)</div>
-            <div class=${"text-xs mt-xs " + cVar(hr.xvb_variant)}>XvB (routed): ${hr.xvb_routed_1h} (1h) / ${hr.xvb_routed_24h} (24h)</div>
+            ${
+              // The XvB split line earns its header slot only while donation is on — off, it's a
+              // permanent row of zeros advertising a feature the operator turned off.
+              state.xvb_calc && state.xvb_calc.enabled
+                ? html`<div class=${"text-xs mt-xs " + cVar(hr.xvb_variant)}>XvB (routed): ${hr.xvb_routed_1h} (1h) / ${hr.xvb_routed_24h} (24h)</div>`
+                : null
+            }
         </div>
     </div>`;
 }
@@ -324,7 +330,8 @@ function SyncView({ sync }) {
 function Overview({ state }) {
   const hr = state.hashrate,
     st = state.stratum,
-    t = state.tari;
+    t = state.tari,
+    xvbOn = !!(state.xvb_calc && state.xvb_calc.enabled);
   // Stat order (#159): fleet headline (total / mode / workers) → raffle status (tier / VIP /
   // shares / target) → routed split → reference (last share / Tari / wallets).
   return html`
@@ -334,14 +341,27 @@ function Overview({ state }) {
             <${StatCard} label="Total Hashrate" value=${hr.total} cls="text-accent" />
             <${StatCard} label="Mining Mode" value=${hr.mode_name} cls=${cVar(hr.mode_variant)} />
             <${StatCard} label="Workers Alive" value=${state.proxy_workers} />
+            ${
+              // Five of these tiles are raffle/split state — on a non-donating box they'd all
+              // read None / N/A / zeros, a third of the Overview spent saying "off" five ways.
+              // The mode tile already says it once.
+              xvbOn
+                ? html`
             <${StatCard} label="Current Tier" value=${hr.tier} />
-            <${StatCard} label="Raffle Eligible" value=${state.raffle_eligible.label} cls=${raffleCls(state.raffle_eligible)} />
+            <${StatCard} label="Raffle Eligible" value=${state.raffle_eligible.label} cls=${raffleCls(state.raffle_eligible)} />`
+                : null
+            }
             <${SharesStat} sw=${state.shares_window} />
-            <${StatCard} label="Target Tier" value=${hr.target_tier} />
+            ${xvbOn ? html`<${StatCard} label="Target Tier" value=${hr.target_tier} />` : null}
             <${StatCard} label="P2Pool 1h (routed)" value=${hr.p2p_1h} cls=${cVar(hr.p2p_variant)} />
             <${StatCard} label="P2Pool 24h (routed)" value=${hr.p2p_24h} cls=${cVar(hr.p2p_variant)} />
+            ${
+              xvbOn
+                ? html`
             <${StatCard} label="XvB 1h (routed)" value=${hr.xvb_routed_1h} cls=${cVar(hr.xvb_variant)} />
-            <${StatCard} label="XvB 24h (routed)" value=${hr.xvb_routed_24h} cls=${cVar(hr.xvb_variant)} />
+            <${StatCard} label="XvB 24h (routed)" value=${hr.xvb_routed_24h} cls=${cVar(hr.xvb_variant)} />`
+                : null
+            }
             <${StatCard} label="Last Share" value=${st.last_share} />
             <div class="stat-card"><h5>Tari Mining</h5><${TariStatus} tari=${t} /></div>
             <${StatCard} label="Wallet XMR" value=${st.wallet_short} cls="font-mono text-xs" />
@@ -408,6 +428,9 @@ function GlobalStats({ state }) {
 
 function XvBStats({ state }) {
   const hr = state.hashrate;
+  // A non-donating box gets no XvB stats card at all — every figure in it would be a zero or a
+  // "None", and the tier calculator alongside already hides itself the same way.
+  if (!(state.xvb_calc && state.xvb_calc.enabled)) return null;
   // When the xmrvsbeast.com fetch is stale (#311) the CREDITED figures are frozen —
   // grey them and tag the label so they don't read as live. Routed (our own proxy
   // history) is unaffected. Tooltip explains why.
@@ -431,6 +454,7 @@ function XvBStats({ state }) {
         </div>
         <div class="mt-2">
             <div class="text-small text-muted">Raffle Wins</div>
+            <div class="raffle-wins-list">
             ${
               (state.raffle_wins || []).length
                 ? state.raffle_wins.map(
@@ -439,6 +463,7 @@ function XvBStats({ state }) {
                   )
                 : html`<div class="text-xs text-muted">No wins recorded yet — a win lands here and as a gold star on the chart.</div>`
             }
+            </div>
         </div>
         <div class=${"text-xs mt-2 " + (hr.xvb_stale ? "status-warn" : "text-muted")} title=${credTitle}>
             ${hr.xvb_stale ? "⚠ Stale — last successful fetch from xmrvsbeast.com: " : "Stats fetched from xmrvsbeast.com (Updated: "}${hr.xvb_updated}${hr.xvb_stale ? "" : ")"}
@@ -688,7 +713,8 @@ function ExpectedVsActualCard({ summary }) {
       title:
         "Raffle wins recorded in the last 30 days (last-win recency can predate the window). " +
         "Expected is computed from XvB's public winners file: how often your tier's rounds are " +
-        "drawn ÷ how many qualifiers they have. A win's XMR arrives through ordinary payouts, " +
+        "drawn ÷ how many qualifiers they have — for the tier you hold, or the tier you're " +
+        "targeting while none is held yet. A win's XMR arrives through ordinary payouts, " +
         "so its value is counted in the Monero + XvB row above — this row tracks the draw.",
     });
   }

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -545,6 +545,14 @@ tr:last-child td {
   padding: 24px 12px;
   text-align: center;
 }
+/* The wins log is capped at 20 rows of data, but even a dozen rows made the XvB card the tallest
+ * thing in its grid row — and grid rows are as tall as their tallest card, so every neighbour
+ * trailed white space (#817's align-items:start stops the stretch, not the row height). Cap the
+ * list at roughly six rows and scroll the rest. */
+.raffle-wins-list {
+  max-height: 120px;
+  overflow-y: auto;
+}
 .workers-empty code {
   font-family: monospace;
 }

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -51,15 +51,19 @@ export function heroKpis(state) {
   const hr = state.hashrate,
     sw = state.shares_window,
     p = state.pool,
-    raffle = state.raffle_eligible || {};
+    raffle = state.raffle_eligible || {},
+    // On a box that isn't donating, two raffle KPI slots ("Raffle Eligible: N/A", "XvB Tier:
+    // None") are dead weight in the most prominent strip on the page — the mode badge already
+    // says XvB is off, once. Dropped entirely; they return the moment XvB is enabled.
+    xvbOn = !!(state.xvb_calc && state.xvb_calc.enabled);
   return [
     { label: "Total Hashrate", value: hr.total, cls: "text-accent" },
     { label: "Shares in Window", value: sw.count, cls: sw.ok ? "status-ok" : "status-bad" },
     // Raffle Eligible (#158): Yes only when you'd WIN and COLLECT — in a donor tier AND holding a
-    // PPLNS share. Muted "N/A" when XvB is off; red "No" when donating but a gate is unmet.
-    { label: "Raffle Eligible", value: raffle.label, cls: raffleCls(raffle) },
+    // PPLNS share. Red "No" when donating but a gate is unmet.
+    ...(xvbOn ? [{ label: "Raffle Eligible", value: raffle.label, cls: raffleCls(raffle) }] : []),
     { label: "Blocks Found", value: p.blocks, cls: "" },
-    { label: "XvB Tier", value: hr.tier, cls: "" },
+    ...(xvbOn ? [{ label: "XvB Tier", value: hr.tier, cls: "" }] : []),
     { label: "Mining Mode", value: hr.mode_name, cls: "c-" + hr.mode_variant },
   ];
 }

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1521,6 +1521,18 @@ _XVB_REALIZATION_MIN_WINS = 5
 _XVB_REALIZATION_WINDOW_S = 45 * SECONDS_PER_DAY
 
 
+def xvb_forecast_tier_key(metrics, tiers):
+    """The tier the expected-wins forecast should speak to: held, else targeted (#866).
+
+    Before any tier is held — a fleet still ramping its credited average, or an operator weighing
+    whether donating is worth enabling at all — the honest forecast is for the TARGET tier: "what
+    would this buy", rather than a dash that reads as unknowable."""
+    key = xvb_current_tier_key(metrics, tiers)
+    if key is None and metrics.target_threshold > 0:
+        key = next((k for k, t in tiers.items() if t == metrics.target_threshold), None)
+    return key
+
+
 def xvb_expected_wins_day(round_stats_state, tier_key, tiers):
     """Expected raffle wins per day for the held tier (#866), from XvB's own winners file.
 
@@ -1988,7 +2000,7 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
     if metrics.xvb_enabled:
         xvb_tiers = state_mgr.get_tiers()
         xvb_wins_day = xvb_expected_wins_day(
-            state_mgr.get_xvb_round_stats(), xvb_current_tier_key(metrics, xvb_tiers), xvb_tiers
+            state_mgr.get_xvb_round_stats(), xvb_forecast_tier_key(metrics, xvb_tiers), xvb_tiers
         )
         xvb_realized = xvb_realization(
             monero_payouts, raffle_wins, earnings["xvb_day"], xvb_wins_day

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -1103,6 +1103,26 @@ test('ExpectedVsActualCard counts Tari blocks and windows XvB wins (#808)', () =
     assert.doesNotMatch(renderApp({ state: s }), /XvB wins \(30d\)/);
 });
 
+test('disabled XvB de-emphasizes: no stats card, no header split line, no hero raffle slots', () => {
+    // One mention — the mode badge — is enough on a non-donating box. The stats card, the
+    // header's routed-split line, and the two hero raffle KPIs all stand down with it.
+    const s = clone();
+    assert.match(renderApp({ state: s }), /XvB Donation Stats/); // fixture has XvB on
+    assert.match(renderApp({ state: s }), /XvB \(routed\):/);
+    s.xvb_calc = { enabled: false };
+    const off = renderApp({ state: s });
+    assert.doesNotMatch(off, /XvB Donation Stats/);
+    assert.doesNotMatch(off, /XvB \(routed\):/);
+    assert.doesNotMatch(off, /Raffle Eligible/);
+    assert.doesNotMatch(off, /XvB Tier</);
+});
+
+test('raffle wins render inside the scroll-capped list wrapper', () => {
+    // The wins log is what made the XvB card the tallest in its grid row (whitespace under every
+    // neighbour) — the wrapper carries the max-height cap.
+    assert.match(renderApp({ state: clone() }), /class="raffle-wins-list"/);
+});
+
 test('ExpectedVsActualCard forecasts XvB wins from the winners feed, dash when unmeasured (#866)', () => {
     const s = clone();
     s.earnings_summary.xvb = {

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -427,6 +427,7 @@ const _heroState = (over = {}) => ({
     shares_window: { count: 5, ok: true, ...over.shares_window },
     raffle_eligible: { applies: true, eligible: true, label: 'Yes', ...over.raffle_eligible },
     pool: { blocks: 42, ...over.pool },
+    xvb_calc: 'xvb_calc' in over ? over.xvb_calc : { enabled: true },
 });
 const _byLabel = (state) => Object.fromEntries(heroKpis(state).map((k) => [k.label, k]));
 
@@ -434,6 +435,19 @@ test('heroKpis: surfaces the six headline numbers under stable labels, in order'
     assert.deepEqual(
         heroKpis(_heroState()).map((k) => k.label),
         ['Total Hashrate', 'Shares in Window', 'Raffle Eligible', 'Blocks Found', 'XvB Tier', 'Mining Mode'],
+    );
+});
+
+test('heroKpis: the raffle slots vanish while XvB is disabled — no N/A dead weight', () => {
+    // The mode badge says XvB is off, once; the band should not repeat it as two empty KPIs.
+    assert.deepEqual(
+        heroKpis(_heroState({ xvb_calc: { enabled: false } })).map((k) => k.label),
+        ['Total Hashrate', 'Shares in Window', 'Blocks Found', 'Mining Mode'],
+    );
+    // A payload without the section at all (old server) behaves like disabled — never a crash.
+    assert.deepEqual(
+        heroKpis(_heroState({ xvb_calc: undefined })).map((k) => k.label),
+        ['Total Hashrate', 'Shares in Window', 'Blocks Found', 'Mining Mode'],
     );
 });
 

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -1904,6 +1904,25 @@ class TestXvbExpectedWinsDay:
 _REALIZATION_NOW = 1_760_000_000
 
 
+class TestXvbForecastTierKey:
+    def test_held_tier_wins_over_target(self):
+        m = _metrics(xvb_1h=100_000.0, xvb_24h=100_000.0, target_threshold=10_000.0)
+        assert views.xvb_forecast_tier_key(m, _WINS_TIERS) == "donor_whale"
+
+    def test_falls_back_to_the_target_tier_while_none_is_held(self):
+        # A fleet still ramping (or weighing whether to enable donation at all) has zero credited
+        # average — the forecast speaks to the TARGET tier instead of dashing out (#866).
+        m = _metrics(xvb_1h=0.0, xvb_24h=0.0, target_threshold=1_000.0)
+        assert views.xvb_forecast_tier_key(m, _WINS_TIERS) == "donor"
+
+    def test_none_when_neither_held_nor_targeted(self):
+        m = _metrics(xvb_1h=0.0, xvb_24h=0.0, target_threshold=0.0)
+        assert views.xvb_forecast_tier_key(m, _WINS_TIERS) is None
+        # A target threshold matching no tier (drifted config) stays None, never a KeyError.
+        m = _metrics(xvb_1h=0.0, xvb_24h=0.0, target_threshold=123.0)
+        assert views.xvb_forecast_tier_key(m, _WINS_TIERS) is None
+
+
 class TestXvbRealization:
     NOW = _REALIZATION_NOW
     # 6 settled wins, hourly; face value 0.016 XMR/day at 1 expected win/day => 16 mXMR face/win.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -131,10 +131,13 @@ A strip of headline KPIs sits below the top bar:
 |---|---|
 | **Total Hashrate** | Your combined hashrate across all workers. |
 | **Shares in Window** | Shares you currently hold in the P2Pool PPLNS window (green when above zero). |
-| **Raffle Eligible** | Whether you'd actually win **and** collect an XvB raffle payout: green **Yes**, red **No**, or muted **N/A** when XvB is off. (Full definition in [Overview](#overview).) |
+| **Raffle Eligible** | Whether you'd actually win **and** collect an XvB raffle payout: green **Yes**, red **No**. (Full definition in [Overview](#overview).) |
 | **Blocks Found** | P2Pool sidechain blocks your node has found. |
 | **XvB Tier** | The donation tier you're currently holding. |
 | **Mining Mode** | What your hashrate is routed to right now: P2Pool, XvB, or a split. |
+
+While XvB is disabled the two raffle KPIs stand down entirely — the mode badge already says XvB
+is off, and a strip of **N/A** and **None** would just repeat it.
 
 ### Mine cart train
 
@@ -259,6 +262,10 @@ The summary panel pulls the key numbers together:
 | **Tari Mining** | Whether merge-mining of Tari is active and healthy. |
 | **Wallet XMR / Wallet TARI** | Your configured Monero and Tari payout addresses, one card each. |
 
+While XvB is disabled the five raffle/split tiles (Current Tier, Raffle Eligible, Target Tier,
+XvB routed averages) drop out of the card, along with the header's XvB routed line and the whole
+*XvB Donation Stats* card — one mode badge says XvB is off; nothing else repeats it.
+
 ### Earnings — Expected vs Actual
 
 One compact table, shown in **both** views, that answers "am I earning what this hashrate should?"
@@ -269,7 +276,7 @@ trailing **30-day** window:
 |---|---|---|
 | **Monero + XvB (30d)** | The P2Pool linear estimate at your **30-day average** routed hashrate — the hashrate that actually ran the window — **plus** the XvB share for your current tier, when XvB is on and the estimate is fresh (the label drops "+ XvB" otherwise). Once enough of your wins have confirmed payouts to measure, the XvB share is XvB's published figure **scaled to what your wins actually paid** — the tooltip names the measured percentage and sample. Until then the published face value stands, and the tooltip says it is an upper bound. | All confirmed on-chain payouts over the window ([payout confirmation](#payout-confirmation)), with a percent-of-expected. |
 | **Tari (30d)** | Expected **blocks** (hashrate × window ÷ Tari difficulty). Tari is merge-mined solo, so blocks are the honest unit — at fractions of a block per month, zero found is the normal case, not a fault. | Blocks found (each confirmed Tari payout is one solo-found block) and the XTM they paid. |
-| **XvB wins (30d)** | Forecast wins for your tier, from XvB's own winners file: how often your tier's rounds are drawn ÷ how many qualifiers they have (summed with the lower donor rounds you also qualify for). `—` while the file hasn't been read or has gone stale. | Raffle wins recorded in the window, and how long ago the most recent win on record landed (which can predate the window). |
+| **XvB wins (30d)** | Forecast wins for your tier, from XvB's own winners file: how often your tier's rounds are drawn ÷ how many qualifiers they have (summed with the lower donor rounds you also qualify for). While no tier is held yet — a fleet still ramping, or an operator weighing whether donating is worth it — the forecast uses your **target** tier instead. `—` while the file hasn't been read or has gone stale. | Raffle wins recorded in the window, and how long ago the most recent win on record landed (which can predate the window). |
 
 Monero and XvB share one row **on both sides** deliberately: an XvB win pays out through ordinary
 small payouts that can't be told apart from P2Pool payouts, so the confirmed actual always


### PR DESCRIPTION
Three operator-reported gaps from the first live look at #874 on the bench:

- **Forecast for the target tier.** The expected-wins cell dashed out on a box holding no tier yet — exactly the operator weighing whether donating is worth enabling. It now forecasts for the **target** tier until one is held (`xvb_forecast_tier_key`), and the tooltip/docs say which tier it speaks to.
- **XvB stands down when disabled.** A non-donating box still spent five Overview tiles, two hero KPIs, the header's routed-split line and the whole *XvB Donation Stats* card saying "off" in zeros and Nones. All of it now hides behind the one mode badge; it returns the moment XvB is enabled.
- **Whitespace.** Grid rows are as tall as their tallest card and the raffle-wins log made the XvB card the tallest by far — neighbours trailed white space. The log now scrolls inside a capped list (`.raffle-wins-list`, ~6 rows).

## Testing

Unit tests for the tier-key fallback (held > target > none, drifted-config guard); heroKpis disabled/absent-section cases; component render tests for the stand-down set and the capped-list wrapper. Full suite green, patch coverage 100%, lint + docs voice clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)