### PR TITLE
docs(tests/os): document the rig phase, and stop crediting the commit gate to the update phase

### DIFF
--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -4,7 +4,7 @@ Tier-4 tests for the `pithead-os` appliance image (#77 phase 2): the properties 
 firmware and a real A/B updater can prove. The compose/CLI stack is covered by the other
 tiers ([`docs/dev/testing-strategy.md`](../../docs/dev/testing-strategy.md)); this harness
 covers what the flashed image adds — EFI boot, the first-boot wizard window, install-to-disk,
-and the update → commit → rollback cycle that is the phase-2 exit criterion.
+the rig role, and the update → commit → rollback cycle that is the phase-2 exit criterion.
 
 It needs a Linux host with KVM, libvirt and qemu, and root (the bench, not CI):
 
@@ -24,9 +24,9 @@ runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).
   banner reaches the serial console, the first-boot wizard announces its URL + one-time token,
   and the token gate answers.
 - **update** — build a v2 bundle, `rauc install` it, boot the spare slot, and assert the whole
-  A/B contract: an uncommitted slot auto-rolls-back, a healthy one commits (the gate is
-  `pithead doctor --json`), and a committed version can still be rolled off. Also asserts `/data`
-  grew to fill the disk.
+  A/B contract: an uncommitted slot auto-rolls-back, `rauc status mark-good` makes the update
+  stick across a reboot, and `rauc status mark-bad booted` still rolls off a committed version.
+  Also asserts `/data` grew to fill the disk.
 - **install** — boot the image as removable media beside a blank disk, run the disk installer,
   then boot the target and prove the copied system is COMPLETE — the `/var` overlay made an
   incomplete copy easy to produce and invisible to every other phase. Then the reinstall leg:
@@ -35,11 +35,18 @@ runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).
 - **provision** — submit a config through the wizard's real HTTP flow and require the STACK to
   come up: wizard accepted, setup ran, images pulled and verified, containers running, dashboard
   served, Tor-only egress actually enforced, built-in miner up. This is the phase that catches an
-  appliance whose engine cannot run the product.
+  appliance whose engine cannot run the product. Then the stack must return from a reboot with no
+  hands on it, and the real commit gate — `pithead doctor --json` — must pass on that healthy
+  stack yet refuse once a revenue service is down.
+- **rig** — answer `RigForge` on the same page and prove the other machine this image installs:
+  it mines from the baked binary with no compile and no clearnet, starts no containers at all,
+  and takes an A/B update — install, uncommitted rollback, self-commit, persistence — exactly
+  like a coordinator. A rig serves no dashboard, so one that silently never mines is invisible
+  to everything except this.
 - **fault** — power cuts mid-write and mid-commit, plus a corrupt bundle. A brick is
-  disqualifying. Opt-in: `all` runs the four phases above, not this one.
+  disqualifying. Opt-in: `all` runs the five phases above, not this one.
 
-`--keep` leaves the VM and disks for inspection; `--phase boot|update|install|provision|fault|all`
+`--keep` leaves the VM and disks for inspection; `--phase boot|update|install|provision|rig|fault|all`
 scopes the run. A failed assertion is recorded and the run carries on, so one bench boot collects
 the whole battery; the run exits non-zero if anything failed.
 


### PR DESCRIPTION
## What

`tests/os/README.md` documented four phases and a five-phase `all`. `rig` — the leg that proves the other machine this image installs (#797 R4, already on `develop-v2`) — was missing from the phase list, from the `--phase` enumeration, and from the opening line. The only way to find it was to read `run.sh`.

Two accuracy fixes came out of the same pass:

- **The update phase does not use `pithead doctor --json`.** It commits with `rauc status mark-good` and rolls off with `rauc status mark-bad booted` (`_commit_cmd` / `_rollback_cmd` in `tests/os/run.sh`, and the leg-2/leg-3 assertions that call them). The doctor gate belongs to the appliance's own boot path, and it is the **provision** phase that asserts it both ways — pass on a healthy still-syncing stack, refuse once monerod is stopped. The claim moved to the phase that actually makes it.
- **The provision phase's reboot leg was undocumented** — the stack has to return unaided through `pithead-boot`, which is the assertion guarding a miner that sits dark after every power blip.

## Why it looked wrong

This started against an older cut of the branch, where the README still described `rugix-ctrl` and an "open leg / no SSH" Status section. That version was already replaced on `develop-v2` by fcb9184 and 4cba93f. Rebased onto `develop-v2`, the residual gap is what this PR fixes — no rewrite, no churn against the version that just landed.

## Verification

`make lint-md` and `make lint-docs-voice` both pass (this file is covered by each). Every claim in the diff is derived from `tests/os/run.sh` on `develop-v2`; nothing else changed.

No behaviour change — the code was already right, the doc was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)