### PR TITLE
fix(dashboard): a never-reachable Tari can no longer hold worker readmission hostage

### DIFF
--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -705,10 +705,18 @@ class DataService:
                 self.workers_rejected = True
             return
 
-        # Readmit only once every node we reject on is confirmed healthy (not merely 'not
-        # down'), so a dashboard restart mid-outage doesn't bring workers back to a still-down
-        # stack. Tari's health is ignored when it's non-blocking.
-        recovered = self.monero_health.healthy and ((not TARI_REQUIRED) or self.tari_health.healthy)
+        # Readmit once monerod is confirmed healthy (not merely 'not down'), so a dashboard
+        # restart mid-outage doesn't bring workers back to a stack that can't mine. Tari's
+        # health is ignored when it's non-blocking; when it IS blocking, a Tari that has been
+        # reachable and healthy readmits, and so does one that has NEVER been reachable this
+        # run — the mirror of the monitor's ever-up guard. Without that escape, a required
+        # Tari whose gRPC isn't listening yet (it takes many minutes after a boot) held the
+        # proxy stopped indefinitely after a monerod blip: neither down nor healthy, it
+        # blocked readmission forever on a node that never caused the stop, and a shell-less
+        # appliance mined nothing until someone intervened.
+        recovered = self.monero_health.healthy and (
+            (not TARI_REQUIRED) or self.tari_health.healthy or not self.tari_health.ever_up
+        )
         if self.workers_rejected and recovered:
             logger.info(
                 f"Required nodes recovered — starting {REJECT_WORKERS_CONTAINER} to readmit workers."

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -615,17 +615,32 @@ class TestWorkerRejection:
         svc.docker_control.start.assert_awaited_once()
         assert svc.workers_rejected is False
 
-    async def test_no_readmit_while_a_relevant_node_unconfirmed(self):
-        # Rejected + nodes no longer "down", but a node we reject on isn't yet confirmed
-        # healthy (e.g. fresh after restart) → do NOT readmit to a possibly-still-down stack.
+    async def test_no_readmit_while_required_tari_was_up_but_unconfirmed(self):
+        # Rejected + a required Tari that HAS worked this run but isn't confirmed healthy
+        # again yet → do NOT readmit; wait out its recovery window.
         svc = self._svc()
         svc.workers_rejected = True
         svc.monero_health.healthy = True
+        svc.tari_health.ever_up = True
         svc.tari_health.healthy = False
         with self._tari(required=True):
             await svc._apply_worker_rejection(monero_down=False, tari_down=False)
         svc.docker_control.start.assert_not_called()
         assert svc.workers_rejected is True
+
+    async def test_readmit_when_required_tari_never_reachable(self):
+        # A required Tari that has NEVER answered this run (post-boot gRPC not listening
+        # yet) must not hold workers off a healthy monerod — the mirror of the ever-up
+        # guard. Observed live: a monerod blip during a post-update boot stopped the proxy
+        # and Tari's slow gRPC start-up blocked readmission indefinitely.
+        svc = self._svc()
+        svc.workers_rejected = True
+        svc.monero_health.healthy = True
+        assert svc.tari_health.ever_up is False  # fresh monitor: never observed
+        with self._tari(required=True):
+            await svc._apply_worker_rejection(monero_down=False, tari_down=False)
+        svc.docker_control.start.assert_awaited_once()
+        assert svc.workers_rejected is False
 
     async def test_readmit_ignores_tari_when_non_blocking(self):
         # Tari non-blocking → Tari health is irrelevant to readmission; monerod healthy is enough.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -204,7 +204,10 @@ configured, rather than sitting idle on a stack that can't mine. A sustained out
 monerod is required to mine, so a monerod outage always rejects. Whether a Tari outage rejects
 follows [`dashboard.tari_required`](configuration.md): `true` (default) rejects on a Tari outage;
 `false` keeps mining Monero through it. Rejection never triggers for a remote monerod, since the
-stack doesn't manage that node.
+stack doesn't manage that node. Readmission waits for monerod to be confirmed healthy; a required
+Tari holds it back only if Tari has actually answered since the dashboard started — a Tari whose
+gRPC has never come up (it can take many minutes after a boot) can't keep workers off a healthy
+monerod.
 
 **Non-blocking Tari.** With `tari_required: false`, a Tari-only (re)sync doesn't take over the
 screen: the operational view stays up, mining continues, and a `Tari syncing` badge shows Tari's


### PR DESCRIPTION
## What

Fixes #875 — the appliance that looks healthy while earning nothing. The worker-rejection supervisor stops `xmrig-proxy` on a debounced node outage and is supposed to readmit once the nodes it rejects on are confirmed healthy. Readmission required a required Tari to be *confirmed healthy* — but a Tari whose gRPC has never answered this run is neither down nor healthy, so it blocked readmission forever on a node that never caused the stop. A monerod blip during a post-update boot (when Tari's gRPC takes many minutes to start listening) stopped the proxy, and nothing ever started it again. On a shell-less release appliance there is no `pithead up` to recover with.

Readmission now mirrors the stop side's ever-up guard: a required Tari holds readmission only if it has actually been reachable since the dashboard started. monerod's confirmed-healthy requirement is unchanged — it is the node mining actually needs.

## Root cause, re-derived from the live bench

The bench's dashboard log showed `workers_rejected` (restored from the persisted snapshot) held for ~21 hours by a continuous Tari gRPC connection-refused window — and the readmit fired exactly 60 s (the recovery window) after Tari first answered. The coupling removed here is precisely what held it.

## The sibling audit (from the issue)

- **p2pool under the same supervisor**: stopped only by the #35 sync gate (one-way *release* latch — it never re-holds, and a partial start retries every cycle) and the fail-closed gate (re-checks both directions every cycle). Neither has a one-way stop.
- **The commit gate distinguishing a rejected proxy from the sync hold**: with readmission self-healing, a stopped proxy either restarts within ~60 s of node health or a node is genuinely down — committing during that window is acceptable, so no gate change. Noted here rather than built.
- **KVM battery assertion**: deliberately not added — in the harness the stack is freshly provisioned and still syncing, so the sync gate legitimately holds `xmrig-proxy`; asserting it running there would fight #35. The readmit logic is pinned at unit tier and verified on the live bench instead.

## Verification

- Unit tests: the trap case (never-up required Tari + healthy monerod → readmit) and the guard case (was-up-but-unconfirmed Tari → hold) both pinned; the old test encoding the trap as intended behavior is rewritten. Full dashboard suite: 1760 passed. Patch coverage 100%. `make lint` green.
- Adversarially verified in a fresh context: confirms the deadlock trace, the trade-off (Monero-only mining beats zero revenue when a required Tari has never answered), no other consumers of the changed semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)