### PR TITLE
fix(tests/os): the rig A/B leg asserted a revert the rig's own commit gate forbids

### DIFF
--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -42,9 +42,11 @@ runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).
   until the slot commits, then start, with the pending marker consumed.
 - **rig** — answer `RigForge` on the same page and prove the other machine this image installs:
   it mines from the baked binary with no compile and no clearnet, starts no containers at all,
-  and takes an A/B update — install, uncommitted rollback, self-commit, persistence — exactly
-  like a coordinator. A rig serves no dashboard, so one that silently never mines is invisible
-  to everything except this.
+  and takes an A/B update — install, boot, self-commit on the miner running, persistence —
+  exactly like a coordinator. (Uncommitted fallback is the update phase's to prove: a
+  provisioned rig commits the moment its miner is up, so the uncommitted window closes by
+  design.) A rig serves no dashboard, so one that silently never mines is invisible to
+  everything except this.
 - **fault** — power cuts mid-write and mid-commit, plus a corrupt bundle. A brick is
   disqualifying. Opt-in: `all` runs the five phases above, not this one.
 

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1743,27 +1743,14 @@ phase_rig() {
     done
     [ "$miner_v2" -eq 1 ] && ok "the rig mines again on the updated slot" ||
         bad "the rig stopped mining after the A/B update"
-    # An uncommitted update must revert here for the same reason it does on a coordinator.
-    _ssh reboot || true
-    sleep 10
-    _wait_ssh 300 || {
-        bad "the rig never returned after the no-commit reboot"
-        return
-    }
-    marker=$(_ssh cat /etc/pithead-test-marker | tr -d '\r\n')
-    [ "$marker" = "v1" ] && ok "ROLLBACK: an uncommitted update reverts on a rig too" ||
-        bad "expected v1 after the rig's uncommitted reboot, got '$marker'"
-    _ssh "$(_install_cmd /data/update.bundle)" || {
-        bad "the second v2 install failed on the rig"
-        return
-    }
-    _ssh "$(_boot_spare_cmd)" || true
-    sleep 10
-    _wait_ssh 300 || {
-        bad "the rig never returned after the second install"
-        return
-    }
-    # No harness mark-good: the rig's own boot path must commit, the same way it did on v1.
+    # No harness mark-good: the boot that just brought the miner up must have COMMITTED — a rig
+    # commits on the miner running, the same event this leg just waited for. That coupling is
+    # also why an "uncommitted revert" is not observable here: on a provisioned rig the commit
+    # window closes the moment the miner is up (seconds), which is the property itself, not a
+    # gap. The generic uncommitted-fallback machinery — same grub.cfg, same RAUC — is proven by
+    # the update phase on an unprovisioned box, where no boot path self-commits. This leg's
+    # first run asserted the revert anyway and refuted ITSELF: the rig had already committed,
+    # the reboot stayed v2, and a follow-up install then targeted the wrong slot.
     local genv2 tries4=0
     while [ "$tries4" -lt 24 ]; do
         genv2=$(_ssh "grub-editenv /boot/efi/grub/grubenv list" 2>/dev/null | tr '\n' ' ')


### PR DESCRIPTION
The rig phase's first-ever execution (it shipped in #876 and had never run) refuted two of its own assertions. After installing v2 the leg waited for the miner on the new slot — and a rig **commits on the miner running**, the very event it waited for — then expected an "uncommitted" reboot to revert. The rig had already self-committed (which the leg itself proves for slot A three assertions earlier), the reboot stayed v2, and the follow-up install then targeted the wrong slot, reading the grubenv of a machine one step ahead of the script.

The leg now asserts the actual contract: the updated slot **self-commits** (`B_OK=1 B_TRY=0`, no harness hands) and **persists** across a reboot. Uncommitted-fallback machinery — same grub.cfg, same RAUC — stays the update phase's to prove, on an unprovisioned box where no boot path self-commits; on a provisioned rig the closing commit window is the property, not a gap. README updated to match.

## Executed

Re-run on bench-host against the real image after the fix:

```
✓ the rig self-committed the UPDATED slot (B_OK=1 B_TRY=0) — no harness hands
✓ COMMIT: the update persists on the rig across reboot
os harness: 21 passed, 0 failed
```

That green run is the first complete rig-phase pass — the acceptance bar on #77's rig leg (a rig booting from a stick and taking an A/B update like a coordinator) is now demonstrated, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)