### PR TITLE
fix(os): drop the apt lists after the last apt step; correct the stale comment

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -42,9 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # (the RigForge toolchain, the updater) run without their own `apt-get update` and resolve
 # against these lists. They are deleted after the LAST apt step: nothing at runtime uses apt
 # (no apt on the running box), and the rootfs ships as a flat tarball, so a late deletion
-# genuinely leaves every slot and update bundle smaller. (An earlier comment here credited the
-# retired Rugix candidate's build chroot — that reason left with Rugix; this one is checked by
-# the bake itself.)
+# genuinely leaves every slot and update bundle smaller.
 
 # The stack, at the image's exact release state: pithead + schemas + the build/ mount sources
 # (config templates and entrypoints that services bind-mount). Build context = repo root.

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -38,8 +38,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         avahi-daemon libnss-mdns \
         squashfs-tools \
         openssh-server sudo less nano htpdate
-# NB: apt lists are kept on purpose — the Rugix core recipes run `apt-get install` in the build
-# chroot (fdisk/parted etc.) and need resolvable metadata; deleting them fails the bake.
+# NB: the apt lists survive THIS layer on purpose — the later `apt-get install` steps below
+# (the RigForge toolchain, the updater) run without their own `apt-get update` and resolve
+# against these lists. They are deleted after the LAST apt step: nothing at runtime uses apt
+# (no apt on the running box), and the rootfs ships as a flat tarball, so a late deletion
+# genuinely leaves every slot and update bundle smaller. (An earlier comment here credited the
+# retired Rugix candidate's build chroot — that reason left with Rugix; this one is checked by
+# the bake itself.)
 
 # The stack, at the image's exact release state: pithead + schemas + the build/ mount sources
 # (config templates and entrypoints that services bind-mount). Build context = repo root.
@@ -199,6 +204,8 @@ ARG PITHEAD_UPDATER=""
 RUN if [ "$PITHEAD_UPDATER" = "rauc" ]; then \
         apt-get install -y --no-install-recommends rauc rauc-service; \
     fi
+# The last apt step is above — from here the lists are dead weight in every slot and bundle.
+RUN rm -rf /var/lib/apt/lists/*
 # The disk installer and the boot config it writes to a target. No image payload ships with it —
 # it copies the running slot, so the artifact does not carry a compressed copy of itself.
 COPY os/installer/pithead-install /usr/local/sbin/pithead-install


### PR DESCRIPTION
Closes #870

The comment keeping the lists credited the retired Rugix candidate's build-chroot recipes — a reason that left with Rugix, exactly as the issue suspected. But the lists are not simply deletable either: the issue's other prediction was right too. They ARE still load-bearing **inside this Dockerfile** — the RigForge-toolchain and updater steps run `apt-get install` without their own `apt-get update` and resolve against the lists from the first step.

So the honest shape is both halves: the comment now states the real, checked-by-the-bake reason the lists survive the first layer, and a cleanup after the LAST apt step deletes them — nothing at runtime uses apt, and the rootfs ships as a flat tarball, so the late deletion genuinely leaves every slot and update bundle smaller.

## Verified on bench-host

- Full bake from this branch: green (`os/build-image.sh` + `mkimage.sh --dev`), refuting the "deleting them fails the bake" claim on the shipped path.
- `tests/os/verify-image.sh --test`: **69 passed, 0 failed** on the built image.
- Weight: the lists measure **21 MB** (fresh `apt-get update` on the pinned base); the built image now carries ~0 — ×2 slots plus every bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)