### PR TITLE
mkbundle/mkimage refuse a stale rootfs tarball unless explicitly overridden

### DIFF
--- a/os/rauc/mkbundle.sh
+++ b/os/rauc/mkbundle.sh
@@ -55,6 +55,7 @@ trap 'umount "$WORK/mnt" 2>/dev/null || true; rm -rf "$WORK"' EXIT
     echo "missing $TARBALL — run os/build-image.sh first" >&2
     exit 2
 }
+verify_tarball_commit "$TARBALL" || exit $?
 
 # The bundle is signed with this key and RAUC verifies it against the keyring baked at image build.
 # A release bundle must name the key explicitly; --dev auto-generates a labelled throwaway.

--- a/os/rauc/mkimage.sh
+++ b/os/rauc/mkimage.sh
@@ -42,6 +42,7 @@ TARBALL="os/build/pithead-root.tar"
     echo "missing $TARBALL — run os/build-image.sh first to stage the rootfs" >&2
     exit 2
 }
+verify_tarball_commit "$TARBALL" || exit $?
 
 # The keyring baked into slot A is the fleet's update trust root. Resolve it before anything heavy
 # so a release build with no key stops immediately, not after minutes of imaging.

--- a/os/rauc/populate-slot.sh
+++ b/os/rauc/populate-slot.sh
@@ -81,6 +81,39 @@ render_bundle_manifest() { # $1 os_version, $2 variant, $3 data_migration, $4 mi
     printf '\n[image.rootfs]\nfilename=rootfs.ext4\n'
 }
 
+# Refuse a present-but-stale rootfs tarball. A bench deploy once bundled the PREVIOUS session's
+# leftover os/build/pithead-root.tar — mkbundle's only guard was `[ -s ]`, existence, not freshness
+# — and RAUC installed it, the appliance booted it, every service came up green, and only a manual
+# /opt/pithead/BUILD_COMMIT check on the box caught that the fix under test was never on it. The
+# tarball already carries that same stamp (written by build-image.sh from the tree it built), so
+# compare it against the working tree instead of trusting that a stale artifact looks fine.
+#
+#   $1 = tarball path
+#
+# Both mkimage.sh and mkbundle.sh consume the SAME tarball, so the check lives here once rather
+# than drifting between two copies. Fail-closed like the version/variant/signing guards above:
+# mismatch (or a dirty-tree stamp the tree has since moved past) refuses by default, naming both
+# commits, with PITHEAD_STALE_TARBALL_OK=1 as the explicit escape for a deliberate stale rebuild.
+verify_tarball_commit() {
+    local tarball="$1" stamped head
+    stamped=$(tar -xOf "$tarball" opt/pithead/BUILD_COMMIT 2>/dev/null) || stamped=""
+    head=$(git rev-parse HEAD 2>/dev/null || echo unknown)
+    git diff --quiet 2>/dev/null || head="${head}-dirty"
+    [ -n "$stamped" ] || stamped="(no BUILD_COMMIT stamp in the tarball)"
+
+    if [ "$stamped" = "$head" ]; then
+        return 0
+    fi
+    if [ "${PITHEAD_STALE_TARBALL_OK:-0}" = 1 ]; then
+        echo "==> PITHEAD_STALE_TARBALL_OK=1: proceeding with $tarball (stamped $stamped) while the working tree is at $head" >&2
+        return 0
+    fi
+    echo "refusing to use a stale rootfs tarball: $tarball was built from commit $stamped but the" \
+        "working tree is now at $head — rerun os/build-image.sh, or set PITHEAD_STALE_TARBALL_OK=1" \
+        "to use it anyway" >&2
+    return 2
+}
+
 populate_slot() { # $1 = mounted rootfs
     local root="$1"
 

--- a/os/rauc/populate-slot.sh
+++ b/os/rauc/populate-slot.sh
@@ -97,9 +97,19 @@ render_bundle_manifest() { # $1 os_version, $2 variant, $3 data_migration, $4 mi
 verify_tarball_commit() {
     local tarball="$1" stamped head
     stamped=$(tar -xOf "$tarball" opt/pithead/BUILD_COMMIT 2>/dev/null) || stamped=""
-    head=$(git rev-parse HEAD 2>/dev/null || echo unknown)
-    git diff --quiet 2>/dev/null || head="${head}-dirty"
     [ -n "$stamped" ] || stamped="(no BUILD_COMMIT stamp in the tarball)"
+
+    if ! head=$(_working_tree_commit); then
+        if [ "${PITHEAD_STALE_TARBALL_OK:-0}" = 1 ]; then
+            echo "==> PITHEAD_STALE_TARBALL_OK=1: proceeding with $tarball (stamped $stamped) though the working tree's commit cannot be read" >&2
+            return 0
+        fi
+        echo "refusing $tarball: cannot read the working tree's commit to check the tarball's" \
+            "freshness against it (git failed — under sudo, root may refuse another user's" \
+            "checkout). Run from the checkout's owner, or set PITHEAD_STALE_TARBALL_OK=1 to" \
+            "skip the freshness check" >&2
+        return 2
+    fi
 
     if [ "$stamped" = "$head" ]; then
         return 0
@@ -112,6 +122,28 @@ verify_tarball_commit() {
         "working tree is now at $head — rerun os/build-image.sh, or set PITHEAD_STALE_TARBALL_OK=1" \
         "to use it anyway" >&2
     return 2
+}
+
+# The working tree's commit, with build-image.sh's exact -dirty suffix. These scripts normally run
+# under sudo, and root's git refuses to read another user's checkout ("dubious ownership") — and
+# `git -c safe.directory=` is documented as ignored from the command line — so on failure ask
+# again as the invoking user. Without this the guard would refuse EVERY sudo build on a
+# user-owned checkout, which is exactly the flow the stale-tarball incident happened on.
+_working_tree_commit() {
+    local h
+    if h=$(git rev-parse HEAD 2>/dev/null); then
+        git diff --quiet 2>/dev/null || h="${h}-dirty"
+        printf '%s\n' "$h"
+        return 0
+    fi
+    if [ -n "${SUDO_USER:-}" ]; then
+        if h=$(sudo -u "$SUDO_USER" git rev-parse HEAD 2>/dev/null); then
+            sudo -u "$SUDO_USER" git diff --quiet 2>/dev/null || h="${h}-dirty"
+            printf '%s\n' "$h"
+            return 0
+        fi
+    fi
+    return 1
 }
 
 populate_slot() { # $1 = mounted rootfs

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9254,6 +9254,63 @@ unset -f ourun
 rm -rf "$OUSB"
 unset OUSB
 
+# --- os/rauc stale-tarball guard (verify_tarball_commit in populate-slot.sh). A present-but-stale
+# os/build/pithead-root.tar looks identical to a fresh one to `[ -s ]` — a bench deploy once
+# bundled a leftover tarball from a previous session and every downstream check came up green with
+# the old code running. The guard extracts the tarball's own opt/pithead/BUILD_COMMIT stamp and
+# compares it to the working tree, proven here with a fabricated fixture tarball (no image build).
+echo "== unit: os/rauc stale-tarball guard =="
+VTC_TMP=$(mktemp -d)
+# The same commit+dirty-suffix computation verify_tarball_commit does, so the "match" fixture is
+# honest about the state of THIS working tree (it may itself be dirty mid-change).
+VTC_HEAD_SHA=$(cd "$ROOT" && git rev-parse HEAD)
+VTC_HEAD="$VTC_HEAD_SHA"
+(cd "$ROOT" && git diff --quiet) || VTC_HEAD="${VTC_HEAD_SHA}-dirty"
+
+# Build a fixture tarball with the single member the guard reads: opt/pithead/BUILD_COMMIT.
+# $2=NONE fabricates a tarball with the directory but no stamp file (an old/broken build).
+mk_vtc_fixture() { # $1=out-path $2=stamp-content|NONE
+    local d
+    d=$(mktemp -d)
+    mkdir -p "$d/opt/pithead"
+    [ "$2" = NONE ] || printf '%s\n' "$2" >"$d/opt/pithead/BUILD_COMMIT"
+    tar -cf "$1" -C "$d" opt
+    rm -rf "$d"
+}
+vtc() { # $1=tarball -> prints "rc=<n>"; stderr goes to $VTC_TMP/err
+    (
+        cd "$ROOT" || exit
+        # shellcheck disable=SC1090
+        . os/rauc/populate-slot.sh
+        set +e
+        verify_tarball_commit "$1" 2>"$VTC_TMP/err"
+        echo "rc=$?"
+    )
+}
+
+mk_vtc_fixture "$VTC_TMP/fresh.tar" "$VTC_HEAD"
+assert_eq "a tarball stamped with the current HEAD is accepted" "$(vtc "$VTC_TMP/fresh.tar")" "rc=0"
+
+mk_vtc_fixture "$VTC_TMP/stale.tar" "deadbeefcafef00dfeedfacebeeff00ddeadbeef"
+out=$(vtc "$VTC_TMP/stale.tar")
+assert_eq "a tarball stamped with a foreign commit is refused" "$out" "rc=2"
+err="$(cat "$VTC_TMP/err")"
+assert_contains "the refusal names the tarball's stamped commit" "$err" "deadbeefcafef00dfeedfacebeeff00ddeadbeef"
+assert_contains "the refusal names the working tree's commit" "$err" "$VTC_HEAD_SHA"
+assert_contains "the refusal points at the override env var" "$err" "PITHEAD_STALE_TARBALL_OK"
+
+out=$(PITHEAD_STALE_TARBALL_OK=1 vtc "$VTC_TMP/stale.tar")
+assert_eq "PITHEAD_STALE_TARBALL_OK=1 overrides a stale-commit refusal" "$out" "rc=0"
+
+mk_vtc_fixture "$VTC_TMP/nostamp.tar" NONE
+out=$(vtc "$VTC_TMP/nostamp.tar")
+assert_eq "a tarball with no BUILD_COMMIT stamp is refused" "$out" "rc=2"
+assert_contains "the refusal says no stamp was found" "$(cat "$VTC_TMP/err")" "no BUILD_COMMIT stamp"
+
+rm -rf "$VTC_TMP"
+unset -f mk_vtc_fixture vtc
+unset VTC_TMP VTC_HEAD_SHA VTC_HEAD
+
 # --- mkbundle metadata validation (fails fast, before the multi-minute image build) ---
 echo "== unit: mkbundle compatibility-metadata validation =="
 out=$(cd "$ROOT" && PITHEAD_DATA_MIGRATION=maybe bash os/rauc/mkbundle.sh /dev/null 2>&1)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9307,8 +9307,27 @@ out=$(vtc "$VTC_TMP/nostamp.tar")
 assert_eq "a tarball with no BUILD_COMMIT stamp is refused" "$out" "rc=2"
 assert_contains "the refusal says no stamp was found" "$(cat "$VTC_TMP/err")" "no BUILD_COMMIT stamp"
 
+# A checkout git cannot read (sudo on another user's tree, once the SUDO_USER fallback also
+# fails) must refuse rather than silently skip the freshness check — fail closed, with the
+# same explicit escape. Run from a non-repo dir with the fallback neutralized to simulate it.
+vtc_norepo() { # $1=tarball -> prints "rc=<n>"; stderr to $VTC_TMP/err
+    (
+        cd "$VTC_TMP" || exit
+        # shellcheck disable=SC1091
+        . "$ROOT/os/rauc/populate-slot.sh"
+        set +e
+        SUDO_USER="" GIT_DIR="$VTC_TMP/no-such-repo" verify_tarball_commit "$1" 2>"$VTC_TMP/err"
+        echo "rc=$?"
+    )
+}
+out=$(vtc_norepo "$VTC_TMP/fresh.tar")
+assert_eq "an unreadable working tree refuses (fail closed, never skip)" "$out" "rc=2"
+assert_contains "the refusal explains git could not be read" "$(cat "$VTC_TMP/err")" "cannot read the working tree's commit"
+out=$(PITHEAD_STALE_TARBALL_OK=1 vtc_norepo "$VTC_TMP/fresh.tar")
+assert_eq "PITHEAD_STALE_TARBALL_OK=1 overrides the unreadable-tree refusal" "$out" "rc=0"
+
 rm -rf "$VTC_TMP"
-unset -f mk_vtc_fixture vtc
+unset -f mk_vtc_fixture vtc vtc_norepo
 unset VTC_TMP VTC_HEAD_SHA VTC_HEAD
 
 # --- mkbundle metadata validation (fails fast, before the multi-minute image build) ---


### PR DESCRIPTION
Closes #896.

A present-but-stale `os/build/pithead-root.tar` looked identical to a fresh one — a bench deploy bundled the previous session's tarball, RAUC installed it, everything came up green, and only the manual BUILD_COMMIT check caught that the fix under test never shipped. The information was already inside the artifact.

- `verify_tarball_commit()` in `populate-slot.sh` (the file both consumers already share): one `tar -xO` of `opt/pithead/BUILD_COMMIT`, compared against the working tree with build-image.sh's exact `-dirty` suffix. Match proceeds; mismatch refuses naming both commits; `PITHEAD_STALE_TARBALL_OK=1` is the explicit escape — the same fail-closed shape as the existing version/variant/signing guards.
- Called from both `mkbundle.sh` and `mkimage.sh` right after their existence guards.
- Review amendment: these scripts normally run under sudo, and root's git refuses a user-owned checkout (dubious ownership; `-c safe.directory` is documented as ignored from the command line) — the guard falls back to reading the commit as `SUDO_USER`, and an unreadable tree refuses with a message naming the real cause instead of blaming staleness.

Tier-1 coverage with fabricated fixture tarballs: fresh accepted, stale refused (message names both commits + the override), missing stamp refused, unreadable tree refused fail-closed, override works on both refusal classes. Stack suite: 2182 passed, 0 failed.

Ponytail review: two refusal paths each keep their own override block — merging would save ~6 lines but collapse two different diagnoses into one message. Lean otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)