### PR TITLE
machine-id restore must write THROUGH /etc, not unmount it — first A/B update bricked networking

### DIFF
--- a/os/overlay/pithead-machine-id
+++ b/os/overlay/pithead-machine-id
@@ -4,27 +4,35 @@
 # must land before systemd-networkd (DHCP DUID) and systemd-journal-flush (the persistent
 # journal directory name) observe /etc/machine-id, and after /data is mounted.
 #
-# Why a plain write here works: the image ships /etc/machine-id EMPTY, and on this appliance
-# /etc is an overlay whose upper is a volatile tmpfs. PID 1's own first-boot handling (long
-# before any unit, ours included, runs) either writes a freshly generated transient id straight
-# into that writable upper, or — if it judged /etc unwritable — ro-bind-mounts the id from
-# /run/machine-id over the file instead; machine-id(5) describes both shapes. Either way the
-# upper is discarded at power-off, so without the restore below the machine would pick a NEW
-# random id on every single boot — worse than the bug being fixed. The umount guard below
-# covers the bind-mount shape and is a silent no-op on the plain-overlay one.
+# The image ships /etc/machine-id EMPTY, and /etc's overlay upper is a volatile tmpfs, so PID 1
+# runs first-boot machine-id handling on EVERY boot (long before any unit): it writes a fresh
+# transient id into the writable /etc, or — on a read-only root — bind-mounts a WRITABLE file
+# from /run over /etc/machine-id (machine-id(5) — the mount exists so the id can be written).
+# Either way that layer is discarded at power-off, so without the restore below the machine would
+# pick a NEW random id every boot, churning the DHCP lease. We write THROUGH that writable layer;
+# an earlier version unmounted it first and hit the read-only lower image on a post-A/B-swap slot,
+# so the write failed, machine-id stayed empty, and networkd never brought up DHCP.
 set -eu
 
-ID_FILE="/data/pithead/machine-id"
+ID_FILE="${PITHEAD_MACHINE_ID_FILE:-/data/pithead/machine-id}"
+ETC_ID="${PITHEAD_MACHINE_ID_ETC:-/etc/machine-id}"
 mkdir -p "$(dirname "$ID_FILE")"
 
 if [ -s "$ID_FILE" ]; then
-    umount /etc/machine-id 2>/dev/null || true
-    cat "$ID_FILE" >/etc/machine-id
-    echo "pithead-machine-id: restored persisted machine-id from $ID_FILE"
+    if cat "$ID_FILE" >"$ETC_ID" 2>/dev/null; then
+        echo "pithead-machine-id: restored persisted machine-id from $ID_FILE"
+    else
+        # /etc/machine-id was read-only with no writable layer over it — provide one ourselves,
+        # exactly as systemd would, rather than let the box boot with an empty id and no network.
+        cp "$ID_FILE" /run/pithead-machine-id
+        umount "$ETC_ID" 2>/dev/null || true
+        mount --bind /run/pithead-machine-id "$ETC_ID"
+        echo "pithead-machine-id: restored persisted machine-id via bind mount ($ID_FILE)"
+    fi
 else
     # First boot with nothing on /data yet: adopt whatever systemd already generated for THIS
     # boot rather than minting a second one — one machine, one id, chosen once.
-    cp /etc/machine-id "$ID_FILE"
+    cp "$ETC_ID" "$ID_FILE"
     chmod 444 "$ID_FILE"
     echo "pithead-machine-id: adopted this boot's machine-id and persisted it to $ID_FILE"
 fi

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -86,6 +86,10 @@ ip=""
 # only checks the shape, so the crash is the first honest verdict. XMRig's public donation
 # address: obviously not ours, plainly labelled, and any share it ever earned would be a donation.
 HARNESS_WALLET="44MnN1f3Eto8DZYUWuE5XZNUtE3vcRzt2j6PzqWpPau34e6Cf4fAxt6X2MBmrm6F9YMEiMNjN6W4Shn4pLcfNAja621jwyg"
+# A real base58 Tari address: the wizard now decodes + checksum-validates it host-side, so a
+# made-up placeholder is (correctly) rejected before the flow ever reaches the credentials
+# handoff. Same throwaway address the stack suite uses.
+HARNESS_TARI="126J92Yow5y9UoRFd1DNujPmVFq9C1ZeiYWT95UKxz5Y1rzbfjtHg4SCZS1dk83ivzt3m2XRQHTaYUk9SwmyeCvy5BJ"
 
 _ssh() {
     ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
@@ -321,6 +325,15 @@ phase_boot() {
         return
     }
     ok "wizard serves the token gate ($ip)"
+
+    # SSH is a host service that finishes starting a little after the wizard container's HTTP gate
+    # answers, so the first _ssh here must wait it out — a single-shot probe raced ssh.service and
+    # misread a healthy boot as "SSH unreachable". Every other _ssh probe in this file is already
+    # retry-wrapped; these two #895 assertions were the exceptions.
+    _wait_ssh 120 || {
+        bad "host SSH never came up after the wizard gate — cannot read hugepages/machine-id"
+        return
+    }
 
     # Hugepages are load-bearing (the RandomX dataset must land in hugetlbfs, not the cgroup —
     # the Dockerfile's own words): the baked sysctl reserves 3072 2M pages, and a boot that
@@ -648,7 +661,7 @@ phase_install() {
         return
     }
     local body
-    body="monero_wallet=$HARNESS_WALLET&tari_wallet=harness-dummy-tari-address&pool=mini&disk=vda&confirm=vda&wipe=keep"
+    body="monero_wallet=$HARNESS_WALLET&tari_wallet=$HARNESS_TARI&pool=mini&disk=vda&confirm=vda&wipe=keep"
     scode=$(curl -sSk -b "$jar" --data "$body" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
     [ "$scode" = "200" ] || {
         bad "combined submit (config + disk) did not return 200 (got ${scode:-none})"
@@ -1088,7 +1101,7 @@ phase_provision() {
     # Everything else keeps its default — which is itself part of what this proves.
     # local_miner=true: the Both role (#796) — the same submit must also light the built-in
     # RigForge worker, asserted in the local-miner leg below.
-    body="monero_wallet=$HARNESS_WALLET&tari_wallet=harness-dummy-tari-address&pool=mini&local_miner=true"
+    body="monero_wallet=$HARNESS_WALLET&tari_wallet=$HARNESS_TARI&pool=mini&local_miner=true"
     scode=$(curl -sSk -b "$jar" --data "$body" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
     [ "$scode" = "200" ] || {
         bad "config submit did not return 200 (got ${scode:-none} — a 30x means the session was not accepted)"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9532,6 +9532,31 @@ assert_eq "no marker + /data mounts clean -> skip (fail-safe: never touch a heal
 assert_eq "no marker + /data wedged after fsck -> reformat-wedged (recovery)" "$(decide "$DR/no-marker" fail)" "reformat-wedged"
 assert_eq "no marker + fsck repairs the mount -> skip (recoverable /data is never wiped)" "$(decide "$DR/no-marker" repair)" "skip"
 
+echo "== unit: pithead-machine-id — restore writes THROUGH /etc/machine-id, never unmounts it =="
+# The regression this pins: an earlier version unmounted /etc/machine-id before writing, which on
+# a read-only-root A/B slot exposed the lower image and the write failed — leaving an empty id and
+# a dead DHCP lease. The write must land in the (writable) target as-is. ETC + ID_FILE are
+# overridable so this runs without touching the real /etc.
+MID="$SANDBOX/machine-id"
+mkdir -p "$MID"
+# 1) Restore: /data holds an id, /etc has a different (systemd-transient) one -> /etc takes /data's.
+printf 'fa85bfc69f0b451d95bbacf897e431ce\n' >"$MID/data-id"
+printf 'ffffffffffffffffffffffffffffffff\n' >"$MID/etc-id"
+(
+    export PITHEAD_MACHINE_ID_FILE="$MID/data-id" PITHEAD_MACHINE_ID_ETC="$MID/etc-id"
+    sh "$ROOT/os/overlay/pithead-machine-id"
+) >/dev/null 2>&1
+assert_eq "restore overwrites /etc/machine-id with the persisted id" "$(cat "$MID/etc-id")" "fa85bfc69f0b451d95bbacf897e431ce"
+assert_eq "restore leaves the persisted id unchanged" "$(cat "$MID/data-id")" "fa85bfc69f0b451d95bbacf897e431ce"
+# 2) Adopt: /data has none yet -> adopt this boot's /etc id and persist it read-only.
+rm -f "$MID/data-id"
+printf 'abc0000000000000000000000000def0\n' >"$MID/etc-id"
+(
+    export PITHEAD_MACHINE_ID_FILE="$MID/data-id" PITHEAD_MACHINE_ID_ETC="$MID/etc-id"
+    sh "$ROOT/os/overlay/pithead-machine-id"
+) >/dev/null 2>&1
+assert_eq "adopt persists this boot's id to /data" "$(cat "$MID/data-id" 2>/dev/null)" "abc0000000000000000000000000def0"
+
 # ---------------------------------------------------------------------------
 echo ""
 printf 'pithead tests: \033[1;32m%d passed\033[0m, ' "$PASS"


### PR DESCRIPTION
The KVM battery on the merged tip caught a first-A/B-update-bricks-the-box regression I introduced in the identity work.

**Root cause (forensics from the failed guest's persistent journal):** on a read-only-root B slot after the A/B swap, `pithead-machine-id` unmounted `/etc/machine-id` before writing. But systemd's first-boot bind mount over that path is **writable** (a tmpfs file from /run — that's its whole purpose, machine-id(5)); the umount exposed the read-only lower image, the write failed (`cannot create /etc/machine-id: Read-only file system`), machine-id stayed empty, and `systemd-networkd` then never brought up DHCP because it derives the DUID from machine-id. The guest returned with only link-local + the container bridge and was unreachable — which is why `update` leg 1, the `rig` reboot leg, and `fault` A1 all failed identically ("guest never returned").

**Fix:** write through the writable layer (no umount); keep a bind-mount fallback only for a genuinely read-only target. Tier-1 test pins the restore-overwrites and adopt-persists branches (paths made overridable — a boot-path bricking class earns its seam).

**Two harness fixes rode along** (both battery-found, neither a product bug):
- `tests/os/run.sh` submitted `tari_wallet=harness-dummy-tari-address`, which #845's real host-side Tari checksum validation now correctly rejects *before* the credentials handoff — this was the sole cause of the `install` and `provision` handoff failures. Swapped for a valid base58 address.
- the boot phase's hugepage + machine-id asserts used a single-shot `_ssh` that raced `ssh.service` (which finishes just after the wizard's HTTP gate); gated behind `_wait_ssh` like every other probe in the file.

These three clear all 7 battery failures on the merged tip. Battery rerun is the live proof (queued). Ponytail: the bind-mount fallback is the one added branch, and it is load-bearing for the read-only case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)