### PR TITLE
Battery boot phase: give the first SSH the same 240s first-boot budget as the update phase

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -326,11 +326,14 @@ phase_boot() {
     }
     ok "wizard serves the token gate ($ip)"
 
-    # SSH is a host service that finishes starting a little after the wizard container's HTTP gate
-    # answers, so the first _ssh here must wait it out — a single-shot probe raced ssh.service and
-    # misread a healthy boot as "SSH unreachable". Every other _ssh probe in this file is already
-    # retry-wrapped; these two #895 assertions were the exceptions.
-    _wait_ssh 120 || {
+    # SSH is a host service that finishes starting after the wizard container's HTTP gate answers,
+    # so the first _ssh here must wait it out — a single-shot probe raced ssh.service and misread a
+    # healthy boot as "SSH unreachable". The budget is the update phase's own first-boot figure
+    # (_vm_boot_disk + _wait_ssh 240): this is the VERY FIRST cold-host VM of the run — 6 GiB of
+    # hugepages reserved, systemd-repart growing /data to ~24 GiB, the wizard image loading, the
+    # host key generating — and 120 s clipped it (SSH came up just after, per the failed-run
+    # forensics). An equally unprovisioned update-phase guest reaches SSH within 240 s.
+    _wait_ssh 240 || {
         bad "host SSH never came up after the wizard gate — cannot read hugepages/machine-id"
         return
     }


### PR DESCRIPTION
The battery rerun on the fixed tip cleared the two real regressions (update 15/0, install 33/0), leaving one harness-only failure: the boot phase's `_wait_ssh` gate for the #895 hugepage/machine-id asserts timed out at 120s.

Not a product issue — ssh.service is healthy. The boot phase is the very first cold-host VM of a run (6 GiB of hugepages reserved, systemd-repart growing /data to ~24 GiB, the wizard image loading, the host key generating on first boot), and 120s clipped it; the failed-run forensics showed SSH came up just after the window closed (a manual reconnect seconds later worked). The update phase boots an equally unprovisioned image and reaches SSH within its own `_wait_ssh 240` — this just matches that figure.

Held for the next battery run to confirm boot goes 5/0. Ponytail: one number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)