### PR TITLE
docs(workers): RigForge does not prompt for TLS at setup — verified live

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -183,7 +183,8 @@ The fingerprint is the whole trust model: XMRig does no CA validation for stratu
 pins it explicitly. On a rig, set:
 
 ```jsonc
-// the rig's pool entry (RigForge: same fields, prompted at setup)
+// the rig's pool entry (RigForge: same fields, added to its config.json by hand — setup
+// prompts only for the pool URL and stratum password, then `sudo ./rigforge.sh apply`)
 { "url": "YOUR_STACK_IP:3333", "tls": true, "tls-fingerprint": "<the printed fingerprint>" }
 ```
 


### PR DESCRIPTION
One-phrase doc-drift fix from today's live RigForge walkthrough on the rig bench: workers.md claimed the rig's TLS fields are "prompted at setup"; RigForge's first-run prompt asks only pool URL + stratum password, and the TLS pin is hand-added to its config.json then applied. The rigforge repo's matching stale claim (its integration doc says stack-side TLS has not shipped, while it serves live in production) is filed there as rigforge#342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)