### PR TITLE
chore(tests): regenerate the frontend state fixture

### DIFF
--- a/build/dashboard/tests/frontend/fixtures/state.json
+++ b/build/dashboard/tests/frontend/fixtures/state.json
@@ -121,7 +121,7 @@
     },
     "xvb": {
       "enabled": true,
-      "expected_wins_30d": null,
+      "expected_wins_30d": 0.42857142857142855,
       "last_win_ts": 1735689000,
       "wins_30d": 1
     }
@@ -756,6 +756,10 @@
     "target_tier": "Donor (1.00 kH/s+)",
     "tiers": [
       {
+        "assumed_reward_year_range": [
+          0.016800000000000002,
+          0.0234
+        ],
         "expected_reward_year": 0.06,
         "name": "Donor (1.00 kH/s+)",
         "players_avg": 70.0,
@@ -764,6 +768,10 @@
         "win_odds_day": 0.014285714285714285
       },
       {
+        "assumed_reward_year_range": [
+          0.22680000000000003,
+          0.3159
+        ],
         "expected_reward_year": 0.81,
         "name": "Vip (10.00 kH/s+)",
         "players_avg": 28.0,
@@ -772,6 +780,10 @@
         "win_odds_day": 0.14285714285714285
       },
       {
+        "assumed_reward_year_range": [
+          1.7276000000000002,
+          2.4063
+        ],
         "expected_reward_year": 6.17,
         "name": "Whale (100.00 kH/s+)",
         "players_avg": 8.0,
@@ -780,6 +792,10 @@
         "win_odds_day": 1.0
       },
       {
+        "assumed_reward_year_range": [
+          15.932,
+          22.191
+        ],
         "expected_reward_year": 56.9,
         "name": "Mega (1.00 MH/s+)",
         "players_avg": 1.0,


### PR DESCRIPTION
build_state() has grown `assumed_reward_year_range` per tier and a filled `expected_wins_30d` since the fixture was last generated (the drift guard only pins top-level keys, so it stayed quiet). Regenerated with `_gen_state.py` so the canned payload the frontend tests and the visual harness consume matches what the server actually sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)