### PR TITLE
setup() headless on a deployed box: refuse loudly instead of silently reporting success

### DIFF
--- a/pithead
+++ b/pithead
@@ -7303,7 +7303,15 @@ optimize_kernel() {
 
             if ! grep -q "hugepages=" /etc/default/grub; then
                 warn "Persistent HugePages requires editing /etc/default/grub and a reboot."
-                read -r -p "Modify GRUB for persistent HugePages now? (y/N): " GRUB_OK || true
+                if [ -t 0 ]; then
+                    read -r -p "Modify GRUB for persistent HugePages now? (y/N): " GRUB_OK || true
+                else
+                    # Headless: never touch GRUB unattended, but say so — the old EOF-swallow
+                    # skipped this silently and the operator never learned the reservation is
+                    # boot-only.
+                    GRUB_OK=""
+                    warn "No terminal attached — skipping the persistent-HugePages GRUB change. Run '$0 setup' from a terminal (or edit /etc/default/grub) to make it permanent."
+                fi
                 if [[ ! "$GRUB_OK" =~ ^[Yy] ]]; then
                     log "Skipped GRUB edit. HugePages set for this boot only (vm.nr_hugepages=$PITHEAD_HUGEPAGES)."
                     return 0
@@ -7484,12 +7492,14 @@ preflight_resources() {
 setup() {
     if is_deployed; then
         warn "A previous deployment was detected."
-        # Same no-tty rule as resolve_dashboard_host: an interactive ask with no terminal is an
-        # EOF, and `read`'s `|| true` used to swallow that into an empty RERUN — read as decline,
-        # exit 0, deployment untouched. Every headless caller (firstboot's --cli re-run, and its
-        # own retry after a failed provisioning attempt) reached setup() BECAUSE it already
-        # decided to proceed; a silent no-op there reports success while doing nothing (#924).
-        # A real terminal keeps the prompt exactly as before.
+        # An interactive ask with no terminal is an EOF, and `read`'s `|| true` used to swallow
+        # that into an empty answer — read as decline, exit 0: a headless caller believed setup
+        # succeeded while nothing ran (#924's silent false success). Headless now REFUSES loudly
+        # instead of proceeding: an unattended re-provision (Tor container recreate, full
+        # re-render, a possible GRUB edit) must never ride on the mere absence of a terminal —
+        # `pithead setup` has long been a safe probe on a deployed box for cron/automation, and
+        # the appliance's own headless paths never reach this branch (a failed provisioning
+        # attempt is not deployed). A real terminal keeps the prompt exactly as before.
         if [ -t 0 ]; then
             local RERUN
             read -r -p "Re-run setup (re-provisions Tor and may modify GRUB)? (y/N): " RERUN || true
@@ -7499,7 +7509,7 @@ setup() {
                 exit 0
             fi
         else
-            log "No terminal attached — proceeding with the re-run automatically."
+            error "Already provisioned, and re-running setup re-provisions Tor and may modify GRUB — run '$0 setup' from a terminal to confirm that. For configuration changes use '$0 apply'; to start the stack use '$0 up'."
         fi
     fi
 

--- a/pithead
+++ b/pithead
@@ -7484,11 +7484,22 @@ preflight_resources() {
 setup() {
     if is_deployed; then
         warn "A previous deployment was detected."
-        read -r -p "Re-run setup (re-provisions Tor and may modify GRUB)? (y/N): " RERUN || true
-        if [[ ! "$RERUN" =~ ^[Yy] ]]; then
-            log "Setup skipped. Edit config.json and run '$0 apply' to propagate config changes,"
-            log "or '$0 up' to start the stack."
-            exit 0
+        # Same no-tty rule as resolve_dashboard_host: an interactive ask with no terminal is an
+        # EOF, and `read`'s `|| true` used to swallow that into an empty RERUN — read as decline,
+        # exit 0, deployment untouched. Every headless caller (firstboot's --cli re-run, and its
+        # own retry after a failed provisioning attempt) reached setup() BECAUSE it already
+        # decided to proceed; a silent no-op there reports success while doing nothing (#924).
+        # A real terminal keeps the prompt exactly as before.
+        if [ -t 0 ]; then
+            local RERUN
+            read -r -p "Re-run setup (re-provisions Tor and may modify GRUB)? (y/N): " RERUN || true
+            if [[ ! "$RERUN" =~ ^[Yy] ]]; then
+                log "Setup skipped. Edit config.json and run '$0 apply' to propagate config changes,"
+                log "or '$0 up' to start the stack."
+                exit 0
+            fi
+        else
+            log "No terminal attached — proceeding with the re-run automatically."
         fi
     fi
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8191,7 +8191,18 @@ assert_rc "'pithead setup' exits 0 given an existing config.json" "$su_rc" "0"
 assert_contains "'pithead setup' reports completion" "$su_out" "Deployment preparation complete"
 assert_eq "'pithead setup' writes a completed .env" \
     "$(run_sourced "$SU" env_get_file "$SU/.env" DEPLOYMENT_COMPLETED)" "true"
-unset SU su_out su_rc
+
+echo "== black-box: 'pithead setup' re-run with stdin on /dev/null proceeds instead of silently no-opping (#924) =="
+# Exactly how a systemd unit invokes it (no tty, stdin /dev/null): the old `read -r -p ... || true`
+# turned the immediate EOF into an empty RERUN, read as decline, exit 0 with nothing re-provisioned.
+# is_deployed is already true from the setup above, so this re-run hits the same guard the
+# firstboot retry path hits after a failed provisioning attempt.
+su2_out="$(cd "$SU" && DOCKER_LOG=/dev/null PATH="$SU/bin:$PATH" ./pithead setup --skip-deps --skip-optimize </dev/null 2>&1)"
+su2_rc=$?
+assert_rc "headless re-run exits 0" "$su2_rc" "0"
+assert_not_contains "headless re-run does not silently skip" "$su2_out" "Setup skipped"
+assert_contains "headless re-run actually re-provisions" "$su2_out" "Deployment preparation complete"
+unset SU su_out su_rc su2_out su2_rc
 
 echo "== black-box: 'pithead setup' with stratum_tls in a hand-written config generates the keypair (#261) =="
 # The setup path reaches compose through prepare_directories, never ensure_directories — a

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8192,16 +8192,17 @@ assert_contains "'pithead setup' reports completion" "$su_out" "Deployment prepa
 assert_eq "'pithead setup' writes a completed .env" \
     "$(run_sourced "$SU" env_get_file "$SU/.env" DEPLOYMENT_COMPLETED)" "true"
 
-echo "== black-box: 'pithead setup' re-run with stdin on /dev/null proceeds instead of silently no-opping (#924) =="
-# Exactly how a systemd unit invokes it (no tty, stdin /dev/null): the old `read -r -p ... || true`
-# turned the immediate EOF into an empty RERUN, read as decline, exit 0 with nothing re-provisioned.
-# is_deployed is already true from the setup above, so this re-run hits the same guard the
-# firstboot retry path hits after a failed provisioning attempt.
+echo "== black-box: 'pithead setup' re-run with stdin on /dev/null refuses loudly (#924) =="
+# Exactly how a systemd unit or cron invokes it (no tty, stdin /dev/null): the old
+# `read -r -p ... || true` turned the immediate EOF into an empty RERUN, read as decline, exit 0
+# — a silent FALSE SUCCESS. The fix refuses loudly with a nonzero exit instead of proceeding: an
+# unattended re-provision must never ride on the absence of a terminal, and the appliance's own
+# headless paths never reach this guard (a failed provisioning attempt is not deployed).
 su2_out="$(cd "$SU" && DOCKER_LOG=/dev/null PATH="$SU/bin:$PATH" ./pithead setup --skip-deps --skip-optimize </dev/null 2>&1)"
 su2_rc=$?
-assert_rc "headless re-run exits 0" "$su2_rc" "0"
-assert_not_contains "headless re-run does not silently skip" "$su2_out" "Setup skipped"
-assert_contains "headless re-run actually re-provisions" "$su2_out" "Deployment preparation complete"
+assert_rc "headless re-run on a deployed box refuses (nonzero, no silent success)" "$su2_rc" "1"
+assert_contains "the refusal says how to proceed" "$su2_out" "run './pithead setup' from a terminal"
+assert_not_contains "the refusal never claims setup was skipped-as-success" "$su2_out" "Setup skipped"
 unset SU su_out su_rc su2_out su2_rc
 
 echo "== black-box: 'pithead setup' with stratum_tls in a hand-written config generates the keypair (#261) =="


### PR DESCRIPTION
Closes #924. The bug: `read -r -p ... || true` swallowed the headless EOF into an empty answer — read as decline, exit 0 — so a headless retry believed setup succeeded while nothing ran.

The first cut made headless PROCEED; the security pass caught that this turned a long-safe automation probe (`pithead setup` on a deployed box via ssh/cron) into an unattended re-provision — Tor recreate, full re-render, a possible GRUB edit. And the appliance's own headless paths never reach this guard at all (a failed provisioning attempt is not deployed). So the shipped fix is the honest one: headless + deployed **refuses loudly** — nonzero exit, a message naming how to proceed (`run './pithead setup' from a terminal`; `apply` for config changes). Interactive behavior unchanged. The sibling GRUB prompt gets the same treatment: headless skips the GRUB edit **loudly** instead of silently, so the operator learns the hugepage reservation is boot-only.

Tier-1 black-box pins the refusal (nonzero, actionable text, never "skipped"-as-success): stack suite 2274/0 solo. Security re-review of the redesign: the refusal path introduces no new capability. Ponytail: one tty-split reused twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)