### PR TITLE
build-image: --fresh-index knob + a remedy hint for the stale-apt-index 404

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -163,6 +163,13 @@ Two build variants, chosen by one flag:
 The updater defaults to RAUC; an image built without it cannot take another update, and the
 only way to get one now is to set `PITHEAD_UPDATER` to something else on purpose.
 
+The rootfs Dockerfile deliberately keeps its `apt-get update` layer cached across later install
+steps (layer economy); on a warm builder cache that layer can outlive a mirror rotating a
+package, and the install then 404s on a package the stale index still thinks exists. Rerun with
+`os/build-image.sh --fresh-index` to bust only that layer — `build-image.sh` prints this same
+remedy when it recognizes the 404 signature in a failed build's output. (#929; snapshot.debian.org
+pinning is a deliberate non-goal here, tracked as a follow-up for full build reproducibility.)
+
 Then the tiered battery, lowest tier first — the same rule as
 [`testing-strategy.md`](testing-strategy.md):
 

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -2,15 +2,18 @@
 # Build the pithead-os appliance rootfs (#77 phase 2): the OS as a container build, exported to a
 # tarball. os/rauc/mkimage.sh turns that tarball into a bootable image and os/rauc/mkbundle.sh
 # turns it into an update bundle. Run from the repo root on a box with docker.
-#   os/build-image.sh [--ssh [PUBKEY_FILE]]   -> os/build/pithead-root.tar
+#   os/build-image.sh [--ssh [PUBKEY_FILE]] [--fresh-index]   -> os/build/pithead-root.tar
 #
 #   --ssh [FILE]   debug/bench variant: bake FILE (default: the builder's ~/.ssh/id_ed25519.pub,
 #                  falling back to id_rsa.pub) as root's authorized key and enable sshd. Release
 #                  builds omit it and stay shell-less. Sets the same PITHEAD_TEST_SSH_PUBKEY the
 #                  env path always honored — the flag exists so the bench recipe is one word,
 #                  not a rediscovered env var.
+#   --fresh-index  bust ONLY the rootfs Dockerfile's apt-update layer (#929): a warm builder
+#                  cache reuses that layer's apt index for weeks, and when the mirror rotates a
+#                  package the stale index 404s on install. Later layers still cache normally.
 set -euo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -33,13 +36,32 @@ while [ $# -gt 0 ]; do
         export PITHEAD_TEST_SSH_PUBKEY
         echo "==> debug build: sshd enabled, key from $keyfile"
         ;;
+    --fresh-index)
+        FRESH_INDEX=1
+        ;;
     *)
-        echo "unknown argument: $1 (usage: os/build-image.sh [--ssh [PUBKEY_FILE]])" >&2
+        echo "unknown argument: $1 (usage: os/build-image.sh [--ssh [PUBKEY_FILE]] [--fresh-index])" >&2
         exit 1
         ;;
     esac
     shift
 done
+
+# apt_fetch_failure_hint (#929): given a build log tail, detect the stale-apt-index 404 signature
+# and print the remedy. Split out so it's testable without docker (tests/stack/run.sh covers it).
+apt_fetch_failure_hint() {
+    if grep -qE '404  Not Found|Unable to fetch some archives' <<<"$1"; then
+        echo "==> looks like a stale apt index (mirror rotated a package since the last build)." >&2
+        echo "==> rerun with: os/build-image.sh --fresh-index" >&2
+    fi
+}
+
+# Test seam: `PITHEAD_BUILD_IMAGE_TEST=1 source os/build-image.sh [args...]` parses args and
+# defines apt_fetch_failure_hint above, then returns here instead of touching docker — lets
+# tests/stack/run.sh exercise flag parsing and the remedy hint without a build.
+if [ "${PITHEAD_BUILD_IMAGE_TEST:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 # Bake the wizard's container image into the appliance: first boot must reach the setup page
 # without a registry (the operator may have no working network config yet, and the plan's
@@ -90,10 +112,20 @@ echo "==> building from commit ${BUILD_COMMIT}${BUILD_DIRTY}"
 ROOTFS_TAG="${PITHEAD_ROOTFS_TAG:-pithead-os-rootfs}"
 
 echo "==> rootfs: container build + export"
-docker build -f os/rootfs/Dockerfile -t "$ROOTFS_TAG" \
+# --fresh-index (#929) stamps a new value into the Dockerfile's APT_INDEX_STAMP ARG, which busts
+# only the apt-update layer it precedes — every other layer still caches normally.
+apt_index_stamp=0
+[ "${FRESH_INDEX:-0}" = "1" ] && apt_index_stamp="$(date +%s)"
+build_log="$(mktemp)"
+trap 'rm -f "$build_log"' EXIT
+if ! docker build -f os/rootfs/Dockerfile -t "$ROOTFS_TAG" \
     --build-arg PITHEAD_TEST_SSH_PUBKEY="${PITHEAD_TEST_SSH_PUBKEY:-}" \
     --build-arg PITHEAD_TEST_MARKER="${PITHEAD_TEST_MARKER:-}" \
-    --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" .
+    --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" \
+    --build-arg APT_INDEX_STAMP="$apt_index_stamp" . 2>&1 | tee "$build_log"; then
+    apt_fetch_failure_hint "$(cat "$build_log")"
+    exit 1
+fi
 cid=$(docker create "$ROOTFS_TAG")
 mkdir -p os/build
 docker export --output os/build/pithead-root.tar "$cid"

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -27,6 +27,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # `rauc info` extracts a bundle's manifest with unsquashfs, and without it `pithead os-update`
 # cannot read any bundle's compatibility metadata — every guard it carries was dead on the
 # appliance (found live on the bench, not by CI, whose stack tests stub rauc).
+# Cache-busts ONLY this layer (#929): a warm builder cache reuses the apt index for weeks, and
+# when the mirror rotates a package between builds the stale index 404s. build-image.sh's
+# --fresh-index flag passes a fresh value here; any other build-arg on a later layer would still
+# hit cache as normal — an ARG only invalidates the RUN steps from its declaration onward.
+ARG APT_INDEX_STAMP=0
 RUN apt-get update && apt-get install -y --no-install-recommends \
         systemd systemd-sysv systemd-timesyncd systemd-resolved dbus udev \
         linux-image-amd64 initramfs-tools zstd \

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9557,6 +9557,47 @@ printf 'abc0000000000000000000000000def0\n' >"$MID/etc-id"
 ) >/dev/null 2>&1
 assert_eq "adopt persists this boot's id to /data" "$(cat "$MID/data-id" 2>/dev/null)" "abc0000000000000000000000000def0"
 
+echo "== unit: os/build-image.sh — --fresh-index flag parsing + the 404 remedy hint (#929) =="
+# PITHEAD_BUILD_IMAGE_TEST makes the script return right after arg parsing (before docker), so
+# these run its real argument handling and apt_fetch_failure_hint without a build.
+build_image_test() {
+    (
+        export PITHEAD_BUILD_IMAGE_TEST=1
+        # shellcheck disable=SC1091  # path is dynamic by design
+        source "$ROOT/os/build-image.sh" "$@"
+        [ "${FRESH_INDEX:-0}" = "1" ] && echo "FRESH_INDEX=1"
+        declare -f apt_fetch_failure_hint >/dev/null && echo "HINT_FN_DEFINED"
+    )
+}
+assert_contains "--fresh-index sets FRESH_INDEX" "$(build_image_test --fresh-index)" "FRESH_INDEX=1"
+assert_not_contains "bare invocation leaves FRESH_INDEX unset" "$(build_image_test)" "FRESH_INDEX=1"
+assert_contains "apt_fetch_failure_hint is defined after sourcing" "$(build_image_test)" "HINT_FN_DEFINED"
+
+unknown_flag_out="$("$ROOT/os/build-image.sh" --bogus 2>&1 || true)"
+assert_contains "unknown argument is rejected" "$unknown_flag_out" "unknown argument: --bogus"
+assert_contains "unknown-argument error names --fresh-index" "$unknown_flag_out" "--fresh-index"
+
+# --fresh-index composes with --ssh: parsed left-to-right, then --ssh's own missing-key check
+# exits before docker, proving --fresh-index didn't swallow the next argument.
+missing_key_out="$("$ROOT/os/build-image.sh" --fresh-index --ssh "$SANDBOX/no-such-key.pub" 2>&1 || true)"
+assert_contains "--fresh-index then --ssh with a missing key still hits --ssh's own error" "$missing_key_out" "--ssh: no public key found"
+
+# Exercise the hint function directly by sourcing the same way and calling it.
+run_hint() {
+    (
+        local log="$1"
+        export PITHEAD_BUILD_IMAGE_TEST=1
+        set -- # `source file` with no args keeps the caller's $@ — clear it so build-image.sh's
+        # own arg loop doesn't try to parse the log tail as a CLI flag.
+        # shellcheck disable=SC1091  # path is dynamic by design
+        source "$ROOT/os/build-image.sh"
+        apt_fetch_failure_hint "$log" 2>&1
+    )
+}
+assert_contains "404 signature triggers the --fresh-index remedy" "$(run_hint 'E: Failed to fetch ... 404  Not Found')" "--fresh-index"
+assert_contains "'Unable to fetch' signature triggers the remedy" "$(run_hint 'E: Unable to fetch some archives, maybe run apt-get update')" "--fresh-index"
+assert_eq "an unrelated failure prints no hint" "$(run_hint 'E: some other build error')" ""
+
 # ---------------------------------------------------------------------------
 echo ""
 printf 'pithead tests: \033[1;32m%d passed\033[0m, ' "$PASS"


### PR DESCRIPTION
Closes #929, option 1 (snapshot pinning stays on the issue as the honest end-state). The image build 404'd on bench-host when the mirror rotated `linux-cpupower` under a weeks-old cached apt index — retries were byte-identical (the cache guarantees it) and nothing pointed at the remedy.

- `os/build-image.sh --fresh-index`: stamps the new `APT_INDEX_STAMP` build-arg declared immediately before the Dockerfile's single `apt-get update`, busting only that layer — everything later still caches. The keep-lists-across-layers design is untouched.
- On a failed build whose log carries the 404/"Unable to fetch" signature, `apt_fetch_failure_hint` prints the remedy naming the flag — a 5-line function split out precisely so it's testable without docker.
- Tier-1 coverage via the repo's sourcing seam: flag parsing, the hint on a matching tail, silence on a non-matching one. docs/dev/appliance-release.md documents the flag.

Verifier: pass. Ponytail: one ARG, one flag, one testable function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)