### PR TITLE
Wizard token lockout: send the 429 before exiting — the browser finally sees the console hint

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/build/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -304,14 +304,28 @@ export class WizardApp extends Component {
     tick();
   }
 
+  // A dropped connection reads identically to the lockout to the operator: the machine
+  // exits right after refusing the last attempt, so a network failure gets the same
+  // actionable message as the 429 it raced.
+  static LOCKOUT_MESSAGE =
+    "Too many attempts — the machine printed a fresh token on its console; enter that one.";
+
   auth = async (e) => {
     e.preventDefault();
-    const res = await fetch("/auth", {
-      method: "POST",
-      body: new URLSearchParams(new FormData(e.target)),
-    });
-    if (res.ok && (await this.loadState())) return;
-    this.setState({ error: "Wrong token." });
+    try {
+      const res = await fetch("/auth", {
+        method: "POST",
+        body: new URLSearchParams(new FormData(e.target)),
+      });
+      if (res.ok && (await this.loadState())) return;
+      if (res.status === 429) {
+        this.setState({ error: WizardApp.LOCKOUT_MESSAGE });
+        return;
+      }
+      this.setState({ error: "Wrong token." });
+    } catch {
+      this.setState({ error: WizardApp.LOCKOUT_MESSAGE });
+    }
   };
 
   // Field edit → config → JSON pane. The JSON is the single source of what gets submitted.

--- a/build/dashboard/mining_dashboard/wizard.py
+++ b/build/dashboard/mining_dashboard/wizard.py
@@ -194,9 +194,22 @@ async def auth(request: web.Request) -> web.Response:
         raise resp
     request.app["failures"] += 1
     if request.app["failures"] >= MAX_FAILURES:
-        # The host restarts the container with a fresh token; nothing to serve beyond this.
+        resp = web.json_response(
+            {
+                "error": "Too many attempts — this machine printed a fresh token on its "
+                "console; enter that one."
+            },
+            status=429,
+        )
+        # Flush the refusal to the browser BEFORE the host restarts the container for a
+        # re-mint. prepare/write_eof are idempotent, so aiohttp's own finish step (which
+        # runs them again once this handler returns) is a no-op — this just moves the bytes
+        # onto the wire ahead of the exit, instead of the process tearing down mid-request.
+        await resp.prepare(request)
+        await resp.write_eof()
         print("wizard: token failure limit reached — exiting for a re-mint", flush=True)
         request.app["exit"](EXIT_TOKEN_LOCKOUT)
+        return resp
     return web.json_response({"error": "wrong token"}, status=403)
 
 

--- a/build/dashboard/tests/frontend/wizard.test.mjs
+++ b/build/dashboard/tests/frontend/wizard.test.mjs
@@ -571,3 +571,46 @@ test("before a disk is chosen, the page asks ONLY that", async () => {
   assert.match(after, /Type the disk name to confirm/);
   restore();
 });
+
+// --- the token gate: the lockout must read as actionable, not as a dead page -----------------
+
+test("auth: a 429 (lockout) shows the console-token message, not the generic wrong-token one", async () => {
+  const inst = new WizardApp({});
+  stubSetState(inst);
+  const real = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 429,
+    json: async () => ({ error: "server-side lockout text" }),
+  });
+  await inst.auth({ preventDefault() {}, target: undefined });
+  globalThis.fetch = real;
+  assert.match(inst.state.error, /too many attempts/i);
+  assert.match(inst.state.error, /console/i);
+});
+
+test("auth: a genuinely dropped connection reads the same as the 429 it raced", async () => {
+  // The exact bug: the lockout's exit used to race the response, so the fetch this app makes
+  // rejects instead of resolving 429. Uncaught, that was a silent unhandled rejection — the
+  // operator just saw the page do nothing.
+  const inst = new WizardApp({});
+  stubSetState(inst);
+  const real = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new TypeError("Failed to fetch");
+  };
+  await inst.auth({ preventDefault() {}, target: undefined });
+  globalThis.fetch = real;
+  assert.match(inst.state.error, /too many attempts/i);
+  assert.match(inst.state.error, /console/i);
+});
+
+test("auth: an ordinary wrong token still gets the plain message, not the lockout one", async () => {
+  const inst = new WizardApp({});
+  stubSetState(inst);
+  const real = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: false, status: 403, json: async () => ({}) });
+  await inst.auth({ preventDefault() {}, target: undefined });
+  globalThis.fetch = real;
+  assert.equal(inst.state.error, "Wrong token.");
+});

--- a/build/dashboard/tests/web/test_wizard.py
+++ b/build/dashboard/tests/web/test_wizard.py
@@ -113,6 +113,47 @@ async def test_lockout_exits_3_after_max_failures(client):
     assert client.server.app["exits"] == [wizard.EXIT_TOKEN_LOCKOUT]
 
 
+async def test_lockout_response_is_429_with_console_hint(client):
+    # Every failure before the last is the plain 403; only the one that trips the limit gets
+    # the distinguishing status and the pointer to the console.
+    for _ in range(wizard.MAX_FAILURES - 1):
+        r = await _auth(client, "pit-WRONGX")
+        assert r.status == 403
+    r = await _auth(client, "pit-WRONGX")
+    assert r.status == 429
+    body = await r.json()
+    assert "too many attempts" in body["error"].lower()
+    assert "console" in body["error"].lower()
+
+
+async def test_lockout_writes_the_429_before_the_exit_hook_runs(spool, monkeypatch):
+    """Regression: the exit hook used to fire before the response was ever written, so the
+    process could tear down before a single byte reached the browser. Track the real order of
+    'bytes handed to the transport' vs 'exit hook called' rather than trusting that both merely
+    happened."""
+    order = []
+    real_write_eof = web.Response.write_eof
+
+    async def tracking_write_eof(self, *a, **kw):
+        order.append("written")
+        return await real_write_eof(self, *a, **kw)
+
+    monkeypatch.setattr(web.Response, "write_eof", tracking_write_eof)
+
+    app = wizard.make_app(exit_fn=lambda code: order.append("exit"))
+    c = TestClient(TestServer(app))
+    await c.start_server()
+    try:
+        for _ in range(wizard.MAX_FAILURES - 1):
+            await _auth(c, "pit-WRONGX")
+        r = await _auth(c, "pit-WRONGX")
+        assert r.status == 429
+    finally:
+        await c.close()
+    assert order[0] == "written"
+    assert order.count("exit") == 1
+
+
 def test_main_requires_token(monkeypatch):
     monkeypatch.delenv("WIZARD_TOKEN", raising=False)
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
UX-audit finding, confirmed: the 5th failed token attempt called the exit hook BEFORE returning, so the process tore down mid-request and the operator's browser got a dropped connection with no message — at exactly the moment "a fresh token is printed on the console" matters most. And the frontend's `auth()` had no try/catch, so the drop surfaced as an unhandled rejection.

Fix: the final refusal is a real 429 ("Too many attempts — this machine printed a fresh token on its console; enter that one"), flushed via prepare/write_eof BEFORE the exit hook fires; the frontend renders the same actionable message for both the 429 and a genuinely dropped connection, while ordinary wrong-token 403s keep their plain text. Security semantics identical: same MAX_FAILURES, same re-mint, constant-time compare untouched.

Tests pin the exact regression: a monkeypatched write_eof records call order against the exit hook (response-before-exit), plus the 403-until-lockout progression and three frontend rendering cases. Patch coverage 100% on wizard.py. Verifier: pass. Ponytail: flush-then-exit plus one shared message constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)