### PR TITLE
Slim the appliance first-run form to the CLI wizard's own core (chain size, healthchecks, timezone → Advanced)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/build/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -571,17 +571,7 @@ export class WizardApp extends Component {
                             autocomplete="new-password" />
                     <//>
                 </div>`
-                : html`<div class="wizard-when">
-                    <${Field} label="Chain size">
-                        <select value=${String(v("prune") ?? true)} onChange=${on("prune")}>
-                            <option value="true">Pruned — about 120 GB (default, mines exactly the same)</option>
-                            <option value="false">Full — about 320 GB (only if you need the whole chain)</option>
-                        </select>
-                    <//>
-                    <${Note}>A local Tari node adds about 170 GB on top. Under roughly 350 GB of
-                    disk, pruned Monero plus a ${" "}<em>remote</em>${" "}Tari node is the
-                    combination that fits.<//>
-                </div>`
+                : null
             }
 
             <h3>Tari node</h3>
@@ -667,13 +657,7 @@ export class WizardApp extends Component {
                     to you on the next screen.<//>`
             }
 
-            <h3>Alerts <span class="text-muted">(optional — skip both if you are not sure)</span></h3>
-            <${Field} label="Healthchecks.io ping URL">
-                <input value=${v("healthchecks") || ""} onInput=${on("healthchecks")}
-                    autocomplete="off" spellcheck=${false} placeholder="https://hc-ping.com/your-uuid" />
-            <//>
-            <${Note}>Tells you when this machine goes ${" "}<em>silent</em>${" "}— a power cut
-            or a crash, which the machine itself cannot report.<//>
+            <h3>Alerts <span class="text-muted">(optional — skip if you are not sure)</span></h3>
             <${Field} label="Telegram bot token">
                 <input value=${v("telegramToken") || ""} onInput=${on("telegramToken")}
                     autocomplete="off" spellcheck=${false} placeholder="123456:ABC-DEF…" />
@@ -684,16 +668,36 @@ export class WizardApp extends Component {
             <//>
             ${tg.partial && html`<p class="c-bad">Telegram needs both fields, or leave both blank.</p>`}
 
-            <${Field} label="Time zone">
-                <input value=${v("timezone") || "auto"} onInput=${on("timezone")} list="wizard-tzs"
-                    autocomplete="off" />
-            <//>
-            <datalist id="wizard-tzs">${TIMEZONES.map((t) => html`<option value=${t} />`)}</datalist>
-            <${Note}><code>auto</code>${" "}uses this machine's own setting — for dashboard
-            timestamps and the daily summary.<//>
-
             <details>
                 <summary><strong>Advanced</strong> — the exact configuration, every key and default</summary>
+                <${Note}>Everything here already has a sane default — the machine runs fine
+                untouched. Change these only if you know you need to.<//>
+                ${
+                  !remoteMonero &&
+                  html`<${Field} label="Chain size">
+                    <select value=${String(v("prune") ?? true)} onChange=${on("prune")}>
+                        <option value="true">Pruned — about 120 GB (default, mines exactly the same)</option>
+                        <option value="false">Full — about 320 GB (only if you need the whole chain)</option>
+                    </select>
+                <//>
+                <${Note}>A local Tari node adds about 170 GB on top. Under roughly 350 GB of
+                disk, pruned Monero plus a ${" "}<em>remote</em>${" "}Tari node is the
+                combination that fits.<//>`
+                }
+                <${Field} label="Healthchecks.io ping URL">
+                    <input value=${v("healthchecks") || ""} onInput=${on("healthchecks")}
+                        autocomplete="off" spellcheck=${false} placeholder="https://hc-ping.com/your-uuid" />
+                <//>
+                <${Note}>Tells you when this machine goes ${" "}<em>silent</em>${" "}— a power cut
+                or a crash, which the machine itself cannot report.<//>
+                <${Field} label="Time zone">
+                    <input value=${v("timezone") || "auto"} onInput=${on("timezone")} list="wizard-tzs"
+                        autocomplete="off" />
+                <//>
+                <datalist id="wizard-tzs">${TIMEZONES.map((t) => html`<option value=${t} />`)}</datalist>
+                <${Note}><code>auto</code>${" "}uses this machine's own setting — for dashboard
+                timestamps and the daily summary.<//>
+
                 <${Note}>This is what the machine will run. Editing a field above updates it;
                 editing it here directly wins. Keys still at their documented default are not
                 written to disk, so this machine keeps receiving improved defaults from future

--- a/build/dashboard/tests/frontend/wizard.test.mjs
+++ b/build/dashboard/tests/frontend/wizard.test.mjs
@@ -331,6 +331,23 @@ test("wipe everything (or an empty disk): the full form asks everything", async 
   assert.match(empty, /Payout addresses/);
 });
 
+test("chain size, healthchecks and time zone sit under Advanced, not the first-run form", async () => {
+  // Audit-confirmed slim first-run (Home Assistant model): these three are the only appliance
+  // questions beyond the DIY CLI's own core shortlist, so they move to day-2, not day-1.
+  const all = await appWithPick("sda", "all");
+  const advancedAt = all.indexOf("Advanced");
+  assert.ok(advancedAt > -1, "Advanced pane should render");
+  for (const label of ["Chain size", "Healthchecks.io ping URL", "Time zone"]) {
+    const at = all.indexOf(label);
+    assert.ok(at > -1, `${label} should still render (day-2 need is real)`);
+    assert.ok(at > advancedAt, `${label} should render inside the Advanced pane, not the main form`);
+  }
+  // The primary form's own headings stay above Advanced, unmoved.
+  for (const label of ["Payout addresses", "Dashboard login", "Alerts"]) {
+    assert.ok(all.indexOf(label) < advancedAt, `${label} should stay in the primary form`);
+  }
+});
+
 test("keep everything submits NO config — only the disk request", async () => {
   const { inst, restore } = await appOn([
     stateFor("installer", {

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -160,16 +160,19 @@ Then a handful of choices, all with sensible defaults:
 | Question | Default | When to change it |
 |---|---|---|
 | Tari payout address | — | Required, like the Monero one: this stack always merge-mines both coins from the same work. |
-| Monero chain | Pruned (~120 GB) | Only asked when this machine runs the node. Full is ~320 GB and mines identically. |
 | P2Pool sidechain | mini | `nano` for a single low-power rig, `main` only for very large hashrate. Changeable later. |
-| Healthchecks ping URL | — | Optional. Tells you when the machine goes *silent* — a power cut or crash, which it cannot report itself. |
 | Telegram bot | — | Optional. Alerts and status commands; needs both the token and the chat id. |
 | Monero node | run it here | Point at a node you already run. |
 | Tari node | run it here | Same, over a network you trust. |
 | Mine with this machine's CPU | off | On if this box should mine as well as coordinate. Nothing to install: the image carries its own [RigForge](https://github.com/p2pool-starter-stack/rigforge) miner, pointed at this machine's own pool. It starts by itself once the stack is up, comes back on every boot, and appears in the dashboard's Workers view. Mining tunes the whole box for hashrate (CPU governor, memory reservations) — what a dedicated appliance is for. |
 | First sync | private over Tor | Faster over the open internet if days of syncing is too slow; it uses Tor afterwards either way. |
-| Time zone | UTC | For dashboard timestamps. |
 | Dashboard login | generate one for me | Or choose your own password. "No login" is offered but leaves the dashboard — payout addresses, hashrate — open to anyone on your network; never combine it with the Tor onion. |
+
+That is the whole first-run form — fewer questions than the DIY install, on purpose: anything
+with a default that is right for almost every home rig lives one level down, in **Advanced**,
+not on the quick form. Today that means the Monero chain size (pruned, ~120 GB, vs. the full
+~320 GB — only asked at all when this machine runs the node), the Healthchecks ping URL, and
+the time zone (UTC unless set). They are still there to change, just not asked outright.
 
 The dashboard login is also the machine's **console login**: sit at the machine, log in as
 `root` with the dashboard password. It is set fresh at every boot and never stored on disk.
@@ -180,8 +183,8 @@ browser session would own the machine, wallets and all.
 
 **Already know exactly what you want?** Open **Advanced** at the bottom. It shows the complete
 configuration — every key, with its default filled in — and it *is* what the machine will run:
-answering a question above rewrites it, and editing it directly wins. Paste a whole
-`config.json` in there if you have one.
+answering a question above (or one of the Advanced fields) rewrites it, and editing it directly
+wins. Paste a whole `config.json` in there if you have one.
 
 ### Press "Validate, then install"
 

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -172,7 +172,7 @@ That is the whole first-run form — fewer questions than the DIY install, on pu
 with a default that is right for almost every home rig lives one level down, in **Advanced**,
 not on the quick form. Today that means the Monero chain size (pruned, ~120 GB, vs. the full
 ~320 GB — only asked at all when this machine runs the node), the Healthchecks ping URL, and
-the time zone (UTC unless set). They are still there to change, just not asked outright.
+the time zone (detected from the machine unless set). They are still there to change, just not asked outright.
 
 The dashboard login is also the machine's **console login**: sit at the machine, log in as
 `root` with the dashboard password. It is set fresh at every boot and never stored on disk.


### PR DESCRIPTION
UX-audit finding, confirmed: the appliance form asked three questions beyond the DIY CLI wizard's deliberately-narrow core (its own comment block names the policy) — Chain size (monero.prune), the Healthchecks ping URL, and the time zone. All three now live under the existing Advanced pane: present for day-2-minded operators, absent from the first-run read. Defaults hold when untouched (pruned=true per the wizard's own "right for almost every home rig" copy; healthchecks empty; timezone auto-detected). Role/disk/wallet/pool/node questions untouched; nothing removed, only relocated — the operator's bar verbatim: fewest first-run questions, real security kept, day-2 for the rest.

Render-probe tests updated to the new structure; docs/appliance.md's question-list prose kept truthful (verifier caught one stale phrase — the timezone default is auto-detected, not UTC — fixed). Suite green. Ponytail: pure relocation, net −31 primary-form lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)