### PR TITLE
Warn when clearnet_initial_sync is silently defeated by the egress firewall

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -245,6 +245,23 @@ That's the same exposure as running any ordinary (non-Tor) full node, scoped to 
 a privacy-first deployment it's still a real disclosure, which is why it is off by default and must
 be explicitly opted into.
 
+### It needs the egress firewall turned off
+
+The trade-off above only actually happens if the clearnet dials can leave the host. The [fail-closed
+egress firewall](#enforced-fail-closed-not-just-configured-270) is on by default and DROPs any direct
+dial to the public internet from the mining bridge — including the clearnet peers, priority nodes, and
+DNS seeds a clearnet sync needs. With both left at their defaults, the sync simply falls back to
+whatever it can still reach over Tor: no faster, and no less private, than leaving
+`clearnet_initial_sync` off in the first place. Nothing leaks — the firewall is doing exactly its
+job — but the speed the flag promised never materializes, and nothing said so.
+
+To actually get a clearnet-speed sync, turn the firewall off for the duration:
+`network.tor_egress_firewall: false`. `pithead` warns at `apply`/`doctor` time whenever a
+`clearnet_initial_sync` flag and the egress firewall are both on, naming the choice: turn the firewall
+off for a real clearnet sync, or turn the sync flag off and accept the normal Tor-speed sync. A
+scoped exception that lets only the sync's own dials through without opening the firewall generally is
+a real feature, not yet built — for now it's an explicit either/or.
+
 ### It switches back to Tor automatically (#234)
 
 The dashboard tracks each chain's sync state. The first time a clearnet node reports fully synced, the

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -250,7 +250,7 @@ be explicitly opted into.
 The trade-off above only actually happens if the clearnet dials can leave the host. The [fail-closed
 egress firewall](#enforced-fail-closed-not-just-configured-270) is on by default and DROPs any direct
 dial to the public internet from the mining bridge — including the clearnet peers, priority nodes, and
-DNS seeds a clearnet sync needs. With both left at their defaults, the sync simply falls back to
+DNS seeds a clearnet sync needs. With both left at their defaults, the sync falls back to
 whatever it can still reach over Tor: no faster, and no less private, than leaving
 `clearnet_initial_sync` off in the first place. Nothing leaks — the firewall is doing exactly its
 job — but the speed the flag promised never materializes, and nothing said so.

--- a/pithead
+++ b/pithead
@@ -5009,6 +5009,22 @@ parse_and_validate_config() {
     # Fail-closed Tor-only egress firewall (#270); default on. Renders to .env so `up` can read it.
     # config_bool (not a plain `// true`) so an explicit false actually disables it — see #294.
     TOR_EGRESS_FIREWALL=$(normalize_bool "$(config_bool '.network.tor_egress_firewall' true)")
+    # Clearnet initial sync vs. the egress firewall: a clearnet_initial_sync flag asks a daemon's
+    # first sync to dial out over clearnet (fast); the egress firewall (default on) DROPs every
+    # non-Tor dial, so that clearnet sync is silently defeated — the daemon just falls back to
+    # syncing over Tor at ordinary speed instead of failing. Nothing leaks (the firewall did its
+    # job), so this is WARN not FAIL — refusing would block a config that is merely slower than
+    # the operator intended, not one that's unsafe. Checked here (not just in render_env, which
+    # only runs for `up`/`apply`) so the contradiction surfaces on every command that validates
+    # config, including `doctor` and `edit`.
+    if [ "$TOR_EGRESS_FIREWALL" = "true" ]; then
+        local _cn_sync=""
+        [ "$(config_bool '.monero.clearnet_initial_sync' false)" = "true" ] && _cn_sync="Monero"
+        [ "$(config_bool '.tari.clearnet_initial_sync' false)" = "true" ] && _cn_sync="${_cn_sync:+$_cn_sync + }Tari"
+        if [ -n "$_cn_sync" ]; then
+            warn "$_cn_sync clearnet_initial_sync is on, but network.tor_egress_firewall is also on — the firewall drops the clearnet dials, so the sync will not actually leave Tor. Either turn off tor_egress_firewall for a real clearnet sync, or turn off clearnet_initial_sync and accept the normal Tor-speed sync."
+        fi
+    fi
     # Tor guard self-heal (#424); OPT-IN, default off — a tor restart drops all circuits, so the
     # stack never restarts its privacy boundary unbidden. Renders to .env for the dashboard,
     # which owns the probe/restart loop (build/dashboard .../service/tor_heal.py).

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4390,6 +4390,32 @@ printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","n
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_contains "doctor: OK when Tor-only (#183)" "$(cd "$V" && PATH="$V/bin:$PATH" ./pithead doctor 2>&1)" "Tor-only"
 
+echo "== black-box: clearnet_initial_sync vs. tor_egress_firewall contradiction warning =="
+# A clearnet_initial_sync flag asks a daemon to sync off-Tor; the egress firewall (default on) DROPs
+# every non-Tor dial, so that combination is self-defeating (the sync just runs over Tor anyway,
+# slower than intended) rather than unsafe (nothing leaks — the firewall still holds). WARN, not
+# FAIL: apply must still succeed, but say so loudly. Covers the contradictory pair and all three
+# non-contradictory combinations so the warning fires only where it's actually true.
+CN_WARN_NEEDLE="the firewall drops the clearnet dials"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p","clearnet_initial_sync":true}, "tari":{"wallet_address":"'"$VALID_TARI"'"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "monero clearnet + firewall on: apply still succeeds (warn, not fail)" "$?" "0"
+assert_contains "monero clearnet + firewall on: warns" "$out" "$CN_WARN_NEEDLE"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"'"$VALID_TARI"'","clearnet_initial_sync":true}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_rc "tari clearnet + firewall on: apply still succeeds (warn, not fail)" "$?" "0"
+assert_contains "tari clearnet + firewall on: warns" "$out" "$CN_WARN_NEEDLE"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p","clearnet_initial_sync":true}, "tari":{"wallet_address":"'"$VALID_TARI"'"}, "network":{"tor_egress_firewall":false}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_not_contains "clearnet sync + firewall OFF: no warning (not contradictory)" "$out" "$CN_WARN_NEEDLE"
+seed_env
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"'"$VALID_TARI"'"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
+out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
+assert_not_contains "no clearnet sync + firewall on: no warning (not contradictory)" "$out" "$CN_WARN_NEEDLE"
+
 # p2pool compose↔image coupling fail-safe (#273): clearnet is off, so apply renders P2POOL_FLAGS with
 # the #165 --socks5. doctor reads the RUNNING p2pool argv (/proc/1/cmdline, stubbed via P2POOL_PROC1)
 # and must FAIL loudly if --socks5 is absent (a stale pre-#165 image silently dropping the env flags),


### PR DESCRIPTION
Closes #941's option (b) — the scoped-ACCEPT design stays on the issue. The two flags are self-defeating together: the firewall (default on) drops the very clearnet dials the sync flag asks for, so the sync just runs over Tor at ordinary speed and nothing says why. Both are wizard-reachable, so real users will pick the pair.

Warn, not fail — nothing leaks (the firewall is doing its job); the config is merely slower than intended, matching the codebase's precedent for self-defeating-but-harmless combinations (rationale in a comment at the check). Placed in parse_and_validate_config so every validating command surfaces it, doctor and edit included. Four-quadrant tier-1 coverage (fires on both contradictory pairs, silent on both sane ones); docs/privacy.md documents the either/or and names the unbuilt scoped exception honestly. Suite 2191/0 solo. Ponytail: one guarded warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)