### PR TITLE
Commit-gate reclassification, reshaped by its own security review: two land, three revert

### DIFF
--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -136,15 +136,21 @@ EDITABLE_ENV_KEY_PATHS = {
     "MONERO_MEM_LIMIT": ("monero.mem_limit",),
     "TARI_MEM_LIMIT": ("tari.mem_limit",),
     "MONERO_PREP_THREADS": ("monero.prep_blocks_threads",),
+    "MONERO_OUT_PEERS": ("monero.out_peers",),
+    "PROXY_DONATE_LEVEL": ("proxy.donate_level",),
     "HASHRATE_DROP_THRESHOLD_PCT": ("dashboard.hashrate_drop_threshold",),
     "HASHRATE_DROP_MINUTES": ("dashboard.hashrate_drop_minutes",),
     "TELEGRAM_DAILY_SUMMARY_TIME": ("telegram.daily_summary_time",),
     # TELEGRAM_EVENT_<NAME> -> telegram.events.<name> is a mechanical rename (pithead's tg_event()
     # helper and render_env do the same thing per event), so it's generated below rather than
-    # hand-typed 24 times. wallet_changed / clearnet_exposed are the two events NOT in this list —
+    # hand-typed 25 times. wallet_changed / clearnet_exposed are the two events NOT in this list —
     # deliberately excluded: they're the tamper-evidence alarms on the very channel a compromised
     # container would use to silence them, so the dashboard must never be able to turn them off.
     # They still render (greyed) in the Notifications > Telegram events nested subgroup (#612).
+    # NOTE (2026-08 audit): raffle_win was missing from this generated set for a while — the one
+    # event toggle out of step with its siblings. If you add a new event toggle, list it here AND
+    # in pithead's CONTROL_DASHBOARD_EDITABLE_KEYS — the drift guard below only catches a mismatch
+    # between the two, not an omission from both.
     **{
         f"TELEGRAM_EVENT_{name.upper()}": (f"telegram.events.{name}",)
         for name in (
@@ -172,6 +178,7 @@ EDITABLE_ENV_KEY_PATHS = {
             "payout_found",
             "payout_confirmed",
             "container_unhealthy",
+            "raffle_win",
         )
     },
 }
@@ -216,6 +223,11 @@ CONFIRM_ENV_KEY_PATHS = {
     "MONERO_CLEARNET_SYNC": ("monero.clearnet_initial_sync",),
     "TARI_CLEARNET_SYNC": ("tari.clearnet_initial_sync",),
     "MONERO_PRUNE": ("monero.prune",),
+    # 2026-08 audit reclassification: wallet-creation metadata, not a security boundary. A wrong
+    # value only re-scans from a different height on the wallet's NEXT creation — recoverable, not
+    # destructive — so these moved from host-only to confirm-gated rather than the editable set.
+    "PAYOUT_SCAN_HEIGHT": ("monero.payout_scan_height",),
+    "TARI_WALLET_BIRTHDAY": ("tari.payout_scan_birthday",),
 }
 
 

--- a/build/dashboard/mining_dashboard/service/control_service.py
+++ b/build/dashboard/mining_dashboard/service/control_service.py
@@ -136,8 +136,6 @@ EDITABLE_ENV_KEY_PATHS = {
     "MONERO_MEM_LIMIT": ("monero.mem_limit",),
     "TARI_MEM_LIMIT": ("tari.mem_limit",),
     "MONERO_PREP_THREADS": ("monero.prep_blocks_threads",),
-    "MONERO_OUT_PEERS": ("monero.out_peers",),
-    "PROXY_DONATE_LEVEL": ("proxy.donate_level",),
     "HASHRATE_DROP_THRESHOLD_PCT": ("dashboard.hashrate_drop_threshold",),
     "HASHRATE_DROP_MINUTES": ("dashboard.hashrate_drop_minutes",),
     "TELEGRAM_DAILY_SUMMARY_TIME": ("telegram.daily_summary_time",),
@@ -223,11 +221,12 @@ CONFIRM_ENV_KEY_PATHS = {
     "MONERO_CLEARNET_SYNC": ("monero.clearnet_initial_sync",),
     "TARI_CLEARNET_SYNC": ("tari.clearnet_initial_sync",),
     "MONERO_PRUNE": ("monero.prune",),
-    # 2026-08 audit reclassification: wallet-creation metadata, not a security boundary. A wrong
-    # value only re-scans from a different height on the wallet's NEXT creation — recoverable, not
-    # destructive — so these moved from host-only to confirm-gated rather than the editable set.
-    "PAYOUT_SCAN_HEIGHT": ("monero.payout_scan_height",),
-    "TARI_WALLET_BIRTHDAY": ("tari.payout_scan_birthday",),
+    # 2026-08 security review: bounded (8-1024) and instantly reversible, but the biggest
+    # steady-state knob on the shared Tor daemon's CPU — confirm-gated, not free-commit. The same
+    # review kept proxy.donate_level and the two payout restore points host-only (donate traffic
+    # bypasses the Tor socks5 per docs/privacy.md; a future-dated restore point silently defeats
+    # payout-confirmation tamper evidence).
+    "MONERO_OUT_PEERS": ("monero.out_peers",),
 }
 
 

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -299,8 +299,14 @@ class TestEditableKeys:
         assert "xvb.donation_level" in cfg["_editable_keys"]
         # 2026-08 audit reclassification: same risk class as their already-editable siblings.
         assert "telegram.events.raffle_win" in cfg["_editable_keys"]
-        assert "monero.out_peers" in cfg["_editable_keys"]
-        assert "proxy.donate_level" in cfg["_editable_keys"]
+        # 2026-08 security review: out_peers is confirm-gated (Tor-load knob); donate_level and
+        # the payout restore points stay host-only entirely.
+        assert "monero.out_peers" in cfg["_confirm_keys"]
+        assert "monero.out_peers" not in cfg["_editable_keys"]
+        assert "proxy.donate_level" not in cfg["_editable_keys"]
+        assert "proxy.donate_level" not in cfg["_confirm_keys"]
+        assert "monero.payout_scan_height" not in cfg["_confirm_keys"]
+        assert "tari.payout_scan_birthday" not in cfg["_confirm_keys"]
         # telegram.control.confirm_timeout stays OUT: telegram.control.* is the approval
         # channel's own trust anchor (never-approve as a block), and the timeout is unbounded
         # at validation — a compromised container could stretch the confirm window for days.
@@ -376,8 +382,7 @@ class TestConfirmKeys:
             "monero.clearnet_initial_sync",
             "tari.clearnet_initial_sync",
             "monero.prune",
-            "monero.payout_scan_height",
-            "tari.payout_scan_birthday",
+            "monero.out_peers",
         ):
             assert path in cfg["_confirm_keys"], path
         assert cfg["_confirm_keys"] == sorted(cfg["_confirm_keys"])  # stable, deterministic order

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -297,6 +297,14 @@ class TestEditableKeys:
         cfg = control_service.read_config()
         assert "p2pool.pool" in cfg["_editable_keys"]
         assert "xvb.donation_level" in cfg["_editable_keys"]
+        # 2026-08 audit reclassification: same risk class as their already-editable siblings.
+        assert "telegram.events.raffle_win" in cfg["_editable_keys"]
+        assert "monero.out_peers" in cfg["_editable_keys"]
+        assert "proxy.donate_level" in cfg["_editable_keys"]
+        # telegram.control.confirm_timeout stays OUT: telegram.control.* is the approval
+        # channel's own trust anchor (never-approve as a block), and the timeout is unbounded
+        # at validation — a compromised container could stretch the confirm window for days.
+        assert "telegram.control.confirm_timeout" not in cfg["_editable_keys"]
         assert cfg["_editable_keys"] == sorted(cfg["_editable_keys"])  # stable, deterministic order
 
     def test_dashboard_energy_is_the_special_case_addition(self, spool):
@@ -368,6 +376,8 @@ class TestConfirmKeys:
             "monero.clearnet_initial_sync",
             "tari.clearnet_initial_sync",
             "monero.prune",
+            "monero.payout_scan_height",
+            "tari.payout_scan_birthday",
         ):
             assert path in cfg["_confirm_keys"], path
         assert cfg["_confirm_keys"] == sorted(cfg["_confirm_keys"])  # stable, deterministic order

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -198,16 +198,18 @@ serves them as `blocks`, `disk_growth`, and `xvb_history`, range-filtered the sa
 overlay reads `xvb_history`; only `disk_growth` is persistence and API exposure alone, no
 renderer yet.
 
-While a node is down, the dashboard rejects workers so they fail over to the backup pools you've
+While monerod is down, the dashboard rejects workers so they fail over to the backup pools you've
 configured, rather than sitting idle on a stack that can't mine. A sustained outage stops the
 `xmrig-proxy` container (a `Workers rejected` badge shows) and a confirmed recovery restarts it.
-monerod is required to mine, so a monerod outage always rejects. Whether a Tari outage rejects
-follows [`dashboard.tari_required`](configuration.md): `true` (default) rejects on a Tari outage;
-`false` keeps mining Monero through it. Rejection never triggers for a remote monerod, since the
-stack doesn't manage that node. Readmission waits for monerod to be confirmed healthy; a required
-Tari holds it back only if Tari has actually answered since the dashboard started — a Tari whose
-gRPC has never come up (it can take many minutes after a boot) can't keep workers off a healthy
-monerod.
+monerod is required to mine, so a monerod outage always rejects; rejection never triggers for a
+remote monerod, since the stack doesn't manage that node. Readmission waits for monerod to be
+confirmed healthy, not merely no-longer-down, so a dashboard restart mid-outage doesn't wave
+workers back onto a stack that still can't mine.
+
+A Tari outage never rejects workers, regardless of [`dashboard.tari_required`](configuration.md):
+p2pool keeps mining Monero through a Tari-only outage, so kicking workers to their backup pools
+over Tari alone would trade partial revenue for none. The outage still shows up — the Tari panel
+and its alerts track it independently — but the fleet keeps mining.
 
 **Non-blocking Tari.** With `tari_required: false`, a Tari-only (re)sync doesn't take over the
 screen: the operational view stays up, mining continues, and a `Tari syncing` badge shows Tari's
@@ -732,7 +734,7 @@ the config tab now behave identically.) The pieces:
   read-only, with a tooltip ("Host-only — edit `config.json` and run `./pithead apply`") instead of
   letting you edit it and finding out only at Save. A smaller set of operationally-disruptive
   fields — the four service data directories, the stratum port, the clearnet initial-sync toggles,
-  enabling Monero pruning, and the Monero/Tari wallet restore points — render **editable but
+  enabling Monero pruning, and the Monero outbound-peer count — render **editable but
   confirm-gated**
   ([#719](https://github.com/p2pool-starter-stack/pithead/issues/719)): editable, tooltipped
   "you'll type `APPLY` to confirm at Save". Both sets are derived from the same allowlists the gate
@@ -774,8 +776,9 @@ direction, to anything else. A second, confirm-gated allowlist
 ([#719](https://github.com/p2pool-starter-stack/pithead/issues/719)) adds the
 operationally-disruptive-but-recoverable settings — a data-directory move (re-sync), a stratum-port
 change (rigs repoint), a clearnet initial-sync enable (host IP exposed during IBD, auto-reverts),
-enabling Monero pruning, changing the Monero/Tari wallet restore point (only affects the wallet's
-NEXT creation) — which commit only behind the typed `APPLY`. Type-to-confirm here is
+enabling Monero pruning, and the Monero outbound-peer count (bounded, but the biggest
+steady-state knob on the shared Tor daemon's load) — which commit only behind the typed
+`APPLY`. Type-to-confirm here is
 friction, not a security control: a compromised dashboard that can set a field can also fill the
 confirm box, so the boundary stays where a breach would happen. Form mode's grey-out and
 confirm-gating (above) are those SAME allowlists surfaced to the browser up front, not a separate

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -732,7 +732,8 @@ the config tab now behave identically.) The pieces:
   read-only, with a tooltip ("Host-only — edit `config.json` and run `./pithead apply`") instead of
   letting you edit it and finding out only at Save. A smaller set of operationally-disruptive
   fields — the four service data directories, the stratum port, the clearnet initial-sync toggles,
-  and enabling Monero pruning — render **editable but confirm-gated**
+  enabling Monero pruning, and the Monero/Tari wallet restore points — render **editable but
+  confirm-gated**
   ([#719](https://github.com/p2pool-starter-stack/pithead/issues/719)): editable, tooltipped
   "you'll type `APPLY` to confirm at Save". Both sets are derived from the same allowlists the gate
   enforces (see below) and surfaced on `GET /api/config` as `_editable_keys` and `_confirm_keys`,
@@ -773,7 +774,8 @@ direction, to anything else. A second, confirm-gated allowlist
 ([#719](https://github.com/p2pool-starter-stack/pithead/issues/719)) adds the
 operationally-disruptive-but-recoverable settings — a data-directory move (re-sync), a stratum-port
 change (rigs repoint), a clearnet initial-sync enable (host IP exposed during IBD, auto-reverts),
-enabling Monero pruning — which commit only behind the typed `APPLY`. Type-to-confirm here is
+enabling Monero pruning, changing the Monero/Tari wallet restore point (only affects the wallet's
+NEXT creation) — which commit only behind the typed `APPLY`. Type-to-confirm here is
 friction, not a security control: a compromised dashboard that can set a field can also fill the
 confirm box, so the boundary stays where a breach would happen. Form mode's grey-out and
 confirm-gating (above) are those SAME allowlists surfaced to the browser up front, not a separate

--- a/pithead
+++ b/pithead
@@ -7740,6 +7740,10 @@ describe_change() {
         msg="On-chain payout confirmation → $([ "$new" == "true" ] && echo on || echo off)."
         ;;
     PAYOUT_SCAN_HEIGHT)
+        # #719 (2026-08 audit reclassification): confirm-gated — wallet-creation metadata, not a
+        # security boundary. A wrong value only re-scans from a different height on the wallet's
+        # NEXT creation; nothing is destroyed.
+        flag=CONFIRM
         msg="Payout wallet restore height: $old → $new — only affects a first-time wallet creation."
         ;;
     WALLET_RPC_USERNAME | MONERO_WALLET_RPC_URL)
@@ -7767,6 +7771,10 @@ describe_change() {
         msg="Tari on-chain payout confirmation → $([ "$new" == "true" ] && echo on || echo off)."
         ;;
     TARI_WALLET_BIRTHDAY)
+        # #719 (2026-08 audit reclassification): confirm-gated — wallet-creation metadata, not a
+        # security boundary. A wrong value only re-scans from a different height on the wallet's
+        # NEXT creation; nothing is destroyed.
+        flag=CONFIRM
         msg="Tari payout wallet birthday: $old → $new (days since the Unix epoch) — only affects a first-time wallet creation."
         ;;
     TARI_SPEND_PUBLIC_KEY | TARI_WALLET_GRPC_ADDRESS | TARI_WALLET_SECRET_FILE)
@@ -8134,18 +8142,27 @@ run_chain() {
 # command line, URL, or credential. Everything else — wallets, auth, onion exposure, the control
 # channel itself, Tor egress/clearnet toggles, binds and ports, node endpoints, the XvB pool URL
 # and donor id, tokens and passwords, the #381 payout-confirmation secrets (MONERO_VIEW_KEY,
-# WALLET_RPC_PASSWORD) plus PAYOUT_CONFIRM_ENABLED / PAYOUT_SCAN_HEIGHT, and their #462 Tari siblings
-# (TARI_VIEW_KEY, TARI_WALLET_PASSWORD, TARI_SPEND_PUBLIC_KEY) plus TARI_PAYOUT_CONFIRM_ENABLED /
-# TARI_WALLET_BIRTHDAY / TARI_WALLET_GRPC_ADDRESS / TARI_WALLET_SECRET_FILE — stays host-CLI-only.
+# WALLET_RPC_PASSWORD) plus PAYOUT_CONFIRM_ENABLED, and their #462 Tari siblings (TARI_VIEW_KEY,
+# TARI_WALLET_PASSWORD, TARI_SPEND_PUBLIC_KEY) plus TARI_PAYOUT_CONFIRM_ENABLED /
+# TARI_WALLET_GRPC_ADDRESS / TARI_WALLET_SECRET_FILE — stays host-CLI-only. PAYOUT_SCAN_HEIGHT and
+# TARI_WALLET_BIRTHDAY moved to the confirm-gated set below (2026-08 audit reclassification):
+# they're wallet-creation metadata, not a secret, and a wrong value only re-scans from a different
+# height on the wallet's NEXT creation — recoverable, not destructive.
 # Each view key reveals every incoming payout amount/time, so it is never dashboard-committable
 # (default-deny already refuses it; named here deliberately). The WALLET_CHANGED and
 # CLEARNET_EXPOSED alert toggles are excluded on purpose: they are the tamper-evidence alarms on
 # the Telegram channel (the future #338 approval channel), so the dashboard must not silence
 # them. Space-separated exact env-key names.
+#
+# NOTE (2026-08 audit): TELEGRAM_EVENT_RAFFLE_WIN was missing from this list for a while — the one
+# event toggle out of step with its 24 siblings, all otherwise editable. If you add a new event
+# toggle, list it here AND in control_service.EDITABLE_ENV_KEY_PATHS (build/dashboard) — the drift
+# guard only catches a mismatch between the two, not an omission from both.
 CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
     XVB_ENABLED XVB_DONATION_LEVEL TARI_REQUIRED DASHBOARD_FAIL_CLOSED
     DASHBOARD_CHECK_UPDATES DASHBOARD_TZ
-    MONERO_MEM_LIMIT TARI_MEM_LIMIT MONERO_PREP_THREADS
+    MONERO_MEM_LIMIT TARI_MEM_LIMIT MONERO_PREP_THREADS MONERO_OUT_PEERS
+    PROXY_DONATE_LEVEL
     HASHRATE_DROP_THRESHOLD_PCT HASHRATE_DROP_MINUTES TELEGRAM_DAILY_SUMMARY_TIME
     TELEGRAM_EVENT_NODE_DOWN TELEGRAM_EVENT_NODE_RECOVERED
     TELEGRAM_EVENT_WORKER_OFFLINE TELEGRAM_EVENT_WORKER_RECOVERED
@@ -8157,7 +8174,8 @@ CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
     TELEGRAM_EVENT_HASHRATE_LOW TELEGRAM_EVENT_HASHRATE_LOSS
     TELEGRAM_EVENT_HUGEPAGES TELEGRAM_EVENT_LOW_RAM
     TELEGRAM_EVENT_HIGH_REJECT_RATE TELEGRAM_EVENT_BLOCK_FOUND
-    TELEGRAM_EVENT_PAYOUT_FOUND TELEGRAM_EVENT_PAYOUT_CONFIRMED TELEGRAM_EVENT_CONTAINER_UNHEALTHY'
+    TELEGRAM_EVENT_PAYOUT_FOUND TELEGRAM_EVENT_PAYOUT_CONFIRMED TELEGRAM_EVENT_CONTAINER_UNHEALTHY
+    TELEGRAM_EVENT_RAFFLE_WIN'
 
 # The confirm-gated editable set (#719): operationally-disruptive env keys the dashboard MAY commit
 # behind a type-to-confirm — NOT the security perimeter (wallets, keys, credentials, onion,
@@ -8166,12 +8184,16 @@ CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
 # that can set a field can also fill the confirm box, so this set is strictly the "expensive but
 # recoverable, not a breach" class — a data-dir move (re-sync), a stratum-port repoint (rigs
 # reconnect), a clearnet-sync enable (host IP exposed during IBD, auto-reverts), a prune enable
-# (reclaims disk). describe_change flags each CONFIRM only in its in-scope DIRECTION — the flag
-# carries the direction (prune DISABLE, TOR data-dir move, etc. still emit DEST and stay refused);
-# this list is the static allowlist the gate's default-deny pass consults and the UI mirrors
-# (control_service.CONFIRM_ENV_KEY_PATHS, drift-guarded like CONTROL_DASHBOARD_EDITABLE_KEYS).
+# (reclaims disk), or a wallet restore-point (PAYOUT_SCAN_HEIGHT / TARI_WALLET_BIRTHDAY, 2026-08
+# audit reclassification: wallet-creation metadata, not a secret — a wrong value only re-scans
+# from a different height on the wallet's NEXT creation, nothing destroyed). describe_change flags
+# each CONFIRM only in its in-scope DIRECTION — the flag carries the direction (prune DISABLE, TOR
+# data-dir move, etc. still emit DEST and stay refused); this list is the static allowlist the
+# gate's default-deny pass consults and the UI mirrors (control_service.CONFIRM_ENV_KEY_PATHS,
+# drift-guarded like CONTROL_DASHBOARD_EDITABLE_KEYS).
 CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DASHBOARD_DATA_DIR
-    STRATUM_PORT MONERO_CLEARNET_SYNC TARI_CLEARNET_SYNC MONERO_PRUNE'
+    STRATUM_PORT MONERO_CLEARNET_SYNC TARI_CLEARNET_SYNC MONERO_PRUNE
+    PAYOUT_SCAN_HEIGHT TARI_WALLET_BIRTHDAY'
 
 control_approval_gate() { # <staged-file> [confirm-token]
     local staged="$1" confirm="${2:-}" porcelain

--- a/pithead
+++ b/pithead
@@ -7618,6 +7618,10 @@ describe_change() {
         msg="Monero block-prep threads: $old → $new."
         ;;
     MONERO_OUT_PEERS)
+        # Confirm-gated (2026-08 security review): bounded 8-1024 and instantly reversible, but
+        # the biggest steady-state knob on the shared Tor daemon's CPU — one typed confirm, not
+        # free-commit.
+        flag=CONFIRM
         msg="Monero outbound peer target: $old → $new — monerod restarts; over Tor each outbound peer is roughly one circuit."
         ;;
     HEALTHCHECKS_PING_URL)
@@ -7740,10 +7744,6 @@ describe_change() {
         msg="On-chain payout confirmation → $([ "$new" == "true" ] && echo on || echo off)."
         ;;
     PAYOUT_SCAN_HEIGHT)
-        # #719 (2026-08 audit reclassification): confirm-gated — wallet-creation metadata, not a
-        # security boundary. A wrong value only re-scans from a different height on the wallet's
-        # NEXT creation; nothing is destroyed.
-        flag=CONFIRM
         msg="Payout wallet restore height: $old → $new — only affects a first-time wallet creation."
         ;;
     WALLET_RPC_USERNAME | MONERO_WALLET_RPC_URL)
@@ -7771,10 +7771,6 @@ describe_change() {
         msg="Tari on-chain payout confirmation → $([ "$new" == "true" ] && echo on || echo off)."
         ;;
     TARI_WALLET_BIRTHDAY)
-        # #719 (2026-08 audit reclassification): confirm-gated — wallet-creation metadata, not a
-        # security boundary. A wrong value only re-scans from a different height on the wallet's
-        # NEXT creation; nothing is destroyed.
-        flag=CONFIRM
         msg="Tari payout wallet birthday: $old → $new (days since the Unix epoch) — only affects a first-time wallet creation."
         ;;
     TARI_SPEND_PUBLIC_KEY | TARI_WALLET_GRPC_ADDRESS | TARI_WALLET_SECRET_FILE)
@@ -8161,8 +8157,7 @@ run_chain() {
 CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
     XVB_ENABLED XVB_DONATION_LEVEL TARI_REQUIRED DASHBOARD_FAIL_CLOSED
     DASHBOARD_CHECK_UPDATES DASHBOARD_TZ
-    MONERO_MEM_LIMIT TARI_MEM_LIMIT MONERO_PREP_THREADS MONERO_OUT_PEERS
-    PROXY_DONATE_LEVEL
+    MONERO_MEM_LIMIT TARI_MEM_LIMIT MONERO_PREP_THREADS
     HASHRATE_DROP_THRESHOLD_PCT HASHRATE_DROP_MINUTES TELEGRAM_DAILY_SUMMARY_TIME
     TELEGRAM_EVENT_NODE_DOWN TELEGRAM_EVENT_NODE_RECOVERED
     TELEGRAM_EVENT_WORKER_OFFLINE TELEGRAM_EVENT_WORKER_RECOVERED
@@ -8184,16 +8179,21 @@ CONTROL_DASHBOARD_EDITABLE_KEYS='P2POOL_FLAGS P2POOL_PORT
 # that can set a field can also fill the confirm box, so this set is strictly the "expensive but
 # recoverable, not a breach" class — a data-dir move (re-sync), a stratum-port repoint (rigs
 # reconnect), a clearnet-sync enable (host IP exposed during IBD, auto-reverts), a prune enable
-# (reclaims disk), or a wallet restore-point (PAYOUT_SCAN_HEIGHT / TARI_WALLET_BIRTHDAY, 2026-08
-# audit reclassification: wallet-creation metadata, not a secret — a wrong value only re-scans
-# from a different height on the wallet's NEXT creation, nothing destroyed). describe_change flags
+# (reclaims disk), or a Tor-load repoint (MONERO_OUT_PEERS: bounded 8-1024 at validation and
+# instantly reversible, but the biggest steady-state knob on the shared Tor daemon's CPU — 2026-08
+# security review placed it here, not free-commit). The same review REVERTED three keys the
+# configurability audit had proposed: PROXY_DONATE_LEVEL (docs/privacy.md's own words — donate
+# traffic bypasses the Tor socks5, and a self-approving container could divert up to 99% of
+# revenue silently), and PAYOUT_SCAN_HEIGHT / TARI_WALLET_BIRTHDAY (a future-dated value lands at
+# the NEXT wallet creation and silently defeats the payout-confirmation tamper evidence — not the
+# recoverable class this tier is for). All three stay host-only. describe_change flags
 # each CONFIRM only in its in-scope DIRECTION — the flag carries the direction (prune DISABLE, TOR
 # data-dir move, etc. still emit DEST and stay refused); this list is the static allowlist the
 # gate's default-deny pass consults and the UI mirrors (control_service.CONFIRM_ENV_KEY_PATHS,
 # drift-guarded like CONTROL_DASHBOARD_EDITABLE_KEYS).
 CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DASHBOARD_DATA_DIR
     STRATUM_PORT MONERO_CLEARNET_SYNC TARI_CLEARNET_SYNC MONERO_PRUNE
-    PAYOUT_SCAN_HEIGHT TARI_WALLET_BIRTHDAY'
+    MONERO_OUT_PEERS'
 
 control_approval_gate() { # <staged-file> [confirm-token]
     local staged="$1" confirm="${2:-}" porcelain

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -569,6 +569,11 @@ assert_contains "monero clearnet keeps tx on Tor" "$(run_sourced "$SANDBOX" desc
 assert_contains "monero clearnet disable is INFO" "$(run_sourced "$SANDBOX" describe_change MONERO_CLEARNET_SYNC true false)" "INFO"
 assert_contains "tari clearnet enable is CONFIRM" "$(run_sourced "$SANDBOX" describe_change TARI_CLEARNET_SYNC false true)" "CONFIRM"
 assert_contains "tari clearnet enable warns exposure" "$(run_sourced "$SANDBOX" describe_change TARI_CLEARNET_SYNC false true)" "CLEARNET"
+# Wallet restore points (#719, 2026-08 audit reclassification): wallet-creation metadata, not a
+# security boundary — a wrong value only re-scans from a different height on the wallet's NEXT
+# creation, so both moved from host-only to confirm-gated (CONFIRM), not the plain editable set.
+assert_contains "monero payout scan height change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change PAYOUT_SCAN_HEIGHT auto 3200000)" "CONFIRM"
+assert_contains "tari wallet birthday change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change TARI_WALLET_BIRTHDAY auto 19500)" "CONFIRM"
 
 echo "== unit: p2pool_outbound_flags — Tor-by-default for outbound P2P (#165) =="
 # Default (clearnet absent/false) routes outbound sidechain dials through the bundled Tor SOCKS proxy.
@@ -6211,17 +6216,23 @@ roundtrip_key "DASHBOARD_TZ" '.dashboard.timezone="Europe/Paris"' '.dashboard.ti
 roundtrip_key "MONERO_MEM_LIMIT" '.monero.mem_limit="5g"' '.monero.mem_limit' "5g"
 roundtrip_key "TARI_MEM_LIMIT" '.tari.mem_limit="2g"' '.tari.mem_limit' "2g"
 roundtrip_key "MONERO_PREP_THREADS" '.monero.prep_blocks_threads=8' '.monero.prep_blocks_threads' "8"
+# 2026-08 audit reclassification: same risk class as the already-editable performance knobs above.
+roundtrip_key "MONERO_OUT_PEERS" '.monero.out_peers=64' '.monero.out_peers' "64"
+# 2026-08 audit reclassification: exact sibling of the already-editable XVB_DONATION_LEVEL.
+roundtrip_key "PROXY_DONATE_LEVEL" '.proxy.donate_level=5' '.proxy.donate_level' "5"
+# 2026-08 audit reclassification: a UX timeout on the confirm gate, not the gate itself.
 roundtrip_key "HASHRATE_DROP_THRESHOLD_PCT" '.dashboard.hashrate_drop_threshold=40' '.dashboard.hashrate_drop_threshold' "40"
 roundtrip_key "HASHRATE_DROP_MINUTES" '.dashboard.hashrate_drop_minutes=15' '.dashboard.hashrate_drop_minutes' "15"
 roundtrip_key "TELEGRAM_DAILY_SUMMARY_TIME" '.telegram.daily_summary_time="09:30"' '.telegram.daily_summary_time' "09:30"
 roundtrip_key "P2POOL_FLAGS/P2POOL_PORT" '.p2pool.pool="mini"' '.p2pool.pool' "mini"
-# The 24 allowlisted TELEGRAM_EVENT_* toggles. wallet_changed + clearnet_exposed are deliberately
-# NOT on the allowlist (tamper-evidence alarms; their refusal is asserted above), so they are
-# excluded here. Each flips true->false as a single-key diff.
+# The 25 allowlisted TELEGRAM_EVENT_* toggles (raffle_win added 2026-08: audit found it was the one
+# event toggle missing from its siblings, all otherwise editable). wallet_changed + clearnet_exposed
+# are deliberately NOT on the allowlist (tamper-evidence alarms; their refusal is asserted above),
+# so they are excluded here. Each flips true->false as a single-key diff.
 for ev in node_down node_recovered worker_offline worker_recovered worker_joined worker_left \
     sync_finished disk_space db_unhealthy db_reset xvb_no_share xvb_registration new_release \
     stack_online daily_summary hashrate_low hashrate_loss hugepages low_ram high_reject_rate \
-    block_found payout_found payout_confirmed container_unhealthy; do
+    block_found payout_found payout_confirmed container_unhealthy raffle_win; do
     roundtrip_key "TELEGRAM_EVENT ${ev}" ".telegram.events.${ev}=false" ".telegram.events.${ev}" "false"
 done
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -569,11 +569,11 @@ assert_contains "monero clearnet keeps tx on Tor" "$(run_sourced "$SANDBOX" desc
 assert_contains "monero clearnet disable is INFO" "$(run_sourced "$SANDBOX" describe_change MONERO_CLEARNET_SYNC true false)" "INFO"
 assert_contains "tari clearnet enable is CONFIRM" "$(run_sourced "$SANDBOX" describe_change TARI_CLEARNET_SYNC false true)" "CONFIRM"
 assert_contains "tari clearnet enable warns exposure" "$(run_sourced "$SANDBOX" describe_change TARI_CLEARNET_SYNC false true)" "CLEARNET"
-# Wallet restore points (#719, 2026-08 audit reclassification): wallet-creation metadata, not a
-# security boundary — a wrong value only re-scans from a different height on the wallet's NEXT
-# creation, so both moved from host-only to confirm-gated (CONFIRM), not the plain editable set.
-assert_contains "monero payout scan height change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change PAYOUT_SCAN_HEIGHT auto 3200000)" "CONFIRM"
-assert_contains "tari wallet birthday change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change TARI_WALLET_BIRTHDAY auto 19500)" "CONFIRM"
+# 2026-08 security review: the outbound-peer count is confirm-gated (bounded 8-1024 but the
+# biggest steady-state knob on the shared Tor daemon's CPU). The same review kept the payout
+# restore points and proxy.donate_level host-only — a future-dated restore point silently defeats
+# payout-confirmation tamper evidence, and donate traffic bypasses the Tor socks5.
+assert_contains "monero outbound-peer change is CONFIRM" "$(run_sourced "$SANDBOX" describe_change MONERO_OUT_PEERS 12 64)" "CONFIRM"
 
 echo "== unit: p2pool_outbound_flags — Tor-by-default for outbound P2P (#165) =="
 # Default (clearnet absent/false) routes outbound sidechain dials through the bundled Tor SOCKS proxy.
@@ -6216,11 +6216,6 @@ roundtrip_key "DASHBOARD_TZ" '.dashboard.timezone="Europe/Paris"' '.dashboard.ti
 roundtrip_key "MONERO_MEM_LIMIT" '.monero.mem_limit="5g"' '.monero.mem_limit' "5g"
 roundtrip_key "TARI_MEM_LIMIT" '.tari.mem_limit="2g"' '.tari.mem_limit' "2g"
 roundtrip_key "MONERO_PREP_THREADS" '.monero.prep_blocks_threads=8' '.monero.prep_blocks_threads' "8"
-# 2026-08 audit reclassification: same risk class as the already-editable performance knobs above.
-roundtrip_key "MONERO_OUT_PEERS" '.monero.out_peers=64' '.monero.out_peers' "64"
-# 2026-08 audit reclassification: exact sibling of the already-editable XVB_DONATION_LEVEL.
-roundtrip_key "PROXY_DONATE_LEVEL" '.proxy.donate_level=5' '.proxy.donate_level' "5"
-# 2026-08 audit reclassification: a UX timeout on the confirm gate, not the gate itself.
 roundtrip_key "HASHRATE_DROP_THRESHOLD_PCT" '.dashboard.hashrate_drop_threshold=40' '.dashboard.hashrate_drop_threshold' "40"
 roundtrip_key "HASHRATE_DROP_MINUTES" '.dashboard.hashrate_drop_minutes=15' '.dashboard.hashrate_drop_minutes' "15"
 roundtrip_key "TELEGRAM_DAILY_SUMMARY_TIME" '.telegram.daily_summary_time="09:30"' '.telegram.daily_summary_time' "09:30"


### PR DESCRIPTION
From the on-the-fly configurability audit — and the best argument this session for the adversarial pass. The audit proposed six reclassifications as "same risk class as existing members"; the dedicated security review killed three of them with the project's own documentation:

**Landed:** `telegram.events.raffle_win` → editable (the one event toggle out of step with its 24 siblings; audit-note comments at both lists so the next new event checks both). `monero.out_peers` → **confirm-gated**, not free-commit (bounded 8-1024 and instantly reversible, but the biggest steady-state knob on the shared Tor daemon's CPU — the review's downgrade).

**Reverted to host-only, with the review's evidence:** `proxy.donate_level` (docs/privacy.md's own words: donate traffic bypasses the Tor socks5 — a self-approving container could silently divert up to 99% of revenue; wallet-grade, and CONFIRM is documented as UX friction, not a control); `monero.payout_scan_height` + `tari.payout_scan_birthday` (a future-dated value lands at the NEXT wallet creation and silently defeats payout-confirmation tamper evidence — not the recoverable class the confirm tier covers, and unboundable offline). `telegram.control.confirm_timeout` was also excluded at review (the approval channel's own trust anchor; unbounded at validation) with a negative test pinning it.

Both drift-guard sides move together; gate-table rows per key; docs/dashboard.md reset to the current base first (an earlier edit had restored pre-merge prose from a stale checkout) then re-touched minimally. Solo suite 2188/0 + pytest clean. Ponytail: list edits + decision-record comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)