### PR TITLE
docs(configuration): name the setup-vs-day-2 split explicitly

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 `./pithead setup` and the dashboard's first-run web wizard only ask for the fields listed in
 [Getting Started › Run setup](getting-started.md#3-run-setup) — wallet addresses, node mode,
 pool tier, and a handful of other high-level questions. Every other key in
-[`config.reference.json`](../config.reference.json) is day-2: not missing from either wizard,
+[`config.reference.json`](../config.reference.json) is day-2: not asked by either wizard,
 deliberately out of scope for a first run. Set it by editing `config.json` directly (then
 `./pithead apply`) or through the dashboard's config editor once the stack is up. Examples include
 stratum TLS and the stratum password (`p2pool.stratum_tls`, `p2pool.stratum_password`), onion

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,20 @@ plain HTTP, edit `config.json` and run `./pithead apply`.
 
 ---
 
+## Setup vs. day-2
+
+`./pithead setup` and the dashboard's first-run web wizard only ask for the fields listed in
+[Getting Started › Run setup](getting-started.md#3-run-setup) — wallet addresses, node mode,
+pool tier, and a handful of other high-level questions. Every other key in
+[`config.reference.json`](../config.reference.json) is day-2: not missing from either wizard,
+deliberately out of scope for a first run. Set it by editing `config.json` directly (then
+`./pithead apply`) or through the dashboard's config editor once the stack is up. Examples include
+stratum TLS and the stratum password (`p2pool.stratum_tls`, `p2pool.stratum_password`), onion
+client authentication (`dashboard.onion.client_auth`), the XvB raffle switch (`xvb.*`), energy
+pricing (`dashboard.energy.*`), and notification webhooks (`notifications.webhooks`).
+
+---
+
 ## Configuration reference
 
 > Only `monero.wallet_address` and `tari.wallet_address` are required. Everything below is optional


### PR DESCRIPTION
Mode-coverage audit finding: several supported modes are deliberately config.json-only — inexpressible in either setup wizard — and nothing told operators these are day-2 features rather than missing ones. The new "Setup vs. day-2" section states the split plainly, with the field set verified by diffing config.reference.json's surface against the union of both wizards' asked fields (stratum TLS/auth details, onion client-auth, XvB, energy pricing, notification webhooks among the named examples). Verifier: pass (one ambiguous phrase, fixed). Lint green, house voice. Ponytail: doc section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)