### PR TITLE
Consolidate partition derivation on lsblk-by-PARTLABEL — where early boot allows it

### DIFF
--- a/os/overlay/pithead-data-reset
+++ b/os/overlay/pithead-data-reset
@@ -32,17 +32,29 @@ SEED_DIRS="/overlay/var /overlay/var-work /pithead"
 # gets stderr from a unit exactly as it gets stdout, so nothing is lost by moving it.
 log() { echo "pithead-data-reset: $*" >&2; }
 
-# The data and ESP partitions on the disk the system booted from — the same derivation
-# pithead-mount-generator uses (never by label: every pithead disk carries the same labels, so a
-# stick + an installed disk present together make LABEL=data ambiguous). Partition numbers are
-# fixed by the layout: 1 = ESP, 4 = data.
-boot_disk_part() { # $1: partition number -> prints /dev/node, or nothing
-    local rootsrc disk sep
+# The data and ESP partitions on the disk the system booted from, resolved by PARTLABEL (#926)
+# scoped to that ONE disk — never a bare LABEL=/PARTLABEL= lookup: every pithead disk carries the
+# same labels by design, so a stick + an installed disk present together would make an unscoped
+# lookup ambiguous. Here the label is read off the disk we already resolved, so that ambiguity
+# never applies.
+#
+# Deliberately NOT pithead-mount-generator's derivation, even though both start from the same
+# boot-disk question. This runs as a plain systemd service (After=systemd-repart.service, not a
+# generator), so it can rely on lsblk the way pithead-install already does. The generator cannot:
+# systemd.generator(7) is explicit that generators run before any other unit — including
+# systemd-udevd — and "cannot rely on any external services", but lsblk's PARTLABEL column comes
+# from the udev database first (falling back to a direct blkid probe only once that database is
+# unavailable, and even then its own man page recommends a `udevadm settle` a generator has no
+# daemon left to settle against). Consolidating the generator onto lsblk would trade a
+# self-contained sed/awk derivation for one with an unprovable early-boot dependency, so it keeps
+# its own arithmetic; only this script and pithead-install share the lsblk shape.
+boot_disk_part() { # $1: PARTLABEL ("esp" or "data") -> prints /dev/node, or nothing
+    local rootsrc disk
     rootsrc=$(findmnt -no SOURCE / 2>/dev/null) || return 1
     case "$rootsrc" in /dev/*) ;; *) return 1 ;; esac
-    disk=$(printf '%s' "$rootsrc" | sed -E 's/[0-9]+$//; s/(^.*[0-9])p$/\1/')
-    case "$disk" in *[0-9]) sep="p" ;; *) sep="" ;; esac
-    printf '%s%s%s' "$disk" "$sep" "$1"
+    disk=$(lsblk -no PKNAME "$rootsrc" 2>/dev/null) || return 1
+    [ -n "$disk" ] || return 1
+    lsblk -lnpo NAME,PARTLABEL "/dev/$disk" 2>/dev/null | awk -v label="$1" '$2 == label { print $1; exit }'
 }
 
 # Read-only probe mount (so it never dirties the fs), cleaned up either way. rc mirrors the mount.
@@ -102,7 +114,7 @@ reformat_data() { # $1: data partition
 
 main() {
     local data_part esp_part esp_mnt marker verdict
-    data_part=$(boot_disk_part 4) || {
+    data_part=$(boot_disk_part data) || {
         log "could not resolve the data partition from the boot disk — doing nothing"
         return 0
     }
@@ -113,7 +125,7 @@ main() {
 
     # Read (and later clear) the factory-reset marker on the ESP. The ESP is not mounted this early,
     # so mount it ourselves; if it will not mount we simply have no marker to act on.
-    esp_part=$(boot_disk_part 1) || esp_part=""
+    esp_part=$(boot_disk_part esp) || esp_part=""
     esp_mnt=$(mktemp -d)
     marker=""
     if [ -n "$esp_part" ] && [ -b "$esp_part" ] && mount "$esp_part" "$esp_mnt" 2>/dev/null; then

--- a/os/overlay/pithead-data-reset
+++ b/os/overlay/pithead-data-reset
@@ -54,7 +54,12 @@ boot_disk_part() { # $1: PARTLABEL ("esp" or "data") -> prints /dev/node, or not
     case "$rootsrc" in /dev/*) ;; *) return 1 ;; esac
     disk=$(lsblk -no PKNAME "$rootsrc" 2>/dev/null) || return 1
     [ -n "$disk" ] || return 1
-    lsblk -lnpo NAME,PARTLABEL "/dev/$disk" 2>/dev/null | awk -v label="$1" '$2 == label { print $1; exit }'
+    local part
+    part=$(lsblk -lnpo NAME,PARTLABEL "/dev/$disk" 2>/dev/null | awk -v label="$1" '$2 == label { print $1; exit }')
+    # awk exits 0 whether or not anything matched — an empty answer must be a FAILURE, not a
+    # silent success an unquoted caller could mistake for a device.
+    [ -n "$part" ] || return 1
+    printf '%s' "$part"
 }
 
 # Read-only probe mount (so it never dirties the fs), cleaned up either way. rc mirrors the mount.

--- a/os/overlay/pithead-mount-generator
+++ b/os/overlay/pithead-mount-generator
@@ -12,6 +12,16 @@
 # pithead-install): 1 = ESP, 2/3 = system slots, 4 = data. On first boot partition 4 may not
 # exist yet — systemd-repart creates it — and systemd waits on the device unit exactly as it
 # waited on the label, so ordering is unchanged.
+#
+# NOT consolidated onto lsblk -o PARTLABEL (#926), unlike pithead-data-reset and pithead-install,
+# which both resolve the same disk this way. A generator runs before any other unit — including
+# systemd-udevd — and per systemd.generator(7) "cannot rely on any external services"; lsblk's
+# PARTLABEL column is sourced from the udev database first, falling back to a direct blkid probe
+# only once that database is unavailable, and its own man page recommends running `udevadm
+# settle` first when it might not be — a settle this generator has no daemon left to run against.
+# The awk/sed derivation below touches only /proc and does its own arithmetic, so it owes nothing
+# to udev having run yet. Trading that self-containment for the shared shape would be the exact
+# kind of behavior-with-an-unprovable-early-boot-dependency this refactor exists to avoid.
 set -eu
 
 GENDIR="${1:-/run/systemd/generator}"

--- a/os/rootfs/repart.d/10-esp.conf
+++ b/os/rootfs/repart.d/10-esp.conf
@@ -6,7 +6,11 @@
 # claims the populated slot the image shipped and 30-system-b is created empty beside it.
 [Partition]
 Type=esp
-Label=ESP
+# Lowercase on purpose: every path that actually CREATES an ESP labels it lowercase
+# (mkimage.sh `sgdisk -c 1:esp`, pithead-install the same), and boot_disk_part/pithead-install
+# look partitions up by exact PARTLABEL match. This rule only ever MATCHES the existing ESP
+# (repart never recreates it), but a second casing here is a trap for the next reader.
+Label=esp
 Format=vfat
 SizeMinBytes=256M
 SizeMaxBytes=256M

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9540,11 +9540,18 @@ echo "== unit: pithead-data-reset boot_disk_part resolves by PARTLABEL on the bo
 DRP="$SANDBOX/data-reset-partition"
 mkdir -p "$DRP/bin"
 printf '#!/usr/bin/env bash\necho "/dev/vda2"\n' >"$DRP/bin/findmnt"
-cat >"$DRP/bin/lsblk" <<'EOF'
+# The stub's labels are DERIVED from the real build inputs, not hand-typed: mkimage's sgdisk line
+# names the ESP, repart.d names the data partition. If either file ever changes its casing or
+# name, this test fails instead of green-lighting a lookup that no longer matches reality.
+DRP_ESP_LABEL=$(grep -oE '\-c 1:[a-zA-Z]+' "$ROOT/os/rauc/mkimage.sh" | cut -d: -f2)
+DRP_DATA_LABEL=$(grep -oE '^Label=.*' "$ROOT/os/rootfs/repart.d/40-data.conf" | cut -d= -f2)
+assert_eq "the ESP label mkimage bakes is the one data-reset looks up" "$DRP_ESP_LABEL" "esp"
+assert_eq "the data label repart declares is the one data-reset looks up" "$DRP_DATA_LABEL" "data"
+cat >"$DRP/bin/lsblk" <<EOF
 #!/usr/bin/env bash
-case "$1" in
+case "\$1" in
 -no) echo "vda" ;;
--lnpo) printf '/dev/vda1 esp\n/dev/vda4 data\n' ;;
+-lnpo) printf '/dev/vda1 ${DRP_ESP_LABEL}\n/dev/vda4 ${DRP_DATA_LABEL}\n' ;;
 esac
 EOF
 chmod +x "$DRP/bin/findmnt" "$DRP/bin/lsblk"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9532,6 +9532,47 @@ assert_eq "no marker + /data mounts clean -> skip (fail-safe: never touch a heal
 assert_eq "no marker + /data wedged after fsck -> reformat-wedged (recovery)" "$(decide "$DR/no-marker" fail)" "reformat-wedged"
 assert_eq "no marker + fsck repairs the mount -> skip (recoverable /data is never wiped)" "$(decide "$DR/no-marker" repair)" "skip"
 
+echo "== unit: pithead-data-reset boot_disk_part resolves by PARTLABEL on the boot disk (#926) =="
+# Stubbed findmnt + lsblk (the same PATH-stub shape pithead's own prefill_from_previous_install
+# test uses for lsblk). findmnt always answers the fake root partition; lsblk branches on its
+# first flag: -no PKNAME returns the parent disk name, -lnpo NAME,PARTLABEL lists that disk's
+# partitions with their labels — never a bare/unscoped label lookup.
+DRP="$SANDBOX/data-reset-partition"
+mkdir -p "$DRP/bin"
+printf '#!/usr/bin/env bash\necho "/dev/vda2"\n' >"$DRP/bin/findmnt"
+cat >"$DRP/bin/lsblk" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+-no) echo "vda" ;;
+-lnpo) printf '/dev/vda1 esp\n/dev/vda4 data\n' ;;
+esac
+EOF
+chmod +x "$DRP/bin/findmnt" "$DRP/bin/lsblk"
+resolve() { # $1: partlabel
+    (
+        export PATH="$DRP/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-data-reset"
+        boot_disk_part "$1"
+    )
+}
+assert_eq "boot_disk_part data -> the data partition on the boot disk" "$(resolve data)" "/dev/vda4"
+assert_eq "boot_disk_part esp -> the ESP on the boot disk" "$(resolve esp)" "/dev/vda1"
+assert_eq "boot_disk_part on a label the boot disk doesn't carry -> empty (first boot, pre-repart)" \
+    "$(resolve nosuchlabel)" ""
+
+# A container/unexpected root (mountinfo source isn't /dev/*) must fail closed, not guess.
+printf '#!/usr/bin/env bash\necho "overlay"\n' >"$DRP/bin/findmnt"
+out=$(
+    export PATH="$DRP/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$ROOT/os/overlay/pithead-data-reset"
+    boot_disk_part data
+)
+rc=$?
+assert_rc "boot_disk_part on a non-/dev root -> rc 1" "$rc" "1"
+assert_eq "boot_disk_part on a non-/dev root -> prints nothing" "$out" ""
+
 echo "== unit: pithead-machine-id — restore writes THROUGH /etc/machine-id, never unmounts it =="
 # The regression this pins: an earlier version unmounted /etc/machine-id before writing, which on
 # a read-only-root A/B slot exposed the lower image and the write failed — leaving an empty id and


### PR DESCRIPTION
Closes #926, with the honest partial scope the issue asked for: `pithead-data-reset`'s boot_disk_part() and `pithead-install` now share the lsblk-by-PARTLABEL shape; `pithead-mount-generator` deliberately keeps its positional arithmetic — lsblk's PARTLABEL lookup is udev-database-first and generators run before systemd-udevd, an unprovable early-boot dependency the commit documents in place.

**Review round closed three findings** (this is the reformat path — a wrong device here formats the wrong disk):
- repart.d's `Label=ESP` (uppercase) contradicted every path that actually creates an ESP (mkimage/installer sgdisk: lowercase `esp`) — a latent trap normalized at the source. The verifier flagged this as critical against the lookup; ground truth showed live systems are all-lowercase, so the fix is the config file, not the lookup.
- boot_disk_part returned rc 0 with empty output on a missing label (awk exits 0 either way) — now fails closed.
- the stub test hand-typed labels that happened to match the code — it now DERIVES them from mkimage's sgdisk line and repart.d's Label=, so casing/name drift fails the test instead of green-lighting a dead lookup.

Solo suite 2192/0. Battery boot/install phases are the live proof (queued). Ponytail: net-deletion consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)