### PR TITLE
Diagnosable battery legs: boot budget, restore-leg log tail, commit-gate doctor capture

### DIFF
--- a/os/overlay/pithead-boot
+++ b/os/overlay/pithead-boot
@@ -98,7 +98,10 @@ for _ in $(seq 90); do
     # unhealthy or still-booting stack just loops here without paying for a full diagnostic. doctor
     # only has to pass ONCE — a chain node that is still 'starting' fails a pass and the loop retries
     # it, so the gate waits out a slow start without ever committing on partial evidence.
-    if [ "${code:-000}" != "000" ] && ./pithead doctor --json >/dev/null 2>&1; then
+    # doctor's verdicts land in /run (volatile, no /data wear): when this gate never passes, the
+    # LAST failing run names the exact blocking check — without it a deadlock here was
+    # undiagnosable (the battery hit exactly that).
+    if [ "${code:-000}" != "000" ] && ./pithead doctor --json >/run/pithead-boot-doctor.json 2>/dev/null; then
         command -v rauc >/dev/null 2>&1 && rauc status mark-good
         echo "pithead-boot: stack is serving (HTTP $code) and doctor reports healthy — booted slot committed"
         # Post-commit, the held chain services start and the forward migration runs NOW — the

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -339,7 +339,10 @@ phase_boot() {
     # hugepages reserved, systemd-repart growing /data to ~24 GiB, the wizard image loading, the
     # host key generating — and 120 s clipped it (SSH came up just after, per the failed-run
     # forensics). An equally unprovisioned update-phase guest reaches SSH within 240 s.
-    _wait_ssh 240 || {
+    # 420, not the update phase's 240: this is the run's very FIRST cold boot — 6 GiB of
+    # hugepages, systemd-repart growing /data, the wizard image unpacking, host-key generation —
+    # and under full-battery host load 240 s clipped a boot that answered SSH moments later.
+    _wait_ssh 420 || {
         bad "host SSH never came up after the wizard gate — cannot read hugepages/machine-id"
         return
     }
@@ -1069,6 +1072,9 @@ phase_install() {
         ok "restore leg: took a real encrypted backup off the live machine"
     else
         bad "restore leg: could not take the source backup"
+        # The reason lives on the guest — print it, or this failure is undiagnosable after the
+        # VM is recycled (exactly what happened on its first live run).
+        printf '     guest backup log tail: %s\n' "$(_ssh "tail -c 600 /tmp/restore-backup.log 2>/dev/null" | tr '\n' ' ' | tail -c 500)"
         rm -f "$target_disk"
         return
     fi


### PR DESCRIPTION
Three fixes from the final battery run — all diagnosis-or-budget, none changing what is tested:

- The boot phase's first SSH gets 420s: the run's very FIRST cold boot (6 GiB hugepages + repart growing /data + wizard unpack + host-key generation) missed 240s under full-battery host load while answering moments later — third budget iteration, now sized to the actual worst case observed.
- The restore leg prints the guest's backup-log tail on failure — its first live run failed with no reachable reason once the VM recycled (exactly the undiagnosable-failure class the harness history warns about).
- `pithead-boot`'s commit gate writes doctor's verdicts to `/run/pithead-boot-doctor.json` instead of discarding them: when the gate never passes, the last failing run names the exact blocking check. The migration-leg deadlock is currently undiagnosable precisely because this output was thrown away; this is the instrument for that investigation.

Ponytail: a number, a print, a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)