### PR TITLE
fix(e2e): honest --no-miner skips + bench chain pre-flight (#905, #914)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -129,6 +129,7 @@ Useful flags (full list in `run.sh --help`):
 | `--readiness` | Non-destructive: assess whether the box is fit to be a release/validation server (synced chains reusable, snapshot-capable FS, disk headroom, secrets owner-only, dashboard localhost-only). See [Release Server](release-server.md). |
 | `--scenario <name>` | Run just one scenario. |
 | `--workers <n>` | Miners expected online while mining (default `2`). |
+| `--no-mining-asserts` | Skip the two mining assertions — workers online ≥ `--workers` and stratum total hashes > 0 — with a logged notice, for a box that has no miner connected. Every other assertion stays binding. `e2e.sh --no-miner` passes this automatically ([#905](https://github.com/p2pool-starter-stack/pithead/issues/905)). |
 | `--remote-monero-host <h>` | External node endpoint for the `remote` scenario. |
 | `--pruned-data-dir` / `--full-data-dir` | Synced alt DB to enable the opposite prune mode. |
 | `--lifecycle` | Also run the lifecycle phase (restart, apply secret-preservation). |
@@ -159,6 +160,13 @@ tests/integration/e2e.sh claude/my-feature --mode check    # non-destructive smo
 tests/integration/e2e.sh claude/my-feature --mode matrix   # full config sweep (opt-in, pre-release)
 ```
 
+Pre-flight, before anything is locked or borrowed: both chains must read `done` on the bench
+dashboard's sync panels. Otherwise it prints each chain's current/target height and aborts — a
+bench that starts hours behind tip fails the required-sync assertions as environment noise, not
+a regression, and burns the borrowed-rig hour finding out
+([#914](https://github.com/p2pool-starter-stack/pithead/issues/914)). `--skip-preflight`
+overrides.
+
 What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` trap):
 
 1. Dedicated checkout. Provisions `/srv/code/pithead-e2e` (clone-once, then `git fetch`) and checks
@@ -169,11 +177,21 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    is never git-touched. Because the Compose project name is pinned to `pithead`, the two checkouts
    drive the same containers and the same shared chains. They're two code copies of one stack, run one
    at a time, so borrow→test→restore is a fast code/image swap, never a re-sync.
-2. Seeds the e2e checkout with the canonical `config.json`/`.env` (same wallet, secrets, onion keys,
-   and shared `monero/tari/p2pool` data dirs), so only the branch's code differs.
+2. Seeds the e2e checkout's `config.json`/`.env` from the live release bundle when one exists —
+   the `current ->` symlink next to `CANONICAL_DIR` (e.g. `/srv/code/current`), resolved with
+   `readlink -f` — falling back to the canonical checkout's copies otherwise
+   ([#880](https://github.com/p2pool-starter-stack/pithead/issues/880); a release bumps the
+   bundle's config, not canonical's, so canonical can lag for months). When both configs exist it
+   always prints a key-level diff summary (full dotted paths via `jq`, nested keys included), so
+   drift is loud instead of a stale config being deployed silently. Either way the seed carries
+   the same wallet, secrets, onion keys, and shared `monero/tari/p2pool` data dirs — only the
+   branch's code differs.
 3. Safety backup (`pithead backup`) as the rollback anchor.
 4. Borrows a miner (default the configured miner): backs up its xmrig config and repoints it at the
    bench so the matrix has a real worker mining through this stack (1 worker → run with `--workers 1`).
+   With `--no-miner` nothing is borrowed, and the harness runs with `--no-mining-asserts`: the
+   workers-online and stratum-hashes assertions skip with a logged notice while every other
+   assertion stays binding ([#905](https://github.com/p2pool-starter-stack/pithead/issues/905)).
 5. Deploys the branch (`pithead upgrade` — re-renders the generated configs and rebuilds the
    first-party images from `build/`, so a Dockerfile or entrypoint change is actually under test;
    `apply` never builds and would reuse whatever images were last built on the box,

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -44,6 +44,7 @@ GIT_REMOTE_URL="${GIT_REMOTE_URL:-https://github.com/p2pool-starter-stack/pithea
 MODE="targeted" # targeted (default, lean) | check | matrix (full sweep, opt-in)
 WORKERS=1
 BORROW_MINER=1
+SKIP_PREFLIGHT=0
 KEEP=0
 BRANCH=""
 
@@ -92,7 +93,10 @@ OPTIONS:
   --workers <n>     workers expected mining through the stack (default: 1 — the borrowed miner)
   --bench <host>    SSH host of the test bench to deploy onto (or set BENCH_HOST)
   --miner <host>    SSH host of the miner to borrow (or set MINER_HOST)
-  --no-miner        don't borrow a miner (mining assertions will be skipped/limited)
+  --no-miner        don't borrow a miner; the harness skips its two mining assertions
+                    (workers online, stratum hashes) with a logged notice — everything else binds
+  --skip-preflight  skip the bench-chains-synced pre-flight (a cold bench then fails the
+                    required-sync assertions as environment noise — use knowingly)
   --keep            don't restore at the end (leave the branch deployed + miner repointed — debugging)
   -h, --help        this help
 
@@ -126,6 +130,10 @@ while [ $# -gt 0 ]; do
         ;;
     --no-miner)
         BORROW_MINER=0
+        shift
+        ;;
+    --skip-preflight)
+        SKIP_PREFLIGHT=1
         shift
         ;;
     --keep)
@@ -292,6 +300,24 @@ preflight() {
     else
         warn "couldn't resolve the live stack's working dir — restore will use CANONICAL_DIR=$CANONICAL_DIR."
     fi
+    # Chains at tip BEFORE anything is locked or borrowed (#914): a bench that starts hours
+    # behind fails the required-sync assertions as environment noise — not a regression — and
+    # burns the borrowed-rig hour finding out. Same dashboard sync signal wait_synced polls.
+    if [ "$SKIP_PREFLIGHT" = "1" ]; then
+        warn "--skip-preflight: not checking the bench chains are synced."
+    else
+        local sync_line mst mheights tst theights
+        sync_line="$(on_bench "curl -fsS --max-time 8 http://127.0.0.1:8000/api/state 2>/dev/null | jq -r '$E2E_SYNC_SUMMARY_JQ' 2>/dev/null" || true)"
+        [ -n "$sync_line" ] || die "Cannot read the bench dashboard's sync state (127.0.0.1:8000/api/state on $BENCH_HOST) — is the stack up? --skip-preflight overrides."
+        read -r mst mheights tst theights <<<"$sync_line"
+        if [ "$mst" = "done" ] && [ "$tst" = "done" ]; then
+            ok "bench chains synced (monero done, tari done)"
+        else
+            warn "monero: $mst (current/target $mheights)"
+            warn "tari:   $tst (current/target $theights)"
+            die "Bench chains are not at tip — the required-sync assertions would fail on the environment, not the branch (#914). Let the bench catch up, or pass --skip-preflight to run anyway."
+        fi
+    fi
     if [ "$BORROW_MINER" = "1" ]; then
         on_miner 'echo ok >/dev/null' || die "Cannot SSH to miner '$MINER_HOST' (use --no-miner to skip)."
         on_miner "test -f '$MINER_XMRIG_CONFIG'" || die "No xmrig config at $MINER_XMRIG_CONFIG on $MINER_HOST."
@@ -336,24 +362,29 @@ provision() {
     # Seed from the LIVE release bundle when one exists (#880): the canonical checkout's config can
     # drift far behind what's actually deployed (a release bumps config.json/.env in the bundle dir,
     # not in CANONICAL_DIR), so seeding from canonical silently exercises + deploys a stale config.
-    # The bundle lives at the "current" symlink sibling of CANONICAL_DIR (e.g. /srv/code/current).
+    # The bundle lives at the "current" symlink sibling of CANONICAL_DIR (e.g. /srv/code/current) —
+    # readlink -f so the log names the real per-version bundle dir this run seeded from.
     local live_link live_cfg=""
     live_link="$(dirname "$CANONICAL_DIR")/current"
-    on_bench "test -e '$live_link/config.json' -a -e '$live_link/.env'" && live_cfg="$live_link"
+    live_cfg="$(on_bench "readlink -f '$live_link' 2>/dev/null" || true)"
+    [ -n "$live_cfg" ] && on_bench "test -e '$live_cfg/config.json' -a -e '$live_cfg/.env'" || live_cfg=""
     if [ -n "$live_cfg" ]; then
         step "seeding the e2e checkout with the live bundle's config.json/.env ($live_cfg)"
         on_bench "cp -a '$live_cfg/config.json' '$E2E_DIR/config.json' && cp -a '$live_cfg/.env' '$E2E_DIR/.env'" ||
             die "Failed to seed config.json/.env from $live_cfg into $E2E_DIR."
         ok "config seeded from the live bundle (data dirs point at the shared chains)"
-        # Cheap drift check, not a full config differ: canonical is read-only and can lag the bundle
-        # for months, so a top-level-key diff is enough to catch a whole feature silently missing.
+        # Drift diff (#880), ALWAYS printed when both configs exist: canonical is read-only and can
+        # lag the bundle for months. Full dotted key paths, not just top-level keys — the drift that
+        # bit dropped nested keys (monero.view_key, dashboard.energy) whose parents exist in both.
         local live_keys canon_keys key_diff
-        live_keys="$(on_bench "jq -r 'keys[]' '$live_cfg/config.json' 2>/dev/null | sort")"
-        canon_keys="$(on_bench "jq -r 'keys[]' '$CANONICAL_DIR/config.json' 2>/dev/null | sort")"
-        key_diff="$(diff <(echo "$live_keys") <(echo "$canon_keys") 2>/dev/null)"
+        live_keys="$(on_bench "jq -r '$CONFIG_KEY_PATHS_JQ' '$live_cfg/config.json' 2>/dev/null")"
+        canon_keys="$(on_bench "jq -r '$CONFIG_KEY_PATHS_JQ' '$CANONICAL_DIR/config.json' 2>/dev/null")"
+        key_diff="$(diff <(echo "$live_keys") <(echo "$canon_keys") 2>/dev/null | grep '^[<>]')"
         if [ -n "$key_diff" ]; then
-            warn "canonical config.json's top-level keys differ from the live bundle's ($live_cfg) — canonical is drifting:"
+            warn "bundle vs canonical config drift ('<' = bundle only, '>' = canonical only):"
             echo "$key_diff" | sed 's/^/      /' >&2
+        else
+            ok "bundle vs canonical config: no key-level drift"
         fi
     else
         warn "no live bundle at $live_link — seeding from the canonical checkout ($CANONICAL_DIR) instead (may be stale)."
@@ -434,6 +465,11 @@ run_harness() {
     # its control API opted in. matrix only (it mutates config + dials the rig); each leg self-skips
     # loudly when its prerequisite is missing, so this stays safe on a bench without the descriptor.
     [ "$BORROW_MINER" = "1" ] && [ "$MODE" = "matrix" ] && phases="$phases --rigforge-control"
+    # #905: no borrowed miner means no worker will ever appear — tell the harness to SKIP its two
+    # mining assertions (workers online, stratum hashes) instead of failing a healthy stack.
+    local no_mining=""
+    [ "$BORROW_MINER" = "1" ] || no_mining="--no-mining-asserts"
+    phases="$phases $no_mining"
     log "Running the live harness on $BENCH_HOST (mode=$MODE, detached so an SSH drop can't kill it)"
     step "phases: $phases  (workers=$WORKERS)"
 
@@ -455,7 +491,7 @@ RUNNER
     # For non-check modes, run the safe readiness + current-state assertions inline first (fast,
     # gives early signal), then the destructive phases detached.
     if [ "$MODE" != "check" ]; then
-        on_bench "cd '$E2E_DIR' && bash tests/integration/run.sh --local --dir '$E2E_DIR' --readiness --check" ||
+        on_bench "cd '$E2E_DIR' && bash tests/integration/run.sh --local --dir '$E2E_DIR' --readiness --check $no_mining" ||
             warn "readiness/check reported issues (see above) — continuing to the destructive phases"
     fi
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -249,6 +249,21 @@ svc_health_of() { printf '%s' "${1##* }"; }
 # wrongly swallow it because false is falsy in jq).
 jq_get() { printf '%s' "$1" | jq -r "($2)? | values" 2>/dev/null; }
 
+# Every dotted key path of a config JSON, one per line, sorted — the #880 bundle-vs-canonical
+# drift signal. Full paths, not just top-level keys: the drift that bit on the bench dropped
+# NESTED keys (monero.view_key, dashboard.energy) whose parents exist in both configs, so a
+# top-level diff reads clean. Exposed as a constant so e2e.sh can run the same filter on the
+# bench over SSH; config_key_paths is the local/selftest wrapper.
+CONFIG_KEY_PATHS_JQ='[paths | map(tostring) | join(".")] | sort[]'
+config_key_paths() { jq -r "$CONFIG_KEY_PATHS_JQ" "$1" 2>/dev/null; }
+
+# One-line sync summary off /api/state for the #914 e2e pre-flight:
+# "<monero-state> <current>/<target> <tari-state> <current>/<target>". A constant (not a
+# function) because e2e.sh interpolates it into a remote jq call; the selftest pins it
+# against the /api/state fixture so the field paths can't drift from the dashboard payload.
+# shellcheck disable=SC2034  # consumed by e2e.sh + selftest.sh, which source this file
+E2E_SYNC_SUMMARY_JQ='"\(.sync.monero.state) \(.sync.monero.current)/\(.sync.monero.target) \(.sync.tari.state) \(.sync.tari.current)/\(.sync.tari.target)"'
+
 # Authoritative "is Monero caught up?" — query monerod's own get_info on the box (creds stay
 # on the box) and trust its `synchronized` flag / target_height 0, exactly like the sync gate.
 # This is the readiness GATE (the source of truth, and it avoids waiting on a dashboard poll cycle).

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -48,6 +48,7 @@ SAFETY_BACKUP=0
 SAFETY_ARCHIVE=""
 KEEP_STATE=0
 EXPECTED_WORKERS=2
+SKIP_MINING_ASSERTS=0
 REMOTE_MONERO_HOST=""
 PRUNED_DATA_DIR=""
 FULL_DATA_DIR=""
@@ -83,6 +84,9 @@ MATRIX:
                          headroom, secrets not world-readable, dashboard localhost-only).
   --scenario <name>      run only one scenario (see --list)
   --workers <n>          miners expected online while mining (default: 2)
+  --no-mining-asserts    SKIP the two mining assertions (workers online, stratum hashes) with a
+                         logged notice — for a box with no miner connected (e2e --no-miner, #905).
+                         Every other assertion stays binding.
   --remote-monero-host <h>  external node endpoint for the remote-mode scenario
                             (e.g. the box's own synced node on its LAN IP)
   --pruned-data-dir <d>  synced PRUNED monero data dir (enables the pruned case when the
@@ -197,6 +201,10 @@ parse_args() {
         --workers)
             EXPECTED_WORKERS="$2"
             shift 2
+            ;;
+        --no-mining-asserts)
+            SKIP_MINING_ASSERTS=1
+            shift
             ;;
         --remote-monero-host)
             REMOTE_MONERO_HOST="$2"
@@ -421,10 +429,11 @@ run_scenario() {
         return 0
     fi
 
-    # Wait for the stack to settle on real readiness signals before asserting.
+    # Wait for the stack to settle on real readiness signals before asserting. The miner/hash
+    # waits are pointless with --no-mining-asserts (nothing will ever connect) — skip the stall.
     wait_status_ok 240 || true
     wait_monero_synced 120 || true
-    wait_miner_running 180 || true
+    [ "$SKIP_MINING_ASSERTS" = "1" ] || wait_miner_running 180 || true
     # p2pool infers its sidechain from connected peers, so after a pool switch it reads "Unknown"
     # until peers on the new chain connect — wait for the dashboard to classify it (issue #54).
     local _pool
@@ -433,7 +442,7 @@ run_scenario() {
     wait_pool_ready 180 "$(pool_label "$_pool")" || true
     # End-to-end mining: p2pool's stratum hash counter resets on restart and climbs only once the
     # proxy's upstream reconnects and a share lands — wait for it before asserting hashes>0 (issue #54).
-    wait_hashes_flowing 300 || true
+    [ "$SKIP_MINING_ASSERTS" = "1" ] || wait_hashes_flowing 300 || true
     # When Tari is a required sync gate, give it the same treatment as Monero: after a restart it
     # must close its offline gap before the .sync.tari.state assertion, or we'd catch it mid-"loading".
     if [ "$(jq_get "$config" '.dashboard.tari_required')" = "true" ]; then
@@ -576,15 +585,21 @@ assert_running_state() {
     #    minute later, and which scenario loses that race moves run to run. The re-fetched
     #    assertion below stays the arbiter: a rig that never returns still fails after the
     #    timeout.
-    local workers conns hashes
-    wait_stratum_hashes 180 || true
-    st="$(api_state)" # re-fetch so this step and everything after read post-wait state
-    workers="$(jq_get "$st" '.proxy_workers')"
-    conns="$(jq_get "$st" '.stratum.conns')"
-    hashes="$(jq_get "$st" '.stratum.total_hashes')"
-    assert_num_ge "workers online (>= $EXPECTED_WORKERS)" "${workers:-0}" "$EXPECTED_WORKERS"
-    assert_num_gt "stratum total hashes > 0" "${hashes:-0}" 0
-    it_step "stratum conns=${conns:-?} (informational)"
+    if [ "$SKIP_MINING_ASSERTS" = "1" ]; then
+        # #905: no miner is connected on purpose (e2e --no-miner), so a live worker/hash count
+        # would fail a healthy stack. Skip these two loudly; every other assertion stays binding.
+        it_warn "SKIPPED mining assertions (workers online, stratum hashes): --no-mining-asserts"
+    else
+        local workers conns hashes
+        wait_stratum_hashes 180 || true
+        st="$(api_state)" # re-fetch so this step and everything after read post-wait state
+        workers="$(jq_get "$st" '.proxy_workers')"
+        conns="$(jq_get "$st" '.stratum.conns')"
+        hashes="$(jq_get "$st" '.stratum.total_hashes')"
+        assert_num_ge "workers online (>= $EXPECTED_WORKERS)" "${workers:-0}" "$EXPECTED_WORKERS"
+        assert_num_gt "stratum total hashes > 0" "${hashes:-0}" 0
+        it_step "stratum conns=${conns:-?} (informational)"
+    fi
 
     # 7. Tari sync-gate posture matches tari_required. The sync verdict tolerates post-restart
     #    target re-discovery ONLY once Tari has proved "done" earlier this run (#746).
@@ -1915,8 +1930,8 @@ run_subnet_scenario() {
     fi
     wait_status_ok 300 || true
     wait_monero_synced 120 || true
-    wait_miner_running 180 || true
-    wait_hashes_flowing 300 || true
+    [ "$SKIP_MINING_ASSERTS" = "1" ] || wait_miner_running 180 || true
+    [ "$SKIP_MINING_ASSERTS" = "1" ] || wait_hashes_flowing 300 || true
     # The down/up restarted Tari too, so — like the per-scenario deploy path — let it close its
     # post-restart offline gap before assert_running_state's sync check, or we catch it mid-"loading".
     if [ "$(jq_get "$config" '.dashboard.tari_required')" = "true" ]; then

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -455,36 +455,56 @@ if [ ! -e "$_gt/stray-cruft" ]; then it_pass "clean removes untracked cruft"; el
 rm -rf "$_gt"
 
 echo "== provision: seeds from the live bundle when one exists, else falls back to canonical (#880) =="
-# Mirrors e2e.sh provision()'s config-seeding selection + drift check, with plain dirs standing in
+# Mirrors e2e.sh provision()'s config-seeding selection + drift diff, with plain dirs standing in
 # for the on_bench SSH calls — the selection/diff logic itself is pure and needs no bench.
 _sd="$(mktemp -d)"
 _canon="$_sd/canonical"
-_live="$_sd/current"
+_bundle="$_sd/bundle-v9.9.9"
 _e2e="$_sd/e2e"
-mkdir -p "$_canon" "$_live" "$_e2e"
-echo '{"monero":{},"dashboard":{}}' >"$_canon/config.json"
+mkdir -p "$_canon" "$_bundle" "$_e2e"
+ln -s "$_bundle" "$_sd/current"
+_live="$(readlink -f "$_sd/current")" # provision() resolves the current -> symlink to the bundle dir
+# Canonicalize the expectation too: on macOS, mktemp's /var/… is itself a symlink to /private/var/….
+assert_eq "current -> symlink resolves to the bundle dir" "$_live" "$(readlink -f "$_bundle")"
+# The bundle carries a top-level key canonical lacks (telegram) AND a nested one (monero.view_key) —
+# the drift shape that actually bit: .monero exists in both, so a top-level-key diff reads clean.
+echo '{"monero":{"wallet_address":"49x"},"dashboard":{}}' >"$_canon/config.json"
 echo canon-env >"$_canon/.env"
-echo '{"monero":{},"dashboard":{},"telegram":{}}' >"$_live/config.json" # live has a key canonical lacks
+echo '{"monero":{"wallet_address":"49x","view_key":"vk"},"dashboard":{},"telegram":{}}' >"$_live/config.json"
 echo live-env >"$_live/.env"
 
 seed_from() { # <cfg_dir> -> copies into $_e2e, mirroring the cp -a pair in provision()
     cp -a "$1/config.json" "$_e2e/config.json" && cp -a "$1/.env" "$_e2e/.env"
 }
 
-# Live bundle present: seeds from it, and a top-level-key diff is non-empty (the drift signal).
+# Live bundle present: seeds from it, and the key-path diff names every drifted key.
 seed_from "$_live"
 assert_eq "seeds config.json from the live bundle" "$(cat "$_e2e/config.json")" "$(cat "$_live/config.json")"
 assert_eq "seeds .env from the live bundle" "$(cat "$_e2e/.env")" "live-env"
-_kd="$(diff <(jq -r 'keys[]' "$_live/config.json" | sort) <(jq -r 'keys[]' "$_canon/config.json" | sort))"
-if [ -n "$_kd" ]; then it_pass "drift check flags canonical missing a live key"; else it_fail "drift check flags canonical missing a live key" "no diff reported"; fi
+_kd="$(diff <(config_key_paths "$_live/config.json") <(config_key_paths "$_canon/config.json") | grep '^[<>]')"
+assert_contains "drift diff flags the missing top-level key" "$_kd" "telegram"
+assert_contains "drift diff flags the missing NESTED key" "$_kd" "monero.view_key"
+# Identical configs -> an empty diff, the "no key-level drift" arm of the always-printed summary.
+cp "$_live/config.json" "$_canon/config.json"
+_kd="$(diff <(config_key_paths "$_live/config.json") <(config_key_paths "$_canon/config.json") | grep '^[<>]')"
+assert_eq "identical configs -> empty drift diff" "$_kd" ""
 
 # No live bundle (symlink missing/broken): falls back to canonical, and there's nothing to diff.
-rm -rf "$_live"
+rm -rf "$_bundle"
 [ -e "$_live/config.json" ] && [ -e "$_live/.env" ] && it_fail "no-live-bundle detection" "should be absent" || it_pass "no-live-bundle detection treats missing dir as absent"
 seed_from "$_canon"
 assert_eq "falls back to seeding config.json from canonical" "$(cat "$_e2e/config.json")" "$(cat "$_canon/config.json")"
 assert_eq "falls back to seeding .env from canonical" "$(cat "$_e2e/.env")" "canon-env"
 rm -rf "$_sd"
+
+echo "== e2e pre-flight sync summary: the #914 jq reads the dashboard payload shape =="
+# e2e.sh aborts before the miner borrow unless both chains read done, printing current/target per
+# chain. Pin the shared filter against a representative /api/state payload so its field paths
+# can't silently drift from what build_sync serves.
+_ss='{"sync":{"monero":{"state":"done","current":3487100,"target":3487100},"tari":{"state":"syncing","current":12000,"target":12217}}}'
+assert_eq "sync summary reads state + current/target for both chains" \
+    "$(printf '%s' "$_ss" | jq -r "$E2E_SYNC_SUMMARY_JQ")" \
+    "done 3487100/3487100 syncing 12000/12217"
 
 # --- Tally ------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Parked-branch submission from the 2026-08-14 repo audit: the branch was finished 2026-08-13 (single self-contained commit with tests and docs) but no PR was ever opened.

- **#905**: `--no-miner` now threads `--no-mining-asserts` into `run.sh`, so the flag actually skips the two mining assertions it promises to skip (workers online, stratum hashes) with a logged notice — everything else stays binding.
- **#914**: e2e pre-flight reads both sync panels off `/api/state` and aborts unless both report done, so a matrix run can no longer burn a borrowed-rig hour against a syncing chain. `--skip-preflight` overrides; the jq filter is pinned in selftest so it can't drift from the dashboard payload.
- Polish on the #880 seeding fix: `readlink -f` on the `current ->` pointer, full dotted-key drift diff (the drift that bit was nested keys), always-print verdict.

Ponytail-review: lean, nothing to cut.

Closes #905
Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)