### PR TITLE
fix(dashboard): temper the energy/net-profit XvB figure by measured delivery (#902)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -591,14 +591,15 @@ function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
                          title=${"The tier the donation controller is configured to aim for" + (calc.sustainable ? "." : " — currently NOT sustainable at your hashrate.")} />
         </div>
         ${
-          // Current-tier expected reward (#712's published per-day figure) in the same
-          // standardized Day/Month/Year table every other tab shows. Only when the server sent a
-          // fresh estimate — never fabricated; a fixed published figure, NOT scaled by the
-          // what-if hashrate, and the heading says so.
+          // Current-tier expected reward (#712) in the same standardized Day/Month/Year table
+          // every other tab shows. Only when the server sent a fresh estimate — never fabricated.
+          // The server tempers the published figure by measured delivery (#902): this wallet's
+          // measured win payouts when enough wins exist, else the study band's midpoint — never
+          // face value. A fixed figure, NOT scaled by the what-if hashrate; the heading says so.
           est && est.xvbDay !== null
             ? html`
-        <h4 class="est-heading" title="XvB's published expected reward for the tier your fleet holds now — a raffle expectation across all qualifiers, not scaled by the what-if hashrate above.">
-            Current Tier Expected Reward — published by XvB</h4>
+        <h4 class="est-heading" title="XvB's published expected reward for the tier your fleet holds now, tempered by measured delivery: scaled to what this wallet's wins measurably paid when enough wins exist, else by the midpoint of the measured delivery band (28–39% of face value). XvB's raw figure shows only in the decision table's own column. A raffle expectation across all qualifiers, not scaled by the what-if hashrate above.">
+            Current Tier Expected Reward — tempered by measured delivery</h4>
         <${EstTable} unit="XMR" day=${est.xvbDay} month=${est.xvbMonth} year=${est.xvbYear}
                      price=${energy ? energy.xmr_price : 0} currency=${energy ? energy.currency : "USD"} />`
             : null
@@ -906,19 +907,20 @@ class EarningsCard extends Component {
 // then energy cost once an electricity price is set, then net profit once an XMR price is also set —
 // each layer appears only when its inputs exist, so the operator never sees a fabricated figure.
 // Setting a Tari price too (#520) folds the Tari merge-mining estimate into gross, and the current
-// XvB tier's published expected reward folds in when XvB sends a fresh one (#712); the heading and
-// the Net/day tooltip say exactly what's counted — including that XvB is an estimate — so the net
-// is never silently partial or over-confident. `est` is the earnings for the shared what-if
-// hashrate; the client does the kWh/cost/net math.
+// XvB tier's expected reward — tempered by measured delivery server-side (#902), never face
+// value — folds in when XvB sends a fresh one (#712); the heading and the Net/day tooltip say
+// exactly what's counted — including that XvB is a tempered estimate — so the net is never
+// silently partial or over-confident. `est` is the earnings for the shared what-if hashrate;
+// the client does the kWh/cost/net math.
 function EnergyPanel({ energy, est }) {
   const en = computeEnergy(energy, est);
   const cur = energy.currency;
   const haveCost = energy.cost_per_kwh > 0;
   const haveNet = haveCost && energy.xmr_price > 0;
-  // Honest label (#520, #712): say exactly what gross counts so the net figure is never silently
-  // partial. XvB is tagged "(est.)" — it's the current tier's published expected reward, and the
-  // raffle draw is probabilistic. When XvB isn't folded in, the strings are byte-identical to the
-  // pre-#712 label/tooltip.
+  // Honest label (#520, #712, #902): say exactly what gross counts so the net figure is never
+  // silently partial. XvB is tagged "(est.)" — the current tier's expected reward, tempered by
+  // measured delivery server-side, and the raffle draw is probabilistic. When XvB isn't folded
+  // in, the strings are byte-identical to the pre-#712 label/tooltip.
   const netLabel = en.includesXvb
     ? en.includesTari
       ? "P2Pool + Tari + XvB (est.), after power"
@@ -928,8 +930,8 @@ function EnergyPanel({ energy, est }) {
       : "P2Pool XMR only, after power";
   const netTitle = en.includesXvb
     ? en.includesTari
-      ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, plus the current XvB tier's published expected reward valued at your XMR price, minus power cost. XvB is an estimate — the raffle draw is random among qualifiers."
-      : "P2Pool XMR earnings at your XMR price plus the current XvB tier's published expected reward valued at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it). XvB is an estimate — the raffle draw is random among qualifiers."
+      ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, plus the current XvB tier's expected reward valued at your XMR price, minus power cost. XvB is an estimate, tempered by measured delivery (your wallet's measured win payouts when enough wins exist, else the measured delivery band's midpoint) — never XvB's face value — and the raffle draw is random among qualifiers."
+      : "P2Pool XMR earnings at your XMR price plus the current XvB tier's expected reward valued at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it). XvB is an estimate, tempered by measured delivery (your wallet's measured win payouts when enough wins exist, else the measured delivery band's midpoint) — never XvB's face value — and the raffle draw is random among qualifiers."
     : en.includesTari
       ? "P2Pool XMR + Tari (merge-mined) earnings at your set prices, minus power cost. Excludes XvB (raffle status, not a per-day income estimate)."
       : "P2Pool XMR earnings at your XMR price, minus power cost. Excludes Tari (set dashboard.energy.tari_price to include it) and XvB (raffle status, not a per-day income estimate).";

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -279,7 +279,8 @@ export function computeEarnings(hashrateHs, earnings) {
     tariYear: tariDay === null ? null : tariDay * DAYS_PER_YEAR,
     tariTimeToBlockSec,
     tariRewardPerBlock: earnings.tari_available ? earnings.tari_reward : null,
-    // Current-tier XvB expected reward, XMR/day (#712). A fixed published figure, NOT scaled by the
+    // Current-tier XvB expected reward, XMR/day (#712) — the published figure tempered by
+    // measured delivery server-side (#902), never face value. A fixed figure, NOT scaled by the
     // what-if hashrate (unlike day/tariDay); null unless the server sent a fresh estimate. Month/
     // year are the same day/month/year spans every other estimate gets, so the XvB tab can show
     // the standardized table.
@@ -417,11 +418,12 @@ export function formatXtm(xtm) {
 //           + (current-tier XvB/day × xmr_price, when the server sent a fresh estimate).
 // `est` is the already-computed earnings for this what-if hashrate (computeEarnings; `est.tariDay`
 // is the same Tari/day estimate the Tari tab already shows — no separate estimate invented here).
-// XvB (#712): `est.xvbDay` is the current tier's published expected reward (XMR/day), folded into
-// the single net — the whole net is already probabilistic, so one number stays coherent, and the
-// UI labels the XvB slice as an estimate (the raffle draw is random among qualifiers). It's a
-// fixed published figure, so it does NOT scale with the what-if hashrate; null (server-gated on a
-// fresh, non-stale estimate for a held donor tier) means it's simply left out — never fabricated.
+// XvB (#712): `est.xvbDay` is the current tier's expected reward (XMR/day; the published figure
+// tempered by measured delivery server-side, #902 — never face value), folded into the single
+// net — the whole net is already probabilistic, so one number stays coherent, and the UI labels
+// the XvB slice as a tempered estimate (the raffle draw is random among qualifiers). It's a
+// fixed figure, so it does NOT scale with the what-if hashrate; null (server-gated on a fresh,
+// non-stale estimate for a held donor tier) means it's simply left out — never fabricated.
 // Any figure whose inputs are missing comes back null so the card shows "—" rather than a bogus
 // number: cost needs cost_per_kwh > 0; net additionally needs xmr_price > 0 and a valid XMR
 // estimate — Tari and XvB only ever ADD to that base (mirrors the existing xmr_price-gates-net
@@ -454,8 +456,9 @@ export function computeEnergy(energy, est) {
   const haveXmr = Number.isFinite(xmrPrice) && xmrPrice > 0 && est && Number.isFinite(est.day);
   const includesTari =
     haveXmr && Number.isFinite(tariPrice) && tariPrice > 0 && Number.isFinite(est.tariDay);
-  // XvB (#712): the current tier's published expected reward (XMR/day), valued at the XMR price —
-  // an estimate blended into the single net, gated on a real XMR price like every other addend.
+  // XvB (#712): the current tier's expected reward (XMR/day, delivery-tempered server-side,
+  // #902), valued at the XMR price — an estimate blended into the single net, gated on a real
+  // XMR price like every other addend.
   const includesXvb = haveXmr && Number.isFinite(est.xvbDay) && est.xvbDay > 0;
   const grossDay = haveXmr
     ? est.day * xmrPrice +

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1471,7 +1471,8 @@ def xvb_current_tier_reward_day(metrics, state_mgr):
 
     Feeds the net-profit calculator (``est.xvbDay``): the whole net is already probabilistic, so
     blending the raffle's expected reward into the single figure is coherent — but it's an
-    *estimate* (the draw is random among qualifiers), so the UI labels it as one.
+    *estimate* (the draw is random among qualifiers), so the UI labels it as one. This is the
+    FACE value; ``build_state`` tempers it (``xvb_tempered_day``, #902) before the payload ships.
 
     Uses the **current** tier (``min(xvb_1h, xvb_24h)`` — the same lower-of-two rule as
     ``metrics.current_tier``), not the target: what the fleet is actually credited now. Returns
@@ -1611,6 +1612,19 @@ def xvb_realization(payouts, raffle_wins, xvb_day, expected_wins_day, now=None, 
     return (max(0.0, min(1.0, frac)), len(stamps))
 
 
+def xvb_tempered_day(xvb_day, realization):
+    """The per-day XvB figure the calculator and energy net fold in (#902) — never face value.
+
+    Same precedence as the decision table: this wallet's measured realization when enough wins
+    exist to measure it (``xvb_realization``), else the midpoint of the measured delivery prior
+    (``XVB_REALIZATION_PRIOR``). ``None``/0 passes through — nothing published means nothing to
+    temper, never a fabricated figure."""
+    if not xvb_day:
+        return xvb_day
+    frac = realization[0] if realization else sum(XVB_REALIZATION_PRIOR) / 2
+    return xvb_day * frac
+
+
 def build_earnings(data, metrics, payouts=None, tari_payouts=None, xvb_day=None):
     """Expected-XMR-from-P2Pool calculator inputs for the Advanced view (Issue #12).
 
@@ -1665,6 +1679,8 @@ def build_earnings(data, metrics, payouts=None, tari_payouts=None, xvb_day=None)
         "tari_reward": metrics.tari_reward,  # full XTM paid per Tari block (solo, lumpy)
         # Current-tier XvB expected reward, XMR/day, folded into the net-profit estimate (#712).
         # None unless XvB is on with a fresh published estimate for the tier the fleet holds now.
+        # build_state tempers this by measured delivery (xvb_tempered_day, #902) before the
+        # payload ships — clients never see the raw published figure.
         "xvb_day": xvb_day,
         "pool_difficulty": metrics.pool_difficulty,  # for expected time-to-share (diff/hr)
         "block_reward": f"{reward_atomic / 1e12:.4f} XMR",  # context, server-formatted like NetworkCard
@@ -2039,6 +2055,21 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
             p2pool_day=earnings["coeff_day"] * metrics.p2pool_30d,
         )
 
+    # Expected vs actual (#808) reads the published FACE value — it tempers its own XvB leg by
+    # the measured factor and labels the untempered fallback face value in the tooltip — so it
+    # is built before the calculator's copy is tempered below.
+    earnings_summary = build_earnings_vs_actual(
+        metrics,
+        earnings,
+        raffle_wins,
+        expected_wins_day=xvb_wins_day,
+        realization=xvb_realized,
+    )
+    # The calculator/energy copy (est.xvbDay) ships TEMPERED (#902): measured realization when
+    # this wallet has one, else the delivery prior's midpoint — the raw published figure was the
+    # last untempered money surface (a donating box's fiat net read ~3x high on the XvB addend).
+    earnings["xvb_day"] = xvb_tempered_day(earnings["xvb_day"], xvb_realized)
+
     egress = egress_posture_from_config()  # per-component egress route + privacy roll-up (#170)
     topology = (
         topology_from_config()
@@ -2090,13 +2121,8 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         # (feature off → earnings shows only the estimate). Built above, before the payload.
         "earnings": earnings,
         # Expected vs actual, one row per stream (#808) — the Simple view's earnings figure.
-        "earnings_summary": build_earnings_vs_actual(
-            metrics,
-            earnings,
-            raffle_wins,
-            expected_wins_day=xvb_wins_day,
-            realization=xvb_realized,
-        ),
+        # Built above, from the face-value earnings dict, before the #902 tempering.
+        "earnings_summary": earnings_summary,
         "xvb_calc": build_xvb_calc(metrics, state_mgr, realization=xvb_realized),
         # On a backup stack, the XvB controller state last pulled from the primary (#249) — held as
         # standby, adopted only at failover. None on a single stack (nothing pulls). Inspectable so

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -424,8 +424,10 @@ test('EarningsCard Energy tab folds the current-tier XvB estimate into net, labe
     const html = renderApp({ state: s });
     assert.match(html, /scope="col"[^>]*>Net</);
     assert.match(html, /P2Pool \+ XvB \(est\.\), after power/);
-    // Tooltip drops the "Excludes XvB" clause and states it's an estimate.
-    assert.match(html, /XvB is an estimate/);
+    // Tooltip drops the "Excludes XvB" clause and states it's an estimate — tempered by
+    // measured delivery, never face value (#902).
+    assert.match(html, /XvB is an estimate, tempered by measured delivery/);
+    assert.match(html, /never XvB(?:'|&#39;)s face value/);
     assert.doesNotMatch(html, /Excludes XvB/);
     assert.doesNotMatch(html, /P2Pool XMR only, after power/);
 });
@@ -550,12 +552,14 @@ test('EarningsCard marks running windows the payout history does not fully cover
     assert.match(html, /no payouts on record yet/);
 });
 
-test('EarningsCard XvB tab shows the published current-tier reward as a day/month/year table', () => {
+test('EarningsCard XvB tab shows the tempered current-tier reward as a day/month/year table', () => {
     const s = clone();
     s.earnings.available = true;
-    s.earnings.xvb_day = 0.002; // fresh published estimate → the standardized table appears
+    s.earnings.xvb_day = 0.002; // fresh (server-tempered, #902) estimate → the standardized table
     let html = renderApp({ state: s });
-    assert.match(html, /Current Tier Expected Reward — published by XvB/);
+    // The heading says the figure is tempered by measured delivery, not XvB's face value (#902).
+    assert.match(html, /Current Tier Expected Reward — tempered by measured delivery/);
+    assert.match(html, /tempered by measured delivery: scaled to what this wallet/);
     assert.match(html, /0\.002000 XMR/);  // day
     assert.match(html, /0\.060000 XMR/);  // month, same shared precision
     assert.match(html, /0\.730000 XMR/);  // year

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import mining_dashboard.service.metrics as service_metrics
 import mining_dashboard.web.views as views
 from mining_dashboard.config import config as egress_config
 from mining_dashboard.config.config import (
@@ -61,6 +62,7 @@ from mining_dashboard.web.views import (
     xvb_current_tier_reward_day,
     xvb_expected_wins_day,
     xvb_realization,
+    xvb_tempered_day,
 )
 
 # --- Metrics fixtures for the presentation builders -----------------------------------
@@ -1980,6 +1982,55 @@ class TestXvbRealization:
             self._payouts(4_800_000_000), self.WINS, 0.016, 1.0, now=self.NOW, p2pool_day=0.0064
         )
         assert out == (pytest.approx(0.2), 6)
+
+
+class TestXvbTemperedDay:
+    """The calculator/energy figure ships tempered — never XvB's raw published number (#902)."""
+
+    def test_measured_realization_beats_the_prior(self):
+        assert xvb_tempered_day(0.016, (0.19, 15)) == pytest.approx(0.016 * 0.19)
+
+    def test_unmeasured_falls_back_to_the_prior_midpoint(self):
+        lo, hi = views.XVB_REALIZATION_PRIOR
+        assert xvb_tempered_day(0.016, None) == pytest.approx(0.016 * (lo + hi) / 2)
+
+    def test_never_the_raw_published_figure(self):
+        # Whichever branch resolves, face value must not survive the tempering.
+        assert xvb_tempered_day(0.016, None) < 0.016
+        assert xvb_tempered_day(0.016, (0.99, 5)) < 0.016
+
+    def test_nothing_published_passes_through(self):
+        # None (no fresh estimate / XvB off) and 0 stay as-is — nothing fabricated either way.
+        assert xvb_tempered_day(None, None) is None
+        assert xvb_tempered_day(None, (0.19, 15)) is None
+        assert xvb_tempered_day(0.0, (0.19, 15)) == 0.0
+
+    def test_build_state_ships_tempered_while_the_summary_keeps_face_value(self, monkeypatch):
+        # The wiring the issue is about: est.xvbDay (earnings.xvb_day) leaves build_state
+        # tempered, while the expected-vs-actual summary still works from the face value (it
+        # applies the measured factor itself — feeding it the tempered figure would double-count).
+        monkeypatch.setattr(views.config, "PAYOUT_CONFIRM_ENABLED", False)
+        monkeypatch.setattr(views.config, "TARI_PAYOUT_CONFIRM_ENABLED", False)
+        monkeypatch.setattr(service_metrics, "ENABLE_XVB", True)
+        monkeypatch.setattr(views, "xvb_current_tier_reward_day", lambda m, s: 0.016)
+        monkeypatch.setattr(views, "xvb_realization", lambda *a, **k: (0.25, 6))
+        st = build_state(_data(), _state_mgr(), "all")
+        assert st["earnings"]["xvb_day"] == pytest.approx(0.016 * 0.25)
+        # Measured tempering applied exactly ONCE on the summary side (0.016 × 30 × 0.25).
+        assert st["earnings_summary"]["xmr"]["expected_30d"] == pytest.approx(0.016 * 30 * 0.25)
+
+    def test_build_state_unmeasured_box_ships_the_prior_midpoint(self, monkeypatch):
+        # No measured wins: the calculator figure drops to the prior midpoint; the summary keeps
+        # the face value (its tooltip labels it an upper bound) — asymmetric by design.
+        monkeypatch.setattr(views.config, "PAYOUT_CONFIRM_ENABLED", False)
+        monkeypatch.setattr(views.config, "TARI_PAYOUT_CONFIRM_ENABLED", False)
+        monkeypatch.setattr(service_metrics, "ENABLE_XVB", True)
+        monkeypatch.setattr(views, "xvb_current_tier_reward_day", lambda m, s: 0.016)
+        monkeypatch.setattr(views, "xvb_realization", lambda *a, **k: None)
+        st = build_state(_data(), _state_mgr(), "all")
+        lo, hi = views.XVB_REALIZATION_PRIOR
+        assert st["earnings"]["xvb_day"] == pytest.approx(0.016 * (lo + hi) / 2)
+        assert st["earnings_summary"]["xmr"]["expected_30d"] == pytest.approx(0.016 * 30)
 
 
 class TestEarningsVsActualTempering:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -431,8 +431,9 @@ figures.
 The card is split into tabs — **Monero**, **Tari**, **XvB**, and **Energy** — driven by one
 **what-if hashrate** input that sits above the tabs, so switching tabs keeps the value you entered.
 Monero holds the XMR estimate, time-to-share, and block reward; Tari holds the solo time-to-block,
-per-block reward, and long-run average; XvB holds the tier/cost block, the current tier's published
-expected reward, and the per-tier payout comparison. The XvB tab appears only when XvB is enabled,
+per-block reward, and long-run average; XvB holds the tier/cost block, the current tier's expected
+reward (tempered by measured delivery — see the decision table below), and the per-tier payout
+comparison. The XvB tab appears only when XvB is enabled,
 and the Energy tab only when the fleet reports power (see [Energy & profit](#energy--profit)).
 
 Every tab presents its rate estimate in the same **Day / Month / Year** table: the coin figure,
@@ -495,7 +496,7 @@ current draw) is always there; three optional prices add the money columns:
 | Config | Adds |
 |---|---|
 | `dashboard.energy.cost_per_kwh` | The **Power Cost** column (`kWh × price`). |
-| `dashboard.energy.xmr_price`    | The **Revenue (est.)** and **Net** columns: P2Pool XMR earnings × your XMR price, gross and then minus power cost. Needs `cost_per_kwh` set too — without a power cost there is no net for revenue to lead into. Also values the current-tier XvB expected reward (an estimate) into both when XvB has a fresh figure. |
+| `dashboard.energy.xmr_price`    | The **Revenue (est.)** and **Net** columns: P2Pool XMR earnings × your XMR price, gross and then minus power cost. Needs `cost_per_kwh` set too — without a power cost there is no net for revenue to lead into. Also values the current-tier XvB expected reward (an estimate, tempered by measured delivery — never XvB's face value) into both when XvB has a fresh figure. |
 | `dashboard.energy.tari_price`   | Folds Tari merge-mining earnings into that same revenue and net, at your Tari price. Requires `xmr_price` to be set too. |
 
 All three are in your `dashboard.energy.currency` label (e.g. `USD`, `EUR`) — a label only, no
@@ -507,13 +508,17 @@ when power costs more than it earns.
 Net profit counts **P2Pool XMR**, plus **Tari** merge-mining earnings once a Tari price is also
 known (Tari's contribution uses the same what-if Tari/day estimate the Tari tab already shows), plus
 the **XvB** raffle's expected reward for the tier you currently hold, valued at your XMR price. The
-whole net is already probabilistic, so it stays one figure — but the XvB slice is an **estimate**:
-it is XvB's published expected reward for your current tier (the lower of your credited 1h and 24h
-averages), and the raffle draw is random among qualifiers, so it is not a payout you are owed. The
-card's heading and the Net column's tooltip label it `XvB (est.)` and say exactly what the figure counts,
-so it is never silently partial. XvB folds in only while its published estimate is fresh (the same
-staleness rule as the *XvB Donation Stats* card) and you clear a donor tier; otherwise it is left
-out rather than guessed, and the label reverts to P2Pool (and Tari, if priced) alone.
+whole net is already probabilistic, so it stays one figure — but the XvB slice is an **estimate**,
+and never XvB's face value: the published expected reward for your current tier (the lower of your
+credited 1h and 24h averages) is **tempered by measured delivery** — scaled to what your own wins
+measurably paid once enough wins have confirmed payouts, else by the midpoint of the measured
+delivery band (28–39% of face value — the
+[XvB delivery study](research/xvb-delivery-study/PAPER.md)). The raffle draw is random among
+qualifiers, so it is not a payout you are owed either way. The card's heading and the Net column's
+tooltip label it `XvB (est.)` and say exactly what the figure counts, so it is never silently
+partial. XvB folds in only while its published estimate is fresh (the same staleness rule as the
+*XvB Donation Stats* card) and you clear a donor tier; otherwise it is left out rather than
+guessed, and the label reverts to P2Pool (and Tari, if priced) alone.
 
 Prices come from one of two places, and the card always says which:
 


### PR DESCRIPTION
Parked-branch submission from the 2026-08-14 repo audit: finished 2026-08-13, no PR was ever opened.

Closes the last untempered money surface: the energy/net-profit calculator's `est.xvbDay` shipped XvB's face-value published reward, reading ~3x high on a donating box. Now `build_state` tempers it by measured delivery before the payload ships — this wallet's measured win payouts when enough wins exist, else the delivery-study band's midpoint (28–39% of face value). The expected-vs-actual summary deliberately keeps face value (it applies the measured factor itself; feeding it the tempered figure would double-count) — a test pins that boundary. Headings and tooltips in the XvB tab and Energy panel now say the figure is tempered, and docs/dashboard.md links the delivery study.

Ponytail-review: lean, nothing to cut.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)