### PR TITLE
fix(dashboard): adaptive winners-sync gate so the in-round hold engages within minutes (#892)

### DIFF
--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -69,6 +69,7 @@ from mining_dashboard.helper.utils import (
     DEFAULT_PPLNS_WINDOW,
     effective_hashrate,
     format_hashrate,
+    get_tier_info,
     pplns_block_time,
     shares_in_pplns_window,
 )
@@ -126,9 +127,19 @@ _HOURLY_CAPTURE_SEC = 3600  # disk_growth + network_history
 _WORKER_HISTORY_CAPTURE_SEC = 300  # ~5 min
 
 # XvB's public winners file updates once per hourly round and covers ~4 days, so a 30-min re-read
-# can never miss a win while keeping the fetch off the every-10th-poll cadence. Wall-clock gated
-# like the capture cadences above.
+# can never miss a win outright. But the in-round hold (#769) reacts only when the mirror runs, so
+# a win landing at the wrong phase went undetected — and unprotected — for up to 30 min (#892).
+# The gate is therefore adaptive (_xvb_winners_gate_sec): 30-min baseline, dropping to the fast
+# cadence in exactly the windows where detection latency costs money. Wall-clock gated like the
+# capture cadences above.
 _XVB_WINNERS_SYNC_SEC = 1800
+_XVB_WINNERS_SYNC_FAST_SEC = 150
+# The fast windows: the credited 1h average within 25% above the current tier threshold (the band
+# the controller deliberately rides, #769's threshold + cushion — where a won round is one
+# steering step from sagging out), or a recorded win younger than 90 min (rounds run ~an hour, so
+# one may still be live).
+_XVB_WINNERS_MARGIN = 0.25
+_XVB_WIN_FRESH_S = 5400
 
 # Per-worker flood cap on NEW rig-edit audit rows (#724). The enriched worker feed is
 # unauthenticated LAN input, so a rogue device presenting as a worker can report a fresh random
@@ -139,6 +150,31 @@ _XVB_WINNERS_SYNC_SEC = 1800
 # most, so a legitimate cadence never trips it — only a flood does.
 _RIG_EDIT_CAP_PER_HOUR = 12
 _RIG_EDIT_WINDOW_SEC = 3600
+
+
+def _xvb_winners_gate_sec(avg_1h, avg_24h, tiers, last_win_ts, now):
+    """Seconds the winners mirror must wait between fetches — the adaptive gate (#892).
+
+    Fast (150 s) in the sensitive window: the wallet credited at a tier (the LOWER of the 1h/24h
+    averages, the raffle's qualifying rule, #157) with the 1h average within 25% above that
+    tier's threshold — the band the controller holds it in, where a win the dashboard hasn't
+    seen yet is one downward step from termination — or a recorded win younger than 90 min (a
+    won round may still be live). 30-min baseline everywhere else. The caller only runs while
+    XvB is enabled, so a disabled stack never fetches at all.
+
+    Extra Tor load, honestly: the fast gate admits at most 24 fetches/h vs 2/h at baseline, and
+    the every-10th-poll outer throttle caps it at ~12/h at the default 30 s UPDATE_INTERVAL —
+    only while the sensitive window holds. Win-detection latency in that window falls from up
+    to 30 min to the first eligible poll past the gate: ~5 min at the default interval, 2.5 min
+    at the gate's own floor. This is the detection half of #892; the other half — steering off
+    the credited average's projected trajectory instead of its current reading — remains open.
+    """
+    _, threshold = get_tier_info(min(avg_1h, avg_24h), tiers)
+    if threshold > 0 and avg_1h <= threshold * (1 + _XVB_WINNERS_MARGIN):
+        return _XVB_WINNERS_SYNC_FAST_SEC
+    if last_win_ts > 0 and now - last_win_ts < _XVB_WIN_FRESH_S:
+        return _XVB_WINNERS_SYNC_FAST_SEC
+    return _XVB_WINNERS_SYNC_SEC
 
 
 def _parse_proxy_list_worker(w):
@@ -883,10 +919,24 @@ class DataService:
         the XvB card read the table.
 
         Same "no write on failure" contract as the other XvB syncs: a failed fetch returns None,
-        nothing is written, and the 30-min gate is NOT stamped so the next 10th poll retries.
+        nothing is written, and the gate is NOT stamped so the next 10th poll retries.
+
+        The gate is adaptive (#892): ``_xvb_winners_gate_sec`` picks the fast cadence while a
+        won round is plausibly live or at stake, the 30-min baseline otherwise.
         """
         now = time.time()
-        if now - self._last_xvb_winners_sync < _XVB_WINNERS_SYNC_SEC:
+        xvb = self.state_manager.get_xvb_stats()
+        recent_wins = await asyncio.to_thread(
+            self.state_manager.get_raffle_wins, now - _XVB_WIN_FRESH_S
+        )
+        gate = _xvb_winners_gate_sec(
+            xvb.get("avg_1h", 0) or 0,
+            xvb.get("avg_24h", 0) or 0,
+            self.state_manager.get_tiers(),
+            max((w.get("ts", 0) or 0 for w in recent_wins), default=0.0),
+            now,
+        )
+        if now - self._last_xvb_winners_sync < gate:
             return
         result = await asyncio.to_thread(self.xvb_client.get_recent_wins)
         if result is None:

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -16,6 +16,8 @@ from mining_dashboard.client.xvb_client import (
 from mining_dashboard.config.config import XVB_REGISTER_INTERVAL_S
 from mining_dashboard.service.data_service import (
     _XVB_REGISTER_FAIL_ALERT,
+    _XVB_WINNERS_SYNC_FAST_SEC,
+    _XVB_WINNERS_SYNC_SEC,
     DataService,
     WorkerLifecycle,
     _aggregate_hashrate,
@@ -32,6 +34,7 @@ from mining_dashboard.service.data_service import (
     _read_host_config,
     _shares_to_record,
     _summary_deltas,
+    _xvb_winners_gate_sec,
 )
 
 
@@ -1736,6 +1739,10 @@ class TestXvbWinnersSync:
     def _svc(self):
         sm = MagicMock()
         sm.load_snapshot.return_value = None
+        # Adaptive-gate reads (#892): defaults that resolve to the 30-min baseline.
+        sm.get_xvb_stats.return_value = {}
+        sm.get_tiers.return_value = {}
+        sm.get_raffle_wins.return_value = []
         xvb = MagicMock()
         return DataService(sm, MagicMock(), xvb), sm, xvb
 
@@ -1806,6 +1813,63 @@ class TestXvbWinnersSync:
             svc.alert_service.raffle_win_alert.assert_awaited_once()
         finally:
             sm.close()
+
+
+class TestXvbWinnersGate:
+    """The adaptive winners-mirror gate (#892): the fast cadence only in the windows where a
+    late-detected win costs money — the credited 1h average riding just above its tier
+    threshold, or a recorded win still fresh — and the 30-min baseline everywhere else."""
+
+    _TIERS = {"donor": 1_000, "donor_whale": 100_000}
+    _NOW = 1_000_000.0
+
+    def _gate(self, avg_1h, avg_24h, last_win_ts=0.0):
+        return _xvb_winners_gate_sec(avg_1h, avg_24h, self._TIERS, last_win_ts, self._NOW)
+
+    def test_baseline_at_comfortable_margin_with_no_fresh_win(self):
+        # 250k credited over the 100k whale threshold: >25% above, no recorded win → 30 min.
+        assert self._gate(250_000, 250_000) == _XVB_WINNERS_SYNC_SEC
+
+    def test_fast_while_credited_rides_the_tier_threshold(self):
+        # The controller's steady state: the 1h average held at threshold + cushion (#769) —
+        # the exact band the #892 incident sagged out of.
+        assert self._gate(103_000, 105_000) == _XVB_WINNERS_SYNC_FAST_SEC
+
+    def test_margin_boundary_is_inclusive(self):
+        assert self._gate(125_000, 125_000) == _XVB_WINNERS_SYNC_FAST_SEC
+        assert self._gate(125_001, 125_001) == _XVB_WINNERS_SYNC_SEC
+
+    def test_tier_qualifies_on_the_lower_of_the_two_averages(self):
+        # 24h still ramping: the wallet qualifies at donor (1k), and 103k is far above THAT
+        # threshold — no whale round to protect yet → baseline.
+        assert self._gate(103_000, 50_000) == _XVB_WINNERS_SYNC_SEC
+
+    def test_baseline_below_the_lowest_tier(self):
+        # Cold ramp, no tier credited: nothing can be won, nothing to protect → 30 min.
+        assert self._gate(500, 400) == _XVB_WINNERS_SYNC_SEC
+
+    def test_fast_while_a_recorded_win_is_younger_than_90_min(self):
+        gate = self._gate(250_000, 250_000, last_win_ts=self._NOW - 89 * 60)
+        assert gate == _XVB_WINNERS_SYNC_FAST_SEC
+
+    def test_baseline_once_the_recorded_win_ages_out(self):
+        gate = self._gate(250_000, 250_000, last_win_ts=self._NOW - 91 * 60)
+        assert gate == _XVB_WINNERS_SYNC_SEC
+
+    async def test_sensitive_window_reopens_the_sync_gate_early(self):
+        # Wiring: in the sensitive band _sync_xvb_winners refetches after 150+ s, where the
+        # old fixed 30-min gate would have suppressed the second fetch.
+        sm = MagicMock()
+        sm.load_snapshot.return_value = None
+        sm.get_xvb_stats.return_value = {"avg_1h": 103_000, "avg_24h": 105_000}
+        sm.get_tiers.return_value = self._TIERS
+        sm.get_raffle_wins.return_value = []
+        svc = DataService(sm, MagicMock(), MagicMock())
+        svc.xvb_client.get_recent_wins.return_value = {"wins": [], "round_stats": {}}
+        await svc._sync_xvb_winners()
+        svc._last_xvb_winners_sync -= _XVB_WINNERS_SYNC_FAST_SEC + 1
+        await svc._sync_xvb_winners()
+        assert svc.xvb_client.get_recent_wins.call_count == 2
 
 
 class _RecordingGet:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -663,10 +663,13 @@ resets your PPLNS shares — and with them XvB win collectability until a new sh
 
 **Raffle Wins log.** The *XvB Donation Stats* card (Advanced view) lists the rounds your wallet
 actually won — time, round type, and the hashrate XvB credited the win at — newest first, capped at
-the 20 most recent. The dashboard reads XvB's public winners log about every half hour over Tor,
-matches your wallet by the masked form the file uses, and stores each win permanently, so the list
-(and the chart's gold stars) survives restarts and covers wins far older than the ~4 days the file
-itself keeps. Each new win is also announced once in the dashboard's container log. The file
+the 20 most recent. The dashboard reads XvB's public winners log over Tor, matches your wallet by
+the masked form the file uses, and stores each win permanently, so the list (and the chart's gold
+stars) survives restarts and covers wins far older than the ~4 days the file itself keeps. The
+read runs about every half hour, tightening to every few minutes while your credited 1h average
+sits within 25% above its tier threshold or a recorded win is under 90 minutes old — the windows
+where a fresh win needs the donation controller's in-round hold engaged within minutes, not up to
+half an hour later. Each new win is also announced once in the dashboard's container log. The file
 carries only masked wallets and the fetch sends nothing about you.
 
 ### Pool Cadence & Luck


### PR DESCRIPTION
Parked-branch submission from the 2026-08-14 repo audit: finished 2026-08-13, no PR was ever opened.

The in-round hold (#769) reacts only when the winners mirror runs, so a win landing at the wrong phase went unprotected for up to 30 minutes — measured credited dips killed won rounds. The winners-sync gate is now adaptive: 30-minute baseline, tightening to 150 s exactly where detection latency costs money — the credited 1h average riding within 25% above its tier threshold (the band the controller deliberately holds), or a recorded win younger than 90 minutes. Extra Tor load is bounded and accounted for in the docstring (≤ ~12 fetches/h at the default poll interval, only while the sensitive window holds).

This is the **detection half** of #892 only — the steering half (driving off the credited average's projected trajectory instead of its current reading) remains open, so this PR deliberately does **not** auto-close the issue. Review (2026-08-14, adversarial pass): real StateManager interface verified against the MagicMock assumptions (get_xvb_stats/get_tiers/get_raffle_wins signatures all match), gate math verified (~5 min detection at default polls), 'ts' row key correct.

Part of #892

🤖 Generated with [Claude Code](https://claude.com/claude-code)