### PR TITLE
feat(scripts): ship the XvB winners-feed archiver as an operator tool (#906)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -230,15 +230,18 @@ point 0.33, 95% CI 0.28–0.39). XvB can change its payout behaviour at any time
 feed is the raw material for re-running that measurement; without an archive, anything older
 than ~45 days is gone.
 
-Run it daily from cron on the deploy box:
+Run it daily from cron on the deploy box, and give it an archive directory **outside** the
+version directories:
 
 ```
-10 0 * * * $HOME/mining/current/scripts/xvb-winners-archive.sh
+10 0 * * * $HOME/mining/current/scripts/xvb-winners-archive.sh $HOME/mining/xvb-winners-archive
 ```
 
-Snapshots land in `xvb-winners-archive/` in the stack directory as `winners-YYYYMMDD.txt`
-(UTC date); pass a different directory as the only argument. Each snapshot is ~90 KB, so a
-daily archive grows about 3 MB a month.
+Snapshots land there as `winners-YYYYMMDD.txt` (UTC date). The directory argument matters:
+without it the script defaults to `xvb-winners-archive/` inside the stack directory, and the
+deploy layout above rotates old version directories away on upgrade — taking any archive
+inside them along. The explicit directory survives every upgrade. Each snapshot is ~90 KB,
+so a daily archive grows about 3 MB a month.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -214,6 +214,34 @@ the cap is visible — the marker names it, and the dashboard logs a warning.
 
 ---
 
+## Archiving the XvB winners feed
+
+`scripts/xvb-winners-archive.sh` saves a dated snapshot of the public XvB winners feed
+(`https://xmrvsbeast.com/p2pool/winners_recent_full_pub.txt`) — the full round schedule with
+per-round prize hashrates and qualifier counts — before the feed's ~45-day rolling window drops
+the oldest rounds. The fetch runs inside the dashboard container, so it rides the stack's Tor
+SOCKS like every other XvB call; the feed is public and carries no wallet. The stack must be
+running.
+
+This is optional. The reason to run it: the dashboard's XvB earnings estimate rests on a
+measured delivery band — the fraction of the advertised prize that actually arrives on-chain,
+measured once in the [XvB delivery study](research/xvb-delivery-study/README.md) (Jun–Aug 2026:
+point 0.33, 95% CI 0.28–0.39). XvB can change its payout behaviour at any time, and the winners
+feed is the raw material for re-running that measurement; without an archive, anything older
+than ~45 days is gone.
+
+Run it daily from cron on the deploy box:
+
+```
+10 0 * * * $HOME/mining/current/scripts/xvb-winners-archive.sh
+```
+
+Snapshots land in `xvb-winners-archive/` in the stack directory as `winners-YYYYMMDD.txt`
+(UTC date); pass a different directory as the only argument. Each snapshot is ~90 KB, so a
+daily archive grows about 3 MB a month.
+
+---
+
 ## Updating the stack
 
 The update path depends on how you installed (see [Getting Started](getting-started.md#2-get-the-code)).

--- a/scripts/xvb-winners-archive.sh
+++ b/scripts/xvb-winners-archive.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Snapshot the public XvB winners feed — the full round schedule and qualifier counts — before
+# its ~45-day rolling window drops the oldest rounds. The fetch runs inside the dashboard
+# container so it rides the stack's Tor SOCKS (TOR_SOCKS_PROXY); the file is public and carries
+# no wallet. See docs/operations.md ("Archiving the XvB winners feed").
+set -eu
+
+usage() {
+    cat <<EOF
+usage: xvb-winners-archive.sh [output-dir]
+
+Saves https://xmrvsbeast.com/p2pool/winners_recent_full_pub.txt to
+<output-dir>/winners-YYYYMMDD.txt (UTC date), fetched over the stack's Tor
+SOCKS from inside the running dashboard container.
+
+output-dir defaults to xvb-winners-archive/ in the stack directory.
+EOF
+}
+
+case "${1:-}" in
+-h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+stack_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+out_dir=${1:-"$stack_dir/xvb-winners-archive"}
+out_file="$out_dir/winners-$(date -u +%Y%m%d).txt"
+
+mkdir -p -- "$out_dir"
+tmp="$out_file.tmp"
+trap 'rm -f -- "$tmp"' EXIT
+
+docker exec -i dashboard python3 /dev/stdin >"$tmp" <<'PY'
+import os, requests
+
+proxy = os.environ.get("TOR_SOCKS_PROXY", "socks5h://tor:9050")
+s = requests.Session()
+s.proxies = {"http": proxy, "https": proxy}
+print(s.get("https://xmrvsbeast.com/p2pool/winners_recent_full_pub.txt", timeout=60).text, end="")
+PY
+
+mv -- "$tmp" "$out_file"
+echo "archived $out_file"


### PR DESCRIPTION
Parked-branch submission from the 2026-08-14 repo audit: finished 2026-08-13, no PR was ever opened.

This implements the **formalize** side of #906 (formalize or retire): `scripts/xvb-winners-archive.sh` snapshots the public winners feed before its ~45-day window drops rounds — the raw material for re-running the delivery-band measurement if XvB changes payout behaviour. The fetch runs inside the dashboard container so it rides the stack's Tor SOCKS; the feed is public and carries no wallet. docs/operations.md documents the optional daily cron.

If the operator's answer to #906 is instead **retire** (stop archiving, accept the study stands as a point-in-time measurement), close this PR unmerged and close #906 with that decision — the PR exists so the choice is a one-click either way.

Ponytail-review: lean, nothing to cut.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)