### PR TITLE
docs(appliance): stale-note removal, backup-story reconciliation, debt-ledger refresh

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -327,9 +327,9 @@ and what it contains), and warns you before it moves on. Save the kit and downlo
 archive together, and keep them somewhere other than this machine. Without the
 passphrase, the archive cannot be opened.
 
-**NOTE:** restoring from a backup is not available yet. Exporting a backup off the
-machine closes the "a dead box loses everything" gap; a guided restore back onto a fresh
-install is separate, coming work.
+Putting a backup to use is the [Recovering from a backup](#recovering-from-a-backup)
+section below: a fresh install accepts the archive and its passphrase in place of the
+setup form.
 
 ## Starting over: the two resets
 
@@ -364,19 +364,22 @@ into setup when the reset is done.
 Fresh flash, restore, done — if the machine is gone (dead disk, stolen, dropped), a backup
 taken beforehand provisions a replacement in one page, with nothing retyped.
 
-**Take a backup before you need it.** From the machine's console (or a checkout with SSH
-access):
+**Take a backup before you need it.** The dashboard's **Configuration → Backup** card is
+the machine's own way to do that ([Backing up your data](#backing-up-your-data) above): the
+archive it downloads and the passphrase from its kit are exactly what restore asks for. The
+console works too — log in as `root` with the dashboard password and run:
 
 ```
 pithead backup
 ```
 
-This writes an encrypted archive under `backups/`: config, wallets, the Tor identity, and the
-dashboard's history — never the blockchain, which re-syncs. Type a passphrase when prompted, or
-set `PITHEAD_BACKUP_PASSPHRASE` for an unattended run. Copy the resulting
-`pithead-backup-*.tar.gz.enc` off the machine and keep the passphrase somewhere else — the
-archive is useless without it, and the machine you are backing up is exactly the thing you
-might lose next.
+This writes the same kind of encrypted archive under `backups/`, with a passphrase you type
+(or set `PITHEAD_BACKUP_PASSPHRASE` for an unattended run). Either way the archive holds
+config, wallets, the Tor identity, and the dashboard's history — never the blockchain, which
+re-syncs — and restore opens it with whichever passphrase sealed it: the kit's, or yours.
+Copy the archive off the machine and keep the passphrase somewhere else — the archive is
+useless without it, and the machine you are backing up is exactly the thing you might lose
+next.
 
 **Restore it at setup.** Write a fresh image, boot the machine, and on the setup page choose
 "Restoring an existing Pithead? Upload its backup instead." above the form. Upload the archive

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -1,10 +1,13 @@
 # pithead-os build — known issues
 
-## Status: RAUC appliance, installs to disk, all batteries green (2026-07-25)
+## Status: RAUC appliance, installs to disk; the battery gates every cut
 
-`tests/os/run.sh` passes all five phases on the RAUC appliance — boot 4/4, update 15/15,
-provision 21/21, install 33/33 and fault 11/11 — with no brick in any run. The per-phase
-assertion list is in
+`tests/os/run.sh` has grown from the original five phases to eight — boot, update, install,
+provision, media, rig, fault and reset — and "green" means the full battery passing on the
+tip being cut, not a dated badge here: the 2026-08 waves each found real product bugs on a
+tip whose previous run had passed. The last fully-green run of the original five phases was
+2026-07-25 (boot 4/4, update 15/15, provision 21/21, install 33/33, fault 11/11, no brick in
+any run). The per-phase assertion list is in
 [the release doc's battery table](../docs/dev/appliance-release.md#the-automated-battery).
 The image ships the ESP and slot A only (636 MB);
 systemd-repart builds slot B and /data on the target's own disk, and `/data` measured
@@ -189,30 +192,31 @@ reason as the page's error text, the config as the retry prefill.
 
 ## Open
 
-- **Installing to a disk still needs a human.** Pre-seeding (`pithead-token.txt` /
+- **Installing to a disk still needs a human (#979).** Pre-seeding (`pithead-token.txt` /
   `pithead-config.json` on the ESP) covers configuration headlessly and the installer carries
   both onto the target, so a fleet can be flashed and provisioned from one file. Choosing
   which disk to erase is deliberately NOT automated — an unattended installer that picks a
   disk itself will eventually pick the wrong one. A pre-seeded target would need to name the
   disk by serial, not by `/dev/` path, and that is unbuilt.
-- **Everything host-CLI-only is impossible on the appliance (#786).** The control gate's
-  host-only class — wallets, view keys, auth, onion, workers.list, backup/restore — assumes
-  a host terminal that the appliance does not have. Right by design, unreachable by
-  accident: the wizard covers setup, but changing these later means reinstalling. #338's
-  out-of-band approval (or a physical-presence channel via the stick) is the lift;
-  dashboard backup export is the sharpest single loss.
-- **No user-facing OS update path exists yet.** RAUC and rollback are proven at the OS
-  layer, but nothing a user can reach applies an update: the dashboard action for
+- **Part of the host-CLI surface is still unreachable on the appliance (#786).** The GA
+  trio closed the sharpest losses: dashboard backup export (#908), restore at setup
+  (#909), and the media config channel (#910) — which also carries the settings the
+  dashboard never exposes, so "changing these later means reinstalling" no longer holds.
+  What remains rides the post-GA fast-follows: out-of-band approval at the commit gate
+  (#911), fleet descriptor editing (#912), and the CLI remainder on the dashboard (#913).
+- **No user-facing OS update path exists yet (#976).** RAUC and rollback are proven at the
+  OS layer, but nothing a user can reach applies an update: the dashboard action for
   install/commit/rollback of OS bundles is the pre-GA blocker, and the DIY one-click
   upgrade deliberately refuses on the appliance (a tarball upgrade would silently revert
-  at the next boot).
+  at the next boot). #976 holds the decision: build it before GA, or record that GA ships
+  without it — the roadmap's gate list (#394) currently omits it.
 - **The manual hardware battery has not been run.** Everything above is KVM. Secure Boot,
   real disks, headless discovery and a genuine power cut are exactly what a VM cannot
   show — M1-M10 in the release doc must pass on a physical box before an image ships.
-- **Only the wizard image is baked in.** The rest of the stack still pulls at provision
-  time, so the plan's "first boot works offline" property is partial: the setup page
-  works without a network, provisioning does not. Baking the full set roughly triples
+- **Only the wizard image is baked in (#978).** The rest of the stack still pulls at
+  provision time, so the plan's "first boot works offline" property is partial: the setup
+  page works without a network, provisioning does not. Baking the full set roughly triples
   the image and inflates every update bundle — sized deliberately, not forgotten.
-- **Hugepages are reserved unconditionally** (6 GiB), so the appliance needs ≥ 16 GiB
+- **Hugepages are reserved unconditionally (#977)** (6 GiB), so the appliance needs ≥ 16 GiB
   RAM to leave room for the stack. The harness sizes its VM accordingly; a real
   appliance should either check or scale the reservation.


### PR DESCRIPTION
Three accuracy fixes from the 2026-08-14 repo audit, all doc-only:

1. **appliance.md** carried a "restoring from a backup is not available yet" note written before #909 merged — directly contradicted by the "Recovering from a backup" section 30 lines below. Removed, replaced with a pointer.
2. **appliance.md** told two unreconciled backup stories (dashboard card with a machine-minted kit passphrase vs console `pithead backup` with a typed one) and never said which restore expects. The recovery section now leads with the card as the shell-less path, keeps the console as the alternative, and states restore accepts either archive with the passphrase that sealed it — which is what `firstboot_consume_restore` implements.
3. **os/KNOWN-ISSUES.md** is the appliance's debt ledger, and its status header was lying: "all batteries green (2026-07-25)" with five phases, while `tests/os/run.sh` has eight and the 2026-08 waves found real bugs on previously-green tips. Reworded so green means the full battery on the tip being cut. The #786 bullet predated the GA trio shipping — rewritten to the post-GA remainder (#911/#912/#913). Open bullets now carry the tracker numbers filed from the audit (#976–#979).

`make lint-docs-voice` and `make lint-md` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)