### PR TITLE
docs(release): draft-first publish ordering for a two-channel version

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -283,8 +283,12 @@ the morning.
 
 ## Cutting a release
 
-1. `develop` is green: `make lint && make test`, and `tests/os/run.sh --phase all` on the
-   bench.
+The branch mechanics are the DIY doc's ([releasing.md](releasing.md#branch-mechanics)):
+`develop` merges to `main` with a real merge and the cut runs from `main`. The steps here
+assume that has happened and both channels share one version and one GitHub Release.
+
+1. The release commit is green: `make lint && make test`, and `tests/os/run.sh --phase all`
+   on the bench.
 2. Bump `VERSION`. The tag is `v<VERSION>` and every artifact derives from it —
    `STACK_VERSION` is the single place the registry tag comes from.
 3. Build the image and bundle with the **release key**, never the throwaway `--dev` chain. Point
@@ -322,7 +326,11 @@ the morning.
    oneshot cgroup and systemd SIGKILLed the containers it had just spawned). Every check exists because its absence shipped, or nearly
    shipped, once.
 4. Run the manual battery (M1–M10) on real hardware. Record results.
-5. Publish image + bundle + checksums; the bundle's signature is what devices verify.
+5. Attach image + bundle + checksums to the version's GitHub Release **while it is still a
+   draft** (the DIY cut opens it with `release.sh --draft`), then publish once everything is
+   attached. Published release assets are immutable — v1.18.0 burned its tag this way — so
+   the release publishes exactly once, with both channels' artifacts aboard. The bundle's
+   signature is what devices verify.
 6. Back-merge `main` → `develop`, per the DIY release rule.
 
 ## Shipping a bad release

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -117,6 +117,11 @@ working tree is on any other branch. The branch model itself is in
    battery-tested and attached by hand *after* this stage (see
    [appliance-release.md](appliance-release.md#cutting-a-release)). Publishing before they
    are attached burns the tag. Draft first, attach both channels' artifacts, publish once.
+
+   One nuance: the git tag itself is pushed at this stage, and the `v*` ruleset blocks
+   re-pointing it — the draft protects the assets and the publish moment, not the version
+   number. A hardware-battery failure after the DIY cut still spends the version, so do not
+   start this stage until the appliance tree is believed final.
 9. Post-publish smoke ([#459](https://github.com/p2pool-starter-stack/pithead/issues/459)): run
    `make release-smoke` once against the just-published tag. It downloads the published bundle +
    images and verifies them for real, and — on the previous-release bench box — drives the real #59

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -110,6 +110,13 @@ working tree is on any other branch. The branch model itself is in
    notes, and attach release assets: a pinned `docker-compose.yml` / config bundle referencing
    `${STACK_VERSION}=vX.Y.Z`, its detached signature (`pithead.tar.gz.sig`), plus the ingredients
    manifest (exact component versions + promoted image digests).
+
+   **When the version ships the appliance channel too, pass `--draft`.** Published release
+   assets are immutable — v1.18.0 shipped an asset that could not be amended and the whole
+   version had to be withdrawn — and the appliance's `.img`/`.raucb` are built,
+   battery-tested and attached by hand *after* this stage (see
+   [appliance-release.md](appliance-release.md#cutting-a-release)). Publishing before they
+   are attached burns the tag. Draft first, attach both channels' artifacts, publish once.
 9. Post-publish smoke ([#459](https://github.com/p2pool-starter-stack/pithead/issues/459)): run
    `make release-smoke` once against the just-published tag. It downloads the published bundle +
    images and verifies them for real, and — on the previous-release bench box — drives the real #59


### PR DESCRIPTION
Gap found by the 2026-08-14 repo audit while sketching the v2 cut: neither release doc states when the shared GitHub Release may publish, and the two-channel flow makes the ordering load-bearing.

- Published release assets are **immutable** — v1.18.0 burned its tag on exactly this and had to be withdrawn as v1.18.1.
- The appliance's `.img`/`.raucb` are built, hardware-battery-tested, and attached **by hand after** the DIY stage completes.
- So a non-draft publish at the DIY stage bricks the shared-release model for any version that ships both channels.

releasing.md step 8 now mandates `release.sh --draft` for a two-channel version (the flag already exists — `scripts/release.sh:29`); appliance-release.md step 5 attaches to the still-draft release and publishes once, and its cut section now anchors to the DIY doc's branch mechanics (its step 1 said "`develop` is green" while the cut actually runs from `main`).

Doc-only. `make lint-docs-voice` and `make lint-md` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)