### PR TITLE
docs(README): present the two distributions — appliance + Compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ DIY is for a box that already does other things.
 
 This is the DIY path. For the appliance, download `pithead-os-vX.Y.Z.img` from
 [Releases](https://github.com/p2pool-starter-stack/pithead/releases) and follow
-[the appliance guide](docs/appliance.md) instead — there is nothing to type at all.
+[the appliance guide](docs/appliance.md) instead — no Linux to set up, no command line to learn.
 
 ```bash
 # Grab the latest release — pulls the published, tested images (no local build)
@@ -132,7 +132,7 @@ Full walkthrough: [docs/getting-started.md](docs/getting-started.md)
 
 | Guide | What's inside |
 |---|---|
-| **[Pithead OS — the appliance](docs/appliance.md)** | Write a USB stick, install on a dedicated machine, configure from a browser. The whole stack as one signed, self-updating image. |
+| **[Pithead OS — the appliance](docs/appliance.md)** | Write a USB stick, install on a dedicated machine, configure from a browser. The whole stack as one signed image with automatic fallback. |
 | **[Getting Started](docs/getting-started.md)** | The DIY path: prerequisites, install, first-run setup, and what to expect while the node syncs. |
 | **[Hardware Requirements](docs/hardware.md)** | Minimum vs. recommended specs for the stack host (CPU, RAM, disk, network), and how to run leaner. (Miner specs live in [RigForge](https://github.com/p2pool-starter-stack/rigforge).) |
 | **[Configuration](docs/configuration.md)** | Every `config.json` key, applying changes safely, reusing an existing node, and remote Monero nodes. |

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@
 
 [![CI](https://github.com/p2pool-starter-stack/pithead/actions/workflows/ci.yml/badge.svg)](https://github.com/p2pool-starter-stack/pithead/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-![Platform: Ubuntu 24.04](https://img.shields.io/badge/Platform-Ubuntu%2024.04-E95420?logo=ubuntu&logoColor=white)
+![Platform: appliance image or Ubuntu 24.04](https://img.shields.io/badge/Platform-appliance%20image%20%C2%B7%20Ubuntu%2024.04-E95420)
 ![Tor](https://img.shields.io/badge/Networking-Tor--first-7D4698?logo=torproject&logoColor=white)
 
 Docker Compose stack for Monero + Tari merge-mining on [P2Pool](https://github.com/SChernykh/p2pool),
 with a [Monero](https://www.getmonero.org/) full node, [Tari](https://www.tari.com/) base node, and
 a Tor daemon. The `pithead` script renders config, provisions Tor, and drives docker-compose.
+It ships two ways: **Pithead OS**, a bootable appliance image for a machine you dedicate to
+mining, and the **Compose stack** you run on a host you manage.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./images/launch/hero.png">
@@ -71,7 +73,23 @@ a Tor daemon. The `pithead` script renders config, provisions Tor, and drives do
 
 ---
 
+## 📀 Two ways to run it
+
+| | What you get | Start here |
+|---|---|---|
+| **Pithead OS** — the appliance | A bootable USB image that installs itself on a dedicated machine: no Linux to set up, configured from a browser, updated as one signed image that falls back on failure. | [The appliance guide](docs/appliance.md) |
+| **The Compose stack** — DIY | The same stack on a host you manage (Ubuntu Server 24.04): you keep the OS, `pithead` drives Docker Compose. | The Quick Start below |
+
+Same stack, same dashboard, same configuration either way. The appliance is the short road;
+DIY is for a box that already does other things.
+
+---
+
 ## 🚀 Quick Start
+
+This is the DIY path. For the appliance, download `pithead-os-vX.Y.Z.img` from
+[Releases](https://github.com/p2pool-starter-stack/pithead/releases) and follow
+[the appliance guide](docs/appliance.md) instead — there is nothing to type at all.
 
 ```bash
 # Grab the latest release — pulls the published, tested images (no local build)
@@ -114,7 +132,8 @@ Full walkthrough: [docs/getting-started.md](docs/getting-started.md)
 
 | Guide | What's inside |
 |---|---|
-| **[Getting Started](docs/getting-started.md)** | Prerequisites, install, first-run setup, and what to expect while the node syncs. |
+| **[Pithead OS — the appliance](docs/appliance.md)** | Write a USB stick, install on a dedicated machine, configure from a browser. The whole stack as one signed, self-updating image. |
+| **[Getting Started](docs/getting-started.md)** | The DIY path: prerequisites, install, first-run setup, and what to expect while the node syncs. |
 | **[Hardware Requirements](docs/hardware.md)** | Minimum vs. recommended specs for the stack host (CPU, RAM, disk, network), and how to run leaner. (Miner specs live in [RigForge](https://github.com/p2pool-starter-stack/rigforge).) |
 | **[Configuration](docs/configuration.md)** | Every `config.json` key, applying changes safely, reusing an existing node, and remote Monero nodes. |
 | **[The Dashboard](docs/dashboard.md)** | Sync Mode, a tour of the live operational view, and the opt-in control channel: editing config, one-click upgrades, and the audit logs from the browser. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,6 +3,10 @@
 Install and first-run setup, from a fresh Ubuntu host to a synced, mining stack. The `pithead`
 script drives every step.
 
+This is the DIY path: your host, your OS. To dedicate a machine and skip the host management
+entirely, write [the appliance image](appliance.md) to a USB stick instead — same stack, same
+dashboard, no Linux to set up.
+
 > **TL;DR**
 >
 > ```bash

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,9 +1,8 @@
 # Hardware Requirements
 
-Hardware sizing for the stack host. The same sizing applies whether the host runs
-[the appliance image](appliance.md) or the DIY Compose stack — the appliance guide's
-"What you need" section restates the essentials for that path. The stack runs on two kinds
-of machine with different needs:
+Hardware sizing for the stack host. For a machine running [the appliance image](appliance.md),
+the appliance guide's "What you need" section is the short version to follow. The stack runs
+on two kinds of machine with different needs:
 
 1. The stack host: the one machine that runs `./pithead` and the Docker stack (Monero node, P2Pool,
    Tari, the XMRig proxy, the dashboard, Tor). It does not mine — it runs the nodes and coordinates;

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -1,6 +1,9 @@
 # Hardware Requirements
 
-Hardware sizing for the stack host. The stack runs on two kinds of machine with different needs:
+Hardware sizing for the stack host. The same sizing applies whether the host runs
+[the appliance image](appliance.md) or the DIY Compose stack — the appliance guide's
+"What you need" section restates the essentials for that path. The stack runs on two kinds
+of machine with different needs:
 
 1. The stack host: the one machine that runs `./pithead` and the Docker stack (Monero node, P2Pool,
    Tari, the XMRig proxy, the dashboard, Tor). It does not mine — it runs the nodes and coordinates;


### PR DESCRIPTION
From the 2026-08-14 repo audit: README on develop-v2 was byte-identical to develop — the v2 headline feature was invisible from the repo front page. A reader could not learn Pithead OS exists.

- Intro sentence and platform badge now name both channels (the badge said Ubuntu 24.04; the appliance is its own OS).
- A **Two ways to run it** table sits ahead of Quick Start; Quick Start opens by routing appliance users to the image download and guide.
- The docs table gains an appliance row and labels Getting Started as the DIY path.
- `getting-started.md` and `hardware.md` each carry a one-line pointer to the appliance path, so no entry doc strands an appliance reader (the audit found zero appliance mentions in either).

Deliberately not touched: screenshots/imagery (rides #479, blocked on the logo decision) and faq.md (no natural slot without restructuring it).

Doc-only. `make lint-docs-voice` and `make lint-md` pass. Ponytail-review: one optional 1-line shrink, declined for voice-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)