### PR TITLE
fix: restart monerod whenever tor restarts, and notice when it strands (#972)

### DIFF
--- a/build/dashboard/mining_dashboard/client/monero/monero_client.py
+++ b/build/dashboard/mining_dashboard/client/monero/monero_client.py
@@ -78,6 +78,12 @@ class MoneroClient:
         `db_size` is monerod's on-disk database size in bytes (from get_info, available even
         under restricted RPC). The UI shows it next to the configured pruned/full mode so a
         config/DB mismatch is visible at a glance (Issue #32).
+
+        `synchronized` is monerod's raw network-sync verdict, passed through for the peer-loss
+        detector (#972): after a tor restart a stranded node can read as "synced" here (stale
+        target_height 0) while `synchronized` is false. Only this RPC path sets the key — the
+        log-scrape fallback and remote nodes have no verdict, and the detector treats absence
+        as no verdict.
         """
         info = self.get_info()
         if info is None:
@@ -86,12 +92,13 @@ class MoneroClient:
         height = int(info.get("height", 0) or 0)
         target = int(info.get("target_height", 0) or 0)
         db_size = int(info.get("database_size", 0) or 0)
+        synchronized = bool(info.get("synchronized", False))
 
         # `synchronized` is monerod's authoritative "caught up" flag; once synced it also
         # reports target_height: 0. Trust it over the height comparison (mirrors how the
         # Tari client trusts initial_sync_achieved).
-        if info.get("synchronized") or target == 0 or height >= target:
-            return {"is_syncing": False, "db_size": db_size}
+        if synchronized or target == 0 or height >= target:
+            return {"is_syncing": False, "db_size": db_size, "synchronized": synchronized}
 
         percent = int((height / target) * 100)
         return {
@@ -100,4 +107,5 @@ class MoneroClient:
             "target": target,
             "percent": percent,
             "db_size": db_size,
+            "synchronized": synchronized,
         }

--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -444,6 +444,13 @@ DASHBOARD_FAIL_CLOSED = os.environ.get("DASHBOARD_FAIL_CLOSED", "false").strip()
 NODE_DOWN_AFTER_SEC = int(os.environ.get("NODE_DOWN_AFTER_SEC", 90))
 NODE_RECOVERY_AFTER_SEC = int(os.environ.get("NODE_RECOVERY_AFTER_SEC", 60))
 
+# Peer-loss staleness (#972): a reachable monerod reporting `synchronized: false` must persist
+# this long before the out-of-sync alert fires. 10 minutes rides out normal tip-lag blips AND
+# the coupled monerod restart after a tor recreate (compose depends_on restart / tor_heal), so
+# only a node that genuinely failed to re-peer alarms. Env-only (tests/mini-stack), not a
+# config.json knob — nobody should have to tune a detector.
+NODE_STALE_AFTER_SEC = int(os.environ.get("NODE_STALE_AFTER_SEC", 600))
+
 # --- Healthchecks.io dead-man's switch (Issue #79) ---
 # Optional external liveness monitor. Set a ping URL and the dashboard loop pings it every cycle;
 # if the whole host dies (power loss, kernel panic, NIC death) the dashboard dies with it, the pings

--- a/build/dashboard/mining_dashboard/service/alert_service.py
+++ b/build/dashboard/mining_dashboard/service/alert_service.py
@@ -61,6 +61,10 @@ class AlertService:
       flag per node (#31). Tari is only alerted when it's treated as required; a non-blocking
       Tari going down isn't operator-critical (we keep mining Monero), matching the
       worker-rejection rule.
+    - **node out of sync / back in sync** — the debounced peer-loss strand (#972): monerod
+      reachable and healthy-looking but reporting ``synchronized: false`` past the stale
+      threshold (a tor restart kills its SOCKS peers and it doesn't re-dial). Rides the
+      ``node_down``/``node_recovered`` toggles — same conversation, different failure mode.
     - **sync finished** — the sync gate's ``miner_released`` latch flipping open once (#35).
     - **worker offline / back online / joined / left** — a debounced :class:`WorkerPresenceMonitor`
       over the live worker rows (offline keys off the same DOWN status the dashboard shows; joined /
@@ -184,6 +188,7 @@ class AlertService:
         self.host_label = "" if host_label in (None, "", "Unknown Host") else host_label
         # None = "not yet observed": the first cycle seeds the baseline without emitting.
         self._prev_monero_down = None
+        self._prev_monero_stale = None
         self._prev_tari_down = None
         self._prev_released = None
         self._prev_disk_level = None
@@ -232,6 +237,7 @@ class AlertService:
         self,
         *,
         monero_down,
+        monero_stale=False,
         tari_down,
         tari_required,
         miner_released,
@@ -273,6 +279,7 @@ class AlertService:
 
         # --- Node down / recovered (consume NodeHealthMonitor edges) ---
         alerts += self._node_edges("Monero", monero_down, "_prev_monero_down")
+        alerts += self._stale_edges(monero_stale)
         if tari_required:
             alerts += self._node_edges("Tari", tari_down, "_prev_tari_down")
         else:
@@ -377,6 +384,35 @@ class AlertService:
             (
                 self.EVT_NODE_RECOVERED,
                 self._fmt(f"\U0001f7e2 ⛓️ {label} node recovered — workers readmitted."),
+            )
+        ]
+
+    def _stale_edges(self, stale):
+        """Monero node reachable but OUT of sync (#972): the debounced ``synchronized: false``
+        strand a tor restart leaves behind. Distinct from node-down — the node answers its RPC
+        and every container reads healthy while mining sits on a stale tip. Rides the
+        node_down/node_recovered toggles: same conversation, different failure mode."""
+        prev = self._prev_monero_stale
+        self._prev_monero_stale = stale
+        if prev is None or stale == prev:
+            return []
+        if stale:
+            self._record_incident(self.EVT_NODE_DOWN)
+            return [
+                (
+                    self.EVT_NODE_DOWN,
+                    self._fmt(
+                        "\U0001f534 ⛓️ Monero node is OUT OF SYNC — reachable but reporting "
+                        "not-synchronized (peers usually die like this after a Tor restart). "
+                        "Mining sits on a stale tip until it re-peers: run "
+                        "'./pithead restart monerod'."
+                    ),
+                )
+            ]
+        return [
+            (
+                self.EVT_NODE_RECOVERED,
+                self._fmt("\U0001f7e2 ⛓️ Monero node is back in sync with the network."),
             )
         ]
 

--- a/build/dashboard/mining_dashboard/service/data_service.py
+++ b/build/dashboard/mining_dashboard/service/data_service.py
@@ -53,6 +53,7 @@ from mining_dashboard.config.config import (
     LOW_RAM_GB,
     MONERO_CLEARNET_SYNC,
     MONERO_WALLET_ADDRESS,
+    NODE_STALE_AFTER_SEC,
     PAYOUT_CONFIRM_ENABLED,
     REJECT_WORKERS_CONTAINER,
     SYNC_GATE_CONTAINERS,
@@ -638,6 +639,11 @@ class DataService:
         self.docker_control = DockerControl()
         self.monero_health = NodeHealthMonitor()
         self.tari_health = NodeHealthMonitor()
+        # Peer-loss staleness (#972): the same debounce machine, fed monerod's own
+        # `synchronized` flag instead of reachability. "Ever synchronized" plays the ever-up
+        # guard, so a node mid-initial-sync (synchronized false for days) never alarms; only a
+        # node that WAS in sync and stayed out for NODE_STALE_AFTER_SEC trips `down` (= stale).
+        self.monero_sync_stale = NodeHealthMonitor(down_after=NODE_STALE_AFTER_SEC)
 
         # Healthchecks.io dead-man's switch (Issue #79). Disabled by default — when off this is
         # a no-op. When on, each cycle pings a unique URL; the alert fires externally on the
@@ -1503,6 +1509,17 @@ class DataService:
                     monero_sync["down"] = monero_down
                     tari_sync["down"] = tari_down
 
+                    # 3b. Peer-loss staleness (#972): monerod can survive a tor restart with
+                    # every SOCKS peer dead — reachable, healthcheck green, height creeping,
+                    # but `synchronized: false` for hours. The RPC path is the only one that
+                    # carries the flag; absence (log-scrape fallback, remote node) is no
+                    # verdict, so the monitor isn't fed and its streaks stay put.
+                    monero_reports_synced = monero_sync.get("synchronized")
+                    if monero_reports_synced is not None:
+                        self.monero_sync_stale.update(monero_reports_synced)
+                    monero_stale = self.monero_sync_stale.down
+                    monero_sync["stale"] = monero_stale
+
                     # 4. Sync gate (Issue #35): hold p2pool + xmrig-proxy until the required
                     # chain(s) first sync, then release. monerod must be synced; Tari must be
                     # synced too unless it's non-blocking. #31's runtime failover only applies
@@ -1558,6 +1575,9 @@ class DataService:
                     )
                     await self.alert_service.process(
                         monero_down=monero_down,
+                        # Debounced "reachable but out of sync" (#972) — the 0-peer strand
+                        # after a tor restart that node-down can't see.
+                        monero_stale=monero_stale,
                         tari_down=tari_down,
                         tari_required=TARI_REQUIRED,
                         miner_released=self.miner_released,

--- a/build/dashboard/mining_dashboard/service/tor_heal.py
+++ b/build/dashboard/mining_dashboard/service/tor_heal.py
@@ -33,6 +33,13 @@ Tor network is overloaded", so fresh guards may be just as bad):
 
 The restart goes through the same start/stop-only docker-control proxy as the #31 failover.
 The manual leg is ``./pithead restart tor``. Real stuck-guard recovery is tier 4 (the live bench).
+
+A successful tor restart is followed by a monerod restart when the node is local (#972): the tor
+restart kills every SOCKS connection, and monerod keeps its dead peer sockets — bench-observed at
+0 in / 0 out peers for ~6 hours while every healthcheck stayed green. Compose couples the same
+restart for its own operations (``depends_on: tor: restart: true``); this healer bypasses compose,
+so it couples it here. Best-effort: a failed monerod cycle is logged and never refunds the tor
+attempt (the tor restart DID happen) — the out-of-sync alert is the backstop.
 """
 
 import asyncio
@@ -41,7 +48,12 @@ import time
 
 import requests
 
-from mining_dashboard.config.config import TOR_AUTO_HEAL, TOR_SOCKS_PROXY
+from mining_dashboard.config.config import (
+    LOCAL_MONERO_HOST,
+    MONERO_NODE_HOST,
+    TOR_AUTO_HEAL,
+    TOR_SOCKS_PROXY,
+)
 from mining_dashboard.helper.http import bounded_get
 
 logger = logging.getLogger("TorHeal")
@@ -74,9 +86,23 @@ class TorEgressHealer:
     """
 
     CONTAINER = "tor"
+    MONEROD = "monerod"
 
-    def __init__(self, docker_control, enabled=None, probe=None, notify=None, clock=time.monotonic):
+    def __init__(
+        self,
+        docker_control,
+        enabled=None,
+        probe=None,
+        notify=None,
+        clock=time.monotonic,
+        restart_monerod=None,
+    ):
         self.enabled = TOR_AUTO_HEAL if enabled is None else enabled
+        # Cycle monerod after a successful tor restart (#972) — only when the node is local
+        # (a remote monerod has no container here and keeps its own tor).
+        if restart_monerod is None:
+            restart_monerod = MONERO_NODE_HOST == LOCAL_MONERO_HOST
+        self._restart_monerod = restart_monerod
         self._docker = docker_control
         self._probe = probe or self._probe_egress
         self._notify = notify  # optional async callable(text) — the Telegram one-off
@@ -197,6 +223,26 @@ class TorEgressHealer:
                         "tor restart could not be issued via docker-control (unreachable) — "
                         "the attempt was refunded and will be retried on the next probe (#424)."
                     )
+                elif self._restart_monerod:
+                    # The tor restart just killed every SOCKS connection; monerod holds its
+                    # dead peer sockets and can sit at 0 in / 0 out peers for hours while
+                    # looking healthy (#972). Cycle it so it re-dials through the fresh tor.
+                    # monerod's stop_grace_period is 1m, so the stop timeout matches it and the
+                    # HTTP timeout outlasts the stop (#234's lesson).
+                    logger.warning(
+                        "Restarting monerod alongside tor so it re-dials its peers through "
+                        "the fresh Tor (#972)."
+                    )
+                    m_stopped = await self._docker.stop(
+                        self.MONEROD, stop_timeout=60, request_timeout=90
+                    )
+                    m_started = await self._docker.start(self.MONEROD, request_timeout=60)
+                    if not (m_stopped and m_started):
+                        logger.warning(
+                            "monerod restart alongside tor could not be issued — if the node "
+                            "stays out of sync, restart it manually: './pithead restart "
+                            "monerod' (#972)."
+                        )
             elif action == "exhausted":
                 if not self._warned_exhausted:
                     self._warned_exhausted = True

--- a/build/dashboard/tests/client/test_monero_client.py
+++ b/build/dashboard/tests/client/test_monero_client.py
@@ -76,6 +76,7 @@ class TestGetSyncStatus:
             "target": 100,
             "percent": 50,
             "db_size": 85_000_000_000,
+            "synchronized": False,
         }
 
     def test_synced_via_flag(self):
@@ -89,16 +90,39 @@ class TestGetSyncStatus:
                 "database_size": 200_000_000_000,
             }
         )
-        assert client.get_sync_status() == {"is_syncing": False, "db_size": 200_000_000_000}
+        assert client.get_sync_status() == {
+            "is_syncing": False,
+            "db_size": 200_000_000_000,
+            "synchronized": True,
+        }
 
     def test_synced_via_zero_target(self):
         # Synced monerod reports target_height: 0.
         client = self._client_with_info({"status": "OK", "height": 100, "target_height": 0})
-        assert client.get_sync_status() == {"is_syncing": False, "db_size": 0}
+        assert client.get_sync_status() == {
+            "is_syncing": False,
+            "db_size": 0,
+            "synchronized": False,
+        }
 
     def test_synced_when_height_reaches_target(self):
         client = self._client_with_info({"status": "OK", "height": 100, "target_height": 100})
-        assert client.get_sync_status() == {"is_syncing": False, "db_size": 0}
+        assert client.get_sync_status() == {
+            "is_syncing": False,
+            "db_size": 0,
+            "synchronized": False,
+        }
+
+    def test_stranded_node_reads_synced_but_carries_the_false_flag(self):
+        # The #972 strand: after a tor restart a peerless monerod can report target_height 0
+        # (stale) with synchronized false — the height math calls it "synced", so the raw
+        # `synchronized` passthrough is the ONLY signal the peer-loss detector gets.
+        client = self._client_with_info(
+            {"status": "OK", "synchronized": False, "height": 100, "target_height": 0}
+        )
+        status = client.get_sync_status()
+        assert status["is_syncing"] is False
+        assert status["synchronized"] is False
 
     def test_unreachable_returns_none(self):
         client = self._client_with_info(None)

--- a/build/dashboard/tests/service/test_alert_service.py
+++ b/build/dashboard/tests/service/test_alert_service.py
@@ -51,6 +51,7 @@ def _ev(
     svc,
     *,
     monero_down=False,
+    monero_stale=False,
     tari_down=False,
     tari_required=True,
     miner_released=True,
@@ -77,6 +78,7 @@ def _ev(
 ):
     return svc.evaluate(
         monero_down=monero_down,
+        monero_stale=monero_stale,
         tari_down=tari_down,
         tari_required=tari_required,
         miner_released=miner_released,
@@ -135,6 +137,38 @@ class TestNodeEdges:
         _ev(svc, monero_down=False)
         _, text = _ev(svc, monero_down=True)[0]
         assert "Monero" in text
+
+
+class TestNodeStale:
+    """The #972 peer-loss strand: monerod reachable but out of sync. Rides the node_down /
+    node_recovered toggles (same conversation), so it needs no new config surface."""
+
+    def test_first_cycle_seeds_baseline_silently(self):
+        svc = _svc()
+        # Already-stale at dashboard startup must not replay as a fresh alert.
+        assert _ev(svc, monero_stale=True) == []
+
+    def test_stale_then_back_in_sync(self):
+        svc = _svc()
+        _ev(svc, monero_stale=False)  # seed
+        assert _keys(_ev(svc, monero_stale=True)) == [AlertService.EVT_NODE_DOWN]
+        assert _ev(svc, monero_stale=True) == []  # no repeat while still stale
+        assert _keys(_ev(svc, monero_stale=False)) == [AlertService.EVT_NODE_RECOVERED]
+
+    def test_stale_text_names_the_fix_and_counts_an_incident(self):
+        svc = _svc()
+        _ev(svc, monero_stale=False)
+        _, text = _ev(svc, monero_stale=True)[0]
+        assert "OUT OF SYNC" in text and "restart monerod" in text
+        assert svc.drain_incidents() == {AlertService.EVT_NODE_DOWN: 1}
+
+    def test_independent_of_node_down_edge(self):
+        # Down and stale are different failure modes: a down edge must not clear or mask the
+        # stale baseline, and both can alert in the same cycle.
+        svc = _svc()
+        _ev(svc, monero_down=False, monero_stale=False)  # seed both
+        keys = _keys(_ev(svc, monero_down=True, monero_stale=True))
+        assert keys.count(AlertService.EVT_NODE_DOWN) == 2
 
 
 class TestTariGating:

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -1330,6 +1330,38 @@ class TestRunIteration:
             with pytest.raises(StopAsyncIteration):
                 await svc.run()
 
+    async def test_stale_monitor_not_fed_without_a_synchronized_verdict(self):
+        # No `synchronized` key (log-scrape fallback / remote node) = no verdict (#972): the
+        # stale monitor must not be fed, so its streaks stay put across blind cycles.
+        svc, sm, proxy = _make_service()
+        proxy.get_workers.return_value = {"workers": []}
+        svc.monero_sync_stale = MagicMock()
+        svc.monero_sync_stale.down = False
+        await self._run_one_iteration(
+            svc,
+            monero_sync={"is_syncing": False, "reachable": True},
+            tari_sync={"is_syncing": False, "reachable": True},
+        )
+        svc.monero_sync_stale.update.assert_not_called()
+        assert svc.latest_data["monero_sync"]["stale"] is False
+
+    async def test_stale_flag_fed_surfaced_and_passed_to_the_alerter(self):
+        # RPC verdict present (#972): the monitor is fed the raw flag, its debounced `down`
+        # lands in the snapshot as `stale`, and the alerter receives it as monero_stale.
+        svc, sm, proxy = _make_service()
+        proxy.get_workers.return_value = {"workers": []}
+        svc.monero_sync_stale = MagicMock()
+        svc.monero_sync_stale.down = True
+        svc.alert_service.process = AsyncMock(return_value=[])
+        await self._run_one_iteration(
+            svc,
+            monero_sync={"is_syncing": False, "reachable": True, "synchronized": False},
+            tari_sync={"is_syncing": False, "reachable": True},
+        )
+        svc.monero_sync_stale.update.assert_called_once_with(False)
+        assert svc.latest_data["monero_sync"]["stale"] is True
+        assert svc.alert_service.process.await_args.kwargs["monero_stale"] is True
+
     async def test_healthchecks_pinged_when_healthy(self):
         # Enabled + healthy → a plain liveness ping (no args) each cycle.
         svc, sm, proxy = _make_service()

--- a/build/dashboard/tests/service/test_tor_heal.py
+++ b/build/dashboard/tests/service/test_tor_heal.py
@@ -58,13 +58,16 @@ class _FailingDocker:
         return False
 
 
-def _healer(clock=None, enabled=True, probe=None, notify=None, docker=None):
+def _healer(clock=None, enabled=True, probe=None, notify=None, docker=None, restart_monerod=None):
+    # restart_monerod=None exercises the config default: the test env's MONERO_NODE_HOST equals
+    # LOCAL_MONERO_HOST (both defaults), i.e. a LOCAL node — heals also cycle monerod (#972).
     return TorEgressHealer(
         docker or _FakeDocker(),
         enabled=enabled,
         probe=probe or (lambda: False),
         notify=notify,
         clock=clock or _Clock(),
+        restart_monerod=restart_monerod,
     )
 
 
@@ -219,7 +222,9 @@ class TestCheck:
         await h.check()
         assert len(calls) == 2
 
-    async def test_heal_restarts_the_tor_container(self, caplog):
+    async def test_heal_restarts_tor_then_monerod(self, caplog):
+        # The tor restart kills monerod's SOCKS peers; the heal cycles monerod right after so
+        # it re-dials (#972) — order matters: monerod must come back to a LIVE tor.
         clock = _Clock()
         docker = _FakeDocker()
         h = _healer(clock, probe=lambda: False, docker=docker)
@@ -227,8 +232,42 @@ class TestCheck:
             await h.check()  # starts the failure streak
             clock.t += BROKEN_AFTER_SEC
             await h.check()  # sustained -> heal
-        assert docker.calls == [("stop", "tor"), ("start", "tor")]
+        assert docker.calls == [
+            ("stop", "tor"),
+            ("start", "tor"),
+            ("stop", "monerod"),
+            ("start", "monerod"),
+        ]
         assert any("Restarting the tor container" in r.message for r in caplog.records)
+
+    async def test_remote_node_heal_touches_only_tor(self):
+        # A remote monerod has no container here — the heal must stay tor-scoped.
+        clock = _Clock()
+        docker = _FakeDocker()
+        h = _healer(clock, probe=lambda: False, docker=docker, restart_monerod=False)
+        await h.check()
+        clock.t += BROKEN_AFTER_SEC
+        await h.check()
+        assert docker.calls == [("stop", "tor"), ("start", "tor")]
+
+    async def test_failed_monerod_cycle_warns_but_keeps_the_tor_attempt(self, caplog):
+        # monerod failing to cycle must not refund the tor budget slot — the tor restart DID
+        # happen; the warning points at the manual leg and the stale alert is the backstop.
+        class _MonerodFailingDocker(_FakeDocker):
+            async def start(self, container, **kwargs):
+                self.calls.append(("start", container))
+                return container != "monerod"
+
+        clock = _Clock()
+        docker = _MonerodFailingDocker()
+        h = _healer(clock, probe=lambda: False, docker=docker)
+        with caplog.at_level("WARNING", logger="TorHeal"):
+            await h.check()
+            clock.t += BROKEN_AFTER_SEC
+            await h.check()
+        assert ("stop", "monerod") in docker.calls
+        assert h._restarts == 1  # tor attempt kept, not refunded
+        assert any("restart monerod" in r.message for r in caplog.records)
 
     async def test_exhausted_warns_but_never_restarts(self, caplog):
         clock = _Clock()
@@ -238,11 +277,11 @@ class TestCheck:
         for _ in range(MAX_RESTARTS):
             clock.t += max(BROKEN_AFTER_SEC, COOLDOWN_SEC)
             await h.check()
-        assert len(docker.calls) == 2 * MAX_RESTARTS  # budget fully spent
+        assert len(docker.calls) == 4 * MAX_RESTARTS  # budget fully spent (tor + monerod each)
         with caplog.at_level("WARNING", logger="TorHeal"):
             clock.t += COOLDOWN_SEC
             await h.check()
-        assert len(docker.calls) == 2 * MAX_RESTARTS  # no further restarts, ever
+        assert len(docker.calls) == 4 * MAX_RESTARTS  # no further restarts, ever
         assert any("STILL broken" in r.message for r in caplog.records)
 
     async def test_recovery_sends_the_one_time_notify(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -822,8 +822,9 @@ services:
       - proxy_net
 
   # --- Docker Control Proxy (start/stop only) ---
-  # A second, minimal proxy used ONLY to stop/start p2pool + xmrig-proxy: node-down worker
-  # failover (Issue #31) and holding the miner until the nodes finish syncing (Issue #35).
+  # A second, minimal proxy used ONLY to stop/start p2pool + xmrig-proxy — node-down worker
+  # failover (Issue #31), holding the miner until the nodes finish syncing (Issue #35) — plus
+  # tor (#424) and monerod after a tor heal (#972).
   # With POST=1 but every section (CONTAINERS, EXEC, IMAGES, …) left off, the v0.4.2 ruleset
   # allows exactly `POST /containers/<id>/{start,stop}` and denies everything else
   # (create/kill/exec/reads). Kept separate from the read-only proxy above so opening POST
@@ -856,7 +857,8 @@ services:
     # can't scope start/stop to specific containers, so keeping this proxy off `mining_net` and only
     # on the host loopback is what stops a compromised mining container from start/stopping the whole
     # stack. The dashboard reaches it at 127.0.0.1:12376; it only ever names p2pool/xmrig-proxy —
-    # plus tor for the opt-in guard self-heal restart (#424).
+    # plus tor for the opt-in guard self-heal restart (#424), and monerod right after a successful
+    # tor heal (#972: a tor cycle strands monerod's peers, so the heal re-dials the local node too).
     ports:
       - "127.0.0.1:12376:2375"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,14 @@ services:
     depends_on:
       tor:
         condition: service_healthy
+        # A tor restart/recreate kills every SOCKS connection, and monerod keeps its dead peer
+        # sockets: bench-observed at 0 in / 0 out peers for ~6h with the healthcheck passing
+        # throughout (#972). restart: true makes every compose operation that restarts or
+        # recreates tor (up/apply/upgrade recreation, './pithead restart tor') restart monerod
+        # right after tor is healthy again, so it re-dials through the fresh Tor (recovers in
+        # about a minute). Needs compose >= 2.17. The dashboard's tor auto-heal (#424) bypasses
+        # compose, so tor_heal.py couples the same restart itself.
+        restart: true
     healthcheck:
       # The RPC username/password are read from the container's env inside the script, NOT
       # interpolated into the test command — so they no longer leak via `docker inspect` (#90).

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -68,6 +68,7 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | Tari down + required → reject; Tari down + non-blocking → **ignore** | `tari_down ∧ TARI_REQUIRED?` | 1 ✅ · 3 ▶ |
 | Recovery hysteresis — readmit only after stable `NODE_RECOVERY_AFTER_SEC` | reachable again | 1 ✅ |
 | Transient blip / never-reachable → **no** false reject | debounce / `ever_up` | 1 ✅ |
+| Monero node reachable but **out of sync** — the post-tor-restart 0-peer strand (#972): raw `synchronized` passthrough, debounced stale flag, alert via the `node_down` toggle, monerod restarted alongside tor (compose `depends_on: restart` + the #424 auto-heal), `restart monerod` leg, doctor WARN | `synchronized: false` ≥ `NODE_STALE_AFTER_SEC` after being in sync once | 1 ✅ (client/data_service/alert/tor_heal pytest, `tests/stack` doctor + restart + compose invariants) · 2 ✅ (flag over the wire) · 4 (real strand + re-peer needs the bench) |
 | Double outage; readmit only when **both** healthy | both down → both up | 1 ✅ (added) · 3 ▶ |
 | #35 latch × #31 failover coexist after release | down post-release | 1 ✅ (added) · 3 ▶ |
 | Stop/start fails → retry next cycle (idempotent) | docker error | 1 ✅ |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,11 +10,11 @@ Command reference for `pithead`, the CLI that manages the stack. Run `./pithead 
 | `./pithead apply` | Preview and apply `config.json` changes. Warns before disruptive ones and recreates only what changed. `-y` / `--yes` skips the prompt. |
 | `./pithead up` | Start the stack. |
 | `./pithead down` | Stop the stack. |
-| `./pithead restart [tor]` | Restart the stack. `restart tor` restarts only the tor container so it picks fresh guards when Tor clearnet egress is stuck (#424) — every Tor circuit drops and rebuilds, mining onions included. See [Tor egress broken while mining works](#troubleshooting). |
+| `./pithead restart [tor\|monerod]` | Restart the stack, or one container. `restart tor` picks fresh guards when Tor clearnet egress is stuck (#424) — every Tor circuit drops and rebuilds, mining onions included, and a local monerod restarts right after tor is healthy again so it re-dials its peers (#972). `restart monerod` re-dials peers on its own when the node reports not synchronized after a Tor restart. See [Tor egress broken while mining works](#troubleshooting). |
 | `./pithead upgrade` | Re-render the generated config, then **pull** (release bundle) or **rebuild** (source checkout) the images and restart. Run after downloading a newer bundle or a `git pull`. |
 | `./pithead logs [service]` | Follow logs for all containers, or a single service (e.g. `logs p2pool`). |
 | `./pithead status` | Show container status and health-check every expected service. Warns about anything down/unhealthy and exits non-zero if so (handy for cron/monitoring). Profile-aware, and treats a stopped `p2pool`/`xmrig-proxy` as intentional during a node-down failover or while the miner is held until the chains sync. |
-| `./pithead doctor` | Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk, `.env`/onion state, and container status — plus runtime checks: the Tor container is actually running while the mining stack runs (a loud FAIL when it's down — the privacy backbone is dead), the Tor-egress firewall rules are actually installed (a reboot silently drops them while the containers auto-restart), something is listening on stratum `:3333` (and whether that port sits on a public IP), the dashboard app answers behind its container, and a clearnet request through Tor's SOCKS succeeds (a failing Tor guard breaks Healthchecks/Telegram/XvB while mining still works — fix with `./pithead restart tor`, or set `tor.auto_heal: true` to automate it). A paste-able health report. |
+| `./pithead doctor` | Read-only diagnostics: deps, Docker, AVX2, HugePages, RAM/disk, `.env`/onion state, and container status — plus runtime checks: the Tor container is actually running while the mining stack runs (a loud FAIL when it's down — the privacy backbone is dead), the Tor-egress firewall rules are actually installed (a reboot silently drops them while the containers auto-restart), something is listening on stratum `:3333` (and whether that port sits on a public IP), the dashboard app answers behind its container, a clearnet request through Tor's SOCKS succeeds (a failing Tor guard breaks Healthchecks/Telegram/XvB while mining still works — fix with `./pithead restart tor`, or set `tor.auto_heal: true` to automate it), and a local monerod reports `synchronized` from its own RPC (a node stranded at 0 peers by a Tor restart keeps a green healthcheck while mining sits on a stale tip — fix with `./pithead restart monerod`, #972). A paste-able health report. |
 | `./pithead backup` | Save `config.json`, `.env`, `Caddyfile`, the Tor onion keys, and the dashboard's database (your hashrate history & settings) to a timestamped, passphrase-encrypted archive under `backups/` (checks free space first; stops a running stack for a clean copy, then restarts it). `--with-chains` also includes the blockchain data; `--no-encrypt` writes a plaintext `tar.gz`; `-y` / `--yes` skips the prompts (low free space and stopping the stack). |
 | `./pithead restore <archive>` | Restore those files from a backup archive, encrypted or plaintext (asks before overwriting; fixes Tor key ownership). `-y` / `--yes` skips the prompt. |
 | `./pithead reset-dashboard` | **DESTRUCTIVE**. Wipes and recreates the dashboard and P2Pool data. `-y` / `--yes` skips the prompt. |
@@ -532,14 +532,34 @@ confirms it: the Tor clearnet-egress check WARNs while everything else reads hea
 ./pithead restart tor
 ```
 
-The restart makes Tor reselect guards; all Tor circuits drop and rebuild (p2pool/monerod re-peer
-on their own within minutes). Re-run `./pithead doctor` to confirm egress recovered. To have the
-stack do this itself, set `tor.auto_heal: true` in `config.json` and run `./pithead apply`: the
-dashboard then probes Tor clearnet egress every 5 minutes and restarts tor once egress has been
-broken for 15 minutes — at most 3 restarts per outage, 30 minutes apart, each logged and followed
-by a Telegram note once the path is back. If the Tor network itself is overloaded, it stops
+The restart makes Tor reselect guards; all Tor circuits drop and rebuild. p2pool re-peers on its
+own within minutes; monerod does **not** — it keeps its dead SOCKS connections and can sit at
+0 peers for hours while its healthcheck stays green (#972) — so a local monerod is restarted
+right after tor is healthy again and re-dials in about a minute. Re-run `./pithead doctor` to
+confirm egress recovered. To have the stack do this itself, set `tor.auto_heal: true` in
+`config.json` and run `./pithead apply`: the dashboard then probes Tor clearnet egress every 5
+minutes and restarts tor (and, on a local node, monerod) once egress has been broken for 15
+minutes — at most 3 restarts per outage, 30 minutes apart, each logged and followed by a
+Telegram note once the path is back. If the Tor network itself is overloaded, it stops
 restarting and keeps warning instead. Off by default: a tor restart drops every circuit, so the
 stack does not restart its privacy boundary unbidden. (#424)
+
+**Monero node out of sync after a Tor restart.**
+Anything that restarts or recreates the tor container outside the stack's own operations — a
+Docker daemon restart, a manual `docker restart tor` — kills every SOCKS connection, and monerod
+keeps the dead sockets: 0 in / 0 out peers, `get_info` reporting `synchronized: false`, height
+creeping on occasional lucky dials, every healthcheck green. Detection: the dashboard alerts
+through the `node_down` toggle once the node has been out of sync for 10 minutes (only after it
+was in sync at least once, so initial sync never trips it), and `./pithead doctor` (Monero sync
+check) WARNs on the live state. Fix:
+
+```bash
+./pithead restart monerod
+```
+
+Stack operations don't need the manual step: compose restarts monerod automatically whenever it
+restarts or recreates tor (`up`, `apply`, `upgrade`, `restart tor`), and the `tor.auto_heal`
+restart does the same. (#972)
 
 **The dashboard data looks broken and you want a clean slate.**
 `./pithead reset-dashboard` wipes and recreates the dashboard and P2Pool data. This is

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -154,8 +154,8 @@ block and set it to `false` — any event you don't list stays on:
 
 | Event key | Default | Alert |
 |---|---|---|
-| `node_down` | `true` | Monero/Tari node went down |
-| `node_recovered` | `true` | …and came back |
+| `node_down` | `true` | Monero/Tari node went down; also the Monero node reachable but out of sync for 10+ minutes (peers lost after a Tor restart) |
+| `node_recovered` | `true` | …and came back / back in sync |
 | `worker_offline` | `true` | A rig went DOWN |
 | `worker_recovered` | `true` | …and came back |
 | `worker_joined` | `true` | A new rig joined the fleet |

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -23,8 +23,8 @@ transition, not a stream:
 
 | Alert | When it fires |
 |---|---|
-| 🔴 **Node down** | Your Monero (or Tari) node has been unreachable long enough to be considered down — the stack has stopped serving your rigs so they **fail over to their backup pools**. |
-| 🟢 **Node recovered** | The node is back and stable; the stack has readmitted your rigs. |
+| 🔴 **Node down** | Your Monero (or Tari) node has been unreachable long enough to be considered down — or the Monero node is reachable but has sat out of sync for 10+ minutes (the stranded-peers state a Tor restart can leave behind). Either way the stack has stopped serving your rigs so they **fail over to their backup pools**. |
+| 🟢 **Node recovered** | The node is back — reachable and in sync — and stable; the stack has readmitted your rigs. |
 | 🔴 **Worker offline** | A rig stopped hashing and hasn't been seen for a few minutes (a reboot, a dropped connection, a dead miner) — it's showing **DOWN** on the dashboard. |
 | 🟢 **Worker back online** | A rig that had gone offline is hashing again. |
 | 🟢 **New worker joined** | A rig the stack hasn't seen before connected — a new miner joined the fleet. |

--- a/pithead
+++ b/pithead
@@ -258,7 +258,7 @@ stack_down() {
     log "Stack stopped."
 }
 
-stack_restart() { # [tor]
+stack_restart() { # [tor|monerod]
     case "${1:-}" in
     "")
         log "Restarting stack..."
@@ -268,14 +268,28 @@ stack_restart() { # [tor]
     tor)
         # Manual leg of the #424 guard self-heal: restart ONLY tor so it picks fresh guards
         # when clearnet exits are stuck (the doctor Tor clearnet-egress check WARNs on this).
-        # Only tor is accepted here — other containers must go through apply/upgrade, whose
-        # recreate applies current args (a bare restart would reuse stale ones, #273); tor
-        # takes no args from .env, so a plain restart is safe and is exactly the fix.
-        log "Restarting the tor container to pick fresh guards — ALL Tor circuits drop and rebuild (mining onions included; p2pool/monerod re-peer on their own)..."
+        # Tor takes no args from .env, so a plain restart is safe (other containers go
+        # through apply/upgrade, whose recreate applies current args, #273). Compose then
+        # restarts monerod right after tor is healthy again (depends_on restart: true, #972):
+        # monerod does NOT re-peer on its own after a tor restart kills its SOCKS
+        # connections — it can sit at 0 in / 0 out peers for hours; p2pool re-peers fine.
+        log "Restarting the tor container to pick fresh guards — ALL Tor circuits drop and rebuild (mining onions included; p2pool re-peers on its own, and a local monerod is restarted alongside so it re-dials)..."
         docker compose restart tor
         log "tor restarted. Verify egress recovered: './pithead doctor' (Tor clearnet-egress check)."
         ;;
-    *) error "restart takes no argument, or 'tor' (fresh Tor guards when clearnet egress is stuck). Got: '$1'." ;;
+    monerod)
+        # Peer-loss recovery (#972): a tor restart/recreate outside compose (docker itself, or
+        # the #424 auto-heal when its coupled monerod restart could not be issued) leaves
+        # monerod holding dead SOCKS sockets — reachable, healthcheck green, but
+        # `synchronized: false` with 0 peers for hours. A plain restart re-dials through the
+        # running tor and recovers in about a minute. Safe under the #273 recreate-only rule
+        # for the same reason as tor: re-peering wants the container's args EXACTLY as they
+        # are — config changes still go through apply.
+        log "Restarting the monerod container so it re-dials its peers through Tor..."
+        docker compose restart monerod
+        log "monerod restarted. It should report synchronized again within a few minutes — verify: './pithead doctor' (Monero sync check)."
+        ;;
+    *) error "restart takes no argument, 'tor' (fresh Tor guards when clearnet egress is stuck), or 'monerod' (re-dial peers after a Tor restart left the node out of sync). Got: '$1'." ;;
     esac
 }
 
@@ -1061,6 +1075,7 @@ doctor() {
             dr_warn "No containers reported by 'docker compose ps' — the stack may be stopped (run './pithead up') or run from a different directory."
         fi
         check_dashboard_answers
+        check_monerod_synchronized
     fi
 
     # --- Summary ---
@@ -1512,9 +1527,11 @@ Setup & configuration:
 Lifecycle:
   up                        Start the stack.
   down                      Stop the stack.
-  restart [tor]             Restart the stack — or only the tor container, which picks
-                            fresh guards when Tor clearnet egress is stuck (drops
-                            and rebuilds all Tor circuits).
+  restart [tor|monerod]     Restart the stack — or one container: 'tor' picks fresh
+                            guards when Tor clearnet egress is stuck (drops and rebuilds
+                            all Tor circuits; a local monerod restarts alongside);
+                            'monerod' re-dials peers when the node reports not
+                            synchronized after a Tor restart.
   upgrade                   Re-render generated config and rebuild/restart the stack after
                             an update — a 'git pull' on source installs, or an extracted
                             release bundle (the dashboard's one-click upgrade runs this).
@@ -2000,6 +2017,42 @@ check_tor_clearnet_egress() {
         dr_ok "Tor clearnet egress works — Healthchecks, Telegram, and XvB can reach their services."
     else
         dr_warn "Tor is up but a clearnet request through its SOCKS timed out — Healthchecks pings, Telegram, and XvB stats are likely down while mining still works (a failing Tor guard does this, #424). Fix: './pithead restart tor' picks fresh guards; set tor.auto_heal:true in config.json to have the stack do this itself."
+    fi
+    return 0
+}
+
+# doctor (#972): a monerod that survived a tor restart with every SOCKS peer dead looks healthy —
+# container up, healthcheck green (it only probes the RPC), height even creeping on occasional
+# lucky dials — while `get_info` reports `synchronized: false` and mining sits on a stale tip.
+# Probe from the host with the .env digest creds (the monerod image carries no curl) and trust
+# the RAW `synchronized` flag, like the dashboard's out-of-sync alert: a stranded node can report
+# a stale target_height of 0, so any height math reads it as caught up — the flag is the node's
+# own verdict. WARN not FAIL: a node mid-initial-sync legitimately reports the same thing for
+# days. Silently skips when no monerod container runs (remote mode, stack down).
+check_monerod_synchronized() {
+    container_is_running monerod || return 0
+    if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        dr_info "Monero sync check skipped — needs curl and jq."
+        return 0
+    fi
+    local user pass url body
+    user=$(env_get MONERO_NODE_USERNAME 2>/dev/null)
+    pass=$(env_get MONERO_NODE_PASSWORD 2>/dev/null)
+    url=$(env_get MONERO_RPC_URL 2>/dev/null)
+    [ -n "$url" ] || url="http://127.0.0.1:18081"
+    if [ -n "$user" ]; then
+        body=$(curl -fsS --max-time 8 --digest -u "$user:$pass" "$url/get_info" 2>/dev/null)
+    else
+        body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null)
+    fi
+    if [ -z "$body" ]; then
+        dr_info "Monero sync check skipped — monerod's RPC did not answer (the container table above shows whether it is still starting)."
+        return 0
+    fi
+    if printf '%s' "$body" | jq -e '(.status == "OK") and (.synchronized == true)' >/dev/null 2>&1; then
+        dr_ok "monerod reports synchronized with the Monero network."
+    else
+        dr_warn "monerod is running but reports NOT synchronized — normal during initial sync; if it stays like this on a previously-synced node (peers lost after a Tor restart), './pithead restart monerod' re-dials and recovers in about a minute."
     fi
     return 0
 }

--- a/pithead-completion.bash
+++ b/pithead-completion.bash
@@ -52,10 +52,11 @@ _pithead() {
         COMPREPLY=($(compgen -W "$(_pithead_services "$compose")" -- "$cur"))
         return
     fi
-    # `restart` takes exactly one optional argument: tor (fresh guard selection, #424).
+    # `restart` takes exactly one optional argument: tor (fresh guard selection, #424) or
+    # monerod (re-dial peers after a tor restart left the node out of sync, #972).
     if [ "$prev" = "restart" ]; then
         # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "tor" -- "$cur"))
+        COMPREPLY=($(compgen -W "tor monerod" -- "$cur"))
         return
     fi
     # shellcheck disable=SC2207  # command names never contain whitespace

--- a/tests/integration/fakes/test_contract.py
+++ b/tests/integration/fakes/test_contract.py
@@ -41,7 +41,7 @@ def test_monero_synced_reads_no_sync_and_db_size():
     with FakeMonerod(database_size=85 * 10**9) as m:
         client = MoneroClient(url=m.url, username="")
         st = client.get_sync_status()
-    assert st == {"is_syncing": False, "db_size": 85 * 10**9}
+    assert st == {"is_syncing": False, "db_size": 85 * 10**9, "synchronized": True}
 
 
 def test_monero_syncing_reports_percent():
@@ -52,6 +52,8 @@ def test_monero_syncing_reports_percent():
     assert st["is_syncing"] is True
     assert st["current"] == 1500 and st["target"] == 3000 and st["percent"] == 50
     assert st["db_size"] == 40 * 10**9
+    # The raw wire flag rides along for the peer-loss detector (#972).
+    assert st["synchronized"] is False
 
 
 def test_monero_down_is_unreachable():
@@ -79,7 +81,7 @@ def test_monero_synced_by_height_even_without_flag():
 def test_monero_db_size_unknown_reads_zero():
     with FakeMonerod(database_size=0) as m:
         st = MoneroClient(url=m.url, username="").get_sync_status()
-    assert st == {"is_syncing": False, "db_size": 0}
+    assert st == {"is_syncing": False, "db_size": 0, "synchronized": True}
 
 
 def test_monero_http_control_mutates_state():

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -196,6 +196,7 @@ printf '%s\n' "${SS_OUT:-}"
 EOF
 cat >"$DRBIN/curl" <<'EOF'
 #!/usr/bin/env bash
+[ -n "${CURL_BODY:-}" ] && printf '%s' "$CURL_BODY"
 exit "${CURL_RC:-0}"
 EOF
 chmod +x "$DRBIN"/*
@@ -279,6 +280,27 @@ assert_contains "tor egress probe: WARN never fails doctor (rc 0)" "$out" "rc=0"
 out="$(RUNNING_CONTAINERS="" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_tor_clearnet_egress 2>&1)"
 assert_contains "tor egress probe: tor down -> info skip" "$out" "isn't running"
 
+echo "== unit: doctor Monero sync check — peer-loss strand (#972) =="
+# A monerod stranded by a tor restart keeps a green healthcheck while get_info reports
+# synchronized:false — the check trusts the RAW flag (a stranded node can report a stale
+# target_height of 0, so height math lies) and WARNs, never FAILs (initial sync reads the same).
+out="$(RUNNING_CONTAINERS="monerod" CURL_BODY='{"status":"OK","synchronized":true,"target_height":0}' PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_monerod_synchronized 2>&1)"
+assert_contains "monerod sync: synchronized -> OK" "$out" "reports synchronized"
+out="$(RUNNING_CONTAINERS="monerod" CURL_BODY='{"status":"OK","synchronized":false,"target_height":0,"height":3000000}' PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_monerod_synchronized 2>&1)"
+assert_contains "monerod sync: stranded (raw flag false, stale target 0) -> WARN" "$out" "NOT synchronized"
+assert_contains "monerod sync: WARN names the fix" "$out" "restart monerod"
+out="$(
+    RUNNING_CONTAINERS="monerod" CURL_BODY='{"status":"OK","synchronized":false,"target_height":10}' PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_monerod_synchronized 2>&1
+    echo "rc=$?"
+)"
+assert_contains "monerod sync: WARN never fails doctor (rc 0)" "$out" "rc=0"
+# RPC not answering (container mid-start) -> info skip; no monerod container (remote mode /
+# stack down) -> silent skip, no verdict either way.
+out="$(RUNNING_CONTAINERS="monerod" CURL_RC=7 PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_monerod_synchronized 2>&1)"
+assert_contains "monerod sync: RPC silent -> info skip" "$out" "did not answer"
+out="$(RUNNING_CONTAINERS="" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_monerod_synchronized 2>&1)"
+assert_eq "monerod sync: no container -> silent skip" "$out" ""
+
 echo "== unit: stack_restart — scoped tor restart (#424) =="
 # `restart` bare restarts the whole stack; `restart tor` restarts ONLY tor (fresh guard
 # selection when clearnet egress is stuck); anything else is rejected — other containers must
@@ -296,10 +318,15 @@ assert_contains "restart tor restarts only the tor container" "$(cat "$RSTLOG")"
 assert_contains "restart tor warns that circuits drop" "$out" "circuits drop"
 assert_contains "restart tor points at the doctor verify" "$out" "doctor"
 : >"$RSTLOG"
+# `restart monerod` (#972): the manual re-peer leg after a tor restart left the node out of sync.
+out="$(DOCKER_LOG="$RSTLOG" PATH="$RSTBIN:$PATH" run_sourced "$SANDBOX" stack_restart monerod 2>&1)"
+assert_contains "restart monerod restarts only the monerod container" "$(cat "$RSTLOG")" "compose restart monerod"
+assert_contains "restart monerod says why (re-dial peers)" "$out" "re-dials"
+: >"$RSTLOG"
 out="$(DOCKER_LOG="$RSTLOG" PATH="$RSTBIN:$PATH" run_sourced "$SANDBOX" stack_restart p2pool 2>&1)"
 rc=$?
-assert_rc "restart rejects any service but tor" "$rc" "1"
-assert_contains "restart rejection names the contract" "$out" "takes no argument, or 'tor'"
+assert_rc "restart rejects any service but tor/monerod" "$rc" "1"
+assert_contains "restart rejection names the contract" "$out" "takes no argument, 'tor'"
 assert_eq "rejected restart touches no container" "$(cat "$RSTLOG")" ""
 
 echo "== unit: is_ipv4 =="

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -275,6 +275,14 @@ for edge in "monerod=tor" "tari=tor" "wallet-rpc=monerod" "tari-wallet=tari"; do
 done
 jq_assert "xmrig-proxy waits for p2pool service_started only, not health-gated (#565)" \
     '.services["xmrig-proxy"].depends_on["p2pool"].condition == "service_started"'
+# Peer-loss coupling (#972): a tor restart/recreate kills monerod's SOCKS peers and monerod does
+# NOT re-dial on its own (bench: 0 in / 0 out peers for ~6h, healthcheck green). restart: true
+# makes every compose operation that restarts/recreates tor restart monerod right after — and it
+# is deliberately the ONLY such coupling: p2pool re-peers on its own.
+jq_assert "monerod restarts whenever compose restarts/recreates tor (#972)" \
+    '.services["monerod"].depends_on["tor"].restart == true'
+jq_assert "the tor restart coupling stays monerod-only (#972)" \
+    '[.services[] | (.depends_on // {}) | to_entries[] | select(.value.restart == true)] | length == 1'
 jq_assert "p2pool has no depends_on — both monerod and tari can be profiled off (#103/#565)" \
     '(.services["p2pool"].depends_on // {}) == {}'
 # Count guard: a NEW depends_on edge (health-gated or not) added anywhere in the file must show up


### PR DESCRIPTION
Root cause: a tor container recreate strands monerod's peers (height creeps, `synchronized` stays false) and nothing noticed — the bench recipe was a manual monerod restart.

**Recovery, coupled to the cause rather than a detector:**
- `docker-compose.yml`: monerod's tor dependency gains `restart: true` — every compose operation that cycles tor restarts monerod right after tor is healthy again (empirically verified against compose v2.40: both `restart` and `up -d` recreation propagate, health-gated). Needs compose ≥2.17 (2023); noted inline.
- `tor_heal.py`: the #424 auto-heal bypasses compose, so a successful heal now cycles monerod itself (local node only; timeouts sized to monerod's stop grace).
- `pithead restart monerod`: the manual leg for tor cycles outside the stack; `restart tor` text corrected (monerod does NOT re-peer on its own).

**Detection, reusing what exists:**
- The raw `synchronized` flag rides through `get_sync_status` (a stranded node reports stale `target_height: 0`, so height math lies; the flag is the only honest signal).
- `NodeHealthMonitor` surfaces `monero_sync.stale` in `/api/state` after 10 min out-of-sync (initial sync never alarms — `ever_up` doubles as ever-synchronized), and the alert rides the existing `node_down`/`node_recovered` keys — no new event key, closed schema untouched.
- `doctor` gains a host-side sync probe (WARN naming the fix, not FAIL).

**Deliberately not done** (reasons in the diff): no monerod healthcheck flip (`synchronized:false` would mark days-long legitimate initial sync unhealthy and `service_healthy` gates would deadlock fresh installs); no detector-driven auto-restart (recovery is coupled to the tor events that cause the strand).

Tests: 6 new doctor + 3 restart shell cases, compose invariants, client/alert/data-service/tor-heal pytest, contract-test wire flag. Evidence: `make lint` clean; dashboard 1701 passed (96.99%); stack suite 1704 ✓; patch coverage 100% on changed Python. Real strand + re-peer is tier-4: the pre-cut targeted e2e should observe recreate-tor → auto-restart → `monero_caught_up` green.

Adversarial verify: needs-fix on two doc-honesty items (control-proxy blast-radius comment, telegram.md self-contradiction) — both fixed in the follow-up commit.

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)