### PR TITLE
feat(compose): healthchecks for the five services that had none (#904)

### DIFF
--- a/build/dashboard/Dockerfile
+++ b/build/dashboard/Dockerfile
@@ -50,8 +50,10 @@ RUN python -m pytest --cov=mining_dashboard --cov-report=term-missing --cov-fail
 # ==========================================================================
 FROM base AS production
 COPY --from=build /app/.venv /app/.venv
-COPY entrypoint.sh .
-RUN chmod +x entrypoint.sh
+# entrypoint runs the app; healthcheck.sh (#904) HEADs /api/state with the venv's own python3
+# (the slim image ships no curl/wget).
+COPY entrypoint.sh healthcheck.sh ./
+RUN chmod +x entrypoint.sh healthcheck.sh
 
 # Stack version, baked at build so the running container is self-describing (Issue #58).
 # PITHEAD_VERSION comes from the top-level VERSION file (the source of truth); the git args

--- a/build/dashboard/healthcheck.sh
+++ b/build/dashboard/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Dashboard HTTP liveness (#904).
+#
+# HEAD /api/state against the app's fixed loopback bind (main.py: 127.0.0.1:8000). aiohttp
+# serves HEAD on every GET route, so a 200 proves the web server is listening AND build_state
+# assembles — the exact "container Up while Caddy serves 502s" state the v1.8.1 one-click
+# incident exposed (#622). The slim image ships no curl/wget; python3 (the app's own venv,
+# already on PATH) probes with stdlib urllib, which raises — exiting non-zero — on any
+# connect failure or non-2xx status.
+exec python3 -c 'import urllib.request as u; u.urlopen(u.Request("http://127.0.0.1:8000/api/state", method="HEAD"), timeout=5)'

--- a/build/xmrig-proxy/Dockerfile
+++ b/build/xmrig-proxy/Dockerfile
@@ -24,6 +24,11 @@ RUN wget -O xmrig-proxy.tar.gz https://github.com/xmrig/xmrig-proxy/releases/dow
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Control-API liveness healthcheck (#904) — reads the port from env so nothing rides the compose
+# command line (#90).
+COPY healthcheck.sh /usr/local/bin/xmrig-proxy-healthcheck.sh
+RUN chmod +x /usr/local/bin/xmrig-proxy-healthcheck.sh
+
 # Run non-root (#255) — the easy win: pure network proxy, no bind-mounts, already cap_drop:[ALL]
 # + no-new-privileges in compose. Reuse ubuntu:24.04's 'ubuntu' user (uid 1000) and give it a
 # writable home as the cwd in case xmrig-proxy drops a config/log there.

--- a/build/xmrig-proxy/healthcheck.sh
+++ b/build/xmrig-proxy/healthcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# xmrig-proxy control-API liveness (#904).
+#
+# A TCP connect to the HTTP API port proves the proxy is up and serving. The API — not the
+# stratum listener — is the honest probe here: a failed stratum bind kills the process outright
+# (the container restart is already visible), while the HTTP API can die quietly, and it is what
+# the dashboard polls for worker stats. The port is read from the container env, never
+# interpolated into the compose command (#90); a bare connect needs no token, so auth material
+# stays out of the probe. /dev/tcp is a bash builtin (the image ships bash) so no extra tooling
+# is needed; `timeout` guards against a wedged connect.
+exec timeout 5 bash -c "</dev/tcp/127.0.0.1/${PROXY_API_PORT:?}" 2>/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -533,6 +533,17 @@ services:
         ipv4_address: ${NETWORK_PREFIX:-172.28.0}.29
     depends_on:
       - p2pool
+    healthcheck:
+      # Control-API liveness (#904): a TCP connect to the HTTP API port, via a script that reads
+      # the port from env (#90 — nothing interpolated here). The API is the honest probe: a failed
+      # stratum bind kills the process outright (already visible as a restart), while the API can
+      # die quietly — and it is what the dashboard polls for worker stats. Surfaced in
+      # `pithead status` and the container-health alert (#337); gates nothing (no dependents).
+      test: ["CMD", "/usr/local/bin/xmrig-proxy-healthcheck.sh"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # --- Monitoring Dashboard ---
   dashboard:
@@ -774,6 +785,17 @@ services:
       - NTFY_URL=${NTFY_URL:-}
       - NTFY_TOKEN=${NTFY_TOKEN:-}
       - NOTIFY_TOR=${NOTIFY_TOR:-true}
+    healthcheck:
+      # HTTP liveness (#904): HEAD /api/state against the app's fixed loopback bind — a 200
+      # proves the server answers where Caddy proxies AND that state assembly works, the state a
+      # bare "Up" hid in the v1.8.1 incident (dashboard serving 502s behind an Up container,
+      # #622). start_period covers app start plus a SQLite auto-heal rebuild (#490) without
+      # counting failures, so a warmup blip never false-fails a one-click upgrade's status view.
+      test: ["CMD", "/app/healthcheck.sh"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
 
   # --- Docker Socket Proxy (read-only) ---
   # Read-only window onto the Docker API for the dashboard's container stats/logs.
@@ -812,6 +834,16 @@ services:
       - "127.0.0.1:12375:2375"
     networks:
       - proxy_net
+    healthcheck:
+      # End-to-end liveness (#904): GET /_ping THROUGH HAProxy to the Docker daemon, proving the
+      # proxy actually brokers the socket — not merely that a process exists. /_ping is in the
+      # image's default-allow set (PING=1), so the probe widens nothing; busybox wget ships in
+      # the alpine-based image.
+      test: ["CMD", "wget", "-q", "--spider", "-T", "5", "http://127.0.0.1:2375/_ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # --- Docker Control Proxy (start/stop only) ---
   # A second, minimal proxy used ONLY to stop/start p2pool + xmrig-proxy: node-down worker
@@ -853,6 +885,14 @@ services:
       - "127.0.0.1:12376:2375"
     networks:
       - proxy_net
+    healthcheck:
+      # Same end-to-end /_ping probe as docker-proxy (#904): the PING=1 default allows it
+      # independently of the POST-only ruleset here, so the start/stop scope stays untouched.
+      test: ["CMD", "wget", "-q", "--spider", "-T", "5", "http://127.0.0.1:2375/_ping"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   # --- Caddy Reverse Proxy ---
   # Bridges the local 127.0.0.1 application binding to the LAN
@@ -887,6 +927,18 @@ services:
       # JSON access log (#349): Caddy rolls it natively (4 MiB × 3 files, see generate_caddyfile);
       # the dashboard mounts the same dir read-only to show recent accesses and failed logins.
       - ${CADDY_LOG_DIR:-./data/caddy-logs}:/var/log/caddy
+    healthcheck:
+      # Config-loaded liveness (#904): probe Caddy's admin API on its default localhost:2019 bind
+      # (the host loopback under network_mode: host; the generated Caddyfile never disables it).
+      # /config/ answers 200 only from a running Caddy with its config loaded — more than
+      # process-up, but deliberately not a vhost probe: the LAN vhost's scheme, port and auth all
+      # vary with config, and busybox wget can't speak the internal-CA TLS. wget ships in the
+      # alpine-based image (curl does not).
+      test: ["CMD", "wget", "-q", "--spider", "-T", "5", "http://127.0.0.1:2019/config/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
 # --- Volumes ---
 volumes:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -83,6 +83,10 @@ it works from any checkout or bundle directory.
 
 `status` prints the usual compose table, then a per-service health check: a green ✓ for each
 running (and healthy) service, and a ⚠/✗ for anything unhealthy, restarting, stopped, or missing.
+Every container carries its own healthcheck — including the dashboard, Caddy, xmrig-proxy and the
+two Docker-socket proxies — so a ✓ means the service answers its probe, not merely that a process
+exists. A service whose check hasn't passed yet shows as starting, which is normal for a minute
+after a start or upgrade.
 It exits non-zero when something needs attention, so you can wire it into a cron/monitoring check.
 A stopped `p2pool`/`xmrig-proxy` is reported as intentional, not an error: the dashboard stops it
 either to fail workers over a node-down outage or while the miner is held until the required chains

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -288,6 +288,25 @@ jq_assert "exactly 5 depends_on edges total (#565)" \
 # runs fine (#777). Asserted here because tari-wallet only renders under tari_payout_confirm.
 jq_assert "tari-wallet healthcheck pattern survives ps CMD truncation (#777)" \
     '(.services["tari-wallet"].healthcheck.test | tostring) | contains("[m]inotari_consol") and (contains("[m]inotari_console_wallet") | not)'
+# Compose healthchecks close the #904 gap. `pithead status` and the dashboard's container-health
+# alert (#337) read these states, and a service without a check reports Up even when dead inside —
+# so with every profile active (this render), no service may lack one, and each of the five late
+# arrivals probes real readiness with tooling its own image ships.
+jq_assert "every service carries a healthcheck (#904)" \
+    '[.services[] | select(.healthcheck == null)] | length == 0'
+jq_assert "xmrig-proxy healthcheck probes the control API via script (#904)" \
+    '.services["xmrig-proxy"].healthcheck.test == ["CMD", "/usr/local/bin/xmrig-proxy-healthcheck.sh"]'
+jq_assert "dashboard healthcheck probes /api/state via script (#904)" \
+    '.services.dashboard.healthcheck.test == ["CMD", "/app/healthcheck.sh"]'
+jq_assert "caddy healthcheck probes the admin endpoint with wget (#904)" \
+    '(.services.caddy.healthcheck.test | tostring) | contains("wget") and contains("2019/config/")'
+jq_assert "both socket proxies healthcheck /_ping through HAProxy (#904)" \
+    '[.services["docker-proxy"], .services["docker-control"]] | all((.healthcheck.test | tostring) | contains("wget") and contains("2375/_ping"))'
+# The standing #90 bar, applied to the new probes: no secret rides in a rendered healthcheck
+# command. The env file above sets PROXY_AUTH_TOKEN=token, so any interpolation of the API token
+# into a probe would surface as the literal "token" here.
+jq_assert "no healthcheck command carries the proxy auth token (#90/#904)" \
+    '[.services[] | (.healthcheck.test | tostring)] | all(contains("token") | not)'
 # Profile-map drift guard (#822, same pattern as the depends_on count guard above): compose never
 # removes a profile-deactivated service's container (#795), so remove_deactivated_profile_containers
 # in the pithead script is the only thing that does — and it hardcodes the service↔profile map.


### PR DESCRIPTION
Closes the healthcheck gap for the five services that had none: xmrig-proxy, dashboard, caddy, docker-proxy, docker-control. All 30s interval / 5s timeout / 3 retries, 30s start_period (60s for the dashboard, measured cold-start ~<15s plus DB auto-heal headroom).

Probe choices, each constrained by what exists inside the image:
- **xmrig-proxy**: bash `/dev/tcp` connect to the API port (port from env per #90) — the API is what the dashboard polls and can die quietly, while a failed stratum bind is fatal and already visible.
- **dashboard**: venv python3 urllib HEAD `/api/state` (slim image has no curl/wget).
- **caddy**: busybox wget spider of the admin API (`:2019/config/`, never disabled by our Caddyfile rendering) — the vhost is not probeable generically (scheme/port/auth vary; busybox can't do internal-CA TLS), reason in the compose comment.
- **docker-proxy / docker-control**: wget spider of `/_ping` — end-to-end through HAProxy to the daemon, default-allowed independent of POST gating, and the probe command carries no auth token (asserted by a test).

Flapping/#622 analysis in the PR's compose comments: nothing gates on these healths — no `depends_on` references them, `pithead` never runs `--wait`, and both consumers (`pithead status`, the #337 ContainerHealthMonitor with its 120s debounce) treat "starting" as not-a-problem; verified by reading both paths, zero code changes needed there.

Tier-1: `tests/stack/test_compose.sh` asserts every rendered service now carries a healthcheck, pins the five probe commands, and asserts no token leaks into any healthcheck. docs/operations.md documents the new "starting" states.

Evidence: compose suite 81 ✓ / 0 ✗; `make lint` clean. Adversarial verify: ready-with-nits.

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)