### PR TITLE
fix(dashboard): keep the XvB decision table visible while XvB is off (#938)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -572,23 +572,38 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
 // own auto rule), what holding it costs, and the current vs target tier for context. Labelled
 // raffle status, never a payout. The draw is random above the threshold — donating more within
 // a tier buys nothing — but the odds themselves ARE knowable (#872: qualifier counts from XvB's
-// winners file), so the comparison dropdown shows them. Hidden entirely while XvB is disabled.
+// winners file), so the comparison dropdown shows them. Rendered with XvB disabled too (#938) —
+// the block is the enable/don't-enable decision aid — but the live-credit cards (Current/Target
+// tier) stand down with the flag: there is no credited donation to report.
 // `coeffDay` (earnings.coeff_day) feeds the per-tier payout comparison dropdown below.
 function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
-  if (!calc || !calc.enabled) return null;
+  if (!calc) return null;
   const t = computeXvbTier(hr, calc);
   return html`
     <div class="xvb-tier-block">
         <h4>XvB Tier (raffle)</h4>
+        ${
+          calc.enabled
+            ? null
+            : html`<p class="text-muted text-xs" id="xvb-disabled-note">
+                XvB donation is off — this table prices what enabling it would earn and cost at
+                your hashrate. Nothing is fetched from xmrvsbeast.com while it is off, so the
+                odds and reward columns run from the last cached read.</p>`
+        }
         <div class="stat-grid">
             <${StatCard} label="Sustainable Tier" value=${t ? t.tier : "None"} cls="c-purple"
                          title="The highest XvB donor tier this hashrate sustains while leaving P2Pool its share — the same auto rule the donation controller uses." />
             <${StatCard} label="Hashrate Cost" value=${t ? fmtHashrate(t.cost) : "—"}
                          title="Holding the tier means continuously donating about its threshold — hashrate that earns no P2Pool shares while donated." />
+            ${
+              calc.enabled
+                ? html`
             <${StatCard} label="Current Tier" value=${calc.current_tier}
                          title="The tier your credited XvB donation clears right now (the lower of XvB's 1h and 24h averages)." />
             <${StatCard} label="Target Tier" value=${calc.target_tier}
-                         title=${"The tier the donation controller is configured to aim for" + (calc.sustainable ? "." : " — currently NOT sustainable at your hashrate.")} />
+                         title=${"The tier the donation controller is configured to aim for" + (calc.sustainable ? "." : " — currently NOT sustainable at your hashrate.")} />`
+                : null
+            }
         </div>
         ${
           // Current-tier expected reward (#712) in the same standardized Day/Month/Year table
@@ -807,14 +822,17 @@ class EarningsCard extends Component {
     const est = computeEarnings(hr, e);
     const xvb = this.props.xvb;
     const energy = this.props.energy;
-    // Tabs split the (now multi-domain) card body. XvB only appears when it's enabled and Energy only
-    // when the fleet reports any power — there's nothing to show otherwise. The one what-if input
-    // above the strip drives every tab's estimate.
+    // Tabs split the (now multi-domain) card body. The XvB tab stays with XvB disabled (#938) —
+    // its decision table is exactly the "should I enable it?" aid — as long as the server sent a
+    // tier table (a pre-#938 disabled payload carries none, and enabled always does). Energy only
+    // appears when the fleet reports any power — there's nothing to show otherwise. The one
+    // what-if input above the strip drives every tab's estimate.
+    const showXvb = !!(xvb && (xvb.enabled || (xvb.tiers || []).length));
     const tabs = [
       { id: "monero", label: "Monero" },
       { id: "tari", label: "Tari" },
     ];
-    if (xvb && xvb.enabled) tabs.push({ id: "xvb", label: "XvB" });
+    if (showXvb) tabs.push({ id: "xvb", label: "XvB" });
     if (energy && energy.available) tabs.push({ id: "energy", label: "Energy" });
     const active = tabs.some((t) => t.id === tab) ? tab : "monero";
     // Fiat estimates (#520): each tab grows ≈-fiat rows once its coin's price is known — static
@@ -876,7 +894,7 @@ class EarningsCard extends Component {
             </div>
 
             ${
-              xvb && xvb.enabled
+              showXvb
                 ? html`
             <div role="tabpanel" id="epanel-xvb" aria-labelledby="etab-xvb" hidden=${active !== "xvb"}>
                 <${XvbTierBlock} calc=${xvb} hr=${hr} coeffDay=${e.coeff_day} energy=${energy} est=${est} />

--- a/build/dashboard/mining_dashboard/web/static/logic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/logic.mjs
@@ -295,9 +295,11 @@ export function computeEarnings(hashrateHs, earnings) {
 // helper/utils.resolve_target_threshold (get_tier_info over stable_hr × max_fraction) — a pinned
 // test shares its inputs with the Python unit test so the two can't drift silently. Cost = the
 // threshold itself: XvB qualifies a tier on BOTH the 1h and 24h credited averages, so holding it
-// costs ~threshold H/s of continuous donation. Null when no tier is sustainable or XvB is off.
+// costs ~threshold H/s of continuous donation. Null when no tier is sustainable. Not gated on
+// calc.enabled: the what-if runs from local hashrate and the published thresholds, so it answers
+// "which tier could I hold?" before XvB is ever turned on (#938).
 export function computeXvbTier(hashrateHs, calc) {
-  if (!calc || !calc.enabled || !(hashrateHs > 0)) return null;
+  if (!calc || !(hashrateHs > 0)) return null;
   let best = null;
   for (const t of calc.tiers || []) {
     if (t.threshold > 0 && hashrateHs * calc.max_fraction >= t.threshold) {
@@ -318,8 +320,10 @@ export function computeXvbTier(hashrateHs, calc) {
 //   net        — the actionable verdict: (yours ?? study ?? face) minus cost; [lo,hi] when a band
 // A tier the what-if hashrate cannot sustain is flagged, its net withheld (an unreachable payout
 // must not render as reachable). Pure + unit-tested; the component only renders these rows.
+// Not gated on calc.enabled: the table is the enable/don't-enable decision aid (#938) — the
+// server publishes the tiers either way, and a disabled box just has no live-credit context.
 export function xvbDecisionRows(calc, coeffDay, hr) {
-  if (!calc || !calc.enabled) return [];
+  if (!calc) return [];
   const rows = [];
   for (const t of calc.tiers || []) {
     const cost = t.threshold > 0 && coeffDay > 0 ? t.threshold * coeffDay * DAYS_PER_YEAR : null;

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1822,10 +1822,16 @@ def build_xvb_calc(metrics, state_mgr, realization=None):
     cumulative forecast) and ``players_avg`` (which also makes a single-qualifier artifact like
     Mega's self-evident). ``realized_reward_year`` scales the published figure by this wallet's
     measured win realization (``realization``, from ``xvb_realization``) — None when unmeasured,
-    so the client falls back to the study band; face value shows only in its own column. Returns ``{"enabled": False}`` alone when
-    XvB is off — there is no tier to calculate."""
-    if not metrics.xvb_enabled:
-        return {"enabled": False}
+    so the client falls back to the study band; face value shows only in its own column.
+
+    Published with XvB DISABLED too (#938): the table is the enable/don't-enable decision aid, so
+    hiding it behind the flag defeated its purpose. Everything here is computable from local
+    config plus the cached public feeds; disabling XvB stops the fetches (the egress rule, #726),
+    so on a box that never enabled XvB the odds and reward columns are honestly empty and on a
+    just-disabled box they age out through the same staleness rule as always. The live-credit
+    context goes quiet on its own: ``build_state`` computes ``realization`` only while enabled,
+    and ``Metrics`` reports current/target tier as "Disabled" — the client keys every
+    live-donation surface (and the current/target cards here) off ``enabled``."""
     tiers = state_mgr.get_tiers()
     round_state = state_mgr.get_xvb_round_stats()
     round_types = (
@@ -1851,7 +1857,7 @@ def build_xvb_calc(metrics, state_mgr, realization=None):
     estimates_stale = xvb_stats_are_stale(est_state)
     estimates_available = bool(estimates) and not estimates_stale
     return {
-        "enabled": True,
+        "enabled": metrics.xvb_enabled,
         # Ascending tier table for the client's what-if; names via get_tier_info so they read
         # exactly like the tier strings everywhere else (threshold already embedded in the name).
         # expected_reward_year is XvB's own figure for the tier, or None when unavailable/stale.

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -271,7 +271,7 @@ test('EarningsCard leads with solo time-to-block + per-block reward, day as avg 
     assert.doesNotMatch(down, /NaN/);
 });
 
-test('EarningsCard renders the XvB tier (raffle) block when XvB is on, hides it when off (#118)', () => {
+test('EarningsCard renders the XvB tier (raffle) block on and off — off drops the live-credit cards (#938)', () => {
     const s = clone();
     s.earnings.available = true;
     s.xvb_calc = {
@@ -297,10 +297,18 @@ test('EarningsCard renders the XvB tier (raffle) block when XvB is on, hides it 
     assert.match(up, /Hashrate Cost/);
     assert.match(up, /1\.00 kH\/s/);
     assert.match(up, /not an XMR payout/);   // the required labelling rides on the card
-    // XvB disabled → the whole block disappears; the XMR calculator stays.
-    s.xvb_calc = { enabled: false };
+    assert.doesNotMatch(up, /id="xvb-disabled-note"/); // the off-explainer only shows off
+    // XvB disabled (#938): the decision aid stays — what-if cards, table, note — but the
+    // live-credit cards (Current/Target tier) stand down and the off-explainer appears.
+    s.xvb_calc = { ...s.xvb_calc, enabled: false, current_tier: 'Disabled', target_tier: 'Disabled' };
     const off = renderApp({ state: s });
-    assert.doesNotMatch(off, /XvB Tier \(raffle\)/);
+    assert.match(off, /XvB Tier \(raffle\)/);
+    assert.match(off, /Sustainable Tier/);
+    assert.match(off, /Hashrate Cost/);
+    assert.match(off, /id="xvb-disabled-note"/);
+    assert.match(off, /not an XMR payout/);
+    assert.doesNotMatch(off, /Current Tier/);
+    assert.doesNotMatch(off, /Target Tier/);
     assert.match(off, /Your P2Pool Hashrate/);
 });
 
@@ -331,14 +339,27 @@ test('EarningsCard splits into Monero / Tari / XvB tabs, Monero active by defaul
     assert.match(html, /XvB Tier \(raffle\)/);
 });
 
-test('EarningsCard drops the XvB tab entirely when XvB is disabled (#118)', () => {
+test('EarningsCard keeps the XvB tab when disabled; only a tier-less payload drops it (#938)', () => {
     const s = clone();
     s.earnings.available = true;
+    // Disabled with a tier table (what the server now always sends): the tab stays — it holds
+    // the enable/don't-enable decision aid.
+    s.xvb_calc = {
+        enabled: false, max_fraction: 0.85,
+        tiers: [{ name: 'Donor (1.00 kH/s+)', threshold: 1000 }],
+        current_tier: 'Disabled', target_tier: 'Disabled',
+        note: 'raffle status', mode_note: null,
+    };
+    let html = renderApp({ state: s });
+    assert.match(html, /id="etab-xvb"/);
+    assert.match(html, /id="epanel-xvb"/);
+    assert.match(html, /XvB Tier \(raffle\)/);
+    // A pre-#938 disabled payload carries no tiers — nothing to price, so no tab either.
     s.xvb_calc = { enabled: false };
-    const html = renderApp({ state: s });
+    html = renderApp({ state: s });
     assert.match(html, /id="etab-monero"/);
     assert.match(html, /id="etab-tari"/);
-    assert.doesNotMatch(html, /id="etab-xvb"/); // no XvB tab
+    assert.doesNotMatch(html, /id="etab-xvb"/);
     assert.doesNotMatch(html, /id="epanel-xvb"/);
     assert.doesNotMatch(html, /XvB Tier \(raffle\)/);
 });

--- a/build/dashboard/tests/frontend/logic.test.mjs
+++ b/build/dashboard/tests/frontend/logic.test.mjs
@@ -339,12 +339,15 @@ test('computeXvbTier: between tiers picks the lower one', () => {
     assert.equal(computeXvbTier(60_000, XVB_CALC).threshold, 10_000);
 });
 
-test('computeXvbTier: null when disabled, calc missing, empty tiers, or bad hashrate', () => {
-    assert.equal(computeXvbTier(15_000, { ...XVB_CALC, enabled: false }), null);
+test('computeXvbTier: null when calc missing, empty tiers, or bad hashrate', () => {
     assert.equal(computeXvbTier(15_000, null), null);
     assert.equal(computeXvbTier(15_000, { ...XVB_CALC, tiers: [] }), null);
     assert.equal(computeXvbTier(0, XVB_CALC), null);
     assert.equal(computeXvbTier(null, XVB_CALC), null);
+});
+
+test('computeXvbTier: still computes with XvB disabled — the what-if is the decision aid (#938)', () => {
+    assert.equal(computeXvbTier(15_000, { ...XVB_CALC, enabled: false }).threshold, 10_000);
 });
 
 // --- xvbDecisionRows (#872) — the per-tier decision table's pure math -------------------
@@ -400,7 +403,15 @@ test('xvbDecisionRows: no coeff (network stats down) -> no cost, no net, never a
     assert.equal(whale.cost, null);
     assert.equal(whale.net, null);
     assert.equal(whale.mode, 'none');
-    assert.equal(xvbDecisionRows({ enabled: false }, 1e-7, 200_000).length, 0);
+    assert.equal(xvbDecisionRows(null, 1e-7, 200_000).length, 0);
+});
+
+test('xvbDecisionRows: XvB disabled still prices the table (#938)', () => {
+    // The rows are the enable/don't-enable comparison, so the flag doesn't empty them —
+    // a disabled payload with tiers prices identically to an enabled one.
+    const rows = xvbDecisionRows({ ..._CALC, enabled: false }, 1e-7, 200_000);
+    assert.equal(rows.length, 2);
+    assert.ok(Math.abs(rows[1].cost - 3.65) < 1e-9);
 });
 test('formatXmr: precision scales with magnitude; "—" for null/invalid', () => {
     assert.equal(formatXmr(2.5), '2.5000 XMR');        // >= 1 -> 4 dp

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -2286,9 +2286,27 @@ class TestXvbCalc:
         }
         return sm
 
-    def test_disabled_returns_enabled_false_only(self):
-        # XvB off → nothing to calculate; the whole payload is the single flag.
-        assert build_xvb_calc(_metrics(xvb_enabled=False), self._sm()) == {"enabled": False}
+    def test_disabled_still_publishes_the_decision_table(self):
+        # #938: XvB off no longer collapses the payload to the bare flag — the table is the
+        # enable/don't-enable decision aid, so the tiers, draw odds, and prior band publish
+        # either way (from local config + the cached feeds; the flag stops the fetches, so a
+        # never-enabled box degrades through the same staleness rules as always). enabled=False
+        # still rides along: the client's live-donation surfaces key off it.
+        out = build_xvb_calc(
+            _metrics(xvb_enabled=False, current_tier="Disabled", target_tier="Disabled"),
+            self._sm(),
+        )
+        assert out["enabled"] is False
+        assert [t["threshold"] for t in out["tiers"]] == [1_000, 10_000, 100_000, 1_000_000]
+        whale = next(t for t in out["tiers"] if t["threshold"] == 100_000)
+        assert whale["win_odds_day"] == pytest.approx((56 / 7.0) / 8.0)
+        lo, hi = views.XVB_REALIZATION_PRIOR
+        assert whale["assumed_reward_year_range"] == pytest.approx([6.17 * lo, 6.17 * hi])
+        assert out["max_fraction"] == views.XVB_MAX_DONATION_FRACTION
+        # Live-credit context passes through what Metrics reports on a disabled box; realization
+        # is never computed while off (build_state's gate), so the measured fields stay None.
+        assert out["current_tier"] == "Disabled"
+        assert out["realization_pct"] is None
 
     def test_tier_table_sorted_ascending_and_zero_thresholds_dropped(self):
         out = build_xvb_calc(_metrics(), self._sm())

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -433,8 +433,9 @@ The card is split into tabs — **Monero**, **Tari**, **XvB**, and **Energy** �
 Monero holds the XMR estimate, time-to-share, and block reward; Tari holds the solo time-to-block,
 per-block reward, and long-run average; XvB holds the tier/cost block, the current tier's expected
 reward (tempered by measured delivery — see the decision table below), and the per-tier payout
-comparison. The XvB tab appears only when XvB is enabled,
-and the Energy tab only when the fleet reports power (see [Energy & profit](#energy--profit)).
+comparison. The XvB tab stays with XvB disabled — its decision table is the "should I enable
+it?" aid — and the Energy tab appears only when the fleet reports power (see
+[Energy & profit](#energy--profit)).
 
 Every tab presents its rate estimate in the same **Day / Month / Year** table: the coin figure,
 plus a `≈` fiat column once that coin's price is known (see *Prices* under
@@ -630,9 +631,13 @@ Set the keys in `config.json` and run `./pithead apply`. Key reference: the `mon
 ### XvB Tier (raffle)
 
 A block inside the earnings card, driven by the same what-if hashrate input, that answers "which
-XMRvsBeast tier could this hashrate hold, and what would it cost?". Hidden entirely while XvB is
-disabled (`xvb.enabled: false`). The raffle winner is drawn at random among everyone above the
-threshold, so donating more than the threshold buys zero extra win chance — but the odds
+XMRvsBeast tier could this hashrate hold, and what would it cost?". It renders with XvB disabled
+too (`xvb.enabled: false`) — the decision table below is exactly the enable/don't-enable aid, so
+it must be readable *before* you enable anything. While disabled, the two live-credit rows
+(Current Tier, Target Tier) disappear, and — because disabling XvB stops every fetch from
+xmrvsbeast.com — the odds and reward columns run from the last cached read: on a box that never
+enabled XvB they show tier costs only. The raffle winner is drawn at random among everyone above
+the threshold, so donating more than the threshold buys zero extra win chance — but the odds
 themselves are knowable: XvB's winners file publishes the qualifier count for every round, and
 the comparison below shows them.
 
@@ -640,8 +645,8 @@ the comparison below shows them.
 |---|---|
 | **Sustainable Tier** | The highest XvB donor tier the entered hashrate sustains while leaving P2Pool its share of the split — the same auto rule the donation controller uses (`hashrate × max donation fraction ≥ tier threshold`, default fraction 0.85). `None` when even the lowest tier is out of reach. |
 | **Hashrate Cost** | What holding that tier costs: about its threshold in **continuous** donation, because XvB qualifies a tier on both the 1h and 24h credited averages. This hashrate earns no P2Pool shares while donated. |
-| **Current Tier** | The tier your credited XvB donation clears right now (the lower of XvB's 1h and 24h averages). |
-| **Target Tier** | The tier the donation controller is configured to aim for (`xvb.donation_level`), flagged when your hashrate can't sustain it. |
+| **Current Tier** | The tier your credited XvB donation clears right now (the lower of XvB's 1h and 24h averages). Only while XvB is enabled. |
+| **Target Tier** | The tier the donation controller is configured to aim for (`xvb.donation_level`), flagged when your hashrate can't sustain it. Only while XvB is enabled. |
 
 Below the tier figures sits the **per-tier decision table** — every donor tier on one row, so
 the whole choice is visible at once:


### PR DESCRIPTION
`build_xvb_calc` no longer early-returns `{"enabled": false}`: tiers, odds, and the measured-delivery bands publish always, with `enabled` carrying the live state. The frontend renders the what-if cards + decision table + notes while disabled, hides only the live-credit cards (nothing is credited), and an explainer note states nothing is fetched from xmrvsbeast.com while off (#726's no-egress-while-off posture is unchanged — the table computes from published thresholds and local hashrate). The Earnings XvB tab stays for tier-carrying payloads so a pre-#938 payload still drops it cleanly. #902's tempering precedence respected.

Tests: pytest pins the disabled payload now carrying the table inputs; frontend tests pin disabled-render (table present, live cards absent, note present). docs/dashboard.md updated.

Adversarial verify: ready-with-nits.

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)