### PR TITLE
test(e2e): prove the restored stack runs the on-disk config (#971)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -204,6 +204,15 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    dir, not `CANONICAL_DIR`. That keeps the restore from handing the `pithead` project locally-built
    `:dev` images. If the label can't be read (stack down), it falls back to `CANONICAL_DIR`; override
    with `CANONICAL_DIR=<dir>`. The synced chains are never touched (asserted post-restore).
+7. Proves the restored stack matches the on-disk config
+   ([#971](https://github.com/p2pool-starter-stack/pithead/issues/971)): the credential marker
+   baked into the running dashboard container (`docker inspect`) must equal the on-disk `.env`
+   line — compared as verdict words, values never printed — and monerod must answer a host-side
+   `get_info` authed with the on-disk creds. An e2e run once left the containers on
+   harness-rendered creds while the on-disk `.env` kept the real ones: internally consistent, so
+   the stack mined and looked healthy for a day while every host-side RPC probe 401ed. A failed
+   proof exits non-zero and names the recovery (`docker compose up -d` from the install dir
+   re-bakes everything from disk).
 
 `--mode`: `targeted` (default, lean) validates the dashboard and the sync logic against the
 already-synced node: `check` + `--lifecycle` (one controlled restart exercises the sync gate /

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -18,7 +18,10 @@
 #      images from build/, so a Dockerfile/entrypoint change is actually tested #272) and runs the live
 #      harness (tests/integration/run.sh) DETACHED on the box so an SSH drop can't kill a long matrix.
 #   6. ALWAYS restores: the miner's original pool config, and the canonical baseline stack — even
-#      on failure or Ctrl-C (an EXIT trap). The synced chains are never touched.
+#      on failure or Ctrl-C (an EXIT trap). The synced chains are never touched. The restore then
+#      PROVES the live stack matches the on-disk config (#971): a credential marker baked into a
+#      running container must equal the on-disk .env's line, and monerod must answer a host-side
+#      authed get_info with the on-disk creds. A failed proof exits non-zero, loudly.
 #
 # The Compose project name is pinned to "pithead", so the e2e checkout and the canonical checkout
 # drive the SAME containers + the SAME shared chains — they are two code copies of one stack, run
@@ -169,6 +172,7 @@ on_miner() { ssh "${SSH_OPTS[@]}" "$MINER_HOST" "$1"; }
 SAFETY_ARCHIVE=""
 MINER_CFG_BACKUP=""
 RESTORED=0
+RESTORE_PROOF_FAILED=0
 # Where the LIVE stack actually runs from — resolved in preflight (#454). Defaults to CANONICAL_DIR
 # so the EXIT trap always has a target even if it fires before preflight refines it.
 RESTORE_DIR="$CANONICAL_DIR"
@@ -204,9 +208,13 @@ restore_all() {
     on_bench "cd '$E2E_DIR' && ./pithead down >/dev/null 2>&1 || true"
     if on_bench "cd '$RESTORE_DIR' && ./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"; then
         wait_bench_healthy 300 && ok "baseline stack healthy again" || warn "baseline stack came up but isn't reporting healthy yet — check 'pithead status' on $BENCH_HOST"
+        # Proof, even when the health wait timed out: a stack running the WRONG creds looks
+        # exactly this healthy — that's the incident (#971). Never trust "up" alone.
+        verify_restore_proof || RESTORE_PROOF_FAILED=1
     else
         warn "baseline 'pithead apply/up' returned non-zero in $RESTORE_DIR — check $BENCH_HOST by hand."
         warn "  Safety backup to roll back to: $SAFETY_ARCHIVE"
+        RESTORE_PROOF_FAILED=1
     fi
 
     # 3. Chains sanity: they must be untouched (the whole point).
@@ -214,6 +222,11 @@ restore_all() {
     sync="$(on_bench "curl -fsS --max-time 8 http://127.0.0.1:8000/api/state 2>/dev/null | jq -r '\"\(.sync.monero.state)/\(.sync.tari.state)\"' 2>/dev/null" || true)"
     [ -n "$sync" ] && step "post-restore sync state (monero/tari): $sync"
 
+    if [ "$RESTORE_PROOF_FAILED" = "1" ]; then
+        warn "RESTORE NOT PROVEN: the live stack on $BENCH_HOST did not prove it matches $RESTORE_DIR's on-disk config (see above)."
+        warn "  Re-bake from disk by hand: cd $RESTORE_DIR && docker compose up -d — then verify with a host-side authed get_info."
+        exit 1
+    fi
     if [ "$rc" -eq 0 ]; then ok "restore complete."; else warn "restore complete (the run itself failed — see above)."; fi
 }
 trap restore_all EXIT INT TERM
@@ -246,6 +259,59 @@ wait_synced() { # <timeout_s>
         }
         sleep 8
     done
+}
+
+# Restore proof (#971): after the restore brings the baseline back up, prove the LIVE stack
+# actually runs RESTORE_DIR's on-disk config. A pre-#921 e2e run once left the containers on
+# harness-rendered creds while the on-disk .env kept the real ones — internally consistent, so it
+# mined and looked healthy for a day, while every host-side RPC probe 401ed. Two checks:
+#   1. The credential marker baked into the running dashboard container (docker inspect) is the
+#      same line as the on-disk .env's — env_bake_verdict (lib.sh) prints verdict words only,
+#      never values.
+#   2. monerod answers a host-side get_info with the on-disk creds — the exact probe the incident
+#      broke. Only .status is required (sync may still be re-confirming); polled briefly because
+#      the containers were just recreated. The probe script travels over ssh stdin (bash -s), so
+#      the creds stay on the box and the remote command string carries no shell parens.
+# Returns 0 when both hold.
+RESTORE_PROOF_VAR="MONERO_NODE_PASSWORD"
+verify_restore_proof() {
+    local prc=0 disk cid baked="" verdict
+    disk="$(on_bench "grep -E '^${RESTORE_PROOF_VAR}=' '$RESTORE_DIR/.env' 2>/dev/null | head -n1" || true)"
+    cid="$(on_bench "docker ps -q --filter label=com.docker.compose.project=pithead --filter label=com.docker.compose.service=dashboard 2>/dev/null | head -n1" || true)"
+    [ -n "$cid" ] && baked="$(on_bench "docker inspect --format '{{json .Config.Env}}' '$cid' 2>/dev/null | jq -r '.[]'" || true)"
+    verdict="$(env_bake_verdict "$RESTORE_PROOF_VAR" "$disk" "$baked")"
+    if [ "$verdict" = "match" ]; then
+        ok "restore proof: dashboard container env matches the on-disk .env ($RESTORE_PROOF_VAR)"
+    else
+        warn "restore proof: $RESTORE_PROOF_VAR baked into the live dashboard container vs $RESTORE_DIR/.env: $verdict"
+        prc=1
+    fi
+
+    local out deadline=$(($(date +%s) + 60))
+    while :; do
+        out="$(
+            on_bench "cd '$RESTORE_DIR' && bash -s" <<'PROBE'
+u=$(grep -E '^MONERO_NODE_USERNAME=' .env 2>/dev/null | cut -d= -f2-)
+p=$(grep -E '^MONERO_NODE_PASSWORD=' .env 2>/dev/null | cut -d= -f2-)
+url=$(grep -E '^MONERO_RPC_URL=' .env 2>/dev/null | cut -d= -f2-)
+[ -n "$url" ] || url="http://127.0.0.1:18081"
+if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null)
+else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi
+printf '%s' "$body" | jq -e '.status=="OK"' >/dev/null 2>&1 && echo rpc-ok || echo rpc-fail
+PROBE
+        )" || true
+        if [ "$out" = "rpc-ok" ]; then
+            ok "restore proof: host-side get_info answers with the on-disk creds"
+            break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            warn "restore proof: host-side get_info with the on-disk creds did NOT answer within 60s — the live monerod may be running different creds than $RESTORE_DIR/.env"
+            prc=1
+            break
+        fi
+        sleep 10
+    done
+    return "$prc"
 }
 
 # Nudge the miner's xmrig to reload its (rewritten) config. xmrig watches its config file and

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -264,6 +264,30 @@ config_key_paths() { jq -r "$CONFIG_KEY_PATHS_JQ" "$1" 2>/dev/null; }
 # shellcheck disable=SC2034  # consumed by e2e.sh + selftest.sh, which source this file
 E2E_SYNC_SUMMARY_JQ='"\(.sync.monero.state) \(.sync.monero.current)/\(.sync.monero.target) \(.sync.tari.state) \(.sync.tari.current)/\(.sync.tari.target)"'
 
+# Restore-proof marker compare (#971): does the value a live container was BAKED with (docker
+# inspect .Config.Env) agree with the on-disk .env? Compares whole KEY=VALUE lines and prints a
+# verdict word — never a value, so secrets stay out of logs. The incident this pins: an e2e run
+# recreated the live containers with harness-rendered creds while the on-disk .env kept the real
+# ones — internally consistent, healthy-looking, and every host-side RPC probe 401ed for a day.
+#   match         — both carry the same KEY=VALUE line
+#   mismatch      — both carry the var, values differ (the incident)
+#   no-disk-value — the on-disk .env doesn't set the var (nothing to prove against)
+#   not-baked     — the container env doesn't carry the var at all
+env_bake_verdict() { # <var> <disk-env-lines> <container-env-lines>
+    local disk baked
+    disk="$(printf '%s\n' "$2" | grep -m1 "^$1=")"
+    baked="$(printf '%s\n' "$3" | grep -m1 "^$1=")"
+    if [ -z "$disk" ]; then
+        printf 'no-disk-value'
+    elif [ -z "$baked" ]; then
+        printf 'not-baked'
+    elif [ "$baked" = "$disk" ]; then
+        printf 'match'
+    else
+        printf 'mismatch'
+    fi
+}
+
 # Authoritative "is Monero caught up?" — query monerod's own get_info on the box (creds stay
 # on the box) and trust its `synchronized` flag / target_height 0, exactly like the sync gate.
 # This is the readiness GATE (the source of truth, and it avoids waiting on a dashboard poll cycle).

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -506,6 +506,31 @@ assert_eq "sync summary reads state + current/target for both chains" \
     "$(printf '%s' "$_ss" | jq -r "$E2E_SYNC_SUMMARY_JQ")" \
     "done 3487100/3487100 syncing 12000/12217"
 
+echo "== env_bake_verdict: restore-proof marker compare (#971) =="
+# The incident shape: an e2e restore left the live containers on harness-rendered creds while the
+# on-disk .env kept the real ones. The verdict compares whole KEY=VALUE lines and prints a word —
+# never a value — so e2e.sh can assert the bake without leaking secrets into its log.
+_disk='MONERO_NODE_USERNAME=pithead
+MONERO_NODE_PASSWORD=disk-secret'
+_baked='PATH=/usr/local/bin
+MONERO_NODE_PASSWORD=disk-secret
+TZ=Etc/UTC'
+assert_eq "same baked line -> match" "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" "$_baked")" "match"
+_baked_wrong='PATH=/usr/local/bin
+MONERO_NODE_PASSWORD=harness-secret'
+assert_eq "different value -> mismatch (the incident)" "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" "$_baked_wrong")" "mismatch"
+assert_eq "var missing on disk -> no-disk-value" "$(env_bake_verdict MONERO_NODE_PASSWORD 'OTHER=x' "$_baked")" "no-disk-value"
+assert_eq "var missing in container -> not-baked" "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" 'PATH=/usr/local/bin')" "not-baked"
+# Present-but-empty on both sides is still consistent — the line compare sees VAR= on each.
+assert_eq "empty on both sides -> match" "$(env_bake_verdict MONERO_NODE_PASSWORD 'MONERO_NODE_PASSWORD=' 'MONERO_NODE_PASSWORD=')" "match"
+# A longer var name must not satisfy the marker's anchored grep.
+assert_eq "longer var name is not the marker" "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" 'MONERO_NODE_PASSWORD_FILE=/x')" "not-baked"
+# And the verdicts never echo the secret itself.
+case "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" "$_baked_wrong")" in
+*disk-secret* | *harness-secret*) it_fail "verdict never carries a value" "secret leaked into the verdict" ;;
+*) it_pass "verdict never carries a value" ;;
+esac
+
 # --- Tally ------------------------------------------------------------------
 echo ""
 echo "selftest: $IT_PASS passed, $IT_FAIL failed"


### PR DESCRIPTION
The 2026-08 incident: a harness run left the live containers on harness-rendered creds while the on-disk `.env` said otherwise — host RPC probes 401ed for a day while everything looked healthy. The e2e epilogue now proves the restore it claims:

- New pure helper `env_bake_verdict` (lib.sh) compares a container-baked KEY=VALUE line against the on-disk `.env` — prints verdict words only, secrets never reach logs.
- `verify_restore_proof()` runs after `restore_all` brings the baseline back: (1) `docker inspect` the dashboard container's baked credential line vs on-disk; (2) a host-side `get_info` authed with the on-disk creds (digest, mirroring `monero_caught_up`), polled 60s — proving the running node accepts exactly what the disk says. Probe rides ssh stdin so creds stay on the box.
- A failed proof fails the run loudly — the exact false-green this class of incident produced.

Shell-only diff: patch coverage is vacuous by nature; evidence is the selftest pins for `env_bake_verdict` (match/mismatch/no-disk-value/not-baked) + `make lint`. docs/dev/integration-testing.md documents the proof step.

Adversarial verify: ready-with-nits.

Closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)