### PR TITLE
test(ci): the inventory drift check now exists — and inventory.sh can actually fail (#981)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,12 @@ jobs:
         run: make lint-sh
       - name: Run pithead test suite
         run: bash tests/stack/run.sh
+      - name: Test-inventory drift check
+        # The inventory generator is grep-based; it exits non-zero when any suite it
+        # enumerates counts zero — i.e. a suite moved or changed shape and the inventory
+        # would silently under-count (#981). Output discarded: the generated file is
+        # git-ignored and read on demand via `make test-inventory`.
+        run: bash tests/inventory.sh > /dev/null
       - name: Run integration harness self-test
         # Pure-logic checks for the tests/integration/ harness (config rendering, matrix
         # coverage, redaction). The LIVE matrix (tests/integration/run.sh) needs a real test

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -172,7 +172,8 @@ make test-integration ARGS="--host user@box --dir pithead --lifecycle --fault-in
 
 What gates a merge vs. a release, the standards every test holds to, and the known gaps. For the
 full enumerated coverage, `make test-inventory` generates the list on demand (git-ignored — read it
-locally).
+locally). The generator is grep-based, so CI runs it on every PR and fails if any suite it
+enumerates counts zero — the drift a moved or reshaped suite would otherwise hide.
 
 ### What runs where
 
@@ -185,7 +186,7 @@ locally).
 | Compose interpolation + **security/hardening** invariants | 1 | every PR | ✅ required |
 | Fake-daemon **contract test** | 2 | every PR | ✅ required |
 | Integration harness **self-test** | 4 | every PR | ✅ required |
-| **Test-inventory drift** check | — | every PR | ✅ required |
+| **Test-inventory drift** check (the generator still enumerates every suite) | — | every PR | ✅ required |
 | Fake-daemon **docker mini-stack** | 3 | PRs touching the harness/dashboard | ✅ (own workflow) |
 | **Live config matrix** on real nodes | 4 | manual / pre-release | ✅ **release gate** ([#44](https://github.com/p2pool-starter-stack/pithead/issues/44)) |
 
@@ -209,8 +210,8 @@ Every scenario, at every tier, holds to the same rules.
 - Secrets hygiene. Tokens, RPC creds, and onions are never printed; preservation is checked by
   hashing on the box; all artifacts pass a redactor.
 - Reproducible. The live run records a manifest (stack `VERSION`, git rev, image digests).
-- Test code is real code. The same lint (shellcheck), coverage gate, and inventory drift check
-  apply to the tests themselves.
+- Test code is real code. The same lint (shellcheck) and coverage gate apply to the tests
+  themselves, and the inventory generator fails CI if it stops enumerating a suite.
 
 ### Flake policy
 

--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -43,6 +43,20 @@ n_mini=$(grep -cE 'log "scenario [0-9]' tests/integration/mini-stack/run-mini-st
 
 total=$((n_py_dash + n_py_fake + n_node + n_stack + n_selftest + n_scen + n_mini))
 
+# --- drift gate -----------------------------------------------------------
+# The gathering above is grep-based, so a suite that moves, renames, or changes shape
+# enumerates as zero without erroring. Fail loudly instead of emitting an inventory that
+# silently under-counts — CI runs this on every PR (#981).
+# ponytail: zero-count is the only drift detectable since #414 untracked the generated file;
+# per-suite freshness would need the file back under git and its merge conflicts with it.
+for c in n_py_dash n_py_fake n_node n_stack n_selftest n_scen n_axes n_mini; do
+    if [ "${!c:-0}" -eq 0 ]; then # :-0 — grep -c on a deleted file emits nothing, not 0
+        echo "inventory drift: $c counted 0 tests — a suite moved or its shape changed;" \
+            "update the matching pattern in tests/inventory.sh" >&2
+        exit 1
+    fi
+done
+
 # --- emit -----------------------------------------------------------------
 cat <<EOF
 # Test Inventory


### PR DESCRIPTION
The issue's premise was half-false, and this PR reports it honestly: `tests/inventory.sh` never exited non-zero on drift — #414 deliberately made it a pure generator. So "just add the CI step" would have added a check that can't fail (the vacuous-pass pattern this repo keeps hunting). Instead:

- `inventory.sh` gains a drift gate: any suite count reading zero (including the deleted-file case where `grep -c` emits nothing) exits 1, before any output is written.
- ci.yml runs it as one `run:` step in the existing shell job — no new job, no actions to pin.
- testing-strategy.md's table row now claims exactly what runs.

The issue's two adjacent bullets (ci push-trigger scope, diff-cover vacuous pass) are deliberately not here — the first is moot after the v2 merge, the second is its own fix; filing separately.

Adversarial verify: ready-with-nits.

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)