### PR TITLE
docs+build: name the RigForge integration seams honestly (#1003)

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -276,6 +276,15 @@ who can sniff or MITM the mining LAN and capture the token can push config to yo
 mining LAN isolated from untrusted devices, and treat the token as a secret (it lives only in the
 owner-only `config.json`/`.env`, never in the dashboard container).
 
+NOTE: a rig provisioned by the appliance (the installer's RigForge choice) ships with control
+**off**. Its rendered RigForge config carries the `pools` entry — pool, worker name, stratum
+password — and nothing else: no `control` flag, no `ACCESS_TOKEN`. The appliance's built-in
+miner ships without control the same way. Such a rig mines and reports like any other, but
+Worker Inspect's config push and the [one-click rig upgrade](#one-click-rig-upgrade) cannot
+reach it. To make it editable, enable control on the rig itself (RigForge's `control` flag plus
+an `ACCESS_TOKEN`), then add its `host` + `token` entry to `workers.list[]` here, like any
+other rig.
+
 Entries are matched by `name` — the rig's stratum worker name (the part before any `+` suffix).
 On a name miss the dashboard falls back to matching by the rig's connecting IP against an
 operator-set `host`, which covers a rig that renamed itself but still connects from its declared

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -116,10 +116,14 @@ RUN curl -fsSL -o /tmp/rigforge.tar.gz \
 # where RigForge's "already built" check accepts it (binary + commit marker + sha record, the
 # exact format rigforge.sh writes). The donate-level source patch is skipped on purpose: the
 # default (1%) equals XMRig's own default, and the runtime config carries the value regardless.
+# The sed anchors match rigforge.sh's exact NAME="${NAME:-value}" quoting; a cosmetic upstream
+# reformat extracts nothing, so the guard names the cause instead of failing mute mid-chain.
 RUN set -e \
     && XMRIG_VERSION=$(sed -n 's/^XMRIG_VERSION="${XMRIG_VERSION:-\(.*\)}"$/\1/p' /opt/rigforge/rigforge.sh) \
     && XMRIG_COMMIT=$(sed -n 's/^XMRIG_COMMIT="${XMRIG_COMMIT:-\(.*\)}"$/\1/p' /opt/rigforge/rigforge.sh) \
-    && test -n "$XMRIG_VERSION" && test -n "$XMRIG_COMMIT" \
+    && { test -n "$XMRIG_VERSION" && test -n "$XMRIG_COMMIT" || { \
+            echo "could not extract the XMRig pin from rigforge.sh — its XMRIG_VERSION/XMRIG_COMMIT quoting no longer matches the sed anchors above; update them to the new format" >&2; \
+            exit 1; }; } \
     && git clone --quiet --branch "$XMRIG_VERSION" --depth 1 https://github.com/xmrig/xmrig.git /tmp/xmrig \
     && test "$(git -C /tmp/xmrig rev-parse HEAD)" = "$XMRIG_COMMIT" \
     && cmake -S /tmp/xmrig -B /tmp/xmrig/build -DWITH_HWLOC=ON >/dev/null \


### PR DESCRIPTION
Two seams from the cross-repo audit:

1. **workers.md** now states, where rig editability is defined, that an appliance-provisioned rig ships control-off — the rendered config is the `pools` entry only, no `control`, no `ACCESS_TOKEN` — so config push and one-click upgrade cannot reach it until the operator enables control rig-side and adds `host` + `token` to `workers.list[]`. Verified against `render_rig_miner_config` and `render_local_miner_config`.
2. **os/rootfs/Dockerfile**: honest finding — a bare non-empty check on the sed-extracted XMRig pin already existed, so empty pins never baked silently; it just failed mute mid-chain. It now fails loudly, naming the quoting dependency on rigforge.sh's exact format and what to update. `verify-image.sh` deliberately unchanged (its line 165 already asserts the baked pin equality — a second check would duplicate it).

Guard proven both ways in a scratch harness (real quoting → extracted+exit 0; reformatted → the loud message+exit 1). `make lint` + docs-voice clean. The end-to-end proof of the Dockerfile chain is the image build the os-rootfs CI job runs on this PR.

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)