### PR TITLE
test(frontend): the client entry point gets its tier — 22 tests via the issue's own seam refactor (#903)

### DIFF
--- a/build/dashboard/README.md
+++ b/build/dashboard/README.md
@@ -29,10 +29,13 @@ Testing: the Python API, where the logic and formatting live, is unit-tested. Th
 tests run under Node's built-in runner (`node --test build/dashboard/tests/frontend/`) — no
 `package.json`/`node_modules`/build step, so the repo stays Node-free. They cover the pure logic
 (`logic.test.mjs`: worker sort, tooltip formatting, hero-KPI selection), the chart helpers
-(`chart.test.mjs`: `withAlpha`, `padYAxis`), the topology geometry (`topology.test.mjs`), and
+(`chart.test.mjs`: `withAlpha`, `padYAxis`), the topology geometry (`topology.test.mjs`),
 component rendering (`components.test.mjs`: every card driven through `App` against a real
-`build_state()` fixture, via a DOM-free vnode walker). The DOM-bound wiring (Chart.js canvas,
-the SVG topology component) needs a browser and is left to a manual smoke test.
+`build_state()` fixture, via a DOM-free vnode walker), and the entry point
+(`dashboard.test.mjs`: `initDashboard()` takes its browser seams — DOM, storage, fetch, history,
+timer, render — as parameters with real defaults, so the poll loop, its hang-abort, and the
+preference wiring run against fakes). The DOM-bound wiring (Chart.js canvas, the SVG topology
+component) needs a browser and is left to a manual smoke test.
 
 ## Layout
 

--- a/build/dashboard/mining_dashboard/web/static/dashboard.js
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.js
@@ -4,6 +4,11 @@
 // Data comes from GET /api/state (the server builds it; see views.build_state); the client
 // holds only *UI* state that must survive data refreshes — selected range, table sort, and
 // the simple/advanced view — plus the latest data snapshot and connection status.
+//
+// Everything runs inside initDashboard(), whose parameters name the browser seams (DOM, storage,
+// fetch, history, timer, render) with real defaults. The browser boot at the bottom is guarded on
+// `document`, so `node --test` can import this file with no DOM and drive the loop through fakes
+// (#903, tests/frontend/dashboard.test.mjs).
 
 import { App } from "./components.mjs";
 import {
@@ -16,184 +21,225 @@ import {
 } from "./logic.mjs";
 import { html, render } from "./preact.mjs";
 
-const root = document.getElementById("app");
-const REFRESH_MS = 30000;
+export const REFRESH_MS = 30000;
 // Abort a poll that hasn't answered before the next tick would fire. Without this a hung
 // connection (a dropped Tor circuit hangs rather than fails) never rejects, and the `inflight`
 // guard then blocks every later tick — the page freezes on stale data with no banner (#382).
 // Derived from REFRESH_MS so the two can't drift apart; far above a healthy Tor round-trip,
 // so it only trips on dead links.
-const FETCH_TIMEOUT_MS = REFRESH_MS - 5000;
+export const FETCH_TIMEOUT_MS = REFRESH_MS - 5000;
 
 // A manual-zoom window {from, to} (epoch seconds) read from ?from=&to= so a zoomed URL is
 // shareable and survives reload (Issue #47); null/garbage falls back to the preset range.
-function windowFromUrl() {
-  const p = new URL(location.href).searchParams;
-  const from = parseFloat(p.get("from"));
-  const to = parseFloat(p.get("to"));
+export function windowFromUrl(params) {
+  const from = parseFloat(params.get("from"));
+  const to = parseFloat(params.get("to"));
   return Number.isFinite(from) && Number.isFinite(to) && from > 0 && to > from
     ? { from, to }
     : null;
 }
 
 // Which chart series are shown — persisted so a hidden series stays hidden across reloads.
-function loadSeries() {
+// Takes the raw localStorage string; garbage (or nothing) falls back to all-visible.
+export function loadSeries(raw) {
   try {
-    return normalizeSeries(JSON.parse(localStorage.getItem("dashboardSeries")));
+    return normalizeSeries(JSON.parse(raw));
   } catch {
     return normalizeSeries(null);
   }
 }
 
-const ui = {
-  range: new URL(location.href).searchParams.get("range") || "all",
-  window: windowFromUrl(), // {from,to} epoch-s when zoomed, else null
-  series: loadSeries(), // one boolean per SERIES_KEYS entry (Issue #47)
-  // Hashrate-averaging window the chart plots (#168); persisted, default 10m (today's series).
-  avg: normalizeAvgWindow(localStorage.getItem("dashboardAvgWindow")),
-  // Workers-table sort (#658); persisted like the other view preferences.
-  ...normalizeSort(localStorage.getItem("dashboardSort"), WORKER_COLUMNS.length),
-  view: ["advanced", "config"].includes(localStorage.getItem("dashboardView"))
-    ? localStorage.getItem("dashboardView")
-    : "simple",
-  // Theme is persisted in localStorage so it survives reloads and stack restarts (Issue #43).
-  // theme-init.js already applied it to <html> before first paint; we mirror it into the UI
-  // state and re-apply on toggle.
-  theme: normalizeTheme(localStorage.getItem("dashboardTheme")),
-  // Simple-view pointer to the Advanced-only earnings/XvB calculators (#425). Persisted once
-  // dismissed — either explicitly or by visiting Advanced view — so it shows once per browser.
-  hintDismissed: localStorage.getItem("dashboardCalcHint") === "dismissed",
-  // Worker Inspect (#185): the name of the worker whose panel is open, or null. Transient UI —
-  // not persisted; the panel fetches its own /api/worker detail on open.
-  inspectWorker: null,
-};
+export function initDashboard({
+  doc = document,
+  storage = localStorage,
+  href = location.href,
+  fetchFn = (url, opts) => fetch(url, opts),
+  replaceUrl = (url) => history.replaceState(null, "", url),
+  schedule = (fn, ms) => setInterval(fn, ms),
+  renderApp = null,
+} = {}) {
+  const root = doc.getElementById("app");
+  const pageUrl = new URL(href);
+  const path = pageUrl.pathname;
+  const params = pageUrl.searchParams;
 
-// Reflect the current theme onto <html data-theme>; the CSS palette (and the chart, which reads
-// the resolved CSS variables) follow from there.
-function applyTheme(theme) {
-  document.documentElement.setAttribute("data-theme", theme);
-}
+  const ui = {
+    range: params.get("range") || "all",
+    window: windowFromUrl(params), // {from,to} epoch-s when zoomed, else null
+    series: loadSeries(storage.getItem("dashboardSeries")), // booleans per SERIES_KEYS (Issue #47)
+    // Hashrate-averaging window the chart plots (#168); persisted, default 10m (today's series).
+    avg: normalizeAvgWindow(storage.getItem("dashboardAvgWindow")),
+    // Workers-table sort (#658); persisted like the other view preferences.
+    ...normalizeSort(storage.getItem("dashboardSort"), WORKER_COLUMNS.length),
+    view: ["advanced", "config"].includes(storage.getItem("dashboardView"))
+      ? storage.getItem("dashboardView")
+      : "simple",
+    // Theme is persisted in localStorage so it survives reloads and stack restarts (Issue #43).
+    // theme-init.js already applied it to <html> before first paint; we mirror it into the UI
+    // state and re-apply on toggle.
+    theme: normalizeTheme(storage.getItem("dashboardTheme")),
+    // Simple-view pointer to the Advanced-only earnings/XvB calculators (#425). Persisted once
+    // dismissed — either explicitly or by visiting Advanced view — so it shows once per browser.
+    hintDismissed: storage.getItem("dashboardCalcHint") === "dismissed",
+    // Worker Inspect (#185): the name of the worker whose panel is open, or null. Transient UI —
+    // not persisted; the panel fetches its own /api/worker detail on open.
+    inspectWorker: null,
+  };
 
-let state = null; // latest /api/state payload, or null before the first response
-let connected = true; // false after a failed fetch (we keep showing the last snapshot)
-let inflight = false; // guard against overlapping fetches if one is slow
+  // Reflect the current theme onto <html data-theme>; the CSS palette (and the chart, which reads
+  // the resolved CSS variables) follow from there.
+  function applyTheme(theme) {
+    doc.documentElement.setAttribute("data-theme", theme);
+  }
 
-function rerender() {
-  render(
-    html`<${App} state=${state} connected=${connected} ui=${ui}
-                     onRange=${setRange} onSort=${onSort} onView=${setView} onTheme=${setTheme}
-                     onZoom=${setZoom} onResetZoom=${resetZoom} onToggleSeries=${toggleSeries}
-                     onAvgWindow=${setAvgWindow} onDismissHint=${dismissHint}
-                     onInspect=${openInspect} onCloseInspect=${closeInspect} />`,
-    root,
-  );
-}
+  let state = null; // latest /api/state payload, or null before the first response
+  let connected = true; // false after a failed fetch (we keep showing the last snapshot)
+  let inflight = false; // guard against overlapping fetches if one is slow
 
-// Worker Inspect (#185): open/close the per-worker panel. Not persisted — transient UI state.
-function openInspect(name) {
-  ui.inspectWorker = name;
-  rerender();
-}
-function closeInspect() {
-  ui.inspectWorker = null;
-  rerender();
-}
+  // Tests inject renderApp to observe exactly what the App would receive; the browser default
+  // renders the real <App> with the same props.
+  const paint =
+    renderApp ??
+    ((p) =>
+      render(
+        html`<${App} state=${p.state} connected=${p.connected} ui=${p.ui}
+                     onRange=${p.onRange} onSort=${p.onSort} onView=${p.onView} onTheme=${p.onTheme}
+                     onZoom=${p.onZoom} onResetZoom=${p.onResetZoom} onToggleSeries=${p.onToggleSeries}
+                     onAvgWindow=${p.onAvgWindow} onDismissHint=${p.onDismissHint}
+                     onInspect=${p.onInspect} onCloseInspect=${p.onCloseInspect} />`,
+        root,
+      ));
 
-async function tick() {
-  if (inflight) return;
-  inflight = true;
-  try {
-    // A custom zoom window overrides the preset range; the server adapts resolution to it. The
-    // averaging window (#168) applies to both — the server selects which window's columns to plot.
-    const base = ui.window
-      ? "from=" + ui.window.from + "&to=" + ui.window.to
-      : "range=" + encodeURIComponent(ui.range);
-    const qs = base + "&avg=" + encodeURIComponent(ui.avg);
-    const res = await fetch("/api/state?" + qs, {
-      headers: { "X-Requested-With": "fetch" },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  function rerender() {
+    paint({
+      state,
+      connected,
+      ui,
+      onRange: setRange,
+      onSort,
+      onView: setView,
+      onTheme: setTheme,
+      onZoom: setZoom,
+      onResetZoom: resetZoom,
+      onToggleSeries: toggleSeries,
+      onAvgWindow: setAvgWindow,
+      onDismissHint: dismissHint,
+      onInspect: openInspect,
+      onCloseInspect: closeInspect,
     });
-    if (!res.ok) throw new Error("HTTP " + res.status);
-    state = await res.json();
-    connected = true;
-    if (state.page_title) document.title = state.page_title;
-  } catch (e) {
-    connected = false;
-    console.warn("dashboard refresh failed", e);
-  } finally {
-    inflight = false;
+  }
+
+  // Worker Inspect (#185): open/close the per-worker panel. Not persisted — transient UI state.
+  function openInspect(name) {
+    ui.inspectWorker = name;
     rerender();
   }
-}
-
-function setRange(r) {
-  ui.range = r;
-  ui.window = null; // picking a preset exits any manual zoom
-  history.replaceState(null, "", r === "all" ? location.pathname : "?range=" + r);
-  tick(); // re-fetch immediately; the chart/series depend on the range
-}
-
-// Called (debounced) by the chart when a zoom/pan gesture settles: pin the visible window and
-// refetch it from the server at duration-adaptive resolution (Issue #47).
-function setZoom(fromS, toS) {
-  ui.window = { from: fromS, to: toS };
-  history.replaceState(null, "", "?from=" + Math.round(fromS) + "&to=" + Math.round(toS));
-  tick();
-}
-
-function resetZoom() {
-  ui.window = null;
-  history.replaceState(null, "", ui.range === "all" ? location.pathname : "?range=" + ui.range);
-  tick();
-}
-
-function onSort(idx) {
-  ui.sortAsc = ui.sortIndex === idx ? !ui.sortAsc : true;
-  ui.sortIndex = idx;
-  savePref("dashboardSort", `${idx}:${ui.sortAsc ? "asc" : "desc"}`);
-  rerender(); // client-side sort only, no fetch
-}
-
-function setView(mode) {
-  ui.view = mode;
-  localStorage.setItem("dashboardView", mode);
-  // Visiting Advanced retires the calculators hint (#425) — its discoverability job is done.
-  if (mode === "advanced" && !ui.hintDismissed) {
-    ui.hintDismissed = true;
-    localStorage.setItem("dashboardCalcHint", "dismissed");
+  function closeInspect() {
+    ui.inspectWorker = null;
+    rerender();
   }
-  rerender();
+
+  async function tick() {
+    if (inflight) return;
+    inflight = true;
+    try {
+      // A custom zoom window overrides the preset range; the server adapts resolution to it. The
+      // averaging window (#168) applies to both — the server selects which window's columns to plot.
+      const base = ui.window
+        ? "from=" + ui.window.from + "&to=" + ui.window.to
+        : "range=" + encodeURIComponent(ui.range);
+      const qs = base + "&avg=" + encodeURIComponent(ui.avg);
+      const res = await fetchFn("/api/state?" + qs, {
+        headers: { "X-Requested-With": "fetch" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      state = await res.json();
+      connected = true;
+      if (state.page_title) doc.title = state.page_title;
+    } catch (e) {
+      connected = false;
+      console.warn("dashboard refresh failed", e);
+    } finally {
+      inflight = false;
+      rerender();
+    }
+  }
+
+  function setRange(r) {
+    ui.range = r;
+    ui.window = null; // picking a preset exits any manual zoom
+    replaceUrl(r === "all" ? path : "?range=" + r);
+    return tick(); // re-fetch immediately; the chart/series depend on the range
+  }
+
+  // Called (debounced) by the chart when a zoom/pan gesture settles: pin the visible window and
+  // refetch it from the server at duration-adaptive resolution (Issue #47).
+  function setZoom(fromS, toS) {
+    ui.window = { from: fromS, to: toS };
+    replaceUrl("?from=" + Math.round(fromS) + "&to=" + Math.round(toS));
+    return tick();
+  }
+
+  function resetZoom() {
+    ui.window = null;
+    replaceUrl(ui.range === "all" ? path : "?range=" + ui.range);
+    return tick();
+  }
+
+  function onSort(idx) {
+    ui.sortAsc = ui.sortIndex === idx ? !ui.sortAsc : true;
+    ui.sortIndex = idx;
+    savePref("dashboardSort", `${idx}:${ui.sortAsc ? "asc" : "desc"}`);
+    rerender(); // client-side sort only, no fetch
+  }
+
+  function setView(mode) {
+    ui.view = mode;
+    storage.setItem("dashboardView", mode);
+    // Visiting Advanced retires the calculators hint (#425) — its discoverability job is done.
+    if (mode === "advanced" && !ui.hintDismissed) {
+      ui.hintDismissed = true;
+      storage.setItem("dashboardCalcHint", "dismissed");
+    }
+    rerender();
+  }
+
+  // Dismiss the Simple-view calculators hint (#425) without leaving Simple view.
+  function dismissHint() {
+    ui.hintDismissed = true;
+    storage.setItem("dashboardCalcHint", "dismissed");
+    rerender();
+  }
+
+  function setTheme(theme) {
+    ui.theme = theme;
+    storage.setItem("dashboardTheme", theme);
+    applyTheme(theme); // updates <html data-theme>; the chart recolours on the next render
+    rerender();
+  }
+
+  function toggleSeries(key) {
+    ui.series = { ...ui.series, [key]: !ui.series[key] };
+    storage.setItem("dashboardSeries", JSON.stringify(ui.series));
+    rerender(); // visibility-only; the chart hides/shows the dataset, no refetch needed
+  }
+
+  // Pick the chart's hashrate-averaging window (#168). Persist it and refetch — the server returns
+  // a different per-window series, so (unlike series visibility) this needs a round-trip.
+  function setAvgWindow(w) {
+    ui.avg = normalizeAvgWindow(w);
+    storage.setItem("dashboardAvgWindow", ui.avg);
+    return tick();
+  }
+
+  applyTheme(ui.theme); // re-assert the (normalized) theme before the first paint
+  rerender(); // paint the loading shell immediately
+  const firstLoad = tick(); // first data load
+  schedule(tick, REFRESH_MS); // then live updates
+  return { tick, firstLoad };
 }
 
-// Dismiss the Simple-view calculators hint (#425) without leaving Simple view.
-function dismissHint() {
-  ui.hintDismissed = true;
-  localStorage.setItem("dashboardCalcHint", "dismissed");
-  rerender();
-}
-
-function setTheme(theme) {
-  ui.theme = theme;
-  localStorage.setItem("dashboardTheme", theme);
-  applyTheme(theme); // updates <html data-theme>; the chart recolours on the next render
-  rerender();
-}
-
-function toggleSeries(key) {
-  ui.series = { ...ui.series, [key]: !ui.series[key] };
-  localStorage.setItem("dashboardSeries", JSON.stringify(ui.series));
-  rerender(); // visibility-only; the chart hides/shows the dataset, no refetch needed
-}
-
-// Pick the chart's hashrate-averaging window (#168). Persist it and refetch — the server returns a
-// different per-window series, so (unlike series visibility) this needs a round-trip.
-function setAvgWindow(w) {
-  ui.avg = normalizeAvgWindow(w);
-  localStorage.setItem("dashboardAvgWindow", ui.avg);
-  tick();
-}
-
-applyTheme(ui.theme); // re-assert the (normalized) theme before the first paint
-rerender(); // paint the loading shell immediately
-tick(); // first data load
-setInterval(tick, REFRESH_MS); // then live updates
+// Boot for real in the browser. Under `node --test` there is no `document`, so importing this
+// module has no side effects and tests call initDashboard() themselves.
+if (typeof document !== "undefined") initDashboard();

--- a/build/dashboard/tests/frontend/dashboard.test.mjs
+++ b/build/dashboard/tests/frontend/dashboard.test.mjs
@@ -1,0 +1,364 @@
+// Tier-1 tests for the dashboard entry point (mining_dashboard/web/static/dashboard.js).
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test build/dashboard/tests/frontend/
+//
+// dashboard.js owns the client's refresh loop and UI-state dispatch: the 30s poll with the
+// Tor-hang abort (#382), the connected/disconnected flag, preference seeding from the URL and
+// localStorage, and the handler wiring the App receives. initDashboard() names its browser seams
+// (DOM, storage, fetch, history, timer, render) as injectable parameters, so these tests drive the
+// real loop with fakes and observe it through the props handed to renderApp — no DOM, no npm deps.
+// What the App *paints* from those props is components.test.mjs's job; the normalize* helpers'
+// own semantics are logic.test.mjs's. Here we pin only what dashboard.js itself does.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    FETCH_TIMEOUT_MS, initDashboard, loadSeries, REFRESH_MS, windowFromUrl,
+} from '../../mining_dashboard/web/static/dashboard.js';
+import { SERIES_KEYS } from '../../mining_dashboard/web/static/logic.mjs';
+
+// --- fakes ------------------------------------------------------------------------------------
+
+// Build an injectable environment. `responses` is a queue of response factories, one per expected
+// fetch — a test that polls more than it queued fails loudly instead of hanging.
+function makeEnv({ href = 'http://pithead.test/', stored = {}, responses = [] } = {}) {
+    const fetches = []; // { url, opts } per fetch, in order
+    const paints = []; // the full props object of every render, in order
+    const urls = []; // history.replaceState rewrites, in order
+    const doc = {
+        title: '',
+        documentElement: {
+            attrs: {},
+            setAttribute(name, value) { this.attrs[name] = value; },
+        },
+        getElementById: () => null,
+    };
+    let interval = null;
+    const env = {
+        doc,
+        href,
+        storage: {
+            getItem: (k) => (k in stored ? stored[k] : null),
+            setItem: (k, v) => { stored[k] = String(v); },
+        },
+        fetchFn: (url, opts) => {
+            fetches.push({ url, opts });
+            assert.ok(responses.length > 0, `unexpected fetch: ${url}`);
+            return responses.shift()(url, opts);
+        },
+        replaceUrl: (u) => urls.push(u),
+        schedule: (fn, ms) => { interval = { fn, ms }; },
+        renderApp: (props) => paints.push(props),
+    };
+    return {
+        env, fetches, paints, urls, doc, stored,
+        interval: () => interval,
+        last: () => paints[paints.length - 1],
+    };
+}
+
+const ok = (body) => () => Promise.resolve({ ok: true, json: async () => body });
+const httpError = (status) => () => Promise.resolve({ ok: false, status });
+const aborted = () => () => Promise.reject(new DOMException('signal timed out', 'TimeoutError'));
+
+// A poll that hangs like a dropped Tor circuit: never settles on its own; the test fires the
+// abort the same way AbortSignal.timeout eventually would.
+function hangingPoll() {
+    let reject;
+    const promise = new Promise((_, rej) => { reject = rej; });
+    return {
+        response: () => promise,
+        abort: () => reject(new DOMException('signal timed out', 'TimeoutError')),
+    };
+}
+
+// --- pure helpers -----------------------------------------------------------------------------
+
+test('the poll timeout aborts before the next tick would fire (#382)', () => {
+    // The whole point of the abort: a hung fetch must reject before the 30s interval ticks
+    // again, or `inflight` latches and the page freezes on stale data with no banner.
+    assert.ok(FETCH_TIMEOUT_MS > 0);
+    assert.ok(FETCH_TIMEOUT_MS < REFRESH_MS);
+});
+
+test('windowFromUrl: accepts only a sane from/to pair', () => {
+    const parse = (qs) => windowFromUrl(new URLSearchParams(qs));
+    assert.deepEqual(parse('from=100&to=200'), { from: 100, to: 200 });
+    assert.deepEqual(parse('from=100.5&to=200.25'), { from: 100.5, to: 200.25 });
+    assert.equal(parse(''), null); // no zoom in the URL
+    assert.equal(parse('from=100'), null); // half a window
+    assert.equal(parse('to=100'), null);
+    assert.equal(parse('from=200&to=100'), null); // inverted
+    assert.equal(parse('from=100&to=100'), null); // empty span
+    assert.equal(parse('from=0&to=100'), null); // epoch-0 start is garbage, not a window
+    assert.equal(parse('from=abc&to=100'), null);
+});
+
+test('loadSeries: garbage or missing persisted JSON falls back to all-visible', () => {
+    const allOn = Object.fromEntries(SERIES_KEYS.map((k) => [k, true]));
+    assert.deepEqual(loadSeries(null), allOn);
+    assert.deepEqual(loadSeries('{not json'), allOn);
+    assert.deepEqual(loadSeries('"a string"'), allOn);
+});
+
+test('loadSeries: a persisted hidden series stays hidden', () => {
+    const hidden = SERIES_KEYS[0];
+    const out = loadSeries(JSON.stringify({ [hidden]: false }));
+    assert.equal(out[hidden], false);
+    for (const k of SERIES_KEYS.slice(1)) assert.equal(out[k], true);
+});
+
+// --- boot -------------------------------------------------------------------------------------
+
+test('boot: paints the loading shell, then the first poll; refresh scheduled at 30s', async () => {
+    const t = makeEnv({ responses: [ok({ page_title: 'Pithead — mining', workers: [] })] });
+    const d = initDashboard(t.env);
+    // The very first paint happens before any data arrives: state is still null.
+    assert.equal(t.paints[0].state, null);
+    assert.equal(t.paints[0].connected, true);
+    await d.firstLoad;
+    assert.equal(t.last().state.page_title, 'Pithead — mining');
+    assert.equal(t.last().connected, true);
+    assert.equal(t.doc.title, 'Pithead — mining'); // server-provided page title applied
+    assert.equal(t.interval().ms, REFRESH_MS);
+    assert.equal(t.interval().fn, d.tick); // the interval drives the same tick
+});
+
+test('poll request: default query, fetch marker header, and an abort signal (#382)', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    await initDashboard(t.env).firstLoad;
+    const { url, opts } = t.fetches[0];
+    assert.equal(url, '/api/state?range=all&avg=10m');
+    assert.equal(opts.headers['X-Requested-With'], 'fetch');
+    assert.ok(opts.signal instanceof AbortSignal); // the Tor-hang abort is actually wired
+    assert.equal(t.doc.title, ''); // no page_title in the payload → title left alone
+});
+
+test('boot: ui state seeds from the URL and persisted preferences', async () => {
+    const t = makeEnv({
+        href: 'http://pithead.test/?range=24h',
+        stored: {
+            dashboardView: 'advanced',
+            dashboardTheme: 'dark',
+            dashboardAvgWindow: '1h',
+            dashboardSort: '2:desc',
+            dashboardCalcHint: 'dismissed',
+        },
+        responses: [ok({})],
+    });
+    const d = initDashboard(t.env);
+    const ui = t.paints[0].ui;
+    assert.equal(ui.range, '24h');
+    assert.equal(ui.view, 'advanced');
+    assert.equal(ui.theme, 'dark');
+    assert.equal(ui.avg, '1h');
+    assert.equal(ui.sortIndex, 2);
+    assert.equal(ui.sortAsc, false);
+    assert.equal(ui.hintDismissed, true);
+    assert.equal(ui.inspectWorker, null);
+    // The persisted theme is re-asserted on <html data-theme> before the first paint.
+    assert.equal(t.doc.documentElement.attrs['data-theme'], 'dark');
+    await d.firstLoad;
+    assert.equal(t.fetches[0].url, '/api/state?range=24h&avg=1h');
+});
+
+test('boot: garbage persisted preferences are routed through their normalizers', async () => {
+    // logic.test.mjs owns each normalizer's semantics; this pins that dashboard.js actually
+    // feeds every storage key through the right one instead of trusting localStorage.
+    const t = makeEnv({
+        stored: {
+            dashboardView: 'wat',
+            dashboardTheme: 'blorp',
+            dashboardAvgWindow: '7h',
+            dashboardSort: '99:asc',
+            dashboardSeries: '{broken',
+        },
+        responses: [ok({})],
+    });
+    initDashboard(t.env);
+    const ui = t.paints[0].ui;
+    assert.equal(ui.view, 'simple');
+    assert.equal(ui.theme, 'auto');
+    assert.equal(ui.avg, '10m');
+    assert.equal(ui.sortIndex, null);
+    assert.equal(ui.hintDismissed, false);
+    for (const k of SERIES_KEYS) assert.equal(ui.series[k], true);
+});
+
+test('boot: a shareable zoom URL (?from=&to=) wins over the preset range', async () => {
+    const t = makeEnv({ href: 'http://pithead.test/?from=1000&to=2000', responses: [ok({})] });
+    await initDashboard(t.env).firstLoad;
+    assert.equal(t.fetches[0].url, '/api/state?from=1000&to=2000&avg=10m');
+});
+
+// --- the refresh loop -------------------------------------------------------------------------
+
+test('poll failure: disconnected banner state, last snapshot kept, recovery on next tick', async () => {
+    const t = makeEnv({ responses: [ok({ page_title: 'live' }), aborted(), ok({ page_title: 'back' })] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    const snapshot = t.last().state;
+    await d.tick(); // this poll dies (Tor circuit dropped, request aborted)
+    assert.equal(t.last().connected, false);
+    assert.equal(t.last().state, snapshot); // stale data stays on screen, flagged by the banner
+    await d.tick(); // the next 30s tick reaches the server again
+    assert.equal(t.last().connected, true);
+    assert.equal(t.last().state.page_title, 'back');
+});
+
+test('poll failure: a non-2xx response counts as disconnected', async () => {
+    const t = makeEnv({ responses: [httpError(502)] });
+    await initDashboard(t.env).firstLoad;
+    assert.equal(t.last().connected, false);
+    assert.equal(t.last().state, null); // still the loading shell — no made-up data
+});
+
+test('a hung poll cannot stack fetches; the abort unblocks the loop (#382)', async () => {
+    const hang = hangingPoll();
+    const t = makeEnv({ responses: [hang.response, ok({ page_title: 'recovered' })] });
+    const d = initDashboard(t.env);
+    // The 30s interval fires while the first poll is still hanging: the inflight guard drops
+    // the tick instead of stacking a second fetch.
+    await t.interval().fn();
+    assert.equal(t.fetches.length, 1);
+    // The abort rejects the hung fetch — without it, `inflight` would stay latched and every
+    // later tick would no-op forever: frozen page, no banner (the original #382).
+    hang.abort();
+    await d.firstLoad;
+    assert.equal(t.last().connected, false);
+    await d.tick();
+    assert.equal(t.last().state.page_title, 'recovered');
+    assert.equal(t.last().connected, true);
+});
+
+// --- handlers, as handed to the App -----------------------------------------------------------
+
+test('onRange: exits any zoom, rewrites the URL, and refetches the new range', async () => {
+    const t = makeEnv({
+        href: 'http://pithead.test/?from=1000&to=2000',
+        responses: [ok({}), ok({}), ok({})],
+    });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    assert.ok(t.last().ui.window); // zoomed via the URL
+    await t.last().onRange('1h');
+    assert.equal(t.last().ui.range, '1h');
+    assert.equal(t.last().ui.window, null); // picking a preset exits the zoom
+    assert.deepEqual(t.urls, ['?range=1h']);
+    assert.equal(t.fetches[1].url, '/api/state?range=1h&avg=10m');
+    await t.last().onRange('all');
+    assert.deepEqual(t.urls, ['?range=1h', '/']); // "all" restores the bare path
+});
+
+test('onZoom/onResetZoom: pin and release the manual window, with shareable URLs', async () => {
+    const t = makeEnv({ responses: [ok({}), ok({}), ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    await t.last().onZoom(1000.4, 2000.6);
+    assert.deepEqual(t.last().ui.window, { from: 1000.4, to: 2000.6 }); // exact, for the fetch
+    assert.deepEqual(t.urls, ['?from=1000&to=2001']); // rounded, for the shareable URL
+    assert.equal(t.fetches[1].url, '/api/state?from=1000.4&to=2000.6&avg=10m');
+    await t.last().onResetZoom();
+    assert.equal(t.last().ui.window, null);
+    assert.deepEqual(t.urls, ['?from=1000&to=2001', '/']); // back on range "all" → bare path
+    assert.equal(t.fetches[2].url, '/api/state?range=all&avg=10m');
+});
+
+test('onSort: first click ascends, same column flips, new column restarts ascending', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    const polls = t.fetches.length;
+    t.last().onSort(3);
+    assert.equal(t.last().ui.sortIndex, 3);
+    assert.equal(t.last().ui.sortAsc, true);
+    t.last().onSort(3);
+    assert.equal(t.last().ui.sortAsc, false); // same column toggles direction
+    t.last().onSort(1);
+    assert.equal(t.last().ui.sortIndex, 1);
+    assert.equal(t.last().ui.sortAsc, true); // a new column restarts ascending
+    assert.equal(t.fetches.length, polls); // client-side sort only — no refetch
+});
+
+test('onView: persists the view; visiting Advanced retires the calculators hint (#425)', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    assert.equal(t.last().ui.hintDismissed, false);
+    t.last().onView('advanced');
+    assert.equal(t.last().ui.view, 'advanced');
+    assert.equal(t.stored.dashboardView, 'advanced');
+    assert.equal(t.last().ui.hintDismissed, true); // the hint's discoverability job is done
+    assert.equal(t.stored.dashboardCalcHint, 'dismissed');
+});
+
+test('onView: switching to a non-Advanced view leaves the hint alone', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    t.last().onView('config');
+    assert.equal(t.last().ui.view, 'config');
+    assert.equal(t.last().ui.hintDismissed, false);
+    assert.equal('dashboardCalcHint' in t.stored, false);
+});
+
+test('onDismissHint: dismisses the hint without leaving Simple view', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    t.last().onDismissHint();
+    assert.equal(t.last().ui.hintDismissed, true);
+    assert.equal(t.stored.dashboardCalcHint, 'dismissed');
+    assert.equal(t.last().ui.view, 'simple');
+});
+
+test('onTheme: persists and re-applies the theme to <html data-theme>', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    t.last().onTheme('dark');
+    assert.equal(t.last().ui.theme, 'dark');
+    assert.equal(t.stored.dashboardTheme, 'dark');
+    assert.equal(t.doc.documentElement.attrs['data-theme'], 'dark');
+});
+
+test('onToggleSeries: flips one series, persists the set, and never refetches', async () => {
+    const key = SERIES_KEYS[0];
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    const polls = t.fetches.length;
+    t.last().onToggleSeries(key);
+    assert.equal(t.last().ui.series[key], false);
+    assert.equal(JSON.parse(t.stored.dashboardSeries)[key], false); // survives reload
+    t.last().onToggleSeries(key);
+    assert.equal(t.last().ui.series[key], true);
+    assert.equal(t.fetches.length, polls); // visibility only — no round-trip
+});
+
+test('onAvgWindow: clamps, persists, and refetches — the series lives on the server (#168)', async () => {
+    const t = makeEnv({ responses: [ok({}), ok({}), ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    await t.last().onAvgWindow('1h');
+    assert.equal(t.last().ui.avg, '1h');
+    assert.equal(t.stored.dashboardAvgWindow, '1h');
+    assert.equal(t.fetches[1].url, '/api/state?range=all&avg=1h');
+    await t.last().onAvgWindow('bogus'); // garbage clamps to the default window
+    assert.equal(t.last().ui.avg, '10m');
+    assert.equal(t.fetches[2].url, '/api/state?range=all&avg=10m');
+});
+
+test('onInspect/onCloseInspect: transient worker-panel state — no fetch, nothing persisted', async () => {
+    const t = makeEnv({ responses: [ok({})] });
+    const d = initDashboard(t.env);
+    await d.firstLoad;
+    const polls = t.fetches.length;
+    t.last().onInspect('miner-1');
+    assert.equal(t.last().ui.inspectWorker, 'miner-1');
+    t.last().onCloseInspect();
+    assert.equal(t.last().ui.inspectWorker, null);
+    assert.equal(t.fetches.length, polls);
+    assert.deepEqual(Object.keys(t.stored), []); // transient: nothing written to storage
+});

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -107,6 +107,7 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | `share_stats` series populated on a mining box (#116) | polls land | 1 ✅ (shape) · 4 ▶ (`--check`) |
 | Confirmed running earnings (#787): yesterday as a **calendar** day vs the trailing 24h/7d/30d spans, the DST-length day boundary, partial marking when a window outruns the recorded payout history, and one roll-up feeding both the dashboard card and `/earnings` | stored payouts | 1 ✅ (`test_earnings.py`, `test_telegram_commands.py`, `components.test.mjs`) |
 | Expected-vs-actual earnings summary (#808/#817): one shared 30d window, the combined Monero+XvB row (estimate folded on the expected side because win payouts are inseparable on the actual side), per-stream gates and honest degradation, Tari block counts, XvB win windowing, and the card's render branches in both views | metrics + stored payouts | 1 ✅ (`test_views.py` `TestEarningsVsActual`, `test_metrics.py`, `components.test.mjs`) |
+| Client entry point (#903): the 30s poll with its pre-tick abort so a hung Tor circuit can't latch the in-flight guard (#382), disconnected-banner state and recovery with the last snapshot kept, preference seeding from URL/localStorage through the normalizers, zoom/range/avg query building, and the handler wiring the App receives | injected fetch/storage/timer fakes | 1 ✅ (`dashboard.test.mjs`) |
 | Dashboard reads correct live state on a real stack | real daemons | 4 ▶ |
 
 ### G. CLI lifecycle (`pithead`)


### PR DESCRIPTION
dashboard.js — the frontend entry — had no test at any tier while its 13 sibling modules did. The enabling refactor is the one the issue proposed: the client now lives in an exported `initDashboard()` whose parameters name the browser seams with the real facilities as defaults, plus a `typeof document`-guarded boot call — same statements, same order in the browser, zero behavior change; under Node the import is side-effect-free.

22 sibling-style tests pin what the file actually owns: the Tor-hang contract (fetch timeout strictly inside the poll interval, an abort signal on every poll, a hung poll can't stack fetches and un-latches for recovery), the failure→banner-with-last-snapshot→recovery cycle, boot sequencing, URL/localStorage seeding through the normalizers, query building, and each App handler's contract (range/zoom/sort/theme/avg-window/inspect). A stash check incidentally proved the issue: against the old file the tests can't even import.

`make lint` clean; `make test-frontend` green with all pre-existing tests plus the 22.

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)