### PR TITLE
test(ci): the patch-coverage gate can no longer pass vacuously (#1000)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,11 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      (`lychee`) runs on a weekly schedule, not per-PR.
    - **test-dashboard** — the dashboard `pytest` suite (must stay ≥ the **80% total coverage gate**).
      CI also runs **`make test-patch-coverage`** (`diff-cover`): new/changed lines must be **≥ 90%**
-     covered vs `origin/develop`, the ratchet that stops coverage rotting at the margin.
+     covered vs `origin/develop`, the ratchet that stops coverage rotting at the margin. The gate
+     says so explicitly when a diff has nothing it measures (shell/docs-only PRs pass loudly), and
+     fails if a changed dashboard Python file is missing from `coverage.xml` entirely — the
+     silent no-op it used to be. Run it right after `make test-dashboard`, so `coverage.xml`
+     is fresh.
    - **test-frontend** — the frontend logic tests (`node --test`); uses the same Node that the
      lint surfaces already require.
    - **test-stack** — the `pithead` shell test suite.

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,8 @@ test-dashboard: ## Dashboard unit/component tests with coverage gate (deps from 
 test-frontend: ## Frontend logic tests with Node's built-in runner (#632; same invocation as CI)
 	node --test build/dashboard/tests/frontend/*.test.mjs
 
-test-patch-coverage: ## diff-cover (#286): new/changed lines must be >=90% covered (run after test-dashboard)
-	cd build/dashboard && uv run --locked --extra test \
-		diff-cover coverage.xml --compare-branch=origin/develop --fail-under=90
+test-patch-coverage: ## diff-cover (#286) minus its vacuous pass (#1000): >=90% on changed lines (run after test-dashboard)
+	bash scripts/patch-coverage.sh
 
 test-stack: ## pithead shell test suite
 	bash tests/stack/run.sh

--- a/scripts/patch-coverage.sh
+++ b/scripts/patch-coverage.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# The patch-coverage gate (#286), without the vacuous pass (#1000). diff-cover exits 0 with
+# "No lines with coverage information" when the diff and coverage.xml don't overlap — which is
+# fine for a shell/docs/compose-only PR but a silent hole when the diff changed measured
+# dashboard Python that a stale coverage.xml never saw. This wrapper runs diff-cover, then
+# checks that every changed file under the measured tree (build/dashboard/mining_dashboard/)
+# appears in coverage.xml: absent files fail loudly, a diff with nothing measurable passes
+# loudly and says so. Run `--self-test` to check the overlap logic against fixtures.
+set -euo pipefail
+
+COMPARE=origin/develop
+# The tree the dashboard coverage run measures (pytest --cov=mining_dashboard). Python outside
+# it (tests, integration fakes) is never in coverage.xml, so it can't make the gate applicable.
+MEASURED='build/dashboard/mining_dashboard/*.py'
+
+# Decide the gate's verdict from the changed measured files vs coverage.xml. Args: <coverage.xml>
+# then the changed files (repo-relative). No changed files -> loud not-applicable pass. Every
+# changed file present in the XML -> pass, saying exactly what was checked (a comment-only
+# change legitimately reports no measurable lines). Any file absent -> fail: coverage never saw
+# it, so the >=90% number above proved nothing about it.
+# ponytail: file-level overlap only — added lines a stale XML lacks inside a known file still
+# slip through (catching those needs coverage's own statement analysis). The gate's contract is
+# a fresh coverage.xml: run right after `make test-dashboard`, the order CI enforces.
+check_overlap() {
+    local xml="$1" f rel missing=()
+    shift
+    if [ "$#" -eq 0 ]; then
+        echo "patch coverage: nothing under build/dashboard/mining_dashboard/ changed in this diff — the >=90% gate is not applicable."
+        return 0
+    fi
+    for f in "$@"; do
+        rel="${f#build/dashboard/mining_dashboard/}" # coverage.xml filenames are source-root-relative
+        grep -q "filename=\"$rel\"" "$xml" || missing+=("$f")
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+        echo "patch coverage: FAIL — changed dashboard Python that coverage.xml never measured:"
+        printf '  %s\n' "${missing[@]}"
+        echo "A stale coverage.xml makes the gate above vacuous. Re-run 'make test-dashboard', then this gate."
+        return 1
+    fi
+    echo "patch coverage: all ${#} changed file(s) under the measured tree are present in coverage.xml."
+    return 0
+}
+
+# --- self-test: drive the overlap decision through fixtures (both branches + the quiet pass) ----
+if [ "${1:-}" = "--self-test" ]; then
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    st_fail=0
+    expect_rc() { # <desc> <expected-rc> <actual-rc>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (expected rc $2, got $3)"
+            st_fail=1
+        fi
+    }
+
+    printf '%s\n' '<coverage><class filename="web/views.py"/></coverage>' >"$tmp/coverage.xml"
+
+    rc=0
+    check_overlap "$tmp/coverage.xml" >"$tmp/out" || rc=$?
+    expect_rc "no measured changes -> pass" 0 "$rc"
+    grep -q "not applicable" "$tmp/out" || {
+        echo "  self-test FAIL: not-applicable pass is silent"
+        st_fail=1
+    }
+
+    rc=0
+    check_overlap "$tmp/coverage.xml" build/dashboard/mining_dashboard/web/views.py >"$tmp/out" || rc=$?
+    expect_rc "changed file present in coverage.xml -> pass" 0 "$rc"
+
+    rc=0
+    check_overlap "$tmp/coverage.xml" build/dashboard/mining_dashboard/web/ghost.py >"$tmp/out" || rc=$?
+    expect_rc "changed file absent from coverage.xml -> fail" 1 "$rc"
+    grep -q "ghost.py" "$tmp/out" || {
+        echo "  self-test FAIL: failure doesn't name the unmeasured file"
+        st_fail=1
+    }
+
+    [ "$st_fail" -eq 0 ] && {
+        echo "patch-coverage self-test OK"
+        exit 0
+    }
+    echo "patch-coverage self-test FAILED"
+    exit 1
+fi
+
+# --- main: diff-cover as before, then the overlap check on its green paths ----------------------
+rc=0
+(cd build/dashboard && uv run --locked --extra test \
+    diff-cover coverage.xml --compare-branch="$COMPARE" --fail-under=90) || rc=$?
+[ "$rc" -ne 0 ] && exit "$rc"
+
+# Same diff diff-cover reads: committed vs the compare branch, plus staged and unstaged.
+# --diff-filter=d drops deletions (a deleted file is rightly absent from fresh coverage).
+changed=$({
+    git diff --name-only --diff-filter=d "$COMPARE...HEAD" -- "$MEASURED"
+    git diff --name-only --diff-filter=d HEAD -- "$MEASURED"
+} | sort -u)
+
+# shellcheck disable=SC2086  # repo paths are space-free; intentional word-split into args
+check_overlap build/dashboard/coverage.xml $changed

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -111,6 +111,13 @@ echo "== unit: lint-operator-strings self-test (#755) =="
 bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
 assert_rc "operator-strings guard self-test passes" "$?" "0"
 
+echo "== unit: patch-coverage overlap self-test (#1000) =="
+# diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
+# overlap check is what turns that into a loud not-applicable pass or a real failure; its
+# --self-test drives fixtures through both branches plus the file-present quiet pass.
+bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
+assert_rc "patch-coverage wrapper self-test passes" "$?" "0"
+
 echo "== unit: is_public_ip classifier (#113) =="
 # Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.
 for ip in 8.8.8.8 1.1.1.1 172.15.0.1 172.32.0.1 100.128.0.1 169.1.1.1 2606:4700:4700::1111 2001:db8::1; do


### PR DESCRIPTION
`make test-patch-coverage` exited 0 with "No lines with coverage information" — a green gate that proved nothing (long-known; it survived every audit because nothing could make it fail). Now `scripts/patch-coverage.sh` runs diff-cover exactly as before (passthrough verbatim, including the hardcoded `origin/develop` compare CI actually uses — the brief's GITHUB_BASE_REF claim was wrong on this branch and the wrapper does not invent it), then on green paths verifies every changed file under the measured tree is present in coverage.xml:

- Shell/docs-only diff → explicit "nothing under the measured tree changed — the gate is not applicable", exit 0.
- Changed dashboard Python that coverage never measured → loud FAIL naming the files (demonstrated live: the old target exited 0 on the identical state).
- Comment-only edit to a measured file → pass (no false positive). diff-cover's own <90% failure passes through untouched.

Deliberately file-level: line-level detection needs coverage's own statement analysis (docstring/continuation lines defeat grep heuristics) — ceiling named in a `ponytail:` comment; the fresh-coverage.xml-first contract is the order CI already enforces, now stated in CONTRIBUTING.md. Fixture-driven `--self-test` wired into the stack suite.

Evidence: `make lint` + full `make test` green (dashboard 1703, stack 1705/0 incl. the new self-test section, selftest 165, fakes 23, frontend 278/278).

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)