### PR TITLE
fix(control): the worker pollers speak RigForge's full terminal vocabulary (#1001)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -358,7 +358,8 @@ same `{worker, changes}` request:
 
 Either way, click **Apply to rig**; RigForge validates the change, applies it, and — if the miner
 doesn't come back to a live hashrate — rolls it back on its own. The panel shows the outcome
-(applied / rejected / rolled back) and appends it to the history.
+(applied / rejected / rolled back — or failed with the rig's reason, when its own rollback
+path broke) and appends it to the history.
 
 To make a rig editable, give it `host`, `token`, and (unless it's the default `8082`) `control_port`
 in its [`workers.list[]`](configuration.md#configuration-reference) descriptor. Without a host, or
@@ -368,8 +369,9 @@ When the rig's [new-release badge](#workers-alive) shows and the rig is editable
 rig…** button appears beside it: arm it, confirm, and the rig upgrades its own RigForge to the
 latest release — the per-worker twin of the stack's one-click upgrade. The rig may rebuild its
 miner (about ten minutes when the XMRig pin changed) and rolls itself back if the miner doesn't
-come back live. The panel shows the outcome (applied / rolled back / failed); a repeat click inside
-the rig's own six-hour upgrade window reads as "throttled — retry later", not an error. See
+come back live. The panel shows the outcome (applied / already up to date / rolled back / failed);
+a repeat click inside the rig's own six-hour upgrade window reads as "throttled — retry later",
+not an error. See
 [Connecting Miners › One-click rig upgrade](workers.md#one-click-rig-upgrade) for what the rig
 must enable and how the target is derived.
 

--- a/pithead
+++ b/pithead
@@ -6252,7 +6252,10 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
     # Poll the rig's /status for THIS change_id's terminal outcome. The rig stages → validates →
     # applies → liveness-checks → rolls back if the miner doesn't return live, seconds later. The 20s
     # deadline (plus the 15s dial above) stays under the dashboard's CONTROL_WAIT_S POST wait, so the
-    # dashboard always catches a terminal-ish result and records it in the config history.
+    # dashboard always catches a terminal-ish result and records it in the config history. Terminals
+    # are applied / rejected / rolled_back / failed — failed is the rig unable to restore its own
+    # rollback backup (present since the v1.11.2 fleet floor), a real fault the result must carry
+    # with its reason, never a deadline-burned "accepted".
     local sbody scode status reason ckeys deadline=$((SECONDS + 20))
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 2
@@ -6273,7 +6276,7 @@ control_worker_apply() { # <claimed-file> <id> <actor> <control-dir>
         fi
         status=$(jq -r '.status // ""' "$sbody")
         case "$status" in
-        applied | rejected | rolled_back)
+        applied | rejected | rolled_back | failed)
             # reason is rig-supplied (attacker-influenceable); cap it before it is stored/rendered.
             reason=$(jq -r '.reason // ""' "$sbody" | head -c 500)
             ckeys=$(jq -c '.changed_keys // []' "$sbody")
@@ -6418,11 +6421,12 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
     # well under 90s, while a pin-change rebuild (~10 min) times out to "accepted" below and the
     # badge (#596) clears on its own when the rig reports the new version. Polling the full build
     # would hand a hostile/hung rig 12 minutes of the single-threaded root drain per intent
-    # (sec-review finding) — 90s keeps the stall bound in worker-apply's envelope. There is no
-    # in-progress status (rigforge#320): a non-matching change_id just means pending. Terminals
-    # are applied / rolled_back / failed; a rig-side throttle refusal arrives as
-    # failed+"throttled" and is surfaced as retry-later, not an error. The cap is overridable
-    # (CONTROL_WU_POLL_CAP) so the stack tests can prove the timeout→accepted fallback in seconds.
+    # (sec-review finding) — 90s keeps the stall bound in worker-apply's envelope. Since
+    # rigforge#320 (v1.12.0) the rig writes an in-progress "started" plus first-class noop
+    # (already on the target) and throttled (its own 6h anti-beacon window) terminals; "started",
+    # like a non-matching change_id, just means keep polling. Terminals are applied / noop /
+    # throttled / rolled_back / failed. The cap is overridable (CONTROL_WU_POLL_CAP) so the stack
+    # tests can prove the timeout→accepted fallback in seconds.
     local sbody scode status reason deadline=$((SECONDS + ${CONTROL_WU_POLL_CAP:-90}))
     while [ "$SECONDS" -lt "$deadline" ]; do
         sleep 5
@@ -6444,14 +6448,18 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
         fi
         status=$(jq -r '.status // ""' "$sbody")
         case "$status" in
-        applied | rolled_back | failed)
+        applied | noop | throttled | rolled_back | failed)
             # reason is rig-supplied (attacker-influenceable); cap it before it is stored/rendered.
             reason=$(jq -r '.reason // ""' "$sbody" | head -c 500)
             rm -f "$sbody"
-            # The rig collapses its refusals into failed+free-text (rigforge#320); its 6h
-            # anti-beacon throttle is retry-later, not a fault — give it its own status so the
-            # dashboard renders it calm instead of red.
-            if [ "$status" = "failed" ] && printf '%s' "$reason" | grep -qi "throttl"; then
+            # Legacy remap: a pre-rigforge#320 rig (≤ v1.11.2, the supported floor) collapses its
+            # 6h anti-beacon throttle into failed+"throttled — ..." free text, and retry-later
+            # must render calm, not red. Anchored to that leading word on purpose: a modern rig's
+            # genuine failed can mention the throttle too ("throttle state unavailable",
+            # rigforge#321's fail-closed refusal) and must STAY a fault. Drop the remap once the
+            # fleet floor reaches rigforge v1.12.0 (first-class throttled) — the v2 appliance
+            # bakes v1.15.0, so post-v2 fleets are already past it.
+            if [ "$status" = "failed" ] && printf '%s' "$reason" | grep -qiE '^throttled'; then
                 status="throttled"
             fi
             control_write_result "$results" "$id" "$(jq -n --arg s "$status" --arg c "$change_id" --arg w "$worker" --arg v "$tag" --arg r "$reason" \

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6800,6 +6800,43 @@ assert_eq "worker-apply accept path records the rig's changed_keys" \
     "$(jq -rc '.changed_keys' "$WA3/results/$u9.json" 2>/dev/null)" '["pools"]'
 assert_contains "worker-apply accept is audited as applied" \
     "$(cat "$WA3/audit/control.log")" '"action":"worker-apply","status":"applied"'
+# The rig can also end an apply terminal "failed" — it could not restore its own rollback backup
+# (present since the v1.11.2 fleet floor). The poll must land it as failed-with-reason, never burn
+# the 20s deadline into a vague "accepted".
+WA4="$SANDBOX/ctrl185-failed"
+mkdir -p "$WA4/staged" "$WA4/results" "$WA4/audit" "$WA4/bin"
+cp "$WA3/config.json" "$WA4/config.json"
+cat >"$WA4/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+out="" url=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) url="$1"; shift ;;
+    esac
+done
+case "$url" in
+*/apply)
+    printf '{"change_id":"chg-2"}' >"$out"
+    printf '202' ;;
+*/status)
+    printf '{"change_id":"chg-2","status":"failed","reason":"rollback backup unreadable: /var/lib/rigforge/backup"}' >"$out"
+    printf '200' ;;
+*) printf '000' ;;
+esac
+exit 0
+EOF
+chmod +x "$WA4/bin/curl"
+u10="fafafafa-fafa-4afa-8afa-fafafafafafa"
+printf '{"id":"%s","action":"worker-apply","actor":"admin","worker":"rig1","changes":{"pools":["pool.example:3333"]}}\n' "$u10" >"$WA4/req.json"
+PATH="$WA4/bin:$PATH" CONTROL_WA_BUDGET=1 PITHEAD_CONFIG_FILE="$WA4/config.json" \
+    run_sourced "$SANDBOX" control_process_request "$WA4/req.json" "$WA4" >/dev/null 2>&1
+assert_eq "a failed apply reaches terminal 'failed', not the poll-deadline 'accepted'" \
+    "$(jq -r '.status' "$WA4/results/$u10.json" 2>/dev/null)" "failed"
+assert_contains "the failed apply carries the rig's reason" \
+    "$(jq -r '.reason' "$WA4/results/$u10.json" 2>/dev/null)" "rollback backup unreadable"
+assert_contains "the failed apply is audited as failed" \
+    "$(cat "$WA4/audit/control.log")" '"action":"worker-apply","status":"failed"'
 
 # ---------------------------------------------------------------------------
 echo "== control channel: worker upgrade fails closed (#597) =="
@@ -6920,7 +6957,22 @@ assert_eq "rolled_back result carries the rig's reason" \
     "$(jq -r '.reason' "$WU_LAST_DIR/results/$w8.json" 2>/dev/null)" "miner did not return live"
 w9="34343434-3434-4234-9234-343434343434"
 wu_accept_case "$w9" '{"change_id":"chg-9","status":"failed","reason":"throttled: retry after the window"}' \
-    "rig-side throttle refusal is mapped to retry-later, not a fault" "throttled"
+    "legacy rig (pre-v1.12.0) throttle refusal (failed+text) still maps to retry-later" "throttled"
+# First-class terminals since rigforge#320 (v1.12.0): noop (already on the target) and throttled
+# land their real status on the first poll — neither burns the poll cap into a vague "accepted".
+w17="bcbcbcbc-bcbc-42bc-92bc-bcbcbcbcbcbc"
+wu_accept_case "$w17" '{"change_id":"chg-9","status":"noop","reason":"already on v9.9.9 — nothing to upgrade"}' \
+    "a rig already on the target lands first-class 'noop', not the poll-cap fallback" "noop"
+assert_contains "the noop result carries the rig's already-on-target reason" \
+    "$(jq -r '.reason' "$WU_LAST_DIR/results/$w17.json" 2>/dev/null)" "already on v9.9.9"
+w18="cdcdcdcd-cdcd-42cd-92cd-cdcdcdcdcdcd"
+wu_accept_case "$w18" '{"change_id":"chg-9","status":"throttled","reason":"throttled — too soon since the last upgrade attempt"}' \
+    "a first-class 'throttled' terminal lands as retry-later on the first poll" "throttled"
+# A genuine failure that merely MENTIONS the throttle must stay a fault (rigforge#321's
+# fail-closed refusal): only the legacy leading-"throttled" free text remaps to retry-later.
+w19="dededede-dede-42de-92de-dededededede"
+wu_accept_case "$w19" '{"change_id":"chg-9","status":"failed","reason":"throttle state unavailable under /var/lib/rigforge — refused (fail-closed)"}' \
+    "a broken-rig failure mentioning the throttle stays 'failed', never calmed" "failed"
 # An unreachable rig fails cleanly (nothing changed, rig keeps its version).
 unreach_dir="$SANDBOX/ctrl597-unreach"
 mkdir -p "$unreach_dir/staged" "$unreach_dir/results" "$unreach_dir/audit" "$unreach_dir/bin"


### PR DESCRIPTION
Cross-repo audit finding: RigForge writes `noop`/`throttled` as first-class terminals since its v1.12.0 (#320) and apply can end `failed` — pithead's pollers knew none of them, so real outcomes burned the poll caps and recorded "accepted".

- Apply poll now terminates on `applied | rejected | rolled_back | failed` — a failed apply lands with the rig's reason and a `failed` audit row (the Python/frontend already knew the status; only the shell poll was blind).
- Upgrade poll now terminates on `applied | noop | throttled | rolled_back | failed` — "already on target" renders green, throttled renders retry-later, neither burns 90 s.
- Legacy remap kept for pre-v1.12.0 rigs (floor is v1.11.2), dated for removal — and **root-caused into a second fix**: the old substring `throttl` match would have calmed rigforge#321's deliberate fail-closed refusal ("throttle state unavailable … refused") into retry-later; it's now anchored to the exact legacy prefix.

Evidence: stack suite 1711/0 with a fail-first proof — against the old `pithead`, exactly the 7 new assertions fail. `make lint` clean; docs/dashboard.md outcome lists updated. Patch-coverage honestly N/A (shell-only diff; the behavior proof is the fail-first run — and #1008's honest gate now says so explicitly for future PRs).

Follow-up filed while closing: #1009 — the feed-side reconciler has the same vocabulary gap, and the mirror it reads ships as of today's rigforge v1.15.0.

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)