### PR TITLE
fix: raise the Tari disk budget to 200 GiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cp config.minimal.json config.json   # then set your Monero + Tari payout addres
 > For every tunable, copy `config.reference.json` instead. To build from source (a `dev`
 > build), e.g. to contribute, see [Install from source](docs/getting-started.md#alternative-build-from-source).
 
-> NOTE: Prereqs are Ubuntu Server 24.04 LTS, 16 GB+ RAM, an SSD (~300 GB pruned / ~500 GB full
+> NOTE: Prereqs are Ubuntu Server 24.04 LTS, 16 GB+ RAM, an SSD (~330 GB pruned / ~530 GB full
 > minimum; the chains grow ~100+ GB/year, so 2–4 TB avoids a later resize), and your Monero + Tari
 > payout addresses. Full sizing in [Hardware Requirements](docs/hardware.md).
 

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -12,7 +12,7 @@ manage the host.
 
 - An x86-64 machine with UEFI you can dedicate to mining. It will be **erased**.
 - 16 GB RAM or more, and an internal SSD or NVMe with room for the chains. The stack budgets
-  about 120 GB for pruned Monero and about 170 GB for a local Tari node (measured chains:
+  about 120 GB for pruned Monero and about 200 GB for a local Tari node (measured chains:
   roughly 100 GB and 150 GB in August 2026, and growing — the budget is the growth room), so
   **350 GB or more** runs both locally. On a smaller disk, run pruned Monero and point Tari
   at a node you already have — the setup page asks both questions.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -138,7 +138,7 @@ trick works for reusing a synced Tari node. See
 
 ### What hardware do I need?
 
-Plan for 16 GB+ RAM, a CPU with AVX2 for RandomX, and an SSD (~300 GB pruned / ~500 GB full
+Plan for 16 GB+ RAM, a CPU with AVX2 for RandomX, and an SSD (~330 GB pruned / ~530 GB full
 minimum; Tari's chain alone is ~150 GB, and both chains grow ~100+ GB/year, so a 2–4 TB drive is
 the set-and-forget choice). Full minimum-vs-recommended sizing for the stack host is in
 [Hardware Requirements](hardware.md). (Miner hardware is sized separately in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,7 @@ dashboard, no Linux to set up.
 | Operating system | Ubuntu Server 24.04 LTS is the supported platform. Other Linux distributions and macOS may work but aren't supported. |
 | CPU | A processor with AVX2 support for RandomX performance. |
 | RAM | 16 GB minimum with HugePages enabled (~6 GB is reserved for RandomX); 32 GB for a full node or long uptimes. |
-| Disk | A pruned Monero node needs ~100 GB and a full one ~270 GB, plus ~150 GB for the Tari node (its chain is the biggest single consumer). Plan for ~300 GB (pruned) or ~500 GB (full) of SSD minimum. Both chains grow ~100+ GB/year, so a 2–4 TB drive is the set-and-forget choice. |
+| Disk | A pruned Monero node needs ~100 GB and a full one ~270 GB, plus ~150 GB for the Tari node (its chain is the biggest single consumer). Plan for ~330 GB (pruned) or ~530 GB (full) of SSD minimum. Both chains grow ~100+ GB/year, so a 2–4 TB drive is the set-and-forget choice. |
 | Software | Docker Engine, Docker Compose V2, `jq`, and `openssl`. |
 
 > 📐 Sizing guidance for the stack host — minimum vs. recommended specs, plus ways to run leaner —
@@ -35,8 +35,8 @@ dashboard, no Linux to set up.
 > [RigForge](https://github.com/p2pool-starter-stack/rigforge).
 
 > 🔎 `setup` checks this for you. Before it starts anything, `./pithead setup` runs a best-effort
-> pre-flight on free disk and total RAM. If either is below the recommended minimums (~300 GB
-> pruned / ~500 GB full disk, 16 GB RAM), it prints a warning. It never blocks setup, so you can
+> pre-flight on free disk and total RAM. If either is below the recommended minimums (~330 GB
+> pruned / ~530 GB full disk, 16 GB RAM), it prints a warning. It never blocks setup, so you can
 > proceed on a smaller host at your own risk. See **[Hardware Requirements](hardware.md)**.
 
 You don't have to install the software dependencies yourself. `setup` checks for them and, on

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -26,8 +26,8 @@ Size the host for nodes, storage, and uptime; size the workers for CPU mining pe
 |---|---|---|
 | **CPU** | 4 cores, 64-bit x86 (AVX2 advised) | 6–8+ cores with **AVX2** |
 | **RAM** | **16 GB** | **32 GB** |
-| **Disk — pruned node** | ~300 GB SSD | 1 TB+ SSD |
-| **Disk — full node** | ~500 GB SSD | 2 TB+ SSD |
+| **Disk — pruned node** | ~330 GB SSD | 1 TB+ SSD |
+| **Disk — full node** | ~530 GB SSD | 2 TB+ SSD |
 | **Network** | Always-on broadband | Unmetered broadband |
 | **OS** | Ubuntu Server **24.04 LTS** | Ubuntu Server 24.04 LTS |
 
@@ -58,11 +58,11 @@ reclaim space in place — run `monero-blockchain-prune` to write a new pruned D
 at full size.)
 
 Both chains keep growing, ~100+ GB/year combined (Tari, a young chain, grows fastest; Monero adds
-tens of GB/year). That's why the table lists a ~300 GB (pruned) / ~500 GB (full) minimum but
+tens of GB/year). That's why the table lists a ~330 GB (pruned) / ~530 GB (full) minimum but
 recommends more: for a set-and-forget host, put it on a 2–4 TB SSD. Disk figures are measured on live
 deployments (August 2026: a full node at 267 GB Monero + 149 GB Tari; a pruned node measured
 ~102 GB Monero). `./pithead setup` budgets above these measurements on purpose — 120 GB pruned /
-320 GB full for Monero, 170 GB for Tari — so a host sized to the minimums has growth room from day
+320 GB full for Monero, 200 GB for Tari — so a host sized to the minimums has growth room from day
 one. The
 per-service **RAM** figures are provisioning minimums — steady-state resident memory is much lower
 (`monerod` and P2Pool a few hundred MB each, since their large data lives in the shared HugePages and
@@ -113,7 +113,7 @@ node databases do heavy random I/O that punishes spinning disks. What to provisi
 | Monero chain | ~100 GB | ~270 GB |
 | Tari chain | ~150 GB | ~150 GB |
 | P2Pool + dashboard + Docker images | a few GB | a few GB |
-| **Plan for** | **~300 GB+ SSD** | **~500 GB+ SSD** |
+| **Plan for** | **~330 GB+ SSD** | **~530 GB+ SSD** |
 
 Both chains keep growing, ~100+ GB/year combined (Tari, a young chain, grows fastest), so leave
 headroom: the *recommended* 1 TB+ (pruned) / 2 TB+ (full) sizes exist for that, and a 2–4 TB SSD is
@@ -122,7 +122,7 @@ or not you prune Monero, so pruning only saves disk on the Monero side. Pruning 
 fully validating Monero node at a fraction of the size.
 
 > `setup` pre-flights these. Before a sync, `./pithead setup` checks free disk and total RAM against
-> the minimums on this page (~300 GB pruned / ~500 GB full disk, 16 GB RAM) and warns if the host
+> the minimums on this page (~330 GB pruned / ~530 GB full disk, 16 GB RAM) and warns if the host
 > falls short; it never blocks. `./pithead doctor` re-runs the same disk and RAM checks on demand.
 
 You can put any service's data on a dedicated disk by pointing its `*.data_dir` at an absolute path,

--- a/pithead
+++ b/pithead
@@ -1149,7 +1149,7 @@ doctor() {
         doctor_prune=$(env_get MONERO_PRUNE)
         [ -n "$doctor_prune" ] || doctor_prune=1
         # A remote node (#103) keeps its chain elsewhere, so its dir must not count toward THIS
-        # host's disk budget — otherwise doctor demands ~120 GiB (Monero) / ~170 GiB (Tari) for a
+        # host's disk budget — otherwise doctor demands ~120 GiB (Monero) / ~200 GiB (Tari) for a
         # container that never runs, on exactly the small-disk hosts remote mode exists for. Read
         # the mode from the profile tokens like the container checks above; a pre-#103 .env has no
         # local_tari token yet, so require a rendered TARI_GRPC_ADDRESS (also new in #103) before
@@ -7482,8 +7482,8 @@ prompt_start_stack() {
 
 # Per-component free-disk requirement in GiB — the single source of truth for the stack's disk
 # budget, shared by setup's preflight_resources and doctor's Disk check. Monero (the blockchain) is
-# pruning-aware: ~120 GiB pruned, ~320 GiB full. Tari's chain is the other heavyweight — ~170 GiB and
-# growing fast. Summed, this is ~300 GiB pruned / ~500 GiB full, the documented minimum
+# pruning-aware: ~120 GiB pruned, ~320 GiB full. Tari's chain is the other heavyweight — ~200 GiB and
+# growing fast. Summed, this is ~330 GiB pruned / ~530 GiB full, the documented minimum
 # (docs/hardware.md). These carry generous growth headroom over usage measured on live nodes
 # (August 2026: Monero pruned ~100 GiB / full ~267 GiB, Tari ~149 GiB) because both chains grow
 # ~100+ GiB/year combined — for a set-and-forget host the docs recommend a 2–4 TB drive.
@@ -7491,7 +7491,7 @@ prompt_start_stack() {
 disk_component_gib() {
     case "$1" in
     monero) if [ "${2:-1}" -eq 1 ] 2>/dev/null; then echo 120; else echo 320; fi ;;
-    tari) echo 170 ;;
+    tari) echo 200 ;;
     p2pool) echo 5 ;;
     dashboard) echo 2 ;;
     tor) echo 1 ;;
@@ -7602,7 +7602,7 @@ preflight_resources() {
     # once per volume that can't hold the combined requirement of the components sharing it (so dirs
     # on the same disk produce a single line, not one per dir). check_disk_grouped is WARN-only here.
     # A remote node (#103) keeps its chain elsewhere: blank its dir so the ~120 GiB (Monero) /
-    # ~170 GiB (Tari) budget isn't demanded of THIS host — small disks are exactly why an operator
+    # ~200 GiB (Tari) budget isn't demanded of THIS host — small disks are exactly why an operator
     # goes remote. check_disk_grouped skips empty dirs.
     local pre_mono_dir="${MONERO_DIR:-}" pre_tari_dir="${TARI_DIR:-}"
     [ "$MONERO_MODE" == "remote" ] && pre_mono_dir=""

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2658,7 +2658,7 @@ assert_contains "the ownership scan keys off foreign uid" "$(cat "$EO/find.log")
 echo "== unit: disk_component_gib =="
 assert_eq "monero pruned -> 120" "$(run_sourced "$SANDBOX" disk_component_gib monero 1)" "120"
 assert_eq "monero full -> 320" "$(run_sourced "$SANDBOX" disk_component_gib monero 0)" "320"
-assert_eq "tari -> 170" "$(run_sourced "$SANDBOX" disk_component_gib tari)" "170"
+assert_eq "tari -> 200" "$(run_sourced "$SANDBOX" disk_component_gib tari)" "200"
 assert_eq "tor -> 1" "$(run_sourced "$SANDBOX" disk_component_gib tor)" "1"
 
 echo "== unit: check_disk_grouped (mocked df) =="
@@ -2685,36 +2685,36 @@ mkdir -p "$DM/monero" "$DM/tari" "$DM/p2pool" "$DM/dashboard" "$DM/tor"
 md="$DM/monero" td="$DM/tari" pd="$DM/p2pool" dd="$DM/dashboard" rd="$DM/tor"
 
 # All five dirs on ONE filesystem with plenty of space -> a SINGLE grouped OK line naming every
-# component, with the combined pruned requirement (120+170+5+2+1 = 298 GB).
+# component, with the combined pruned requirement (120+200+5+2+1 = 328 GB).
 one_map="$md=/data $td=/data $pd=/data $dd=/data $rd=/data /data=/data"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
 assert_contains "single line names all components" "$out" "(monero, tari, p2pool, dashboard, tor)"
-assert_contains "single line shows combined ~298 GB" "$out" "needs ~298 GB"
+assert_contains "single line shows combined ~328 GB" "$out" "needs ~328 GB"
 assert_contains "ample space -> OK" "$out" "OK"
 
-# Same single filesystem but too small (100 GiB < 298 GiB) -> ONE WARN line.
+# Same single filesystem but too small (100 GiB < 328 GiB) -> ONE WARN line.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=104857600 DF_AVAIL_H=100G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one small fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
-assert_contains "small fs warns below need" "$out" "below the ~298 GB"
+assert_contains "small fs warns below need" "$out" "below the ~328 GB"
 
 # Two filesystems: monero+tari on /big, the rest on /small -> ONE line per filesystem.
 two_map="$md=/big $td=/big $pd=/small $dd=/small $rd=/small /big=/big /small=/small"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$two_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "two fs -> two lines" "$(printf '%s\n' "$out" | grep -c 'Data on')" "2"
-assert_contains "/big groups monero+tari (~290 GB)" "$out" "/big (monero, tari): 600G free — needs ~290 GB"
+assert_contains "/big groups monero+tari (~320 GB)" "$out" "/big (monero, tari): 600G free — needs ~320 GB"
 assert_contains "/small groups the small three (~8 GB)" "$out" "/small (p2pool, dashboard, tor): 600G free — needs ~8 GB"
 
 # Remote node modes (#103): doctor/preflight blank the remote component's dir (its chain lives on
 # the OTHER host), and an empty dir arg must drop that component from the budget entirely — here
-# tari remote drops the ~170 GB Tari share, leaving monero+the small three (120+5+2+1 = 128 GB).
+# tari remote drops the ~200 GB Tari share, leaving monero+the small three (120+5+2+1 = 128 GB).
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "" "$pd" "$dd" "$rd" 2>&1)"
 assert_contains "remote tari drops tari from the budget" "$out" "(monero, p2pool, dashboard, tor)"
-assert_contains "remote tari budget excludes the 170 GB" "$out" "needs ~128 GB"
+assert_contains "remote tari budget excludes the 200 GB" "$out" "needs ~128 GB"
 
 # Preflight mode is WARN-only and silent when there's enough room.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \


### PR DESCRIPTION
## What

`disk_component_gib()`: the Tari budget goes from 170 to **200 GiB**. Every figure derived from it moves in lockstep — setup preflight / doctor now ask for ~328 GB summed (pruned) / ~528 GB (full), documented as ~330/~530 in README, hardware.md, getting-started.md, faq.md, and appliance.md. Stack-suite asserts updated to the new sums.

## Why — the measurement

| Date | Tari chain (bench-host, `du -sh /srv/code/pithead-data/tari`) | Source |
|---|---|---|
| 2026-06-12 | ~135 GB | #232, when the 170 budget was set |
| 2026-08-15 | **149 GiB** | fresh read-only measurement for this PR (matches the #1005 reconcile) |

That is **+14 GiB in 64 days ≈ 6.6 GiB/month** — the fastest-growing chain in the stack, consistent with hardware.md's "Tari grows fastest" of ~100+ GB/year combined. The 170 budget's remaining headroom is 21 GiB: a host provisioned to the documented minimum today outgrows it in **~3 months** (≈ November 2026).

## Why 200 and not more

- 200 restores **51 GiB of headroom ≈ 8 months** at the observed rate — more absolute and relative margin than the budget has ever carried (the June bump bought 35 GiB).
- It keeps appliance.md's "**350 GB or more** runs both locally" headline true (new pruned sum 328 GB; the slack tightens from 52 to 22 GB).
- The alternative, **220** (~11 months), leaves that headline 2 GB of slack — effectively forcing it to 400 GB and every documented sum up another notch. The years-long runway story belongs to the recommended 1–2 TB+ tier, which is unchanged.

Operator call: if you'd rather buy the extra quarter, say 220 and I'll re-spin the figures.

## Notes

- `develop` carries the same `tari) echo 170` (its pithead:4521) and the old doc figures; it needs the same bump — flagged separately so it isn't lost in the v2 close-out sync.
- Verified locally: `make lint` clean (docs-voice pass included), `make test-stack` 2312 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)