### PR TITLE
fix: raise the Tari disk budget to 200 GiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cp config.minimal.json config.json   # then set your Monero + Tari payout addres
 > For every tunable, copy `config.reference.json` instead. To build from source (a `dev`
 > build), e.g. to contribute, see [Install from source](docs/getting-started.md#alternative-build-from-source).
 
-> NOTE: Prereqs are Ubuntu Server 24.04 LTS, 16 GB+ RAM, an SSD (~300 GB pruned / ~500 GB full
+> NOTE: Prereqs are Ubuntu Server 24.04 LTS, 16 GB+ RAM, an SSD (~330 GB pruned / ~530 GB full
 > minimum; the chains grow ~100+ GB/year, so 2–4 TB avoids a later resize), and your Monero + Tari
 > payout addresses. Full sizing in [Hardware Requirements](docs/hardware.md).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -136,8 +136,8 @@ trick works for reusing a synced Tari node. See
 
 ### What hardware do I need?
 
-Plan for 16 GB+ RAM, a CPU with AVX2 for RandomX, and an SSD (~300 GB pruned / ~500 GB full
-minimum; Tari's chain alone is ~135 GB, and both chains grow ~100+ GB/year, so a 2–4 TB drive is
+Plan for 16 GB+ RAM, a CPU with AVX2 for RandomX, and an SSD (~330 GB pruned / ~530 GB full
+minimum; Tari's chain alone is ~150 GB, and both chains grow ~100+ GB/year, so a 2–4 TB drive is
 the set-and-forget choice). Full minimum-vs-recommended sizing for the stack host is in
 [Hardware Requirements](hardware.md). (Miner hardware is sized separately in
 [RigForge](https://github.com/p2pool-starter-stack/rigforge).)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ script drives every step.
 | Operating system | Ubuntu Server 24.04 LTS is the supported platform. Other Linux distributions and macOS may work but aren't supported. |
 | CPU | A processor with AVX2 support for RandomX performance. |
 | RAM | 16 GB minimum with HugePages enabled (~6 GB is reserved for RandomX); 32 GB for a full node or long uptimes. |
-| Disk | A pruned Monero node needs ~100 GB and a full one ~265 GB, plus ~135 GB for the Tari node (its chain is the biggest single consumer). Plan for ~300 GB (pruned) or ~500 GB (full) of SSD minimum. Both chains grow ~100+ GB/year, so a 2–4 TB drive is the set-and-forget choice. |
+| Disk | A pruned Monero node needs ~100 GB and a full one ~270 GB, plus ~150 GB for the Tari node (its chain is the biggest single consumer). Plan for ~330 GB (pruned) or ~530 GB (full) of SSD minimum. Both chains grow ~100+ GB/year, so a 2–4 TB drive is the set-and-forget choice. |
 | Software | Docker Engine, Docker Compose V2, `jq`, and `openssl`. |
 
 > 📐 Sizing guidance for the stack host — minimum vs. recommended specs, plus ways to run leaner —
@@ -31,8 +31,8 @@ script drives every step.
 > [RigForge](https://github.com/p2pool-starter-stack/rigforge).
 
 > 🔎 `setup` checks this for you. Before it starts anything, `./pithead setup` runs a best-effort
-> pre-flight on free disk and total RAM. If either is below the recommended minimums (~300 GB
-> pruned / ~500 GB full disk, 16 GB RAM), it prints a warning. It never blocks setup, so you can
+> pre-flight on free disk and total RAM. If either is below the recommended minimums (~330 GB
+> pruned / ~530 GB full disk, 16 GB RAM), it prints a warning. It never blocks setup, so you can
 > proceed on a smaller host at your own risk. See **[Hardware Requirements](hardware.md)**.
 
 You don't have to install the software dependencies yourself. `setup` checks for them and, on

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -24,8 +24,8 @@ Size the host for nodes, storage, and uptime; size the workers for CPU mining pe
 |---|---|---|
 | **CPU** | 4 cores, 64-bit x86 (AVX2 advised) | 6–8+ cores with **AVX2** |
 | **RAM** | **16 GB** | **32 GB** |
-| **Disk — pruned node** | ~300 GB SSD | 1 TB+ SSD |
-| **Disk — full node** | ~500 GB SSD | 2 TB+ SSD |
+| **Disk — pruned node** | ~330 GB SSD | 1 TB+ SSD |
+| **Disk — full node** | ~530 GB SSD | 2 TB+ SSD |
 | **Network** | Always-on broadband | Unmetered broadband |
 | **OS** | Ubuntu Server **24.04 LTS** | Ubuntu Server 24.04 LTS |
 
@@ -40,25 +40,28 @@ plus headroom for the OS. Per-component breakdown, from each project's own guida
 
 | Service | RAM it wants | Disk | Notes |
 |---|---|---|---|
-| **[Monero node](https://docs.getmonero.org/running-node/)** (`monerod`) | **4 GB** minimum; more RAM = bigger DB cache and faster sync | **~100 GB** pruned · **~265 GB** full — and growing | SSD strongly recommended. Not run at all in remote-node mode. |
+| **[Monero node](https://docs.getmonero.org/running-node/)** (`monerod`) | **4 GB** minimum; more RAM = bigger DB cache and faster sync | **~100 GB** pruned · **~270 GB** full — and growing | SSD strongly recommended. Not run at all in remote-node mode. |
 | **[P2Pool](https://github.com/SChernykh/p2pool)** | **~2.3 GB** for the RandomX dataset it uses to verify blocks fast (`--light-mode` skips it, saving ~2 GB, but verifies slower) | tiny (sidechain state) | Needs a 64-bit CPU with **AVX2** and a synced `monerod`. |
-| **[Tari base node](https://www.tari.com/integration-guide)** (`minotari_node`) | **4 GB** minimum, **8 GB+** recommended; grows over time | **~140 GB** SSD — and growing | The largest single disk consumer once Monero is pruned (~140 GB vs a pruned Monero node's ~100 GB), so budget for it whether or not you prune Monero. The stack caps its memory so growth can't take the host down. |
+| **[Tari base node](https://www.tari.com/integration-guide)** (`minotari_node`) | **4 GB** minimum, **8 GB+** recommended; grows over time | **~150 GB** SSD — and growing | The largest single disk consumer once Monero is pruned (~150 GB vs a pruned Monero node's ~100 GB), so budget for it whether or not you prune Monero. The stack caps its memory so growth can't take the host down. |
 | **XMRig proxy · Tor · Caddy · dashboard · Docker** | a few hundred MB combined | a few GB (Docker images) | These coordinate and serve the UI. They don't mine, so no special CPU. |
 
 Add the three heavy services' RAM (Monero 4 GB, P2Pool ~2.3 GB, Tari 4 GB) plus a couple of GB for
 the OS, page cache, and supporting containers, and you reach the 16 GB minimum above.
 
-Disk is dominated by the two chains. A pruned Monero node (~100 GB) plus the Tari node (~140 GB) and
-a few GB for P2Pool and the OS put a pruned host near ~250 GB; a *full* Monero node (~265 GB) instead
-of pruned pushes that toward ~410 GB. Pruning Monero doesn't shrink Tari, so budget for Tari
+Disk is dominated by the two chains. A pruned Monero node (~100 GB) plus the Tari node (~150 GB) and
+a few GB for P2Pool and the OS put a pruned host near ~260 GB; a *full* Monero node (~270 GB) instead
+of pruned pushes that toward ~425 GB. Pruning Monero doesn't shrink Tari, so budget for Tari
 regardless. (A *freshly synced* pruned node is ~100 GB, but pruning an existing full chain doesn't
 reclaim space in place — run `monero-blockchain-prune` to write a new pruned DB; until then it sits
 at full size.)
 
 Both chains keep growing, ~100+ GB/year combined (Tari, a young chain, grows fastest; Monero adds
-tens of GB/year). That's why the table lists a ~300 GB (pruned) / ~500 GB (full) minimum but
+tens of GB/year). That's why the table lists a ~330 GB (pruned) / ~530 GB (full) minimum but
 recommends more: for a set-and-forget host, put it on a 2–4 TB SSD. Disk figures are measured on live
-deployments (a pruned node at ~102 GB Monero + ~139 GB Tari; a full node at ~266 GB Monero). The
+deployments (August 2026: a full node at 267 GB Monero + 149 GB Tari; a pruned node measured
+~102 GB Monero). `./pithead setup` budgets above these measurements on purpose — 120 GB pruned /
+320 GB full for Monero, 200 GB for Tari — so a host sized to the minimums has growth room from day
+one. The
 per-service **RAM** figures are provisioning minimums — steady-state resident memory is much lower
 (`monerod` and P2Pool a few hundred MB each, since their large data lives in the shared HugePages and
 in reclaimable page cache; Tari 2–4 GB and climbing), so size for the minimums, not today's usage.
@@ -105,19 +108,19 @@ node databases do heavy random I/O that punishes spinning disks. What to provisi
 
 | | Pruned (default) | Full (`monero.prune: false`) |
 |---|---|---|
-| Monero chain | ~100 GB | ~265 GB |
-| Tari chain | ~135 GB | ~135 GB |
+| Monero chain | ~100 GB | ~270 GB |
+| Tari chain | ~150 GB | ~150 GB |
 | P2Pool + dashboard + Docker images | a few GB | a few GB |
-| **Plan for** | **~300 GB+ SSD** | **~500 GB+ SSD** |
+| **Plan for** | **~330 GB+ SSD** | **~530 GB+ SSD** |
 
 Both chains keep growing, ~100+ GB/year combined (Tari, a young chain, grows fastest), so leave
 headroom: the *recommended* 1 TB+ (pruned) / 2 TB+ (full) sizes exist for that, and a 2–4 TB SSD is
-the set-and-forget choice. Tari's chain (~135 GB) is the largest single item and is the same whether
+the set-and-forget choice. Tari's chain (~150 GB) is the largest single item and is the same whether
 or not you prune Monero, so pruning only saves disk on the Monero side. Pruning (the default) keeps a
 fully validating Monero node at a fraction of the size.
 
 > `setup` pre-flights these. Before a sync, `./pithead setup` checks free disk and total RAM against
-> the minimums on this page (~300 GB pruned / ~500 GB full disk, 16 GB RAM) and warns if the host
+> the minimums on this page (~330 GB pruned / ~530 GB full disk, 16 GB RAM) and warns if the host
 > falls short; it never blocks. `./pithead doctor` re-runs the same disk and RAM checks on demand.
 
 You can put any service's data on a dedicated disk by pointing its `*.data_dir` at an absolute path,
@@ -129,7 +132,7 @@ e.g. to keep the Monero blockchain on a separate SSD. See
 - Always-on broadband. All upstream traffic (Monero, Tari, P2Pool) goes over Tor, with no public
   port forwarding required; the stack uses hidden services for inbound peers.
 - Initial sync is the heavy part. The first run downloads and verifies both chains over Tor (slower
-  than clearnet): ~100 GB pruned / ~265 GB full for Monero, plus ~135 GB for Tari. This takes a few
+  than clearnet): ~100 GB pruned / ~270 GB full for Monero, plus ~150 GB for Tari. This takes a few
   hours to a day or more. Avoid it by
   [reusing an existing synced node](configuration.md#reusing-an-existing-node), or speed it up with
   an [optional clearnet initial sync](privacy.md#optional-clearnet-initial-sync-off-by-default)
@@ -159,7 +162,7 @@ The defaults assume a self-hosted, pruned, HugePages-tuned local node. You can t
 
 | Want to… | Do this | Saves |
 |---|---|---|
-| Skip the Monero node entirely | Remote-node mode (`monero.mode: remote`); the bundled `monerod` isn't started | ~100–265 GB disk + Monero's 4 GB RAM/CPU |
+| Skip the Monero node entirely | Remote-node mode (`monero.mode: remote`); the bundled `monerod` isn't started | ~100–270 GB disk + Monero's 4 GB RAM/CPU |
 | Skip the initial sync wait | [Reuse an existing synced chain](configuration.md#reusing-an-existing-node) | Hours–days + sync bandwidth |
 | Free the 6 GB HugePages reservation | `./pithead setup --skip-optimize` | ~6 GB RAM (at the cost of RandomX performance) |
 | Free RAM for other apps | Lower `tari.mem_limit` (e.g. `"4g"`) | Caps Tari's ceiling lower |

--- a/pithead
+++ b/pithead
@@ -968,7 +968,7 @@ doctor() {
         doctor_prune=$(env_get MONERO_PRUNE)
         [ -n "$doctor_prune" ] || doctor_prune=1
         # A remote node (#103) keeps its chain elsewhere, so its dir must not count toward THIS
-        # host's disk budget — otherwise doctor demands ~120 GiB (Monero) / ~170 GiB (Tari) for a
+        # host's disk budget — otherwise doctor demands ~120 GiB (Monero) / ~200 GiB (Tari) for a
         # container that never runs, on exactly the small-disk hosts remote mode exists for. Read
         # the mode from the profile tokens like the container checks above; a pre-#103 .env has no
         # local_tari token yet, so require a rendered TARI_GRPC_ADDRESS (also new in #103) before
@@ -4509,16 +4509,16 @@ prompt_start_stack() {
 
 # Per-component free-disk requirement in GiB — the single source of truth for the stack's disk
 # budget, shared by setup's preflight_resources and doctor's Disk check. Monero (the blockchain) is
-# pruning-aware: ~120 GiB pruned, ~320 GiB full. Tari's chain is the other heavyweight — ~170 GiB and
-# growing fast. Summed, this is ~300 GiB pruned / ~500 GiB full, the documented minimum
+# pruning-aware: ~120 GiB pruned, ~320 GiB full. Tari's chain is the other heavyweight — ~200 GiB and
+# growing fast. Summed, this is ~330 GiB pruned / ~530 GiB full, the documented minimum
 # (docs/hardware.md). These carry generous growth headroom over usage measured on live nodes
-# (Monero pruned ~100 GiB / full ~265 GiB, Tari ~135 GiB) because both chains grow ~100+ GiB/year
-# combined — for a set-and-forget host the docs recommend a 2–4 TB drive.
+# (August 2026: Monero pruned ~100 GiB / full ~267 GiB, Tari ~149 GiB) because both chains grow
+# ~100+ GiB/year combined — for a set-and-forget host the docs recommend a 2–4 TB drive.
 # Args: <component> [<prune>] where prune (1 = on, 0 = off) only matters for "monero". Prints GiB.
 disk_component_gib() {
     case "$1" in
     monero) if [ "${2:-1}" -eq 1 ] 2>/dev/null; then echo 120; else echo 320; fi ;;
-    tari) echo 170 ;;
+    tari) echo 200 ;;
     p2pool) echo 5 ;;
     dashboard) echo 2 ;;
     tor) echo 1 ;;
@@ -4629,7 +4629,7 @@ preflight_resources() {
     # once per volume that can't hold the combined requirement of the components sharing it (so dirs
     # on the same disk produce a single line, not one per dir). check_disk_grouped is WARN-only here.
     # A remote node (#103) keeps its chain elsewhere: blank its dir so the ~120 GiB (Monero) /
-    # ~170 GiB (Tari) budget isn't demanded of THIS host — small disks are exactly why an operator
+    # ~200 GiB (Tari) budget isn't demanded of THIS host — small disks are exactly why an operator
     # goes remote. check_disk_grouped skips empty dirs.
     local pre_mono_dir="${MONERO_DIR:-}" pre_tari_dir="${TARI_DIR:-}"
     [ "$MONERO_MODE" == "remote" ] && pre_mono_dir=""

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2471,7 +2471,7 @@ assert_contains "the ownership scan keys off foreign uid" "$(cat "$EO/find.log")
 echo "== unit: disk_component_gib =="
 assert_eq "monero pruned -> 120" "$(run_sourced "$SANDBOX" disk_component_gib monero 1)" "120"
 assert_eq "monero full -> 320" "$(run_sourced "$SANDBOX" disk_component_gib monero 0)" "320"
-assert_eq "tari -> 170" "$(run_sourced "$SANDBOX" disk_component_gib tari)" "170"
+assert_eq "tari -> 200" "$(run_sourced "$SANDBOX" disk_component_gib tari)" "200"
 assert_eq "tor -> 1" "$(run_sourced "$SANDBOX" disk_component_gib tor)" "1"
 
 echo "== unit: check_disk_grouped (mocked df) =="
@@ -2498,36 +2498,36 @@ mkdir -p "$DM/monero" "$DM/tari" "$DM/p2pool" "$DM/dashboard" "$DM/tor"
 md="$DM/monero" td="$DM/tari" pd="$DM/p2pool" dd="$DM/dashboard" rd="$DM/tor"
 
 # All five dirs on ONE filesystem with plenty of space -> a SINGLE grouped OK line naming every
-# component, with the combined pruned requirement (120+170+5+2+1 = 298 GB).
+# component, with the combined pruned requirement (120+200+5+2+1 = 328 GB).
 one_map="$md=/data $td=/data $pd=/data $dd=/data $rd=/data /data=/data"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
 assert_contains "single line names all components" "$out" "(monero, tari, p2pool, dashboard, tor)"
-assert_contains "single line shows combined ~298 GB" "$out" "needs ~298 GB"
+assert_contains "single line shows combined ~328 GB" "$out" "needs ~328 GB"
 assert_contains "ample space -> OK" "$out" "OK"
 
-# Same single filesystem but too small (100 GiB < 298 GiB) -> ONE WARN line.
+# Same single filesystem but too small (100 GiB < 328 GiB) -> ONE WARN line.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=104857600 DF_AVAIL_H=100G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "one small fs -> single line" "$(printf '%s\n' "$out" | grep -c 'Data on')" "1"
-assert_contains "small fs warns below need" "$out" "below the ~298 GB"
+assert_contains "small fs warns below need" "$out" "below the ~328 GB"
 
 # Two filesystems: monero+tari on /big, the rest on /small -> ONE line per filesystem.
 two_map="$md=/big $td=/big $pd=/small $dd=/small $rd=/small /big=/big /small=/small"
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$two_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "$td" "$pd" "$dd" "$rd" 2>&1)"
 assert_eq "two fs -> two lines" "$(printf '%s\n' "$out" | grep -c 'Data on')" "2"
-assert_contains "/big groups monero+tari (~290 GB)" "$out" "/big (monero, tari): 600G free — needs ~290 GB"
+assert_contains "/big groups monero+tari (~320 GB)" "$out" "/big (monero, tari): 600G free — needs ~320 GB"
 assert_contains "/small groups the small three (~8 GB)" "$out" "/small (p2pool, dashboard, tor): 600G free — needs ~8 GB"
 
 # Remote node modes (#103): doctor/preflight blank the remote component's dir (its chain lives on
 # the OTHER host), and an empty dir arg must drop that component from the budget entirely — here
-# tari remote drops the ~170 GB Tari share, leaving monero+the small three (120+5+2+1 = 128 GB).
+# tari remote drops the ~200 GB Tari share, leaving monero+the small three (120+5+2+1 = 128 GB).
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \
     run_sourced "$SANDBOX" check_disk_grouped doctor 1 "$md" "" "$pd" "$dd" "$rd" 2>&1)"
 assert_contains "remote tari drops tari from the budget" "$out" "(monero, p2pool, dashboard, tor)"
-assert_contains "remote tari budget excludes the 170 GB" "$out" "needs ~128 GB"
+assert_contains "remote tari budget excludes the 200 GB" "$out" "needs ~128 GB"
 
 # Preflight mode is WARN-only and silent when there's enough room.
 out="$(PATH="$DISK/bin:$PATH" DF_MAP="$one_map" DF_AVAIL_KB=629145600 DF_AVAIL_H=600G \


### PR DESCRIPTION
Develop half of the Tari budget raise — mirrors #1011 (develop-v2). Part of #1004; close it when #1011 lands the operator-approved value on the v2 side.

## What

`disk_component_gib()`: the Tari budget goes from 170 to **200 GiB**. Everything derived moves in lockstep: setup preflight / doctor now ask for ~328 GB summed (pruned) / ~528 GB (full), documented as **~330/~530 GB** in README, hardware.md, getting-started.md, and faq.md. Stack-suite asserts updated (`tari -> 200`, `needs ~328 GB`, `~320 GB`; remote-Tari's `~128 GB` correctly unchanged). Touched doc lines also adopt the develop-v2 reconciled measured figures (#1005: Monero ~270 GB full, Tari ~150 GB, the "budgets above these measurements" sentence) — every touched line is **byte-identical to develop-v2**, verified by branch diff, so the close-out develop → develop-v2 sync merges these files clean.

## The measurement — three points, linear

| Date | Tari chain | Source |
|---|---|---|
| 2026-06-12 | ~135 GB | #232, when the 170 budget was set |
| 2026-07-02 | ~139–140 GB | #334 figure refresh |
| 2026-08-15 | **149 GiB** | fresh `du -sh /srv/code/pithead-data/tari` on bench-host |

Both intervals independently give **~6.6–6.8 GiB/month** (~80 GB/yr) — the growth is linear, so extrapolation is sound. The 170 budget's remaining headroom (21 GiB) is ~3 months; a minimum-sized host provisioned today outgrows it around November 2026.

## Validation against upstream Tari resources

- [Tari's integration guide](https://tari.com/integration-guide) still advises **"50GB+ SSD for blockchain data"** — a third of the live archival chain. Upstream guidance is not a usable source for this number; live measurement stays the budget's source of truth.
- The [tari-project/tari README](https://github.com/tari-project/tari) states no disk requirement at all.
- Upstream announced [pruned mode for base nodes](https://tari.substack.com/p/less-disk-space-more-mining) back in 2020; the stack exposes no Tari prune knob today and the linear growth of our node shows it keeps everything. A Tari-side prune option is a possible future lever if growth compounds — separate discussion, not this change.

## Why 200 and not 220

200 restores **51 GiB ≈ 8 months** at the observed rate — more margin than the budget has ever carried — and keeps the documented totals at ~330/~530. 220 (~11 months) pushes every total up another notch for one extra quarter. The years-long runway story stays with the recommended 1–2 TB+ tier, which is unchanged. **The value tracks #1011**: if the operator lands 220 there, this PR re-spins to match.

## Verification

`make lint` clean (docs-voice pass included); `make test-stack` **1712 passed / 0 failed** — the new `~328 GB` asserts prove the grouped disk check re-derives the sum. Residual grep for every stale figure (170/298/290/300/500/135/139/140/265/410/250) returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)