### PR TITLE
fix(dashboard): the enriched-feed reconciler speaks RigForge's full terminal vocabulary (#1009)

### DIFF
--- a/build/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/build/dashboard/mining_dashboard/client/xmrig_client.py
@@ -79,16 +79,20 @@ def parse_rigforge(payload):
     }
 
 
-# Terminal control-apply outcomes (pithead control_worker_apply / rigforge#236). "accepted" and
-# "running" are non-terminal — never reconciled from a read poll, only ever written by the host
-# runner itself while a change is still in flight.
-_CONTROL_TERMINAL = ("applied", "rejected", "rolled_back")
+# Terminal control outcomes the rig may mirror: applied/rejected/rolled_back/failed from a
+# control-apply (pithead control_worker_apply / rigforge#236), plus noop/throttled from a
+# control-upgrade (rigforge#320, v1.12.0). "started" (rigforge#320's in-flight upgrade marker) and
+# "accepted"/"running" (this dashboard's own still-polling placeholders) are non-terminal — never
+# reconciled from a read poll, only ever written while a change is still in flight. Mirrors
+# pithead's own control_worker_apply/control_worker_upgrade poll cases (#1001) so the mirror-side
+# and poll-side vocabularies can't drift apart again.
+_CONTROL_TERMINAL = ("applied", "rejected", "rolled_back", "failed", "noop", "throttled")
 
 
 def parse_worker_control_status(payload):
-    """The rig's last control-apply outcome, mirrored read-only into the SAME enriched feed body
-    under ``rigforge.control`` (#579) — no new port, no token, it rides the poll that already
-    fetches the ``rigforge`` block for :func:`parse_rigforge`.
+    """The rig's last control-apply/control-upgrade outcome, mirrored read-only into the SAME
+    enriched feed body under ``rigforge.control`` (#579, rigforge#346) — no new port, no token, it
+    rides the poll that already fetches the ``rigforge`` block for :func:`parse_rigforge`.
 
     The host runner's synchronous ``/status`` poll after a worker-apply is capped at 20s
     (rigforge#236's auto-rollback can take minutes); a change still mid-flight past that deadline
@@ -97,10 +101,12 @@ def parse_worker_control_status(payload):
     mirrors its own last outcome into the already-open, unauthenticated read feed so the next
     routine poll can catch up.
 
-    Returns ``{"change_id", "status", "reason"}`` only for a TERMINAL outcome
-    (``applied``/``rejected``/``rolled_back``); ``None`` for a still-in-flight change, a malformed
-    block, or a rig that doesn't mirror this yet (older RigForge, plain xmrig) — so a #185 history
-    row is never force-terminaled on bad or absent data.
+    Returns ``{"change_id", "status", "reason"}`` only for a TERMINAL outcome: applied / rejected /
+    rolled_back / failed (rigforge#236), or noop (already on the target)/throttled (the rig's own
+    anti-beacon window — retry-later, not a fault) from rigforge#320. Returns ``None`` for a
+    still-in-flight change (``started``/``accepted``/``running``), a malformed block, or a rig that
+    doesn't mirror this yet (older RigForge, plain xmrig) — so a #185 history row is never
+    force-terminaled on bad or absent data.
     """
     rf = payload.get("rigforge") if isinstance(payload, dict) else None
     ctrl = rf.get("control") if isinstance(rf, dict) else None

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -51,6 +51,12 @@ RAFFLE_WINS_MAX_ROWS = 5000
 # Table names carrying a per-table write-health signal (see __init__ / _table_write_ok below).
 _TELEMETRY_TABLES = ("blocks", "xvb_history", "network_history", "disk_growth", "worker_history")
 
+# The full terminal vocabulary the rig's control mirror can report (#1009) — applied/rejected/
+# rolled_back/failed from a control-apply, plus noop (already on target)/throttled (retry-later)
+# from a control-upgrade (rigforge#320). Mirrors xmrig_client._CONTROL_TERMINAL and pithead's own
+# control_worker_apply/control_worker_upgrade poll cases (#1001) — one vocabulary, three places.
+_RECONCILE_TERMINAL = ("applied", "rejected", "rolled_back", "failed", "noop", "throttled")
+
 
 class StateManager:
     """
@@ -888,10 +894,12 @@ class StateManager:
         row ``accepted`` forever otherwise — nothing re-polls it. This is the reconciler: called
         from the dashboard's regular per-rig read poll (data_service.py), never a new dial. The
         ``WHERE status = 'accepted'`` is the whole safety property — a row already terminal
-        (``applied``/``rejected``/``rolled_back``) is never touched, even by a stale or duplicate
-        report for the same ``change_id``.
+        (applied/rejected/rolled_back/failed/noop/throttled) is never touched, even by a stale or
+        duplicate report for the same ``change_id``. ``status`` is recorded as-is: it becomes the
+        row's outcome verbatim, and the frontend's ``STATUS_META`` already renders every member of
+        this vocabulary (``workerview.mjs``).
         """
-        if status not in ("applied", "rejected", "rolled_back") or not change_id:
+        if status not in _RECONCILE_TERMINAL or not change_id:
             return
         try:
             with self._db_lock:

--- a/build/dashboard/tests/client/test_xmrig_client.py
+++ b/build/dashboard/tests/client/test_xmrig_client.py
@@ -484,8 +484,10 @@ def test_parse_worker_control_status_absent_is_none():
 
 
 def test_parse_worker_control_status_non_terminal_is_none():
-    # 'accepted' (queued, outcome not yet observed) and 'running' are in-flight — never reconciled.
-    for status in ("accepted", "running", "unknown", ""):
+    # 'accepted' (queued, outcome not yet observed) and 'running' are this dashboard's own
+    # in-flight placeholders; 'started' is rigforge#320's own in-flight upgrade marker — all
+    # never reconciled.
+    for status in ("accepted", "running", "started", "unknown", ""):
         block = {**RIGFORGE_BLOCK, "control": {"change_id": "abc123", "status": status}}
         assert parse_worker_control_status({"rigforge": block}) is None
 
@@ -516,3 +518,20 @@ def test_parse_worker_control_status_reason_defaults_none():
     block = {**RIGFORGE_BLOCK, "control": {"change_id": "abc123", "status": "applied"}}
     ctrl = parse_worker_control_status({"rigforge": block})
     assert ctrl == {"change_id": "abc123", "status": "applied", "reason": None}
+
+
+def test_parse_worker_control_status_full_terminal_vocabulary():
+    # #1009: applied/rejected/rolled_back/failed from a control-apply, plus noop (already on
+    # target)/throttled (the rig's own anti-beacon window) from a control-upgrade (rigforge#320) —
+    # the SAME vocabulary pithead's own control_worker_apply/control_worker_upgrade poll cases
+    # accept (#1001). Each must parse through, not just the three pre-#1009 members.
+    for status in ("applied", "rejected", "rolled_back", "failed", "noop", "throttled"):
+        block = {
+            **RIGFORGE_BLOCK,
+            "control": {"change_id": "abc123", "status": status, "reason": "rig-supplied"},
+        }
+        assert parse_worker_control_status({"rigforge": block}) == {
+            "change_id": "abc123",
+            "status": status,
+            "reason": "rig-supplied",
+        }

--- a/build/dashboard/tests/service/test_data_service.py
+++ b/build/dashboard/tests/service/test_data_service.py
@@ -2105,6 +2105,34 @@ class TestReconcileWorkerConfig:
         finally:
             sm.close()
 
+    def test_terminal_report_reconciles_accepted_row_for_the_1009_vocabulary(self):
+        # #1009: failed/noop/throttled (rigforge#320) must reach the SAME reconcile path as
+        # applied/rejected/rolled_back — the mirror now ships live (rigforge v1.15.0, #346), and
+        # the pre-#1009 three-status allowlist dropped exactly these on the floor as "accepted"
+        # forever.
+        svc, sm = self._svc_with_real_storage()
+        try:
+            for status in ("failed", "noop", "throttled"):
+                cid = f"cid-{status}"
+                self._seed(sm, "accepted", change_id=cid)
+                worker_results = [
+                    {
+                        "rigforge": {
+                            "control": {
+                                "change_id": cid,
+                                "status": status,
+                                "reason": "rig-supplied",
+                            }
+                        }
+                    }
+                ]
+                asyncio.run(svc._reconcile_worker_config(self._workers("rig1"), worker_results))
+                row = self._status_of(sm, change_id=cid)
+                assert row["status"] == status
+                assert row["reason"] == "rig-supplied"
+        finally:
+            sm.close()
+
     def test_terminal_row_is_never_overwritten(self):
         svc, sm = self._svc_with_real_storage()
         try:

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -1368,6 +1368,17 @@ class TestWorkerConfigReconcile:
         assert row["status"] == "rolled_back"
         assert row["reason"] == "miner did not return to a live hashrate"
 
+    def test_accepted_row_becomes_terminal_for_the_1009_vocabulary(self, state_manager):
+        # #1009: failed/noop/throttled — the rigforge#320 members #579's original three-status
+        # allowlist dropped — must reconcile an accepted row exactly like applied/rejected/
+        # rolled_back always have.
+        for status in ("failed", "noop", "throttled"):
+            self._seed(state_manager, "accepted", change_id=f"cid-{status}")
+            state_manager.reconcile_worker_config_status(f"cid-{status}", status, "rig-supplied")
+            row = self._status_of(state_manager, change_id=f"cid-{status}")
+            assert row["status"] == status
+            assert row["reason"] == "rig-supplied"
+
     def test_applied_row_is_never_overwritten(self, state_manager):
         # A genuinely terminal row must survive even a (stale/duplicate) reconcile report.
         self._seed(state_manager, "applied")
@@ -1393,11 +1404,12 @@ class TestWorkerConfigReconcile:
 
     def test_non_terminal_status_is_a_noop(self, state_manager):
         # A defensive guard: reconcile() is only ever called with a terminal status by
-        # parse_worker_control_status, but a bad caller must not be able to write 'accepted' or
-        # 'running' back over itself.
+        # parse_worker_control_status, but a bad caller must not be able to write 'accepted',
+        # 'running', or 'started' (rigforge#320's in-flight upgrade marker) back over itself.
         self._seed(state_manager, "accepted")
         state_manager.reconcile_worker_config_status("cid-1", "running")
         state_manager.reconcile_worker_config_status("cid-1", "accepted")
+        state_manager.reconcile_worker_config_status("cid-1", "started")
         assert self._status_of(state_manager)["status"] == "accepted"
 
     def test_write_error_flags_db_unhealthy(self, state_manager):

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -1553,3 +1553,17 @@ class TestAuditEvents:
         with state_manager._db_lock:
             state_manager._conn.execute("DROP TABLE audit_events")
         assert state_manager.get_audit_events() == []
+
+
+def test_reconcile_terminal_matches_the_parser_verbatim():
+    """The reconciler's allowlist and the feed parser's must never drift apart.
+
+    They are deliberately declared separately (the parser lives with the client, the allowlist
+    with the store, and neither should import the other for a six-string tuple) — so this is the
+    thing that keeps the two honest: a status the parser hands over must be one the store will
+    act on, or a terminal outcome silently stops reconciling and history rows freeze at accepted,
+    which is the exact bug this pair was widened to fix.
+    """
+    from mining_dashboard.client.xmrig_client import _CONTROL_TERMINAL
+
+    assert storage_service._RECONCILE_TERMINAL == _CONTROL_TERMINAL

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -314,15 +314,17 @@ unchanged: send the rig's `token` only if it sets an `ACCESS_TOKEN` (the read AP
 If the block also carries a `control` object — `{change_id, status, reason}`, mirroring the rig's
 own control-API `/status` response read-only — the dashboard reconciles it against the [Worker
 Inspect](dashboard.md#worker-inspect) change history (#579): a still-`accepted` row whose
-`change_id` matches is updated to the reported terminal `status`
-(`applied`/`rejected`/`rolled_back`). This is how a rollback slower than the host runner's 20s
-status-poll deadline still reaches a terminal state without a second authenticated dial to the
+`change_id` matches is updated to the reported terminal `status` — `applied` / `rejected` /
+`rolled_back` / `failed` (a control-apply outcome) or `noop` (already on the target) / `throttled`
+(the rig's own anti-beacon window, retry-later not a fault — both control-upgrade outcomes). This
+is how a rollback, or any other terminal outcome the rig reports past the host runner's own
+status-poll deadline, still reaches a terminal state without a second authenticated dial to the
 control port.
 
-RigForge does not ship this mirror yet — its enriched feed carries `config_meta` provenance
-(revision, `changed_at`, source, `last_change_id`) but no `control` status object — so this parses to
-nothing today, and a rollback slower than the status-poll deadline stays `accepted` until
-the rig ships the mirror.
+RigForge ships this mirror from **v1.15.0** (rigforge#346). A rig on an older release, or one with
+no `control` block at all (plain xmrig, or a rig that has never taken a control-apply/-upgrade),
+parses to nothing — a slow-terminal outcome on those rigs stays `accepted` until the rig reports a
+status the dashboard recognizes.
 
 #### RigForge new-release badge
 


### PR DESCRIPTION
The feed-side twin of #1001, and it went live today: RigForge v1.15.0 ships the control status mirror (#346) that this path reads, so for the first time the reconciler actually receives outcomes — and it knew only three of the six terminals. `failed`, `noop` and `throttled` fell through, leaving a change-history row frozen at `accepted` forever in exactly the slow-terminal case the mirror exists to close.

- Parser (`xmrig_client`) and reconciler allowlist (`storage_service`) both widened to the full set, verified against RigForge's own source (`_api_control_json`, `control_apply`, `control_upgrade`) rather than assumed: `applied, rejected, rolled_back, failed, noop, throttled` terminal; `started`/`accepted`/`running` stay non-terminal and never terminalize a row.
- Statuses are recorded verbatim — no translation table needed, because `workerview.mjs`'s `STATUS_META` already renders all six (added for the #597 upgrade badge), so there is no frontend change.
- The two tuples stay separately declared (parser with the client, allowlist with the store — neither should import the other for six strings), so a **drift guard** now pins them equal: a status the parser accepts but the store ignores would silently stop reconciling, which is this bug's exact shape.
- docs/workers.md's reconcile list updated, and its stale "RigForge does not ship this mirror yet" replaced with the v1.15.0 floor.

Evidence: `make lint` clean; dashboard suite **1707 passed**; patch coverage 100% on changed lines (non-vacuous under the new honest wrapper).

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)
