### PR TITLE
test(os): bound every remote call so a stalled handshake cannot hang the battery (#1016)

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -103,12 +103,14 @@ HARNESS_TARI="126J92Yow5y9UoRFd1DNujPmVFq9C1ZeiYWT95UKxz5Y1rzbfjtHg4SCZS1dk83ivz
 # An unbounded call therefore outlives its caller's deadline instead of failing it: on 2026-08-15
 # one boot-phase probe held for five hours against a guest that answered ssh normally the whole
 # time, and the phase reported "SSH never came up" the instant that probe was killed. SSH_TIMEOUT
-# is the per-call ceiling; the default clears the longest legitimate remote command in this file
-# (the 1800 s local-miner wait) and exists only so no single call can hang a release gate forever.
+# is the per-call ceiling. The default is deliberately far larger than any legitimate call (the
+# longest here is the 1800 s local-miner wait; a slot copy on slow storage is the other long one):
+# this exists ONLY to stop an infinite hang, so it must never be the thing that ends real work —
+# if a call is legitimately slower than this, raise it rather than let the ceiling arbitrate.
 # ponytail: polling loops lower it to a few seconds — a stalled handshake must read as "not ready
 # yet" so the loop re-evaluates its own deadline, which is the whole point of having one.
 _ssh() {
-    timeout "${SSH_TIMEOUT:-2400}" ssh -i "$KEY" -o StrictHostKeyChecking=no \
+    timeout "${SSH_TIMEOUT:-5400}" ssh -i "$KEY" -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8 "root@$ip" "$@" 2>/dev/null
 }
 _wait_ssh() { # $1 seconds — the definition of "not bricked"

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1448,7 +1448,11 @@ phase_provision() {
     tries=0
     local code=000 served=0
     while [ "$tries" -lt 60 ]; do
-        code=$(curl -ksS -o /dev/null -w '%{http_code}' -m 8 "https://$ip/" 2>/dev/null || echo 000)
+        # `|| true`, never `|| echo 000`: on a connection failure curl ALREADY prints 000 (-w
+        # always fires) and exits non-zero, so the echo appended a SECOND 000 — the retry case
+        # below then matched neither, broke on the first iteration, and reported the impossible
+        # "HTTP 000000". The loop existed to wait out exactly that state and never once waited.
+        code=$(curl -ksS -o /dev/null -w '%{http_code}' -m 8 "https://$ip/" 2>/dev/null || true)
         case "$code" in
         2?? | 3?? | 401 | 403)
             ok "dashboard is served through caddy (HTTP $code)"
@@ -1628,7 +1632,7 @@ phase_provision() {
     tries=0
     local answered=0
     while [ "$tries" -lt 36 ]; do
-        code=$(curl -ksS -o /dev/null -w '%{http_code}' -m 8 "https://$ip/" 2>/dev/null || echo 000)
+        code=$(curl -ksS -o /dev/null -w '%{http_code}' -m 8 "https://$ip/" 2>/dev/null || true)
         case "$code" in
         2?? | 3?? | 401 | 403)
             ok "dashboard answers again after the reboot (HTTP $code) — through a REGENERATED Caddyfile"

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -97,12 +97,22 @@ HARNESS_WALLET="44MnN1f3Eto8DZYUWuE5XZNUtE3vcRzt2j6PzqWpPau34e6Cf4fAxt6X2MBmrm6F
 # handoff. Same throwaway address the stack suite uses.
 HARNESS_TARI="126J92Yow5y9UoRFd1DNujPmVFq9C1ZeiYWT95UKxz5Y1rzbfjtHg4SCZS1dk83ivzt3m2XRQHTaYUk9SwmyeCvy5BJ"
 
+# Every remote call is bounded. Debian socket-activates sshd: the socket unit accepts the TCP
+# connection as soon as it listens and only THEN starts ssh@.service, so a guest that is still
+# booting satisfies ConnectTimeout and stalls in the handshake — which no ssh option bounds.
+# An unbounded call therefore outlives its caller's deadline instead of failing it: on 2026-08-15
+# one boot-phase probe held for five hours against a guest that answered ssh normally the whole
+# time, and the phase reported "SSH never came up" the instant that probe was killed. SSH_TIMEOUT
+# is the per-call ceiling; the default clears the longest legitimate remote command in this file
+# (the 1800 s local-miner wait) and exists only so no single call can hang a release gate forever.
+# ponytail: polling loops lower it to a few seconds — a stalled handshake must read as "not ready
+# yet" so the loop re-evaluates its own deadline, which is the whole point of having one.
 _ssh() {
-    ssh -i "$KEY" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-        -o ConnectTimeout=8 "root@$ip" "$@" 2>/dev/null
+    timeout "${SSH_TIMEOUT:-2400}" ssh -i "$KEY" -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8 "root@$ip" "$@" 2>/dev/null
 }
 _wait_ssh() { # $1 seconds — the definition of "not bricked"
-    local deadline=$(($(date +%s) + $1))
+    local deadline=$(($(date +%s) + $1)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
     while [ "$(date +%s)" -lt "$deadline" ]; do
         _ssh true && return 0
         sleep 5
@@ -211,7 +221,9 @@ _rollback_cmd() {
 }
 
 require_host() {
-    for c in virsh virt-install qemu-img; do
+    # timeout bounds every remote call (see _ssh) — without it each one dies 127 and the whole
+    # run reads as a bricked guest, so it is a hard dependency, not a nicety.
+    for c in virsh virt-install qemu-img timeout; do
         have "$c" || {
             echo "missing $c — install libvirt/qemu (see tests/os/README.md)" >&2
             exit 2
@@ -1409,7 +1421,7 @@ phase_provision() {
     fi
     ok "config validated and installed by the host"
 
-    local deadline=$(($(date +%s) + 1500)) names=""
+    local deadline=$(($(date +%s) + 1500)) names="" SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
     while [ "$(date +%s)" -lt "$deadline" ]; do
         names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
         case "$names" in
@@ -1895,7 +1907,7 @@ phase_media() {
         bad "the ESP pre-seed never reached the running system — nothing to change from here"
         return
     fi
-    local deadline=$(($(date +%s) + 1500)) names=""
+    local deadline=$(($(date +%s) + 1500)) names="" SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
     while [ "$(date +%s)" -lt "$deadline" ]; do
         names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
         case "$names" in *dashboard*caddy* | *caddy*dashboard*) break ;; esac
@@ -2448,6 +2460,7 @@ phase_reset() {
     fi
     ok "provisioned: config installed by the host"
 
+    local SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" # scoped: later calls in this phase run long
     names="" deadline=$(($(date +%s) + 1500))
     while [ "$(date +%s)" -lt "$deadline" ]; do
         names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')


### PR DESCRIPTION
Found live on the bench today, twice, and it explains two earlier "failures" that were never diagnosed correctly.

**Mechanism.** Debian socket-activates sshd: the socket unit accepts the TCP connection the moment it listens and only *then* starts `ssh@.service`. A booting guest therefore satisfies `ConnectTimeout` (TCP is connected) and stalls in the **handshake**, which no ssh option bounds. `_ssh` had no ceiling, and `_wait_ssh` only evaluates its deadline *between* probes — so one stalled probe outlives the deadline entirely.

**Observed.** A boot-phase probe started 13:55Z was still alive at 18:54Z — five hours — with the battery producing no output at all, while the guest answered `ssh root@… true` by hand with exit 0 throughout. The phase printed `host SSH never came up after the wizard gate` the instant that probe was killed. The same race landing the other way (fast connection-refused, loop ages out) produces a *false* failure on a healthy guest — which is what the previous two battery runs hit, and why raising the budget 420→900 s did nothing: the deadline was never re-read.

**Fix.** `_ssh` takes a per-call ceiling (`SSH_TIMEOUT`, default generous enough for the longest legitimate remote command here — the 1800 s local-miner wait) so no single call can hang a release gate forever; the four polling sites (`_wait_ssh` plus three `podman ps` container waits) lower it to 20 s so a stall reads as "not ready yet" and the loop re-evaluates its own deadline. One site needed an explicit `local` so the tighter ceiling cannot leak into the long-running calls later in that phase. `timeout` is now a declared hard dependency of the harness — without it every remote call would die 127 and read as a bricked guest, so it fails loudly at preflight instead.

Validation: `bash -n` + shellcheck clean; the real proof is the battery itself — run 3 is executing on this fix and cleared the boot and update phases that previously failed or wedged.

Closes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)
