### PR TITLE
feat(dashboard): per-worker hashrate chart with change markers, and the upgrade history row that was never written (#1013, #1014, #1015)

### DIFF
--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -355,6 +355,11 @@ DASHBOARD_ENERGY = load_energy_config()
 # How long a preview/commit POST waits for the host-side runner's result before returning 202 and
 # leaving the client to poll /api/control/result. The systemd path unit fires within seconds.
 CONTROL_WAIT_S = float(os.environ.get("CONTROL_WAIT_S", 30))
+# A worker-upgrade POST never waits inline (a rig rebuild can run minutes) — it returns 202 at
+# once and a background task records the terminal outcome once the host runner writes it. This
+# bounds that background wait; matches the client's own polling budget (workerview.mjs
+# UPGRADE_POLL_MAX = 150 * 2s = 300s), well past the host's own ~90s dial+poll cap.
+CONTROL_WORKER_UPGRADE_WAIT_S = float(os.environ.get("CONTROL_WORKER_UPGRADE_WAIT_S", 300))
 GITHUB_RELEASES_API = os.environ.get(
     "GITHUB_RELEASES_API",
     "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest",

--- a/build/dashboard/mining_dashboard/service/storage_service.py
+++ b/build/dashboard/mining_dashboard/service/storage_service.py
@@ -323,14 +323,16 @@ class StateManager:
         # config history on the rig, so Pithead owns it: one row per change the dashboard applied,
         # with the writable-key `changes` we sent (each row IS a diff from the prior state, by
         # construction — we only ever record deltas we authored) and the rig's terminal outcome.
-        # Additive, forward-only (mirrors events / payouts) — no _migrate_db change needed. `changes`
-        # holds only the writable allowlist keys; NO secret ever lands here (the rig token stays
-        # host-side, #440). change_id is the rig's 16-hex id, or NULL for a request that never reached
-        # a rig (rejected host-side).
+        # `changes` holds only the writable allowlist keys; NO secret ever lands here (the rig token
+        # stays host-side, #440). change_id is the rig's 16-hex id, or NULL for a request that never
+        # reached a rig (rejected host-side). `type` distinguishes a config apply from a one-click
+        # rig upgrade (#1014) — an upgrade's `changes` carries `{"version": ...}` instead of a
+        # writable-key diff, and get_last_applied_worker_config must never merge that into the
+        # config-editor prefill. New column, existing installs migrated in _migrate_db (below).
         self._conn.execute(
             "CREATE TABLE IF NOT EXISTS worker_config "
             "(id INTEGER PRIMARY KEY AUTOINCREMENT, worker TEXT, change_id TEXT, ts REAL, "
-            "status TEXT, changes TEXT, reason TEXT)"
+            "status TEXT, changes TEXT, reason TEXT, type TEXT DEFAULT 'apply')"
         )
         # v1.7 telemetry backbone (#196 Wave-0 proposal): five independent, additive time-series
         # tables. Each has its own retention (see the RETENTION_SEC constants above) and is
@@ -448,6 +450,14 @@ class StateManager:
         # which was dead code — the worker list is sourced live from the xmrig-proxy. Tidies old
         # DBs; harmless no-op on fresh ones.
         self._conn.execute("DROP TABLE IF EXISTS workers")
+
+        # worker_config.type (#1014): every pre-existing row was written before rig upgrades were
+        # recorded at all, so it was necessarily a config apply — backfill 'apply', matching the
+        # column's own DEFAULT for any row a future ALTER-less write path might still hit.
+        cursor.execute("PRAGMA table_info(worker_config)")
+        if "type" not in {info[1] for info in cursor.fetchall()}:
+            self.logger.info("Migrating DB: Adding type column to worker_config")
+            self._conn.execute("ALTER TABLE worker_config ADD COLUMN type TEXT DEFAULT 'apply'")
 
     def load(self):
         """
@@ -831,16 +841,19 @@ class StateManager:
         changes: dict[str, Any],
         reason: str | None,
         ts: float | None = None,
+        change_type: str = "apply",
     ) -> None:
-        """Record one applied/attempted worker config change (#185). ``changes`` is the writable-key
-        delta the dashboard sent (stored as JSON — no secret ever lands here). Forward-only."""
+        """Record one applied/attempted worker change (#185): a config apply, or (``change_type=
+        "upgrade"``, #1014) a one-click RigForge upgrade attempt — ``changes`` then carries
+        ``{"version": ...}`` instead of a writable-key diff. Stored as JSON — no secret ever lands
+        here. Forward-only."""
         try:
             with self._db_lock:
                 if not self._conn:
                     return
                 self._conn.execute(
-                    "INSERT INTO worker_config (worker, change_id, ts, status, changes, reason) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO worker_config (worker, change_id, ts, status, changes, reason, type) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         worker,
                         change_id,
@@ -848,6 +861,7 @@ class StateManager:
                         status,
                         json.dumps(changes),
                         reason,
+                        change_type,
                     ),
                 )
                 self._conn.commit()
@@ -855,14 +869,16 @@ class StateManager:
             self._db_error("Worker Config Write Error", e)
 
     def get_worker_config_history(self, worker: str, limit: int = 50) -> list[dict[str, Any]]:
-        """The change history for ``worker``, newest first, with ``changes`` parsed back to a dict."""
+        """The change history for ``worker``, newest first, with ``changes`` parsed back to a dict.
+        ``type`` is ``"apply"`` or ``"upgrade"`` (#1014); a row from before that column existed
+        reads back ``"apply"`` too (the migration backfills it, same as a fresh insert's default)."""
         try:
             with self._db_lock:
                 if not self._conn:
                     return []
                 cursor = self._conn.cursor()
                 cursor.execute(
-                    "SELECT change_id, ts, status, changes, reason FROM worker_config "
+                    "SELECT change_id, ts, status, changes, reason, type FROM worker_config "
                     "WHERE worker = ? ORDER BY ts DESC, id DESC LIMIT ?",
                     (worker, limit),
                 )
@@ -873,6 +889,7 @@ class StateManager:
                         d["changes"] = json.loads(d["changes"]) if d["changes"] else {}
                     except (TypeError, ValueError):
                         d["changes"] = {}
+                    d["type"] = d.get("type") or "apply"
                     out.append(d)
                 return out
         except sqlite3.Error as e:
@@ -968,10 +985,16 @@ class StateManager:
     def get_last_applied_worker_config(self, worker: str) -> dict[str, Any]:
         """The merged writable config the dashboard last successfully applied to ``worker`` — the
         best prefill for the editor, since the rig's enriched feed does not expose the writable config
-        values (#185). Later applied changes lay over earlier ones (last write wins per key)."""
+        values (#185). Later applied changes lay over earlier ones (last write wins per key).
+        Upgrade rows (#1014) are excluded — their ``changes`` is a ``{"version": ...}`` marker, not
+        writable-key config, and must never leak into the editor prefill."""
         merged: dict[str, Any] = {}
         for row in reversed(self.get_worker_config_history(worker, limit=200)):
-            if row.get("status") == "applied" and isinstance(row.get("changes"), dict):
+            if (
+                row.get("status") == "applied"
+                and row.get("type", "apply") == "apply"
+                and isinstance(row.get("changes"), dict)
+            ):
                 merged.update(row["changes"])
         return merged
 

--- a/build/dashboard/mining_dashboard/web/server.py
+++ b/build/dashboard/mining_dashboard/web/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import math
 import mimetypes
@@ -214,32 +215,55 @@ async def handle_control_upgrade(request):
     return web.json_response({"id": rid, "status": "pending"}, status=202)
 
 
-def _record_worker_result(state_mgr, worker, changes, res):
-    """Log a worker-apply outcome to the per-worker config history (#185). Only terminal-ish
-    statuses are kept; ``changes`` carries no secret (the rig token stays host-side)."""
+# Terminal-ish outcomes worth a history row — shared by worker-apply and worker-upgrade (#1014).
+# noop/throttled are upgrade-only (the host runner's control_worker_upgrade case statement); the
+# rest are common to both actions. "accepted" is genuinely non-terminal (still running on the rig
+# past the wait budget) but IS the runner's final write for that request id, so it's recorded too
+# — the alternative is a change the operator made that the dashboard never mentions again.
+_RECORDABLE_WORKER_STATUSES = (
+    "applied",
+    "rejected",
+    "rolled_back",
+    "accepted",
+    "failed",
+    "noop",
+    "throttled",
+)
+
+
+def _record_worker_result(state_mgr, worker, changes, res, change_type="apply"):
+    """Log a worker-apply or worker-upgrade outcome to the per-worker config history (#185/#1014).
+    Only terminal-ish statuses are kept; ``changes`` carries no secret (the rig token stays
+    host-side). ``worker``/``changes`` come from the caller's own request, never ``res`` — the
+    host runner omits ``worker`` from a pre-dial reject, so this stays correct either way."""
     status = res.get("status", "unknown")
-    if status in ("applied", "rejected", "rolled_back", "accepted", "failed"):
+    if status in _RECORDABLE_WORKER_STATUSES:
         state_mgr.add_worker_config_version(
             worker,
             res.get("change_id"),
             status,
             changes,
             res.get("reason") or res.get("error"),
+            change_type=change_type,
         )
 
 
 async def handle_worker_detail(request):
     """Per-worker inspect data (#185): the rig's current enriched telemetry, the writable config the
     dashboard last applied (the prefill — the rig's feed does not expose the writable config values),
-    and the change history with per-change diffs."""
+    the change history with per-change diffs, and (#1013) its own hashrate-over-time chart — same
+    ``range``/``from``/``to`` query params as ``/api/state``, so the per-rig chart can offer its own
+    range control."""
     name = request.query.get("name", "")
     if not name:
         raise web.HTTPBadRequest(text="'name' is required.")
     app = request.app
     data = app["latest_data"] or {}
     state_mgr = app["state_manager"]
+    range_arg = request.query.get("range", "all")
+    window = parse_window(request.query.get("from"), request.query.get("to"))
     try:
-        return web.json_response(build_worker_detail(name, data, state_mgr))
+        return web.json_response(build_worker_detail(name, data, state_mgr, range_arg, window))
     except Exception:
         logger.exception("Error building worker detail")
         return web.json_response({"error": "Failed to build worker detail."}, status=500)
@@ -284,6 +308,25 @@ async def handle_worker_apply(request):
     return web.json_response({"id": rid, **res})
 
 
+async def _finalize_worker_upgrade(state_mgr, worker, version, rid):
+    """The server-side half of recording a worker-upgrade attempt (#1014): ``handle_worker_upgrade``
+    returns 202 before any result exists (a rig rebuild can take minutes, so it never waits inline
+    like ``handle_worker_apply`` does), so this runs as its own background task and records the
+    terminal outcome once the host runner writes it — independent of whether the operator's browser
+    tab stays open to see it land. One row per upgrade attempt, same shape as an apply's (#185)."""
+    try:
+        res = await control_service.wait_result(
+            rid,
+            done=lambda r: r.get("status") != "running",
+            timeout_s=config.CONTROL_WORKER_UPGRADE_WAIT_S,
+        )
+    except Exception:
+        logger.exception("Error waiting for worker-upgrade result (id=%s)", rid)
+        return
+    if res is not None:
+        _record_worker_result(state_mgr, worker, {"version": version}, res, change_type="upgrade")
+
+
 async def handle_worker_upgrade(request):
     """One-click RigForge upgrade for a single rig (#597), via the HOST-side control runner.
 
@@ -292,7 +335,8 @@ async def handle_worker_upgrade(request):
     from the RigForge release API over Tor and refuses a mismatch, then resolves the rig's address
     + bearer from config.json — this container never holds the token and cannot choose what gets
     installed. Returns 202 + the request id immediately (a rig build can take minutes); the client
-    polls /api/control/result. A rig already reporting the requested version short-circuits to a
+    polls /api/control/result, and a background task records the terminal outcome to the per-worker
+    history once it lands (#1014). A rig already reporting the requested version short-circuits to a
     no-op without spooling — a dial would just burn the rig's own 6h upgrade throttle."""
     _require_control_header(request)
     try:
@@ -320,6 +364,11 @@ async def handle_worker_upgrade(request):
     except Exception:
         logger.exception("Error submitting worker-upgrade")
         return web.json_response({"error": "Failed to submit the worker upgrade."}, status=500)
+    state_mgr = request.app["state_manager"]
+    bg_tasks = request.app["_bg_tasks"]
+    task = asyncio.create_task(_finalize_worker_upgrade(state_mgr, worker, version, rid))
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
     return web.json_response({"id": rid, "status": "pending"}, status=202)
 
 
@@ -452,12 +501,27 @@ async def security_headers_middleware(request, handler):
         raise _apply_security_headers(exc) from exc
 
 
+async def _cancel_bg_tasks(app):
+    """Cancel any still-pending worker-upgrade recorder tasks (#1014) on shutdown — otherwise a
+    task waiting out its up-to-5-minute budget outlives the app and asyncio logs a "Task was
+    destroyed but it is pending" warning at interpreter exit."""
+    tasks = list(app["_bg_tasks"])
+    for t in tasks:
+        t.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
 def create_app(state_manager, latest_data_ref):
     """Factory to create the web app instance."""
     app = web.Application(middlewares=[security_headers_middleware])
     # Pass shared state objects to the app context
     app["state_manager"] = state_manager
     app["latest_data"] = latest_data_ref
+    # Fire-and-forget recorder tasks (worker-upgrade, #1014) — tracked so they can't be
+    # garbage-collected mid-flight and so shutdown can cancel any still in progress.
+    app["_bg_tasks"] = set()
+    app.on_cleanup.append(_cancel_bg_tasks)
 
     app.add_routes(
         [

--- a/build/dashboard/mining_dashboard/web/static/chart.mjs
+++ b/build/dashboard/mining_dashboard/web/static/chart.mjs
@@ -27,6 +27,16 @@ const RANGES = [
   ["all", "All"],
 ];
 
+// Reduced range set for the per-worker hashrate chart (#1013), sized to what worker_history can
+// honestly support: it samples ~5 min (vs the main history's 30s), so a "1 Hr" button would show
+// ~12 points — dropped rather than shipped dishonest. Retention is 30 days — exactly what "1 Mo"
+// would mean — so "All" stands alone instead of offering an identical neighbour.
+const WORKER_RANGES = [
+  ["24h", "24 Hr"],
+  ["1w", "1 Wk"],
+  ["all", "All"],
+];
+
 // Hashrate-averaging windows for the chart toggle (#168): [param key, button label]. The keys match
 // the server's `avg` param; labels are spelled out so the "1m" window (1 MINUTE) isn't mistaken for
 // the "1 Mo" RANGE above. Persisted in dashboard.js ui.avg (localStorage), default 10m. 12h/24h read
@@ -504,6 +514,168 @@ export class ChartCard extends Component {
                 })}
             </div>
             <div class="chart-wrap"><canvas ref=${this.canvasRef}></canvas></div>
+        </div>`;
+  }
+}
+
+// Per-worker hashrate chart (#1013): the same card/range-control/palette idioms as ChartCard
+// above, sized down to what a single rig's data actually supports — one hashrate line, no
+// avg-window toggle (worker_history stores only h15), no zoom (not asked for; ChartCard's zoom
+// exists for #47's wide fleet range, not a per-rig glance). The "Changes" scatter overlay (#1015)
+// is a fourth instance of the hidden-0-1-axis marker pattern Events/Raffle/Payouts already use
+// above — not a new mechanism, just fed config-apply/rig-upgrade points instead.
+//
+// `props.chart` is pre-shaped by the caller (workerlogic.mjs's buildChartMarkers), the same way
+// ChartCard's own d.events/d.raffle/d.payouts arrive pre-shaped: `{hashrate: [{x,y}], markers:
+// [{x, y, label, kind, quiet}]}`. `quiet` marks an outcome where nothing actually changed
+// (rejected/rolled_back/failed/throttled/noop/accepted) — still shown, just muted, rather than
+// dropped (#1015).
+
+// Per-point style for the "Changes" marker dataset (#1015): a triangle for a rig upgrade, a
+// diamond (matching the Events marker above) for a config apply; muted (c.ticks) for an outcome
+// that didn't actually change anything (quiet), the chart's accent colour otherwise. Kept pure and
+// exported, mirroring eventColors above, so the branch is unit-tested without a canvas.
+export function workerMarkerStyle(markers, c) {
+  return {
+    pointStyle: (markers || []).map((m) => (m.kind === "upgrade" ? "triangle" : "rectRot")),
+    color: (markers || []).map((m) => (m.quiet ? c.ticks : c.accent)),
+  };
+}
+
+export class WorkerChartCard extends Component {
+  constructor(props) {
+    super(props);
+    this.canvasRef = createRef();
+  }
+
+  componentDidMount() {
+    this.create();
+  }
+  componentDidUpdate() {
+    this.sync();
+  }
+  componentWillUnmount() {
+    if (this.chart) {
+      this.chart.destroy();
+      this.chart = null;
+    }
+  }
+
+  create() {
+    const canvas = this.canvasRef.current;
+    const d = this.props.chart;
+    if (!canvas || typeof Chart === "undefined" || !d.hashrate.length) return;
+    const c = paletteColors();
+    const mk = workerMarkerStyle(d.markers, c);
+    this.chart = new Chart(canvas, {
+      type: "line",
+      data: {
+        datasets: [
+          {
+            label: "Hashrate",
+            data: d.hashrate,
+            borderColor: c.accent,
+            borderWidth: AREA_BORDER_WIDTH,
+            tension: 0.3,
+            fill: true,
+            backgroundColor: areaFill(c.accent),
+            pointRadius: 0,
+            pointHitRadius: 20,
+          },
+          // Config-apply / rig-upgrade markers, on their own hidden 0-1 axis so they ride near
+          // the top and never affect the hashrate y-range — same technique as Events above.
+          {
+            label: "Changes",
+            data: d.markers,
+            yAxisID: "markers",
+            pointStyle: mk.pointStyle,
+            pointRadius: 7,
+            pointHoverRadius: 10,
+            pointHitRadius: 100,
+            showLine: false,
+            pointBackgroundColor: mk.color,
+            pointBorderColor: mk.color,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        interaction: { mode: "nearest", axis: "x", intersect: false },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              title(items) {
+                return items.length ? fmtTimestamp(items[0].parsed.x) : "";
+              },
+              label(context) {
+                if (context.dataset.label === "Changes") return context.raw.label;
+                return context.parsed.y !== null ? fmtHashrate(context.parsed.y) : "";
+              },
+            },
+          },
+        },
+        scales: {
+          x: { type: "linear", display: false },
+          y: { grid: { color: c.grid }, ticks: { color: c.ticks }, afterDataLimits: padYAxis },
+          markers: { type: "linear", display: false, min: 0, max: 1 },
+        },
+      },
+    });
+  }
+
+  sync() {
+    const d = this.props.chart;
+    if (!d.hashrate.length) {
+      // Range switched to a slice with no samples (e.g. a rig that's only been up an hour, on
+      // "1 Wk") — drop the instance so render()'s empty state takes over instead of an empty axis.
+      if (this.chart) {
+        this.chart.destroy();
+        this.chart = null;
+      }
+      return;
+    }
+    if (!this.chart) {
+      this.create();
+      return;
+    }
+    const c = paletteColors(); // re-read so a theme switch recolours in place
+    const mk = workerMarkerStyle(d.markers, c);
+    const ds = this.chart.data.datasets;
+    ds[0].data = d.hashrate;
+    ds[0].borderColor = c.accent;
+    ds[0].backgroundColor = areaFill(c.accent);
+    ds[1].data = d.markers;
+    ds[1].pointStyle = mk.pointStyle;
+    ds[1].pointBackgroundColor = mk.color;
+    ds[1].pointBorderColor = mk.color;
+    this.chart.options.scales.y.grid.color = c.grid;
+    this.chart.options.scales.y.ticks.color = c.ticks;
+    this.chart.update();
+    this.chart.resize();
+  }
+
+  render(props) {
+    const empty = !props.chart.hashrate.length;
+    return html`
+        <div class="card">
+            <div class="chart-controls" role="group" aria-label="Hashrate chart range">
+                <span class="chart-control-label text-small mr-1">Range:</span>
+                ${WORKER_RANGES.map(
+                  ([r, label]) => html`<button type="button"
+                    class=${"btn-range" + (props.range === r ? " active" : "")}
+                    aria-pressed=${props.range === r}
+                    title=${"Chart range: " + label}
+                    onClick=${() => props.onRange(r)}>${label}</button>`,
+                )}
+            </div>
+            ${
+              empty
+                ? html`<p class="text-muted text-small">No hashrate history for this rig yet.</p>`
+                : html`<div class="chart-wrap"><canvas ref=${this.canvasRef}></canvas></div>`
+            }
         </div>`;
   }
 }

--- a/build/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -83,3 +83,35 @@ export function parseJsonChanges(text, writableKeys) {
   if (bad.length) return { error: `Not writable: ${bad.join(", ")}` };
   return { changes };
 }
+
+// Per-worker hashrate chart markers (#1015): one change-history row -> one tooltip label. The
+// server keeps `status`/`type`/`changes`/`reason` as raw tokens (views.py "formats at the edge"
+// only for display strings); this is the client mapping them to text, the same job STATUS_META
+// already does for the History table's Outcome column, just phrased as a tooltip sentence.
+export function markerLabel(row) {
+  const changes = row.changes || {};
+  if (row.type === "upgrade") {
+    const version = changes.version || "an update";
+    if (row.status === "applied") return `Upgraded to ${version}`;
+    if (row.status === "noop") return `Upgrade to ${version}: rig already current`;
+    return `Upgrade to ${version}: ${row.status}` + (row.reason ? ` — ${row.reason}` : "");
+  }
+  const keys = Object.keys(changes);
+  const changed = keys.length ? keys.join(", ") : "config";
+  if (row.status === "applied") return `Applied: ${changed}`;
+  return `Apply ${row.status}` + (row.reason ? ` — ${row.reason}` : "");
+}
+
+// Change-history rows (server-shaped, range-filtered to match the chart's own hashrate slice) ->
+// WorkerChartCard's marker points. `quiet` covers every outcome where the rig's config/build did
+// NOT actually change (rejected/rolled_back/failed/throttled/noop/accepted) — shown with a muted
+// glyph rather than dropped, so "we tried and it bounced" still explains a flat stretch (#1015).
+export function buildChartMarkers(markers) {
+  return (markers || []).map((row) => ({
+    x: row.x,
+    y: 0.5,
+    label: markerLabel(row),
+    kind: row.type === "upgrade" ? "upgrade" : "apply",
+    quiet: row.status !== "applied",
+  }));
+}

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -13,10 +13,12 @@
 // one apply() below. A "Load from file" button inside JSON mode reads a local file into the
 // textarea (FileReader, no upload) for pushing the same profile to several rigs.
 
+import { WorkerChartCard } from "./chart.mjs";
 import { SECRET_HINT } from "./configlogic.mjs";
 import { loadPref, savePref } from "./logic.mjs";
 import { Component, createRef, html } from "./preact.mjs";
 import {
+  buildChartMarkers,
   buildFields,
   buildTableChanges,
   jsonSyntaxError,
@@ -78,14 +80,22 @@ function StatusLine({ result }) {
 }
 
 // One history row: the change keys, the outcome, and when. `changes` IS the diff (we record only
-// the deltas we authored), so listing its keys is the per-change diff.
+// the deltas we authored), so listing its keys is the per-change diff — except a rig-upgrade row
+// (#1014), whose `changes` carries `{version}` rather than a writable-key diff, shown as its own
+// target version instead of the literal key name "version".
 function HistoryRow({ row }) {
   const meta = STATUS_META[row.status] || { cls: "text-muted", label: row.status };
   const keys = Object.keys(row.changes || {});
+  const changed =
+    row.type === "upgrade"
+      ? `upgrade → ${row.changes?.version || "?"}`
+      : keys.length
+        ? keys.join(", ")
+        : "—";
   return html`
     <tr>
         <td class="text-xs text-muted">${row.applied_at || ""}</td>
-        <td class="font-mono text-xs">${keys.length ? keys.join(", ") : "—"}</td>
+        <td class="font-mono text-xs">${changed}</td>
         <td><span class=${"text-small " + meta.cls}>${meta.label}</span></td>
         <td class="text-xs text-muted">${row.reason || ""}</td>
     </tr>`;
@@ -155,6 +165,11 @@ export class WorkerInspect extends Component {
       upgArmed: false,
       upgBusy: false,
       upgResult: null,
+      // Per-worker hashrate chart (#1013): its own range preference (persisted, like the editor
+      // mode above) and its own loading flag — a range switch refetches ONLY the chart data
+      // (loadChart), never the full load(), so it can't wipe an in-progress config edit.
+      chartRange: loadPref("dashboardWorkerChartRange", ["24h", "1w", "all"], "24h"),
+      chartLoading: false,
     };
     this.dialogRef = createRef();
   }
@@ -172,7 +187,9 @@ export class WorkerInspect extends Component {
   async load() {
     this.setState({ phase: "loading", error: null });
     try {
-      const res = await fetch(`/api/worker?name=${encodeURIComponent(this.props.name)}`);
+      const res = await fetch(
+        `/api/worker?name=${encodeURIComponent(this.props.name)}&range=${this.state.chartRange}`,
+      );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const detail = await res.json();
       // Prefill the editor with the last-applied writable config, or an empty object to start from.
@@ -181,6 +198,32 @@ export class WorkerInspect extends Component {
     } catch (e) {
       this.setState({ phase: "error", error: String(e) });
     }
+  }
+
+  // Hashrate chart range change (#1013): re-fetch /api/worker at the new range and replace ONLY
+  // detail.hashrate_history — unlike load(), this must never reset tableEdits/editText/phase, or
+  // clicking a range button mid-edit would silently drop the operator's in-progress changes.
+  async loadChart(range) {
+    this.setState({ chartLoading: true });
+    try {
+      const res = await fetch(
+        `/api/worker?name=${encodeURIComponent(this.props.name)}&range=${range}`,
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const detail = await res.json();
+      this.setState((s) => ({
+        chartLoading: false,
+        detail: { ...s.detail, hashrate_history: detail.hashrate_history },
+      }));
+    } catch {
+      this.setState({ chartLoading: false });
+    }
+  }
+
+  setChartRange(range) {
+    savePref("dashboardWorkerChartRange", range);
+    this.setState({ chartRange: range });
+    return this.loadChart(range);
   }
 
   onJsonInput(text) {
@@ -277,8 +320,19 @@ export class WorkerInspect extends Component {
   }
 
   renderBody(detail) {
-    const { mode, tableEdits, editText, jsonError, busy, result, upgArmed, upgBusy, upgResult } =
-      this.state;
+    const {
+      mode,
+      tableEdits,
+      editText,
+      jsonError,
+      busy,
+      result,
+      upgArmed,
+      upgBusy,
+      upgResult,
+      chartRange,
+      chartLoading,
+    } = this.state;
     const canEdit = detail.control_enabled && detail.editable;
     return html`
         <div class="worker-inspect-body">
@@ -318,6 +372,15 @@ export class WorkerInspect extends Component {
             }
             <${StatusLine} result=${upgResult} />
             ${detail.rigforge ? html`<${StatsTable} stats=${detail.rigforge.stats} />` : null}
+
+            <h4 class="mt-2">Hashrate${chartLoading ? html` <span class="text-muted text-small">refreshing…</span>` : null}</h4>
+            <${WorkerChartCard}
+                chart=${{
+                  hashrate: detail.hashrate_history?.hashrate || [],
+                  markers: buildChartMarkers(detail.hashrate_history?.markers),
+                }}
+                range=${chartRange}
+                onRange=${(r) => this.setChartRange(r)} />
 
             <h4 class="mt-2">Edit config</h4>
             ${

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1955,14 +1955,43 @@ def _egress_badge(summary):
     }
 
 
-def build_worker_detail(name, data, state_mgr):
+def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
+    """Per-worker hashrate-over-time chart (#1013): ``worker_history.h15`` for one rig, same
+    range/window/downsampling idiom as the telemetry backbone's other gauge series (``_gauge_series``
+    — reused as-is, not reimplemented). Markers (#1015) are the SAME range/window slice of this rig's
+    change history — config applies and rig upgrades (#1014) — so a step in the line has a visible
+    cause; kept as raw tokens (status/type/changes/reason), not display strings, so the client builds
+    the tooltip label the same way it already builds the history table's Outcome column."""
+    hashrate = [
+        {"x": p["x"], "y": p["h15"]}
+        for p in _gauge_series(
+            state_mgr.get_worker_history(name=worker), range_arg, window, ("h15",)
+        )
+    ]
+    markers = [
+        {
+            "x": int(row["ts"] * 1000),
+            "status": row.get("status"),
+            "type": row.get("type", "apply"),
+            "changes": row.get("changes") or {},
+            "reason": row.get("reason"),
+        }
+        for row in _filter_events(
+            state_mgr.get_worker_config_history(worker, limit=200), range_arg, window
+        )
+    ]
+    return {"hashrate": hashrate, "markers": markers}
+
+
+def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     """Per-worker Inspect payload (#185): the rig's current enriched telemetry, the writable config
     the dashboard last applied (the editor prefill — the rig's feed does not expose the writable
     config values, so Pithead's own last-applied record is the honest source), and the change history
     (each row's ``changes`` is a diff by construction, since we only ever record deltas we authored).
     ``hashrate_by_config`` (#492) is that same version timeline with each version's measured
     hashrate (worker_history) aggregated over its active window, so an operator can compare config
-    versions empirically.
+    versions empirically. ``hashrate_history`` (#1013) is the same rig's hashrate as a chartable
+    time series, honoring the same ``range_arg``/``window`` ``/api/state`` already uses.
 
     ``editable`` is whether the worker has an operator-set ``host`` in ``dashboard.workers[]`` — the
     precondition for the host-side write path. The rig's token is masked out of this container (#440),
@@ -1997,6 +2026,7 @@ def build_worker_detail(name, data, state_mgr):
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,
         "hashrate_by_config": hashrate_by_config,
+        "hashrate_history": build_worker_hashrate_history(state_mgr, name, range_arg, window),
     }
 
 

--- a/build/dashboard/tests/frontend/chart.test.mjs
+++ b/build/dashboard/tests/frontend/chart.test.mjs
@@ -9,7 +9,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { withAlpha, padYAxis, eventColors, donationSeries } from '../../mining_dashboard/web/static/chart.mjs';
+import { withAlpha, padYAxis, eventColors, donationSeries, workerMarkerStyle } from '../../mining_dashboard/web/static/chart.mjs';
 
 test('withAlpha: appends an 8-bit alpha to a #rrggbb hex', () => {
     assert.equal(withAlpha('#58a6ff', '26'), '#58a6ff26');
@@ -83,4 +83,29 @@ test('donationSeries: maps xvb_history donation_fraction (0..1) to a 0..100 perc
 test('donationSeries: tolerates a missing history (XvB off / no samples yet)', () => {
     assert.deepEqual(donationSeries(undefined), []);
     assert.deepEqual(donationSeries([]), []);
+});
+
+test('workerMarkerStyle: upgrade markers are triangles, config-apply markers are diamonds (#1015)', () => {
+    const c = { accent: '#58a6ff', ticks: '#8b949e' };
+    const markers = [
+        { kind: 'apply', quiet: false },
+        { kind: 'upgrade', quiet: false },
+    ];
+    const style = workerMarkerStyle(markers, c);
+    assert.deepEqual(style.pointStyle, ['rectRot', 'triangle']);
+});
+
+test('workerMarkerStyle: a quiet outcome (nothing changed) renders muted, not accent', () => {
+    const c = { accent: '#58a6ff', ticks: '#8b949e' };
+    const markers = [
+        { kind: 'apply', quiet: false },
+        { kind: 'apply', quiet: true },
+    ];
+    const style = workerMarkerStyle(markers, c);
+    assert.deepEqual(style.color, [c.accent, c.ticks]);
+});
+
+test('workerMarkerStyle: tolerates a missing marker list', () => {
+    const c = { accent: '#58a6ff', ticks: '#8b949e' };
+    assert.deepEqual(workerMarkerStyle(undefined, c), { pointStyle: [], color: [] });
 });

--- a/build/dashboard/tests/frontend/workerlogic.test.mjs
+++ b/build/dashboard/tests/frontend/workerlogic.test.mjs
@@ -8,9 +8,11 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  buildChartMarkers,
   buildFields,
   buildTableChanges,
   jsonSyntaxError,
+  markerLabel,
   parseJsonChanges,
 } from "../../mining_dashboard/web/static/workerlogic.mjs";
 
@@ -111,4 +113,66 @@ test("jsonSyntaxError: live check used for inline feedback while typing", () => 
   assert.equal(jsonSyntaxError("  "), null);
   assert.equal(jsonSyntaxError('{"a": 1}'), null);
   assert.match(jsonSyntaxError("{not json"), /Not valid JSON/);
+});
+
+// --- markerLabel / buildChartMarkers (#1015) ------------------------------------------------
+
+test("markerLabel: an applied config change lists its changed keys", () => {
+  const label = markerLabel({ type: "apply", status: "applied", changes: { DONATION: 3 } });
+  assert.equal(label, "Applied: DONATION");
+});
+
+test("markerLabel: a rejected/rolled_back apply carries its reason, not the changed keys", () => {
+  assert.equal(
+    markerLabel({ type: "apply", status: "rejected", reason: "bad value", changes: { a: 1 } }),
+    "Apply rejected — bad value",
+  );
+  assert.equal(
+    markerLabel({ type: "apply", status: "rolled_back", reason: "miner did not return live" }),
+    "Apply rolled_back — miner did not return live",
+  );
+});
+
+test("markerLabel: an applied upgrade names the version it moved to", () => {
+  const label = markerLabel({ type: "upgrade", status: "applied", changes: { version: "v1.12.0" } });
+  assert.equal(label, "Upgraded to v1.12.0");
+});
+
+test("markerLabel: upgrade noop/throttled read calm, not as a fault", () => {
+  assert.equal(
+    markerLabel({ type: "upgrade", status: "noop", changes: { version: "v1.12.0" } }),
+    "Upgrade to v1.12.0: rig already current",
+  );
+  assert.equal(
+    markerLabel({
+      type: "upgrade",
+      status: "throttled",
+      changes: { version: "v1.12.0" },
+      reason: "retry after the window",
+    }),
+    "Upgrade to v1.12.0: throttled — retry after the window",
+  );
+});
+
+test("buildChartMarkers: maps each row to a chart point, quiet only for a non-applied outcome", () => {
+  const rows = [
+    { x: 1000, status: "applied", type: "apply", changes: { a: 1 } },
+    { x: 2000, status: "rejected", type: "apply", changes: {}, reason: "bad" },
+    { x: 3000, status: "applied", type: "upgrade", changes: { version: "v2" } },
+  ];
+  const pts = buildChartMarkers(rows);
+  assert.deepEqual(
+    pts.map((p) => [p.x, p.y, p.kind, p.quiet]),
+    [
+      [1000, 0.5, "apply", false],
+      [2000, 0.5, "apply", true],
+      [3000, 0.5, "upgrade", false],
+    ],
+  );
+  assert.equal(pts[0].label, "Applied: a");
+});
+
+test("buildChartMarkers: tolerates a missing/empty marker list", () => {
+  assert.deepEqual(buildChartMarkers(undefined), []);
+  assert.deepEqual(buildChartMarkers([]), []);
 });

--- a/build/dashboard/tests/frontend/workerview.test.mjs
+++ b/build/dashboard/tests/frontend/workerview.test.mjs
@@ -26,6 +26,7 @@ const DETAIL = {
   writable_keys: ["DONATION", "max_temp_c", "token"],
   last_applied: { DONATION: 5, max_temp_c: 70, token: SENTINEL },
   history: [],
+  hashrate_history: { hashrate: [], markers: [] },
 };
 
 // WorkerInspect is never mounted here (no DOM/jsdom — this repo's frontend tests deliberately run
@@ -177,6 +178,44 @@ test("the fill button is a no-op when the file picker is dismissed with no file"
   assert.equal(inst.state.editText, before);
 });
 
+// --- Change history (#1014) -------------------------------------------------------------------
+
+test("a config-apply history row lists its changed keys", () => {
+  const detail = {
+    ...DETAIL,
+    history: [
+      {
+        applied_at: "2026-07-16 12:00",
+        status: "applied",
+        type: "apply",
+        changes: { DONATION: 3 },
+        reason: null,
+      },
+    ],
+  };
+  const out = renderToString(readyInstance(detail).render());
+  assert.match(out, /DONATION/);
+  assert.doesNotMatch(out, /upgrade →/);
+});
+
+test("a rig-upgrade history row shows the version it moved to, not the literal key 'version'", () => {
+  const detail = {
+    ...DETAIL,
+    history: [
+      {
+        applied_at: "2026-07-16 12:00",
+        status: "applied",
+        type: "upgrade",
+        changes: { version: "v1.12.0" },
+        reason: null,
+      },
+    ],
+  };
+  const out = renderToString(readyInstance(detail).render());
+  assert.match(out, /upgrade → v1\.12\.0/);
+  assert.doesNotMatch(out, />version</); // never the raw changed-key name for an upgrade row
+});
+
 // --- Hashrate by config (#492) ----------------------------------------------------------------
 
 test("renders one row per config version with its aggregated hashrate", () => {
@@ -232,6 +271,88 @@ test("a version with no samples yet shows a dash, not a crash", () => {
 test("no applied config versions yet falls back to an explanatory message", () => {
   const out = renderToString(readyInstance({ ...DETAIL, hashrate_by_config: [] }).render());
   assert.match(out, /No applied config changes to correlate hashrate against yet/);
+});
+
+// --- Hashrate chart (#1013/#1015) -------------------------------------------------------------
+
+test("a rig with no hashrate history yet renders an honest empty state, not a broken chart", () => {
+  const out = renderToString(readyInstance(DETAIL).render());
+  assert.match(out, /No hashrate history for this rig yet/);
+  // The range control still renders (the operator can still try a wider range).
+  assert.match(out, /24 Hr/);
+  assert.match(out, />All</);
+});
+
+test("a rig with samples renders the range control and the chart canvas, not the empty state", () => {
+  const detail = {
+    ...DETAIL,
+    hashrate_history: { hashrate: [{ x: 1000, y: 500 }], markers: [] },
+  };
+  const out = renderToString(readyInstance(detail).render());
+  assert.doesNotMatch(out, /No hashrate history for this rig yet/);
+  assert.match(out, /<canvas/);
+  assert.match(out, /24 Hr/);
+  assert.match(out, /1 Wk/);
+});
+
+test("only the current chart range button is marked active", () => {
+  const detail = { ...DETAIL, hashrate_history: { hashrate: [{ x: 1, y: 1 }], markers: [] } };
+  const inst = readyInstance(detail);
+  inst.state.chartRange = "1w";
+  const out = renderToString(inst.render());
+  assert.match(out, /class="btn-range active"[^>]*>1 Wk/);
+});
+
+test("clicking a range button refetches only the chart data, leaving an in-progress edit alone", async () => {
+  const detail = { ...DETAIL, hashrate_history: { hashrate: [{ x: 1, y: 1 }], markers: [] } };
+  const inst = readyInstance(detail);
+  inst.state.tableEdits = { DONATION: "9" }; // an in-progress, unsaved edit
+  let requested = null;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    requested = url;
+    return {
+      ok: true,
+      json: async () => ({ hashrate_history: { hashrate: [{ x: 2, y: 2 }], markers: [] } }),
+    };
+  };
+  try {
+    await inst.setChartRange("1w");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.match(requested, /\/api\/worker\?name=rig1&range=1w/);
+  assert.equal(inst.state.chartRange, "1w");
+  assert.equal(inst.state.chartLoading, false);
+  assert.deepEqual(inst.state.detail.hashrate_history.hashrate, [{ x: 2, y: 2 }]);
+  // Nothing else in detail, and no unrelated state, was touched by the chart-only refresh.
+  assert.deepEqual(inst.state.tableEdits, { DONATION: "9" });
+  assert.equal(inst.state.phase, "ready");
+});
+
+test("load() requests the current chart range from /api/worker", async () => {
+  const inst = new WorkerInspect({ name: "rig1", onClose: () => {} });
+  stubSetState(inst);
+  let requested = null;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    requested = url;
+    return { ok: true, json: async () => DETAIL };
+  };
+  try {
+    await inst.load();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+  assert.match(requested, /range=24h/); // the default chart-range preference
+  assert.equal(inst.state.phase, "ready");
+});
+
+test("a detail payload missing hashrate_history entirely still renders (defensive, no crash)", () => {
+  const withoutChart = { ...DETAIL };
+  delete withoutChart.hashrate_history;
+  const out = renderToString(readyInstance(withoutChart).render());
+  assert.match(out, /No hashrate history for this rig yet/);
 });
 
 // --- One-click rig upgrade (#597) -------------------------------------------------------------

--- a/build/dashboard/tests/service/test_storage_service.py
+++ b/build/dashboard/tests/service/test_storage_service.py
@@ -598,6 +598,35 @@ class TestSchemaMigration:
         finally:
             sm.close()
 
+    def test_worker_config_type_column_added_on_upgrade(self, tmp_path):
+        # Intent (#1014): a pre-`type` worker_config table (the #185 original schema) gains the
+        # column in place, and an existing row — necessarily a config apply, since rig upgrades
+        # were never recorded before this — reads back type='apply', not NULL/blank.
+        db = str(tmp_path / "pre_1014.db")
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE worker_config (id INTEGER PRIMARY KEY AUTOINCREMENT, worker TEXT, "
+            "change_id TEXT, ts REAL, status TEXT, changes TEXT, reason TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO worker_config (worker, change_id, ts, status, changes, reason) "
+            "VALUES ('rig1', 'cid1', 100.0, 'applied', '{}', NULL)"
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StateManager(db_path=db)
+        try:
+            cols = {
+                info[1] for info in sm._conn.execute("PRAGMA table_info(worker_config)").fetchall()
+            }
+            assert "type" in cols
+            history = sm.get_worker_config_history("rig1")
+            assert len(history) == 1
+            assert history[0]["type"] == "apply"
+        finally:
+            sm.close()
+
 
 class TestRetention:
     """Long-running behavior: history/workers must not grow unbounded. Tests are white-box
@@ -1264,6 +1293,26 @@ class TestWorkerHashrateByConfig:
         assert rows[0]["change_id"] == "cid1"
         assert rows[0]["sample_count"] == 1
 
+    def test_applied_upgrade_is_also_a_boundary(self, state_manager):
+        # #1014: hashrate_by_config must split on an applied rig upgrade the same way it splits on
+        # an applied config change — otherwise a version change misattributes the build's effect.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
+        state_manager.add_worker_config_version(
+            "rig1", "cid2", "applied", {"version": "v1.12.0"}, None, ts=200, change_type="upgrade"
+        )
+        state_manager.add_worker_history(
+            [{"ts": 150, "name": "rig1", "h15": 1000.0, "accepted": 0, "rejected": 0}]
+        )
+        state_manager.add_worker_history(
+            [{"ts": 250, "name": "rig1", "h15": 5000.0, "accepted": 0, "rejected": 0}]
+        )
+        rows = state_manager.get_worker_hashrate_by_config("rig1")
+        assert [r["change_id"] for r in rows] == ["cid2", "cid1"]
+        assert (
+            rows[0]["avg_h15"] == 5000.0
+        )  # post-upgrade sample bucketed into the upgrade's window
+        assert rows[1]["avg_h15"] == 1000.0  # pre-upgrade sample stays with the config version
+
     def test_other_workers_hashrate_is_excluded(self, state_manager):
         state_manager.add_worker_config_version("rig1", "cid1", "applied", {"a": 1}, None, ts=100)
         state_manager.add_worker_history(
@@ -1438,6 +1487,34 @@ class TestWorkerConfigChangeKnown:
         with state_manager._db_lock:
             state_manager._conn.execute("DROP TABLE worker_config")
         assert state_manager.worker_config_change_known("cid-1") is True
+
+
+class TestWorkerConfigType:
+    """worker_config.type (#1014) distinguishes a config apply from a one-click rig upgrade so
+    the change history can show it and hashrate_by_config can attribute a build change correctly."""
+
+    def test_default_type_is_apply(self, state_manager):
+        # An ordinary worker-apply call never passes change_type — must default to 'apply', not
+        # blank/None, so get_last_applied_worker_config's type check keeps working unmodified.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"DONATION": 2}, None)
+        assert state_manager.get_worker_config_history("rig1")[0]["type"] == "apply"
+
+    def test_upgrade_type_round_trips(self, state_manager):
+        state_manager.add_worker_config_version(
+            "rig1", "cid1", "applied", {"version": "v1.12.0"}, None, change_type="upgrade"
+        )
+        row = state_manager.get_worker_config_history("rig1")[0]
+        assert row["type"] == "upgrade"
+        assert row["changes"] == {"version": "v1.12.0"}
+
+    def test_last_applied_config_excludes_upgrade_rows(self, state_manager):
+        # An applied upgrade's changes = {"version": ...} must never leak into the editor prefill
+        # (it isn't a writable config key at all) — only 'apply'-type applied rows merge.
+        state_manager.add_worker_config_version("rig1", "cid1", "applied", {"DONATION": 2}, None)
+        state_manager.add_worker_config_version(
+            "rig1", "cid2", "applied", {"version": "v1.12.0"}, None, change_type="upgrade"
+        )
+        assert state_manager.get_last_applied_worker_config("rig1") == {"DONATION": 2}
 
 
 class TestAuditEvents:

--- a/build/dashboard/tests/web/test_server.py
+++ b/build/dashboard/tests/web/test_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import uuid
 from unittest.mock import MagicMock
@@ -993,6 +994,9 @@ class TestWorkerUpgrade:
         assert resp.status == 200
         assert (await resp.json())["status"] == "noop"
         assert list((control_spool / "requests").glob("*.json")) == []
+        # Nothing was ever asked of a rig — a local version comparison, not an upgrade attempt —
+        # so it gets no history row (#1014 is about recording real attempts, not every click).
+        assert worker_client.sm.get_worker_config_history("rig1") == []
 
     async def test_route_absent_when_control_disabled(self, client):
         resp = await client.post(
@@ -1001,6 +1005,110 @@ class TestWorkerUpgrade:
             headers=CONTROL_HEADERS,
         )
         assert resp.status == 404
+
+
+class TestWorkerUpgradeRecordsHistory:
+    """#1014: a one-click rig upgrade is 202-then-poll (a rebuild can run minutes), so the
+    terminal outcome is recorded by a background task, not inline like worker-apply's. These pin
+    that task down directly (`await asyncio.gather(*app["_bg_tasks"])`) rather than sleeping."""
+
+    async def _upgrade(self, worker_client, control_spool, monkeypatch, result):
+        rid = str(uuid.uuid4())
+        monkeypatch.setattr(control_service.uuid, "uuid4", lambda: uuid.UUID(rid))
+        (control_spool / "results" / f"{rid}.json").write_text(json.dumps(result))
+        resp = await worker_client.post(
+            "/api/control/worker-upgrade",
+            json={"worker": "rig1", "version": "v1.11.2"},
+            headers=CONTROL_HEADERS,
+        )
+        assert resp.status == 202
+        await asyncio.gather(*worker_client.app["_bg_tasks"])
+        return rid
+
+    async def test_applied_upgrade_recorded_as_its_own_type(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        result = {
+            "status": "applied",
+            "change_id": "deadbeef",
+            "worker": "rig1",
+            "version": "v1.11.2",
+            "reason": None,
+        }
+        await self._upgrade(worker_client, control_spool, monkeypatch, result)
+        history = worker_client.sm.get_worker_config_history("rig1")
+        assert len(history) == 1
+        assert history[0]["status"] == "applied"
+        assert history[0]["type"] == "upgrade"
+        assert history[0]["changes"] == {"version": "v1.11.2"}
+        assert history[0]["change_id"] == "deadbeef"
+        # An applied upgrade must never leak into the config-editor prefill (#1014's own guard).
+        assert worker_client.sm.get_last_applied_worker_config("rig1") == {}
+
+    async def test_noop_and_throttled_terminals_from_a_real_dial_are_recorded(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        # Distinct from the synchronous short-circuit noop above: this is the RIG's own /status
+        # terminal for a dial that actually happened (rigforge#320's first-class noop/throttled).
+        for status in ("noop", "throttled"):
+            result = {
+                "status": status,
+                "change_id": f"cid-{status}",
+                "worker": "rig1",
+                "version": "v1.11.2",
+                "reason": "already current" if status == "noop" else "throttled: retry later",
+            }
+            await self._upgrade(worker_client, control_spool, monkeypatch, result)
+        statuses = {h["status"] for h in worker_client.sm.get_worker_config_history("rig1")}
+        assert statuses == {"noop", "throttled"}
+
+    async def test_pre_dial_rejection_recorded_with_the_requesters_worker_name(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        # The host runner's pre-dial _wu_reject writes NO 'worker' key at all — the row must still
+        # land under the right worker, from the request itself, not from the result body.
+        result = {"status": "rejected", "error": "worker has no configured host", "ts": 1.0}
+        await self._upgrade(worker_client, control_spool, monkeypatch, result)
+        history = worker_client.sm.get_worker_config_history("rig1")
+        assert len(history) == 1
+        assert history[0]["status"] == "rejected"
+        assert history[0]["type"] == "upgrade"
+        assert history[0]["reason"] == "worker has no configured host"
+        assert history[0]["changes"] == {"version": "v1.11.2"}  # the operator-proposed target
+
+    async def test_runner_never_answering_records_nothing(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        monkeypatch.setattr(control_service.config, "CONTROL_WORKER_UPGRADE_WAIT_S", 0.05)
+        rid = str(uuid.uuid4())
+        monkeypatch.setattr(control_service.uuid, "uuid4", lambda: uuid.UUID(rid))
+        resp = await worker_client.post(
+            "/api/control/worker-upgrade",
+            json={"worker": "rig1", "version": "v1.11.2"},
+            headers=CONTROL_HEADERS,
+        )
+        assert resp.status == 202
+        await asyncio.gather(*worker_client.app["_bg_tasks"])
+        assert worker_client.sm.get_worker_config_history("rig1") == []
+
+    async def test_wait_result_error_is_swallowed_not_raised(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        # A crash while polling for the terminal result (e.g. a spool read error) must not blow up
+        # the background task or take the app down with it — logged and dropped, like every other
+        # exception boundary in this module.
+        async def boom(*a, **k):
+            raise OSError("spool read failed")
+
+        monkeypatch.setattr(control_service, "wait_result", boom)
+        resp = await worker_client.post(
+            "/api/control/worker-upgrade",
+            json={"worker": "rig1", "version": "v1.11.2"},
+            headers=CONTROL_HEADERS,
+        )
+        assert resp.status == 202
+        await asyncio.gather(*worker_client.app["_bg_tasks"])  # must not raise
+        assert worker_client.sm.get_worker_config_history("rig1") == []
 
 
 class TestWorkerApplyEdgeCases:

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -3259,3 +3259,85 @@ class TestBuildWorkerDetail:
         )
         sm.close()
         assert d["hashrate_by_config"] == []
+
+
+class TestBuildWorkerHashrateHistory:
+    """The per-worker hashrate-over-time chart (#1013) + its change-marker overlay (#1015)."""
+
+    def _detail(self, monkeypatch, workers=None, descriptors=None, range_arg="all", window=None):
+        from mining_dashboard.service.storage_service import StateManager
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", descriptors or [])
+        sm = StateManager(db_path=":memory:")
+        data = {"workers": workers or [{"name": "rig1", "status": "online", "h60": 0}]}
+        return sm, data, range_arg, window
+
+    def test_no_history_yet_is_an_honest_empty_series(self, monkeypatch):
+        # A brand new rig: no worker_history samples, no change history. The chart must render an
+        # empty state client-side, not a broken axis — this is the data half of that contract.
+        sm, data, range_arg, window = self._detail(monkeypatch)
+        try:
+            d = build_worker_detail("rig1", data, sm, range_arg, window)
+        finally:
+            sm.close()
+        assert d["hashrate_history"] == {"hashrate": [], "markers": []}
+
+    def test_hashrate_series_and_markers_present(self, monkeypatch):
+        sm, data, range_arg, window = self._detail(monkeypatch)
+        try:
+            sm.add_worker_history(
+                [{"ts": 1000.0, "name": "rig1", "h15": 1234.0, "accepted": 0, "rejected": 0}]
+            )
+            sm.add_worker_config_version("rig1", "cid1", "applied", {"DONATION": 2}, None, ts=900.0)
+            d = build_worker_detail("rig1", data, sm, range_arg, window)
+        finally:
+            sm.close()
+        hist = d["hashrate_history"]
+        assert hist["hashrate"] == [{"x": 1000000, "y": 1234.0}]
+        assert len(hist["markers"]) == 1
+        m = hist["markers"][0]
+        assert m["x"] == 900000
+        assert m["status"] == "applied"
+        assert m["type"] == "apply"
+        assert m["changes"] == {"DONATION": 2}
+
+    def test_upgrade_row_marked_with_its_own_type(self, monkeypatch):
+        sm, data, range_arg, window = self._detail(monkeypatch)
+        try:
+            sm.add_worker_config_version(
+                "rig1",
+                "cid1",
+                "applied",
+                {"version": "v1.12.0"},
+                None,
+                ts=900.0,
+                change_type="upgrade",
+            )
+            d = build_worker_detail("rig1", data, sm, range_arg, window)
+        finally:
+            sm.close()
+        m = d["hashrate_history"]["markers"][0]
+        assert m["type"] == "upgrade"
+        assert m["changes"] == {"version": "v1.12.0"}
+
+    def test_range_filters_both_hashrate_and_markers(self, monkeypatch):
+        # Same range/window bound the chart line and its markers together, so a marker never
+        # renders outside the window its own hashrate slice covers.
+        now = time.time()
+        sm, data, _, _ = self._detail(monkeypatch)
+        try:
+            sm.add_worker_history(
+                [{"ts": now - 7200, "name": "rig1", "h15": 1.0, "accepted": 0, "rejected": 0}]
+            )
+            sm.add_worker_history(
+                [{"ts": now - 60, "name": "rig1", "h15": 2.0, "accepted": 0, "rejected": 0}]
+            )
+            sm.add_worker_config_version("rig1", "c-old", "applied", {"a": 1}, None, ts=now - 7200)
+            sm.add_worker_config_version("rig1", "c-new", "applied", {"a": 2}, None, ts=now - 60)
+            d = build_worker_detail("rig1", data, sm, "1h", None)  # 2h-old sample/marker excluded
+        finally:
+            sm.close()
+        hist = d["hashrate_history"]
+        assert len(hist["hashrate"]) == 1 and hist["hashrate"][0]["y"] == 2.0
+        assert len(hist["markers"]) == 1 and hist["markers"][0]["status"] == "applied"

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -340,9 +340,19 @@ crosses 5%.
 ### Worker Inspect
 
 With the control channel on (`dashboard.control.enabled`), a worker's name in the Workers Alive table
-is a link. Click it to open **Worker Inspect** — a dialog with that rig's live telemetry, an editor
-for the writable slice of its config, and the change history. Close it with the ✕ button, a click
-outside it, or Escape.
+is a link. Click it to open **Worker Inspect** — a dialog with that rig's live telemetry, a hashrate
+chart, an editor for the writable slice of its config, and the change history. Close it with the ✕
+button, a click outside it, or Escape.
+
+A **hashrate** chart sits above the editor: the rig's own `worker_history` samples (~5-minute
+cadence) as a line, with **24 Hr / 1 Wk / All** range buttons — no "1 Mo" button, since at the
+30-day retention it would show the same thing "All" already does. There's no averaging-window
+toggle here (unlike the [main chart](#hashrate-chart)) — the per-rig table stores only one window.
+Every config apply and rig upgrade in the change history below also marks the chart, so a step in
+the line has a visible cause; hover a marker for what changed. A rejected or rolled-back attempt
+still gets a marker, muted rather than dropped, since it tried but nothing on the rig actually
+changed. A rig with no samples yet (just added, or never online) shows an empty-chart message
+instead of a blank axis.
 
 The editor covers the keys RigForge lets the control path change: `pools`, `DONATION`, `autotune`,
 `watchdog`, `watchdog_interval_min`, and `max_temp_c`. Nothing else (identity, filesystem paths, API
@@ -371,7 +381,10 @@ latest release — the per-worker twin of the stack's one-click upgrade. The rig
 miner (about ten minutes when the XMRig pin changed) and rolls itself back if the miner doesn't
 come back live. The panel shows the outcome (applied / already up to date / rolled back / failed);
 a repeat click inside the rig's own six-hour upgrade window reads as "throttled — retry later",
-not an error. See
+not an error. Like a config apply, the outcome appends to the change history — with the version it
+moved to — so it isn't lost once the dialog closes, and both the hashrate chart above and the
+hashrate-by-config table below attribute what the hashrate does next to the upgrade, not to
+whatever config version happened to be active when it ran. See
 [Connecting Miners › One-click rig upgrade](workers.md#one-click-rig-upgrade) for what the rig
 must enable and how the target is derived.
 
@@ -397,14 +410,16 @@ config *values*, the editor prefills from the last config the dashboard applied 
 the rig — so a change made directly on the rig (via `rigforge.sh`) won't show here until the next
 dashboard apply.
 
-Below the change history sits a **Hashrate by config version** table: each *applied* change, with the
-rig's measured hashrate (the same per-rig `worker_history` samples, taken roughly every 5 minutes)
-averaged over the window that version was active — from the moment it was applied to the moment the
-next one was, or now for the current version. A version with no samples yet (just applied) shows a
-dash rather than zero. This is a correlation over existing data, not a new measurement — no rig-side
-change was needed to add it — so use it to compare versions empirically ("config #3 did 5.1 kH/s,
-config #4 did 4.8 kH/s") rather than as a precise A/B test; a version's window can include restarts,
-sync gaps, or other noise the average doesn't separate out.
+Below the change history sits a **Hashrate by config version** table: each *applied* change — a
+config apply or a rig upgrade — with the rig's measured hashrate (the same per-rig `worker_history`
+samples, taken roughly every 5 minutes) averaged over the window that change was active — from the
+moment it was applied to the moment the next one was, or now for the current one. A rig upgrade
+starts its own window the same way a config change does, so a version comparison here reflects a
+build change, not whatever config value happened to be active when the build changed. A row with no
+samples yet (just applied) shows a dash rather than zero. This is a correlation over existing data,
+not a new measurement — no rig-side change was needed to add it — so use it to compare changes
+empirically ("v1.11 did 5.1 kH/s, v1.12 did 4.8 kH/s") rather than as a precise A/B test; a window
+can include restarts, sync gaps, or other noise the average doesn't separate out.
 
 ### Simple vs. Advanced view
 


### PR DESCRIPTION
Three issues on one branch because they share the per-rig history and change-record plumbing. **#1014 is the load-bearing one** and was fixed first.

**#1014 — a one-click rig upgrade left no record at all.** `handle_worker_upgrade` returns 202 immediately (a rebuild takes minutes) and, unlike the apply path, never awaited a result — so `_record_worker_result` was never called and no history row existed. It now spawns a tracked background task that waits out the host runner's terminal result and records one row per attempt (worker + target version + terminal status + reason), independent of whether the operator's tab stays open. `worker_config` gains a `type` column (`apply`|`upgrade`, migrated forward) so the config-editor prefill ignores an upgrade's `{"version": …}` marker, while the existing `status=='applied'` boundary logic in `get_worker_hashrate_by_config` now treats an applied upgrade as a version boundary — hashrate stops being misattributed to whatever config happened to be active. Recordable statuses cover the upgrade-only `noop`/`throttled` terminals from #1001/#1009.

Cross-repo premise verified rather than assumed: RigForge's `control_upgrade` writes the same `status.json` as `control_apply`, and its v1.15.0 feed mirror (#346) exposes it — so #346 + #1009 + this fix close the loop end to end.

**#1013 — Worker Inspect gets the chart the fleet already had.** `/api/worker` takes the same `range`/`from`/`to` as `/api/state` and reuses the existing downsample path; the client adds a card to `chart.mjs` using the same palette, gradient and CSS classes as the fleet chart rather than a second charting approach. Ranges are **24 Hr / 1 Wk / All** deliberately — worker history samples every ~5 min, so a "1 Hr" button would be dishonest, and 30-day retention already makes "All" mean what "1 Mo" would. A rig with no samples renders an explicit empty state, not a broken axis.

**#1015 — applies and upgrades are marked on that chart** as a fourth instance of the hidden-axis scatter pattern Events/Raffle/Payouts already use: diamond for a config apply, triangle for an upgrade, accent colour for applied, muted for the non-applied outcomes (shown, not dropped — a rejected change is exactly what explains a step that *didn't* happen).

Evidence: `make lint` clean; dashboard **1717 passed** (97.01%); frontend **317 passed**; patch coverage **100%** on all changed Python. The author also ran a live visual check (both themes, marker glyphs read back off the chart instance, the empty state, and the post-upgrade version split).

Deliberately deferred, each with a reason in the report: read-gating `/api/worker` (a separate access-model decision, not a rider on a charting change), share-delta series (no per-poll differencing path exists today), and the `control_audit` keys sanitizer (a JSONL-injection chokepoint in host bash — #1014 itself says change it carefully or not at all).

Closes #1013
Closes #1014
Closes #1015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
