### PR TITLE
test(integration): five live-matrix rows + the rig upgrade and pools legs (#942, #1002)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -131,12 +131,14 @@ Useful flags (full list in `run.sh --help`):
 | `--workers <n>` | Miners expected online while mining (default `2`). |
 | `--no-mining-asserts` | Skip the two mining assertions — workers online ≥ `--workers` and stratum total hashes > 0 — with a logged notice, for a box that has no miner connected. Every other assertion stays binding. `e2e.sh --no-miner` passes this automatically ([#905](https://github.com/p2pool-starter-stack/pithead/issues/905)). |
 | `--remote-monero-host <h>` | External node endpoint for the `remote` scenario. |
+| `--remote-tari-host <h>` | External Tari node endpoint for the `tari.mode=remote` scenario ([#103](https://github.com/p2pool-starter-stack/pithead/issues/103)) — an already-synced Tari node, same shape as `--remote-monero-host`. |
 | `--pruned-data-dir` / `--full-data-dir` | Synced alt DB to enable the opposite prune mode. |
 | `--lifecycle` | Also run the lifecycle phase (restart, apply secret-preservation). |
 | `--fault-injection` | Also break monerod (stop / SIGSTOP / remove) and assert `status`' down/unhealthy/missing verdicts and the failover→recovery cycle, plus a dashboard DB-write fault (data dir made read-only → `/api/state` reports `db_healthy:false` → write access restored, [#202](https://github.com/p2pool-starter-stack/pithead/issues/202)). Destructive-then-restored; local mode only; slow. |
 | `--auth-fail-closed` | Also empty `PROXY_AUTH_TOKEN` in `.env` and assert `pithead up` refuses to start (the live counterpart to the tier-1 compose-config check, [#153](https://github.com/p2pool-starter-stack/pithead/issues/153)/[#203](https://github.com/p2pool-starter-stack/pithead/issues/203)), then restore the exact token and recover. Destructive-then-restored; ssh or local mode. |
-| `--rigforge-control` | Also drive the RigForge WRITE paths against a real rig with `dashboard.control` on and the rig pinned in `workers.list[]` (#506; a baseline that still carries the deprecated `dashboard.workers[]` fallback is left as-is, so that shape stays exercised too): the enriched read survives a populated masked-token descriptor ([#514](https://github.com/p2pool-starter-stack/pithead/issues/514)), the rig is editable and a reversible Worker Inspect edit lands on it ([#508](https://github.com/p2pool-starter-stack/pithead/issues/508)/[#513](https://github.com/p2pool-starter-stack/pithead/issues/513)), a rig-side edit reflects back in the feed + masked prefill ([#516](https://github.com/p2pool-starter-stack/pithead/issues/516)), and an auto-rollback is recorded end-to-end ([#517](https://github.com/p2pool-starter-stack/pithead/issues/517)). Destructive-then-restored; local mode only; each leg self-skips without its prerequisites (see below). |
+| `--rigforge-control` | Also drive the RigForge WRITE paths against a real rig with `dashboard.control` on and the rig pinned in `workers.list[]` (#506; a baseline that still carries the deprecated `dashboard.workers[]` fallback is left as-is, so that shape stays exercised too): the enriched read survives a populated masked-token descriptor ([#514](https://github.com/p2pool-starter-stack/pithead/issues/514)), the rig is editable and a reversible Worker Inspect edit lands on it on two of the six writable keys — `max_temp_c` ([#508](https://github.com/p2pool-starter-stack/pithead/issues/508)/[#513](https://github.com/p2pool-starter-stack/pithead/issues/513)) and `pools` (needs `IT_RIG_POOLS_PROBE`) — a rig-side edit reflects back in the feed + masked prefill ([#516](https://github.com/p2pool-starter-stack/pithead/issues/516)), and an auto-rollback is recorded end-to-end ([#517](https://github.com/p2pool-starter-stack/pithead/issues/517)). Destructive-then-restored; local mode only; each leg self-skips without its prerequisites (see below). |
 | `--rig-host <h>` / `--rig-control-port <p>` | The borrowed rig's LAN host and writable control API port (default `8082`), used to inject a `workers.list[]` descriptor when the box's baseline lacks one ([#185](https://github.com/p2pool-starter-stack/pithead/issues/185)/#506). Pair with `IT_RIG_TOKEN` (env; never a flag). |
+| `--rigforge-upgrade` | With `--rigforge-control`, also POST the rig's own already-installed version through `/api/control/worker-upgrade` and assert it converges on `noop` — non-destructive, never rebuilds the rig. Proves the dashboard → host-runner → rig `/upgrade` route end to end, including the noop/throttled/failed poll vocabulary `control_worker_upgrade` learned when it started matching the rig's own terminal states. |
 | `--subnet` | Also bring the stack down then up on a non-default `network.subnet` (`10.84.0.0/24`) and assert the moved prefix reached `.env`, the docker bridge, Tor's render-at-start IP, monerod's proxy IP, the dashboard SSRF CIDR, and the [#344](https://github.com/p2pool-starter-stack/pithead/issues/344) onion vhost, then run the standard battery ([#201](https://github.com/p2pool-starter-stack/pithead/issues/201)/[#180](https://github.com/p2pool-starter-stack/pithead/issues/180)). Destructive-then-restored; local mode only. |
 | `--safety-backup` | Take a `pithead backup` before the destructive scenarios and auto-roll-back (down → restore → up) if anything fails; the archive is removed on success. Recommended for the destructive matrix on a precious box; also exercises backup/restore end-to-end. |
 | `--keep` | Don't restore the original config (leave the box on the last scenario). |
@@ -242,11 +244,16 @@ and `--list` prints it).
 | `dashboard.secure` | `true` (Caddy TLS) / `false` | Caddy config / scheme |
 | `dashboard.tari_required` | `true` (blocking) / `false` | sync-gate behavior ([#35](https://github.com/p2pool-starter-stack/pithead/issues/35)/[#51](https://github.com/p2pool-starter-stack/pithead/issues/51)) |
 | `network.subnet` | default `172.28.0.0/24` / a moved `/24` | the docker bridge prefix every static IP, Tor's rendered torrc, monerod's proxy IP, and the SSRF CIDR key off ([#180](https://github.com/p2pool-starter-stack/pithead/issues/180)/[#201](https://github.com/p2pool-starter-stack/pithead/issues/201)) — runs via `--subnet` (a move needs a full down/up, not a hot apply) |
+| `tari.mode` | `local` / `remote` | profile gating, onion gating, the sync gate against a remote target — the [#103](https://github.com/p2pool-starter-stack/pithead/issues/103) GO verdict's operating mode, needs `--remote-tari-host` |
+| `p2pool.stratum_tls` | `false` / `true` | a live TLS handshake on the published stratum port, and that the served certificate matches the fingerprint rigs are told to pin ([#261](https://github.com/p2pool-starter-stack/pithead/issues/261)) |
+| `network.tor_egress_firewall` | `true` (default) / `false` | the opt-out actually opens a direct clearnet dial from a `mining_net` container, not just that no rule got installed ([#270](https://github.com/p2pool-starter-stack/pithead/issues/270)) |
+| `monero.view_key` / `tari.view_key` | unset (default) / a real key | payout-confirmation wallet-rpc / tari-wallet wiring ([#381](https://github.com/p2pool-starter-stack/pithead/issues/381)/[#462](https://github.com/p2pool-starter-stack/pithead/issues/462)) — needs `IT_MONERO_VIEW_KEY` (env; the box's own real Monero view key), optionally paired with `IT_TARI_VIEW_KEY` + `IT_TARI_SPEND_PUBLIC_KEY` |
 
 ### What each scenario asserts
 
 - Expected containers up, unexpected absent. Every service for that config is running and
-  healthy; in `remote` mode there is no `monerod`.
+  healthy; in `remote` mode there is no `monerod` (and, independently, no `tari` when
+  `tari.mode=remote`); `wallet-rpc`/`tari-wallet` appear only when their view key is set.
 - `pithead status` exit code: `0` for a healthy config.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.
@@ -254,6 +261,21 @@ and `--list` prints it).
   and total hashes are accumulating ([#28](https://github.com/p2pool-starter-stack/pithead/issues/28)).
 - Posture propagated. `MONERO_RPC_BIND`, `DASHBOARD_SECURE`, `XVB_ENABLED`, and `TARI_REQUIRED`
   in `.env` match the config; the Caddyfile uses the right scheme.
+- Node onions follow the node. The Monero and Tari hidden services are each published only when
+  their own mode is `local` ([#103](https://github.com/p2pool-starter-stack/pithead/issues/103)).
+- Stratum TLS is live (`p2pool.stratum_tls=true` row only). A TLS handshake against the published
+  stratum port succeeds, and the served certificate's fingerprint matches the one
+  `announce_stratum_tls` tells rigs to pin ([#261](https://github.com/p2pool-starter-stack/pithead/issues/261)).
+- Firewall opt-out actually opens the path (`network.tor_egress_firewall=false` row only). No
+  `pithead-tor-egress`-tagged rule is installed, and a direct clearnet dial from a `mining_net`
+  container succeeds — the mirror of the fail-closed default `assert_egress_posture` proves
+  elsewhere ([#270](https://github.com/p2pool-starter-stack/pithead/issues/270)).
+- Payout confirmation is live (the view-key row only). `PAYOUT_CONFIRM_ENABLED`/
+  `TARI_PAYOUT_CONFIRM_ENABLED` in `.env` match the config, and the dashboard's own
+  `earnings.confirmed.enabled`/`earnings.tari_confirmed.enabled` flags read `true`
+  ([#381](https://github.com/p2pool-starter-stack/pithead/issues/381)/[#462](https://github.com/p2pool-starter-stack/pithead/issues/462)). A real
+  confirmed payout needs days of chain time no e2e run has, so that total staying `0` is expected
+  and not asserted otherwise — only that the feature is genuinely ON, not just configured.
 - Idempotency. A second `apply -y` with no change is a clean no-op.
 - Secrets preserved. The proxy token and onion addresses are unchanged across every apply.
 
@@ -279,7 +301,7 @@ can prove — the tier-2 fake covers the `:8081` read only. It enables `dashboar
 borrowed rig in `workers.list[]` (#506; its token seen inside the container only as the
 `{"__secret__": true}` sentinel, [#440](https://github.com/p2pool-starter-stack/pithead/issues/440)
 — a baseline that still carries the deprecated `dashboard.workers[]` fallback is left as-is rather
-than force-migrated, so that shape stays exercised too), and drives four legs, each self-skipping
+than force-migrated, so that shape stays exercised too), and drives five legs, each self-skipping
 loudly without its prerequisite:
 
 - Read with a populated masked descriptor ([#514](https://github.com/p2pool-starter-stack/pithead/issues/514)):
@@ -289,6 +311,15 @@ loudly without its prerequisite:
   Worker Inspect reports the rig `editable`, and a `max_temp_c` nudge applied via
   `/api/control/worker-apply` lands on the rig's `/status` and is recorded in the per-worker
   history, then reverted.
+- A second writable key, `pools` (the repoint-your-hashrate key): unlike `max_temp_c`, the
+  enriched feed carries no writable-config *values* at all, so there is no live telemetry to read
+  the current value back from before mutating it — the real Worker Inspect editor has the exact
+  same limitation and prefills from the dashboard's own last-applied record instead
+  (`GET /api/worker`'s `.last_applied.pools`). This leg does the same: it reads that record as the
+  restore target, applies an operator-supplied probe value (`IT_RIG_POOLS_PROBE` — pithead treats
+  `pools` as opaque passthrough, so a guessed value risks a real `rejected` instead of proving the
+  round trip), asserts it landed, then reverts. Self-skips if the dashboard has never applied a
+  `pools` value to this rig before (nothing to safely restore).
 - Rig-side edit reflects ([#516](https://github.com/p2pool-starter-stack/pithead/issues/516)):
   a change made straight on the rig's control API shows up in the dashboard's enriched feed, and a
   `config.json` hand-edit shows up in the masked prefill (with the token still masked).
@@ -297,8 +328,33 @@ loudly without its prerequisite:
 
 Prerequisites: a real RigForge rig connected (self-skips otherwise); `--rig-host` + `IT_RIG_TOKEN`
 to inject a descriptor when the baseline lacks one, and to dial the rig directly for the #516 feed
+leg; `IT_RIG_POOLS_PROBE` (a JSON `pools` value safe to apply to the borrowed rig) for the pools
 leg; `IT_RIG_ROLLBACK_CHANGES` (a writable-key `changes` object the rig's fault-injection reverts)
 for the #517 leg.
+
+### RigForge upgrade (`--rigforge-upgrade`)
+
+With `--rigforge-control`, also POSTs the rig's own already-installed version back through
+`/api/control/worker-upgrade` and asserts the terminal status is `noop` — non-destructive, no
+rebuild, no rig restart. Proves the dashboard → host-runner → rig `/upgrade` route end to end,
+including the `control_worker_upgrade` poll loop's full terminal vocabulary
+(`applied`/`noop`/`throttled`/`rolled_back`/`failed`) matching the rig's own terminal states.
+
+Two honest paths reach the `noop` terminal, and which one fires on a given run depends on the
+dashboard's own poll cache, not on the harness:
+
+- The cache already agrees the rig is on the requested version (the common steady-state case):
+  `handle_worker_upgrade`'s client-side shortcut answers `noop` synchronously, without ever
+  dialing the rig or spending its 6h anti-beacon window.
+- The cache is momentarily stale: the request proceeds through the host runner's
+  `control_worker_upgrade`, dials the rig's `/upgrade` for real, and polls its `/status` for the
+  rig's own first-class `noop` terminal (rigforge#320).
+
+Either way the host independently re-derives "latest" from the RigForge release API and refuses
+any mismatch before dialing (the rig never decides its own target), so proposing "what's already
+installed" can only ever terminate `noop` or — on host-side version drift — a safe `rejected`,
+never a real upgrade. Needs `--rigforge-control`'s already-enabled control channel and pinned rig;
+its own extra prerequisite is a clean `vX.Y.Z` version in the rig's live feed.
 
 ### Moved subnet (`--subnet`)
 

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -47,6 +47,10 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | `monero.rpc_lan_access`, `dashboard.secure`, `xvb.enabled`, `dashboard.tari_required` | config → `.env`/Caddyfile | 4 ▶ |
 | `p2pool.pool` main / mini / nano (sidechain, flags) | config | 4 ▶ |
 | `network.subnet` moved off the default /24 (#180/#201): docker bridge, Tor render-at-start IP, monerod proxy IP, SSRF CIDR, onion vhost gateway | config → live (a subnet move needs a down/up) | 1 ✅ (rendered compose) · 4 ▶ (`run.sh --subnet`) |
+| `tari.mode` local vs remote (#103): tari container/onion present/absent, sync gate against a remote target | config | 4 ▶ |
+| `p2pool.stratum_tls` (#261): a live TLS handshake on the published stratum port, served cert matches the pinned fingerprint | config → live dial | 1 ✅ (render) · 4 ▶ (server-side handshake; a real xmrig client with `pools[].tls:true` stays deferred, see Known gaps) |
+| `network.tor_egress_firewall=false` (#270): the opt-out actually opens a direct clearnet dial, not just that no rule installed | config → live kernel | 1 ✅ (stubbed iptables installs no rule) · 4 ▶ (real dial succeeds) |
+| `monero.view_key` / `tari.view_key` (#381/#462): payout-confirmation wallet-rpc/tari-wallet wiring live | config → live | 4 ▶ (needs `IT_MONERO_VIEW_KEY`/`IT_TARI_VIEW_KEY`+`IT_TARI_SPEND_PUBLIC_KEY`; a confirmed payout landing is real-money real-time, not e2e-reachable) |
 
 ### B. Sync lifecycle (#35)
 
@@ -147,10 +151,12 @@ it — the worker-API **auth model is the #315 none/name/token matrix**, not the
 | Real worker mines through the real proxy: appears via its stratum name, hashrate aggregates, backup-pool failover | live rig + proxy | 4 ▶ (`run.sh --workers`) |
 | Enriched read survives a populated masked-token descriptor — `api_ok` + rigforge feed resolve with `workers.list[].token` (#506; `dashboard.workers[]` legacy fallback) seen only as the `{"__secret__":true}` sentinel (the v1.5.2 regression + #508) | live rig + `workers.list[]` populated | 4 ▶ (`run.sh --rigforge-control`, #514) |
 | Worker Inspect edit lands on the rig: `editable` true, a `max_temp_c` nudge via `/api/control/worker-apply` hits the rig's `/status` + records history, reverted | live rig control API on | 4 ▶ (`run.sh --rigforge-control`, #513) |
+| Worker Inspect edit on a second writable key, `pools` (#1002b): unlike `max_temp_c` the enriched feed exposes no live readback, so the restore target is the dashboard's own `last_applied.pools` record — the same source the real editor prefills from | live rig control API on | 4 ▶ (`run.sh --rigforge-control`, #1002b; operator supplies `IT_RIG_POOLS_PROBE`) |
 | Rig-side edit reflects: a direct rig control-API change shows in the enriched feed; a `config.json` hand-edit shows in the masked prefill | live rig + direct dial | 4 ▶ (`run.sh --rigforge-control`, #516) |
 | Control-apply auto-rollback (rigforge#236): a hashrate-tanking change is recorded `rolled_back` in the worker-apply result + per-worker history | live rig + fault-injection | 4 ▶ (`run.sh --rigforge-control`, #517; operator supplies `IT_RIG_ROLLBACK_CHANGES`) |
 | Per-worker RigForge new-release badge (#596): one fleet-wide latest-release fetch (hourly throttle, disabled = never dials) compared against each rig's reported `version`, bare-vs-`v`-prefixed SemVer | `dashboard.check_for_updates` + rig-reported version | 1 ✅ (`test_update_checker` comparison/throttle/no-dial; `test_views` + node tests for the per-worker plumbing) · 4 (deferred — live badge on a real rig, owed to the #597 gouda loaner session) |
-| One-click rig upgrade (#597): the #596 badge proposes a version, the host re-derives the target from the RigForge release API over Tor and dials the rig's `/upgrade`; refusals (non-latest, GitHub unreachable/no tag, old rig < v1.11.2 non-202), the anti-beacon throttle, and the poll-cap timeout→accepted fallback | `/api/control/worker-upgrade` + host runner + badge render | 1 ✅ (`test_server.py` + `test_control_service.py`, `tests/stack` #597 cases, `workerview.test.mjs`) · 4 (deferred — gouda loaner: badge → click → applied → badge clears, repeat-click throttle, old-rig refusal) |
+| One-click rig upgrade (#597): the #596 badge proposes a version, the host re-derives the target from the RigForge release API over Tor and dials the rig's `/upgrade`; refusals (non-latest, GitHub unreachable/no tag, old rig < v1.11.2 non-202), the anti-beacon throttle, and the poll-cap timeout→accepted fallback | `/api/control/worker-upgrade` + host runner + badge render | 1 ✅ (`test_server.py` + `test_control_service.py`, `tests/stack` #597 cases, `workerview.test.mjs`) · 4 (deferred — gouda loaner: badge → click → **applied** → badge clears, repeat-click throttle, old-rig refusal — a real rebuild) |
+| Remote-upgrade chain, the already-installed version: dashboard → host-runner → rig `/upgrade` converges on `noop` without a rebuild, exercising the same `applied`/`noop`/`throttled`/`rolled_back`/`failed` terminal vocabulary the poller matches | `/api/control/worker-upgrade` + host runner + a real rig | 4 ▶ (`run.sh --rigforge-control --rigforge-upgrade`) |
 | Stratum auth accept/reject: matching `pass` mines, wrong/missing `pass` rejected, rotation | live proxy `--access-password` | 4 (deferred — a headless xmrig login probe, real proxy binary) |
 | Dev-fee independence (#173): proxy `--donate-level` and rig `DONATION` both honored | live proxy + rig | 4 (deferred) |
 
@@ -303,9 +309,14 @@ tier 3/4:
   restart tor and re-assert both the egress proof and `pithead status`.
   (`check_egress_firewall_installed` and `check_tor_clearnet_egress` still info-skip without a
   running tor container, by design: the dedicated verdict already fails the outage.)
-- **Insecure + main matrix row.** `dashboard.secure=false` only ever pairs with `p2pool.pool=nano`,
-  so the Caddy-scheme / bind assertions for insecure mode are entangled with the nano path; an
-  insecure+main regression has no row.
+- **Insecure + main matrix row.** ✅ Now a dedicated `local-pruned-main-insecure` row: the two axes
+  decouple, so a regression specific to insecure+main (vs. the pre-existing insecure+nano row) has
+  somewhere to fail.
+- **A real xmrig client over stratum TLS.** The `p2pool.stratum_tls=true` row proves the server side
+  live (a real TLS handshake on the published port, served cert matches the pinned fingerprint);
+  a real rig actually mining with `pools[].tls:true` set is deferred, the same class of gap as the
+  stratum-password headless-probe row above (a rig-configuration step outside this harness's
+  control, needing a real xmrig binary).
 - **`verify_release_images()` against a real signed bundle.** ✅ Now exercised directly (not
   reimplemented) by `scripts/release-smoke.sh`: the real function runs in the extracted, published
   bundle dir against the real pinned digests + committed `cosign.pub` (positive, needs a signed

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -118,17 +118,19 @@ render_scenario_config() {
 # the final override string and returns 0; on a missing prerequisite sets SKIP_REASON and
 # returns 1 — no silent drops, and never a prune flip on the canonical synced DB (which would
 # invalidate it). Reads the globals BASELINE_PRUNE / PRUNED_DATA_DIR / FULL_DATA_DIR /
-# REMOTE_MONERO_HOST (all optional). Pure given those globals, so the self-test exercises it.
+# REMOTE_MONERO_HOST / REMOTE_TARI_HOST / IT_MONERO_VIEW_KEY / IT_TARI_VIEW_KEY /
+# IT_TARI_SPEND_PUBLIC_KEY (all optional). Pure given those globals, so the self-test exercises it.
 RESOLVED=""
 SKIP_REASON=""
 # shellcheck disable=SC2034  # RESOLVED/SKIP_REASON are output globals consumed by run.sh & selftest.sh
 resolve_overrides() {
-    local overrides="$1" prune mode subnet out="$1"
+    local overrides="$1" prune mode tari_mode subnet out="$1"
     RESOLVED=""
     SKIP_REASON=""
 
     prune="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^monero\.prune=//p')"
     mode="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^monero\.mode=//p')"
+    tari_mode="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^tari\.mode=//p')"
     subnet="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^network\.subnet=//p')"
 
     # A network.subnet move can't be hot-applied — Compose won't recreate the bridge's IPAM subnet
@@ -166,31 +168,69 @@ resolve_overrides() {
         out="$out monero.remote.host=$REMOTE_MONERO_HOST"
     fi
 
+    # tari.mode remote (#103/#942) needs its own external endpoint — same shape as monero's above,
+    # a separate global since the two chains can point at different remote hosts.
+    if [ "$tari_mode" = "remote" ]; then
+        [ -n "${REMOTE_TARI_HOST:-}" ] || {
+            SKIP_REASON="needs --remote-tari-host"
+            return 1
+        }
+        out="$out tari.remote.host=$REMOTE_TARI_HOST"
+    fi
+
+    # Payout confirmation (#381/#462, #942): monero.view_key / tari.view_key are real wallet-scanning
+    # secrets for the box's OWN wallet — never hardcoded in the matrix. The scenario instead carries
+    # the marker "payout_confirm=env" (not a real config path, always stripped below); an
+    # operator-supplied IT_MONERO_VIEW_KEY gates the whole row, the same shape as remote mode needing
+    # an endpoint. Tari's pair (IT_TARI_VIEW_KEY + IT_TARI_SPEND_PUBLIC_KEY) is an optional extra
+    # folded in only when BOTH are set; it never gates the row on its own.
+    if printf '%s' "$overrides" | tr ' ' '\n' | grep -qx 'payout_confirm=env'; then
+        out="$(printf '%s' "$out" | tr ' ' '\n' | grep -vx 'payout_confirm=env' | tr '\n' ' ')"
+        out="${out% }" # strip the trailing space left by removing the marker token
+        out="${out# }" # ...and a leading one, when the marker was the only/first token
+        [ -n "${IT_MONERO_VIEW_KEY:-}" ] || {
+            SKIP_REASON="needs IT_MONERO_VIEW_KEY (env; a real Monero view key for the box's monero.wallet_address)"
+            return 1
+        }
+        out="${out:+$out }monero.view_key=$IT_MONERO_VIEW_KEY"
+        if [ -n "${IT_TARI_VIEW_KEY:-}" ] && [ -n "${IT_TARI_SPEND_PUBLIC_KEY:-}" ]; then
+            out="$out tari.view_key=$IT_TARI_VIEW_KEY tari.spend_public_key=$IT_TARI_SPEND_PUBLIC_KEY"
+        fi
+    fi
+
     RESOLVED="$out"
     return 0
 }
 
 # --- Expectation derivation (pure) ------------------------------------------
-# Given a rendered config.json, list the services we expect to be running. The bundled
-# monerod only runs in local mode (the local_node compose profile); in remote mode it must
-# be ABSENT. Everything else is always expected. Mirrors stack_status()'s profile gating.
-EXPECTED_ALWAYS="caddy dashboard docker-control docker-proxy p2pool tari tor xmrig-proxy"
+# Given a rendered config.json, list the services we expect to be running. The bundled monerod
+# only runs in local mode (the local_node compose profile) and the bundled tari only runs in
+# local mode (local_tari, #103) — each independently, since the two chains toggle mode on their
+# own axis; in remote mode the matching bundled node must be ABSENT. wallet-rpc/tari-wallet
+# (#381/#462) only run when their view key is set (payout_confirm/tari_payout_confirm). Everything
+# else is always expected. Mirrors stack_status()'s profile gating.
+EXPECTED_ALWAYS="caddy dashboard docker-control docker-proxy p2pool tor xmrig-proxy"
 
 expected_services() {
-    local config_json="$1" mode
-    mode="$(printf '%s' "$config_json" | jq -r '.monero.mode // "local"')"
-    if [ "$mode" = "local" ]; then
-        printf '%s\n' "monerod $EXPECTED_ALWAYS" | tr ' ' '\n' | sort
-    else
-        printf '%s\n' "$EXPECTED_ALWAYS" | tr ' ' '\n' | sort
-    fi
+    local config_json="$1" mmode tmode out
+    mmode="$(printf '%s' "$config_json" | jq -r '.monero.mode // "local"')"
+    tmode="$(printf '%s' "$config_json" | jq -r '.tari.mode // "local"')"
+    out="$EXPECTED_ALWAYS"
+    [ "$mmode" = "local" ] && out="monerod $out"
+    [ "$tmode" = "local" ] && out="tari $out"
+    [ -n "$(printf '%s' "$config_json" | jq -r '.monero.view_key // empty')" ] && out="wallet-rpc $out"
+    [ -n "$(printf '%s' "$config_json" | jq -r '.tari.view_key // empty')" ] && out="tari-wallet $out"
+    printf '%s\n' "$out" | tr ' ' '\n' | sort
 }
 
-# Services that must NOT exist for this config (remote mode -> no local monerod).
+# Services that must NOT exist for this config (remote mode -> no bundled node for that chain).
 absent_services() {
-    local config_json="$1" mode
-    mode="$(printf '%s' "$config_json" | jq -r '.monero.mode // "local"')"
-    [ "$mode" = "remote" ] && printf 'monerod\n'
+    local config_json="$1" mmode tmode
+    mmode="$(printf '%s' "$config_json" | jq -r '.monero.mode // "local"')"
+    tmode="$(printf '%s' "$config_json" | jq -r '.tari.mode // "local"')"
+    [ "$mmode" = "remote" ] && printf 'monerod\n'
+    [ "$tmode" = "remote" ] && printf 'tari\n'
+    return 0
 }
 
 # Human-readable pool label as the dashboard reports it, from the config pool key.

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -41,6 +41,7 @@ RUN_AUTH_FAIL_CLOSED=0
 RUN_HARDENING=0
 RUN_RIGFORGE=0
 RUN_RIGFORGE_CONTROL=0
+RUN_RIGFORGE_UPGRADE=0
 RUN_SUBNET=0
 RIG_HOST=""
 RIG_CONTROL_PORT="8082"
@@ -50,6 +51,7 @@ KEEP_STATE=0
 EXPECTED_WORKERS=2
 SKIP_MINING_ASSERTS=0
 REMOTE_MONERO_HOST=""
+REMOTE_TARI_HOST=""
 PRUNED_DATA_DIR=""
 FULL_DATA_DIR=""
 OUT_DIR="$HERE/results"
@@ -89,6 +91,8 @@ MATRIX:
                          Every other assertion stays binding.
   --remote-monero-host <h>  external node endpoint for the remote-mode scenario
                             (e.g. the box's own synced node on its LAN IP)
+  --remote-tari-host <h>  external Tari node endpoint for the tari.mode=remote scenario (#103;
+                         e.g. an already-synced Tari node on the LAN)
   --pruned-data-dir <d>  synced PRUNED monero data dir (enables the pruned case when the
                          box's baseline is full)
   --full-data-dir <d>    synced FULL monero data dir (enables the full case when the box's
@@ -124,19 +128,28 @@ MATRIX:
   --rigforge             also run the RigForge integration phase (#185/#235/#260): assert the
                          dashboard consumed a REAL rigforge rig's enriched feed and Worker Inspect
                          reads it. Non-destructive; self-skips if no rigforge rig is connected.
-  --rigforge-control     also run the RigForge control phase (#513/#514/#516/#517), local mode only:
-                         with dashboard.control ON and workers.list[] populated for the borrowed rig
-                         (masked-token descriptor, #440/#506 — the box's pre-existing dashboard.workers[]
-                         legacy descriptor is honored as-is if that's what the baseline already carries),
-                         assert the enriched read path survives populated descriptors (#514) and the rig
-                         is editable (#508/#513), drive a reversible Worker Inspect edit end-to-end to the
-                         rig's control API (#513), reflect a rig-side edit back into the dashboard (#516),
+  --rigforge-control     also run the RigForge control phase (#513/#514/#516/#517/#1002b), local mode
+                         only: with dashboard.control ON and workers.list[] populated for the borrowed
+                         rig (masked-token descriptor, #440/#506 — the box's pre-existing
+                         dashboard.workers[] legacy descriptor is honored as-is if that's what the
+                         baseline already carries), assert the enriched read path survives populated
+                         descriptors (#514) and the rig is editable (#508/#513), drive a reversible
+                         Worker Inspect edit end-to-end to the rig's control API on TWO of the six
+                         writable keys — max_temp_c (#513) and pools (#1002b, needs
+                         IT_RIG_POOLS_PROBE) — reflect a rig-side edit back into the dashboard (#516),
                          and record an auto-rollback (#517). DESTRUCTIVE-then-restored. Needs a real rig
                          with its control API opted in; each leg self-skips loudly without its
                          prerequisites.
   --rig-host <h>         the borrowed rig's LAN host/IP for control dials — needed to inject a
                          workers.list[] descriptor when the box's baseline lacks one (#513/#514/#506).
   --rig-control-port <p> the rig's writable control API port (default: 8082, #185).
+  --rigforge-upgrade     with --rigforge-control, also POST the rig's own ALREADY-INSTALLED version
+                         through /api/control/worker-upgrade and assert it converges on noop
+                         (#1002a) — non-destructive, never rebuilds the rig. Exercises the real
+                         dashboard -> host-runner -> rig /upgrade route end to end, including the
+                         #1001 noop/throttled/failed poll vocabulary on whichever run hits it (the
+                         common case is the dashboard's own already-on-this-version shortcut, which
+                         answers noop without ever dialing the rig). Needs --rigforge-control.
   --subnet               also run the moved-subnet phase (#201/#180), local mode only: bring the
                          stack DOWN then UP on a non-default network.subnet (10.84.0.0/24) — the one
                          axis a hot apply can't move — and assert the moved prefix reached .env, the
@@ -210,6 +223,10 @@ parse_args() {
             REMOTE_MONERO_HOST="$2"
             shift 2
             ;;
+        --remote-tari-host)
+            REMOTE_TARI_HOST="$2"
+            shift 2
+            ;;
         --pruned-data-dir)
             PRUNED_DATA_DIR="$2"
             shift 2
@@ -240,6 +257,10 @@ parse_args() {
             ;;
         --rigforge-control)
             RUN_RIGFORGE_CONTROL=1
+            shift
+            ;;
+        --rigforge-upgrade)
+            RUN_RIGFORGE_UPGRADE=1
             shift
             ;;
         --rig-host)
@@ -464,9 +485,11 @@ run_scenario() {
 # first poll lands after a restart. proxy_workers signals mining liveness (stratum.conns can read 0).
 assert_running_state() {
     local name="$1" config="$2"
-    local st mode pool secure tari_req xvb rpc_lan monero_clearnet tari_clearnet
+    local st mode tmode pool secure tari_req xvb rpc_lan monero_clearnet tari_clearnet
     mode="$(jq_get "$config" '.monero.mode')"
     mode="${mode:-local}"
+    tmode="$(jq_get "$config" '.tari.mode')"
+    tmode="${tmode:-local}"
     pool="$(jq_get "$config" '.p2pool.pool')"
     pool="${pool:-main}"
     secure="$(jq_get "$config" '.dashboard.secure')"
@@ -521,18 +544,36 @@ assert_running_state() {
         *) it_pass "monerod absent in remote mode" ;;
         esac
     fi
-    # 1b. A node's inbound onion follows the node (#103): the LIVE torrc must carry the Monero
+    # tari.mode is an independent axis from monero.mode (#103/#942): the bundled tari container
+    # must be absent whenever it's remote, same as monerod above. Exact-line match, not a
+    # substring case — "tari" is a prefix of "tari-wallet" (the payout-confirm container, #462),
+    # so a loose `*tari*` pattern would false-positive on a box also running that.
+    if [ "$tmode" = "remote" ]; then
+        if printf '%s\n' "$running" | grep -qx tari; then
+            it_fail "tari absent in remote mode (#103/#942)" "tari is running"
+        else
+            it_pass "tari absent in remote mode (#103/#942)"
+        fi
+    fi
+    # 1b. A node's inbound onion follows the node (#103): the LIVE torrc must carry the node's
     #     hidden service only in local mode, or the stack advertises an onion address that accepts
     #     connections into a container that never started. Tier-1 proves the rendering; only here
     #     can we prove the running container actually got the gate through compose. Read the torrc
     #     rather than the hostname file — a key minted during an earlier local scenario stays on
-    #     disk, so its presence proves nothing; what tor publishes is what the torrc lists.
-    local hs_monero
+    #     disk, so its presence proves nothing; what tor publishes is what the torrc lists. Monero
+    #     and Tari toggle this independently (their onions are gated by separate compose profiles).
+    local hs_monero hs_tari
     hs_monero="$(rx "docker exec tor grep -c -F 'HiddenServiceDir /var/lib/tor/monero/' /tmp/torrc 2>/dev/null")"
     if [ "$mode" = "remote" ]; then
         assert_eq "no Monero inbound onion in remote mode (#103)" "${hs_monero:-0}" "0"
     else
         assert_num_ge "Monero inbound onion published in local mode (#103)" "${hs_monero:-0}" 1
+    fi
+    hs_tari="$(rx "docker exec tor grep -c -F 'HiddenServiceDir /var/lib/tor/tari/' /tmp/torrc 2>/dev/null")"
+    if [ "$tmode" = "remote" ]; then
+        assert_eq "no Tari inbound onion in remote mode (#103/#942)" "${hs_tari:-0}" "0"
+    else
+        assert_num_ge "Tari inbound onion published in local mode (#103)" "${hs_tari:-0}" 1
     fi
 
     # 2. pithead status is green for a healthy config.
@@ -699,6 +740,57 @@ assert_running_state() {
         *'--access-password='*) it_fail "default-off stratum: no --access-password live (#152)" "found --access-password with no stratum_password set — would reject rigs" ;;
         *) it_pass "default-off stratum: no --access-password live (#152)" ;;
         esac
+    fi
+
+    # 8c. Stratum-over-TLS (#261/#942): tier 1 proves the render (PROXY_STRATUM_TLS -> the
+    # wrapper's cert flags); nothing before this dialed it. A LIVE TLS handshake against the
+    # published stratum port proves xmrig-proxy actually terminates TLS there, and that the
+    # served certificate is the SAME one the operator was told to pin (announce_stratum_tls's
+    # fingerprint) — not just that a keypair exists on disk. Same-port cleartext/TLS
+    # autodetection means already-connected cleartext rigs are unaffected (the mining assertions
+    # above already prove they keep hashing); a real xmrig client dialing with pools[].tls:true is
+    # a rig-configuration step outside this harness's control, deferred like the stratum-password
+    # headless-probe gap (docs/dev/testing-strategy.md).
+    if [ "$mode" = "local" ] && [ "$(jq_get "$config" '.p2pool.stratum_tls')" = "true" ]; then
+        local tls_port tls_dir served_fp announced_fp
+        tls_port="$(env_on_box STRATUM_PORT)"
+        [ -n "$tls_port" ] || tls_port=3333
+        tls_dir="$(env_on_box PROXY_TLS_DIR)"
+        served_fp="$(rx "openssl s_client -connect 127.0.0.1:$tls_port </dev/null 2>/dev/null | openssl x509 -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]'")"
+        assert_ne "stratum TLS handshake succeeds on the published port (#261/#942)" "$served_fp" ""
+        announced_fp="$(rx "openssl x509 -in $(quote_arg "$tls_dir/cert.pem") -noout -fingerprint -sha256 2>/dev/null | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]'")"
+        assert_eq "live-served cert fingerprint matches the one rigs are told to pin (#261/#942)" "$served_fp" "$announced_fp"
+    fi
+
+    # 8d. Firewall opt-out actually opens the path (#270/#942) — the mirror of the fail-closed
+    # default that assert_egress_posture/fault_firewall_rollback prove elsewhere: no rule
+    # installed is necessary but not sufficient, so dial a real clearnet IP DIRECTLY from a
+    # mining_net container (bypassing its own --socks5 config) with wget (already present in every
+    # first-party image for the build-time binary download — no new tool). Read the CONNECT-phase
+    # line, not the HTTP result — a 403/redirect still proves the TCP handshake got through, while
+    # a DROPped SYN would just hang to wget's own timeout instead.
+    if [ "$mode" = "local" ] && [ "$(jq_get "$config" '.network.tor_egress_firewall')" = "false" ]; then
+        assert_eq "no pithead-tagged firewall rule installed when opted out (#270/#942)" \
+            "$(rx "sudo iptables-save 2>/dev/null | grep -c pithead-tor-egress")" "0"
+        local dial
+        dial="$(rx "docker exec xmrig-proxy wget -T 8 -t 1 -O /dev/null http://1.1.1.1/ 2>&1")"
+        assert_contains "clearnet dial SUCCEEDS with the firewall opted out (#270/#942)" "$dial" "connected."
+    fi
+
+    # 8e. Payout confirmation is live (#381/#462/#942) — the flagship feature's live leg. A real
+    # payout landing (and thus a non-empty confirmed total) needs days of chain time no e2e run
+    # has; what IS honestly provable now is that the view-only wallet-rpc/tari-wallet actually
+    # started (expected_services already asserts the container up) and that the dashboard's own
+    # feature flag — the same one build_earnings reads to decide "on, nothing confirmed yet" vs.
+    # "off" — reads ON. .earnings.confirmed.enabled is False only when payouts is None
+    # (service/earnings.py:confirmed_payouts_summary), i.e. exactly PAYOUT_CONFIRM_ENABLED.
+    if [ "$mode" = "local" ] && [ -n "$(jq_get "$config" '.monero.view_key')" ]; then
+        assert_eq "PAYOUT_CONFIRM_ENABLED matches config (#381/#942)" "$(env_on_box PAYOUT_CONFIRM_ENABLED)" "true"
+        assert_eq "dashboard confirms Monero payout tracking is live (#381/#942)" "$(jq_get "$st" '.earnings.confirmed.enabled')" "true"
+    fi
+    if [ "$mode" = "local" ] && [ -n "$(jq_get "$config" '.tari.view_key')" ]; then
+        assert_eq "TARI_PAYOUT_CONFIRM_ENABLED matches config (#462/#942)" "$(env_on_box TARI_PAYOUT_CONFIRM_ENABLED)" "true"
+        assert_eq "dashboard confirms Tari payout tracking is live (#462/#942)" "$(jq_get "$st" '.earnings.tari_confirmed.enabled')" "true"
     fi
 
     # 9. Caddy scheme matches dashboard.secure.
@@ -2106,11 +2198,49 @@ run_rigforge_control() {
             "$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)" "applied"
     fi
 
+    # ---- #1002b: a second writable key (pools) proves the edit isn't max_temp_c-specific ----
+    # pools is the repoint-your-hashrate key; unlike max_temp_c its CURRENT value has no live
+    # telemetry readback — the enriched feed carries no writable-config VALUES at all (only
+    # health/power/tune telemetry), which is exactly why Worker Inspect's own editor prefills from
+    # the dashboard's last-applied record instead of a live rig read (docs/dashboard.md, "Worker
+    # Inspect": "the rig's enriched feed doesn't expose the writable config values"). So the honest
+    # "original" here is GET /api/worker's .last_applied.pools — the same source the real editor
+    # prefills from — and the probe value is operator-supplied (IT_RIG_POOLS_PROBE): pithead treats
+    # `pools` as opaque passthrough (WORKER_WRITABLE_KEYS only checks the key NAME, never the
+    # value shape), so guessing a value shaped wrong for this rig's RigForge version risks a real
+    # rejected/failed instead of proving the round trip — the same reasoning
+    # IT_RIG_ROLLBACK_CHANGES already applies to the #517 leg below.
+    if [ -z "${IT_RIG_POOLS_PROBE:-}" ]; then
+        it_warn "no IT_RIG_POOLS_PROBE (a JSON pools value safe to apply to rig '$rig') — skipping the pools write leg (#1002b)"
+    elif ! printf '%s' "$IT_RIG_POOLS_PROBE" | jq -e . >/dev/null 2>&1; then
+        it_fail "IT_RIG_POOLS_PROBE is valid JSON (#1002b)" "got [$IT_RIG_POOLS_PROBE]"
+    else
+        local orig_pools
+        orig_pools="$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/worker?name=$rig")" 2>/dev/null | jq -c '.last_applied.pools // empty' 2>/dev/null)"
+        if [ -z "$orig_pools" ]; then
+            it_warn "rig '$rig' has no dashboard-applied pools on record (.last_applied.pools) — skipping the pools write leg (can't read the original to restore it) (#1002b)"
+        else
+            it_step "Worker Inspect edit: pools -> the operator-supplied probe via /api/control/worker-apply…"
+            res="$(_worker_apply "$rig" "{\"pools\":$IT_RIG_POOLS_PROBE}")"
+            status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
+            ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
+            assert_eq "pools edit applied on the rig (#1002b)" "$status" "applied"
+            assert_contains "the rig's /status confirms pools changed (#1002b)" "$ckeys" "pools"
+            it_step "reverting pools to the dashboard's last-applied value…"
+            res="$(_worker_apply "$rig" "{\"pools\":$orig_pools}")"
+            assert_eq "pools edit reverted on the rig (#1002b)" \
+                "$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)" "applied"
+        fi
+    fi
+
     # ---- #516: a rig-side edit reflects in the dashboard's enriched feed + the masked prefill ----
     run_rigforge_reverse "$rig" "$orig_maxt"
 
     # ---- #517: an auto-rollback (rigforge#236) is recorded end-to-end from the dashboard ----
     run_rigforge_rollback "$rig"
+
+    # ---- #1002a: the already-installed version converges on noop end-to-end (opt-in: --rigforge-upgrade) ----
+    [ "$RUN_RIGFORGE_UPGRADE" = "1" ] && run_rigforge_upgrade "$rig"
 
     [ "$IT_FAIL" -gt "$fails_before" ] && capture_artifacts "rigforge-control" "$OUT_DIR"
 
@@ -2266,6 +2396,57 @@ run_rigforge_rollback() { # <rig-name>
     rolled_back | accepted) it_pass "the dashboard's per-worker history records the change (#517: $histstatus)" ;;
     *) it_fail "the dashboard's per-worker history records the change (#517)" "expected rolled_back|accepted, got [$histstatus]" ;;
     esac
+}
+
+# --- RigForge upgrade leg (--rigforge-upgrade, #1002a) ----------------------
+# POST the rig's OWN already-installed version back through /api/control/worker-upgrade and assert
+# the terminal status is noop — non-destructive (no rebuild, no rig restart) proof of the dashboard
+# -> host-runner -> rig /upgrade route, including the #1001 status vocabulary control_worker_upgrade's
+# poll loop just learned (noop/throttled/failed, rigforge#320). Two honest paths reach that terminal
+# and which one fires depends on the DASHBOARD's own poll cache, not on us:
+#   - cache already agrees the rig is on the requested version (the common steady-state case):
+#     handle_worker_upgrade's client-side shortcut answers noop SYNCHRONOUSLY, never dialing the rig
+#     or spending its 6h anti-beacon window — proves a repeat click on an up-to-date rig costs it
+#     nothing.
+#   - cache is momentarily stale: the request proceeds through control_service.submit_worker_upgrade
+#     -> the host runner's control_worker_upgrade -> a REAL dial to the rig's /upgrade -> its own
+#     /status poll -> the rig's first-class noop terminal (rigforge#320) — the #1001 poll-vocabulary
+#     path itself.
+# Either way the host independently re-derives "latest" from GitHub and refuses ANY mismatch before
+# dialing (ADR 0002 D4: the rig never decides its own target), so proposing "what's already
+# installed" can only ever terminate noop or (on host-side version drift) a safe rejected — never a
+# real upgrade. Called from run_rigforge_control, which has already put the rig in a dialable state
+# (dashboard.control on, host+token pinned); this leg's own prerequisite is just a clean vX.Y.Z
+# version in the live feed to build a valid request from.
+run_rigforge_upgrade() { # <rig-name>
+    local rig="$1" ver posted body id status result_body deadline
+    it_log "   #1002a: --rigforge-upgrade: already-installed version converges on noop"
+    ver="$(printf '%s' "$(api_state)" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .rigforge.version) // empty' 2>/dev/null)"
+    posted="v${ver#v}"
+    if ! printf '%s' "$posted" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        it_warn "rig '$rig' isn't reporting a clean vX.Y.Z version (got [$ver]) — skipping the upgrade leg (#1002a)"
+        return 0
+    fi
+
+    body="$(rx "curl -fsS --max-time 15 -X POST -H 'Content-Type: application/json' -H 'X-Pithead-Control: 1' --data $(quote_arg "$(jq -nc --arg w "$rig" --arg v "$posted" '{worker:$w,version:$v}')") http://127.0.0.1:8000/api/control/worker-upgrade" 2>/dev/null)"
+    status="$(printf '%s' "$body" | jq -r '.status // empty' 2>/dev/null)"
+    if [ "$status" = "pending" ]; then
+        id="$(printf '%s' "$body" | jq -r '.id // empty' 2>/dev/null)"
+        if [ -z "$id" ]; then
+            it_fail "worker-upgrade request accepted with a pollable id (#1002a)" "no id in [$body]"
+            return 0
+        fi
+        it_step "cache was stale — upgrade running on the host; polling /api/control/result for a terminal…"
+        deadline=$((SECONDS + 200))
+        while [ "$SECONDS" -lt "$deadline" ]; do
+            sleep 5
+            result_body="$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/control/result?id=$id")" 2>/dev/null)"
+            status="$(printf '%s' "$result_body" | jq -r '.status // empty' 2>/dev/null)"
+            case "$status" in "" | pending | running) continue ;; esac
+            break
+        done
+    fi
+    assert_eq "already-installed version converges on noop (#1002a)" "$status" "noop"
 }
 
 # --- Main -------------------------------------------------------------------

--- a/tests/integration/scenarios.sh
+++ b/tests/integration/scenarios.sh
@@ -18,10 +18,16 @@
 #   dashboard.tari_required .. true (blocking) | false (non-blocking)
 #   monero/tari.clearnet_initial_sync (#183) .. true (clearnet IBD) | false (Tor, the default)
 #   network.subnet (#180/#201) .. default 172.28.0.0/24 | a moved /24 (e.g. 10.84.0.0/24)
+#   tari.mode ................ local | remote (#103)
+#   p2pool.stratum_tls ........ false | true (#261)
+#   network.tor_egress_firewall .. true (default) | false (#270)
+#   payout confirmation ...... unset (default) | monero.view_key (+ optional tari pair, #381/#462)
 #
 # The clearnet_initial_sync `false` value is the default exercised by every other scenario (they
 # never set the key); only the `true` value needs a dedicated case, so axis_coverage lists just
 # the `true`s — run.sh asserts the rendered Tor-vs-clearnet config for both states on every run.
+# tari.mode/stratum_tls/tor_egress_firewall follow the same rule: only the non-default value gets
+# a dedicated case.
 #
 # Prerequisite-gated axes (skipped-with-a-loud-log, never silently, when the box can't host
 # them — see run.sh):
@@ -30,11 +36,18 @@
 #     SKIPPED so we never silently drop coverage or mutate the canonical chain.
 #   * monero.mode=remote needs a reachable external node (REMOTE_MONERO_HOST); the natural
 #     choice is the box's own synced monerod on its LAN address.
+#   * tari.mode=remote (#103) needs its own reachable external node (REMOTE_TARI_HOST) — the
+#     same shape as monero's, an already-synced Tari node.
 #   * network.subnet is a set-at-install knob: moving it changes the docker bridge's IPAM subnet,
 #     which Compose cannot recreate while containers are attached — a hot `apply` fails. So the
 #     matrix line documents the axis for coverage, resolve_overrides SKIPS it in the hot-apply
 #     loop (with a loud reason), and run.sh's `--subnet` phase runs it for real via a full
 #     down -> up on the moved subnet (chains are bind-mounted by path, so they are never touched).
+#   * Payout confirmation (#381/#462) needs a REAL Monero view key for the box's own wallet
+#     (IT_MONERO_VIEW_KEY) — never hardcoded here. The row carries the marker
+#     "payout_confirm=env"; resolve_overrides swaps it for the real monero.view_key override (and
+#     folds in tari.view_key/spend_public_key too when IT_TARI_VIEW_KEY + IT_TARI_SPEND_PUBLIC_KEY
+#     are BOTH set), or SKIPs the row when the env var is absent.
 
 # Emit the matrix as `NAME<TAB>overrides…`, one scenario per line. Lines starting with the
 # canonical-first scenario are ordered so the cheapest, most-common config runs first.
@@ -50,6 +63,11 @@ local-pruned-main-tari-optional	monero.mode=local monero.prune=true p2pool.pool=
 local-pruned-main-clearnet-sync	monero.mode=local monero.prune=true monero.clearnet_initial_sync=true tari.clearnet_initial_sync=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true
 remote-main-secure-tari	monero.mode=remote p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true
 local-pruned-main-subnet	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true network.subnet=10.84.0.0/24
+remote-tari-main-secure	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true tari.mode=remote
+local-pruned-main-stratum-tls	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true p2pool.stratum_tls=true
+local-pruned-main-firewall-off	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true network.tor_egress_firewall=false
+local-pruned-main-payout-confirm	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=true dashboard.tari_required=true payout_confirm=env
+local-pruned-main-insecure	monero.mode=local monero.prune=true p2pool.pool=main xvb.enabled=true dashboard.secure=false dashboard.tari_required=true
 EOF
 }
 
@@ -75,6 +93,10 @@ dashboard.tari_required=false
 monero.clearnet_initial_sync=true
 tari.clearnet_initial_sync=true
 network.subnet=10.84.0.0/24
+tari.mode=remote
+p2pool.stratum_tls=true
+network.tor_egress_firewall=false
+payout_confirm=env
 EOF
 }
 

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -65,6 +65,46 @@ resolve_overrides "monero.mode=remote"
 rc=$?
 assert_rc "remote ok with endpoint" "$rc" "0"
 assert_contains "augments remote host" "$RESOLVED" "monero.remote.host=10.0.0.5:18081"
+# tari.mode remote (#103/#942): same shape as monero's above, its own global/endpoint.
+REMOTE_TARI_HOST=""
+resolve_overrides "tari.mode=remote"
+rc=$?
+assert_rc "tari remote skips without endpoint" "$rc" "1"
+assert_contains "skip names --remote-tari-host" "$SKIP_REASON" "--remote-tari-host"
+REMOTE_TARI_HOST="10.0.0.6:18142"
+resolve_overrides "tari.mode=remote"
+rc=$?
+assert_rc "tari remote ok with endpoint" "$rc" "0"
+assert_contains "augments remote tari host" "$RESOLVED" "tari.remote.host=10.0.0.6:18142"
+unset REMOTE_TARI_HOST
+# Payout confirmation (#381/#462/#942): the "payout_confirm=env" marker gates on
+# IT_MONERO_VIEW_KEY, is always stripped from RESOLVED, and folds in tari's pair only when BOTH
+# tari env vars are set.
+unset IT_MONERO_VIEW_KEY IT_TARI_VIEW_KEY IT_TARI_SPEND_PUBLIC_KEY
+resolve_overrides "p2pool.pool=main payout_confirm=env"
+rc=$?
+assert_rc "payout confirm skips without IT_MONERO_VIEW_KEY" "$rc" "1"
+assert_contains "skip names IT_MONERO_VIEW_KEY" "$SKIP_REASON" "IT_MONERO_VIEW_KEY"
+IT_MONERO_VIEW_KEY="deadbeef"
+resolve_overrides "p2pool.pool=main payout_confirm=env"
+rc=$?
+assert_rc "payout confirm ok with the monero key" "$rc" "0"
+assert_contains "augments monero.view_key" "$RESOLVED" "monero.view_key=deadbeef"
+case "$RESOLVED" in
+*payout_confirm=env*) it_fail "marker stripped from RESOLVED" "payout_confirm=env leaked into $RESOLVED" ;;
+*) it_pass "marker stripped from RESOLVED" ;;
+esac
+case "$RESOLVED" in
+*tari.view_key=*) it_fail "tari pair absent without both tari env vars" "tari.view_key present in $RESOLVED" ;;
+*) it_pass "tari pair absent without both tari env vars" ;;
+esac
+IT_TARI_VIEW_KEY="tvk" IT_TARI_SPEND_PUBLIC_KEY="tspk"
+resolve_overrides "payout_confirm=env"
+rc=$?
+assert_rc "payout confirm ok with both tari env vars too" "$rc" "0"
+assert_contains "augments tari.view_key" "$RESOLVED" "tari.view_key=tvk"
+assert_contains "augments tari.spend_public_key" "$RESOLVED" "tari.spend_public_key=tspk"
+unset IT_MONERO_VIEW_KEY IT_TARI_VIEW_KEY IT_TARI_SPEND_PUBLIC_KEY
 # Compound prerequisites both augment.
 BASELINE_PRUNE=1
 FULL_DATA_DIR="/srv/full"
@@ -111,6 +151,19 @@ echo "== moved-subnet matrix scenario (#201/#180) =="
 assert_contains "matrix has a moved-subnet scenario" "$(scenario_names)" "local-pruned-main-subnet"
 assert_contains "subnet scenario sets a non-default /24" "$(scenario_overrides local-pruned-main-subnet)" "network.subnet=10.84.0.0/24"
 
+echo "== #942 matrix rows: tari-remote, stratum TLS, firewall opt-out, payout confirm, insecure+main =="
+assert_contains "matrix has a tari.mode=remote scenario" "$(scenario_names)" "remote-tari-main-secure"
+assert_contains "tari-remote scenario sets tari.mode=remote" "$(scenario_overrides remote-tari-main-secure)" "tari.mode=remote"
+assert_contains "matrix has a stratum-TLS scenario" "$(scenario_names)" "local-pruned-main-stratum-tls"
+assert_contains "stratum-TLS scenario sets p2pool.stratum_tls=true" "$(scenario_overrides local-pruned-main-stratum-tls)" "p2pool.stratum_tls=true"
+assert_contains "matrix has a firewall opt-out scenario" "$(scenario_names)" "local-pruned-main-firewall-off"
+assert_contains "firewall opt-out scenario sets network.tor_egress_firewall=false" "$(scenario_overrides local-pruned-main-firewall-off)" "network.tor_egress_firewall=false"
+assert_contains "matrix has a payout-confirmation scenario" "$(scenario_names)" "local-pruned-main-payout-confirm"
+assert_contains "payout-confirm scenario carries the env marker" "$(scenario_overrides local-pruned-main-payout-confirm)" "payout_confirm=env"
+assert_contains "matrix has an insecure+main scenario (decoupled from nano)" "$(scenario_names)" "local-pruned-main-insecure"
+assert_contains "insecure+main scenario pairs secure=false with pool=main" "$(scenario_overrides local-pruned-main-insecure)" "dashboard.secure=false"
+assert_contains "insecure+main scenario pairs secure=false with pool=main" "$(scenario_overrides local-pruned-main-insecure)" "p2pool.pool=main"
+
 echo "== expected/absent services: profile gating =="
 LOCAL='{"monero":{"mode":"local"}}'
 REMOTE='{"monero":{"mode":"remote"}}'
@@ -119,6 +172,28 @@ assert_contains "local includes p2pool" "$(expected_services "$LOCAL")" "p2pool"
 case "$(expected_services "$REMOTE")" in *monerod*) it_fail "remote excludes monerod" "monerod present" ;; *) it_pass "remote excludes monerod" ;; esac
 assert_eq "remote marks monerod absent" "$(absent_services "$REMOTE")" "monerod"
 assert_eq "local marks nothing absent" "$(absent_services "$LOCAL")" ""
+# tari.mode is an independent axis from monero.mode (#103/#942): each chain toggles its own
+# bundled-node/onion coverage without disturbing the other's.
+TARI_REMOTE='{"tari":{"mode":"remote"}}'
+BOTH_REMOTE='{"monero":{"mode":"remote"},"tari":{"mode":"remote"}}'
+assert_contains "monero-local still includes tari (tari.mode unset -> local default)" "$(expected_services "$LOCAL")" "tari"
+assert_contains "monero-remote still includes tari (independent axis)" "$(expected_services "$REMOTE")" "tari"
+if printf '%s\n' "$(expected_services "$TARI_REMOTE")" | grep -qx tari; then
+    it_fail "tari.mode=remote excludes tari" "tari present"
+else
+    it_pass "tari.mode=remote excludes tari"
+fi
+assert_eq "tari.mode=remote marks tari absent" "$(absent_services "$TARI_REMOTE")" "tari"
+assert_eq "both remote marks both absent" "$(absent_services "$BOTH_REMOTE")" "$(printf 'monerod\ntari')"
+# wallet-rpc/tari-wallet (#381/#462) only run when their view key is set.
+VIEWKEY_MONERO='{"monero":{"mode":"local","view_key":"vk"}}'
+VIEWKEY_TARI='{"tari":{"mode":"local","view_key":"tvk"}}'
+assert_contains "monero.view_key set -> wallet-rpc expected" "$(expected_services "$VIEWKEY_MONERO")" "wallet-rpc"
+case "$(expected_services "$LOCAL")" in
+*wallet-rpc*) it_fail "no view_key -> wallet-rpc not expected" "wallet-rpc present" ;;
+*) it_pass "no view_key -> wallet-rpc not expected" ;;
+esac
+assert_contains "tari.view_key set -> tari-wallet expected" "$(expected_services "$VIEWKEY_TARI")" "tari-wallet"
 assert_eq "pool_label main" "$(pool_label main)" "Main"
 assert_eq "pool_label mini" "$(pool_label mini)" "Mini"
 assert_eq "pool_label nano" "$(pool_label nano)" "Nano"


### PR DESCRIPTION
Fills the two coverage gaps the cross-repo audit named, ahead of the v1.19.0 cut so the new legs get their live validation during the release e2e.

**#942 — five new matrix rows**, each following `scenarios.sh`'s existing axis idiom:
- `remote-tari-main-secure` (`tari.mode=remote`) — asserts the bundled tari container and its onion are absent and the sync gate proves against the remote target. **This row immediately found a real bug**: `expected_services`/`absent_services` hardcoded `tari` as always-expected, so a remote-Tari deployment would have been mis-asserted; fixed as part of the row.
- `local-pruned-main-stratum-tls` — a live TLS handshake against the published stratum port, and the served certificate's SHA-256 matches the fingerprint operators are told to pin.
- `local-pruned-main-firewall-off` — the positive mirror of the fail-closed proofs: with the fence deliberately off, zero egress rules are installed *and* a real clearnet dial from a mining_net container succeeds.
- `local-pruned-main-payout-confirm` — a marker in the row resolves to a real view key from env (never a key in the matrix itself), then asserts both the rendered flag and the dashboard's own `earnings.confirmed.enabled`. Self-skips loudly without the env var.
- `local-pruned-main-insecure` — decouples insecure mode from its previous nano-only pairing.

**#1002 — two legs on the live control path:**
- `--rigforge-upgrade` POSTs the rig's already-installed version and asserts terminal `noop`. Honest scoping: tracing `handle_worker_upgrade` showed a client-side shortcut that can answer `noop` synchronously without dialling the host runner, so the leg tolerates both outcomes rather than claiming it always exercises the deep chain — documented in the code and docs.
- A reversible `pools` edit, the second writable key driven live (the enriched feed has no readback for writable values, so the restore target is the dashboard's own `last_applied.pools` record; probe value is operator-supplied).

Evidence: `bash -n` clean on all four edited scripts; selftest **165 → 201 passed** (36 new pure-logic assertions); `make lint` exit 0; inventory drift check clean.

All seven additions are tier-4 by nature and need the bench — they are listed with their prerequisites in the PR discussion so the v1.19.0 release run can drive them.

Closes #942
Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
