### PR TITLE
fix(upgrade): require cosign before the one-click download, key or no key (#1023)

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -933,12 +933,17 @@ is also cryptographically verified
 ([#376](https://github.com/p2pool-starter-stack/pithead/issues/376)): with the release public key
 on disk (`cosign.pub`, shipped in every signed bundle), the runner fetches the release's
 `pithead.tar.gz.sig` and checks the download against the key it **already holds** before
-extracting a byte — a bad or missing signature, or a missing cosign binary, fails the upgrade
-with nothing changed, and a swapped key inside a malicious bundle cannot vouch for itself. The
-`pithead upgrade` that follows verifies each image's signature the same way before pulling. An
-install without `cosign.pub` (older than the first signed release) still rests on TLS to GitHub
-(over Tor) plus that tag pinning, and says so in the journal — upgrading once to a signed release
-picks up the key. See [Releasing › Signed releases](dev/releasing.md#signed-releases).
+extracting a byte — a bad or missing signature fails the upgrade with nothing changed, and a
+swapped key inside a malicious bundle cannot vouch for itself. The `pithead upgrade` that follows
+verifies each image's signature the same way before pulling. An install without `cosign.pub`
+(older than the first signed release) still rests on TLS to GitHub (over Tor) plus that tag
+pinning, and says so in the journal — upgrading once to a signed release picks up the key. See
+[Releasing › Signed releases](dev/releasing.md#signed-releases).
+
+The `cosign` binary itself is checked first, before the release API is dialled: every bundle ships
+the key, so the upgrade the runner ends up performing will need the verifier no matter what this
+install currently holds. Without it the request is refused outright, with nothing downloaded and
+the throttle unclaimed — install cosign on the host and retry immediately.
 
 **Upgrading from v1.7.x or older shows one last false failure.** Dashboard versions before
 v1.8.1 treat the reverse proxy's brief 502 — normal while the dashboard container recreates

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -283,6 +283,13 @@ bundle), `upgrade` verifies each image's cosign signature before pulling and abo
 including when the `cosign` binary itself is missing. Install cosign once and the check runs on
 every upgrade; see [Releasing › Verifying a release](dev/releasing.md#verifying-a-release).
 
+**Install cosign before your first upgrade to a signed release.** Every release bundle carries the
+key, so an install cut before signing engaged holds none — there was nothing to make the binary
+necessary, and nothing warns until the upgrade needs it. The one-click upgrade checks first and
+refuses with nothing downloaded; the host `upgrade` aborts at the image gate, after the generated
+config has been re-rendered. Neither touches the running containers, and re-running once cosign is
+installed picks up where it stopped.
+
 Run `./pithead version` to see what is currently installed before and after an upgrade.
 
 ### Switching a source checkout to release images

--- a/pithead
+++ b/pithead
@@ -5841,6 +5841,20 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_reject "this install builds from source — upgrade from the host with 'git pull' then './pithead upgrade'."
         return 0
     fi
+    # #376/#1023: cosign is a PRECONDITION of a one-click upgrade, not a consequence of already
+    # holding a key. Every release bundle ships cosign.pub (make_bundle copies the committed key
+    # unconditionally), so the `pithead upgrade` this runner ends up calling will demand the
+    # verifier at its image gate whatever the current install holds. Testing the LOCAL cosign.pub
+    # instead — what this guard used to do — was blind to the one upgrade that needs it most: an
+    # install cut before signing engaged moving to a signed release, which every fielded install
+    # makes exactly once. That sailed past here and aborted inside the new CLI, after the download,
+    # the extraction, and a full config re-render. Checked with the source-checkout refusal above:
+    # both are "this install cannot take a one-click upgrade at all", and neither claims the
+    # throttle or dials out, so a refusal here costs the operator nothing.
+    if ! command -v cosign >/dev/null 2>&1; then
+        _upg_reject "cosign is not installed on the host — release bundles ship a signing key and every image is verified against it before it is pulled, so this upgrade would fail partway through. Install cosign (docs/dev/releasing.md § Verifying a release) and retry."
+        return 0
+    fi
     # Throttle: one attempt per 10 minutes, checked before any network dial.
     local stamp="$cdir/staged/.upgrade-stamp"
     if [ -n "$(find "$stamp" -mmin -10 2>/dev/null)" ]; then
@@ -5887,12 +5901,6 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     fi
     if ! semver_newer "$tag" "v$PITHEAD_VERSION"; then
         _upg_reject "already up to date (running v$PITHEAD_VERSION; latest release is $tag)."
-        return 0
-    fi
-    # #376: with a release key on disk the bundle WILL be verified below — so an install that can't
-    # verify (cosign.pub present, cosign binary missing) is refused here, before the download.
-    if [ -f cosign.pub ] && ! command -v cosign >/dev/null 2>&1; then
-        _upg_reject "cosign.pub is present but cosign is not installed on the host — refusing an unverified bundle (#376). Install cosign (docs/dev/releasing.md § Verifying a release) and retry."
         return 0
     fi
     control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"running",version:$v,ts:(now|floor)}')"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5934,6 +5934,12 @@ make_stubs "$UPG/bin"
 # tolerates non-empty dirs and would mask the regression. CI (Linux) and real installs run GNU
 # tar; on a Mac with gnu-tar installed, route this block's tar there too so the bug reproduces.
 command -v gtar >/dev/null 2>&1 && ln -sf "$(command -v gtar)" "$UPG/bin/tar"
+# Every release bundle ships cosign.pub, so the runner requires the verifier before it downloads
+# anything (#1023) — the fixture carries one so the paths that are supposed to proceed do not
+# depend on whether the host happens to have cosign installed. It stays inert: this install has no
+# cosign.pub, so no signature is ever fetched and nothing here invokes it.
+printf '#!/usr/bin/env bash\nexit 0\n' >"$UPG/bin/cosign"
+chmod +x "$UPG/bin/cosign"
 printf '1.3.1' >"$UPG/VERSION"
 printf '{}' >"$UPG/config.json" # #637: the in-place path snapshots config.json before extracting
 # #544/#555: a real release install carries non-empty build/* config-template mounts (see the
@@ -6032,6 +6038,25 @@ assert_contains "channel-off refusal names the flag" "$out" "not enabled"
 [ ! -f "$UPGRESULTS/$UUPG.json" ] && ok "channel-off intent gets no result" || bad "channel-off intent gets no result" "result written"
 rm -f "$UPGREQS/$UUPG.json"
 seed_upgrade_env true
+
+# #1023: no cosign on the host -> refused before a single dial, whether or not this install already
+# holds a key. This fixture has NO cosign.pub (it models an install cut before signing engaged),
+# which is exactly the shape that used to sail past the old `[ -f cosign.pub ] &&` guard, download
+# the bundle, extract it over the install, and only then abort inside the new CLI's image gate.
+# Same pinned PATH as its key-holding twin below, so a host cosign can't decide the test.
+reset_upgrade_state
+ln -sf "$(command -v jq)" "$UPG/bin/jq" # PATH is pinned below, which may not carry jq
+mv "$UPG/bin/cosign" "$UPG/cosign.hidden"
+upgrade_intent "$UUPG" "v9.9.9"
+(cd "$UPG" && PATH="$UPG/bin:/usr/bin:/bin" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+    CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
+mv "$UPG/cosign.hidden" "$UPG/bin/cosign"
+rm -f "$UPG/bin/jq"
+assert_eq "upgrade without cosign is rejected on a key-less install" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "cosign-missing refusal names the verifier" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "cosign is not installed"
+assert_eq "cosign-missing refusal dials nothing" "$(cat "$UPG/curl.log" 2>/dev/null)" ""
+assert_eq "cosign-missing refusal extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
+assert_eq "cosign-missing refusal claims no throttle" "$(ls "$UPG/data/control/staged/.upgrade-stamp" 2>/dev/null)" ""
 
 # Malformed / missing version: refused BEFORE any network dial (curl must never run).
 reset_upgrade_state
@@ -6426,9 +6451,10 @@ assert_eq "missing signature asset reports failed" "$(jq -r '.status' "$UPGRESUL
 assert_contains "missing-signature failure names the asset" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "no bundle signature"
 assert_eq "missing signature extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
 
-# cosign.pub present but no cosign binary: refused BEFORE the download, with an install pointer.
-# PATH is pinned to the stub bin + /usr/bin:/bin so a real host cosign can't leak in; jq rides
-# along as a symlink since the pinned PATH may not carry it.
+# The other half of the same precondition (#1023): an install that already HOLDS the key is
+# refused for the same reason a key-less one is — no cosign, no upgrade — BEFORE the download, with
+# an install pointer. PATH is pinned to the stub bin + /usr/bin:/bin so a real host cosign can't
+# leak in; jq rides along as a symlink since the pinned PATH may not carry it.
 reset_upgrade_state
 ln -sf "$(command -v jq)" "$UPG/bin/jq"
 rm -f "$UPG/bin/cosign"


### PR DESCRIPTION
Closes #1023.

Found live: `pithead-coordinator` took the v1.18.1 one-click upgrade, and the runner reported `failed`
after downloading the bundle, extracting it over the install, and running the new CLI far enough to
re-render `.env`, the Caddyfile, the control-runner units and the Tor-egress firewall. The abort
came from `verify_release_images`: `cosign.pub` present, `cosign` binary absent.

## The hole

`control_upgrade` has a guard for exactly that, meant to fire *before* the download — but it tested
the **local** `cosign.pub`:

```bash
if [ -f cosign.pub ] && ! command -v cosign >/dev/null 2>&1; then
```

Prod was on a release cut before signing engaged, so it held no key, and the guard short-circuited.
The bundle it then installed ships one. The guard was structurally blind to the single upgrade that
needs it — **unsigned install → signed release** — which every fielded install makes exactly once.

## The fix

Require `cosign` for any one-click upgrade, checked beside the source-checkout refusal, before the
throttle claim and before the GitHub dial.

Making it unconditional is sound because both preconditions already hold at that point:

- `control_upgrade` refuses source checkouts at the top of the function, so everything reaching this
  line is a release install.
- Every bundle it can fetch carries `cosign.pub` — `make_bundle` copies the committed key
  unconditionally (`scripts/release.sh:591`), independent of whether signing was on for that cut.
  There is already a tier-2 assertion pinning this: *"the bundle ships cosign.pub (the install-side
  verifier)"*.

So the new CLI will demand the verifier no matter what the old one held, and asking up front turns
a half-finished upgrade into a refusal with nothing downloaded and the throttle unclaimed — the
operator installs cosign and retries immediately rather than going to find a shell on the box they
were upgrading from the dashboard precisely so they would not have to.

## Coverage

Tier 2, both halves of the widened condition:

- **key-less install** (new): the shape that used to sail through. Asserts `rejected`, the error
  names the verifier, the curl log is empty, `VERSION` unchanged, no throttle stamp.
- **key-holding install** (existing, at the end of the `$UPG` block): still refused, still before
  the download — now for the general reason rather than the narrow one. Comment updated to say so.

The new case is a real red test: reverting `pithead` alone turns all five assertions red
(`1712 passed, 5 failed`) and green again with the fix.

The `$UPG` fixture gains an inert `cosign` stub, because the paths that are *meant* to proceed now
need one on `PATH` — without it the suite's result would depend on whether the developer happens to
have cosign installed. It is never invoked: that fixture has no `cosign.pub`, so no signature is
fetched.

## Docs

- `docs/operations.md` — the upgrade section gains the operator-facing consequence: install cosign
  before your first upgrade to a signed release, what each path does when it is missing, and that
  neither touches the running containers.
- `docs/dashboard.md` — the one-click description said a missing cosign binary "fails the upgrade";
  it now refuses it, before the release API is dialled.

## Gates

`make lint` clean · `make test` clean (stack 1717/0, selftest 201/0, dashboard 1721 passed / 97%) ·
`make test-patch-coverage` not applicable, nothing under `build/dashboard/mining_dashboard/` changed.

Not covered here: the dead `docs/dev/releasing.md` pointer both refusals carry — release bundles
ship no `docs/`, and they stay lean. That is #1024, stacked on this branch.
