### PR TITLE
fix(appliance): rebuild a container store left corrupt by an interrupted write (#1029)

### DIFF
--- a/pithead
+++ b/pithead
@@ -1945,10 +1945,39 @@ consume_install_request() { # <spool-dir>
 # owners run this — pithead-boot on provisioned machines, the first-boot wizard before it
 # serves — so every path converges on the shipped images, and a normal boot pays one sha256
 # per archive.
+# An unclean reset — a power cut, or the hardware watchdog firing while slow media is mid-write —
+# can leave containers/storage with ZERO-LENGTH `lower` files. containers/storage splits an
+# empty-but-present `lower` on ":" into one EMPTY element, joins that onto the graph root and
+# readlinks THAT directory, so every container start dies with
+# "readlink <graphroot>/overlay: invalid argument". The digest records in load_baked_images then
+# report the images as already loaded, so nothing ever reloads: the damage survives every later
+# boot, the wizard never serves, and the console sits on "preparing the setup page" forever. That
+# is how an appliance ended up unable to install from its own stick — the store was broken by the
+# reset, not by anything the wizard did. A correct BASE layer carries no `lower` file at all, so a
+# zero-length one is damage, never a legitimate state.
+#
+# ponytail: rebuilds the WHOLE store, so a machine past provisioning re-pulls whatever is not
+# baked (only the dashboard is). Fine as a floor — a store in this state starts no container at
+# all, so re-pulling beats staying dead. Narrow it to the baked set if that ever bites.
+repair_broken_image_store() { # $1: container engine
+    local engine="$1" root
+    root=$("$engine" info --format '{{.Store.GraphRoot}}' 2>/dev/null) || return 0
+    { [ -n "$root" ] && [ -d "$root/overlay" ]; } || return 0
+    find "$root/overlay" -maxdepth 2 -name lower -size 0 -print -quit 2>/dev/null | grep -q . || return 0
+    warn "The container image store is damaged (an interrupted write left empty layer metadata) — rebuilding it."
+    "$engine" rm -af >/dev/null 2>&1 || true
+    rm -rf "${root:?}"
+    rm -f "$PWD/data"/.loaded-*.sha
+}
+
 load_baked_images() { # $1 (optional): image ref whose absence forces a load despite a matching digest
     local required="${1:-}" dir="${PITHEAD_IMAGES_DIR:-/opt/pithead/images}"
     local engine archive sha rec recorded
     engine=$(container_engine)
+    # Before trusting any digest record: a record describes what was LOADED, and the check below
+    # only asks whether the image still EXISTS. A store damaged as described above satisfies both
+    # and still cannot run a thing, which is exactly how the failure became permanent.
+    repair_broken_image_store "$engine"
     # The wizard-era record lived at a different path; retire it so an upgraded machine doesn't
     # carry a stale file forever (its absence costs one reload on the first boot after upgrading).
     rm -f "$PWD/.wizard-image-sha"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8629,6 +8629,61 @@ unset -f lbl sha_of
 rm -rf "$WSB"
 unset WSB WREC WV2SHA
 
+echo "== unit: load_baked_images — a store damaged by an interrupted write is rebuilt =="
+# An unclean reset mid-load (power cut, or the watchdog firing while slow media is written) leaves
+# ZERO-LENGTH `lower` files; containers/storage then readlinks the graph root itself and EVERY
+# container start fails. The digest record still matches AND the image still exists, so the two
+# guards above both pass and the reload was skipped — which is what made the damage permanent and
+# left an appliance unable to install from its own stick. A base layer carries no `lower` file at
+# all, so a zero-length one is damage, never a legitimate state.
+RSB=$(mktemp -d)
+mkdir -p "$RSB/images" "$RSB/bin" "$RSB/data"
+printf 'archive' >"$RSB/images/dashboard.tar.gz"
+cat >"$RSB/bin/podman" <<'EOF'
+#!/usr/bin/env bash
+echo "[podman] $*" >>"${PODMAN_LOG:-/dev/null}"
+case "$1" in
+info) printf '%s\n' "${FAKE_GRAPHROOT:-}" ;;
+image) exit 0 ;; # the image ALWAYS exists — that is the point of this test
+load) exit 0 ;;
+rm) exit 0 ;;
+esac
+EOF
+chmod +x "$RSB/bin/podman"
+export PODMAN_LOG="$RSB/podman.log" PITHEAD_IMAGES_DIR="$RSB/images" FAKE_GRAPHROOT="$RSB/store"
+rbl() { PITHEAD_ENGINE=podman PATH="$RSB/bin:$PATH" run_sourced "$RSB" load_baked_images; }
+# A healthy store: the base layer has NO `lower`, the layer above carries a real chain.
+mk_store() {
+    rm -rf "$RSB/store"
+    mkdir -p "$RSB/store/overlay/base/diff" "$RSB/store/overlay/top/diff"
+    printf 'l/BASE' >"$RSB/store/overlay/top/lower"
+}
+mk_store
+printf '%s' "$(sha256sum "$RSB/images/dashboard.tar.gz" | cut -d' ' -f1)" >"$RSB/data/.loaded-dashboard.tar.gz.sha"
+: >"$PODMAN_LOG"
+rbl >/dev/null 2>&1
+[ -d "$RSB/store/overlay/top" ] &&
+    ok "a healthy store is left alone — no needless re-pull" ||
+    bad "a healthy store is left alone" "the store was rebuilt"
+grep -q "load -i" "$PODMAN_LOG" &&
+    bad "a healthy store still honours the digest record" "reloaded anyway" ||
+    ok "a healthy store still honours the digest record"
+
+mk_store
+: >"$RSB/store/overlay/base/lower" # zero-length: the corruption itself
+: >"$PODMAN_LOG"
+rbl >/dev/null 2>&1
+[ -d "$RSB/store/overlay" ] &&
+    bad "a damaged store is torn down" "the store survived" ||
+    ok "a damaged store is torn down"
+grep -q "load -i" "$PODMAN_LOG" &&
+    ok "a damaged store reloads the archive despite a matching record" ||
+    bad "a damaged store reloads the archive" "no load call"
+unset PODMAN_LOG PITHEAD_IMAGES_DIR FAKE_GRAPHROOT
+unset -f rbl mk_store
+rm -rf "$RSB"
+unset RSB
+
 echo "== unit: pre-seeding from the installation medium =="
 # The ESP is FAT and anyone can write it, so both readers treat its contents as input, not truth.
 PSD=$(mktemp -d)


### PR DESCRIPTION
Closes #1029.

**Validated end to end on the physical HP bench today: a stick built from this branch installed the appliance to its internal NVMe and brought the full stack up (8 containers).** That is the flow #1029 said was impossible.

## The reported root cause was wrong

The issue blamed an unguarded `mkdir -p "$PWD/data"` against a read-only root. That is a **reproduction artifact**, and the evidence is in the issue's own transcript:

- `/opt/pithead/data` **does not exist** on the box, and the unit runs `ExecStart=/data/pithead/pithead` with `WorkingDirectory=/data/pithead` — a real rw ext4 mountpoint (`pithead-mount-generator` mounts partition 4 of the disk the system booted from, which on a stick boot is the stick's own).
- An *earlier* unguarded write, `mkdir -p "$spool"` at `pithead:2066`, would have aborted before the `Loading this build's container images` line the transcript shows. `/data/pithead/data/firstboot` exists on disk owned `1000:1000`. It succeeded.
- `mkdir -p` reports the deepest component it could not create, so both writes produce a byte-identical message. The string alone cannot identify the line.

The by-hand repro was run from `/opt/pithead`, which is not where the service runs.

## What actually breaks it

Running the wizard as the unit does, and a bare `podman run` with no wizard involved, both give:

```
Error: readlink /data/containers/storage/overlay: invalid argument
```

The store held **seven zero-length `lower` files**. containers/storage splits an empty-but-present `lower` on `:` into one *empty* element, joins it onto the graph root and readlinks that directory — hence the error naming `overlay` itself. A correct base layer carries **no** `lower` file (`f2ec4de…` correctly had none), so zero-length is damage, never valid. Signature of an interrupted write.

**Why it was permanent — the actual product defect.** `load_baked_images` had two guards: the digest record matched, and `image exists` returned true (the image *was* there, just unrunnable). Both passed, so the archive was never reloaded and one unclean reset bricked the medium across every later boot, with nothing on the console.

## The fix

Detect the defect before trusting any digest record, tear the store down, reload. Keyed on the defect itself, so a healthy store is untouched and a provisioned machine never re-pulls for nothing.

Proven by live repair before writing it: wiping the store and reloading brought the wizard up on the bricked box.

## Verification

| Gate | Result |
|---|---|
| Real hardware | Install-from-stick completed to internal NVMe; 8 containers up |
| New unit tests | 4, covering damaged **and** healthy stores |
| Mutation check | With the repair disabled, both damage tests fail — the tests are not vacuous |
| `make lint` | 0 errors |
| `tests/stack` | 2320 passed, 0 failed |

## Scope

Does **not** address what interrupted the write — filed as #1030 (the journal is `volatile`, so the failing boot's evidence was gone; that is #1030's first recommendation). The unguarded `$PWD` writes at `pithead:2066`/`6605` remain real latent bugs, just not this one.

Base is `develop-v2`; retarget before merge if auto-close is wanted.