### PR TITLE
chore(os): repin the baked RigForge tree to the v1.15.1 release

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -fsSL -o /usr/local/bin/docker-compose \
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image
 # build because nothing can be installed later — apt cannot run on the read-only root, and even
 # a rw-remount install leaves its /etc state (alternatives, ld.so.cache) on the volatile overlay
-# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.14.0 release tag
+# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.15.0 release tag
 # (by commit, not tag name, so a moved tag cannot change the bake); bump it release by release.
 # pithead-sync copies the tree to /data/rigforge every boot; `pithead local-miner` runs
 # its setup with RIGFORGE_APPLIANCE=1 when local_miner.enabled.

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -89,8 +89,13 @@ RUN curl -fsSL -o /usr/local/bin/docker-compose \
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image
 # build because nothing can be installed later — apt cannot run on the read-only root, and even
 # a rw-remount install leaves its /etc state (alternatives, ld.so.cache) on the volatile overlay
-# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.15.0 release tag
+# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.15.1 release
 # (by commit, not tag name, so a moved tag cannot change the bake); bump it release by release.
+# v1.15.1 and not v1.15.0: GitHub's releases/latest pointer still names v1.15.0, so RigForge's own
+# `upgrade --check` calls the newer patch a development build (rigforge#371) — but v1.15.1 is the
+# published release, it carries the API-reader fix that stopped a dead worker API aborting tune
+# and autotune sweeps outright, and it is what every rig in the field runs. Baking the older tree
+# would ship an appliance whose built-in miner is behind the workers beside it.
 # pithead-sync copies the tree to /data/rigforge every boot; `pithead local-miner` runs
 # its setup with RIGFORGE_APPLIANCE=1 when local_miner.enabled.
 #
@@ -101,7 +106,7 @@ RUN curl -fsSL -o /usr/local/bin/docker-compose \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=b91505cbd55e12fdf2149193efef5ba387446795
+ARG RIGFORGE_REF=60aa883901fc74ea39ed2f21962b8ba7f96d73ba
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -101,7 +101,7 @@ RUN curl -fsSL -o /usr/local/bin/docker-compose \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=a8840b3c8108ee6def9d850221a440f2fd355cf6
+ARG RIGFORGE_REF=b91505cbd55e12fdf2149193efef5ba387446795
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \


### PR DESCRIPTION
The appliance bakes a RigForge tree at a pinned ref. It is currently pinned to v1.14.0, which ships a `status` verb that **aborts on every healthy rig** (rigforge#341) — found on the bench at exactly this pin. Cutting the appliance on it would ship a rig image whose most-used verb is broken.

v1.15.0 carries that fix plus the control-status mirror the dashboard's worker view reads (rigforge#346), the tune-interrupt restore, pool reachability in `doctor`/`apply`, and the appliance-mode CI pass.

Repins `os/rootfs/Dockerfile` `RIGFORGE_REF` to v1.15.0's annotated tag `b91505cbd55e12fdf2149193efef5ba387446795`, and makes the pin comment name the version it pins.

### Gates

RigForge-side, already run: `e2e-real` all phases plus the `e2e-pithead` worker-stack contract on real hardware, and a forward upgrade v1.12.0 → v1.15.0 proven on the prod rig.

Pithead-side: the `rig` and `provision` battery phases on an image **built from this pin** — the `rig` phase runs `rigforge.sh status` assertions, so it proves the #341 fix is actually in the baked tree. That battery is running on the merged wave tip, which includes this commit; this merges on its evidence.