### PR TITLE
fix(os): compile docker-compose and cosign in the rootfs instead of downloading them

### DIFF
--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -52,7 +52,7 @@ jobs:
             gh issue create \
               --title "${name}: pinned ${pinned}, upstream released ${latest}" \
               --label appliance --label infra \
-              --body "Weekly pin-watch (#833): \`os/rootfs/Dockerfile\` pins ${name} at \`${pinned}\`; upstream's latest release is \`${latest}\` (https://github.com/${upstream}/releases). Bumping means updating both the version ARG and its sha256 ARG in the Dockerfile. If the pin is being held back on purpose, say why here and leave this open — the watcher will not file a duplicate while it is."
+              --body "Weekly pin-watch (#833): \`os/rootfs/Dockerfile\` pins ${name} at \`${pinned}\`; upstream's latest release is \`${latest}\` (https://github.com/${upstream}/releases). Bumping means updating both the version ARG and its _COMMIT ARG in the Dockerfile (the rootfs COMPILES these two from source on a pinned Go toolchain rather than downloading release binaries, so the pin is an upstream commit, not a binary sha256). Get the commit with \`gh api repos/${upstream}/commits/${latest} --jq .sha\`. If the pin is being held back on purpose, say why here and leave this open — the watcher will not file a duplicate while it is."
             echo "${name}: stale (${pinned} -> ${latest}) — issue filed"
           }
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -22,12 +22,12 @@ CVE-2026-56852
 # github.com/docker/docker authz bypass, vendored in compose (server-side moby code, and the
 # appliance talks to podman's compat socket, not dockerd — no exposed authz plugin path here):
 CVE-2026-34040
-# Go stdlib (both binaries built with go1.26.4; clears with upstream rebuilds):
-CVE-2026-39822
-# Go stdlib net/http idna + dns/dnsmessage (2026-08 batch, fixed only in go1.25.13/1.26.6 —
-# compose v5.4.0 is still go1.26.5, cosign has no newer release; verified 2026-08-14):
-CVE-2026-39821
-CVE-2026-46600
+# NOTE ON GO STDLIB FINDINGS — there are none listed here on purpose. The appliance rootfs used
+# to download upstream release binaries and inherit whichever Go toolchain built them, so every Go
+# stdlib CVE became an accepted finding we could not clear (nine of them by 2026-08). It now
+# COMPILES docker-compose and cosign itself on a pinned, patched toolchain (os/rootfs/Dockerfile,
+# the gobuild stage), so stdlib findings are fixed at the source instead of accepted. If a stdlib
+# CVE appears here again, the answer is to bump the builder image, not to add a line below.
 # google.golang.org/grpc vendored in both pinned binaries (GHSA id — Trivy gates on it like a
 # CVE; same clearing condition as the three above: upstream rebuilds on the fixed module):
 GHSA-hrxh-6v49-42gf

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -12,6 +12,55 @@
 # Pinned by digest (#135) so the debian:trixie-slim tag can't be silently re-pointed. The digest
 # bump is how base-distro CVE fixes reach the appliance (#833): there is no apt on the running
 # box — every Debian package here is frozen until the next bake.
+# ---------------------------------------------------------------------------------------------
+# Builder: docker-compose and cosign, compiled here rather than downloaded as upstream binaries.
+#
+# Both projects publish release binaries built on whatever Go toolchain they happened to use, and
+# that toolchain's stdlib CVEs become ours — baked into a read-only appliance image that cannot be
+# patched in place. In August 2026 that was nine fixable HIGH findings the scan gated on, and no
+# pin bump could clear them: cosign v3.1.3 (the newest release) ships built with go1.26.4, the
+# same toolchain as v3.1.2, and docker-compose v5.4.0 ships go1.26.5 — both below the go1.26.6
+# that carries the fixes. Verified by reading the build stamps out of the published binaries, not
+# from release notes. Waiting for upstream to rebuild is not a schedule we control, so we compile
+# them ourselves on a patched toolchain and the findings go away at the source.
+#
+# Provenance is not weakened by this, it moves: the old pin was a sha256 of a downloaded binary,
+# this one is an exact upstream COMMIT (never a tag — a tag can be re-pointed, the same reason
+# RIGFORGE_REF below pins a commit) plus Go module integrity from each project's own go.sum. The
+# build flags mirror each project's Makefile so the binaries identify themselves normally:
+# `docker-compose version` and `cosign version` report the release they were built from.
+FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS gobuild
+
+ARG COMPOSE_VERSION=v5.4.0
+ARG COMPOSE_COMMIT=ef61d7410a0c816a71705026e638ec256a591d69
+ARG COSIGN_VERSION=v3.1.3
+ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
+ENV CGO_ENABLED=0
+
+# Blobless clone then detach to the commit: the tag is only a convenience for the version string.
+RUN git clone --filter=blob:none --no-checkout https://github.com/docker/compose /src/compose \
+    && git -C /src/compose checkout --detach "${COMPOSE_COMMIT}" \
+    && go build -C /src/compose -trimpath -tags e2e \
+        -ldflags "-w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
+        -o /out/docker-compose ./cmd
+
+RUN git clone --filter=blob:none --no-checkout https://github.com/sigstore/cosign /src/cosign \
+    && git -C /src/cosign checkout --detach "${COSIGN_COMMIT}" \
+    && go build -C /src/cosign -trimpath \
+        -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=${COSIGN_VERSION} \
+            -X sigs.k8s.io/release-utils/version.gitCommit=${COSIGN_COMMIT} \
+            -X sigs.k8s.io/release-utils/version.gitTreeState=clean" \
+        -o /out/cosign ./cmd/cosign
+
+# Fail the build here rather than shipping a binary that cannot run: a wrong build path or a
+# broken ldflag produces a file that exists and does nothing useful, which every later stage
+# would happily copy.
+RUN /out/docker-compose version && /out/cosign version
+
+# ---------------------------------------------------------------------------------------------
+# Pinned by digest (#135) so the debian:trixie-slim tag can't be silently re-pointed. The digest
+# bump is how base-distro CVE fixes reach the appliance (#833): there is no apt on the running
+# box — every Debian package here is frozen until the next bake.
 FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -73,17 +122,11 @@ RUN chmod +x /opt/pithead/pithead
 # the tracked migration (docs/dev/dual-distribution-plan.md), not a second parallel path.
 # /etc/containers/nodocker silences the shim's stderr banner, which would otherwise leak into
 # every parsed command output.
-ARG COMPOSE_VERSION=v5.3.1
-ARG COMPOSE_SHA256=f9ebc6ebdb19d769b793c245a736caaeb198c62587f13b25c660c13b4987f959
-ARG COSIGN_VERSION=v3.1.2
-ARG COSIGN_SHA256=f7622ed3cf22e55e1ae6377c080979ff77a22da9981c11df222a2e444991e7cf
-RUN curl -fsSL -o /usr/local/bin/docker-compose \
-        "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-linux-x86_64" \
-    && echo "${COMPOSE_SHA256}  /usr/local/bin/docker-compose" | sha256sum -c - \
-    && curl -fsSL -o /usr/local/bin/cosign \
-        "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
-    && echo "${COSIGN_SHA256}  /usr/local/bin/cosign" | sha256sum -c - \
-    && chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
+# Built in the gobuild stage above, on a Go toolchain we choose, rather than downloaded. See the
+# rationale there — upstream release binaries carry their builder's stdlib CVEs into an image that
+# cannot be patched in place.
+COPY --from=gobuild /out/docker-compose /out/cosign /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
     && touch /etc/containers/nodocker
 
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image


### PR DESCRIPTION
Patches the CVEs rather than accepting them. **Supersedes #1056**, which allowlisted the same findings.

### The problem with downloading release binaries

The rootfs fetched upstream binaries, so whichever Go toolchain those projects happened to build with became ours — baked into a read-only appliance image that cannot be patched in place. By August 2026 that was **nine fixable HIGH stdlib findings** the `os-rootfs` scan gated on, red on every branch touching `os/`.

No pin bump could clear them:

| Binary | Newest release | Built with | Needed |
|---|---|---|---|
| cosign | v3.1.3 | go1.26.4 — *same toolchain as the pinned v3.1.2* | ≥ go1.26.6 |
| docker-compose | v5.4.0 | go1.26.5 | ≥ go1.26.6 |

Read out of the published binaries' build stamps, not from release notes. Waiting for upstream to rebuild is not a schedule this project controls.

### So the rootfs compiles them

A `gobuild` stage on a digest-pinned `golang:1.26.6-trixie` builds both from source. **Nine stdlib entries come out of `.trivyignore`** rather than six more going in. Three module-vendored findings stay — `x/text`, `docker`, `grpc` — because those need upstream *module* bumps, not a toolchain. A stdlib finding appearing there again now means bump the builder image, not add a line, and the file says so.

### Provenance moves rather than weakens

The old pin was a sha256 of a downloaded binary. The new one is an exact upstream **commit** — never a tag, which can be re-pointed, the same reasoning `RIGFORGE_REF` already applies — plus each project's own `go.sum`.

Build flags mirror each project's Makefile, taken from the upstream sources, so the binaries still identify themselves normally. Verified by building the stage locally:

```
GitVersion:    v3.1.3
GitCommit:     11926fa5bbbbde47e88fc006b625a17769b743b2
GitTreeState:  clean
GoVersion:     go1.26.6
```
```
Docker Compose version v5.4.0
```

The stage then **runs both binaries and fails the build if either cannot execute** — a wrong build path or a broken ldflag produces a file that exists and does nothing, which every later stage would happily copy.

It also takes both to their newest releases as a side effect (cosign v3.1.2 → v3.1.3, compose v5.3.1 → v5.4.0).

### Also

`pin-watch`'s bump instructions move from "update the sha256 ARG" to "update the `_COMMIT` ARG", with the command to get it — otherwise the next person to act on a pin-watch issue follows directions for a file layout that no longer exists.

Note for reviewers: `make lint` does **not** run hadolint — only CI does, at `failure-threshold: warning`. The first draft of this used `cd` inside a `RUN` (DL3003) and would have passed locally and failed CI. It uses `go build -C` now, and hadolint is clean against the repo's own config.