### PR TITLE
fix: make the one-click upgrade survive its own failures (#1070, #1071, #1072)

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/configview.mjs
@@ -39,7 +39,12 @@ import { Component, html } from "./preact.mjs";
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
 const POLL_MS = 2000;
 const POLL_MAX = 90; // 3 minutes — a commit recreates containers, which can take a while
-const UPGRADE_POLL_MAX = 450; // 15 minutes — an upgrade pulls a whole release of images first
+// #1071: 45 minutes. The old 900s ceiling sat BELOW what the host runner is allowed to spend before
+// the image pull even starts — 60s on the release API, 900s on the bundle over Tor, 120s on the
+// signature — so a healthy upgrade on a slow circuit hit the ceiling with the slowest step still
+// ahead of it and was reported as a failure. No constant can be provably enough (the pull is
+// unbounded), which is why the message below no longer claims the upgrade failed.
+const UPGRADE_POLL_MAX = 1350;
 
 // Poll /api/control/result until a terminal result lands; shared by the Configuration view and
 // the Upgrade button (#59). `skip` ignores an intermediate status under the same id (the
@@ -67,8 +72,12 @@ async function pollResult(id, skip, max = POLL_MAX) {
     if (out.status === skip) continue;
     return out;
   }
+  // Stopping the wait is not the same as the work failing: the runner is a host unit that carries on
+  // regardless of this page, and it records its own outcome. Saying "failed" here sent operators to
+  // check a control channel that was healthy, and invited a re-click that only met the 10-minute
+  // throttle. Say what is actually known instead.
   throw new Error(
-    "Timed out waiting for the host runner — is dashboard.control enabled and the pithead-control unit running?",
+    "Stopped waiting — this can take longer than expected on a slow connection. The host keeps going and finishes on its own; reload in a few minutes to see the result. If the version is unchanged after that, check that dashboard.control is enabled and the pithead-control unit is running.",
   );
 }
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -957,10 +957,10 @@ verifies each image's signature the same way before pulling. An install without 
 pinning, and says so in the journal — upgrading once to a signed release picks up the key. See
 [Releasing › Signed releases](dev/releasing.md#signed-releases).
 
-The `cosign` binary itself is checked first, before the release API is dialled: every bundle ships
-the key, so the upgrade the runner ends up performing will need the verifier no matter what this
-install currently holds. Without it the request is refused outright, with nothing downloaded and
-the throttle unclaimed — install cosign on the host and retry immediately.
+The verifier needs nothing installed. It runs as a digest-pinned container, so the button works on
+any host that can already run the stack; the image is fetched once, quietly, the first time an
+upgrade verifies something. If Docker itself is unreachable the request is refused outright, with
+nothing downloaded and the throttle unclaimed — but a box in that state is not mining either.
 
 **Upgrading from v1.7.x or older shows one last false failure.** Dashboard versions before
 v1.8.1 treat the reverse proxy's brief 502 — normal while the dashboard container recreates

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -184,9 +184,18 @@ digests — the exact bytes the smoke stage validated — never a mutable tag.
   trust anchor for its own verification, so a malicious bundle cannot vouch for itself; a key
   rotation reaches installs through a bundle signed with the previous key.
 - Verification fails closed. With `cosign.pub` present, a bad signature, a stripped
-  `pithead.tar.gz.sig`, or a missing `cosign` binary each abort the upgrade with a message naming
-  the fix. Only an install with no `cosign.pub` at all — older than the first signed release —
-  proceeds unverified, with a warning saying exactly that; `pithead doctor` reports the state.
+  `pithead.tar.gz.sig`, or an image the bundle does not pin by digest each abort the upgrade with a
+  message naming the fix. Only an install with no `cosign.pub` at all — older than the first signed
+  release — proceeds unverified, with a warning saying exactly that; `pithead doctor` reports the
+  state.
+- The verifier is a container, not a host binary
+  ([#1072](https://github.com/p2pool-starter-stack/pithead/issues/1072)): `cosign_run` invokes a
+  digest-pinned `cosign` image with the install dir mounted read-only. Operators install nothing,
+  and cosign never appears in the prerequisites. Requiring it on the host made signing a hidden
+  dependency that no prerequisite listed and no dependency check installed — a fresh bundle install
+  dead-ended at first `up`, and every install cut before signing engaged hit the same wall on its
+  first signed upgrade, after the download and the extract. The release box is the exception: it
+  signs, so it keeps a real pinned cosign (see [release-server.md](release-server.md)).
 - Source checkouts skip verification: locally built images are unsigned by design.
 
 What the signature does and does not prove: it proves the artifact was produced by the holder of
@@ -196,10 +205,9 @@ holds the key and cuts the releases.
 
 ### Verifying a release
 
-`pithead upgrade` runs the checks automatically once `cosign` is installed
-(pinned install: [release-server.md](release-server.md#the-release-signing-key) — the same
-snippet works on any host). To verify by hand against the committed
-`cosign.pub`:
+`pithead upgrade` runs the checks automatically, with no cosign install on the host — it calls a
+digest-pinned cosign image. To verify by hand instead, use a cosign of your own (pinned install:
+[release-server.md](release-server.md#the-release-signing-key)) against the committed `cosign.pub`:
 
 ```bash
 # An image (repeat per image, or pin the digest from the ingredients manifest):

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -302,16 +302,16 @@ the new release *before* pulling/rebuilding, so a release that changes a config 
 blockchain sync and settings survive an upgrade.
 
 On a release install with the release public key on disk (`cosign.pub`, shipped in every signed
-bundle), `upgrade` verifies each image's cosign signature before pulling and aborts on any failure —
-including when the `cosign` binary itself is missing. Install cosign once and the check runs on
-every upgrade; see [Releasing › Verifying a release](dev/releasing.md#verifying-a-release).
+bundle), `upgrade` verifies each image's cosign signature before pulling and aborts on any failure.
+There is nothing to install for this: the verifier runs as a digest-pinned container, so Docker —
+already a prerequisite — is the only thing it needs. The first upgrade fetches that image once and
+never mentions it again. See
+[Releasing › Verifying a release](dev/releasing.md#verifying-a-release) for what is checked.
 
-**Install cosign before your first upgrade to a signed release.** Every release bundle carries the
-key, so an install cut before signing engaged holds none — there was nothing to make the binary
-necessary, and nothing warns until the upgrade needs it. The one-click upgrade checks first and
-refuses with nothing downloaded; the host `upgrade` aborts at the image gate, after the generated
-config has been re-rendered. Neither touches the running containers, and re-running once cosign is
-installed picks up where it stopped.
+Verification fails closed. A bad signature, a stripped `pithead.tar.gz.sig`, or an image the bundle
+does not pin by digest each abort the upgrade before anything is pulled, and the stack keeps running
+the version it was on. The one and only way to end up unverified is an install older than the first
+signed release, which carries no `cosign.pub` at all — that case warns loudly and proceeds.
 
 Run `./pithead version` to see what is currently installed before and after an upgrade.
 

--- a/pithead
+++ b/pithead
@@ -380,6 +380,60 @@ compose_pinned_digest() {
         grep -oE 'sha256:[0-9a-f]+' | head -1
 }
 
+# The verifier runs as a container, not a host binary (#1072). cosign has no Ubuntu apt package, so
+# requiring it on the host made signing a hidden prerequisite that no doc listed and no dependency
+# check installed: a fresh bundle install dead-ended at first `up`, and every fielded install cut
+# before signing engaged hit the same wall on its first signed upgrade — after the download, the
+# extract, and the control-unit re-provision (#1070). Docker is already a hard prerequisite and the
+# very next step of both callers pulls images with it, so running cosign this way costs the operator
+# nothing to install and nothing to know about.
+#
+# The @sha256 pin is LOAD-BEARING, not cosmetic housekeeping: verifying release images by first
+# pulling a verifier image is itself an unverified pull, and the digest is the only thing that
+# closes it. Pinned, a hostile registry can serve nothing but the exact bytes named here or fail the
+# pull outright; on a tag it could serve a "cosign" that exits 0 on everything and silently turn the
+# whole gate off. Bootstrapping is therefore trust-on-first-use exactly as downloading the binary
+# from GitHub was — no weaker, and pinned to bytes rather than to a mutable tag. Never relax this to
+# a tag, and treat bumping it as a supply-chain change.
+readonly COSIGN_IMAGE="ghcr.io/sigstore/cosign/cosign@sha256:4bedb8de1c5c1abd8dea60de704ba449402d238623fa8bb33d2ccaa9beffcbf5" # v2.6.3
+
+# Verification is possible at all — i.e. we can run the verifier. Kept as its own predicate so the
+# callers' fail-closed refusals read the same as they did when this was `command -v cosign`.
+cosign_available() {
+    command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
+}
+
+# Run cosign in a container, with the install dir mounted read-only at /w as its working dir.
+# ponytail: ONE mount, because every file cosign is ever handed lives under the install dir —
+# cosign.pub sits next to this script, and the bundle + .sig it verifies on a one-click upgrade go
+# under CONTROL_DIR, which is derived as "$PWD/data/control" and is not operator-settable. A caller
+# that ever needs a path outside $PWD must add its own mount rather than assume this one covers it.
+# HOME=/tmp: cosign caches TUF material under $HOME and prints a multi-line warning when it cannot
+# write there — noise on every verify, and the operator is not meant to see this run at all.
+# The image pull is quiet and happens once; without it docker streams pull progress mid-`up`.
+cosign_run() {
+    docker image inspect "$COSIGN_IMAGE" >/dev/null 2>&1 ||
+        docker pull -q "$COSIGN_IMAGE" >/dev/null 2>&1 ||
+        return 1
+    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp \
+        -v "$PWD:/w:ro" -w /w "$COSIGN_IMAGE" "$@"
+}
+
+# Translate a host path under the install dir into the path cosign_run's container sees. Both sides
+# are canonicalized, so a caller reaching the same file through a symlink (`current -> pithead-vX`)
+# still resolves. Fails — rather than emitting a path the mount does not cover — when the file is
+# outside the install dir, because every caller reports a cosign failure as a signature failure.
+cosign_container_path() { # <path>
+    local dir root
+    dir=$(cd -- "$(dirname -- "$1")" 2>/dev/null && pwd -P) || return 1
+    root=$(pwd -P) || return 1
+    case "$dir" in
+    # One arm for both depths: at the install root the strip leaves "", giving /w/<name>.
+    "$root" | "$root"/*) printf '/w%s/%s\n' "${dir#"$root"}" "$(basename -- "$1")" ;;
+    *) return 1 ;;
+    esac
+}
+
 # Cryptographic gate on a release pull (#376). Runs before both the upgrade pull and the
 # first-install pull (#452), so every first-party image the pull would fetch must carry a cosign
 # signature that verifies against the cosign.pub shipped next to this script. Key-based signing from
@@ -397,8 +451,9 @@ compose_pinned_digest() {
 #   source checkout                          -> skip: locally built images are unsigned by design
 #   no cosign.pub (an older/unsigned bundle) -> proceed with one loud warning (signing is opt-in per
 #                                               #461; the digest-pinned bundle is the protection)
-#   cosign.pub present, cosign missing       -> ABORT with an install pointer — an absent verifier
-#                                               must not silently disable verification
+#   cosign.pub present, docker missing       -> ABORT — an absent verifier must not silently
+#                                               disable verification (docker is a prerequisite and
+#                                               the very next step pulls images with it anyway)
 #   cosign.pub present, image not pinned     -> ABORT: with no digest there's nothing to bind the
 #                                               verification to the pulled bytes (the #451 window)
 #   any signature that fails to verify       -> ABORT naming the image; nothing pulled or restarted
@@ -408,8 +463,8 @@ verify_release_images() {
         warn "No cosign.pub next to pithead — the release images will NOT be signature-verified. Releases up to v1.3.x shipped no key; the first signed bundle brings it."
         return 0
     fi
-    command -v cosign >/dev/null 2>&1 ||
-        error "cosign.pub is present but the cosign binary is not installed — refusing an unverified pull. Install cosign (docs/dev/releasing.md § Verifying a release) and re-run '$0'."
+    cosign_available ||
+        error "cosign.pub is present but docker is not available to run the verifier — refusing an unverified pull. Install Docker (see the Prerequisites in the docs) and re-run '$0'."
     # The 5 first-party images, verified by the exact digest compose pins them to (#451/#461).
     local suffix repo sha image out
     for suffix in tor monero p2pool xmrig-proxy dashboard; do
@@ -420,7 +475,7 @@ verify_release_images() {
             error "cosign.pub is present but pithead-${suffix} is not digest-pinned in docker-compose.yml — cannot bind verification to the bytes compose pulls; refusing. A signed release bundle pins every first-party image by @sha256."
         fi
         image="${repo}@${sha}"
-        if ! out=$(cosign verify --key cosign.pub --private-infrastructure "$image" 2>&1); then
+        if ! out=$(cosign_run verify --key cosign.pub --private-infrastructure "$image" 2>&1); then
             # Strip control chars: cosign's stderr echoes registry-supplied bytes, and error()
             # prints via `echo -e`, so an attacker-controlled registry response could otherwise
             # inject ANSI escapes into the operator's terminal (#376 review).
@@ -455,7 +510,6 @@ stack_upgrade() {
     provision_node_onions # #103: as in apply — a node switched to local needs its onion first
     inject_service_configs
     generate_caddyfile
-    provision_control_runner # #33: converge the control-runner units on the current toggle
     log "Re-rendered generated config for the current release."
     migrate_compose_project
     # (Re)assert the Tor-only egress firewall BEFORE compose — same ordering as stack_up (#276), for
@@ -496,6 +550,17 @@ stack_upgrade() {
         fi
     fi
     update_current_symlink # #455: only a SUCCESSFUL upgrade moves the `current ->` pointer
+    # #33: converge the control-runner units on the current toggle — LAST, and deliberately after
+    # update_current_symlink. #1070: a fresh-dir one-click deploy runs this function from the NEW
+    # version dir while `current ->` still points at the old one, so provisioning it early (where it
+    # used to sit, before the image gate) pointed the units at a directory that had not become the
+    # install yet. Any abort in between — the image gate, a failed pull, a health-gate failure —
+    # then left the path unit watching a spool the running dashboard never writes to, silently
+    # killing the control channel and with it the one-click upgrade that would have fixed it. The
+    # units are host-global and name an absolute path, so the only safe moment to repoint them is
+    # after this dir IS `current`. A failure before here now leaves the old install's units intact
+    # and still serving. Do not move this back above the pull.
+    provision_control_runner
     log "Stack upgraded."
 }
 
@@ -810,10 +875,10 @@ doctor() {
         dr_info "Source checkout — images build locally and are not signature-verified (#376)."
     elif [ ! -f cosign.pub ]; then
         dr_warn "No cosign.pub next to pithead — image pulls are NOT signature-verified (#376). Release bundles ship the key from the first signed release."
-    elif command -v cosign >/dev/null 2>&1; then
-        dr_ok "cosign found — 'up' and 'upgrade' verify the release images against cosign.pub (#376/#452)."
+    elif cosign_available; then
+        dr_ok "'up' and 'upgrade' verify the release images against cosign.pub; the verifier runs as a container, nothing to install."
     else
-        dr_warn "cosign.pub is present but cosign is not installed — 'up'/'upgrade' refuse to pull until it is (#376). Install: docs/dev/releasing.md § Verifying a release."
+        dr_warn "cosign.pub is present but docker is not available to run the verifier — 'up'/'upgrade' refuse to pull until it is. Start the Docker daemon."
     fi
 
     # --- Docker daemon ---
@@ -5841,18 +5906,20 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         _upg_reject "this install builds from source — upgrade from the host with 'git pull' then './pithead upgrade'."
         return 0
     fi
-    # #376/#1023: cosign is a PRECONDITION of a one-click upgrade, not a consequence of already
+    # #376/#1023: the verifier is a PRECONDITION of a one-click upgrade, not a consequence of already
     # holding a key. Every release bundle ships cosign.pub (make_bundle copies the committed key
     # unconditionally), so the `pithead upgrade` this runner ends up calling will demand the
     # verifier at its image gate whatever the current install holds. Testing the LOCAL cosign.pub
     # instead — what this guard used to do — was blind to the one upgrade that needs it most: an
     # install cut before signing engaged moving to a signed release, which every fielded install
     # makes exactly once. That sailed past here and aborted inside the new CLI, after the download,
-    # the extraction, and a full config re-render. Checked with the source-checkout refusal above:
-    # both are "this install cannot take a one-click upgrade at all", and neither claims the
-    # throttle or dials out, so a refusal here costs the operator nothing.
-    if ! command -v cosign >/dev/null 2>&1; then
-        _upg_reject "cosign is not installed on the host — release bundles ship a signing key and every image is verified against it before it is pulled, so this upgrade would fail partway through. Install cosign (docs/dev/releasing.md § Verifying a release) and retry."
+    # the extraction, and a full config re-render. Since #1072 the verifier is a container, so this
+    # can only fail on a box whose docker is gone — which would also mean nothing is mining. Kept
+    # anyway: checked with the source-checkout refusal above, both are "this install cannot take a
+    # one-click upgrade at all", and neither claims the throttle or dials out, so a refusal here
+    # costs the operator nothing.
+    if ! cosign_available; then
+        _upg_reject "docker is not available to run the release verifier — every image is verified against the shipped signing key before it is pulled, so this upgrade would fail partway through. Check the Docker daemon and retry."
         return 0
     fi
     # Throttle: one attempt per 10 minutes, checked before any network dial.
@@ -5926,7 +5993,18 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
             _upg_fail "the $tag release carries no bundle signature (pithead.tar.gz.sig) — refusing to install it unverified (#376); the stack keeps running v$PITHEAD_VERSION."
             return 0
         fi
-        if ! cosign verify-blob --key cosign.pub --signature "$sig" --insecure-ignore-tlog=true "$bundle" >/dev/null 2>&1; then
+        # The verifier is a container that sees the install dir at /w (#1072), so it needs the two
+        # staged files named as IT sees them. Translated with a guard rather than a blind prefix
+        # strip: a path that fell outside the mount would make cosign fail to open the file, and
+        # this call reports any failure as "signature FAILED" — a mount bug must not be able to
+        # masquerade as a tampered download and burn a legitimate release.
+        local cbundle csig
+        if ! cbundle=$(cosign_container_path "$bundle") || ! csig=$(cosign_container_path "$sig"); then
+            rm -f "$bundle" "$sig"
+            _upg_fail "the staged $tag bundle landed outside the install dir, where the release verifier cannot read it — refusing to install it unverified. The stack keeps running v$PITHEAD_VERSION."
+            return 0
+        fi
+        if ! cosign_run verify-blob --key cosign.pub --signature "$csig" --insecure-ignore-tlog=true "$cbundle" >/dev/null 2>&1; then
             rm -f "$bundle" "$sig"
             _upg_fail "bundle signature verification FAILED for $tag — the download does not match the release key; refusing to extract it (#376). The stack keeps running v$PITHEAD_VERSION."
             return 0

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -839,18 +839,95 @@ up_sig_order=$(
 assert_eq "first-install up verifies release-image signatures before 'compose up' (#452)" \
     "$(printf '%s\n' "$up_sig_order" | grep -xE 'verify|compose' | tr '\n' ',')" "verify,compose,"
 
+echo "== black-box: a failed upgrade never repoints the control-runner units (#1070) =="
+# The units are host-global and bake an absolute path. On a one-click deploy stack_upgrade runs from
+# the NEW version dir while `current ->` still names the old one, so provisioning them before the
+# release is live points them at a dir that may never become the install. That is what bricked
+# pithead-prod: the image gate aborted, `current` never moved, and the path unit was left watching a
+# spool the running dashboard does not write to — silently killing the control channel, and with it
+# the one-click upgrade that would have fixed it. Provisioning must therefore come last, after
+# update_current_symlink. Both directions are asserted: the ordering on success, and — the one that
+# actually bites — that an abort at the gate repoints nothing at all.
+upg_step_order() { # <verify_release_images body> — the step markers stack_upgrade reaches, in order
+    (
+        cd "$SANDBOX" || exit
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        require_env() { :; }
+        ensure_onion_password() { :; }
+        parse_and_validate_config() { :; }
+        load_preserved_state() { :; }
+        ensure_directories() { :; }
+        resolve_dashboard_host() { :; }
+        render_env() { [ -n "${1:-}" ] && : >"$1"; }
+        provision_node_onions() { :; }
+        inject_service_configs() { :; }
+        generate_caddyfile() { :; }
+        migrate_compose_project() { :; }
+        apply_tor_egress_firewall() { :; }
+        migrate_dashboard_data() { :; }
+        is_source_checkout() { return 1; }
+        log() { :; }
+        eval "verify_release_images() { $1 }"
+        compose_up_checked() { echo compose; }
+        update_current_symlink() { echo symlink; }
+        provision_control_runner() { echo provision; }
+        stack_upgrade
+    ) | grep -xE 'verify|compose|symlink|provision' | tr '\n' ','
+}
+assert_eq "successful upgrade provisions the units only after 'current ->' moves (#1070)" \
+    "$(upg_step_order 'echo verify;')" "verify,compose,symlink,provision,"
+# The red test for #1070: abort at the image gate, exactly as a host without a runnable verifier
+# does. If provisioning ever migrates back above the pull, `provision` reappears here and this fails.
+assert_eq "an upgrade that aborts at the gate repoints no units and moves no symlink (#1070)" \
+    "$(upg_step_order 'echo verify; error "gate refused";')" "verify,"
+
 echo "== black-box: verify_release_images fail-closed gate (#376) =="
-# The verification decision itself, against a fake cosign on a PINNED PATH ($VRI/bin:/usr/bin:/bin
-# — coreutils stay, any real cosign install on the host disappears, so the host can never decide
-# the outcome). A release install is a dir without build/dashboard/Dockerfile.
-VRI="$SANDBOX/verify376"
-mkdir -p "$VRI/bin"
-cat >"$VRI/bin/cosign" <<'EOF'
+# The verification decision itself, against a fake docker on a PINNED PATH ($VRI/bin:/usr/bin:/bin
+# — coreutils stay, so the host can never decide the outcome). Since #1072 the verifier is a
+# container, so the stub is `docker`, not `cosign`: it answers the availability probe, pretends the
+# pinned image is already present, and logs the cosign argv that follows the image ref — which keeps
+# every assertion below reading exactly as it did when cosign was a host binary. A release install
+# is a dir without build/dashboard/Dockerfile.
+write_fake_docker() { # <bin-dir> — the containerized verifier's stand-in (#1072)
+    mkdir -p "$1"
+    cat >"$1/docker" <<'EOF'
 #!/usr/bin/env bash
-echo "[cosign] $*" >>"${COSIGN_LOG:-/dev/null}"
-exit "${COSIGN_RC:-0}"
+case "$1" in
+info | pull) exit 0 ;;
+image) exit 0 ;; # `image inspect` -> pinned verifier already local, nothing pulled
+run)
+    shift
+    # Drop the run flags up to and including the pinned verifier image; what remains is the cosign
+    # argv the caller actually asked for.
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        *sigstore/cosign*)
+            shift
+            break
+            ;;
+        *) shift ;;
+        esac
+    done
+    echo "[cosign] $*" >>"${COSIGN_LOG:-/dev/null}"
+    exit "${COSIGN_RC:-0}"
+    ;;
+esac
+exit 0
 EOF
-chmod +x "$VRI/bin/cosign"
+    chmod +x "$1/docker"
+}
+write_unreachable_docker() { # <bin-dir> — docker present, daemon down: the "cannot verify" branch.
+    # Probing the daemon rather than unsetting PATH keeps this deterministic on hosts that ship
+    # /usr/bin/docker, which the pinned PATHs below deliberately still expose.
+    mkdir -p "$1"
+    printf '#!/usr/bin/env bash\n[ "$1" = "info" ] && exit 1\nexit 0\n' >"$1/docker"
+    chmod +x "$1/docker"
+}
+VRI="$SANDBOX/verify376"
+write_fake_docker "$VRI/bin"
+write_unreachable_docker "$VRI/nodocker"
 
 # A deterministic 64-hex digest per image, and a digest-pinned compose (#461) so verify has the same
 # @sha256 bytes to check that a release install's compose would pull (#451). TOR_DG is what the tor
@@ -870,16 +947,16 @@ write_pinned_compose "$VRI"
 
 # No cosign.pub (an install older than the first signed release): documented fallback — proceed,
 # but say loudly that nothing was verified.
-out="$(PATH="/usr/bin:/bin" run_sourced "$VRI" verify_release_images 2>&1)"
+out="$(PATH="$VRI/bin:/usr/bin:/bin" run_sourced "$VRI" verify_release_images 2>&1)"
 assert_rc "no pubkey -> pull proceeds (documented fallback)" "$?" "0"
 assert_contains "no pubkey -> loud NOT-verified warning" "$out" "NOT be signature-verified"
 
-# cosign.pub present but no cosign binary anywhere on PATH: FAIL CLOSED with an install pointer —
-# a missing verifier must not silently disable verification.
+# cosign.pub present but the verifier cannot run (docker daemon unreachable): FAIL CLOSED — an
+# unavailable verifier must not silently disable verification.
 printf 'fake release public key' >"$VRI/cosign.pub"
-out="$(PATH="/usr/bin:/bin" run_sourced "$VRI" verify_release_images 2>&1)"
-assert_rc "pubkey without cosign -> pull aborts" "$?" "1"
-assert_contains "cosign-missing abort points at the install doc" "$out" "not installed"
+out="$(PATH="$VRI/nodocker:/usr/bin:/bin" run_sourced "$VRI" verify_release_images 2>&1)"
+assert_rc "pubkey without a runnable verifier -> pull aborts" "$?" "1"
+assert_contains "verifier-missing abort names docker, not a host cosign" "$out" "docker is not available"
 
 # Valid signatures (fake cosign exits 0): all 5 images verified with the committed key, no Rekor
 # (--private-infrastructure), against the EXACT @sha256 digest compose pins and pulls (#451 — bound
@@ -939,6 +1016,31 @@ out="$(PATH="$VRI/bin:/usr/bin:/bin" COSIGN_RC=1 COSIGN_LOG="$VRI/cosign.log" ru
 assert_rc "source checkout -> verification skipped" "$?" "0"
 assert_eq "source checkout -> cosign never invoked" "$(cat "$VRI/cosign.log")" ""
 rm -rf "$VRI/build"
+
+echo "== unit: cosign_container_path maps host paths into the verifier's mount (#1072) =="
+# The verifier container sees the install dir at /w, so every file argument has to be renamed into
+# that mount. The refusal case is the one that matters: both callers report a cosign failure as a
+# SIGNATURE failure, so a path this function got wrong would read as a tampered download and burn a
+# genuine release. It must fail rather than emit a path the mount does not cover.
+CCP="$SANDBOX/ccp"
+mkdir -p "$CCP/data/control/staged"
+touch "$CCP/cosign.pub" "$CCP/data/control/staged/.abc.tar.gz"
+assert_eq "file beside pithead -> /w/<name>" \
+    "$(run_sourced "$CCP" cosign_container_path "$CCP/cosign.pub")" "/w/cosign.pub"
+assert_eq "staged bundle -> /w/<relative dirs>/<name>" \
+    "$(run_sourced "$CCP" cosign_container_path "$CCP/data/control/staged/.abc.tar.gz")" \
+    "/w/data/control/staged/.abc.tar.gz"
+# The `current -> pithead-vX.Y.Z` layout: CONTROL_DIR in .env can name the same file through the
+# symlink while the runner's cwd is the physical dir. Canonicalizing both sides is what makes these
+# agree — a plain "${path#$PWD/}" prefix strip silently does not, and would fail closed on prod.
+ln -sfn "$CCP" "$SANDBOX/ccp-current"
+assert_eq "same file reached via the current symlink still resolves" \
+    "$(run_sourced "$CCP" cosign_container_path "$SANDBOX/ccp-current/data/control/staged/.abc.tar.gz")" \
+    "/w/data/control/staged/.abc.tar.gz"
+run_sourced "$CCP" cosign_container_path "$SANDBOX/outside.txt" >/dev/null 2>&1
+assert_rc "a path outside the install dir is refused, not guessed at" "$?" "1"
+run_sourced "$CCP" cosign_container_path "/etc/hosts" >/dev/null 2>&1
+assert_rc "an absolute path elsewhere on the box is refused" "$?" "1"
 
 # apply had the same after-compose ordering bug as #272's stack_upgrade — fixed alongside #291. Take
 # the no-change-but-incomplete-marker retry path so apply recreates containers without the interactive
@@ -5935,11 +6037,10 @@ make_stubs "$UPG/bin"
 # tar; on a Mac with gnu-tar installed, route this block's tar there too so the bug reproduces.
 command -v gtar >/dev/null 2>&1 && ln -sf "$(command -v gtar)" "$UPG/bin/tar"
 # Every release bundle ships cosign.pub, so the runner requires the verifier before it downloads
-# anything (#1023) — the fixture carries one so the paths that are supposed to proceed do not
-# depend on whether the host happens to have cosign installed. It stays inert: this install has no
-# cosign.pub, so no signature is ever fetched and nothing here invokes it.
-printf '#!/usr/bin/env bash\nexit 0\n' >"$UPG/bin/cosign"
-chmod +x "$UPG/bin/cosign"
+# anything (#1023) — the fixture carries a runnable one so the paths that are supposed to proceed do
+# not depend on the host. Since #1072 that means a fake docker, not a fake cosign. It stays inert
+# here: this install has no cosign.pub, so no signature is ever fetched and nothing invokes it.
+write_fake_docker "$UPG/bin"
 printf '1.3.1' >"$UPG/VERSION"
 printf '{}' >"$UPG/config.json" # #637: the in-place path snapshots config.json before extracting
 # #544/#555: a real release install carries non-empty build/* config-template mounts (see the
@@ -6046,17 +6147,17 @@ seed_upgrade_env true
 # Same pinned PATH as its key-holding twin below, so a host cosign can't decide the test.
 reset_upgrade_state
 ln -sf "$(command -v jq)" "$UPG/bin/jq" # PATH is pinned below, which may not carry jq
-mv "$UPG/bin/cosign" "$UPG/cosign.hidden"
+write_unreachable_docker "$UPG/nodocker"
+ln -sf "$(command -v jq)" "$UPG/nodocker/jq"
 upgrade_intent "$UUPG" "v9.9.9"
-(cd "$UPG" && PATH="$UPG/bin:/usr/bin:/bin" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+(cd "$UPG" && PATH="$UPG/nodocker:/usr/bin:/bin" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
     CURL_BUNDLE="$UPGB/bundle.tar.gz" ./pithead control-run-pending >/dev/null 2>&1)
-mv "$UPG/cosign.hidden" "$UPG/bin/cosign"
 rm -f "$UPG/bin/jq"
-assert_eq "upgrade without cosign is rejected on a key-less install" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
-assert_contains "cosign-missing refusal names the verifier" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "cosign is not installed"
-assert_eq "cosign-missing refusal dials nothing" "$(cat "$UPG/curl.log" 2>/dev/null)" ""
-assert_eq "cosign-missing refusal extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
-assert_eq "cosign-missing refusal claims no throttle" "$(ls "$UPG/data/control/staged/.upgrade-stamp" 2>/dev/null)" ""
+assert_eq "upgrade without a runnable verifier is rejected on a key-less install" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "verifier-missing refusal names docker" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "docker is not available"
+assert_eq "verifier-missing refusal dials nothing" "$(cat "$UPG/curl.log" 2>/dev/null)" ""
+assert_eq "verifier-missing refusal extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
+assert_eq "verifier-missing refusal claims no throttle" "$(ls "$UPG/data/control/staged/.upgrade-stamp" 2>/dev/null)" ""
 
 # Malformed / missing version: refused BEFORE any network dial (curl must never run).
 reset_upgrade_state
@@ -6406,14 +6507,9 @@ seed_v629_env
 
 echo "== black-box: control upgrade verifies the bundle signature (#376) =="
 # Give the install a trust anchor (cosign.pub next to pithead — what a signed release bundle
-# ships) plus a fake cosign; the runner must fetch pithead.tar.gz.sig over the same Tor SOCKS and
-# verify the download against the EXISTING key before a byte of it is extracted.
-cat >"$UPG/bin/cosign" <<'EOF'
-#!/usr/bin/env bash
-echo "[cosign] $*" >>"${COSIGN_LOG:-/dev/null}"
-exit "${COSIGN_RC:-0}"
-EOF
-chmod +x "$UPG/bin/cosign"
+# ships) plus a runnable verifier; the runner must fetch pithead.tar.gz.sig over the same Tor SOCKS
+# and verify the download against the EXISTING key before a byte of it is extracted.
+write_fake_docker "$UPG/bin"
 printf 'fake release public key' >"$UPG/cosign.pub"
 printf 'fake signature' >"$UPGB/bundle.sig"
 usign() { # <extra env VAR=val...> — one signed-mode runner invocation
@@ -6452,19 +6548,19 @@ assert_contains "missing-signature failure names the asset" "$(jq -r '.error' "$
 assert_eq "missing signature extracts nothing" "$(cat "$UPG/VERSION")" "1.3.1"
 
 # The other half of the same precondition (#1023): an install that already HOLDS the key is
-# refused for the same reason a key-less one is — no cosign, no upgrade — BEFORE the download, with
-# an install pointer. PATH is pinned to the stub bin + /usr/bin:/bin so a real host cosign can't
+# refused for the same reason a key-less one is — no runnable verifier, no upgrade — BEFORE the
+# download. PATH is pinned to the daemon-down stub + /usr/bin:/bin so a working host docker can't
 # leak in; jq rides along as a symlink since the pinned PATH may not carry it.
 reset_upgrade_state
-ln -sf "$(command -v jq)" "$UPG/bin/jq"
-rm -f "$UPG/bin/cosign"
+write_unreachable_docker "$UPG/nodocker"
+ln -sf "$(command -v jq)" "$UPG/nodocker/jq"
 upgrade_intent "$UUPG" "v9.9.9"
-(cd "$UPG" && PATH="$UPG/bin:/usr/bin:/bin" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
+(cd "$UPG" && PATH="$UPG/nodocker:/usr/bin:/bin" CURL_LOG="$UPG/curl.log" CURL_API_RESPONSE="$UPGB/api.json" \
     CURL_BUNDLE="$UPGB/bundle.tar.gz" CURL_SIG="$UPGB/bundle.sig" ./pithead control-run-pending >/dev/null 2>&1)
-assert_eq "pubkey without cosign rejects the upgrade" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
-assert_contains "cosign-missing rejection points at the install doc" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "not installed"
-assert_eq "cosign-missing refusal downloads no bundle" "$(grep -c 'releases/download' "$UPG/curl.log" || true)" "0"
-rm -f "$UPG/cosign.pub" "$UPG/bin/jq"
+assert_eq "pubkey without a runnable verifier rejects the upgrade" "$(jq -r '.status' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "rejected"
+assert_contains "verifier-missing rejection names docker" "$(jq -r '.error' "$UPGRESULTS/$UUPG.json" 2>/dev/null)" "docker is not available"
+assert_eq "verifier-missing refusal downloads no bundle" "$(grep -c 'releases/download' "$UPG/curl.log" || true)" "0"
+rm -f "$UPG/cosign.pub" "$UPG/nodocker/jq"
 reset_upgrade_state
 
 # The runner refuses to run at all when the channel is off (fail-closed).


### PR DESCRIPTION
Closes #1070, closes #1071, closes #1072.

pithead-coordinator's Upgrade button was dead. Diagnosing it turned up three defects that share a cause: signing was wired as a host prerequisite nobody was told about, and the failures that followed were neither contained nor honestly reported. Each is fixed here, and each is a reason the button was not the "one click" it is documented to be.

## The verifier is a container now (#1072)

`cosign` has no Ubuntu apt package, so requiring it on the host made verification a hidden dependency. The prerequisites table lists Docker, Compose, `jq`, `openssl`; `setup`'s dependency check covers exactly those four; and the string "cosign" appeared nowhere in `README.md` or `getting-started.md`. But `stack_up` gates on it too, so **the documented Quick Start dead-ended at first start** on any clean host — after the wizard had already collected the operator's wallet addresses. Every install cut before signing engaged hit the same wall on its first signed upgrade, which is what happened to prod.

Docker is already a hard prerequisite and both callers pull images with it moments later, so `cosign_run` invokes a digest-pinned cosign image with the install dir mounted read-only. Operators install nothing and the prerequisites do not change.

The `@sha256` pin is load-bearing rather than hygiene: pulling a verifier in order to verify things is itself an unverified pull, and the digest is the only thing closing that. On a mutable tag a hostile registry could serve a "cosign" that exits 0 on everything and silently switch the whole gate off. There is a comment saying so, because it would otherwise read as ordinary pinning.

`cosign_container_path` maps host paths into the mount and **refuses rather than guesses** when a path falls outside it. Both callers report a cosign failure as a *signature* failure, so a mount bug must not be able to masquerade as a tampered download and burn a genuine release. It canonicalizes both sides, so a file reached through `current -> pithead-vX.Y.Z` still resolves — a plain prefix strip does not, and would have failed closed on exactly the layout prod runs.

`release.sh` is untouched. The release box signs, so it keeps its pinned host cosign.

## A failed upgrade no longer strands the control units (#1070)

This is the one that bricked prod. The units are host-global and bake an absolute path, and a fresh-dir deploy runs `stack_upgrade` from the **new** version dir while `current ->` still names the old one. Provisioning them before the release was live pointed them at a directory that might never become the install — so when the image gate aborted, the path unit was left watching a spool the running dashboard never writes to. The control channel went silently dead, taking with it the one-click upgrade that would have repaired it.

They are now provisioned after `update_current_symlink`. A failure anywhere earlier leaves the old install's units intact and still serving. `setup` and `apply` are unaffected — they provision for the directory they already run in.

## A running upgrade is no longer reported as a failed one (#1071)

The poll ceiling was 900s. The runner is allowed 60s on the release API, 900s on the bundle over Tor, and 120s on the signature — 1080s **before the image pull even starts**. So a healthy upgrade on a slow circuit hit the ceiling with the slowest step still ahead of it, and the message blamed a control channel that was working, inviting a re-click that met the 10-minute throttle instead.

No constant can be provably enough while the pull is unbounded, so the ceiling now clears the runner's own budget and the message no longer claims to know the outcome — it says the host is still working and to reload.

## Testing

`make lint` and `make test` both exit 0: 1724 stack, 1721 dashboard, 201 selftest, 23 fakes.

New coverage at the unit tier:

- `cosign_container_path` — root and nested paths, the `current ->` symlink case, and two refusal cases.
- **A red test for #1070**: an upgrade aborting at the image gate must repoint no units and move no symlink. If provisioning ever migrates back above the pull, it fails.
- The existing cosign stubs became `docker` stubs, so the assertions still read as they did when cosign was a host binary.

Verified end to end before any of this was written: the containerized verifier checking a **real published v1.18.1 image** against the committed `cosign.pub`.

## Reviewer notes

- CI will be red on the dashboard Trivy job — that is #1073, unrelated and affecting every branch. Trivy appears only in `ci.yml`; the release gate does not run it.
- Overlaps #1027, which rewrites the same three cosign operator strings. Mine carry no bare `docs/` paths, so they already satisfy that PR's new lint rule.
- Supersedes the host-binary guard added by #1025. Under a containerized verifier `command -v cosign` is the wrong precondition — it would reject every one-click upgrade. The replacement probes the Docker daemon, still fails closed, and stays ahead of the throttle claim and the GitHub dial so a refusal still costs zero egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
