### PR TITLE
fix(cli): doctor names control units that point at another install

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -981,6 +981,15 @@ CLI upgrade. The result names the restore point ([#637](https://github.com/p2poo
 on the versioned layout, the previous `pithead-vX.Y.Z` dir; in place, the pre-upgrade
 `config.json`/`.env` copies.
 
+**If the button does nothing at all — no result, no error, no modal — the control units are
+pointing at a different directory than the dashboard writes to.** The dashboard drops each request
+into its own install's spool and a systemd path unit runs the host-side runner when a file lands
+there. The unit names an absolute path and is shared box-wide, so an upgrade that aborted partway
+can leave it watching a tree that is no longer the install. Nothing reports the mismatch: requests
+queue up unread, and the config editor and the upgrade button both sit there. `./pithead doctor`
+names it under **Dashboard control channel**, printing the directory the units point at next to the
+one you ran it from, and `./pithead apply` from the install directory repoints them.
+
 ## Tips
 
 - **First visit certificate warning.** With `dashboard.secure: true` (the default), Caddy uses a

--- a/pithead
+++ b/pithead
@@ -907,6 +907,8 @@ doctor() {
         fi
     fi
 
+    check_control_units
+
     # --- CPU: AVX2 (performance only) ---
     echo ""
     echo "CPU:"
@@ -1909,6 +1911,40 @@ host_public_ips() {
 # warn only when the host has a public IP AND stratum listens on all interfaces (the default bind).
 # Home/NAT hosts (no public IP on an interface) and hosts that narrowed p2pool.stratum_bind stay
 # quiet in setup. $1 = "setup" (emit via warn, only on exposure) or "doctor" (emit OK/WARN/skip).
+# Doctor check (#33): do the installed control units point at THIS install?
+# The dashboard writes control requests into its own install's spool and a systemd path unit
+# watches that spool. The unit names an absolute path and is box-global, so it can end up naming a
+# different directory than the dashboard writes to — and when it does, nothing anywhere reports it:
+# requests pile up unread, and the config editor and one-click upgrade simply never complete. A
+# failed upgrade was enough to cause it in the field (#1070 fixed the ordering that did it; this
+# finds a box already stranded, which that fix by definition cannot reach — the channel it would
+# arrive through is the broken one).
+check_control_units() {
+    [ "$OS_TYPE" == "Linux" ] || return 0
+    command -v systemctl >/dev/null 2>&1 || return 0
+    echo ""
+    echo "Dashboard control channel:"
+    local unit_dir owner here spool
+    unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}"
+    if [ "$(normalize_bool "$(env_get DASHBOARD_CONTROL_ENABLED)")" != "true" ]; then
+        dr_info "Disabled for this install — the dashboard cannot apply config changes or upgrade."
+        return 0
+    fi
+    owner=$(control_units_owner_dir)
+    here=$(pwd -P)
+    spool=$(env_get CONTROL_DIR)
+    if [ -z "$owner" ]; then
+        dr_fail "The control channel is enabled but no runner units are installed — the dashboard's config changes and one-click upgrades will never run, with no error shown. Fix: run './pithead apply' from this directory."
+    elif [ "$owner" != "$here" ]; then
+        dr_fail "The control runner units point at $owner, but this install is $here — the dashboard writes its requests here and nothing reads them, so config changes and one-click upgrades silently never run. Fix: run './pithead apply' from this directory."
+    elif [ -n "$spool" ] &&
+        ! grep -qsF "PathExistsGlob=$spool/requests/*.json" "$unit_dir/pithead-control.path"; then
+        dr_fail "The control runner watches a different spool than this install writes to ($spool) — requests are never picked up, with no error shown. Fix: run './pithead apply' from this directory."
+    else
+        dr_ok "Control runner units target this install."
+    fi
+}
+
 check_stratum_exposure() {
     local mode="$1" bind pub msg port
     bind="${STRATUM_BIND:-}"
@@ -6671,6 +6707,25 @@ control_run_pending() {
     log "Processed $n control request(s)."
 }
 
+# Physical directory the installed control units name, or "" when there is no service unit or its
+# ExecStart is unparseable. One checkout has two spellings — the `current` symlink and the versioned
+# dir it points at (production units carry the versioned spelling) — so this resolves to a PHYSICAL
+# path; comparing the literal string would call our own unit foreign. A stranded unit usually names
+# a directory that no longer exists, so resolve the deepest existing ancestor and keep the rest
+# verbatim: the caller still gets a comparable, printable path instead of an empty answer.
+control_units_owner_dir() {
+    local unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}" owner_dir dir tail
+    owner_dir=$(sed -n 's|^ExecStart=\(/.*\)/pithead control-run-pending$|\1|p' \
+        "$unit_dir/pithead-control.service" 2>/dev/null | head -n 1)
+    [ -n "$owner_dir" ] || return 0
+    dir="$owner_dir" tail=""
+    while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -d "$dir" ]; do
+        tail="/$(basename "$dir")$tail"
+        dir=$(dirname "$dir")
+    done
+    printf '%s' "$(cd "$dir" 2>/dev/null && pwd -P)$tail"
+}
+
 # Install (or remove) the systemd trigger for the runner (#33): a path unit that fires
 # `pithead control-run-pending` whenever a request file lands in the spool. Root, because `apply`
 # needs iptables/chown; the service is a FIXED ExecStart with no parameter from the container, so
@@ -6693,16 +6748,9 @@ provision_control_runner() {
             # it. If the unit's dir is gone, resolve the deepest existing ancestor and keep the
             # rest verbatim; an unparseable ExecStart is foreign (fail safe, leave it alone).
             if [ -e "$unit_dir/pithead-control.service" ]; then
-                local owner_dir dir tail
-                owner_dir=$(sed -n 's|^ExecStart=\(/.*\)/pithead control-run-pending$|\1|p' \
-                    "$unit_dir/pithead-control.service" | head -n 1)
-                dir="$owner_dir" tail=""
-                while [ -n "$dir" ] && [ "$dir" != "/" ] && [ ! -d "$dir" ]; do
-                    tail="/$(basename "$dir")$tail"
-                    dir=$(dirname "$dir")
-                done
-                if [ -z "$owner_dir" ] ||
-                    [ "$(cd "$dir" 2>/dev/null && pwd -P)$tail" != "$(pwd -P)" ]; then
+                local owner_dir
+                owner_dir=$(control_units_owner_dir)
+                if [ -z "$owner_dir" ] || [ "$owner_dir" != "$(pwd -P)" ]; then
                     log "Leaving the dashboard control runner units alone — they belong to another checkout."
                     return 0
                 fi

--- a/pithead
+++ b/pithead
@@ -1963,6 +1963,20 @@ check_control_units() {
     owner=$(control_units_owner_dir)
     here=$(pwd -P)
     spool=$(env_get CONTROL_DIR)
+    # A versioned dir that `current` no longer names is a superseded rollback copy, not a
+    # stranded install: the units SHOULD name the live dir, and the dashboard writes there, not
+    # here. Verdicts about the control channel belong to the live install, so say what this dir
+    # is and stop. Same pattern update_current_symlink uses to recognise the layout (#455).
+    local _name _parent _live
+    _name=$(basename "$here")
+    _parent=$(dirname "$here")
+    if [[ "$_name" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -L "$_parent/current" ]; then
+        _live=$(cd "$_parent/current" 2>/dev/null && pwd -P)
+        if [ -n "$_live" ] && [ "$_live" != "$here" ]; then
+            dr_info "This is not the live install — '$_parent/current' points at $_live. Run doctor there to check its control channel."
+            return 0
+        fi
+    fi
     if [ -z "$owner" ]; then
         dr_fail "The control channel is enabled but no runner units are installed — the dashboard's config changes and one-click upgrades will never run, with no error shown. Fix: run './pithead apply' from this directory."
     elif [ "$owner" != "$here" ]; then
@@ -5374,6 +5388,12 @@ apply() {
     else
         rm -f "$newenv"
         if [ "$incomplete" -eq 0 ]; then
+            # #33: converge the control-runner units BEFORE returning. A box whose units point at
+            # a dead install has an unchanged config by definition — the fault is in the unit
+            # files, not config.json — so returning here first made `apply` the one thing that
+            # could not repair it, while doctor was telling the operator to run exactly that.
+            # Idempotent and sudo-free when the units already match.
+            provision_control_runner
             log "No configuration changes detected. Nothing to apply."
             return 0
         fi

--- a/pithead
+++ b/pithead
@@ -1911,6 +1911,36 @@ host_public_ips() {
 # warn only when the host has a public IP AND stratum listens on all interfaces (the default bind).
 # Home/NAT hosts (no public IP on an interface) and hosts that narrowed p2pool.stratum_bind stay
 # quiet in setup. $1 = "setup" (emit via warn, only on exposure) or "doctor" (emit OK/WARN/skip).
+check_stratum_exposure() {
+    local mode="$1" bind pub msg port
+    bind="${STRATUM_BIND:-}"
+    if [ -z "$bind" ] && [ -f "${ENV_FILE:-.env}" ]; then bind="$(env_get STRATUM_BIND 2>/dev/null || true)"; fi
+    [ -n "$bind" ] || bind="0.0.0.0"
+    port=$(stratum_port_effective)
+
+    if ! command -v ip >/dev/null 2>&1; then
+        [ "$mode" = doctor ] && dr_info "Skipped public-IP exposure check (no 'ip' command; Linux-only)."
+        return 0
+    fi
+    case "$bind" in
+    0.0.0.0 | "") ;; # all interfaces — the exposed case
+    *)
+        [ "$mode" = doctor ] && dr_ok "Stratum :$port bound to $bind (not all interfaces) — not publicly exposed."
+        return 0
+        ;;
+    esac
+
+    pub="$(host_public_ips)"
+    pub="${pub//$'\n'/, }"
+    if [ -n "$pub" ]; then
+        msg="This host appears to have a public IP ($pub). The stratum port $port is unauthenticated by default and cleartext — firewall it to your LAN, set p2pool.stratum_bind to a LAN IP / 127.0.0.1, and/or require a p2pool.stratum_password. See docs/workers.md#firewall."
+        if [ "$mode" = doctor ]; then dr_warn "$msg"; else warn "$msg"; fi
+    else
+        [ "$mode" = doctor ] && dr_ok "No public IP on host interfaces — stratum :$port isn't directly internet-exposed."
+    fi
+    return 0
+}
+
 # Doctor check (#33): do the installed control units point at THIS install?
 # The dashboard writes control requests into its own install's spool and a systemd path unit
 # watches that spool. The unit names an absolute path and is box-global, so it can end up naming a
@@ -1943,36 +1973,6 @@ check_control_units() {
     else
         dr_ok "Control runner units target this install."
     fi
-}
-
-check_stratum_exposure() {
-    local mode="$1" bind pub msg port
-    bind="${STRATUM_BIND:-}"
-    if [ -z "$bind" ] && [ -f "${ENV_FILE:-.env}" ]; then bind="$(env_get STRATUM_BIND 2>/dev/null || true)"; fi
-    [ -n "$bind" ] || bind="0.0.0.0"
-    port=$(stratum_port_effective)
-
-    if ! command -v ip >/dev/null 2>&1; then
-        [ "$mode" = doctor ] && dr_info "Skipped public-IP exposure check (no 'ip' command; Linux-only)."
-        return 0
-    fi
-    case "$bind" in
-    0.0.0.0 | "") ;; # all interfaces — the exposed case
-    *)
-        [ "$mode" = doctor ] && dr_ok "Stratum :$port bound to $bind (not all interfaces) — not publicly exposed."
-        return 0
-        ;;
-    esac
-
-    pub="$(host_public_ips)"
-    pub="${pub//$'\n'/, }"
-    if [ -n "$pub" ]; then
-        msg="This host appears to have a public IP ($pub). The stratum port $port is unauthenticated by default and cleartext — firewall it to your LAN, set p2pool.stratum_bind to a LAN IP / 127.0.0.1, and/or require a p2pool.stratum_password. See docs/workers.md#firewall."
-        if [ "$mode" = doctor ]; then dr_warn "$msg"; else warn "$msg"; fi
-    else
-        [ "$mode" = doctor ] && dr_ok "No public IP on host interfaces — stratum :$port isn't directly internet-exposed."
-    fi
-    return 0
 }
 
 # True if the named container is currently running. State only, no sudo — safe for doctor.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7672,6 +7672,85 @@ assert_contains "own unit under its versioned spelling, run via the current syml
     "$(pcr_run "$PCR/versions/pithead-v1.9.3" "$PCR/current")" "sudo:rm -f"
 unset PCR pcr_run
 
+echo "== unit: doctor sees control units that do not point at this install (#33) =="
+# The failure this guards is silent by construction: the dashboard writes control requests into
+# its own install's spool, a box-global systemd unit watches some absolute path, and when the two
+# disagree nothing reports it — the config editor and one-click upgrade just never complete.
+# Seen in the field on a production box: a failed upgrade repointed the units at the half-installed
+# tree, and two operator upgrade requests sat unread for a day with no error on either side.
+#
+# Mutation proof (each assertion below fails if the guard regresses):
+#   - drop the `[ "$owner" != "$here" ]` arm      -> "units point elsewhere" goes green->red
+#   - flip that `!=` to `=`                        -> mismatch AND aligned assertions both flip
+#   - drop the spool comparison arm                -> "watches a different spool" goes red
+#   - drop the `-z "$owner"` arm                   -> "no units installed" loses its message
+#   - drop the enabled gate's `return 0`           -> "disabled" assertion sees a FAIL
+CCU="$SANDBOX/ccu"
+mkdir -p "$CCU/units" "$CCU/bin" "$CCU/install" "$CCU/other"
+# uname/systemctl stubs: the check gates on Linux + systemctl, so dev Macs run the branch too.
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$CCU/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$CCU/bin/systemctl"
+chmod +x "$CCU/bin/uname" "$CCU/bin/systemctl"
+
+ccu_run() { # <owner-dir|-> <spool-in-path-unit|-> <enabled> <run-dir> [control-dir-in-env] -> output
+    rm -f "$CCU/units/pithead-control.service" "$CCU/units/pithead-control.path"
+    [ "$1" != "-" ] && printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$CCU/units/pithead-control.service"
+    [ "$2" != "-" ] && printf '[Path]\nPathExistsGlob=%s/requests/*.json\n' "$2" >"$CCU/units/pithead-control.path"
+    printf 'DASHBOARD_CONTROL_ENABLED=%s\nCONTROL_DIR=%s\n' "$3" "${5:-$4/data/control}" >"$4/.env"
+    (
+        cd "$4" || exit
+        PATH="$CCU/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        PITHEAD_UNIT_DIR="$CCU/units" check_control_units 2>&1
+    )
+}
+
+# The production shape: units name a tree that is not this install. Must FAIL, and must name both
+# paths — an operator who cannot see which directory is wrong cannot fix it.
+out="$(ccu_run "$CCU/other" "$CCU/install/data/control" true "$CCU/install")"
+assert_contains "units point elsewhere -> FAIL" "$out" "FAIL"
+assert_contains "units point elsewhere -> names the unit's directory" "$out" "$CCU/other"
+assert_contains "units point elsewhere -> names this install" "$out" "$CCU/install"
+
+# Aligned: same install, same spool. Must be OK and must NOT fail.
+out="$(ccu_run "$CCU/install" "$CCU/install/data/control" true "$CCU/install")"
+assert_not_contains "aligned units -> no FAIL" "$out" "FAIL"
+assert_contains "aligned units -> OK" "$out" "target this install"
+
+# Control enabled but the units were never installed at all. Assert the DISTINCT message, not just
+# that something failed: with no units the owner is empty, so the mismatch arm below would fail on
+# its own and an assertion for bare "FAIL" would stay green with this arm deleted — and the operator
+# would get "point at , but this install is ..." instead of being told the units are simply missing.
+out="$(ccu_run - - true "$CCU/install")"
+assert_contains "no units installed -> FAIL naming the real cause" "$out" "no runner units are installed"
+
+# Service unit right, path unit watching someone else's spool: requests are still never read.
+out="$(ccu_run "$CCU/install" "$CCU/other/data/control" true "$CCU/install")"
+assert_contains "path unit watches a different spool -> FAIL" "$out" "FAIL"
+
+# Control disabled: the units are irrelevant, so a mismatch must NOT be reported as a fault.
+out="$(ccu_run "$CCU/other" "$CCU/other/data/control" false "$CCU/install")"
+assert_not_contains "control disabled -> no FAIL" "$out" "FAIL"
+
+# The two spellings of one checkout (versioned dir vs the `current` symlink) are the SAME install.
+# A literal string compare would call this a mismatch and cry wolf on every production box.
+mkdir -p "$CCU/versions/pithead-v1.9.3"
+ln -sfn "$CCU/versions/pithead-v1.9.3" "$CCU/current"
+# .env and the path unit both carry the versioned spelling, as one render always writes them;
+# only the invocation goes through the symlink. The owner compare must resolve both to one install.
+out="$(ccu_run "$CCU/versions/pithead-v1.9.3" "$CCU/versions/pithead-v1.9.3/data/control" true \
+    "$CCU/current" "$CCU/versions/pithead-v1.9.3/data/control")"
+assert_not_contains "versioned dir vs current symlink -> same install, no FAIL" "$out" "FAIL"
+
+# A stranded unit usually names a directory that no longer exists; the check must still resolve a
+# printable path and report the mismatch rather than going quiet on an empty answer.
+out="$(ccu_run "$CCU/deleted-tree" "$CCU/install/data/control" true "$CCU/install")"
+assert_contains "unit names a deleted directory -> still FAILs" "$out" "FAIL"
+assert_contains "unit names a deleted directory -> still names it" "$out" "$CCU/deleted-tree"
+unset CCU ccu_run out
+
 # ---------------------------------------------------------------------------
 echo ""
 printf 'pithead tests: \033[1;32m%d passed\033[0m, ' "$PASS"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7749,7 +7749,58 @@ assert_not_contains "versioned dir vs current symlink -> same install, no FAIL" 
 out="$(ccu_run "$CCU/deleted-tree" "$CCU/install/data/control" true "$CCU/install")"
 assert_contains "unit names a deleted directory -> still FAILs" "$out" "FAIL"
 assert_contains "unit names a deleted directory -> still names it" "$out" "$CCU/deleted-tree"
+
+# The documented layout keeps the PREVIOUS version dir for rollback, and the one-click upgrade runs
+# in the browser, so the operator's shell is routinely still sitting in it. The units correctly name
+# the live dir there. Calling that box broken would be a cry-wolf FAIL on a healthy install — and
+# worse, the printed fix ('apply' from here) would repoint the units at the rollback dir and break
+# the live install for real. A superseded version dir must report INFO and no verdict.
+# Mutation: delete the `current`-symlink guard in check_control_units -> this goes red (FAIL returns).
+mkdir -p "$CCU/deploy/pithead-v1.19.0" "$CCU/deploy/pithead-v1.19.1/data/control"
+ln -sfn pithead-v1.19.1 "$CCU/deploy/current"
+out="$(ccu_run "$CCU/deploy/pithead-v1.19.1" "$CCU/deploy/pithead-v1.19.1/data/control" true \
+    "$CCU/deploy/pithead-v1.19.0" "$CCU/deploy/pithead-v1.19.1/data/control")"
+assert_not_contains "superseded rollback dir -> no FAIL (units belong to the live install)" "$out" "FAIL"
+assert_contains "superseded rollback dir -> says which dir is live" "$out" "$CCU/deploy/pithead-v1.19.1"
+# ...and the live dir itself still gets a real verdict, so the guard cannot silence everything.
+out="$(ccu_run "$CCU/deploy/pithead-v1.19.1" "$CCU/deploy/pithead-v1.19.1/data/control" true \
+    "$CCU/deploy/pithead-v1.19.1" "$CCU/deploy/pithead-v1.19.1/data/control")"
+assert_contains "the live install still gets a verdict" "$out" "target this install"
 unset CCU ccu_run out
+
+echo "== unit: apply converges the control units even when nothing changed (#33) =="
+# doctor's fix instruction is "run './pithead apply' from this directory". A box whose units point
+# at a dead install has an UNCHANGED config by definition — the fault is in the unit files, not
+# config.json — so apply's "nothing to apply" early return used to make the prescribed fix a no-op
+# on the only box the check fires for.
+# Mutation: remove provision_control_runner from apply's no-change branch -> this goes red.
+apply_noop_steps() {
+    (
+        cd "$SANDBOX" || exit
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        require_env() { :; }
+        ensure_onion_password() { :; }
+        parse_and_validate_config() { :; }
+        load_preserved_state() { :; }
+        onion_missing() { return 1; }
+        is_deployed() { return 0; }
+        ensure_directories() { :; }
+        resolve_dashboard_host() { :; }
+        render_env() { [ -n "${1:-}" ] && : >"$1"; }
+        env_changed_keys() { :; } # nothing changed
+        P2POOL_ONION="abc.onion"  # provisioning marker; read under `set -u` before the stub
+        log() { :; }
+        provision_control_runner() { echo provision; }
+        compose_up_checked() { echo compose; }
+        apply
+    ) | grep -xE 'provision|compose' | tr '\n' ','
+}
+: >"$SANDBOX/.env"
+assert_eq "a no-change apply still converges the control units, and recreates nothing" \
+    "$(apply_noop_steps)" "provision,"
+unset apply_noop_steps
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## The failure, found live

A production coordinator was running v1.17.0 with a dead control channel, and had been for a day.

A v1.18.1 upgrade got as far as installing the control runner units — which repointed the
box-global systemd path unit at the **new, half-installed** version directory — then aborted at
the cosign gate and rolled the stack back to v1.17.0. The unit repoint was not rolled back. From
then on:

- the dashboard wrote control requests into the **running** version's spool
- the path unit watched the **aborted** version's spool

Two operator upgrade requests, a day apart, sat unread in the live spool. No error was raised
anywhere — not in the dashboard, not in the journal, and not by `./pithead doctor`, which reported
a healthy box the whole time because **it had no check for this at all**.

#1070 fixed the ordering that causes this. It cannot help a box already stranded: the channel the
fix would arrive through is the broken one. That is what makes this a diagnostic gap and not only
an ordering bug.

## What this adds

A `Dashboard control channel` section in `doctor`:

| State | Verdict |
|---|---|
| Units name a different directory than this install | FAIL, printing both paths |
| Control enabled, no units installed | FAIL, naming that as the cause |
| Path unit watches a different spool than this install writes to | FAIL |
| Everything aligned | OK |
| `dashboard.control.enabled` false | INFO — not a fault |

The two spellings of one checkout — the versioned dir and the `current` symlink — resolve to the
same install, so a normal production box is never told it is broken.

## Reuse, not new code

`control_units_owner_dir` lifts the `ExecStart` parse and physical-path resolution out of
`provision_control_runner`'s removal branch, which now calls it instead of repeating it. That
branch gets shorter, the ownership rules live in one place, and its existing tests still pass.

## Appliance safety

Checked before proposing this, because `doctor` exiting non-zero is load-bearing there:
`pithead-boot` gates the A/B slot commit on `pithead doctor --json`. It runs `./pithead render`
first, and `render` → `render_derived()` calls `provision_control_runner` unconditionally — so the
units exist and name the boot working directory before the gate runs. The new check reports OK on
an appliance and cannot block a slot commit.

## Testing

Tier 1 per `docs/dev/testing-strategy.md` — decision logic over a parsed unit file, provable with
stubs. `tests/stack/run.sh`: **1735 passed, 0 failed**.

**Mutation proof.** Per the standing rule, each assertion ships with the mutation that turns it
red:

| Mutation | Result |
|---|---|
| drop the owner-mismatch arm | "units point elsewhere" goes green |
| flip that `!=` to `=` | mismatch **and** aligned assertions both flip |
| drop the spool comparison arm | "different spool" goes green |
| drop the `-z "$owner"` arm | "no units installed" loses its message |

That last row is worth reading. My first version asserted only that a bare `FAIL` appeared when no
units were installed — and it **stayed green with the arm it named deleted**, because with no units
the owner is empty and the mismatch arm fires anyway. A #1069-class assertion, in a PR about
catching silent failures. The mutation run caught it; the assertion now checks the distinct message
and fails when that arm goes.

## Docs

`docs/dashboard.md`, in the upgrade section: what to do when the button does nothing at all — no
result, no error, no modal — and how `doctor` names it. Voice and operator-string lints pass.

## Second commit

The first commit wedged the new function between `check_stratum_exposure`'s doc comment and its
function; the second moves it below. No behaviour change; mutation proof and suite re-run after.