### PR TITLE
chore: stop hardcoding a home directory in the research analysis scripts

### DIFF
--- a/docs/research/xvb-delivery-study/analysis/round2_final.py
+++ b/docs/research/xvb-delivery-study/analysis/round2_final.py
@@ -1,6 +1,6 @@
-import json, time
+import json, time, sys
 WIN = 1786021262.0  # 08-06 09:01:02 local
-rows = [json.loads(l) for l in open("/home/vijit/xvb-experiment/log.jsonl")]
+rows = [json.loads(l) for l in open(sys.argv[1] if len(sys.argv) > 1 else "xvb-experiment/log.jsonl")]
 r = rows[-1]
 shares = [s for s in r.get("shares", []) if s["ts"] and s["ts"] >= WIN - 60]
 diff = r["pool"]["diff"]

--- a/docs/research/xvb-delivery-study/analysis/round_live.py
+++ b/docs/research/xvb-delivery-study/analysis/round_live.py
@@ -1,6 +1,6 @@
-import json, time, datetime
+import json, time, datetime, sys
 
-rows = [json.loads(l) for l in open("/home/vijit/xvb-experiment/log.jsonl")]
+rows = [json.loads(l) for l in open(sys.argv[1] if len(sys.argv) > 1 else "xvb-experiment/log.jsonl")]
 r = rows[-1]
 now = r["t"]
 print("latest poll:", time.strftime("%H:%M:%S", time.localtime(now)),


### PR DESCRIPTION
`docs/research/xvb-delivery-study/analysis/{round2_final,round_live}.py` both opened an absolute
path inside a specific user's home directory. That is not reproducible for anyone else, and a
public repo should not carry it.

They now take the log path as an argument and default to a relative one:

```python
rows = [json.loads(l) for l in open(sys.argv[1] if len(sys.argv) > 1 else "xvb-experiment/log.jsonl")]
```

One line each, and it makes the scripts runnable by someone who is not the person who wrote them.

This is the only occurrence of that path on `develop`. The companion fixture cleanup on
`develop-v2` landed as #1100, which also covered a globally-routable IPv6 address and a specific
LAN address in the Caddy and quadlet fixtures.

Both files compile (`python3 -m py_compile`). Nothing else references them.

ponytail-review: two lines changed, no new code — nothing to cut.