### PR TITLE
fix(cli): restart caddy when the rendered Caddyfile changes, not when a listed key does

### DIFF
--- a/pithead
+++ b/pithead
@@ -5320,17 +5320,13 @@ apply() {
     local apply_marker="${ENV_FILE}.apply-incomplete" incomplete=0
     [ -f "$apply_marker" ] && incomplete=1
 
-    local destructive=0 caddy_changed=0 wallet_keys=() line flag msg old new
+    local destructive=0 caddy_changed=0 caddy_before="" wallet_keys=() line flag msg old new
     if [ "${#changed[@]}" -gt 0 ]; then
         echo ""
         log "The following changes will be applied:"
         for key in "${changed[@]}"; do
             old=$(env_get_file "$ENV_FILE" "$key")
             new=$(env_get_file "$newenv" "$key")
-            # DASHBOARD_CONTROL_ENABLED rides along (#33): the Caddyfile always renders the
-            # X-Auth-User header_up now, but a pre-upgrade caddy may still run without it —
-            # restart caddy at the moment the audit actor starts to matter.
-            case "$key" in HOST_IP | HOST_PORT | DASHBOARD_SECURE | DASHBOARD_AUTH_USER | DASHBOARD_AUTH_HASH_B64 | DASHBOARD_ONION_ENABLED | DASHBOARD_CONTROL_ENABLED) caddy_changed=1 ;; esac
             # Payout-wallet change (#375): remember WHICH wallet keys change for the typed
             # confirmation below — one prompt per key, so a Monero+Tari double change can't
             # ride through on a single typed prefix.
@@ -5384,7 +5380,20 @@ apply() {
         mv "$newenv" "$ENV_FILE"
         provision_node_onions # #103: a node that just went local needs its onion before it starts
         inject_service_configs
+        # Whether caddy needs a restart is decided by COMPARING the rendered file, never by a list
+        # of keys someone has to remember to extend (#1052). The list had drifted:
+        # dashboard.expose_public_ip was missing from it, so turning OFF the opt-in that serves the
+        # dashboard on a globally-routable address re-rendered the Caddyfile without its bind lines
+        # and left caddy holding the wildcard listener — the operator sees the setting saved, sees
+        # the file change, and the box stays exposed. Any Caddyfile input has the same shape, so
+        # the guard is the content, not the cause. An absent previous file is a fresh install:
+        # compose starts caddy on the new one below, and there is no old configuration to displace.
+        caddy_before=""
+        [ -f "Caddyfile" ] && caddy_before=$(cat "Caddyfile")
         generate_caddyfile
+        if [ -n "$caddy_before" ] && [ "$caddy_before" != "$(cat "Caddyfile" 2>/dev/null)" ]; then
+            caddy_changed=1
+        fi
     else
         rm -f "$newenv"
         if [ "$incomplete" -eq 0 ]; then

--- a/pithead
+++ b/pithead
@@ -5320,7 +5320,7 @@ apply() {
     local apply_marker="${ENV_FILE}.apply-incomplete" incomplete=0
     [ -f "$apply_marker" ] && incomplete=1
 
-    local destructive=0 caddy_changed=0 caddy_before="" wallet_keys=() line flag msg old new
+    local destructive=0 caddy_changed=0 caddy_before="" caddy_had=0 wallet_keys=() line flag msg old new
     if [ "${#changed[@]}" -gt 0 ]; then
         echo ""
         log "The following changes will be applied:"
@@ -5385,13 +5385,17 @@ apply() {
         # dashboard.expose_public_ip was missing from it, so turning OFF the opt-in that serves the
         # dashboard on a globally-routable address re-rendered the Caddyfile without its bind lines
         # and left caddy holding the wildcard listener — the operator sees the setting saved, sees
-        # the file change, and the box stays exposed. Any Caddyfile input has the same shape, so
-        # the guard is the content, not the cause. An absent previous file is a fresh install:
-        # compose starts caddy on the new one below, and there is no old configuration to displace.
-        caddy_before=""
-        [ -f "Caddyfile" ] && caddy_before=$(cat "Caddyfile")
+        # the file change, and the box stays exposed.
+        #
+        # An absent previous file is a fresh install: compose starts caddy on the new one below, so
+        # there is no old configuration to displace. Emptiness is not absence — a zero-byte file
+        # left by a crashed render is a box whose caddy serves nothing, and that wants the restart.
+        if [ -f "Caddyfile" ]; then
+            caddy_had=1
+            caddy_before=$(cat "Caddyfile")
+        fi
         generate_caddyfile
-        if [ -n "$caddy_before" ] && [ "$caddy_before" != "$(cat "Caddyfile" 2>/dev/null)" ]; then
+        if [ "$caddy_had" -eq 1 ] && [ "$caddy_before" != "$(cat "Caddyfile" 2>/dev/null)" ]; then
             caddy_changed=1
         fi
     else


### PR DESCRIPTION
Closes #1052.

`apply` decided whether to restart caddy from a hand-maintained list of .env keys. A list like that works only while someone remembers to extend it, and it had already drifted.

## The drift, and why it matters

On the appliance, `dashboard.expose_public_ip` is not in the list. Flipping it re-renders the Caddyfile correctly — with or without the `bind` lines — and then leaves caddy running the old configuration.

Turning that key **off** is a security action. The operator sees the setting saved, sees the rendered file change, and reasonably concludes the box is no longer serving the dashboard on a globally-routable address. It is, until something else happens to restart caddy.

## The fix

Snapshot the Caddyfile, render, restart if the content differs. The key list is gone.

That covers every input at once — including the ones nobody has added yet — and it cannot drift, because the cause no longer has to be enumerated, only the effect observed.

Two edge cases are handled deliberately:

- **Absent previous file** is a fresh install. Compose starts caddy on the new one moments later; there is no old configuration to displace, so no restart is queued.
- **Empty previous file** is *not* absence. A zero-byte Caddyfile left by a crashed render is a box whose caddy is serving nothing, and that is exactly a box that wants the restart. Existence is tracked separately from content.

## Lane

`dashboard.expose_public_ip` **does not exist on `develop`** — it is appliance-only, and the issue was queued as a non-appliance candidate. What is shared between the twins is the fragile mechanism, so the fix lands here and reaches the appliance through the normal `develop` → `develop-v2` sync rather than as a both-sides conflict. The `expose_public_ip`-specific assertion belongs on the v2 side, where the key exists.

## Testing

No new test — the existing assertion covers the new mechanism and proves it can fail:

| Run | `auth change recreates caddy` |
|---|---|
| baseline — **1739 passed, 0 failed** | ✓ |
| mutant: content comparison deleted — **1738 passed, 1 failed** | ✗ |

A password change alters the rendered `basic_auth` hash, so the content differs and caddy restarts; delete the comparison and nothing restarts it. One assertion, one failure, exactly the guard.

`make lint-sh` clean. Net −4 lines of logic.