### PR TITLE
Make the cosign chain one contract, producer to consumer (#1108)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,16 +1,27 @@
-name: Release gate (self-hosted)
+name: Release gate (self-hosted, manual dispatch only)
 
 # Tier-4 end-to-end validation against the REAL synced Monero + Tari nodes — the pre-release
 # gate (#54). It runs on the dedicated, self-hosted release server (which holds real wallet /
 # onion keys), so it MUST only ever run code we trust.
 #
+# DISPATCH ONLY. This workflow does not gate `main` and does not claim to (#1048). It carried a
+# `push: [main]` trigger behind an `if:` that no repo variable ever set, so every merge to main
+# recorded a *skipped* run — and a skipped job is green/neutral, so `main` displayed a passing
+# release gate that had never once executed. The gating that is real happens elsewhere and is named
+# in docs/dev/releasing.md § Which gates are automated: `scripts/release.sh` stage 2 runs `make test`
+# and the #54 live matrix at cut time and aborts on failure, plus the operator-run bench e2e.
+#
+# To make this automatic, a self-hosted runner has to exist first: register the release server with
+# the `self-hosted, pithead-release` labels (docs/dev/release-server.md), then add back
+#   push:
+#     branches: [main]
+# Do not add the trigger before the runner — a queued job no runner can claim is auto-cancelled
+# after 24h and shows as a permanent red ✗ on main.
+#
 # SECURITY: there is deliberately NO `pull_request` trigger. A fork PR's code running on this
 # runner could steal the box's keys or persist a backdoor (GitHub recommends against self-hosted
-# runners on public repos for exactly this reason). The gate runs only on:
-#   - workflow_dispatch — a maintainer manually runs it on a ref they've reviewed, OR
-#   - push to main      — post-merge, on trusted code.
-# To end-to-end a specific fork PR, review it first, then dispatch this workflow on that ref.
-# See docs/dev/release-server.md.
+# runners on public repos for exactly this reason). To end-to-end a specific fork PR, review it
+# first, then dispatch this workflow on that ref.
 on:
   workflow_dispatch:
     inputs:
@@ -24,8 +35,6 @@ on:
         default: "check"
         type: choice
         options: [check, matrix]
-  push:
-    branches: [main]
 
 # Never run two gates against the one shared box at the same time.
 concurrency:
@@ -39,12 +48,6 @@ permissions:
 jobs:
   release-gate:
     name: Tier-4 live matrix (real nodes)
-    # Only run automatically once a self-hosted runner is actually wired up — set the repo variable
-    # ENABLE_RELEASE_GATE=true when one is registered. Without this guard, every push to main queues
-    # a job no runner can claim, and GitHub auto-cancels it after a 24h timeout — a permanent red ✗
-    # on main. A skipped job is green/neutral instead. A manual workflow_dispatch ALWAYS runs, so a
-    # maintainer can still validate a reviewed ref on a registered runner on demand.
-    if: ${{ github.event_name == 'workflow_dispatch' || vars.ENABLE_RELEASE_GATE == 'true' }}
     # Register the server with these labels: `pithead-release` scopes the gate to the dedicated
     # box; prefer an ephemeral / just-in-time runner in its own runner group.
     runs-on: [self-hosted, pithead-release]

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -123,11 +123,22 @@ The pipeline signs every promoted image digest and the install bundle with cosig
 ([#376](https://github.com/p2pool-starter-stack/pithead/issues/376), key-based — see
 [Releasing › Signed releases](releasing.md#signed-releases) for what installs verify and how).
 The private key lives only on this box, like the GHCR token; the public key is committed in the
-repo as `cosign.pub`. The release preflight refuses to run without cosign, `COSIGN_KEY`, and
-`cosign.pub` all in place.
+repo as `cosign.pub`. The release preflight refuses to run without cosign, `COSIGN_KEY`,
+`COSIGN_PASSWORD`, and `cosign.pub` all in place — signing is mandatory to publish because it is
+mandatory to consume ([#960](https://github.com/p2pool-starter-stack/pithead/issues/960)), so a
+missing piece aborts the cut rather than warning past it. `--dry-run` reaches the same decision and
+skips only the signing, so a rehearsal on this box tells you whether the real cut would sign.
+
+Preflight then proves the key end to end: it signs a probe blob and verifies it through the same
+digest-pinned cosign container installs use. A `cosign.pub` that is no longer the public half of
+`COSIGN_KEY` fails here rather than in the field
+([#1084](https://github.com/p2pool-starter-stack/pithead/issues/1084)).
 
 Install cosign (pinned — there is no Ubuntu apt package; the same snippet works on any host that
-wants to verify):
+wants to verify). Take **v2.6.3**, not the newest: cosign v3 removed the `--tlog-upload` flag both
+signing calls pass, and a drifted box would otherwise pass every other check and die at the signing
+stage with the images already promoted. Preflight probes for the flag and aborts early if it is
+gone.
 
 ```bash
 curl -fsSL -o /tmp/cosign https://github.com/sigstore/cosign/releases/download/v2.6.3/cosign-linux-amd64

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -160,6 +160,31 @@ failure is a regression. Without the flag, `workers online` and `stratum total h
 every miner-less bench and have to be eyeballed as "expected", which is exactly the
 tolerated-known-failure habit the flag exists to end.
 
+### Which gates are automated, and which are not
+
+Every gate below runs at cut time or is run by hand. **Nothing gates a merge to `main`**, and no
+workflow claims to ([#1048](https://github.com/p2pool-starter-stack/pithead/issues/1048)):
+`release-gate.yml` is dispatch-only, because a self-hosted runner on a key-holding box is not
+registered. It previously carried a `push: [main]` trigger behind a repo variable nobody set, so
+every merge recorded a *skipped* run — and a skipped job is green, which made `main` display a
+passing live-node gate that had never once executed.
+
+| Gate | When | Run by | Blocking |
+| --- | --- | --- | --- |
+| `make test` (tiers 1–3) + `make lint` | every PR | CI | yes |
+| `make test` again, on the release box | `release.sh` stage 2 | the cut | yes |
+| #54 live matrix, `--readiness` | `release.sh` stage 2 | the cut | yes |
+| Targeted e2e with a borrowed rig | before `make release` | you | yes — by policy, not by code |
+| Release signing environment + pinned verifier | `release.sh` stage 1 | the cut | yes |
+| Staged-image smoke (pull back, check version) | `release.sh` stage 5 | the cut | yes |
+| `release-smoke` (real cosign, real #59 upgrade) | after publish | you | no — the assets already exist |
+| `release-gate.yml` tier-4 live matrix | on demand | you, via *Run workflow* | no |
+| Live `--check` sweep on the bench | after deploy | you | no |
+
+The two human-run rows are policy, not automation: the release is not finished until they are green.
+To move `release-gate.yml` into the automated column, register the runner first — see
+[Release / Validation Server](release-server.md) and the note at the top of the workflow.
+
 ## Signed releases
 
 Every promoted image digest and the install bundle carry a cosign key signature
@@ -172,6 +197,26 @@ cut from a private box with no CI OIDC identity, and `--tlog-upload=false` keeps
 out of the public transparency log — which is why verification passes `--private-infrastructure`
 (images) / `--insecure-ignore-tlog` (the bundle blob). Signatures pin the promoted manifest-list
 digests — the exact bytes the smoke stage validated — never a mutable tag.
+
+Signing is **mandatory to publish, because it is mandatory to consume**
+([#960](https://github.com/p2pool-starter-stack/pithead/issues/960),
+[#1108](https://github.com/p2pool-starter-stack/pithead/issues/1108)). Once `cosign.pub` is
+committed it ships in every bundle, so every install from that release on refuses a release with no
+`pithead.tar.gz.sig`. A cut made on a box with no key therefore does not produce a degraded release
+— it produces one every one-click upgrade in the field rejects, and GitHub release assets are
+immutable, so the signature can never be attached afterwards. That is how v1.18.0 shipped unsigned
+and had to be withdrawn and re-cut. Preflight now aborts the cut instead, naming what is missing;
+`--unsigned` is the explicit, loud way to publish one anyway. The check runs on `--dry-run` too and
+only the signing itself is skipped, so a rehearsal reports the decision the real cut will make —
+it used to sit inside the dry-run guard and could only ever print "signing OFF".
+
+Preflight also proves the pinned verifier before anything is built
+([#1084](https://github.com/p2pool-starter-stack/pithead/issues/1084)): it pulls `COSIGN_IMAGE`,
+signs a probe blob with this box's key, verifies it through the container, and requires a tampered
+blob to be refused. That round trip catches a digest that no longer pulls, an image that is not the
+cosign it claims to be, and a committed `cosign.pub` that is no longer the public half of
+`COSIGN_KEY` — each of which would otherwise surface as *signature verification failed* on every
+install, which reads as tampering rather than as our own pin having moved.
 
 `pithead` verifies before it changes anything:
 
@@ -220,6 +265,42 @@ cosign verify-blob --key cosign.pub --signature pithead.tar.gz.sig --insecure-ig
 ```
 
 Releases up to v1.3.x are unsigned; verification gates every release from the first signed one.
+If an upgrade sent you here saying cosign is not installed, read the next section — that box needs
+the host binary once, not a manual verify.
+
+### Upgrading an install older than v1.19.1
+
+The verifier became a container in **v1.19.1**
+([#1072](https://github.com/p2pool-starter-stack/pithead/issues/1072)). Before that it was a host
+binary, and an upgrade is driven by the code the box is **already running** — so an install still on
+v1.18.1 or v1.19.0 checks `command -v cosign` on its next one-click upgrade and refuses when the
+binary is absent:
+
+- **v1.19.0** refuses unconditionally: *"cosign is not installed on the host…"*
+- **v1.18.1** refuses when `cosign.pub` is present: *"cosign.pub is present but cosign is not
+  installed on the host…"*
+
+cosign has no apt package, so this is not something an operator can resolve from the message alone —
+and containerising the verifier does not help the boxes that have not taken the upgrade yet. This bit
+a production install on 2026-08-15.
+
+The escape path, once per box:
+
+1. Install the pinned cosign **v2.6.3** binary on the host — the snippet in
+   [Release / Validation Server › The release signing key](release-server.md#the-release-signing-key).
+   Take that version, not the newest: cosign v3 removed the `--tlog-upload` / `--insecure-ignore-tlog`
+   flags these releases pass, so a v3 binary satisfies `command -v cosign` and then fails the verify.
+2. Retry the upgrade from the dashboard. It now passes the old guard, verifies the bundle, and lands
+   on a release whose verifier is the container.
+3. From the next upgrade on the host binary is unused and can be removed.
+
+`pithead doctor` on v1.19.1 and later answers this before an upgrade rather than during one: it
+reports whether the pinned verifier image is present, and names the pre-fetch command if it is not.
+On the older versions `doctor` cannot report it, which is why it is written here.
+
+> **Not yet proven on a live install.** The guards above were read from the released `pithead` at
+> each tag; the escape path has not been driven end to end on a box actually running v1.18.1 or
+> v1.19.0. Do that on the bench before the next release notes repeat this claim.
 
 ## Post-publish smoke test (#459)
 
@@ -241,9 +322,8 @@ It runs two phases:
   `:vX.Y.Z` images and verifies them against the committed `cosign.pub`. A good signature must pass;
   a byte-changed bundle must be refused (this is what proves the check is real, not the pre-merge
   fake); the bundle's own `VERSION` must equal the tag (the #376 rollback guard); and an unrelated
-  key must be refused. If the release is **unsigned** — signing is opt-in (#376), so releases up to
-  v1.3.x and any cut with the key off ship without a signature — that is reported plainly and the
-  phase is skipped. It never reports a signed pass for an unsigned release. This phase needs only
+  key must be refused. If the release is **unsigned** — releases up to v1.3.x predate signing, and a
+  `--unsigned` cut ships without one — that is reported plainly and the phase is skipped. It never reports a signed pass for an unsigned release. This phase needs only
   `gh` auth and network; run it anywhere.
 - **Real #59 upgrade** (`--upgrade DIR`). On a box still running the *previous* release, it enqueues
   the exact upgrade intent the dashboard writes into the #33 control spool, runs the host control

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -313,6 +313,12 @@ does not pin by digest each abort the upgrade before anything is pulled, and the
 the version it was on. The one and only way to end up unverified is an install older than the first
 signed release, which carries no `cosign.pub` at all — that case warns loudly and proceeds.
 
+If your install is still on **v1.18.1 or v1.19.0**, the upgrade refuses with *"cosign is not
+installed on the host"*. Those versions verify with a host binary rather than the container, and an
+upgrade is driven by the code the box is already running — so the fix has to happen on the box once,
+before it can move forward. See
+[Releasing › Upgrading an install older than v1.19.1](dev/releasing.md#upgrading-an-install-older-than-v1191).
+
 Run `./pithead version` to see what is currently installed before and after an upgrade.
 
 ### Switching a source checkout to release images

--- a/pithead
+++ b/pithead
@@ -232,7 +232,8 @@ stack_up() {
     # #452: a fresh release install's first `up` pulls the 5 first-party images (pull policy
     # `missing`) — gate that pull on the same cosign check `upgrade` uses, so first install is not
     # the one unverified pull. Same guard: source checkouts skip, a missing cosign.pub warns and
-    # proceeds (signing is opt-in, #461), a present key that fails aborts before anything starts.
+    # proceeds (#461 — an install predating the first signed release has no key to verify against),
+    # a present key that fails aborts before anything starts.
     verify_release_images
     # Docker Compose automatically picks up COMPOSE_PROFILES from .env
     if ! compose_up_checked -d; then
@@ -456,8 +457,11 @@ cosign_container_path() { # <path>
 #
 # The decision table, fail-closed where a key exists:
 #   source checkout                          -> skip: locally built images are unsigned by design
-#   no cosign.pub (an older/unsigned bundle) -> proceed with one loud warning (signing is opt-in per
-#                                               #461; the digest-pinned bundle is the protection)
+#   no cosign.pub (an older/unsigned bundle) -> proceed with one loud warning (#461 — an install
+#                                               predating the first signed release has no key to
+#                                               verify with; the digest-pinned bundle is what
+#                                               protects it. Every bundle since ships the key, so
+#                                               this is a legacy path, not a way to opt out)
 #   cosign.pub present, docker missing       -> ABORT — an absent verifier must not silently
 #                                               disable verification (docker is a prerequisite and
 #                                               the very next step pulls images with it anyway)
@@ -844,6 +848,28 @@ cpu_has_avx2() {
     fi
 }
 
+# Release-signature verification (#376): the state the next pull — `up` or `upgrade` — will act on.
+# Extracted from doctor() so each branch is unit-testable, like the other doctor checks. Every branch
+# mirrors a refusal the one-click upgrade runner makes, so this answers "can this box take an
+# upgrade" BEFORE one is attempted rather than during it (#1108). Read-only: nothing is pulled.
+check_release_verification() {
+    if is_source_checkout; then
+        dr_info "Source checkout — images build locally and are not signature-verified (#376), and the dashboard's one-click upgrade does not apply: upgrade with 'git pull' then './pithead upgrade'."
+    elif [ ! -f cosign.pub ]; then
+        dr_warn "No cosign.pub next to pithead — image pulls are NOT signature-verified (#376). Release bundles ship the key from the first signed release."
+    elif ! cosign_available; then
+        dr_warn "cosign.pub is present but docker is not available to run the verifier — 'up'/'upgrade' refuse to pull until it is. Start the Docker daemon."
+    elif docker image inspect "$COSIGN_IMAGE" >/dev/null 2>&1; then
+        dr_ok "'up' and 'upgrade' verify the release images against cosign.pub; the pinned verifier image is already here, nothing to install."
+    else
+        # The verifier is fetched on demand, so a box that has never run a verified operation simply
+        # does not have it yet. Worth saying plainly: if that one fetch fails, the operation reports a
+        # *signature* failure — which reads as a tampered release rather than as an image this host
+        # could not pull (#1084).
+        dr_warn "The pinned release verifier image is not on this host yet — the next 'up' or 'upgrade' fetches it. If that fetch fails, the operation reports a signature failure even though nothing was tampered with. Pre-fetch it with: docker pull $COSIGN_IMAGE"
+    fi
+}
+
 doctor() {
     DR_OK=0
     DR_WARN=0
@@ -877,16 +903,7 @@ doctor() {
     else
         dr_fail "docker compose (v2 plugin) not found — install 'docker-compose-v2'."
     fi
-    # Release-signature verification (#376): report the state the next pull (up or upgrade) will act on.
-    if is_source_checkout; then
-        dr_info "Source checkout — images build locally and are not signature-verified (#376)."
-    elif [ ! -f cosign.pub ]; then
-        dr_warn "No cosign.pub next to pithead — image pulls are NOT signature-verified (#376). Release bundles ship the key from the first signed release."
-    elif cosign_available; then
-        dr_ok "'up' and 'upgrade' verify the release images against cosign.pub; the verifier runs as a container, nothing to install."
-    else
-        dr_warn "cosign.pub is present but docker is not available to run the verifier — 'up'/'upgrade' refuse to pull until it is. Start the Docker daemon."
-    fi
+    check_release_verification
 
     # --- Docker daemon ---
     echo ""

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -15,7 +15,7 @@
 #     - the bundle's own VERSION equals the tag (the #376 rollback guard — an older signed bundle
 #       served at the vX.Y.Z URL is caught);
 #     - every published image verifies, and an unrelated key is refused.
-#   If the release is UNSIGNED (signing is opt-in, #376), that is reported plainly — never a false
+#   If the release is UNSIGNED (releases up to v1.3.x, or a --unsigned cut) that is reported plainly — never a false
 #   pass. Runnable from any box with `gh` auth + network; needs no deployed stack.
 #
 # Phase 2 (--upgrade DIR): drive the REAL #59 host path against a previous-release install — enqueue
@@ -109,7 +109,7 @@ verify_release() {
     # running install already trusts), never the bundle's own copy — a key that arrives inside the
     # artifact it vouches for proves nothing.
     if [ ! -f "$pub" ] && [ "$SIG_PUBLISHED" -eq 0 ]; then
-        warn "UNSIGNED release: no committed cosign.pub and no pithead.tar.gz.sig asset. Release signing is opt-in (#376) — releases up to v1.3.x, and any cut with signing off, ship unsigned. Nothing to cosign-verify; bundle integrity rests on the digest-pinned compose + TLS to GitHub. (Not a failure.)"
+        warn "UNSIGNED release: no committed cosign.pub and no pithead.tar.gz.sig asset. Releases up to v1.3.x predate signing, and a --unsigned cut ships without it (#960). Nothing to cosign-verify; bundle integrity rests on the digest-pinned compose + TLS to GitHub. (Not a failure.)"
         return 0
     fi
     # A half state is a misconfiguration, not a pass — surface it.
@@ -205,7 +205,7 @@ verify_release_images_direct() {
     # Negative: corrupt ONE image's pinned digest in a COPY of the bundle and re-run the real
     # function. Needs a cosign.pub to reach the real cosign dial (the bundle's own, or the one
     # committed to this checkout) — without one, verify_release_images's documented fallback is to
-    # WARN and proceed (#376 opt-in), which is a different, already-covered behaviour, not this gate.
+    # WARN and proceed (#461 — an install predating signing), a different, already-covered behaviour.
     local pub_src=""
     [ -f "$bundle_dir/cosign.pub" ] && pub_src="$bundle_dir/cosign.pub"
     [ -z "$pub_src" ] && [ -f "$REPO_ROOT/cosign.pub" ] && pub_src="$REPO_ROOT/cosign.pub"
@@ -314,5 +314,5 @@ printf '\n'
 if [ "$SIGNED" -eq 1 ]; then
     ok "Smoke passed: $TAG is signed and verifies for real$([ -n "$UPGRADE_DIR" ] && echo ', and upgrades cleanly')."
 else
-    ok "Smoke passed: $TAG downloaded and checked; release is UNSIGNED (opt-in signing off)$([ -n "$UPGRADE_DIR" ] && echo '; upgrade path exercised')."
+    ok "Smoke passed: $TAG downloaded and checked; release is UNSIGNED (cut without signing)$([ -n "$UPGRADE_DIR" ] && echo '; upgrade path exercised')."
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,6 +29,8 @@
 #   --draft              Create the GitHub Release as a DRAFT (held for review; publish it by hand).
 #   --resume-promote     Skip build/stage; promote the already-staged digests (retry after a smoke pass).
 #   --allow-dirty        Don't require a clean git working tree (for local experimentation only).
+#   --unsigned           Publish WITHOUT cosign signatures. One-click upgrades refuse an unsigned
+#                        release once cosign.pub is committed — deliberate, loud, and rarely right.
 #   -y, --yes            Don't prompt before the irreversible steps (push, tag, publish).
 #   -h, --help           Show this help.
 #
@@ -41,6 +43,7 @@
 #   COSIGN_KEY / COSIGN_PASSWORD  Release signing (#376): path to the cosign private key on this box
 #                           and its passphrase. Promoted digests + the bundle get key signatures;
 #                           the committed cosign.pub (repo root, shipped in the bundle) verifies them.
+#                           Required — preflight refuses the cut without them (#960).
 #
 set -euo pipefail
 
@@ -115,6 +118,7 @@ RESUME_PROMOTE=0
 ALLOW_DIRTY=0
 ASSUME_YES=0
 DRAFT=0
+UNSIGNED=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -130,9 +134,10 @@ while [ $# -gt 0 ]; do
     --draft) DRAFT=1 ;;
     --resume-promote) RESUME_PROMOTE=1 ;;
     --allow-dirty) ALLOW_DIRTY=1 ;;
+    --unsigned) UNSIGNED=1 ;;
     -y | --yes) ASSUME_YES=1 ;;
     -h | --help)
-        sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+        sed -n '2,47p' "$0" | sed 's/^# \{0,1\}//'
         exit 0
         ;;
     *) die "Unknown option: $1 (try --help)" ;;
@@ -216,6 +221,125 @@ check_release_toolchain() {
     ok "Lint/test toolchain present (${LINT_TOOLCHAIN[*]})."
 }
 
+# --- Release signing (#376, #960) -----------------------------------------------------------------
+#
+# Signing is MANDATORY to publish, because it is mandatory to consume. Once `cosign.pub` is committed
+# it ships inside every bundle, and from that release on `pithead`'s one-click upgrade refuses any
+# release with no `pithead.tar.gz.sig`. So a cut made on a box with no key does not produce a
+# degraded release — it produces a bundle every install in the fleet rejects, and GitHub release
+# assets are immutable, so the signature can never be attached afterwards. That is how v1.18.0 had to
+# be withdrawn and re-cut (#960). The decision below therefore aborts the cut rather than warning.
+#
+# It also runs on --dry-run, and only the signing itself is skipped. The check used to sit inside
+# `if [ "$DRY_RUN" -eq 0 ]`, which meant the one rehearsal that exists to catch a mis-configured
+# signing box could only ever print "signing OFF" — the failure state, unconditionally (#1108).
+
+# What the signing environment is missing, one gap per line; empty output means it is complete. Pure
+# given PATH and the environment, so the tests can drive every combination without a release.
+signing_env_gaps() {
+    command -v cosign >/dev/null 2>&1 || echo "cosign is not on PATH"
+    if [ -z "${COSIGN_KEY:-}" ]; then
+        echo "COSIGN_KEY is unset"
+    elif [ ! -f "$COSIGN_KEY" ]; then
+        echo "COSIGN_KEY names no file ($COSIGN_KEY)"
+    fi
+    # Set-but-empty is a legitimate key with no passphrase; unset is not. cosign would prompt for it
+    # at stage 6b — after the images are promoted, where there is nothing left to abort into.
+    [ -n "${COSIGN_PASSWORD+x}" ] || echo "COSIGN_PASSWORD is unset"
+}
+
+# Both signing calls pass `--tlog-upload=false`, which cosign v3 removed. A box that has drifted to
+# v3 passes every other check here and then dies at stage 6b with the tag pushed and the images
+# promoted (#960 — the bench box had drifted exactly this way). Probe the flag rather than parse a
+# version: the flag is the thing that actually has to work, and it stays true across future majors.
+cosign_flags_supported() {
+    local sub
+    for sub in sign sign-blob; do
+        cosign "$sub" --help 2>&1 | grep -q -- '--tlog-upload' || return 1
+    done
+}
+
+resolve_signing() {
+    local gaps
+    gaps="$(signing_env_gaps)"
+    if [ -z "$gaps" ]; then
+        cosign_flags_supported ||
+            die "This box's cosign does not support --tlog-upload, which both signing calls pass — cosign v3 removed it. The cut would die at stage 6b with the images already promoted. Install the pinned cosign: docs/dev/release-server.md § The release signing key."
+        COSIGN_ENABLED=1
+        ok "Release signing ON — the promoted digests and the install bundle will be signed."
+        return 0
+    fi
+    COSIGN_ENABLED=0
+    # No committed public key means no install has a verifier, so nothing in the field fails closed
+    # on a missing signature. Honest, and the state every release before v1.18.1 shipped in.
+    if [ ! -f cosign.pub ]; then
+        warn "Release signing OFF — no cosign.pub is committed, so installs have no key to verify against and will proceed unverified (${gaps//$'\n'/; })."
+        return 0
+    fi
+    if [ "$UNSIGNED" -eq 1 ]; then
+        warn "Release signing OFF by --unsigned, with cosign.pub committed: this release will carry no pithead.tar.gz.sig, and every one-click upgrade in the field REFUSES a release that has none. Release assets are immutable — the signature cannot be added later."
+        return 0
+    fi
+    die "Release signing is not configured on this box: ${gaps//$'\n'/; }. cosign.pub is committed, so the bundle this cut would publish is one every one-click upgrade refuses, and release assets are immutable — it could not be signed afterwards (#960). Configure the key (docs/dev/release-server.md § The release signing key), or pass --unsigned to publish an unsigned release deliberately."
+}
+
+# --- The release verifier image (#1084) -----------------------------------------------------------
+#
+# Since #1072 every install verifies its images and its one-click upgrade bundle by running ONE
+# digest-pinned cosign container — `pithead`'s COSIGN_IMAGE — so that image is the trust root for the
+# whole fleet, and it was the one input nothing checked. The stack tests exercise the logic around it
+# against a fake `docker`, which passes identically whether the digest is real, typo'd or deleted
+# upstream; the tier-4 e2e deploys a source checkout, where verification is skipped by design; and
+# release-smoke runs AFTER the publish, when the assets are already immutable. So a bad pin shipped a
+# stack that cannot start, and the operator-facing failure reads "signature verification FAILED" —
+# tampering, not our pin having moved. The realistic cause is mundane: a CVE bump, one wrong
+# character, every test still green.
+
+# The pin, read from `pithead` the same way pin() reads the component versions out of the Dockerfiles.
+cosign_image_pin() { grep -oE '^readonly COSIGN_IMAGE="[^"]+"' pithead | head -1 | cut -d'"' -f2; }
+
+# One verify-blob through the pinned container, mirroring pithead's cosign_run: a single read-only
+# mount at /w with every path relative to it, and HOME=/tmp so cosign does not warn about a TUF cache
+# it cannot write. Same shape the install side runs, so a mount or path mistake shows up here first.
+verifier_verify_blob() { # <probe-dir> <image>
+    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$1:/w:ro" -w /w "$2" \
+        verify-blob --key cosign.pub --signature blob.sig --insecure-ignore-tlog=true blob >/dev/null 2>&1
+}
+
+# Prove the pinned verifier before anything is built: it pulls, it runs, and — when this box can sign
+# — it accepts a signature made with THIS release key and refuses a tampered blob. The round trip is
+# what makes the check real rather than a liveness probe: it also catches a `cosign.pub` that no
+# longer matches `COSIGN_KEY`, which would make every install refuse every artifact of this release.
+check_verifier_image() {
+    local img
+    img="$(cosign_image_pin)"
+    [ -n "$img" ] || die "Could not read COSIGN_IMAGE out of ./pithead — the release verifier pin moved or changed shape, so this cut cannot validate the thing every install verifies with."
+    case "$img" in
+    *@sha256:*) ;;
+    *) die "COSIGN_IMAGE is not pinned by digest ($img). On a tag, a hostile registry could serve a 'cosign' that exits 0 on everything and turn verification into theatre — pin it by @sha256 (pithead: COSIGN_IMAGE)." ;;
+    esac
+    docker run --rm "$img" version >/dev/null 2>&1 ||
+        die "The pinned release verifier will not run: $img. Every install and every one-click upgrade pulls exactly this digest, so a release cut against it would fail at the first 'up'. Check the pin in pithead (COSIGN_IMAGE) and that the digest is still published."
+    if [ "${COSIGN_ENABLED:-0}" -ne 1 ]; then
+        warn "Release verifier pulls and runs, but the signature round trip was skipped — this cut is not signing, so there is no signature to prove it against."
+        return 0
+    fi
+    local d
+    d="$(mktemp -d)"
+    printf 'pithead release verifier probe\n' >"$d/blob"
+    cp cosign.pub "$d/cosign.pub"
+    cosign sign-blob --key "${COSIGN_KEY:-}" --tlog-upload=false --yes --output-signature "$d/blob.sig" "$d/blob" >/dev/null 2>&1 ||
+        die "Could not sign a probe blob with COSIGN_KEY — the key or COSIGN_PASSWORD is wrong. Better here than at stage 6b, with the images already promoted."
+    verifier_verify_blob "$d" "$img" ||
+        die "The pinned release verifier refused a signature this box just made with COSIGN_KEY. Either the verifier image is not the cosign it claims to be, or the committed cosign.pub is not the public half of COSIGN_KEY — in which case every install would refuse every artifact of this release."
+    printf 'tampered\n' >>"$d/blob"
+    if verifier_verify_blob "$d" "$img"; then
+        die "The pinned release verifier ACCEPTED a tampered blob — it is not verifying anything. Every install trusts this image (pithead: COSIGN_IMAGE); do not cut a release against it."
+    fi
+    rm -rf "$d"
+    ok "Release verifier validated end to end (${img##*@}: signs, verifies, refuses a tampered blob)."
+}
+
 preflight() {
     stage "1/7  Preflight"
 
@@ -228,22 +352,8 @@ preflight() {
     if [ "$DRY_RUN" -eq 0 ] && [ "$SKIP_TESTS" -eq 0 ] && [ "$RESUME_PROMOTE" -eq 0 ]; then
         check_release_toolchain
     fi
-    # Release signing (#376) is OPT-IN and pure defense-in-depth. The tag-substitution vector it
-    # exists for — the first-party images pull by mutable `:vX.Y.Z` tag, so a re-pointed tag / leaked
-    # registry token could serve a malicious root-running image — is ALREADY closed by digest-pinning
-    # those images in the bundle (make_bundle). cosign additionally signs the promoted digests + the
-    # bundle for operators who want to verify. So a normal cut needs NOTHING off-repo: signing turns
-    # on only when a key is configured on this box AND cosign.pub is committed; otherwise we warn and
-    # skip it rather than block the release.
-    COSIGN_ENABLED=0
-    if [ "$DRY_RUN" -eq 0 ]; then
-        if command -v cosign >/dev/null 2>&1 && [ -n "${COSIGN_KEY:-}" ] && [ -f "${COSIGN_KEY:-/nonexistent}" ] && [ -f cosign.pub ]; then
-            COSIGN_ENABLED=1
-            ok "Release signing ON (cosign key + committed cosign.pub present)."
-        else
-            warn "Release signing OFF — shipping digest-pinned images + bundle without cosign signatures (#376 is opt-in). Installs are protected by the pinned digests; to also sign, see docs/dev/release-server.md § The release signing key."
-        fi
-    fi
+    resolve_signing
+    check_verifier_image
 
     STACK_VERSION="$(tr -d ' \t\r\n' <VERSION)"
     is_semver "$STACK_VERSION" || die "VERSION ('$STACK_VERSION') is not SemVer (expected X.Y.Z)."
@@ -473,7 +583,7 @@ promote() {
 # the environment — it never touches argv, run(), or the log.
 sign_images() {
     if [ "${COSIGN_ENABLED:-0}" -ne 1 ]; then
-        log "Release signing off — skipping image signatures (the bundle is digest-pinned; #376 opt-in)."
+        log "Release signing off — skipping image signatures; the bundle stays digest-pinned."
         return 0
     fi
     stage "6b/7 Sign the promoted digests (cosign, #376)"
@@ -503,7 +613,7 @@ publish() {
     write_manifest "$manifest"
     local bundle="$WORKDIR/pithead.tar.gz" # versionless name → stable /releases/latest/download/ URL
     make_bundle "$bundle"
-    local bundle_sig="" # pithead.tar.gz.sig — only when signing is on (#376 opt-in)
+    local bundle_sig="" # pithead.tar.gz.sig — absent only on a deliberate --unsigned cut (#960)
     if [ "${COSIGN_ENABLED:-0}" -eq 1 ]; then
         bundle_sig="$bundle.sig" # the #59 upgrade runner fetches it by name
         sign_bundle "$bundle" "$bundle_sig"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -252,12 +252,7 @@ signing_env_gaps() {
 # v3 passes every other check here and then dies at stage 6b with the tag pushed and the images
 # promoted (#960 — the bench box had drifted exactly this way). Probe the flag rather than parse a
 # version: the flag is the thing that actually has to work, and it stays true across future majors.
-cosign_flags_supported() {
-    local sub
-    for sub in sign sign-blob; do
-        cosign "$sub" --help 2>&1 | grep -q -- '--tlog-upload' || return 1
-    done
-}
+cosign_flags_supported() { cosign sign-blob --help 2>&1 | grep -q -- '--tlog-upload'; }
 
 resolve_signing() {
     local gaps

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -287,6 +287,50 @@ assert_contains "tor egress probe: WARN never fails doctor (rc 0)" "$out" "rc=0"
 out="$(RUNNING_CONTAINERS="" PATH="$DRBIN:$PATH" run_sourced "$SANDBOX" check_tor_clearnet_egress 2>&1)"
 assert_contains "tor egress probe: tor down -> info skip" "$out" "isn't running"
 
+echo "== unit: doctor answers 'can this box take an upgrade' (#1108) =="
+# Each branch mirrors a refusal the one-click upgrade runner makes, so a green line here means the
+# runner's preconditions hold. The last branch is the one that did not exist: the verifier is a
+# digest-pinned image fetched on demand, and if THAT fetch fails the upgrade reports a *signature*
+# failure — an operator reads tampering where the truth is an image the host could not pull (#1084).
+DVER="$SANDBOX/doctor-verify"
+mkdir -p "$DVER/bin" "$DVER/src/build/dashboard"
+: >"$DVER/src/build/dashboard/Dockerfile"
+printf '1.19.1\n' >"$DVER/VERSION"
+printf '1.19.1\n' >"$DVER/src/VERSION"
+# A docker whose daemon is up; IMAGE_CACHED decides whether the pinned verifier is already here.
+cat >"$DVER/bin/docker" <<'FAKEDOCKER'
+#!/usr/bin/env bash
+case "$1 $2" in
+"info ") exit "${DOCKER_DEAD:-0}" ;;
+"image inspect") exit $((1 - ${IMAGE_CACHED:-0})) ;;
+esac
+exit 0
+FAKEDOCKER
+chmod +x "$DVER/bin/docker"
+
+# A source checkout cannot take a one-click upgrade at all — the runner refuses it outright.
+out="$(PATH="$DVER/bin:$PATH" run_sourced "$DVER/src" check_release_verification 2>&1)"
+assert_contains "doctor: a source checkout says one-click does not apply" "$out" "one-click upgrade does not apply"
+assert_contains "doctor: a source checkout names the upgrade it CAN take" "$out" "./pithead upgrade"
+# A release install predating the first signed release has no key, so nothing is verified.
+out="$(PATH="$DVER/bin:$PATH" run_sourced "$DVER" check_release_verification 2>&1)"
+assert_contains "doctor: no cosign.pub warns that pulls are unverified" "$out" "WARN"
+assert_contains "doctor: no cosign.pub says what is missing" "$out" "No cosign.pub next to pithead"
+printf 'fake release public key\n' >"$DVER/cosign.pub"
+out="$(DOCKER_DEAD=1 PATH="$DVER/bin:$PATH" run_sourced "$DVER" check_release_verification 2>&1)"
+assert_contains "doctor: a dead docker daemon warns rather than claiming verification works" "$out" "WARN"
+assert_contains "doctor: the dead-daemon line names the fix" "$out" "Start the Docker daemon"
+# The verifier image is present: the box can take an upgrade today.
+out="$(IMAGE_CACHED=1 PATH="$DVER/bin:$PATH" run_sourced "$DVER" check_release_verification 2>&1)"
+assert_contains "doctor: a cached verifier image reports OK" "$out" "OK"
+assert_contains "doctor: the OK line says nothing needs installing" "$out" "nothing to install"
+# The verifier image is NOT here yet. MUTATION PROOF: collapse this branch into the OK above and
+# "an absent verifier image is not reported as OK" goes red.
+out="$(IMAGE_CACHED=0 PATH="$DVER/bin:$PATH" run_sourced "$DVER" check_release_verification 2>&1)"
+assert_contains "doctor: an absent verifier image is not reported as OK" "$out" "WARN"
+assert_contains "doctor: the absent-verifier line pre-empts the misleading signature failure" "$out" "even though nothing was tampered with"
+assert_contains "doctor: the absent-verifier line names the pre-fetch command" "$out" "docker pull ghcr.io/sigstore/cosign/cosign@sha256:"
+
 echo "== unit: doctor Monero sync check — peer-loss strand (#972) =="
 # A monerod stranded by a tor restart keeps a green healthcheck while get_info reports
 # synchronized:false — the check trusts the RAW flag (a stranded node can report a stale
@@ -2348,8 +2392,8 @@ sign_off_out="$(
     for s in "${IMAGES[@]}"; do set_digest "$s" "ghcr.io/test/pithead-$s@sha256:feed$s"; done
     sign_images 2>&1
 )"
-assert_eq "signing off means no cosign invocations (#376 opt-in)" "$(grep -c '^\[cosign\]' "$SIGN/cosign-off.log")" "0"
-assert_contains "signing off announces the skip (#376 opt-in)" "$sign_off_out" "skipping image signatures"
+assert_eq "signing off means no cosign invocations" "$(grep -c '^\[cosign\]' "$SIGN/cosign-off.log")" "0"
+assert_contains "signing off announces the skip" "$sign_off_out" "skipping image signatures"
 # The bundle gets a detached signature the #59 runner can fetch (pithead.tar.gz.sig), and the
 # committed public key ships INSIDE the bundle so a release install has its verifier beside pithead.
 # shellcheck disable=SC1090,SC2030,SC2031,SC2034
@@ -2367,6 +2411,199 @@ assert_contains "signing off announces the skip (#376 opt-in)" "$sign_off_out" "
 assert_contains "bundle signed as a detached blob signature" "$(cat "$SIGN/cosign.log")" \
     "sign-blob --key /release-box/cosign.key --tlog-upload=false --yes --output-signature $SIGN/pithead.tar.gz.sig"
 assert_contains "the bundle ships cosign.pub (the install-side verifier)" "$(cat "$REL")" "config.reference.json config.core-keys.json cosign.pub"
+
+echo "== unit: release.sh refuses to publish unsigned (#960/#1108) =="
+# The producer used to treat signing as opt-in while the consumer treats it as mandatory: once
+# cosign.pub is committed it ships in every bundle, and every one-click upgrade REFUSES a release
+# with no pithead.tar.gz.sig. So a cut on a box with no key does not make a degraded release, it
+# makes one the whole fleet rejects — and GitHub release assets are immutable, so the signature can
+# never be added afterwards. That is how v1.18.0 shipped unsigned and had to be withdrawn (#960).
+# resolve_signing must therefore ABORT the cut. MUTATION PROOF: change its final die() to warn() and
+# "an unconfigured signing box aborts the cut" goes red (verified — see the PR).
+SGN="$SANDBOX/signing960"
+mkdir -p "$SGN/bin" "$SGN/v3" "$SGN/nopub"
+# A cosign that advertises --tlog-upload, the flag both signing calls pass.
+printf '#!/usr/bin/env bash\necho "      --tlog-upload   upload to the transparency log"\nexit 0\n' >"$SGN/bin/cosign"
+# cosign v3 removed that flag: the box passes every other check and then dies at stage 6b, with the
+# images already promoted (#960 — the release box had drifted to v3.1.2 exactly this way).
+printf '#!/usr/bin/env bash\necho "      --yes   skip confirmation"\nexit 0\n' >"$SGN/v3/cosign"
+chmod +x "$SGN/bin/cosign" "$SGN/v3/cosign"
+: >"$SGN/cosign.key"
+
+# One resolve_signing decision, rendered as "rc=N <message> enabled=N". The env arrives as a string
+# because release.sh's option parser needs an empty argv (`set --`), which eats positional args; and
+# COSIGN_ENABLED — the variable that actually drives whether anything gets signed — is reported from
+# an EXIT trap, because die() exits this subshell before a trailing read of it could run.
+signing_decide() { # <cwd> <env-assignments>
+    _out="$(
+        cd "$1" || exit
+        _envs="$2"
+        set --
+        # shellcheck disable=SC1090
+        source "$REL" 2>/dev/null
+        set +eu
+        eval "$_envs"
+        trap 'printf " enabled=%s" "${COSIGN_ENABLED:-unset}"' EXIT
+        resolve_signing 2>&1
+    )"
+    printf 'rc=%s %s' "$?" "$_out"
+}
+SGN_OK="PATH=$SGN/bin:\$PATH; COSIGN_KEY=$SGN/cosign.key; COSIGN_PASSWORD=x; UNSIGNED=0; DRY_RUN=0"
+
+sg="$(signing_decide "$ROOT" "$SGN_OK")"
+assert_contains "a complete signing env turns signing ON" "$sg" "rc=0"
+assert_contains "signing ON is what the later stages actually read" "$sg" "enabled=1"
+assert_contains "signing ON says what will be signed" "$sg" "Release signing ON"
+# The defect itself: cosign.pub committed + no key must stop the cut, and say why it cannot be fixed later.
+sg="$(signing_decide "$ROOT" "${SGN_OK/COSIGN_KEY=$SGN\/cosign.key/unset COSIGN_KEY}")"
+assert_contains "an unconfigured signing box aborts the cut" "$sg" "rc=1"
+assert_contains "the abort names the missing piece" "$sg" "COSIGN_KEY is unset"
+assert_contains "the abort says the fleet would refuse the release" "$sg" "every one-click upgrade refuses"
+assert_contains "the abort says assets are immutable, so this cannot be fixed after publish" "$sg" "immutable"
+assert_contains "the abort offers the deliberate escape hatch" "$sg" "--unsigned"
+# --unsigned is the loud, explicit way to publish one anyway.
+sg="$(signing_decide "$ROOT" "${SGN_OK/COSIGN_KEY=$SGN\/cosign.key/unset COSIGN_KEY}; UNSIGNED=1")"
+assert_contains "--unsigned publishes anyway" "$sg" "rc=0"
+assert_contains "--unsigned leaves signing genuinely off" "$sg" "enabled=0"
+assert_contains "--unsigned warns the fleet will refuse this release" "$sg" "REFUSES a release that has none"
+# No committed public key means nothing in the field fails closed — warn and proceed, as before.
+sg="$(signing_decide "$SGN/nopub" "${SGN_OK/COSIGN_KEY=$SGN\/cosign.key/unset COSIGN_KEY}")"
+assert_contains "no committed cosign.pub still publishes unsigned" "$sg" "rc=0"
+assert_contains "no committed cosign.pub leaves signing off" "$sg" "enabled=0"
+assert_contains "no committed cosign.pub says installs will not verify" "$sg" "proceed unverified"
+# COSIGN_PASSWORD was never checked before: cosign would prompt for it at stage 6b, after promotion.
+sg="$(signing_decide "$ROOT" "${SGN_OK/COSIGN_PASSWORD=x/unset COSIGN_PASSWORD}")"
+assert_contains "an unset COSIGN_PASSWORD aborts the cut" "$sg" "rc=1"
+assert_contains "the abort names COSIGN_PASSWORD" "$sg" "COSIGN_PASSWORD is unset"
+# Set-but-empty is a legitimate key with no passphrase — an -n test would wrongly block that box.
+sg="$(signing_decide "$ROOT" "${SGN_OK/COSIGN_PASSWORD=x/COSIGN_PASSWORD=}")"
+assert_contains "an empty passphrase is a valid key, not a missing one" "$sg" "rc=0"
+assert_contains "an empty passphrase still signs" "$sg" "enabled=1"
+sg="$(signing_decide "$ROOT" "${SGN_OK/COSIGN_KEY=$SGN\/cosign.key/COSIGN_KEY=$SGN\/absent.key}")"
+assert_contains "a COSIGN_KEY naming no file aborts the cut" "$sg" "rc=1"
+assert_contains "the abort names the path it could not find" "$sg" "$SGN/absent.key"
+# The version drift that killed a cut: the flags are probed, not the version number.
+sg="$(signing_decide "$ROOT" "${SGN_OK/PATH=$SGN\/bin/PATH=$SGN\/v3}")"
+assert_contains "a cosign without --tlog-upload aborts the cut" "$sg" "rc=1"
+assert_contains "the abort names the flag that would fail at stage 6b" "$sg" "--tlog-upload"
+# The rehearsal is the point: the decision used to sit inside `if [ "$DRY_RUN" -eq 0 ]`, so a dry run
+# printed "signing OFF" whatever the box was configured to do — the one check that exists to protect
+# a cut could only ever report the failure state (#1108). MUTATION PROOF: put resolve_signing's body
+# back inside that guard and both of the next two go red.
+sg="$(signing_decide "$ROOT" "${SGN_OK/DRY_RUN=0/DRY_RUN=1}")"
+assert_contains "a dry run rehearses the real decision, not a fixed OFF (#1108)" "$sg" "rc=0"
+assert_contains "a dry run reports signing will be ON, not OFF (#1108)" "$sg" "enabled=1"
+sg="$(signing_decide "$ROOT" "${SGN_OK/DRY_RUN=0/DRY_RUN=1}; unset COSIGN_KEY")"
+assert_contains "a dry run on an unconfigured box fails the rehearsal (#1108)" "$sg" "rc=1"
+
+echo "== unit: release.sh validates the pinned verifier image before publish (#1084) =="
+# Since #1072 every install verifies its images and its upgrade bundle by running ONE digest-pinned
+# cosign container, so that image is the trust root for the whole fleet — and nothing checked it.
+# The stack tests around it run against a fake docker (they pass whether the digest is real, typo'd
+# or deleted), the tier-4 e2e skips verification on a source checkout, and release-smoke runs after
+# the publish, when the assets are immutable. So preflight proves the pin end to end instead.
+VER="$SANDBOX/verifier1084"
+mkdir -p "$VER/bin" "$VER/box"
+printf 'fake release public key\n' >"$VER/box/cosign.pub"
+printf 'readonly COSIGN_IMAGE="ghcr.io/sigstore/cosign/cosign@sha256:d1ge57"  # v2.6.3\n' >"$VER/box/pithead"
+# Enough cosign for preflight: it advertises --tlog-upload, and sign-blob writes the blob's sha256 as
+# the "signature" so the fake verifier below can genuinely check it rather than return a canned rc.
+cat >"$VER/bin/cosign" <<'FAKECOSIGN'
+#!/usr/bin/env bash
+case "${2:-}" in --help)
+    echo "      --tlog-upload   upload to the transparency log"
+    exit 0
+    ;;
+esac
+[ "${SIGN_RC:-0}" -eq 0 ] || exit "${SIGN_RC}"
+out="" blob=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --output-signature)
+        out="$2"
+        shift
+        ;;
+    -*) ;;
+    *) blob="$1" ;;
+    esac
+    shift
+done
+[ -n "$out" ] && [ -n "$blob" ] || exit 1
+openssl dgst -sha256 "$blob" | awk '{print $NF}' >"$out"
+FAKECOSIGN
+# A stand-in for the pinned container. `version` answers the liveness probe; verify-blob does the
+# real thing in miniature against the read-only mount, so the tampered-blob leg fails for the right
+# reason. VERIFIER_DEAD / VERIFIER_ALWAYS drive the failure modes a bad pin would produce.
+cat >"$VER/bin/docker" <<'FAKEDOCKER'
+#!/usr/bin/env bash
+mount=""
+for a in "$@"; do case "$a" in *:/w:ro) mount="${a%%:/w:ro}" ;; esac done
+case " $* " in *" version "*)
+    exit "${VERIFIER_DEAD:-0}"
+    ;;
+esac
+case "${VERIFIER_ALWAYS:-}" in
+accept) exit 0 ;;
+refuse) exit 1 ;;
+esac
+[ -n "$mount" ] || exit 1
+[ "$(openssl dgst -sha256 "$mount/blob" | awk '{print $NF}')" = "$(cat "$mount/blob.sig")" ]
+FAKEDOCKER
+chmod +x "$VER/bin/cosign" "$VER/bin/docker"
+
+verifier_check() { # <cwd> <env-assignments>
+    (
+        cd "$1" || exit
+        _envs="$2"
+        set --
+        # shellcheck disable=SC1090
+        source "$REL" 2>/dev/null
+        set +eu
+        eval "$_envs"
+        _out="$(check_verifier_image 2>&1)"
+        printf 'rc=%s %s' "$?" "$_out"
+    )
+}
+VER_OK="PATH=$VER/bin:\$PATH; COSIGN_ENABLED=1; COSIGN_KEY=$VER/box/cosign.key; DRY_RUN=0"
+: >"$VER/box/cosign.key"
+
+# The real tree's pin is what ships, so read it the way preflight will and check its shape.
+# shellcheck disable=SC1090
+assert_contains "the pin is read out of pithead" \
+    "$(cd "$ROOT" && set -- && source "$REL" 2>/dev/null && cosign_image_pin)" "ghcr.io/sigstore/cosign/cosign@sha256:"
+vc="$(verifier_check "$VER/box" "$VER_OK")"
+assert_contains "a working verifier passes preflight" "$vc" "rc=0"
+assert_contains "the pass says the round trip actually ran" "$vc" "refuses a tampered blob"
+# A verifier that says yes to everything is the failure a tag (rather than a digest) would let a
+# hostile registry serve — it must never read as a pass. MUTATION PROOF: delete the tampered-blob
+# leg from check_verifier_image and this goes red.
+vc="$(verifier_check "$VER/box" "$VER_OK; export VERIFIER_ALWAYS=accept")"
+assert_contains "a verifier that accepts a tampered blob aborts the cut" "$vc" "rc=1"
+assert_contains "the abort says it is not verifying anything" "$vc" "ACCEPTED a tampered blob"
+# The mundane realistic failure: a CVE bump, one wrong character, every other test still green.
+vc="$(verifier_check "$VER/box" "$VER_OK; export VERIFIER_DEAD=1")"
+assert_contains "an unpullable pin aborts the cut" "$vc" "rc=1"
+assert_contains "the abort says installs would fail at the first up" "$vc" "will not run"
+# A verifier that refuses a signature this box just made means the committed cosign.pub is no longer
+# the public half of COSIGN_KEY — every install would refuse every artifact of the release.
+vc="$(verifier_check "$VER/box" "$VER_OK; export VERIFIER_ALWAYS=refuse")"
+assert_contains "a key/cosign.pub mismatch aborts the cut" "$vc" "rc=1"
+assert_contains "the abort names the mismatch as a cause" "$vc" "public half"
+vc="$(verifier_check "$VER/box" "$VER_OK; export SIGN_RC=1")"
+assert_contains "a key that cannot sign aborts the cut before stage 6b" "$vc" "rc=1"
+# A tag would let a hostile registry serve a cosign that exits 0 on everything.
+printf 'readonly COSIGN_IMAGE="ghcr.io/sigstore/cosign/cosign:v2.6.3"\n' >"$VER/box/pithead"
+vc="$(verifier_check "$VER/box" "$VER_OK")"
+assert_contains "a verifier pinned by tag rather than digest aborts the cut" "$vc" "rc=1"
+assert_contains "the abort explains what a tag would allow" "$vc" "exits 0 on everything"
+: >"$VER/box/pithead"
+vc="$(verifier_check "$VER/box" "$VER_OK")"
+assert_contains "a pin that cannot be read at all aborts the cut" "$vc" "rc=1"
+# With signing off there is no signature to prove the verifier against — say so, do not imply a pass.
+printf 'readonly COSIGN_IMAGE="ghcr.io/sigstore/cosign/cosign@sha256:d1ge57"\n' >"$VER/box/pithead"
+vc="$(verifier_check "$VER/box" "${VER_OK/COSIGN_ENABLED=1/COSIGN_ENABLED=0}")"
+assert_contains "signing off still proves the pin pulls and runs" "$vc" "rc=0"
+assert_contains "signing off says the round trip was skipped" "$vc" "round trip was skipped"
 
 echo "== unit: pull-vs-build mode (#44) =="
 # is_source_checkout / resolve_pull_policy / STACK_VERSION key off whether the image build CONTEXTS


### PR DESCRIPTION
Closes #1108. Closes #960. Closes #1084. Closes #1048.

## The defect

**A release could ship unsigned; an install could not accept one.** `scripts/release.sh` warned and published when the signing environment was absent; `pithead`'s one-click upgrade runner refuses any release with no `pithead.tar.gz.sig`. A cut on an unconfigured box therefore produced a bundle **every install in the fleet rejects** — and GitHub release assets are immutable, so the signature could never be attached afterwards. That is how v1.18.0 had to be withdrawn and re-cut.

Three releases already shipped unsigned this way. Back then `cosign.pub` was uncommitted, so installs warned and proceeded. It is committed now, which means the same mistake today produces the hard refusal instead. The failure mode got worse while nobody was looking at it.

## What changed

**Signing is mandatory to publish (#960).** Preflight aborts when `cosign.pub` is committed and any of {cosign, `COSIGN_KEY`, `COSIGN_PASSWORD`} is missing, naming the gap and why it cannot be fixed after the publish. `--unsigned` is the explicit, loud escape hatch. `COSIGN_PASSWORD` was never checked before — cosign would have prompted for it at stage 6b, after the images were promoted, where there is nothing left to abort into. It is tested for *set*, not non-empty, so a legitimate passphrase-less key still signs.

**The dry run rehearses the decision.** It sat inside `if [ "$DRY_RUN" -eq 0 ]`, so the one check that exists to protect a cut could only ever print "signing OFF" — the failure state, unconditionally. Now only the signing itself is skipped.

**The cosign flags are probed, not assumed.** cosign v3 removed `--tlog-upload`, which both signing calls pass. A drifted box passed every other check and then died at stage 6b with the images already promoted — which is what happened to the release box on 2026-08-14.

**The pinned verifier is validated before publish (#1084).** Preflight pulls `COSIGN_IMAGE`, signs a probe blob with this box's key, verifies it *through the container*, and requires a tampered blob to be refused. Since #1072 that image is the trust root for every install, and nothing checked it: the stack tests run against a fake `docker` (they pass whether the digest is real, typo'd or deleted), the tier-4 e2e skips verification on a source checkout, and `release-smoke` runs after the assets are immutable. The round trip also catches a `cosign.pub` that is no longer the public half of `COSIGN_KEY` — a failure that would make every install refuse every artifact of the release, and which nothing detected anywhere.

**The release gate stops claiming to gate `main` (#1048).** `release-gate.yml` carried a `push: [main]` trigger behind a repo variable nobody set, so every merge recorded a *skipped* — i.e. green — run of a job that has never once executed. It is dispatch-only now, with the exact steps to re-enable it once a runner exists, and `docs/dev/releasing.md` names which gates are automated and which are human-run, in one table.

**`doctor` answers "can this box take an upgrade" before an upgrade does.** It reports whether the pinned verifier image is present and names the pre-fetch command. If that one fetch fails mid-upgrade the operator sees a *signature* failure — which reads as a tampered release rather than as an image the host could not pull. The source-checkout line now also says one-click does not apply there. The check moved out of `doctor()` into `check_release_verification()` so each branch is unit-testable, matching how the other doctor checks are already factored.

**The legacy cliff is documented.** v1.18.1 and v1.19.0 verify with a host binary, and an upgrade runs the *installed* code — so those boxes refuse until cosign is installed once, with the pinned v2.6.3 (v3 satisfies `command -v` and then fails the verify). Written up in `releasing.md`, linked from `operations.md` where a stuck operator actually looks.

**The prose is reconciled.** Signing is no longer described as "opt-in" anywhere: the consumer became fail-closed and nothing had updated the docs.

## Coverage

51 new tier-1 assertions. Every one is mutation-proven — 10 mutations run, each going red on exactly the named assertions and nothing else:

| Mutation | Assertions that go red |
|---|---|
| `die` to `warn` (signing opt-in again) | an unconfigured signing box aborts the cut (+3) |
| decision back inside the `DRY_RUN` guard | both dry-run rehearsal assertions |
| drop the `COSIGN_PASSWORD` gap | unset-password aborts the cut (+1) |
| `COSIGN_PASSWORD` tested non-empty, not set | an empty passphrase is a valid key (+1) |
| drop the `--tlog-upload` probe | cosign-without-the-flag aborts (+1) |
| drop the tampered-blob leg | a verifier that accepts a tampered blob aborts (+1) |
| drop the good-signature leg | key / `cosign.pub` mismatch aborts (+1) |
| drop the digest-pin shape check | tag-pinned verifier aborts (+1) |
| collapse the absent-verifier doctor branch into OK | absent verifier image is not reported as OK (+2) |
| drop the doctor source-checkout branch | source checkout says one-click does not apply (+1) |

## One claim in #1108 that did not survive re-derivation

#1108 states that the upgrade runner's refusal of an unsigned bundle "exists in behaviour but has no test that would go red if the refusal were deleted." **It does have one.** Deleting the refusal turns three existing assertions red (`tests/stack/run.sh` — "missing signature asset reports failed" / "names the asset" / "extracts nothing"): 1787 passed / 3 failed against a 1790 / 0 baseline. No test was added there.

## Verification

**Live, on the release box, against the real pinned cosign container** — the container round trip cannot be tested from a laptop, and a false positive there would have made releases impossible:

| Scenario | Result |
|---|---|
| complete signing env, `--dry-run` | "Release signing **ON**" — impossible before this change — then the verifier round trip passes |
| no `COSIGN_KEY` (the v1.18.0 mistake) | aborts, naming the gap |
| `--unsigned` | publishes, warning that the fleet will refuse it |
| verifier pinned by tag, not digest | aborts |
| unpullable pinned digest | aborts |
| `cosign.pub` not the public half of `COSIGN_KEY` | aborts |

A throwaway key pair was generated in a scratch clone for this; the release key was never touched, and the box was left as found.

Local gates: tier-1 **1790 / 0**, dashboard **1721 passed at 97.01%**, frontend, compose, integration selftest, fakes, and every lint. `lint-proto` needs a Docker daemon this host does not have.

## Owed, and stated in the docs rather than assumed

The legacy escape path is written from the guards read at each released tag; it has **not** been driven end to end on a box actually running v1.18.1 or v1.19.0. `docs/dev/releasing.md` says so in the section itself. That proof needs a bench deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)