### PR TITLE
fix: name the real first signed release (v1.18.1), and escape the whole regex

### DIFF
--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -113,7 +113,7 @@ test('chart range buttons include All, active on the default full-history view (
 test('chart legend renders a toggle for every layer, including the marker datasets (#652)', () => {
     const html = renderApp();
     for (const label of ['P2Pool (routed)', 'XvB (routed)', 'Shares', 'Events', 'Raffle wins']) {
-        assert.match(html, new RegExp(`legend-item[^>]*>.*?${label.replace(/[()]/g, '\\$&')}</button>`),
+        assert.match(html, new RegExp(`legend-item[^>]*>.*?${label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</button>`),
             `missing legend toggle: ${label}`);
     }
     // A hidden marker layer renders its button in the off state, like the line series do.

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -264,7 +264,9 @@ curl -fsSLO https://github.com/p2pool-starter-stack/pithead/releases/download/vX
 cosign verify-blob --key cosign.pub --signature pithead.tar.gz.sig --insecure-ignore-tlog=true pithead.tar.gz
 ```
 
-Releases up to v1.3.x are unsigned; verification gates every release from the first signed one.
+Releases before **v1.18.1** are unsigned — that is the first cut whose bundle shipped a
+`pithead.tar.gz.sig`, because it is the first tag containing the committed `cosign.pub`;
+verification gates every release from it on.
 If an upgrade sent you here saying cosign is not installed, read the next section — that box needs
 the host binary once, not a manual verify.
 
@@ -322,8 +324,12 @@ It runs two phases:
   `:vX.Y.Z` images and verifies them against the committed `cosign.pub`. A good signature must pass;
   a byte-changed bundle must be refused (this is what proves the check is real, not the pre-merge
   fake); the bundle's own `VERSION` must equal the tag (the #376 rollback guard); and an unrelated
-  key must be refused. If the release is **unsigned** — releases up to v1.3.x predate signing, and a
-  `--unsigned` cut ships without one — that is reported plainly and the phase is skipped. It never reports a signed pass for an unsigned release. This phase needs only
+  key must be refused. If the release is **unsigned** — every release before v1.18.1 predates the
+  committed key, and a deliberate `--unsigned` cut ships without a signature (an unconfigured box
+  aborts the cut instead; see
+  [Release / Validation Server › The release signing key](release-server.md#the-release-signing-key))
+  — that is reported plainly and the phase is skipped. It never reports a signed pass for an
+  unsigned release. This phase needs only
   `gh` auth and network; run it anywhere.
 - **Real #59 upgrade** (`--upgrade DIR`). On a box still running the *previous* release, it enqueues
   the exact upgrade intent the dashboard writes into the #33 control spool, runs the host control

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -15,7 +15,8 @@
 #     - the bundle's own VERSION equals the tag (the #376 rollback guard — an older signed bundle
 #       served at the vX.Y.Z URL is caught);
 #     - every published image verifies, and an unrelated key is refused.
-#   If the release is UNSIGNED (releases up to v1.3.x, or a --unsigned cut) that is reported plainly — never a false
+#   If the release is UNSIGNED (every release before v1.18.1, or a --unsigned cut) that is reported
+#   plainly — never a false
 #   pass. Runnable from any box with `gh` auth + network; needs no deployed stack.
 #
 # Phase 2 (--upgrade DIR): drive the REAL #59 host path against a previous-release install — enqueue
@@ -109,7 +110,7 @@ verify_release() {
     # running install already trusts), never the bundle's own copy — a key that arrives inside the
     # artifact it vouches for proves nothing.
     if [ ! -f "$pub" ] && [ "$SIG_PUBLISHED" -eq 0 ]; then
-        warn "UNSIGNED release: no committed cosign.pub and no pithead.tar.gz.sig asset. Releases up to v1.3.x predate signing, and a --unsigned cut ships without it (#960). Nothing to cosign-verify; bundle integrity rests on the digest-pinned compose + TLS to GitHub. (Not a failure.)"
+        warn "UNSIGNED release: no committed cosign.pub and no pithead.tar.gz.sig asset. Every release before v1.18.1 predates the committed key, and a --unsigned cut ships without a signature (#960). Nothing to cosign-verify; bundle integrity rests on the digest-pinned compose + TLS to GitHub. (Not a failure.)"
         return 0
     fi
     # A half state is a misconfiguration, not a pass — surface it.


### PR DESCRIPTION
Two small correctness fixes on `develop`, found while resolving the twin sync (#1115).

## The first signed release is v1.18.1, not v1.3.x

Three places said releases "up to v1.3.x" are unsigned. Verified from raw evidence rather than
assumed:

- `cosign.pub` was first committed in `fe543ac` — *"release: commit cosign.pub — signing engages for
  the first time"*, 2026-08-14.
- The earliest tag containing that commit is **v1.18.1** (`git tag --contains`).
- `gh release view` on the published assets: v1.3.0, v1.14.0, v1.17.0 and **v1.18.0** carry
  `pithead.tar.gz` and the manifest only; **v1.18.1** and v1.19.2 also carry `pithead.tar.gz.sig`.

Two of the three are operator-facing `release-smoke` output, so anyone checking an unsigned v1.14
release was told signing had been on for eleven minor versions. The same correction, in the same
words, is in #1119 on the v2 lane so the twins converge on the fact instead of drifting apart.

## The legend-label assertion escaped only parentheses

CodeQL alert 1 (`js/incomplete-sanitization`, high) on `components.test.mjs`. There is no untrusted
input — the labels are literals two lines above — so this is not a vulnerability, and dismissing it
would have been defensible. It is worth fixing anyway because the escape is wrong in a way that
fails *silently*:

```
label = "Raffle wins +1"
old escape -> pattern matches "Raffle wins 1"   (true - the wrong string passes)
new escape -> matches only "Raffle wins +1"
```

An assertion that passes on a string the UI never rendered is the failure mode this repo keeps
filing issues about. Widening the class to the full metacharacter set makes it mean what it reads
as, and closes the alert.

## Verification

- `make test-frontend`: **317 passed / 0 failed** — byte-identical behaviour for today's labels,
  which contain only parentheses.
- `make lint-sh`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-js`: pass.
  `lint-proto` needs a Docker daemon and did not run locally; CI covers it.
- No test pins any of the three changed strings (grepped before editing — a message edit is not free).
