### PR TITLE
fix(wizard): stop the plain-port redirect trusting the Host header (#1118)

### DIFF
--- a/build/dashboard/mining_dashboard/wizard.py
+++ b/build/dashboard/mining_dashboard/wizard.py
@@ -25,6 +25,7 @@ import hmac
 import json
 import mimetypes
 import os
+import socket
 import ssl
 import sys
 import tempfile
@@ -566,16 +567,59 @@ def make_app(exit_fn=sys.exit) -> web.Application:
     return app
 
 
+def _host_only(hostport: str) -> str:
+    """Drop the port, keeping an IPv6 literal's brackets: '[fd00::1]:80' -> '[fd00::1]'."""
+    if hostport.startswith("["):
+        return hostport.partition("]")[0] + "]"
+    return hostport.partition(":")[0]
+
+
+def _socket_host(request: web.Request) -> str:
+    """The address this request actually arrived on — what the machine knows about itself.
+
+    Authoritative in a way the Host header is not: it comes from the accepted socket, so it is the
+    address the operator's browser genuinely reached. Falls back to the documented mDNS name when
+    the transport cannot say, which is the one name every pithead answers to.
+    """
+    sockname = None
+    if request.transport is not None:
+        sockname = request.transport.get_extra_info("sockname")
+    if not isinstance(sockname, (tuple, list)) or not sockname:
+        return "pithead.local"
+    host = str(sockname[0])
+    return f"[{host}]" if ":" in host else host
+
+
+def _redirect_host(request: web.Request) -> str:
+    """Which host the plain-port redirect should point at.
+
+    The Host header is chosen by whoever makes the request, not by this machine, so it is honoured
+    only when it names something this box answers to (#1118): the address the request arrived on,
+    the machine's own hostname or FQDN, or the documented `pithead.local`. Anything else would let
+    a forged header 301 the browser off the appliance mid-setup — the one screen where the operator
+    types the dashboard password, and where the address bar still shows the name they typed.
+
+    An unrecognised header falls back to the socket address rather than refusing: a wizard that
+    fails closed on a box with no other way in is worse than one that redirects to the IP.
+    """
+    claimed = _host_only(request.host or "")
+    own = {_socket_host(request), "pithead.local", socket.gethostname(), socket.getfqdn()}
+    known = {n.lower().rstrip(".") for n in own if n}
+    if claimed.lower().rstrip(".") in known:
+        return claimed
+    return _socket_host(request)
+
+
 async def _redirect_to_tls(request: web.Request) -> web.Response:
     """Everything on the plain port becomes a redirect to the TLS one.
 
     An operator who types the address without a scheme lands on :80, and a setup page that
     simply failed there would read as a broken machine — so :80 stays open and points at :443
-    rather than being closed. The host header carries the name or IP they actually used, so the
-    redirect keeps working for pithead.local and for a bare address alike.
+    rather than being closed. The host they actually used is kept when this machine recognises it,
+    so the redirect works for pithead.local and for a bare address alike; see _redirect_host for
+    why an unrecognised one is not.
     """
-    host = request.host.split(":")[0]
-    raise web.HTTPMovedPermanently(f"https://{host}{request.rel_url}")
+    raise web.HTTPMovedPermanently(f"https://{_redirect_host(request)}{request.rel_url}")
 
 
 async def _serve(app: web.Application, bind: str, tls: ssl.SSLContext | None) -> web.AppRunner:

--- a/build/dashboard/tests/web/test_wizard.py
+++ b/build/dashboard/tests/web/test_wizard.py
@@ -572,12 +572,65 @@ def test_a_missing_key_falls_back_rather_than_crashing(monkeypatch, tmp_path):
     assert started["port"] == 8000
 
 
+class _Transport:
+    """Just enough transport to answer "what address did this arrive on"."""
+
+    def __init__(self, sockname):
+        self._sockname = sockname
+
+    def get_extra_info(self, name, default=None):
+        return self._sockname if name == "sockname" and self._sockname else default
+
+
+def _plain_request(host, sockname=("192.168.1.10", 80)):
+    """A :80 request claiming `host`, arriving on `sockname` — the two the redirect weighs."""
+    return make_mocked_request(
+        "GET", "/setup", headers={"Host": host}, transport=_Transport(sockname)
+    )
+
+
 async def test_plain_port_redirects_to_tls_keeping_the_host_used():
     # Someone typing a bare address lands on :80; a dead port there reads as a broken machine.
-    req = make_mocked_request("GET", "/setup", headers={"Host": "pithead.local"})
+    req = _plain_request("pithead.local")
     with pytest.raises(web.HTTPMovedPermanently) as exc:
         await wizard._redirect_to_tls(req)
     assert exc.value.location == "https://pithead.local/setup"
+
+
+async def test_plain_port_keeps_the_address_the_request_arrived_on():
+    # A bare LAN address is the other documented way in, and the socket proves the box owns it.
+    req = _plain_request("192.168.1.10")
+    with pytest.raises(web.HTTPMovedPermanently) as exc:
+        await wizard._redirect_to_tls(req)
+    assert exc.value.location == "https://192.168.1.10/setup"
+
+
+async def test_plain_port_refuses_to_bounce_setup_to_a_forged_host():
+    # The Host header belongs to whoever made the request. Honouring it turns :80 into an open
+    # redirector on the one screen where the operator types the dashboard password — reachable
+    # through a name that resolves here (rebinding, or a LAN whose DNS is not trustworthy), with
+    # the address bar still showing what they typed. It must land back on this machine.
+    req = _plain_request("evil.example")
+    with pytest.raises(web.HTTPMovedPermanently) as exc:
+        await wizard._redirect_to_tls(req)
+    assert exc.value.location == "https://192.168.1.10/setup"
+
+
+async def test_plain_port_redirect_survives_a_transport_that_cannot_say():
+    # Never leave the operator with a broken link: with no socket to fall back to, the documented
+    # mDNS name is the one address every pithead answers to.
+    req = _plain_request("evil.example", sockname=None)
+    with pytest.raises(web.HTTPMovedPermanently) as exc:
+        await wizard._redirect_to_tls(req)
+    assert exc.value.location == "https://pithead.local/setup"
+
+
+async def test_plain_port_redirect_brackets_an_ipv6_address():
+    # https://fd00::1/setup is not a URL; the brackets are what make it one.
+    req = _plain_request("[fd00::1]", sockname=("fd00::1", 80, 0, 0))
+    with pytest.raises(web.HTTPMovedPermanently) as exc:
+        await wizard._redirect_to_tls(req)
+    assert exc.value.location == "https://[fd00::1]/setup"
 
 
 # --- the credentials handoff ----------------------------------------------------------------


### PR DESCRIPTION
Closes #1118. CodeQL alert 2 (`py/url-redirection`), surfaced on #1057.

```python
host = request.host.split(":")[0]
raise web.HTTPMovedPermanently(f"https://{host}{request.rel_url}")
```

`request.host` is the `Host` header — chosen by whoever makes the request, not by the appliance —
so every request to the wizard's plain port was answered with a 301 to whatever host that header
named.

## Why this one is worth closing rather than dismissing

Reaching it needs a name that resolves to the box: DNS rebinding, or a LAN whose DNS or DHCP is not
trustworthy — the same LAN the wizard already assumes is hostile enough to justify TLS on a setup
page. What it lands on is the screen where the operator types the dashboard password, with the
address bar still showing the name they typed. Everything else in the wizard exists to keep that
password on the machine.

Severity is bounded by needing name control on the LAN, so this is hardening, not an emergency.

## The fix

The header is honoured only when it names something this machine answers to — the address the
request arrived on (read from the accepted socket, which the sender cannot forge), the machine's
hostname or FQDN, or the documented `pithead.local`. Every legitimate way in still works:
`pithead.local`, a bare LAN address, and a custom name that resolves to the box's own hostname.

An unrecognised header falls back to the socket address rather than refusing. A wizard that fails
closed on a machine with no other way in is worse than one that redirects you to the IP.

Two smaller defects fall out of doing it properly:

- an IPv6 literal keeps its brackets, so `https://[fd00::1]/setup` is a URL — the old `split(":")`
  truncated `[fd00::1]` to `[fd00`;
- a transport that cannot report its socket falls back to `pithead.local` instead of an empty host.

## Coverage

`test_plain_port_redirects_to_tls_keeping_the_host_used` sent only `Host: pithead.local`, so it
stayed green whatever the function did with a hostile header. Four assertions added:

| Mutation | Result |
| --- | --- |
| `_redirect_host` returns the raw `Host` again (the defect) | RED: `refuses_to_bounce_setup_to_a_forged_host`, `redirect_survives_a_transport_that_cannot_say` |
| `_socket_host` stops bracketing an IPv6 address | RED: `redirect_brackets_an_ipv6_address` |

Dashboard suite **1843 passed**; `ruff check` and `ruff format --check` clean on both files.
