### PR TITLE
fix(appliance): re-stage the wizard spool per session, so a retry keeps TLS (#1063)

### DIFF
--- a/pithead
+++ b/pithead
@@ -2151,6 +2151,38 @@ load_baked_images() { # $1 (optional): image ref whose absence forces a load des
     return 0
 }
 
+# Everything the wizard container needs in its spool, staged fresh for EVERY wizard start.
+#
+# It used to run once, before the loop — and the accept path removes the whole spool before
+# provisioning. So a provisioning failure re-entered the loop with the certificate, the reference
+# schema and the rig pre-fill all gone, and `wizard.py` gates TLS on the cert FILE existing: the
+# retry served the setup page — payout address, dashboard password, node secrets — in CLEARTEXT,
+# while the console still advertised HTTPS and a fingerprint minted before the loop (#1063).
+#
+# Prints the certificate fingerprint, empty when one could not be minted, so the caller can say
+# so honestly instead of promising a scheme it is not serving.
+stage_wizard_spool() { # <spool-dir> -> fingerprint on stdout
+    local spool="$1"
+    mkdir -p "$spool"
+    # The wizard container runs as uid 1000 and must write the spool; transient dir, addresses
+    # only by design, removed at handoff.
+    chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
+    # The wizard renders the EXACT config that will be written, defaults included, so it needs
+    # the reference. It is a read-only schema, not a secret.
+    cp /opt/pithead/config.reference.json "$spool/config.reference.json" 2>/dev/null ||
+        cp "$PWD/config.reference.json" "$spool/config.reference.json" 2>/dev/null || true
+    chown 1000:1000 "$spool/config.reference.json" 2>/dev/null || true
+    # The rig role's pre-fill rides beside the reference — derived fresh each boot, like the
+    # disk inventory, so machine 2 on a fleet stick never opens on machine 1's discovery.
+    publish_rig_defaults "$spool"
+    # Installer mode reads the disk list from here too; a retry with no list is the same dead end
+    # in a different shape.
+    installer_mode_available && publish_disk_inventory "$spool"
+    # Copies the canonical pair off /data — minting only happens the first time, so the
+    # fingerprint the console prints stays the machine's one certificate across retries.
+    wizard_mint_cert "$spool" 2>/dev/null || true
+}
+
 firstboot_wizard() {
     local arg
     for arg in "$@"; do
@@ -2236,24 +2268,12 @@ firstboot_wizard() {
     export_build_provenance
     image="${PITHEAD_REGISTRY}/pithead-dashboard:${STACK_VERSION}"
     spool="$PWD/data/firstboot"
-    mkdir -p "$spool"
-    # The wizard container runs as uid 1000 and must write the spool; transient dir, addresses
-    # only by design, removed at handoff.
-    chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
-    # The wizard renders the EXACT config that will be written, defaults included, so it needs
-    # the reference. It is a read-only schema, not a secret.
-    cp /opt/pithead/config.reference.json "$spool/config.reference.json" 2>/dev/null ||
-        cp "$PWD/config.reference.json" "$spool/config.reference.json" 2>/dev/null || true
-    chown 1000:1000 "$spool/config.reference.json" 2>/dev/null || true
-    # The rig role's pre-fill rides beside the reference — derived fresh each boot, like the
-    # disk inventory, so machine 2 on a fleet stick never opens on machine 1's discovery.
-    publish_rig_defaults "$spool"
+    stage_wizard_spool "$spool" >/dev/null
 
     local installer=0 operator_preseed=0
     [ -f "$PRESEED_DIR/pithead-config.json" ] && operator_preseed=1
     if installer_mode_available; then
-        installer=1
-        publish_disk_inventory "$spool"
+        installer=1 # the disk list is staged with the rest of the spool, every session
         log "Running from the installation medium — install and configure on one page."
         # The pre-fill is derived fresh every boot, never inherited: the stick's spool
         # survives between machines, and machine 2 must not open on machine 1's answers —
@@ -2280,11 +2300,15 @@ firstboot_wizard() {
     # trap also fires after this function's locals are gone — where set -u would turn the trap
     # itself into the crash that masks whatever actually failed.
     local cert_fp=""
-    cert_fp=$(wizard_mint_cert "$spool") || warn "Could not generate a setup certificate — the setup page will be plain HTTP."
 
     # shellcheck disable=SC2064  # expand-now is the point (see above)
     trap "'$engine' rm -f pithead-wizard >/dev/null 2>&1 || true" EXIT
     while :; do
+        # Re-stage per session, and re-derive the fingerprint with it: the accept path removes the
+        # spool, so a retry that reused a cert_fp computed once would advertise HTTPS and a
+        # fingerprint for a certificate the container can no longer read (#1063).
+        cert_fp=$(stage_wizard_spool "$spool")
+        [ -n "$cert_fp" ] || warn "Could not generate a setup certificate — the setup page will be plain HTTP."
         # Every wizard session starts with CLEAN flow state. The spool lives on this medium's
         # /data, which survives reboots — so a fleet stick that installed machine 1 still
         # carries its handoff.json, ack and installed markers, and machine 2's boot would open

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9279,6 +9279,40 @@ unset PITHEAD_TLS_DIR
 rm -rf "$TLSSB"
 unset TLSSB fp1 fp2
 
+echo "== unit: stage_wizard_spool re-arms a wiped spool, so a retry keeps its TLS (#1063) =="
+# The accept path removes the whole spool before provisioning. Staging used to run ONCE before the
+# loop, so a provisioning failure re-entered it with the certificate, the reference schema and the
+# rig pre-fill gone — and wizard.py gates TLS on the cert FILE existing, so the retry served the
+# setup page (payout address, dashboard password, node secrets) in CLEARTEXT while the console
+# still advertised HTTPS and a fingerprint. MUTATION PROOF: stage once before the loop again and
+# "a wiped spool is fully re-armed" + "the retry can still serve TLS" go red.
+SWS=$(mktemp -d)
+export PITHEAD_TLS_DIR="$SWS/tls"
+sws_fp=$(run_sourced "$ROOT" stage_wizard_spool "$SWS/spool" 2>/dev/null)
+assert_contains "staging prints the certificate fingerprint the console advertises" "$sws_fp" ":"
+for f in wizard.crt wizard.key config.reference.json rig-defaults.json; do
+    assert_eq "staged: $f" "$([ -s "$SWS/spool/$f" ] && echo present || echo absent)" "present"
+done
+# The accept path's teardown, exactly as it happens, then the retry the outer loop drives.
+rm -rf "$SWS/spool"
+sws_fp2=$(run_sourced "$ROOT" stage_wizard_spool "$SWS/spool" 2>/dev/null)
+sws_missing=""
+for f in wizard.crt wizard.key config.reference.json rig-defaults.json; do
+    [ -s "$SWS/spool/$f" ] || sws_missing="$sws_missing $f"
+done
+assert_eq "a wiped spool is fully re-armed" "${sws_missing:-none}" "none"
+assert_eq "the retry can still serve TLS — the cert the container is pointed at exists" \
+    "$([ -s "$SWS/spool/wizard.crt" ] && [ -s "$SWS/spool/wizard.key" ] && echo yes || echo no)" "yes"
+# One machine, one certificate: the operator already trusted this fingerprint, and a retry that
+# minted a fresh one would make the console's printed fingerprint a lie in the other direction.
+assert_eq "the fingerprint survives the retry" "$sws_fp2" "$sws_fp"
+# And the loop must actually call it per session — staging that only a caller could reach is the
+# bug this fixes. MUTATION PROOF: delete the call from the loop and this goes red.
+assert_contains "the wizard loop re-stages every session" "$(cat "$STACK")" 'cert_fp=$(stage_wizard_spool "$spool")'
+unset PITHEAD_TLS_DIR
+rm -rf "$SWS"
+unset SWS sws_fp sws_fp2 sws_missing
+
 echo "== unit: preflight_remote_nodes dials before provisioning commits =="
 PFSB=$(mktemp -d)
 printf '{"monero":{"mode":"local"},"tari":{"mode":"local"}}' >"$PFSB/local.json"


### PR DESCRIPTION
Closes #1063.

The accept path removes the whole spool before provisioning. Staging ran **once**, before the loop
— so a provisioning failure re-entered it with the certificate, the reference schema, the rig
pre-fill and the installer's disk list all gone.

`wizard.py` gates TLS on the cert **file** existing, so the retry fell through to
`web.run_app(port=8000)` and served the setup page in **cleartext**: the payout address, the
dashboard password, node secrets. Meanwhile `cert_fp` was assigned once outside the loop, so the
console went on advertising HTTPS and a fingerprint for a certificate the container could no longer
read — the operator's one way to check they were on the right machine, still printing confidently.

## The fix

Staging moves into `stage_wizard_spool`, called at the top of every loop iteration, and `cert_fp` is
re-derived from its output. Those two have to move together: a retry that re-staged the cert but
kept a stale fingerprint, or vice versa, drifts the console's promise away from the served scheme in
the other direction.

Minting stays idempotent — the canonical pair lives on `/data` and `appliance_mint_cert` reuses it —
so the fingerprint the operator has already trusted survives the retry rather than changing under
them.

The installer's disk inventory joins the same staging (its separate pre-loop call is now redundant
and removed): a retry that reopens the install page with no disk list is the same dead end wearing
different clothes.

## Coverage

| Mutation | Result |
| --- | --- |
| stage once before the loop again (the defect) | 2627/1 — "the wizard loop re-stages every session" |
| staging stops copying the certificate into the spool | 2624/4 — "staged: wizard.crt", "staged: wizard.key", "a wiped spool is fully re-armed", "the retry can still serve TLS" |

The first mutation is caught by exactly one assertion, deliberately: the behavioural tests drive
`stage_wizard_spool` directly, so they stay green when the *caller* regresses. That is the
regression this issue is about, so it gets its own assertion on the call site.

Tier-1 **2628 passed / 0 failed**. `shellcheck` clean.

The end-to-end shape — force a provisioning failure on the bench and re-open the page — is not
covered by any current KVM leg; that belongs with #1064's phase-coverage work.
