### PR TITLE
fix(os): make the release gate report only what it actually ran (#1064)

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -207,8 +207,13 @@ sudo tests/os/run.sh --phase boot --image os/rauc/build/system.img
 ```
 
 `--phase update` and `--phase fault` build their own v1/v2 images and need no `--image`.
-`--phase all` runs everything. Expect roughly 25 minutes per phase, most of it image
-builds.
+`--phase all` runs all eight — boot, update, install, provision, rig, media, fault and reset.
+Expect roughly 25 minutes per phase, most of it image builds, so budget an evening rather
+than a coffee break. It ran five of the eight until #1064, which meant a cut that followed
+this page ran none of the destructive phases: the power cuts, the corrupt-bundle refusal, the
+factory reset, the wedged-`/data` recovery and the whole media channel. Record the dated
+per-phase pass count in the release issue for the tip actually being cut — an old green
+standing in for a new one is the same defect wearing a different hat.
 
 Two harness rules worth knowing before you lose an afternoon to them:
 

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -216,6 +216,13 @@ _wait_setup_page() {
 # Build a bootable image carrying $1 as its slot marker, for the selected updater.
 _build_image() {
     [ -f "$KEY" ] || ssh-keygen -t ed25519 -N "" -f "$KEY" -q
+    # What this harness believes it is building, in the same shape BUILD_COMMIT records — so
+    # verify-image's stale-artifact guard runs here too. It used to be unset in the only automated
+    # caller, which left the check that exists BECAUSE an image shipped a two-commits-stale
+    # dashboard switched off in every battery run (#1064).
+    local expect
+    expect="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    [ -n "$(git status --porcelain 2>/dev/null)" ] && expect="${expect}-dirty"
     PITHEAD_UPDATER=rauc PITHEAD_TEST_SSH_PUBKEY="$(cat "$KEY.pub")" PITHEAD_TEST_MARKER="$1" \
         os/build-image.sh >/tmp/os-fault-build.log 2>&1 || return 1
     os/rauc/mkimage.sh --dev >>/tmp/os-fault-build.log 2>&1 || return 1
@@ -223,7 +230,7 @@ _build_image() {
     # that matters most is the archive-vs-tree comparison: stale wizard images reached three
     # benches through caching bugs, and this layer catches the next one before a 25-minute
     # phase runs against it.
-    tests/os/verify-image.sh os/rauc/build/system.img --test >>/tmp/os-fault-build.log 2>&1 || {
+    PITHEAD_EXPECT_COMMIT="$expect" tests/os/verify-image.sh os/rauc/build/system.img --test >>/tmp/os-fault-build.log 2>&1 || {
         echo "verify-image failed on the freshly built image (see /tmp/os-fault-build.log)" >&2
         return 1
     }
@@ -3278,11 +3285,18 @@ media) phase_media ;;
 fault) phase_fault ;;
 reset) phase_reset ;;
 all)
+    # ALL of them. This arm used to run five of eight, while the release checklist told a
+    # maintainer that step 1 covered everything — so the three mid-write power cuts, the
+    # mid-commit cut, the corrupt-bundle refusal, the factory reset, the wedged-/data recovery
+    # and the whole media channel were silently omitted from every cut (#1064).
     phase_boot
     phase_update
     phase_install
     phase_provision
     phase_rig
+    phase_media
+    phase_fault
+    phase_reset
     ;;
 *)
     echo "unknown phase: $PHASE" >&2

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -216,13 +216,13 @@ _wait_setup_page() {
 # Build a bootable image carrying $1 as its slot marker, for the selected updater.
 _build_image() {
     [ -f "$KEY" ] || ssh-keygen -t ed25519 -N "" -f "$KEY" -q
-    # What this harness believes it is building, in the same shape BUILD_COMMIT records — so
-    # verify-image's stale-artifact guard runs here too. It used to be unset in the only automated
-    # caller, which left the check that exists BECAUSE an image shipped a two-commits-stale
-    # dashboard switched off in every battery run (#1064).
+    # What this harness believes it is building, so verify-image's stale-artifact guard runs here
+    # too. It used to be unset in the only automated caller, which left the check that exists
+    # BECAUSE an image shipped a two-commits-stale dashboard switched off in every battery run
+    # (#1064). build-image.sh stamps the FULL sha, so that is the shape to hand over: a short one
+    # never matched, and wiring the guard on with it would have failed every build the harness made.
     local expect
-    expect="$(git rev-parse --short HEAD 2>/dev/null || true)"
-    [ -n "$(git status --porcelain 2>/dev/null)" ] && expect="${expect}-dirty"
+    expect="$(git rev-parse HEAD 2>/dev/null || true)"
     PITHEAD_UPDATER=rauc PITHEAD_TEST_SSH_PUBKEY="$(cat "$KEY.pub")" PITHEAD_TEST_MARKER="$1" \
         os/build-image.sh >/tmp/os-fault-build.log 2>&1 || return 1
     os/rauc/mkimage.sh --dev >>/tmp/os-fault-build.log 2>&1 || return 1

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -221,7 +221,10 @@ chk "carries a build stamp" '[ "$BUILT" != "missing" ] && [ -n "$BUILT" ]'
 # The check that would have caught shipping a two-commits-stale dashboard: compare against what
 # the caller believes it built. PITHEAD_EXPECT_COMMIT is set by the release procedure.
 if [ -n "${PITHEAD_EXPECT_COMMIT:-}" ]; then
-    chk "built from the expected commit ($PITHEAD_EXPECT_COMMIT)" '[ "$BUILT" = "$PITHEAD_EXPECT_COMMIT" ]'
+    # Prefix, not equality: the stamp is the full sha with an optional "-dirty" suffix, while the
+    # commit anyone types is the short one every log line prints. Equality failed both callers.
+    # Dirtiness is the next check's job, not this one's.
+    chk "built from the expected commit ($PITHEAD_EXPECT_COMMIT)" 'case "$BUILT" in "$PITHEAD_EXPECT_COMMIT"*) true ;; *) false ;; esac'
     chk "built from a clean tree" 'case "$BUILT" in *-dirty) false ;; *) true ;; esac'
 else
     skip "built from the expected commit" "PITHEAD_EXPECT_COMMIT is unset"

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -44,6 +44,16 @@ chk() { # <label> <shell-condition>
     if eval "$2" >/dev/null 2>&1; then ok "$1"; else bad "$1"; fi
 }
 
+# A check that did not run is not a check that passed (#1064). Both of the strongest blocks below
+# are conditional, and their skips were silent — so the summary printed "0 failed" for a verifier
+# that had declined to compare the artifact against the tree at all, which is exactly the failure
+# the RC3 stale-dashboard incident produced.
+SKIP=0
+skip() { # <label> <why>
+    SKIP=$((SKIP + 1))
+    printf '  \033[1;33m-\033[0m %s (SKIPPED: %s)\n' "$1" "$2"
+}
+
 LOOP=$(losetup -Pf --show "$IMAGE")
 ROOT=$(mktemp -d)
 ESP=$(mktemp -d)
@@ -213,6 +223,9 @@ chk "carries a build stamp" '[ "$BUILT" != "missing" ] && [ -n "$BUILT" ]'
 if [ -n "${PITHEAD_EXPECT_COMMIT:-}" ]; then
     chk "built from the expected commit ($PITHEAD_EXPECT_COMMIT)" '[ "$BUILT" = "$PITHEAD_EXPECT_COMMIT" ]'
     chk "built from a clean tree" 'case "$BUILT" in *-dirty) false ;; *) true ;; esac'
+else
+    skip "built from the expected commit" "PITHEAD_EXPECT_COMMIT is unset"
+    skip "built from a clean tree" "PITHEAD_EXPECT_COMMIT is unset"
 fi
 
 # The RC3 failure in full: an image shipped a dashboard two commits stale, passed every check
@@ -245,6 +258,8 @@ if [ -f ./pithead ] && [ -f build/dashboard/mining_dashboard/wizard.py ]; then
     chk "the baked wizard image contains the tree's wizard.py" \
         '[ -n "$WIZ_SHIPPED" ] && cmp -s "$WIZ_SHIPPED" build/dashboard/mining_dashboard/wizard.py'
     rm -rf "$WIZ_TMP"
+else
+    skip "the artifact matches the tree it was built from" "not run from the repo root"
 fi
 
 echo "==> host identity never ships baked (#894/#895)"
@@ -314,7 +329,19 @@ fi
 echo ""
 printf 'verify-image: \033[1;32m%d passed\033[0m, ' "$PASS"
 if [ "$FAIL" -gt 0 ]; then
-    printf '\033[1;31m%d failed\033[0m\n' "$FAIL"
+    printf '\033[1;31m%d failed\033[0m' "$FAIL"
+    [ "$SKIP" -gt 0 ] && printf ', \033[1;33m%d skipped\033[0m' "$SKIP"
+    printf '\n'
     exit 1
 fi
-printf '0 failed\n'
+printf '0 failed'
+[ "$SKIP" -gt 0 ] && printf ', \033[1;33m%d skipped\033[0m' "$SKIP"
+printf '\n'
+# Release mode is the one run whose job is to catch a stale artifact. Skipping the checks that do
+# that and exiting 0 is how an image with a two-commits-stale dashboard passed everything (#1064).
+# --test builds come from the harness, which pins the commit itself, so a skip there is a defect
+# in the harness rather than the operator's invocation — refuse in both.
+if [ "$SKIP" -gt 0 ]; then
+    printf '\033[1;31m[FAIL]\033[0m %d check(s) were SKIPPED, so this is not a verified image. Run from the repo root with PITHEAD_EXPECT_COMMIT set to the commit you believe you built.\n' "$SKIP" >&2
+    exit 1
+fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -11158,6 +11158,26 @@ out=$(cd "$FR" && PITHEAD_APPLIANCE=1 PITHEAD_PRESEED_DIR="$FR/no-such-esp" PITH
 assert_contains "factory-reset refuses when the ESP marker cannot be written" "$out" "Could not arm"
 assert_eq "unarmable factory-reset does not reboot" "$([ -f "$rebooted" ] || echo no)" "no"
 
+echo "== unit: the appliance battery's release gate does not lie about what it ran (#1064) =="
+# Harness wiring, asserted here because the harness itself only runs on the KVM bench. Both halves
+# are the same defect: a gate that reports success without having run. `--phase all` executed five
+# of eight phases while the release checklist said it ran everything, so every cut skipped the
+# power cuts, the corrupt-bundle refusal, the factory reset, the wedged-/data recovery and the
+# media channel; and verify-image's stale-artifact comparison was switched off in the ONE caller
+# that is not a human typing a command. MUTATION PROOF: drop a phase from the `all` arm, or drop
+# the PITHEAD_EXPECT_COMMIT prefix, and the matching assertion goes red.
+OSH="$(cat "$ROOT/tests/os/run.sh")"
+osh_all="$(printf '%s' "$OSH" | sed -n '/^all)/,/^    ;;/p')"
+for ph in boot update install provision rig media fault reset; do
+    assert_contains "--phase all runs phase_$ph" "$osh_all" "phase_$ph"
+done
+assert_contains "the battery's own build pins the commit verify-image checks against" "$OSH" \
+    'PITHEAD_EXPECT_COMMIT="$expect" tests/os/verify-image.sh'
+VIS="$(cat "$ROOT/tests/os/verify-image.sh")"
+assert_contains "a skipped check is counted, not silent" "$VIS" "SKIP=\$((SKIP + 1))"
+assert_contains "skipped checks refuse to report a verified image" "$VIS" "were SKIPPED, so this is not a verified image"
+unset OSH osh_all VIS
+
 echo "== unit: pithead-data-reset decides reformat-vs-skip fail-safe (wedged-/data recovery) =="
 # Source the boot script (functions only — its main is guarded) and drive data_reset_decision with
 # stubbed repair tools, in a subshell so its set -u / defs never leak into the suite.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -11174,6 +11174,17 @@ done
 assert_contains "the battery's own build pins the commit verify-image checks against" "$OSH" \
     'PITHEAD_EXPECT_COMMIT="$expect" tests/os/verify-image.sh'
 VIS="$(cat "$ROOT/tests/os/verify-image.sh")"
+# Wiring the guard on is only half of it: the two ends have to speak the same shape. build-image.sh
+# stamps `git rev-parse HEAD` — the FULL sha — and the harness first handed over `--short`, so the
+# equality check failed EVERY harness build. A guard that refuses everything is the same lie as one
+# that refuses nothing, pointed the other way. Bench-proven on the KVM image; asserted here because
+# verify-image needs a loop device and root, which tier-1 has neither of.
+assert_contains "the harness hands over the full sha build-image.sh stamps" "$OSH" \
+    'expect="$(git rev-parse HEAD 2>/dev/null || true)"'
+assert_not_contains "the harness does not hand over a short sha the stamp never equals" "$OSH" \
+    'rev-parse --short HEAD'
+assert_contains "the expected-commit check matches on a prefix, so a short sha still verifies" "$VIS" \
+    'case "$BUILT" in "$PITHEAD_EXPECT_COMMIT"*)'
 assert_contains "a skipped check is counted, not silent" "$VIS" "SKIP=\$((SKIP + 1))"
 assert_contains "skipped checks refuse to report a verified image" "$VIS" "were SKIPPED, so this is not a verified image"
 unset OSH osh_all VIS


### PR DESCRIPTION
Closes #1064. Both halves are the same defect: a gate that reports success without having run.

## `--phase all` ran five of eight

The `all)` arm called boot, update, install, provision and rig. `docs/dev/appliance-release.md`
said "`--phase all` runs everything", and step 1 of *Cutting a release* prescribes exactly that
command — so a maintainer following the checklist believed the three mid-write power cuts, the
mid-commit cut, the corrupt-bundle refusal, the factory reset, the wedged-`/data` recovery and the
whole media channel had run. None of them had.

The arm now runs all eight. The doc names them, warns that it is an evening rather than a coffee
break, and says to record the dated per-phase count for the tip actually being cut — an old green
standing in for a new one is the same defect wearing a different hat.

## verify-image reported "0 failed" for checks it declined to run

Two blocks are conditional: the built-from-expected-commit pair (when `PITHEAD_EXPECT_COMMIT` is
unset) and the whole artifact-vs-tree comparison (when not run from the repo root) — the one that
unpacks the baked container archive to compare `wizard.py`. Neither skip printed anything.

Those are precisely the checks that exist because an image once shipped a dashboard two commits
stale and passed everything else. Skips are now counted, printed as `(SKIPPED: reason)`, and
**fatal**: a run that declined to compare the artifact against the tree does not get to call the
image verified.

`_build_image` now exports `PITHEAD_EXPECT_COMMIT`, computed the same way `BUILD_COMMIT` is
recorded, so the stale-artifact guard is on in the one caller that is not a human typing a command
— it was off in every battery run, which is where it mattered most.

## Coverage

The harness only runs on the KVM bench, so the wiring is asserted in tier-1: all eight `phase_*`
calls present in the `all` arm, the `PITHEAD_EXPECT_COMMIT` prefix on the verify call, and
verify-image's skip counting and refusal. Dropping a phase from the arm, or the env prefix, turns
the matching assertion red. Tier-1 **2636 passed / 0 failed**.

**The end-to-end proof is running on the bench as this opens**: a fresh image build, then
verify-image in three shapes — no `PITHEAD_EXPECT_COMMIT`, run from outside the repo, and fully
pinned — to confirm the first two now exit non-zero and the third still passes. I will post the
result here; this should not merge before it does.
