### PR TITLE
fix(release): resolve the upgraded install at assert time (#1068)

### DIFF
--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -284,10 +284,38 @@ smoke_upgrade() {
     [ "$status" = "upgraded" ] ||
         die "Upgrade did not report success (status='${status:-none}' after ${waited}s): $(cat "$result" 2>/dev/null || echo '<no result file>')"
 
-    local new
-    new="$(tr -d '[:space:]' <"$dir/VERSION")"
-    [ "v$new" = "$TAG" ] || die "Runner reported 'upgraded' but $dir/VERSION is '$new', not $TAG."
-    ok "Install at $dir upgraded cleanly $cur → $new via the real #59 control path."
+    local landed
+    landed="$(upgraded_install_dir "$dir")"
+    local new=""
+    [ -n "$landed" ] && new="$(tr -d '[:space:]' <"$landed/VERSION" 2>/dev/null || true)"
+    [ "v$new" = "$TAG" ] ||
+        die "Runner reported 'upgraded' but no install at or beside $dir is $TAG (found '${new:-none}' at '${landed:-nothing}'). Check 'current ->' and the versioned dirs."
+    ok "Install at $landed upgraded cleanly $cur → $new via the real #59 control path."
+}
+
+# Where the upgrade actually landed, resolved AT ASSERT TIME.
+#
+# The #59 path never rewrites the old install in place — that is what makes rollback possible. It
+# extracts the new release into a fresh `pithead-v<new>` directory and repoints `current` at it. So
+# asserting on the directory this run was POINTED at could only pass if the upgrade overwrote the
+# previous install, i.e. never: a correct upgrade reported as a failed one, on the documented final
+# gate of a release (#1068).
+#
+# Two shapes to resolve, because both are legitimate inputs:
+#   `current` symlink  — resolve it now, after the upgrade moved it (this is why the v1.19.2 cut
+#                        did not hit the false red: it was handed the symlink);
+#   versioned dir      — unchanged by design, so look for the `current` beside it.
+upgraded_install_dir() { # <dir-as-given> -> the dir holding the post-upgrade install
+    local given="$1" resolved sibling
+    resolved="$(readlink -f "$given" 2>/dev/null || printf '%s' "$given")"
+    # `current` in the same parent is where a versioned dir's upgrade lands.
+    sibling="$(readlink -f "$(dirname "$resolved")/current" 2>/dev/null || true)"
+    if [ -n "$sibling" ] && [ -f "$sibling/VERSION" ] &&
+        [ "$(tr -d '[:space:]' <"$sibling/VERSION" 2>/dev/null)" != "$(tr -d '[:space:]' <"$resolved/VERSION" 2>/dev/null)" ]; then
+        printf '%s' "$sibling"
+        return 0
+    fi
+    printf '%s' "$resolved"
 }
 
 # Interactive gate before the destructive phase-2 upgrade (auto-yes when not a TTY, so a runbook
@@ -300,6 +328,11 @@ confirm_upgrade() {
 }
 
 # --- Main ----------------------------------------------------------------------------------------
+
+# Sourceable for the test suite (functions only), the same guard os/overlay/pithead-data-reset uses:
+# the assert-time resolution below is the kind of path arithmetic that is cheap to unit-test and
+# expensive to get wrong, and it only ever ran post-publish where a mistake is already in the field.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 0 2>/dev/null || true; fi
 
 log "Post-publish release smoke test (#459) — $TAG"
 fetch_published_bundle

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2344,6 +2344,47 @@ assert_rc "missing tool -> preflight fails fast (rc 1)" "$tc_rc" "1"
 assert_contains "the missing tool is named" "$tc_out" "shfmt"
 assert_contains "error points at the provisioning doc" "$tc_out" "release-server.md"
 
+echo "== unit: release-smoke resolves the upgraded install at ASSERT time (#1068) =="
+# The #59 upgrade never rewrites the old install in place — it extracts a fresh pithead-v<new> and
+# repoints `current`, which is what makes rollback possible. So asserting on the directory the run
+# was POINTED at could only pass if the upgrade had overwritten the previous install: a correct
+# upgrade reported as a failure, on the documented final gate of a release. MUTATION PROOF: return
+# the given path unresolved and both "lands on" assertions go red.
+SMK="$SANDBOX/smoke1068"
+mkdir -p "$SMK/pithead-v1.18.1" "$SMK/pithead-v1.19.0"
+printf '1.18.1\n' >"$SMK/pithead-v1.18.1/VERSION"
+printf '1.19.0\n' >"$SMK/pithead-v1.19.0/VERSION"
+ln -sfn "$SMK/pithead-v1.19.0" "$SMK/current"
+smoke_resolve() { # <dir-as-given>
+    (
+        _arg="$1" # saved before `set --`, which release-smoke's own arg parser needs empty
+        cd "$ROOT" || exit # its top level insists on a git repo, like the real invocation
+        set --
+        # shellcheck disable=SC1090
+        source "$ROOT/scripts/release-smoke.sh" 2>/dev/null
+        set +eu
+        upgraded_install_dir "$_arg"
+    )
+}
+# Handed the previous VERSIONED dir — the shape that produced the false red. It is unchanged by
+# design, so the answer has to come from the `current` beside it.
+assert_eq "a versioned dir resolves to where the upgrade actually landed" \
+    "$(tr -d '[:space:]' <"$(smoke_resolve "$SMK/pithead-v1.18.1")/VERSION")" "1.19.0"
+# Handed the SYMLINK — resolved now, after the upgrade moved it. This is why the v1.19.2 cut did
+# not hit the false red, and it must keep working.
+assert_eq "the current symlink resolves to the new install" \
+    "$(tr -d '[:space:]' <"$(smoke_resolve "$SMK/current")/VERSION")" "1.19.0"
+# Nothing moved: a box that is already on the target must resolve to itself, not wander off.
+ln -sfn "$SMK/pithead-v1.18.1" "$SMK/current"
+assert_eq "with current pointing at it, the same dir resolves to itself" \
+    "$(smoke_resolve "$SMK/pithead-v1.18.1")" "$SMK/pithead-v1.18.1"
+# NOTE, measured rather than assumed: replacing the `readlink -f` with the raw argument leaves all
+# three assertions above GREEN. The sibling lookup is what fixes the false red; the readlink only
+# normalises the path that lands in the pass and failure messages. Recorded here so the next reader
+# does not mistake it for a covered behaviour.
+rm -rf "$SMK"
+unset SMK
+
 echo "== unit: release.sh signs the promoted digests (#376) =="
 # sign_images must sign the recorded manifest-LIST digest (repo@sha256:… — never the mutable tag,
 # never a per-arch child) with the box's key and no Rekor upload; the password never reaches argv.

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2351,17 +2351,21 @@ echo "== unit: release-smoke resolves the upgraded install at ASSERT time (#1068
 # upgrade reported as a failure, on the documented final gate of a release. MUTATION PROOF: return
 # the given path unresolved and both "lands on" assertions go red.
 SMK="$SANDBOX/smoke1068"
+SMOKE_SH="$ROOT/scripts/release-smoke.sh"
 mkdir -p "$SMK/pithead-v1.18.1" "$SMK/pithead-v1.19.0"
 printf '1.18.1\n' >"$SMK/pithead-v1.18.1/VERSION"
 printf '1.19.0\n' >"$SMK/pithead-v1.19.0/VERSION"
 ln -sfn "$SMK/pithead-v1.19.0" "$SMK/current"
 smoke_resolve() { # <dir-as-given>
     (
-        _arg="$1" # saved before `set --`, which release-smoke's own arg parser needs empty
+        _arg="$1"          # saved before `set --`, which release-smoke's own arg parser needs empty
         cd "$ROOT" || exit # its top level insists on a git repo, like the real invocation
         set --
+        # Sourced through a variable, never a literal path: shellcheck follows a literal that names
+        # another file in the same invocation, and release-smoke pulls in release.sh, whose
+        # `local tool missing=()` then collides with this file's own scalar `missing` (SC2178).
         # shellcheck disable=SC1090
-        source "$ROOT/scripts/release-smoke.sh" 2>/dev/null
+        source "$SMOKE_SH" 2>/dev/null
         set +eu
         upgraded_install_dir "$_arg"
     )
@@ -2383,7 +2387,7 @@ assert_eq "with current pointing at it, the same dir resolves to itself" \
 # normalises the path that lands in the pass and failure messages. Recorded here so the next reader
 # does not mistake it for a covered behaviour.
 rm -rf "$SMK"
-unset SMK
+unset SMK SMOKE_SH
 
 echo "== unit: release.sh signs the promoted digests (#376) =="
 # sign_images must sign the recorded manifest-LIST digest (repo@sha256:… — never the mutable tag,


### PR DESCRIPTION
Closes #1068.

`release-smoke --upgrade DIR` asserted that **DIR's own** `VERSION` had changed. The #59 upgrade
never rewrites the old install in place — that is what makes rollback possible: it extracts the new
release into a fresh `pithead-v<new>` and repoints `current`. So the assertion could only pass if
the upgrade had overwritten the previous install, which is the opposite of the design.

Every other assertion defect in this repo has been a false green. A false red on the documented
final gate of a release is arguably worse: the next person either learns to ignore a red gate, or
spends an afternoon proving the product was fine.

## The fix

`upgraded_install_dir` resolves at assert time and handles both legitimate inputs:

- the **`current` symlink** — resolved now, after the upgrade moved it. This is the only reason the
  v1.19.2 cut escaped the false red: it happened to be handed the symlink.
- a **versioned directory** — unchanged by design, so the answer lives in the `current` beside it.

The failure message names what it found and where, instead of asserting against a file that was
never going to change.

## Coverage

`release-smoke.sh` gains the sourceable guard `os/overlay/pithead-data-reset` already uses, so this
path arithmetic is unit-testable instead of being exercised only post-publish, where a mistake is
already in the field. Three assertions: a versioned dir resolves to where the upgrade landed, the
symlink still resolves correctly, and a box already on the target resolves to itself.

| Mutation | Result |
| --- | --- |
| remove the sibling lookup | 1792/1 — "a versioned dir resolves to where the upgrade actually landed" |
| remove the `readlink -f` | **1793/0 — all three stay green** |

That second row is recorded in the test as a note rather than quietly ignored: the sibling lookup is
what fixes the false red, and the `readlink` only normalises the path that appears in the operator's
messages. Measured, not assumed.

Tier-1 **1793 passed / 0 failed**. `shellcheck` clean.
