### PR TITLE
fix(dashboard): stop the :80 redirect trusting the Host header (#1123)

### DIFF
--- a/pithead
+++ b/pithead
@@ -4464,7 +4464,7 @@ generate_caddyfile() {
     # host can keep 80/443 (co-hosting, #181). In HTTPS mode a custom port also disables Caddy's
     # automatic :80 -> HTTPS redirect (a global option emitted once at the top of the file) so port
     # 80 is left free for that proxy; the fronting proxy owns any http->https bounce instead.
-    local dport="${HOST_PORT:-}" port_suffix="" global_block=""
+    local dport="${HOST_PORT:-}" port_suffix="" global_block="" redirect_block=""
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         [ "$dport" == "443" ] && dport=""
         if [ -n "$dport" ]; then
@@ -4474,6 +4474,33 @@ generate_caddyfile() {
 }
 
 '
+        else
+            # Caddy's own HTTP->HTTPS redirect is a CATCH-ALL, and its target is the Host header
+            # the request carried: :80 answered `Host: evil.example` with `308 -> https://evil.example`
+            # (#1123, measured against a running box, not read off the config). That is the same
+            # open redirector #1118 closed in the setup wizard, except this one is the state the
+            # machine spends its life in, and it lands the operator on a page that looks like the
+            # dashboard login — the screen where they type the dashboard password.
+            #
+            # So take :80 over rather than leaving it to auto_https: disable the built-in redirects
+            # and serve one site whose target is fixed to the address this box answers to. The Host
+            # header stops being able to steer anything, and every legitimate :80 request — bare
+            # name, bare IP, whatever the operator typed — still lands on the dashboard, which a
+            # site block matching only $HOST_IP would not do (Caddy answers an unmatched host with
+            # an empty 200, so a plain refusal here reads as a dead machine).
+            global_block='{
+    auto_https disable_redirects
+}
+
+'
+            # A literal, NOT $(printf ...): command substitution strips the trailing newlines and
+            # the next site block lands on the same line as this one's closing brace, which Caddy
+            # refuses — the same trap the $auth line documents from the other direction.
+            redirect_block="http:// {
+    redir https://$HOST_IP{uri} 308
+}
+
+"
         fi
     else
         [ "$dport" == "80" ] && dport=""
@@ -4482,6 +4509,7 @@ generate_caddyfile() {
 
     : >"Caddyfile"
     [ -n "$global_block" ] && printf '%s' "$global_block" >>"Caddyfile"
+    [ -n "$redirect_block" ] && printf '%s' "$redirect_block" >>"Caddyfile"
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         log "Generating Caddyfile for automatic HTTPS ($HOST_IP$port_suffix)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF >>"Caddyfile"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1505,8 +1505,9 @@ case "$caddy_port_http" in
 *"disable_redirects"*) bad "plain-HTTP custom port has no redirect global" "'disable_redirects' present on a plain-HTTP site" ;;
 *) ok "plain-HTTP custom port has no redirect global" ;;
 esac
-# A port that equals the scheme default (443 secure / unset) renders today's Caddyfile verbatim —
-# no port suffix, no redirect global. Guards the byte-identical default path.
+# A port that equals the scheme default (443 secure / unset) renders the same site address as an
+# unset one — no port suffix. It still takes :80 over from auto_https (see #1123 below), which is
+# what separates it from the custom-port case: there, :80 is deliberately left to a fronting proxy.
 # shellcheck disable=SC1090  # STACK path is dynamic by design
 caddy_port_default="$(
     cd "$SANDBOX" && source "$STACK" 2>/dev/null
@@ -1516,9 +1517,46 @@ caddy_port_default="$(
 )"
 assert_contains "explicit default port keeps the bare site address" "$caddy_port_default" "https://box.lan {"
 case "$caddy_port_default" in
-*"disable_redirects"*) bad "default port emits no redirect global" "'disable_redirects' present at the scheme default" ;;
 *":443"*) bad "default port emits no explicit suffix" "':443' suffix present at the scheme default" ;;
 *) ok "default port renders the bare site address" ;;
+esac
+
+echo "== unit: the :80 redirect cannot be steered by the Host header (#1123) =="
+# Caddy's built-in HTTP->HTTPS redirect is a CATCH-ALL whose target is the request's own Host
+# header, so a provisioned box answered `Host: evil.example` on :80 with `308 -> https://evil.example`
+# — measured on a running machine. That is #1118's open redirector again, in the state the machine
+# spends its life in, and it lands on the screen where the operator types the dashboard password.
+# The render now disables the built-in redirects and serves :80 itself with a FIXED target.
+# MUTATION PROOF: render `redir https://{host}{uri}` instead of the literal host, or drop the
+# `auto_https disable_redirects`, and the two assertions below go red.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_redir="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "the default secure render takes :80 over from auto_https" "$caddy_redir" "auto_https disable_redirects"
+assert_contains "it serves :80 itself" "$caddy_redir" "http:// {"
+assert_contains "and redirects to the box, by name, not to whatever was asked for" "$caddy_redir" \
+    "redir https://box.lan{uri} 308"
+# The whole defect in one assertion: no redirect target may be built from the request. Caddy spells
+# the request's host `{host}` (and `{http.request.host}`), so neither may appear in a redir line.
+caddy_redir_lines="$(printf '%s\n' "$caddy_redir" | grep -a "redir" || true)"
+case "$caddy_redir_lines" in
+*"{host}"* | *"{http.request.host}"*) bad "no redirect target comes from the request" "a redir line interpolates the request host: $caddy_redir_lines" ;;
+*) ok "no redirect target comes from the request" ;;
+esac
+# A custom port means a fronting proxy owns :80 (#740). Taking it over there would break exactly the
+# co-hosting the option exists for, so the catch-all is the default path's alone.
+case "$caddy_port_https" in
+*"http:// {"*) bad "a custom port leaves :80 to the fronting proxy" "the render claimed :80 anyway" ;;
+*) ok "a custom port leaves :80 to the fronting proxy" ;;
+esac
+# Plain-HTTP mode has no redirect to steer: :80 IS the dashboard there.
+case "$caddy_http" in
+*"redir"*) bad "plain-HTTP mode renders no redirect at all" "a redir line appeared on a plain-HTTP site" ;;
+*) ok "plain-HTTP mode renders no redirect at all" ;;
 esac
 # Onion + custom LAN port together (#740 × #343): the LAN vhost moves to the custom port and the
 # `disable_redirects` global is emitted, but the onion vhost MUST stay on the bridge gateway's bare


### PR DESCRIPTION
Caddy's built-in HTTP→HTTPS redirect is a catch-all, and its target is the Host header the request
carried. Measured against a running machine, not read off the config:

```
$ curl -sSI -H 'Host: evil.example' http://<the box>/setup
HTTP/1.1 308 Permanent Redirect
Location: https://evil.example/setup
Server: Caddy
```

A bare-IP header behaves the same way. That is the open redirector #1118 closed in the setup wizard,
except this one is the state the machine spends its life in rather than a one-shot, and the landing
point is the dashboard login — the screen where the operator types the dashboard password. Reaching
it needs a name that resolves to the box (DNS rebinding, or a LAN whose DNS or DHCP is not
trustworthy), which is the threat model the product already accepts by serving TLS on a LAN at all,
so this is hardening rather than an emergency.

## The fix

The render takes `:80` over instead of leaving it to `auto_https`: emit `auto_https
disable_redirects`, and serve one site whose redirect target is the address this box answers to. The
Host header stops being able to steer anything.

A catch-all rather than a site block matching only `$HOST_IP`, deliberately: Caddy answers an
unmatched host with an **empty 200**, so a plain refusal on `:80` reads as a dead machine. Every
legitimate `:80` request — bare name, bare IP, whatever the operator typed — still lands on the
dashboard, which is strictly better than today, where a bare-IP visitor is redirected to a `:443`
vhost that does not match and gets that blank 200.

A **custom** `HOST_PORT` is untouched: `:80` is deliberately left free for the fronting proxy
co-hosting exists for (#740), and the catch-all would break exactly that. Plain-HTTP mode has no
redirect to steer.

One trap on the way in: the block was first built with `$(printf ...)`, and command substitution
strips the trailing newlines, so the next site block landed on the same line as this one's closing
brace and Caddy refused the file. It is a literal now, with a comment saying why — the same trap the
`$auth` and `bind` lines document from the other direction.

## Proof

Against the pinned `caddy:2.11.4` image on the bench, not just against the test's own string
matching — `caddy validate` on all four rendered shapes (default, custom port, plain HTTP,
onion+auth) reports **Valid configuration**, and a real Caddy serving the rendered default answers:

| request | before | after |
| --- | --- | --- |
| `Host: evil.example` → `/setup` | `308 https://evil.example/setup` | `308 https://box.lan/setup` |
| `Host: box.lan` → `/dashboard` | `308 https://box.lan/dashboard` | `308 https://box.lan/dashboard` |
| `Host: 203.0.113.9` → `/` | `308 https://203.0.113.9/` | `308 https://box.lan/` |

The path is preserved; only the host stops being attacker-chosen.

## Coverage

Five assertions at tier 1, in the block the issue asked for. The load-bearing one is stated as the
defect rather than as the shape of the fix: **no redirect target may be built from the request**, so
no `redir` line may interpolate `{host}` or `{http.request.host}`.

Mutations, run: rendering `redir https://{host}{uri}` turns "redirects to the box, by name" and "no
redirect target comes from the request" **red** (1797/2). Dropping `auto_https disable_redirects`
turns "takes :80 over from auto_https" red. Removing the block entirely turns "it serves :80 itself"
red.

Tier-1 on the branch: **1799 passed, 0 failed**.

## Note for the twin

`develop-v2` renders a multi-host site list and a `bind` line, and an unbound site block there asks
Caddy for a **wildcard listener** — which is the whole point of #1021's binding. A sync that carries
this catch-all across without `$(_bind_line)` would reopen every address the bound blocks exclude.
The v2 port is a separate PR that adds it.

Closes #1123
