### PR TITLE
fix(dashboard): stop the provisioned box's :80 redirect trusting the Host header (#1123)

### DIFF
--- a/pithead
+++ b/pithead
@@ -7208,11 +7208,29 @@ generate_caddyfile() {
     # host can keep 80/443 (co-hosting, #181). In HTTPS mode a custom port also disables Caddy's
     # automatic :80 -> HTTPS redirect (a global option emitted once at the top of the file) so port
     # 80 is left free for that proxy; the fronting proxy owns any http->https bounce instead.
-    local dport="${HOST_PORT:-}" port_suffix="" global_block=""
+    local dport="${HOST_PORT:-}" port_suffix="" global_block="" own_plain_port=0
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         [ "$dport" == "443" ] && dport=""
         if [ -n "$dport" ]; then
             port_suffix=":$dport"
+            global_block='{
+    auto_https disable_redirects
+}
+
+'
+        else
+            # Caddy's own HTTP->HTTPS redirect is a CATCH-ALL, and its target is the Host header the
+            # request carried: :80 answered `Host: evil.example` with `308 -> https://evil.example`
+            # (#1123, measured against the running bench appliance, not read off the config). Same
+            # open redirector #1118 closed in the setup wizard, except this one is the state the
+            # machine spends its life in, and it lands the operator on the dashboard login — the
+            # screen where they type the dashboard password.
+            #
+            # So take :80 over rather than leaving it to auto_https. The site is built below, once
+            # $site_hosts and the bind list exist: this is the port decision, that is the address
+            # decision, and the bind list is what keeps the new block from reopening the addresses
+            # #1021 closed.
+            own_plain_port=1
             global_block='{
     auto_https disable_redirects
 }
@@ -7329,8 +7347,38 @@ generate_caddyfile() {
         printf '    bind %s' "${NETWORK_PREFIX}.1"
     }
 
+    # The :80 site that replaces Caddy's reflecting catch-all (#1123). Built here because it needs
+    # both halves that are only settled by now:
+    #
+    #  - the KNOWN hosts keep the address the operator typed, so browsing by mDNS name and browsing
+    #    by IP each land on the name they used and match the certificate minted for it;
+    #  - the trailing catch-all answers everything else — including a forged Host — with THIS box's
+    #    canonical address, never with what the request asked for. Caddy answers an unmatched host
+    #    with an empty 200, so refusing outright would read as a dead machine.
+    #  - and BOTH carry the same bind list as the vhosts above. A site block with no bind asks Caddy
+    #    for a WILDCARD listener, which would reopen every address the bound blocks were written to
+    #    exclude — the globally-routable one included (#1021). That is the whole hazard here.
+    #
+    # A literal, NOT $(printf ...): command substitution strips the trailing newlines and the next
+    # site block lands on the same line as this one's closing brace, which Caddy refuses.
+    local redirect_block=""
+    if [ "$own_plain_port" = 1 ]; then
+        redirect_block="$(_site_addresses http) {
+$(_bind_line)
+    redir https://{host}{uri} 308
+}
+
+http:// {
+$(_bind_line)
+    redir https://$HOST_IP{uri} 308
+}
+
+"
+    fi
+
     : >"Caddyfile"
     [ -n "$global_block" ] && printf '%s' "$global_block" >>"Caddyfile"
+    [ -n "$redirect_block" ] && printf '%s' "$redirect_block" >>"Caddyfile"
     # The appliance hands its ONE certificate to Caddy — the same file the setup page served, so
     # the operator's trust decision survives the handoff. Without this the wizard's cert is
     # replaced by Caddy's own at the exact moment provisioning succeeds, and the browser that

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1966,9 +1966,61 @@ caddy_port_default="$(
 )"
 assert_contains "explicit default port keeps the bare site address" "$caddy_port_default" "https://box.lan {"
 case "$caddy_port_default" in
-*"disable_redirects"*) bad "default port emits no redirect global" "'disable_redirects' present at the scheme default" ;;
 *":443"*) bad "default port emits no explicit suffix" "':443' suffix present at the scheme default" ;;
 *) ok "default port renders the bare site address" ;;
+esac
+
+echo "== unit: the :80 redirect cannot be steered by the Host header (#1123) =="
+# Caddy's built-in HTTP->HTTPS redirect is a CATCH-ALL whose target is the request's own Host
+# header, so the provisioned appliance answered `Host: evil.example` on :80 with
+# `308 -> https://evil.example` — measured against the real hardware. That is #1118's open
+# redirector again, in the state the machine spends its life in, landing on the screen where the
+# operator types the dashboard password. The render now owns :80 itself.
+#
+# Two blocks, not one: the KNOWN hosts keep the address the operator typed (browsing by mDNS name
+# and by IP each stay on the name they used, which is also the name the certificate covers), and a
+# trailing catch-all answers everything else with THIS box's canonical address.
+#
+# MUTATION PROOF: point the catch-all at {host}, and the two "not from the request" assertions go
+# red; drop $(_bind_line) from either block and the bind assertion goes red; drop the
+# disable_redirects and the takeover assertion goes red.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_redir="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    is_appliance() { return 0; }
+    hostname() { printf '192.168.1.10 172.28.0.1 fd00::1\n'; }
+    DASHBOARD_SECURE=true HOST_IP=pithead.local NETWORK_PREFIX=172.28.0 DASHBOARD_AUTH_HASH_B64="" \
+        generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "the default secure render takes :80 over from auto_https" "$caddy_redir" "auto_https disable_redirects"
+assert_contains "the known hosts get their own :80 site" "$caddy_redir" "http://pithead.local, http://192.168.1.10"
+assert_contains "and keep the address the operator actually used" "$caddy_redir" "redir https://{host}{uri} 308"
+assert_contains "everything else lands on this box, by name" "$caddy_redir" "redir https://pithead.local{uri} 308"
+# The defect itself: the CATCH-ALL — the block a forged Host reaches — must never build its target
+# from the request. The known-host block may, because it only matches names this box answers to.
+caddy_catchall="$(printf '%s\n' "$caddy_redir" | sed -n '/^http:\/\/ {/,/^}/p')"
+assert_contains "the catch-all exists" "$caddy_catchall" "redir https://"
+case "$caddy_catchall" in
+*"{host}"* | *"{http.request.host}"*) bad "the catch-all target never comes from the request" "it interpolates the request host: $caddy_catchall" ;;
+*) ok "the catch-all target never comes from the request" ;;
+esac
+# #1021: a site block with NO bind asks Caddy for a WILDCARD listener, which reopens every address
+# the bound blocks exclude — the globally-routable one included. Both new blocks are site blocks.
+# Three site blocks in this render — the two new :80 ones and the HTTPS LAN vhost — so three binds.
+assert_eq "every site block carries the bind, including both new :80 ones" \
+    "$(printf '%s\n' "$caddy_redir" | grep -c 'bind 192.168.1.10 172.28.0.1 fd00::1 127.0.0.1 ::1')" "3"
+# A custom port means a fronting proxy owns :80 (#740). Claiming it there breaks the co-hosting the
+# option exists for.
+case "$caddy_port_https" in
+*"http:// {"*) bad "a custom port leaves :80 to the fronting proxy" "the render claimed :80 anyway" ;;
+*) ok "a custom port leaves :80 to the fronting proxy" ;;
+esac
+# Plain-HTTP mode has no redirect to steer: :80 IS the dashboard there.
+case "$caddy_http" in
+*"redir"*) bad "plain-HTTP mode renders no redirect at all" "a redir line appeared on a plain-HTTP site" ;;
+*) ok "plain-HTTP mode renders no redirect at all" ;;
 esac
 # Onion + custom LAN port together (#740 × #343): the LAN vhost moves to the custom port and the
 # `disable_redirects` global is emitted, but the onion vhost MUST stay on the bridge gateway's bare

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1844,8 +1844,11 @@ caddy_onion_https="$(
         generate_caddyfile >/dev/null 2>&1
     cat Caddyfile
 )"
-assert_eq "secure+onion+provisioned: the HTTPS onion vhost renders (3 site blocks)" \
-    "$(_site_count "$caddy_onion_https")" "3"
+# Five blocks since #1123 took :80 over: the two LAN vhosts (the known-host :80 redirect and the
+# HTTPS one), the :80 catch-all, and the two onion vhosts. The number is worth pinning rather than
+# deriving — it is what caught the redirect blocks arriving without anyone re-counting.
+assert_eq "secure+onion+provisioned: the HTTPS onion vhost renders (5 site blocks)" \
+    "$(_site_count "$caddy_onion_https")" "5"
 assert_eq "secure+onion+provisioned: every site block binds — no unbound wildcard on :443" \
     "$(_bind_count "$caddy_onion_https")" "$(_site_count "$caddy_onion_https")"
 


### PR DESCRIPTION
The `develop` half of this is #1133. This is the appliance lane, where the same defect was
**confirmed live against the real hardware** and where the render has a different shape.

```
$ curl -sSI -H 'Host: evil.example' http://<the appliance>/setup
HTTP/1.1 308 Permanent Redirect
Location: https://evil.example/setup
Server: Caddy
```

Caddy's built-in HTTP→HTTPS redirect is a catch-all whose target is the Host header the request
carried. Same open redirector #1118 closed in the setup wizard, except the wizard runs once and this
is the state the machine spends its life in — and the landing point is the dashboard login, the
screen where the operator types the dashboard password.

## Why this is not just a cherry-pick of #1133

Two things are different here, and both matter.

**The site list is plural.** `_site_addresses` serves the mDNS name, every non-public address the box
holds, and `localhost`, because a headless machine is reached by whichever of those the operator has.
Collapsing every `:80` request onto `$HOST_IP` — what #1133 does, correctly, for a single-host DIY
site — would bounce an operator who deliberately typed the IP (because mDNS did not work for them)
to a name that does not resolve for them. So this renders **two** blocks: the known hosts keep the
address actually used, and a trailing catch-all sends everything else to the box's canonical address.

**A site block with no `bind` asks Caddy for a wildcard listener.** That is exactly what #1021's bind
list exists to prevent, and the comment above `_bind_line` says so in as many words: an unbound block
"reopens every address the bound blocks were written to exclude, including the globally-routable
one". Adding `:80` site blocks here without the bind would have quietly undone that. Both new blocks
carry it, and there is an assertion counting them.

## Proof against real Caddy, not just string matching

The appliance render adapts cleanly under the pinned `caddy:2.11.4`, and a real Caddy serving it
answers:

| request | before | after |
| --- | --- | --- |
| `Host: pithead.local` | `308 https://pithead.local/setup` | `308 https://pithead.local/setup` |
| `Host: <a LAN address of the box>` | unchanged | unchanged — kept |
| `Host: evil.example` | `308 https://evil.example/setup` | `308 https://pithead.local/setup` |

The two legitimate paths are byte-identical to today. Only the forged one moves.

## Coverage

Eight assertions at tier 1, driven through the appliance branch with `is_appliance` and `hostname`
stubbed — the shape the existing bind tests already use. The load-bearing one states the defect
rather than the fix: the **catch-all's** target may never interpolate `{host}` or
`{http.request.host}`. The known-host block may, and does, because it only matches names this box
answers to — so the assertion is scoped to the block a forged Host can actually reach.

Mutations named in the test comment and run: pointing the catch-all at `{host}`, and dropping
`$(_bind_line)` from the new blocks.

Closes #1123
