### PR TITLE
fix(os): reboot a slot that fails its health gate, once (#1065)

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -297,8 +297,14 @@ The appliance keeps **two copies of the system**, and only one runs at a time. A
 is written to the copy that is idle, so the running system is never modified in place.
 The machine installs an update, reboots into the new version, and checks that the stack
 came up. If it did not — it fails to boot, or the stack does not start — **the machine
-goes back to the previous version on its own**, with nobody present. That is the entire
-point of keeping two copies.
+goes back to the previous version on its own**, with nobody present: it restarts itself
+once, and that restart lands on the copy that was working. That is the entire point of
+keeping two copies.
+
+It restarts itself **once**, not repeatedly. If the previous version fails the same way,
+the fault is not in the system copy — something on the data partition is wrong — and the
+machine stays powered on with its reason in the logs rather than looping. In that state
+the dashboard is down; see [If something goes wrong](#if-something-goes-wrong).
 
 Updates are applied from the dashboard: an **OS updates** control in the header checks
 for a new release, downloads its signed image to the data partition (over Tor, resumable
@@ -486,8 +492,14 @@ partial copy fails the same way) and typed the passphrase exactly as it was set 
 `pithead backup`. Nothing is written until this check passes — retry from the same page.
 
 **It came back on the old version after an update.** That is the safety mechanism working:
-the new version did not come up healthy, so the machine reverted. Nothing is lost. Check
-the dashboard logs, and expect a fixed version.
+the new version did not come up healthy, so the machine restarted itself and went back.
+Nothing is lost. Check the dashboard logs, and expect a fixed version.
+
+**It restarted once and the dashboard is still down.** Then both copies failed the same
+check, which points at the data partition rather than at the update — most often a disk
+that has gone bad. The machine deliberately stops restarting at that point so it stays
+still long enough to be looked at. Attach a screen and keyboard: the console prints the
+reason on every boot.
 
 **Nothing responds after I pulled the USB stick out.** The machine was running from it. Hold
 the power button until it switches off, leave the stick out, and power it on: it boots the

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -286,7 +286,8 @@ Expected: the stack provisions and the dashboard comes up.
 `pithead os-update BUNDLE` (the test image carries SSH for exactly this; the command wraps
 `rauc install` and compares the variant stamps first — a debug box taking a release bundle
 must warn before removing its own SSH). Expected: installs, reboots into the new version,
-and an uncommitted update reverts on the next reboot. The dashboard-driven OS update rides
+and an uncommitted update reverts on the next reboot, which `pithead-boot` now triggers itself
+after a failed health gate (#1065). The dashboard-driven OS update rides
 the same mechanism from the header's OS-update control
 ([Dashboard › Updating the appliance OS](../dashboard.md#updating-the-appliance-os)); the
 KVM update phase's leg 4 drives it end-to-end, so this manual step stays about what KVM
@@ -375,8 +376,11 @@ the thing you will want at 3am:
 
 - **It does not boot** — the machine reverts itself. An uncommitted update never survives
   a reboot; this is the case the A/B design exists for and it needs no operator.
-- **It boots but fails its health check** — `pithead` does not commit, and the next reboot
-  reverts. Publish a fixed version; the fleet takes it on the next update.
+- **It boots but fails its health check** — `pithead-boot` does not commit and reboots the
+  machine itself, so the fallback happens with nobody present (#1065). Exactly once: if the
+  slot it falls back to fails the same way the fault is on `/data`, not in the slot, and the
+  machine stays up with the reason in the journal instead of looping. Publish a fixed
+  version; the fleet takes it on the next update.
 - **It boots, passes its checks, and is still wrong** — this one is on us, not the
   updater. Publish `v+1` with the fix. Operators who already committed roll back with
   `rauc status mark-bad booted && reboot`, which the dashboard exposes as a button.

--- a/docs/dev/dual-distribution-plan.md
+++ b/docs/dev/dual-distribution-plan.md
@@ -702,8 +702,14 @@ fault-inject on the bench before every release.
 ### Case 2 — it boots but fails its health check
 
 Also self-healing. The commit gate is `pithead doctor --json`: if the stack does not
-come up healthy, the update is never committed and the next reboot falls back. The
-important design rule is what the gate checks — services up and progressing, never
+come up healthy, the update is never committed and the next reboot falls back — and
+`pithead-boot` triggers that reboot itself, because the fallback is a bootloader decision
+and the bootloader does not get another turn until something reboots (#1065). Bounded to
+one attempt, recorded on `/data`: a fault that lives on the data partition survives the
+fallback, and a box that reboot-loops can never be diagnosed. If the counter cannot be
+written the machine does not reboot at all — an unbounded loop is the worse failure.
+
+The important design rule is what the gate checks — services up and progressing, never
 "chain synced", because a fresh box legitimately takes days to sync and a gate that
 waits for it would never commit anything.
 

--- a/os/overlay/pithead-boot
+++ b/os/overlay/pithead-boot
@@ -20,6 +20,47 @@
 #   box commits while a genuinely broken one does not. A slot that boots but is not healthy is left
 #   UNCOMMITTED on purpose: that is precisely the state A/B fallback exists for.
 set -uo pipefail
+
+# A boot that fails is what A/B fallback exists for — but the fallback is a GRUB decision, and GRUB
+# only gets to make it at the NEXT boot. Leaving the slot uncommitted and exiting is therefore only
+# half of the promise docs/appliance.md makes: without a reboot the machine sits on the broken slot
+# with the stack down until somebody walks over and pulls the power (#1065). A kernel panic and a
+# wedged PID 1 already self-heal; a clean boot with a dead stack — a bad render, a bad image, a
+# crashed node, exactly what this gate is written to catch — did not.
+#
+# BOUNDED, because the fault is not always in the slot. A wedged /data survives the rollback, so
+# both slots fail the same way, and a box that reboots forever is worse than one that stops with a
+# console line an operator can read: it never holds still long enough to be diagnosed. One
+# automatic reboot per failure run — the next boot is the other slot, and if that fails too the
+# counter is spent and the machine stays up and says so.
+#
+# The counter lives on /data on purpose: it has to survive both the reboot and the slot switch,
+# which is the whole point of bounding. If it cannot be written, this refuses to reboot at all —
+# an unbounded reboot loop is the one outcome worse than a stranded box.
+BOOT_FAIL_COUNT=.boot-gate-failures
+boot_gate_passed() { rm -f "$BOOT_FAIL_COUNT"; }
+fail_boot() { # <what went wrong>
+    echo "pithead-boot: $1 — slot left uncommitted so A/B fallback stays armed" >&2
+    local n=0
+    [ -f "$BOOT_FAIL_COUNT" ] && n=$(tr -cd '0-9' <"$BOOT_FAIL_COUNT" 2>/dev/null)
+    n=$((${n:-0} + 1))
+    if ! echo "$n" >"$BOOT_FAIL_COUNT" 2>/dev/null; then
+        echo "pithead-boot: could not record this failed boot on /data, so it will NOT reboot — a reboot it cannot count is a reboot loop. Power-cycle to fall back to the other slot." >&2
+        exit 1
+    fi
+    if [ "$n" -ge 2 ]; then
+        echo "pithead-boot: this is failure $n — the bootloader already fell back and the other slot failed the same way, so the fault is not the slot. The machine stays up for diagnosis; the dashboard is down, see the journal (journalctl -u pithead-boot)." >&2
+        exit 1
+    fi
+    echo "pithead-boot: rebooting now so the bootloader falls back to the previous slot" >&2
+    ${PITHEAD_REBOOT_CMD:-systemctl reboot}
+    exit 1
+}
+
+# Sourceable for the test suite: everything above is definitions, so a `source` stops here and the
+# suite can drive fail_boot in a sandbox. Executed directly — every real boot — this is a no-op.
+[ "${BASH_SOURCE[0]}" = "${0}" ] || return 0
+
 cd /data/pithead || exit 1
 
 # Role fork (#797): a rig is not a small coordinator, it is a different machine. No compose
@@ -39,17 +80,17 @@ if [ -f machine-role ] && [ "$(tr -d '[:space:]' <machine-role)" = "rig" ]; then
     # Same bounded clock as the coordinator's miner leg, for the same reason: the boot unit runs
     # with TimeoutStartSec=infinity, so a stalled native rebuild would leave it activating
     # forever. The prebuilt path finishes in seconds.
-    timeout 1800 ./pithead local-miner || exit 1
+    timeout 1800 ./pithead local-miner || fail_boot "the rig's miner setup failed"
     for _ in $(seq 12); do
         if systemctl is-active --quiet xmrig.service; then
             command -v rauc >/dev/null 2>&1 && rauc status mark-good
+            boot_gate_passed
             echo "pithead-boot: the rig's miner is running — booted slot committed"
             exit 0
         fi
         sleep 5
     done
-    echo "pithead-boot: the rig's miner never came up — slot left uncommitted so A/B fallback stays armed" >&2
-    exit 1
+    fail_boot "the rig's miner never came up"
 fi
 
 # OS-update verdict, rollback half: a dashboard-driven install leaves an in-flight flag naming
@@ -86,7 +127,7 @@ fi
 # stick, a rejected file, or an operator-cancelled change all fall through to the normal path.
 /usr/local/sbin/pithead-media-config
 
-./pithead render || exit 1
+./pithead render || fail_boot "the derived config could not be rendered"
 
 # The migration hold (#851): os-update leaves a marker when the installed bundle declares a
 # forward-only /data migration, stamped with that bundle's version. A marker matching THIS
@@ -104,9 +145,9 @@ if [ -f .os-migration-pending ] &&
 fi
 
 if [ "$hold_chain" = 1 ]; then
-    PITHEAD_HOLD_CHAIN=1 ./pithead up || exit 1
+    PITHEAD_HOLD_CHAIN=1 ./pithead up || fail_boot "the stack could not be brought up"
 else
-    ./pithead up || exit 1
+    ./pithead up || fail_boot "the stack could not be brought up"
 fi
 
 for _ in $(seq 90); do
@@ -123,6 +164,7 @@ for _ in $(seq 90); do
     # undiagnosable (the battery hit exactly that).
     if [ "${code:-000}" != "000" ] && ./pithead doctor --json >/run/pithead-boot-doctor.json 2>/dev/null; then
         command -v rauc >/dev/null 2>&1 && rauc status mark-good
+        boot_gate_passed
         echo "pithead-boot: stack is serving (HTTP $code) and doctor reports healthy — booted slot committed"
         # OS-update verdict, success half: this slot just committed while an in-flight flag names
         # exactly this version — the dashboard-driven update landed and can no longer fall back.
@@ -164,5 +206,4 @@ for _ in $(seq 90); do
     fi
     sleep 10
 done
-echo "pithead-boot: stack never became healthy (serving + doctor) — slot left uncommitted so A/B fallback stays armed" >&2
-exit 1
+fail_boot "the stack never became healthy (serving + doctor)"

--- a/os/overlay/pithead-boot
+++ b/os/overlay/pithead-boot
@@ -53,7 +53,13 @@ fail_boot() { # <what went wrong>
         exit 1
     fi
     echo "pithead-boot: rebooting now so the bootloader falls back to the previous slot" >&2
-    ${PITHEAD_REBOOT_CMD:-systemctl reboot}
+    # --no-block, because this runs INSIDE the unit being asked to stop. Where systemctl reaches
+    # logind the request is asynchronous and the flag changes nothing; where it does not (no
+    # logind), systemctl starts reboot.target and WAITS for that job — a job whose completion needs
+    # this very ExecStart terminated. The unit carries TimeoutStartSec=infinity, so that wait has
+    # no escape: the box would hang in `activating` forever, which is worse than the stranded state
+    # this is fixing. Not a deadlock I reproduced — a tail risk the flag costs nothing to remove.
+    ${PITHEAD_REBOOT_CMD:-systemctl --no-block reboot}
     exit 1
 }
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -11192,6 +11192,75 @@ out=$(cd "$FR" && PITHEAD_APPLIANCE=1 PITHEAD_PRESEED_DIR="$FR/no-such-esp" PITH
 assert_contains "factory-reset refuses when the ESP marker cannot be written" "$out" "Could not arm"
 assert_eq "unarmable factory-reset does not reboot" "$([ -f "$rebooted" ] || echo no)" "no"
 
+echo "== unit: a boot that fails its health gate reboots itself, once (#1065) =="
+# The A/B design's headline promise is that a bad update reverts itself, and for the likeliest bad
+# update — one that boots cleanly with a dead stack — it did not: pithead-boot left the slot
+# uncommitted and exited, and the fallback is a GRUB decision GRUB does not get to make until
+# something reboots. So the box sat on the broken slot with the stack down until a human pulled the
+# power, while two operator docs promised otherwise.
+#
+# Bounded is the load-bearing half. A fault on /data survives the fallback, so both slots fail the
+# same way; a machine that reboot-loops can never be looked at. And if the counter cannot be
+# written the machine must NOT reboot — an unbounded loop is the one outcome worse than a stranded
+# box, so the failure to persist has to fail SAFE, not open.
+#
+# MUTATION PROOF: drop the `[ "$n" -ge 2 ]` bound and the second-failure assertion goes red; make
+# the unwritable-counter branch reboot anyway and the fail-safe assertion goes red; drop the
+# rm in boot_gate_passed and the cleared-on-success assertion goes red.
+BG="$SANDBOX/boot-gate"
+mkdir -p "$BG"
+# shellcheck disable=SC1090  # overlay path is dynamic by design
+bg_run() { # <cwd> — one fail_boot in a sandbox, printing "<reboots> <counter> <stderr>"
+    (
+        cd "$1" 2>/dev/null || exit 1
+        source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+        PITHEAD_REBOOT_CMD="touch $BG/rebooted.$$" fail_boot "the stack never became healthy (serving + doctor)" 2>&1
+    )
+}
+rm -f "$BG"/rebooted.*
+bg_out1=$(bg_run "$BG")
+bg_rebooted1=$(ls "$BG"/rebooted.* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "the first failed health gate reboots the machine" "$bg_rebooted1" "1"
+assert_eq "and records the attempt on /data" "$(cat "$BG/.boot-gate-failures" 2>/dev/null)" "1"
+assert_contains "saying why, on the console" "$bg_out1" "falls back to the previous slot"
+
+rm -f "$BG"/rebooted.*
+bg_out2=$(bg_run "$BG")
+bg_rebooted2=$(ls "$BG"/rebooted.* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "the fallback slot failing the same way does NOT reboot again" "$bg_rebooted2" "0"
+assert_eq "the attempt is still counted" "$(cat "$BG/.boot-gate-failures" 2>/dev/null)" "2"
+assert_contains "and the console says the fault is not the slot" "$bg_out2" "the fault is not the slot"
+
+# A healthy boot clears the counter, or one transient failure months ago would spend the machine's
+# single rollback attempt on the update that actually needs it.
+(
+    cd "$BG" || exit 1
+    source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+    boot_gate_passed
+)
+assert_eq "a boot that commits clears the counter" "$([ -f "$BG/.boot-gate-failures" ] && echo present || echo gone)" "gone"
+
+# Unwritable counter: the cwd is deleted out from under it, which makes the relative write fail for
+# root too — a chmod would not, and this suite runs as both.
+BGX="$SANDBOX/boot-gate-unwritable"
+mkdir -p "$BGX"
+rm -f "$BG"/rebooted.*
+bg_out3=$(
+    cd "$BGX" && rmdir "$BGX"
+    source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+    PITHEAD_REBOOT_CMD="touch $BG/rebooted.$$" fail_boot "the stack never became healthy (serving + doctor)" 2>&1
+)
+assert_eq "a counter it cannot write means it does NOT reboot" "$(ls "$BG"/rebooted.* 2>/dev/null | wc -l | tr -d ' ')" "0"
+assert_contains "and it says a reboot it cannot count is a reboot loop" "$bg_out3" "a reboot it cannot count is a reboot loop"
+rm -f "$BG"/rebooted.*
+
+# Every exit that leaves the slot uncommitted goes through the helper — a bare `exit 1` on any of
+# them is the original defect back on that path alone. The rig leg's two and the coordinator's
+# render, up and health gate are all of them.
+BOOTSCRIPT="$ROOT/os/overlay/pithead-boot"
+bg_bare=$(grep -cE '^[[:space:]]*(\./pithead (render|up)|timeout 1800 \./pithead local-miner).*\|\| exit 1' "$BOOTSCRIPT" || true)
+assert_eq "no boot-failure path exits without arming the fallback" "$bg_bare" "0"
+
 echo "== unit: pithead-data-reset decides reformat-vs-skip fail-safe (wedged-/data recovery) =="
 # Source the boot script (functions only — its main is guarded) and drive data_reset_decision with
 # stubbed repair tools, in a subshell so its set -u / defs never leak into the suite.


### PR DESCRIPTION
The A/B design's headline promise is that a bad update reverts itself. For the likeliest bad update
it did not.

`pithead-boot` left the slot uncommitted and exited. The fallback is a **GRUB** decision, and GRUB
does not get to make it until something reboots — and nothing did. `pithead-boot.service` is
`Type=oneshot` with no `Restart=` and no `OnFailure=`. Two failure shapes already self-heal, a kernel
panic (`panic=60`) and a wedged PID 1 (`RuntimeWatchdogSec`), but neither covers the regression an OS
update actually ships: a **clean boot with a dead stack** — a bad render, a bad image, an unparseable
Caddyfile, a crashed `monerod`. That is precisely what the health gate exists to catch, and catching
it stranded the machine with the stack down until somebody walked over and pulled the power.

Remote recovery cannot help, by construction: the dashboard that would drive it is the thing that is
down. `docs/appliance.md` and `docs/dashboard.md` both told the operator otherwise.

## What changes

`pithead-boot` reboots itself when the gate fails, so the bootloader gets its turn.

**Bounded to one attempt, counted on `/data`.** The counter has to survive both the reboot and the
slot switch, because that is the case it exists for: a fault that lives on `/data` survives the
fallback, both slots then fail the same way, and a box that reboot-loops can never be diagnosed — it
never holds still long enough to be looked at. The second failure stops and says the fault is not the
slot.

**If the counter cannot be written it does not reboot at all.** An unbounded reboot loop is the one
outcome worse than a stranded box, so the failure to persist fails safe rather than open.

**Every exit that leaves the slot uncommitted goes through the helper**, not only the health gate: a
failed `render`, a failed `up`, and both of the rig leg's exits strand the machine in exactly the
same way. A grep assertion keeps a bare `|| exit 1` from creeping back onto any of them.

The helpers sit above a source guard so the suite can drive them in a sandbox — the same shape
`pithead-data-reset` already uses. That is the only structural change to the script; `cd /data/pithead`
moved below the guard so a `source` does not chdir.

## Bench evidence

**The normal path still works, on a real machine.** `tests/os/run.sh --phase update` on the KVM bench
against this branch: **18 passed, 1 failed**. Legs 1–3 are the whole of what `pithead-boot` owns and
all passed —

```
✓ ROLLBACK: an uncommitted update reverts to v1 on reboot
✓ committed the booted update
✓ COMMIT: a committed update persists across reboot
✓ machine-id survived the A/B swap
✓ SSH host-key fingerprint survived the A/B swap
✓ UPDATE REFRESHED THE CONTAINERS: the served page comes from the v2 dashboard image
✓ ROLLBACK: an operator can return to v1 after committing v2
```

The one failure is in leg 4 (the dashboard OS-update action), at the `check` step: *"could not reach
the release API over Tor"*. It is not on any path this branch touches. See the comment below for what
I ruled out and what I did not.

**The new failure path, driven on the guest itself** with the reboot stubbed, so the real script reads
and writes the real `/data`:

```
failure 1 → "rebooting now so the bootloader falls back to the previous slot"
            REBOOT REQUESTED, counter = 1
failure 2 → "this is failure 2 — ... the fault is not the slot. The machine stays up for diagnosis"
            no reboot, counter = 2
commit    → counter cleared
```

**What is still NOT proven: M9 itself** — a genuinely broken bundle installed, booted, and falling
back with nobody present. The mechanism is proven and the surrounding A/B machinery is proven, but
the two have not been run as one sequence. M9 is a written GA gate and it should be run before the
appliance ships regardless of this PR.

## Coverage

Six assertions at tier 1 driving `fail_boot` directly, plus the no-bare-exit grep. Mutations named in
the test comment: dropping the bound, making the unwritable-counter branch reboot anyway, and
stopping `boot_gate_passed` from clearing the counter.

## Docs

`appliance.md` now says the machine restarts itself **once** rather than implying it retries forever,
and gains the both-copies-failed case under *If something goes wrong* — that state is reachable and an
operator meeting it deserves to know it is deliberate. The two dev docs that described the old
behaviour (`appliance-release.md`, `dual-distribution-plan.md`) are corrected rather than left as the
only accurate account.

Closes #1065
