### PR TITLE
fix(upgrade): tell the operator a spent GitHub rate limit is not a dead Tor circuit (#1081)

### DIFF
--- a/pithead
+++ b/pithead
@@ -3356,18 +3356,23 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""
 GH_RELEASE_JSON=""
+# The SOCKS address this fetch used, published so a caller that goes on to download the release over
+# the same Tor path derives it ONCE rather than twice. Folding the lookup into a function deleted the
+# caller's own derivation, and `set -u` then killed the runner at its first download — the upgrade
+# result sat at "running" for ever with a single dial in the log. One derivation, one truth.
+GH_SOCKS=""
 gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE_HINT on failure
-    local repo="$1" prefix socks out code
+    local repo="$1" prefix out code
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
     [ -n "$prefix" ] || prefix="172.28.0"
-    socks="${prefix}.25:9050"
+    GH_SOCKS="${prefix}.25:9050"
     GH_RELEASE_HINT=""
     GH_RELEASE_JSON=""
     # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
     # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
     # failure, which is exactly the distinction that was missing.
     if ! out=$(curl -sS --max-time 60 --max-filesize "$CURL_CAP_SMALL" -w '\n%{http_code}' \
-        --socks5-hostname "$socks" -H 'Accept: application/vnd.github+json' \
+        --socks5-hostname "$GH_SOCKS" -H 'Accept: application/vnd.github+json' \
         "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null); then
         GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
         return 1
@@ -6141,7 +6146,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
     # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.
     local bundle="$cdir/staged/.$id.tar.gz" logf="$cdir/staged/.$id.log"
-    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$socks" -o "$bundle" \
+    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$GH_SOCKS" -o "$bundle" \
         "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz" 2>/dev/null; then
         rm -f "$bundle"
         _upg_fail "could not download the $tag release bundle over Tor — the stack keeps running v$PITHEAD_VERSION."
@@ -6154,7 +6159,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # TLS to GitHub plus tag pinning — with one loud line in the journal.
     if [ -f cosign.pub ]; then
         local sig="$cdir/staged/.$id.tar.gz.sig"
-        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" -o "$sig" \
+        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$GH_SOCKS" -o "$sig" \
             "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz.sig" 2>/dev/null; then
             rm -f "$bundle" "$sig"
             _upg_fail "the $tag release carries no bundle signature (pithead.tar.gz.sig) — refusing to install it unverified (#376); the stack keeps running v$PITHEAD_VERSION."

--- a/pithead
+++ b/pithead
@@ -3351,7 +3351,7 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
 # dial that genuinely failed.
 # NOT stdout, deliberately: the JSON lands in GH_RELEASE_JSON and the caller runs this as a plain
-# command. `rel=$(gh_release_fetch ...)` reads naturally and is WRONG — command substitution is a
+# command. Assigning it through a command substitution reads naturally and is WRONG — that is a
 # subshell, so the hint set here would never reach the caller and every rejection would carry an
 # empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""

--- a/pithead
+++ b/pithead
@@ -3379,6 +3379,16 @@ gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE
     fi
     code=${out##*$'\n'}
     out=${out%$'\n'*}
+    # No status line at all means the response is not one we can reason about — and without this the
+    # WHOLE BODY becomes "$code" and gets echoed into an operator-facing message, which is both
+    # nonsense to read and a way for a remote body to land verbatim in the dashboard.
+    case "$code" in
+    [0-9][0-9][0-9]) ;;
+    *)
+        GH_RELEASE_HINT="the GitHub release API answered in a shape this cannot read — nothing was changed. Check './pithead doctor' and retry."
+        return 1
+        ;;
+    esac
     case "$code" in
     2*)
         GH_RELEASE_JSON="$out"

--- a/pithead
+++ b/pithead
@@ -3350,13 +3350,19 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # hour PER IP, and a Tor exit is shared with everyone else using it, so a spent budget is a normal
 # condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
 # dial that genuinely failed.
+# NOT stdout, deliberately: the JSON lands in GH_RELEASE_JSON and the caller runs this as a plain
+# command. `rel=$(gh_release_fetch ...)` reads naturally and is WRONG — command substitution is a
+# subshell, so the hint set here would never reach the caller and every rejection would carry an
+# empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""
-gh_release_fetch() { # <owner/repo> -> release JSON on stdout
+GH_RELEASE_JSON=""
+gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE_HINT on failure
     local repo="$1" prefix socks out code
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
     [ -n "$prefix" ] || prefix="172.28.0"
     socks="${prefix}.25:9050"
     GH_RELEASE_HINT=""
+    GH_RELEASE_JSON=""
     # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
     # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
     # failure, which is exactly the distinction that was missing.
@@ -3370,7 +3376,7 @@ gh_release_fetch() { # <owner/repo> -> release JSON on stdout
     out=${out%$'\n'*}
     case "$code" in
     2*)
-        printf '%s' "$out"
+        GH_RELEASE_JSON="$out"
         return 0
         ;;
     403 | 429)
@@ -6113,10 +6119,11 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     touch "$stamp"
     # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
     local rel tag
-    if ! rel=$(gh_release_fetch p2pool-starter-stack/pithead); then
+    if ! gh_release_fetch p2pool-starter-stack/pithead; then
         _upg_reject "$GH_RELEASE_HINT"
         return 0
     fi
+    rel=$GH_RELEASE_JSON
     tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
     if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
         _upg_reject "the GitHub release API returned no usable release tag — nothing was changed."
@@ -6620,10 +6627,11 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
         fi
         touch "$stampf"
         local rel
-        if ! rel=$(gh_release_fetch p2pool-starter-stack/rigforge); then
+        if ! gh_release_fetch p2pool-starter-stack/rigforge; then
             _wu_reject "$GH_RELEASE_HINT"
             return 0
         fi
+        rel=$GH_RELEASE_JSON
         tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
         if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             _wu_reject "the GitHub release API returned no usable RigForge release tag — nothing was changed."

--- a/pithead
+++ b/pithead
@@ -3340,6 +3340,50 @@ readonly CURL_CAP_SMALL=1048576 # 1 MiB — GitHub release JSON, rig control res
 # cap-hit surfaces as _upg_fail's "could not download over Tor", loud but network-flavoured).
 readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle (code + configs)
 
+# The latest-release JSON for a GitHub repo, over the stack's own Tor SOCKS like every other
+# stack egress. Prints the JSON and returns 0; on failure prints nothing, returns 1, and leaves
+# GH_RELEASE_HINT holding the sentence the operator should actually be told.
+#
+# The reason this is a function and not two `curl -fsS` calls: `-f` collapses every non-2xx into
+# one exit code, so a 403 came out as "could not reach GitHub over Tor" and sent the operator to a
+# doctor run that correctly reports Tor healthy. GitHub's unauthenticated limit is 60 requests an
+# hour PER IP, and a Tor exit is shared with everyone else using it, so a spent budget is a normal
+# condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
+# dial that genuinely failed.
+GH_RELEASE_HINT=""
+gh_release_fetch() { # <owner/repo> -> release JSON on stdout
+    local repo="$1" prefix socks out code
+    prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
+    [ -n "$prefix" ] || prefix="172.28.0"
+    socks="${prefix}.25:9050"
+    GH_RELEASE_HINT=""
+    # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
+    # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
+    # failure, which is exactly the distinction that was missing.
+    if ! out=$(curl -sS --max-time 60 --max-filesize "$CURL_CAP_SMALL" -w '\n%{http_code}' \
+        --socks5-hostname "$socks" -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null); then
+        GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        return 1
+    fi
+    code=${out##*$'\n'}
+    out=${out%$'\n'*}
+    case "$code" in
+    2*)
+        printf '%s' "$out"
+        return 0
+        ;;
+    403 | 429)
+        if printf '%s' "$out" | grep -qi 'rate limit'; then
+            GH_RELEASE_HINT="the Tor exit this machine is currently using has spent GitHub's shared hourly request budget — nothing is wrong with this box, and 'doctor' will say so. Run './pithead restart tor' to pick a new exit, then retry."
+            return 1
+        fi
+        ;;
+    esac
+    GH_RELEASE_HINT="the GitHub release API answered HTTP $code — nothing was changed. Retry in a few minutes."
+    return 1
+}
+
 # Render the pre-masked prefill copy (#440): the live config with every SET secret leaf replaced
 # by the {"__secret__":true} sentinel, written atomically to <control-dir>/masked/config.json.
 # The dashboard serves the Configuration form from THIS file (mounted read-only) — the raw
@@ -6040,14 +6084,9 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # is the right trade.
     touch "$stamp"
     # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
-    local prefix socks rel tag
-    prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
-    [ -n "$prefix" ] || prefix="172.28.0"
-    socks="${prefix}.25:9050"
-    if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
-        -H 'Accept: application/vnd.github+json' \
-        "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null); then
-        _upg_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+    local rel tag
+    if ! rel=$(gh_release_fetch p2pool-starter-stack/pithead); then
+        _upg_reject "$GH_RELEASE_HINT"
         return 0
     fi
     tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
@@ -6552,14 +6591,9 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
             return 0
         fi
         touch "$stampf"
-        local prefix socks rel
-        prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
-        [ -n "$prefix" ] || prefix="172.28.0"
-        socks="${prefix}.25:9050"
-        if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
-            -H 'Accept: application/vnd.github+json' \
-            "https://api.github.com/repos/p2pool-starter-stack/rigforge/releases/latest" 2>/dev/null); then
-            _wu_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        local rel
+        if ! rel=$(gh_release_fetch p2pool-starter-stack/rigforge); then
+            _wu_reject "$GH_RELEASE_HINT"
             return 0
         fi
         tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6407,7 +6407,16 @@ assert_eq "no release lookup dials the API directly any more" \
 # defect this whole change exists to remove, reintroduced by the refactor that removes it. Neither
 # caller may wrap the fetch in a command substitution.
 assert_eq "neither caller swallows the hint in a subshell" \
-    "$(grep -c '=\$(gh_release_fetch' "$STACK")" "0"
+    "$(grep -cF '=$(gh_release_fetch' "$STACK")" "0"
+# And the other half of the same mistake: folding the lookup into a function DELETED the caller's own
+# `local prefix socks` derivation, while two later downloads in that same function still said
+# "$socks". Under `set -u` the runner died at its first download — the upgrade result sat at
+# "running" for ever with a single dial in the log and nothing extracted, and 60 assertions went red
+# together. The fetch publishes the address it used; every dial on that path reads the same one.
+assert_eq "every dial on the upgrade path uses the address the lookup derived" \
+    "$(grep -cF -- '--socks5-hostname "$GH_SOCKS"' "$STACK")" "3"
+assert_eq "no dial refers to a socks variable nobody declares" \
+    "$(grep -cF -- '--socks5-hostname "$socks"' "$STACK")" "0"
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6410,7 +6410,13 @@ for a in "$@"; do
     prev="$a"
 done
 case "$url" in
-*api.github.com*) cat "${CURL_API_RESPONSE:?}" ;;
+# The release lookup reads the body AND the status now (#1081), so the stub has to answer in the
+# shape `-w '\n%{http_code}'` produces. GH_STUB_CODE lets a test drive a non-2xx through the real
+# control path; unset means the ordinary 200.
+*api.github.com*)
+    cat "${CURL_API_RESPONSE:?}"
+    printf '\n%s' "${GH_STUB_CODE:-200}"
+    ;;
 *releases/download/*.sig) cp "${CURL_SIG:?}" "$out" ;;
 *releases/download/*) cp "${CURL_BUNDLE:?}" "$out" ;;
 *) exit 22 ;;

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6368,8 +6368,8 @@ gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
         cd "$GHR" && source "$STACK" 2>/dev/null
         set +e
         export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
-        out=$(gh_release_fetch p2pool-starter-stack/pithead)
-        printf '%s|%s|%s' "$?" "$out" "$GH_RELEASE_HINT"
+        gh_release_fetch p2pool-starter-stack/pithead
+        printf '%s|%s|%s' "$?" "$GH_RELEASE_JSON" "$GH_RELEASE_HINT"
     )
 }
 gh_ok=$(gh_fetch 200 '{"tag_name":"v1.2.3"}')
@@ -6402,6 +6402,12 @@ assert_eq "both release lookups use the shared fetch" \
     "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "2"
 assert_eq "no release lookup dials the API directly any more" \
     "$(grep -c 'api.github.com/repos/.*/releases/latest' "$STACK")" "1"
+# The hint has to reach the CALLER. `rel=$(gh_release_fetch ...)` reads naturally and is a subshell,
+# so the hint would be set and discarded and every rejection would carry an empty message — the
+# defect this whole change exists to remove, reintroduced by the refactor that removes it. Neither
+# caller may wrap the fetch in a command substitution.
+assert_eq "neither caller swallows the hint in a subshell" \
+    "$(grep -c '=\$(gh_release_fetch' "$STACK")" "0"
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7655,7 +7655,7 @@ mkdir -p "$ghjunk_dir/staged" "$ghjunk_dir/results" "$ghjunk_dir/audit" "$ghjunk
 cp "$WU/config.json" "$ghjunk_dir/config.json"
 cat >"$ghjunk_dir/bin/curl" <<'EOF'
 #!/usr/bin/env bash
-printf '{"message":"Not Found"}'
+printf '{"message":"Not Found"}\n200'
 exit 0
 EOF
 chmod +x "$ghjunk_dir/bin/curl"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6366,7 +6366,9 @@ EOF
 chmod +x "$GHR/bin/curl"
 gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
     (
-        cd "$GHR" && source "$STACK" 2>/dev/null
+        cd "$GHR" || exit 1
+        # shellcheck disable=SC1090  # STACK path is dynamic by design
+        source "$STACK" 2>/dev/null
         set +e
         export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
         gh_release_fetch p2pool-starter-stack/pithead
@@ -6397,7 +6399,9 @@ esac
 # ("answered HTTP {"message":"Not Found"}"): unreadable, and a way for a remote body to reach the
 # dashboard verbatim. GH_STUB_NOCODE makes the stub answer the way that produced it.
 gh_nocode=$(
-    cd "$GHR" && source "$STACK" 2>/dev/null
+    cd "$GHR" || exit 1
+    # shellcheck disable=SC1090  # STACK path is dynamic by design
+    source "$STACK" 2>/dev/null
     set +e
     export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1
     gh_release_fetch p2pool-starter-stack/pithead

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6303,6 +6303,68 @@ out="$(run_pending)"
 assert_contains "next run drains the remainder" "$out" "Processed 10 control request(s)"
 assert_eq "spool empty after the second run" "$(ls "$REQS" | wc -l | tr -d ' ')" "0"
 
+echo "== unit: a spent GitHub rate limit is not a dead Tor circuit (#1081) =="
+# The one-click upgrade was rejected on a healthy box with "could not reach the GitHub release API
+# over Tor". Tor was fine and the dial succeeded; GitHub answered 403 because the unauthenticated
+# limit is 60 requests an hour PER IP and a Tor exit is shared with everyone else using it, so the
+# budget had been spent by strangers. `curl -f` collapses every non-2xx into one exit code, so the
+# only thing the operator was told pointed at 'doctor' — which correctly reports Tor healthy.
+#
+# The remedy is a different one entirely: pick a new exit. The fetch is now ONE function both the
+# pithead and the RigForge lookups go through, so neither can drift back.
+#
+# MUTATION PROOF: make the 403 branch fall through to the generic hint (or restore `curl -fsS`) and
+# the rate-limit assertion goes red; the transport-failure assertion holds it honest in the other
+# direction, so "always blame the rate limit" does not pass either.
+GHR="$SANDBOX/gh-release"
+mkdir -p "$GHR/bin"
+cat >"$GHR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+# Answers with $GH_STUB_CODE and $GH_STUB_BODY, in the shape `-w '\n%{http_code}'` produces.
+[ "${GH_STUB_TRANSPORT_FAIL:-0}" = "1" ] && exit 7
+printf '%s\n%s' "${GH_STUB_BODY:-}" "${GH_STUB_CODE:-200}"
+EOF
+chmod +x "$GHR/bin/curl"
+gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
+    (
+        cd "$GHR" && source "$STACK" 2>/dev/null
+        set +e
+        export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
+        out=$(gh_release_fetch p2pool-starter-stack/pithead)
+        printf '%s|%s|%s' "$?" "$out" "$GH_RELEASE_HINT"
+    )
+}
+gh_ok=$(gh_fetch 200 '{"tag_name":"v1.2.3"}')
+assert_eq "a 200 returns the release JSON" "${gh_ok%%|*}" "0"
+assert_contains "and the JSON is what the caller gets" "$gh_ok" '"tag_name":"v1.2.3"'
+
+gh_rl=$(gh_fetch 403 '{"message":"API rate limit exceeded for 203.0.113.9."}')
+assert_eq "a spent rate limit is a failure" "${gh_rl%%|*}" "1"
+assert_contains "and names the remedy that actually works" "$gh_rl" "restart tor"
+case "$gh_rl" in
+*"could not reach the GitHub release API"*) bad "a spent rate limit is not reported as unreachable" "the hint still blames the dial: $gh_rl" ;;
+*) ok "a spent rate limit is not reported as unreachable" ;;
+esac
+
+gh_tf=$(gh_fetch 000 '' 1)
+assert_eq "a transport failure is still a failure" "${gh_tf%%|*}" "1"
+assert_contains "and still reads as a dial that did not land" "$gh_tf" "could not reach the GitHub release API"
+case "$gh_tf" in
+*"restart tor"*) bad "a dial failure is not blamed on the rate limit" "the hint sends them to restart tor: $gh_tf" ;;
+*) ok "a dial failure is not blamed on the rate limit" ;;
+esac
+
+gh_500=$(gh_fetch 500 'upstream is unwell')
+assert_eq "a server error is a failure" "${gh_500%%|*}" "1"
+assert_contains "and says which status came back" "$gh_500" "HTTP 500"
+
+# Both lookups go through the one function — a second copy is how the two messages drifted apart in
+# the first place, and the RigForge one would have kept the old wrong hint.
+assert_eq "both release lookups use the shared fetch" \
+    "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "2"
+assert_eq "no release lookup dials the API directly any more" \
+    "$(grep -c 'api.github.com/repos/.*/releases/latest' "$STACK")" "1"
+
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel
 # on. The runner's upgrade verb runs against a stub curl (GitHub release API + bundle download)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6360,6 +6360,7 @@ cat >"$GHR/bin/curl" <<'EOF'
 #!/usr/bin/env bash
 # Answers with $GH_STUB_CODE and $GH_STUB_BODY, in the shape `-w '\n%{http_code}'` produces.
 [ "${GH_STUB_TRANSPORT_FAIL:-0}" = "1" ] && exit 7
+[ "${GH_STUB_NOCODE:-0}" = "1" ] && { printf '%s' "${GH_STUB_BODY:-}"; exit 0; }
 printf '%s\n%s' "${GH_STUB_BODY:-}" "${GH_STUB_CODE:-200}"
 EOF
 chmod +x "$GHR/bin/curl"
@@ -6390,6 +6391,22 @@ assert_contains "and still reads as a dial that did not land" "$gh_tf" "could no
 case "$gh_tf" in
 *"restart tor"*) bad "a dial failure is not blamed on the rate limit" "the hint sends them to restart tor: $gh_tf" ;;
 *) ok "a dial failure is not blamed on the rate limit" ;;
+esac
+
+# No status line at all — `code` is then the WHOLE BODY, and it went into an operator-facing string
+# ("answered HTTP {"message":"Not Found"}"): unreadable, and a way for a remote body to reach the
+# dashboard verbatim. GH_STUB_NOCODE makes the stub answer the way that produced it.
+gh_nocode=$(
+    cd "$GHR" && source "$STACK" 2>/dev/null
+    set +e
+    export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1
+    gh_release_fetch p2pool-starter-stack/pithead
+    printf '%s|%s' "$?" "$GH_RELEASE_HINT"
+)
+assert_eq "a response with no status line is a failure" "${gh_nocode%%|*}" "1"
+case "$gh_nocode" in
+*'{"message"'* | *'Not Found'*) bad "the body never reaches the operator" "the hint quotes the response body: $gh_nocode" ;;
+*) ok "the body never reaches the operator" ;;
 esac
 
 gh_500=$(gh_fetch 500 'upstream is unwell')

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7620,7 +7620,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 case "$url" in
-*/releases/latest) printf '{"tag_name":"v9.9.9"}' ;;
+*/releases/latest) printf '{"tag_name":"v9.9.9"}\n200' ;;
 */upgrade) printf '{"change_id":"chg-9"}' >"$out"; printf '202' ;;
 */status) printf '{"change_id":"chg-9","status":"applied"}' >"$out"; printf '200' ;;
 *) printf '000' ;;


### PR DESCRIPTION
Hit live on the bench while deploying v1.19.1. A healthy box refused a one-click upgrade with:

```
could not reach the GitHub release API over Tor — nothing was changed.
Check './pithead doctor' and retry.
```

Tor was fine and the dial landed. GitHub answered **403**, because its unauthenticated limit is 60
requests an hour **per IP** and a Tor exit is shared with everyone else using it, so the budget had
already been spent by strangers. `curl -f` collapses every non-2xx into one exit code, so the only
thing the operator was told pointed at `doctor` — which correctly reports Tor egress healthy. They
are sent to a check that will tell them nothing is wrong, about a box where nothing is wrong.

The remedy is a different one entirely: `./pithead restart tor` picks fresh guards and lands on
another exit with its own budget. On the bench that worked immediately (`HTTP/2 200`,
`x-ratelimit-remaining: 59`), and nothing in the message pointed at it.

## The fix

`-w '%{http_code}'` instead of `-f`, so a non-2xx keeps its **body** — which is where GitHub says
the limit was exceeded — and curl's own non-zero exit now means only a transport failure. That is
exactly the distinction that was missing.

**One function, two callers.** The pithead lookup and the RigForge lookup were two copies of the
same nine-line `curl` block with the same wrong message. Fixing one and leaving the other is how
they would have drifted, so both now go through `gh_release_fetch`, and a tier-1 assertion counts
the callers so a third copy cannot quietly appear. The two call sites get shorter, not longer.

## What I deliberately did NOT do

The issue's fix 2 suggests releasing the 10-minute throttle on a rate-limit refusal so the operator
can act at once. I think that is wrong, and it is worth saying why rather than silently skipping it.

The throttle is claimed **before** the dial so a compromised container cannot use failed attempts as
an unthrottled GitHub-API / Tor-egress beacon. The issue's reasoning is that this "holds for attempts
that *reach* GitHub" — but a rate-limited request **did** reach GitHub. Releasing the stamp on that
condition restores precisely the beacon the throttle exists to stop, and an attacker who can provoke
403s (by exhausting the exit's budget, which anyone sharing the exit can do) gets it on demand.

Fix 3 (retry once on a fresh circuit) is a bigger behavioural change — restarting Tor drops every
circuit including the mining onions — and belongs in its own decision, not smuggled into a message
fix. The message now tells the operator the useful thing to do during a window they have to wait out
anyway.

## Coverage

A stubbed `curl` drives all four outcomes and asserts in **both** directions, so "always blame the
rate limit" fails as loudly as "never blame it":

| stub | asserted |
| --- | --- |
| `200` + release JSON | returns 0, and the caller gets the JSON |
| `403` + `"API rate limit exceeded"` | returns 1, names `restart tor`, **and does not say "could not reach"** |
| transport failure (curl exit 7) | returns 1, still reads as a dial that did not land, **and does not say `restart tor`** |
| `500` | returns 1, names the status |

Plus the two counter assertions pinning both lookups to the shared function.

Mutation named in the test comment: make the 403 arm fall through to the generic hint (the old `-f`
behaviour) and the rate-limit assertion goes red.

Closes #1081
