### PR TITLE
Sync develop into develop-v2 (#1133, #1136) — and the appliance's release lookup had #1081's defect too

### DIFF
--- a/pithead
+++ b/pithead
@@ -3356,18 +3356,23 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""
 GH_RELEASE_JSON=""
+# The SOCKS address this fetch used, published so a caller that goes on to download the release over
+# the same Tor path derives it ONCE rather than twice. Folding the lookup into a function deleted the
+# caller's own derivation, and `set -u` then killed the runner at its first download — the upgrade
+# result sat at "running" for ever with a single dial in the log. One derivation, one truth.
+GH_SOCKS=""
 gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE_HINT on failure
-    local repo="$1" prefix socks out code
+    local repo="$1" prefix out code
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
     [ -n "$prefix" ] || prefix="172.28.0"
-    socks="${prefix}.25:9050"
+    GH_SOCKS="${prefix}.25:9050"
     GH_RELEASE_HINT=""
     GH_RELEASE_JSON=""
     # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
     # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
     # failure, which is exactly the distinction that was missing.
     if ! out=$(curl -sS --max-time 60 --max-filesize "$CURL_CAP_SMALL" -w '\n%{http_code}' \
-        --socks5-hostname "$socks" -H 'Accept: application/vnd.github+json' \
+        --socks5-hostname "$GH_SOCKS" -H 'Accept: application/vnd.github+json' \
         "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null); then
         GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
         return 1
@@ -6141,7 +6146,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "started"
     # Bundle URL built from the HOST-derived tag only; fetched over the same Tor SOCKS.
     local bundle="$cdir/staged/.$id.tar.gz" logf="$cdir/staged/.$id.log"
-    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$socks" -o "$bundle" \
+    if ! curl -fsSL --max-time 900 --max-filesize "$CURL_CAP_BUNDLE" --socks5-hostname "$GH_SOCKS" -o "$bundle" \
         "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz" 2>/dev/null; then
         rm -f "$bundle"
         _upg_fail "could not download the $tag release bundle over Tor — the stack keeps running v$PITHEAD_VERSION."
@@ -6154,7 +6159,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # TLS to GitHub plus tag pinning — with one loud line in the journal.
     if [ -f cosign.pub ]; then
         local sig="$cdir/staged/.$id.tar.gz.sig"
-        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" -o "$sig" \
+        if ! curl -fsSL --max-time 120 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$GH_SOCKS" -o "$sig" \
             "https://github.com/p2pool-starter-stack/pithead/releases/download/$tag/pithead.tar.gz.sig" 2>/dev/null; then
             rm -f "$bundle" "$sig"
             _upg_fail "the $tag release carries no bundle signature (pithead.tar.gz.sig) — refusing to install it unverified (#376); the stack keeps running v$PITHEAD_VERSION."

--- a/pithead
+++ b/pithead
@@ -4464,7 +4464,7 @@ generate_caddyfile() {
     # host can keep 80/443 (co-hosting, #181). In HTTPS mode a custom port also disables Caddy's
     # automatic :80 -> HTTPS redirect (a global option emitted once at the top of the file) so port
     # 80 is left free for that proxy; the fronting proxy owns any http->https bounce instead.
-    local dport="${HOST_PORT:-}" port_suffix="" global_block=""
+    local dport="${HOST_PORT:-}" port_suffix="" global_block="" redirect_block=""
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         [ "$dport" == "443" ] && dport=""
         if [ -n "$dport" ]; then
@@ -4474,6 +4474,33 @@ generate_caddyfile() {
 }
 
 '
+        else
+            # Caddy's own HTTP->HTTPS redirect is a CATCH-ALL, and its target is the Host header
+            # the request carried: :80 answered `Host: evil.example` with `308 -> https://evil.example`
+            # (#1123, measured against a running box, not read off the config). That is the same
+            # open redirector #1118 closed in the setup wizard, except this one is the state the
+            # machine spends its life in, and it lands the operator on a page that looks like the
+            # dashboard login — the screen where they type the dashboard password.
+            #
+            # So take :80 over rather than leaving it to auto_https: disable the built-in redirects
+            # and serve one site whose target is fixed to the address this box answers to. The Host
+            # header stops being able to steer anything, and every legitimate :80 request — bare
+            # name, bare IP, whatever the operator typed — still lands on the dashboard, which a
+            # site block matching only $HOST_IP would not do (Caddy answers an unmatched host with
+            # an empty 200, so a plain refusal here reads as a dead machine).
+            global_block='{
+    auto_https disable_redirects
+}
+
+'
+            # A literal, NOT $(printf ...): command substitution strips the trailing newlines and
+            # the next site block lands on the same line as this one's closing brace, which Caddy
+            # refuses — the same trap the $auth line documents from the other direction.
+            redirect_block="http:// {
+    redir https://$HOST_IP{uri} 308
+}
+
+"
         fi
     else
         [ "$dport" == "80" ] && dport=""
@@ -4482,6 +4509,7 @@ generate_caddyfile() {
 
     : >"Caddyfile"
     [ -n "$global_block" ] && printf '%s' "$global_block" >>"Caddyfile"
+    [ -n "$redirect_block" ] && printf '%s' "$redirect_block" >>"Caddyfile"
     if [ "$DASHBOARD_SECURE" == "true" ]; then
         log "Generating Caddyfile for automatic HTTPS ($HOST_IP$port_suffix)$([ -n "$auth" ] && echo ' with login')..."
         cat <<EOF >>"Caddyfile"

--- a/pithead
+++ b/pithead
@@ -3351,7 +3351,7 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
 # dial that genuinely failed.
 # NOT stdout, deliberately: the JSON lands in GH_RELEASE_JSON and the caller runs this as a plain
-# command. `rel=$(gh_release_fetch ...)` reads naturally and is WRONG — command substitution is a
+# command. Assigning it through a command substitution reads naturally and is WRONG — that is a
 # subshell, so the hint set here would never reach the caller and every rejection would carry an
 # empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""

--- a/pithead
+++ b/pithead
@@ -3379,6 +3379,16 @@ gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE
     fi
     code=${out##*$'\n'}
     out=${out%$'\n'*}
+    # No status line at all means the response is not one we can reason about — and without this the
+    # WHOLE BODY becomes "$code" and gets echoed into an operator-facing message, which is both
+    # nonsense to read and a way for a remote body to land verbatim in the dashboard.
+    case "$code" in
+    [0-9][0-9][0-9]) ;;
+    *)
+        GH_RELEASE_HINT="the GitHub release API answered in a shape this cannot read — nothing was changed. Check './pithead doctor' and retry."
+        return 1
+        ;;
+    esac
     case "$code" in
     2*)
         GH_RELEASE_JSON="$out"

--- a/pithead
+++ b/pithead
@@ -3350,13 +3350,19 @@ readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle
 # hour PER IP, and a Tor exit is shared with everyone else using it, so a spent budget is a normal
 # condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
 # dial that genuinely failed.
+# NOT stdout, deliberately: the JSON lands in GH_RELEASE_JSON and the caller runs this as a plain
+# command. `rel=$(gh_release_fetch ...)` reads naturally and is WRONG — command substitution is a
+# subshell, so the hint set here would never reach the caller and every rejection would carry an
+# empty message. Two globals, one call, no subshell.
 GH_RELEASE_HINT=""
-gh_release_fetch() { # <owner/repo> -> release JSON on stdout
+GH_RELEASE_JSON=""
+gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE_HINT on failure
     local repo="$1" prefix socks out code
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
     [ -n "$prefix" ] || prefix="172.28.0"
     socks="${prefix}.25:9050"
     GH_RELEASE_HINT=""
+    GH_RELEASE_JSON=""
     # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
     # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
     # failure, which is exactly the distinction that was missing.
@@ -3370,7 +3376,7 @@ gh_release_fetch() { # <owner/repo> -> release JSON on stdout
     out=${out%$'\n'*}
     case "$code" in
     2*)
-        printf '%s' "$out"
+        GH_RELEASE_JSON="$out"
         return 0
         ;;
     403 | 429)
@@ -6113,10 +6119,11 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     touch "$stamp"
     # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
     local rel tag
-    if ! rel=$(gh_release_fetch p2pool-starter-stack/pithead); then
+    if ! gh_release_fetch p2pool-starter-stack/pithead; then
         _upg_reject "$GH_RELEASE_HINT"
         return 0
     fi
+    rel=$GH_RELEASE_JSON
     tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
     if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
         _upg_reject "the GitHub release API returned no usable release tag — nothing was changed."
@@ -6620,10 +6627,11 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
         fi
         touch "$stampf"
         local rel
-        if ! rel=$(gh_release_fetch p2pool-starter-stack/rigforge); then
+        if ! gh_release_fetch p2pool-starter-stack/rigforge; then
             _wu_reject "$GH_RELEASE_HINT"
             return 0
         fi
+        rel=$GH_RELEASE_JSON
         tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
         if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             _wu_reject "the GitHub release API returned no usable RigForge release tag — nothing was changed."

--- a/pithead
+++ b/pithead
@@ -3340,6 +3340,50 @@ readonly CURL_CAP_SMALL=1048576 # 1 MiB — GitHub release JSON, rig control res
 # cap-hit surfaces as _upg_fail's "could not download over Tor", loud but network-flavoured).
 readonly CURL_CAP_BUNDLE=16777216 # 16 MiB — the pithead.tar.gz release bundle (code + configs)
 
+# The latest-release JSON for a GitHub repo, over the stack's own Tor SOCKS like every other
+# stack egress. Prints the JSON and returns 0; on failure prints nothing, returns 1, and leaves
+# GH_RELEASE_HINT holding the sentence the operator should actually be told.
+#
+# The reason this is a function and not two `curl -fsS` calls: `-f` collapses every non-2xx into
+# one exit code, so a 403 came out as "could not reach GitHub over Tor" and sent the operator to a
+# doctor run that correctly reports Tor healthy. GitHub's unauthenticated limit is 60 requests an
+# hour PER IP, and a Tor exit is shared with everyone else using it, so a spent budget is a normal
+# condition with nothing wrong with this machine — and a different remedy (pick a new exit) from a
+# dial that genuinely failed.
+GH_RELEASE_HINT=""
+gh_release_fetch() { # <owner/repo> -> release JSON on stdout
+    local repo="$1" prefix socks out code
+    prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
+    [ -n "$prefix" ] || prefix="172.28.0"
+    socks="${prefix}.25:9050"
+    GH_RELEASE_HINT=""
+    # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
+    # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
+    # failure, which is exactly the distinction that was missing.
+    if ! out=$(curl -sS --max-time 60 --max-filesize "$CURL_CAP_SMALL" -w '\n%{http_code}' \
+        --socks5-hostname "$socks" -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null); then
+        GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        return 1
+    fi
+    code=${out##*$'\n'}
+    out=${out%$'\n'*}
+    case "$code" in
+    2*)
+        printf '%s' "$out"
+        return 0
+        ;;
+    403 | 429)
+        if printf '%s' "$out" | grep -qi 'rate limit'; then
+            GH_RELEASE_HINT="the Tor exit this machine is currently using has spent GitHub's shared hourly request budget — nothing is wrong with this box, and 'doctor' will say so. Run './pithead restart tor' to pick a new exit, then retry."
+            return 1
+        fi
+        ;;
+    esac
+    GH_RELEASE_HINT="the GitHub release API answered HTTP $code — nothing was changed. Retry in a few minutes."
+    return 1
+}
+
 # Render the pre-masked prefill copy (#440): the live config with every SET secret leaf replaced
 # by the {"__secret__":true} sentinel, written atomically to <control-dir>/masked/config.json.
 # The dashboard serves the Configuration form from THIS file (mounted read-only) — the raw
@@ -6040,14 +6084,9 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # is the right trade.
     touch "$stamp"
     # Host-side re-derivation of the target: the latest tag according to GitHub, not the request.
-    local prefix socks rel tag
-    prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
-    [ -n "$prefix" ] || prefix="172.28.0"
-    socks="${prefix}.25:9050"
-    if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
-        -H 'Accept: application/vnd.github+json' \
-        "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null); then
-        _upg_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+    local rel tag
+    if ! rel=$(gh_release_fetch p2pool-starter-stack/pithead); then
+        _upg_reject "$GH_RELEASE_HINT"
         return 0
     fi
     tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
@@ -6552,14 +6591,9 @@ control_worker_upgrade() { # <claimed-file> <id> <actor> <control-dir>
             return 0
         fi
         touch "$stampf"
-        local prefix socks rel
-        prefix=$(env_get NETWORK_PREFIX 2>/dev/null)
-        [ -n "$prefix" ] || prefix="172.28.0"
-        socks="${prefix}.25:9050"
-        if ! rel=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
-            -H 'Accept: application/vnd.github+json' \
-            "https://api.github.com/repos/p2pool-starter-stack/rigforge/releases/latest" 2>/dev/null); then
-            _wu_reject "could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        local rel
+        if ! rel=$(gh_release_fetch p2pool-starter-stack/rigforge); then
+            _wu_reject "$GH_RELEASE_HINT"
             return 0
         fi
         tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)

--- a/pithead
+++ b/pithead
@@ -10316,19 +10316,28 @@ os_update_test_base() {
 }
 
 # The latest-release JSON, over the stack's own Tor SOCKS like every other stack egress.
+#
+# The real lookup is gh_release_fetch's, not a third copy of it. This one used `curl -fsS`, and
+# `-f` collapses every non-2xx into one exit code — so a spent GitHub rate limit came out of
+# os-check as "could not reach the release API over Tor" and sent the operator to a doctor run
+# that correctly reports Tor healthy (#1081, which fixed the two DIY lookups and never saw this
+# one). Only the bench seam keeps its own dial: it points at a local URL with no Tor in the path.
+# Sets GH_RELEASE_JSON on success and GH_RELEASE_HINT on failure, like the shared fetch, so the
+# caller must run it as a plain command — a command substitution is a subshell and would discard
+# both.
 os_release_fetch() {
     local base
     if base=$(os_update_test_base); then
-        curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" "$base/releases-latest.json" 2>/dev/null
-        return
+        GH_RELEASE_HINT=""
+        GH_RELEASE_JSON=""
+        if ! GH_RELEASE_JSON=$(curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" \
+            "$base/releases-latest.json" 2>/dev/null); then
+            GH_RELEASE_HINT="could not reach the release API — nothing was changed."
+            return 1
+        fi
+        return 0
     fi
-    local prefix socks
-    prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
-    [ -n "$prefix" ] || prefix="172.28.0"
-    socks="${prefix}.25:9050"
-    curl -fsS --max-time 60 --max-filesize "$CURL_CAP_SMALL" --socks5-hostname "$socks" \
-        -H 'Accept: application/vnd.github+json' \
-        "https://api.github.com/repos/p2pool-starter-stack/pithead/releases/latest" 2>/dev/null
+    gh_release_fetch p2pool-starter-stack/pithead
 }
 
 # One shared refusal writer for the os-* verbs (they share one result/audit shape).
@@ -10439,10 +10448,11 @@ control_os_check() { # <claimed-file> <id> <actor> <control-dir>
             return 0
         fi
         touch "$stampf"
-        if ! rel=$(os_release_fetch); then
-            control_os_refuse "$cdir" "$id" "$actor" "os-check" rejected "could not reach the release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        if ! os_release_fetch; then
+            control_os_refuse "$cdir" "$id" "$actor" "os-check" rejected "$GH_RELEASE_HINT"
             return 0
         fi
+        rel=$GH_RELEASE_JSON
         tag=$(printf '%s' "$rel" | jq -r '.tag_name // ""' 2>/dev/null)
         if ! printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             control_os_refuse "$cdir" "$id" "$actor" "os-check" rejected "the release API returned no usable release tag — nothing was changed."

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7477,10 +7477,12 @@ gh_500=$(gh_fetch 500 'upstream is unwell')
 assert_eq "a server error is a failure" "${gh_500%%|*}" "1"
 assert_contains "and says which status came back" "$gh_500" "HTTP 500"
 
-# Both lookups go through the one function — a second copy is how the two messages drifted apart in
-# the first place, and the RigForge one would have kept the old wrong hint.
-assert_eq "both release lookups use the shared fetch" \
-    "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "2"
+# Every lookup goes through the one function — a second copy is how the two messages drifted apart
+# in the first place, and the RigForge one would have kept the old wrong hint. Three on this lane:
+# the one-click upgrade, the RigForge worker upgrade, and the appliance's os-check, which carried
+# its own `curl -fsS` (and so its own collapsed 403) until the sync that brought #1081 over.
+assert_eq "every release lookup uses the shared fetch" \
+    "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "3"
 assert_eq "no release lookup dials the API directly any more" \
     "$(grep -c 'api.github.com/repos/.*/releases/latest' "$STACK")" "1"
 # The hint has to reach the CALLER. `rel=$(gh_release_fetch ...)` reads naturally and is a subshell,
@@ -7489,6 +7491,11 @@ assert_eq "no release lookup dials the API directly any more" \
 # caller may wrap the fetch in a command substitution.
 assert_eq "neither caller swallows the hint in a subshell" \
     "$(grep -cF '=$(gh_release_fetch' "$STACK")" "0"
+# os_release_fetch wraps the shared fetch for the appliance and publishes the same two globals, so
+# it inherits the same rule. It was `rel=$(os_release_fetch)` before — the exact swallowing form,
+# which is why this one is asserted rather than trusted.
+assert_eq "the appliance os-check does not swallow the hint either" \
+    "$(grep -cF '=$(os_release_fetch' "$STACK")" "0"
 # And the other half of the same mistake: folding the lookup into a function DELETED the caller's own
 # `local prefix socks` derivation, while two later downloads in that same function still said
 # "$socks". Under `set -u` the runner died at its first download — the upgrade result sat at
@@ -7496,8 +7503,16 @@ assert_eq "neither caller swallows the hint in a subshell" \
 # together. The fetch publishes the address it used; every dial on that path reads the same one.
 assert_eq "every dial on the upgrade path uses the address the lookup derived" \
     "$(grep -cF -- '--socks5-hostname "$GH_SOCKS"' "$STACK")" "3"
-assert_eq "no dial refers to a socks variable nobody declares" \
-    "$(grep -cF -- '--socks5-hostname "$socks"' "$STACK")" "0"
+# A whole-file count of `"$socks"` cannot tell a declared one from an undeclared one — the
+# appliance's OS-bundle download legitimately derives its own, because its bench seam has to leave
+# the address EMPTY, and a plain count reads that as the bug. So ask the question the defect
+# actually poses: is every `"$socks"` dial inside a function that declares socks?
+undeclared_socks="$(awk '
+    /^[A-Za-z_][A-Za-z0-9_]*\(\)/ { fn = $1; declared = 0 }
+    fn && /^ *local .*socks/ { declared = 1 }
+    /--socks5-hostname "\$socks"/ && !declared { print FNR " in " fn }
+' "$STACK")"
+assert_eq "no dial refers to a socks variable its own function never declares" "$undeclared_socks" ""
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel
@@ -10840,7 +10855,13 @@ for a in "$@"; do
     prev="$a"
 done
 case "$url" in
-*api.github.com*) cat "${CURL_API_RESPONSE:?}" ;;
+# os-check reads the body AND the status now that it goes through the shared release fetch
+# (#1081), so the stub has to answer in the shape `-w '\n%{http_code}'` produces. GH_STUB_CODE
+# lets a test drive a non-2xx through the real control path; unset means the ordinary 200.
+*api.github.com*)
+    cat "${CURL_API_RESPONSE:?}"
+    printf '\n%s' "${GH_STUB_CODE:-200}"
+    ;;
 *releases/download/*)
     if [ "${CURL_RC:-0}" = "28" ]; then
         head -c "${CURL_PARTIAL_BYTES:-300}" "${CURL_BUNDLE:?}" >"$out"
@@ -11152,6 +11173,37 @@ os_intent "$UOS" os-check
 osrun >/dev/null
 assert_contains "the test seam redirects the release lookup" "$(cat "$OSC/curl.log")" "bench.invalid/updates/releases-latest.json"
 rm -f "$OSC/os-update-test-base" "$OSRES/$UOS.json"
+
+# #1081 reached only the two DIY lookups. The appliance's os-check kept its own `curl -fsS`, and
+# `-f` collapses every non-2xx into one exit code — so a spent GitHub budget came out of the
+# dashboard as "could not reach the release API over Tor", pointing at a doctor run that reports
+# Tor healthy, on a box with no shell to run it from. It goes through the shared fetch now.
+echo "== black-box: a rate-limited os-check names the remedy that works (#1081) =="
+printf '%s' '{"message":"API rate limit exceeded for this IP.","documentation_url":"https://docs.github.com/rest/overview/rate-limits-for-the-rest-api"}' >"$OSC/api-403.json"
+rm -f "$OSDIR/target.json" "$OSDIR/.check-stamp"
+os_reset
+os_intent "$UOS" os-check
+osrun CURL_API_RESPONSE="$OSC/api-403.json" GH_STUB_CODE=403 >/dev/null
+os_403=$(jq -r '.error' "$OSRES/$UOS.json" 2>/dev/null)
+assert_eq "a rate-limited os-check is rejected" "$(jq -r '.status' "$OSRES/$UOS.json" 2>/dev/null)" "rejected"
+assert_contains "and names the remedy that actually works" "$os_403" "restart tor"
+# The defect itself, as the operator read it: the old refusal blamed the transport and sent them to
+# a doctor run that reports Tor healthy. Both halves of that sentence are barred. (The replacement
+# does say the word "doctor" — "nothing is wrong with this box, and 'doctor' will say so" — so this
+# matches the two OLD phrasings, not the word.)
+case "$os_403" in
+*"could not reach the release API"* | *"Check './pithead doctor' and retry"*)
+    bad "a rate limit is not reported as a dead Tor circuit" "the refusal still says: $os_403"
+    ;;
+*) ok "a rate limit is not reported as a dead Tor circuit" ;;
+esac
+# The 10-minute throttle stays HELD on a rate-limit refusal: that request did reach GitHub, so
+# releasing it restores exactly the unthrottled beacon the throttle exists to stop (#1081's fix 2,
+# deliberately not taken).
+assert_eq "the throttle is still held after a rate-limit refusal" \
+    "$([ -f "$OSDIR/.check-stamp" ] && echo held || echo released)" "held"
+os_reset
+rm -f "$OSDIR/target.json" "$OSDIR/.check-stamp"
 
 unset -f osrun os_intent os_reset os_restage
 rm -rf "$OSC"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6407,7 +6407,16 @@ assert_eq "no release lookup dials the API directly any more" \
 # defect this whole change exists to remove, reintroduced by the refactor that removes it. Neither
 # caller may wrap the fetch in a command substitution.
 assert_eq "neither caller swallows the hint in a subshell" \
-    "$(grep -c '=\$(gh_release_fetch' "$STACK")" "0"
+    "$(grep -cF '=$(gh_release_fetch' "$STACK")" "0"
+# And the other half of the same mistake: folding the lookup into a function DELETED the caller's own
+# `local prefix socks` derivation, while two later downloads in that same function still said
+# "$socks". Under `set -u` the runner died at its first download — the upgrade result sat at
+# "running" for ever with a single dial in the log and nothing extracted, and 60 assertions went red
+# together. The fetch publishes the address it used; every dial on that path reads the same one.
+assert_eq "every dial on the upgrade path uses the address the lookup derived" \
+    "$(grep -cF -- '--socks5-hostname "$GH_SOCKS"' "$STACK")" "3"
+assert_eq "no dial refers to a socks variable nobody declares" \
+    "$(grep -cF -- '--socks5-hostname "$socks"' "$STACK")" "0"
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6410,7 +6410,13 @@ for a in "$@"; do
     prev="$a"
 done
 case "$url" in
-*api.github.com*) cat "${CURL_API_RESPONSE:?}" ;;
+# The release lookup reads the body AND the status now (#1081), so the stub has to answer in the
+# shape `-w '\n%{http_code}'` produces. GH_STUB_CODE lets a test drive a non-2xx through the real
+# control path; unset means the ordinary 200.
+*api.github.com*)
+    cat "${CURL_API_RESPONSE:?}"
+    printf '\n%s' "${GH_STUB_CODE:-200}"
+    ;;
 *releases/download/*.sig) cp "${CURL_SIG:?}" "$out" ;;
 *releases/download/*) cp "${CURL_BUNDLE:?}" "$out" ;;
 *) exit 22 ;;

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6368,8 +6368,8 @@ gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
         cd "$GHR" && source "$STACK" 2>/dev/null
         set +e
         export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
-        out=$(gh_release_fetch p2pool-starter-stack/pithead)
-        printf '%s|%s|%s' "$?" "$out" "$GH_RELEASE_HINT"
+        gh_release_fetch p2pool-starter-stack/pithead
+        printf '%s|%s|%s' "$?" "$GH_RELEASE_JSON" "$GH_RELEASE_HINT"
     )
 }
 gh_ok=$(gh_fetch 200 '{"tag_name":"v1.2.3"}')
@@ -6402,6 +6402,12 @@ assert_eq "both release lookups use the shared fetch" \
     "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "2"
 assert_eq "no release lookup dials the API directly any more" \
     "$(grep -c 'api.github.com/repos/.*/releases/latest' "$STACK")" "1"
+# The hint has to reach the CALLER. `rel=$(gh_release_fetch ...)` reads naturally and is a subshell,
+# so the hint would be set and discarded and every rejection would carry an empty message — the
+# defect this whole change exists to remove, reintroduced by the refactor that removes it. Neither
+# caller may wrap the fetch in a command substitution.
+assert_eq "neither caller swallows the hint in a subshell" \
+    "$(grep -c '=\$(gh_release_fetch' "$STACK")" "0"
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7655,7 +7655,7 @@ mkdir -p "$ghjunk_dir/staged" "$ghjunk_dir/results" "$ghjunk_dir/audit" "$ghjunk
 cp "$WU/config.json" "$ghjunk_dir/config.json"
 cat >"$ghjunk_dir/bin/curl" <<'EOF'
 #!/usr/bin/env bash
-printf '{"message":"Not Found"}'
+printf '{"message":"Not Found"}\n200'
 exit 0
 EOF
 chmod +x "$ghjunk_dir/bin/curl"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1505,8 +1505,9 @@ case "$caddy_port_http" in
 *"disable_redirects"*) bad "plain-HTTP custom port has no redirect global" "'disable_redirects' present on a plain-HTTP site" ;;
 *) ok "plain-HTTP custom port has no redirect global" ;;
 esac
-# A port that equals the scheme default (443 secure / unset) renders today's Caddyfile verbatim —
-# no port suffix, no redirect global. Guards the byte-identical default path.
+# A port that equals the scheme default (443 secure / unset) renders the same site address as an
+# unset one — no port suffix. It still takes :80 over from auto_https (see #1123 below), which is
+# what separates it from the custom-port case: there, :80 is deliberately left to a fronting proxy.
 # shellcheck disable=SC1090  # STACK path is dynamic by design
 caddy_port_default="$(
     cd "$SANDBOX" && source "$STACK" 2>/dev/null
@@ -1516,9 +1517,46 @@ caddy_port_default="$(
 )"
 assert_contains "explicit default port keeps the bare site address" "$caddy_port_default" "https://box.lan {"
 case "$caddy_port_default" in
-*"disable_redirects"*) bad "default port emits no redirect global" "'disable_redirects' present at the scheme default" ;;
 *":443"*) bad "default port emits no explicit suffix" "':443' suffix present at the scheme default" ;;
 *) ok "default port renders the bare site address" ;;
+esac
+
+echo "== unit: the :80 redirect cannot be steered by the Host header (#1123) =="
+# Caddy's built-in HTTP->HTTPS redirect is a CATCH-ALL whose target is the request's own Host
+# header, so a provisioned box answered `Host: evil.example` on :80 with `308 -> https://evil.example`
+# — measured on a running machine. That is #1118's open redirector again, in the state the machine
+# spends its life in, and it lands on the screen where the operator types the dashboard password.
+# The render now disables the built-in redirects and serves :80 itself with a FIXED target.
+# MUTATION PROOF: render `redir https://{host}{uri}` instead of the literal host, or drop the
+# `auto_https disable_redirects`, and the two assertions below go red.
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+caddy_redir="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
+assert_contains "the default secure render takes :80 over from auto_https" "$caddy_redir" "auto_https disable_redirects"
+assert_contains "it serves :80 itself" "$caddy_redir" "http:// {"
+assert_contains "and redirects to the box, by name, not to whatever was asked for" "$caddy_redir" \
+    "redir https://box.lan{uri} 308"
+# The whole defect in one assertion: no redirect target may be built from the request. Caddy spells
+# the request's host `{host}` (and `{http.request.host}`), so neither may appear in a redir line.
+caddy_redir_lines="$(printf '%s\n' "$caddy_redir" | grep -a "redir" || true)"
+case "$caddy_redir_lines" in
+*"{host}"* | *"{http.request.host}"*) bad "no redirect target comes from the request" "a redir line interpolates the request host: $caddy_redir_lines" ;;
+*) ok "no redirect target comes from the request" ;;
+esac
+# A custom port means a fronting proxy owns :80 (#740). Taking it over there would break exactly the
+# co-hosting the option exists for, so the catch-all is the default path's alone.
+case "$caddy_port_https" in
+*"http:// {"*) bad "a custom port leaves :80 to the fronting proxy" "the render claimed :80 anyway" ;;
+*) ok "a custom port leaves :80 to the fronting proxy" ;;
+esac
+# Plain-HTTP mode has no redirect to steer: :80 IS the dashboard there.
+case "$caddy_http" in
+*"redir"*) bad "plain-HTTP mode renders no redirect at all" "a redir line appeared on a plain-HTTP site" ;;
+*) ok "plain-HTTP mode renders no redirect at all" ;;
 esac
 # Onion + custom LAN port together (#740 × #343): the LAN vhost moves to the custom port and the
 # `disable_redirects` global is emitted, but the onion vhost MUST stay on the bridge gateway's bare

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6366,7 +6366,9 @@ EOF
 chmod +x "$GHR/bin/curl"
 gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
     (
-        cd "$GHR" && source "$STACK" 2>/dev/null
+        cd "$GHR" || exit 1
+        # shellcheck disable=SC1090  # STACK path is dynamic by design
+        source "$STACK" 2>/dev/null
         set +e
         export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
         gh_release_fetch p2pool-starter-stack/pithead
@@ -6397,7 +6399,9 @@ esac
 # ("answered HTTP {"message":"Not Found"}"): unreadable, and a way for a remote body to reach the
 # dashboard verbatim. GH_STUB_NOCODE makes the stub answer the way that produced it.
 gh_nocode=$(
-    cd "$GHR" && source "$STACK" 2>/dev/null
+    cd "$GHR" || exit 1
+    # shellcheck disable=SC1090  # STACK path is dynamic by design
+    source "$STACK" 2>/dev/null
     set +e
     export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1
     gh_release_fetch p2pool-starter-stack/pithead

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6303,6 +6303,68 @@ out="$(run_pending)"
 assert_contains "next run drains the remainder" "$out" "Processed 10 control request(s)"
 assert_eq "spool empty after the second run" "$(ls "$REQS" | wc -l | tr -d ' ')" "0"
 
+echo "== unit: a spent GitHub rate limit is not a dead Tor circuit (#1081) =="
+# The one-click upgrade was rejected on a healthy box with "could not reach the GitHub release API
+# over Tor". Tor was fine and the dial succeeded; GitHub answered 403 because the unauthenticated
+# limit is 60 requests an hour PER IP and a Tor exit is shared with everyone else using it, so the
+# budget had been spent by strangers. `curl -f` collapses every non-2xx into one exit code, so the
+# only thing the operator was told pointed at 'doctor' — which correctly reports Tor healthy.
+#
+# The remedy is a different one entirely: pick a new exit. The fetch is now ONE function both the
+# pithead and the RigForge lookups go through, so neither can drift back.
+#
+# MUTATION PROOF: make the 403 branch fall through to the generic hint (or restore `curl -fsS`) and
+# the rate-limit assertion goes red; the transport-failure assertion holds it honest in the other
+# direction, so "always blame the rate limit" does not pass either.
+GHR="$SANDBOX/gh-release"
+mkdir -p "$GHR/bin"
+cat >"$GHR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+# Answers with $GH_STUB_CODE and $GH_STUB_BODY, in the shape `-w '\n%{http_code}'` produces.
+[ "${GH_STUB_TRANSPORT_FAIL:-0}" = "1" ] && exit 7
+printf '%s\n%s' "${GH_STUB_BODY:-}" "${GH_STUB_CODE:-200}"
+EOF
+chmod +x "$GHR/bin/curl"
+gh_fetch() { # <code> <body> [transport-fail] -> "<rc>|<stdout>|<hint>"
+    (
+        cd "$GHR" && source "$STACK" 2>/dev/null
+        set +e
+        export PATH="$GHR/bin:$PATH" GH_STUB_CODE="$1" GH_STUB_BODY="$2" GH_STUB_TRANSPORT_FAIL="${3:-0}"
+        out=$(gh_release_fetch p2pool-starter-stack/pithead)
+        printf '%s|%s|%s' "$?" "$out" "$GH_RELEASE_HINT"
+    )
+}
+gh_ok=$(gh_fetch 200 '{"tag_name":"v1.2.3"}')
+assert_eq "a 200 returns the release JSON" "${gh_ok%%|*}" "0"
+assert_contains "and the JSON is what the caller gets" "$gh_ok" '"tag_name":"v1.2.3"'
+
+gh_rl=$(gh_fetch 403 '{"message":"API rate limit exceeded for 203.0.113.9."}')
+assert_eq "a spent rate limit is a failure" "${gh_rl%%|*}" "1"
+assert_contains "and names the remedy that actually works" "$gh_rl" "restart tor"
+case "$gh_rl" in
+*"could not reach the GitHub release API"*) bad "a spent rate limit is not reported as unreachable" "the hint still blames the dial: $gh_rl" ;;
+*) ok "a spent rate limit is not reported as unreachable" ;;
+esac
+
+gh_tf=$(gh_fetch 000 '' 1)
+assert_eq "a transport failure is still a failure" "${gh_tf%%|*}" "1"
+assert_contains "and still reads as a dial that did not land" "$gh_tf" "could not reach the GitHub release API"
+case "$gh_tf" in
+*"restart tor"*) bad "a dial failure is not blamed on the rate limit" "the hint sends them to restart tor: $gh_tf" ;;
+*) ok "a dial failure is not blamed on the rate limit" ;;
+esac
+
+gh_500=$(gh_fetch 500 'upstream is unwell')
+assert_eq "a server error is a failure" "${gh_500%%|*}" "1"
+assert_contains "and says which status came back" "$gh_500" "HTTP 500"
+
+# Both lookups go through the one function — a second copy is how the two messages drifted apart in
+# the first place, and the RigForge one would have kept the old wrong hint.
+assert_eq "both release lookups use the shared fetch" \
+    "$(grep -c 'gh_release_fetch p2pool-starter-stack/' "$STACK")" "2"
+assert_eq "no release lookup dials the API directly any more" \
+    "$(grep -c 'api.github.com/repos/.*/releases/latest' "$STACK")" "1"
+
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel
 # on. The runner's upgrade verb runs against a stub curl (GitHub release API + bundle download)

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6360,6 +6360,7 @@ cat >"$GHR/bin/curl" <<'EOF'
 #!/usr/bin/env bash
 # Answers with $GH_STUB_CODE and $GH_STUB_BODY, in the shape `-w '\n%{http_code}'` produces.
 [ "${GH_STUB_TRANSPORT_FAIL:-0}" = "1" ] && exit 7
+[ "${GH_STUB_NOCODE:-0}" = "1" ] && { printf '%s' "${GH_STUB_BODY:-}"; exit 0; }
 printf '%s\n%s' "${GH_STUB_BODY:-}" "${GH_STUB_CODE:-200}"
 EOF
 chmod +x "$GHR/bin/curl"
@@ -6390,6 +6391,22 @@ assert_contains "and still reads as a dial that did not land" "$gh_tf" "could no
 case "$gh_tf" in
 *"restart tor"*) bad "a dial failure is not blamed on the rate limit" "the hint sends them to restart tor: $gh_tf" ;;
 *) ok "a dial failure is not blamed on the rate limit" ;;
+esac
+
+# No status line at all — `code` is then the WHOLE BODY, and it went into an operator-facing string
+# ("answered HTTP {"message":"Not Found"}"): unreadable, and a way for a remote body to reach the
+# dashboard verbatim. GH_STUB_NOCODE makes the stub answer the way that produced it.
+gh_nocode=$(
+    cd "$GHR" && source "$STACK" 2>/dev/null
+    set +e
+    export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1
+    gh_release_fetch p2pool-starter-stack/pithead
+    printf '%s|%s' "$?" "$GH_RELEASE_HINT"
+)
+assert_eq "a response with no status line is a failure" "${gh_nocode%%|*}" "1"
+case "$gh_nocode" in
+*'{"message"'* | *'Not Found'*) bad "the body never reaches the operator" "the hint quotes the response body: $gh_nocode" ;;
+*) ok "the body never reaches the operator" ;;
 esac
 
 gh_500=$(gh_fetch 500 'upstream is unwell')

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -7620,7 +7620,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 case "$url" in
-*/releases/latest) printf '{"tag_name":"v9.9.9"}' ;;
+*/releases/latest) printf '{"tag_name":"v9.9.9"}\n200' ;;
 */upgrade) printf '{"change_id":"chg-9"}' >"$out"; printf '202' ;;
 */status) printf '{"change_id":"chg-9","status":"applied"}' >"$out"; printf '200' ;;
 *) printf '000' ;;


### PR DESCRIPTION
Routine twin sync, `develop` → `develop-v2`: #1133 (#1123 on the DIY lane) and #1136 (#1081).

It was not routine. The merge turned two tier-1 assertions red, and they were right about a defect
this lane had been carrying the whole time.

## The conflicts, resolved to the v2 side as planned

Four hunks in `pithead` and two in `tests/stack/run.sh`, all in the Caddyfile renderer, all taking
`develop-v2`'s shape — the appliance keeps the known-hosts block plus catch-all, both carrying
`$(_bind_line)`. Resolved hunk-by-hunk, **not** `git checkout --ours`, which would have thrown away
#1136's clean merge into the same file.

Verified after the resolve:

```
$ grep -n 'redirect_block="http:// {' pithead
(nothing — develop's unbound literal is absent)
$ grep -c 'gh_release_fetch\|GH_SOCKS\|GH_RELEASE_JSON\|GH_RELEASE_HINT' pithead
3 / 5 / 7 / 10   (#1136 landed)
$ <the standing topology grep>  tests/ os/ pithead
(0 hits)
```

## What the merge found: `os_release_fetch` is a third release lookup with #1081's exact defect

#1081 fixed two GitHub release lookups. `develop-v2` has a **third** — `os_release_fetch`, behind the
appliance's dashboard `os-check` verb — and it was still dialing GitHub with its own `curl -fsS`.
`-f` collapses every non-2xx into one exit code, so a spent GitHub rate limit reached the operator
as:

> could not reach the release API over Tor — nothing was changed. Check './pithead doctor' and retry.

Which is the message #1081 exists to delete, **on the lane where `./pithead doctor` is not something
the operator can run at all.**

It goes through `gh_release_fetch` now. The bench seam keeps its own dial, because it points at a
local URL with no Tor in the path.

The caller was `rel=$(os_release_fetch)` — the swallowing form #1136 had to guard against on the DIY
side, sitting here unguarded. It is a plain command now, and asserted.

## Two assertions were counting, not checking

- `both release lookups use the shared fetch` expected `2`. There are three lookups on this lane.
  Renamed and re-counted, with the third named in the comment.
- `no dial refers to a socks variable nobody declares` was a whole-file `grep -cF` for the string.
  That cannot tell a declared `socks` from an undeclared one — and the appliance's OS-bundle
  download derives its own **on purpose**, because its bench seam has to leave the address empty.
  The count read that as the bug. It now asks the question the defect actually poses: is every
  `"$socks"` dial inside a function that declares `socks`? That version is lane-neutral and would
  have caught the original #1081 regression directly.

## What was run

| | result |
|---|---|
| `make lint-sh` | clean (the target, not `shellcheck <file>` — that is how the last CI failure happened) |
| `bash tests/stack/run.sh` | **2692 passed, 0 failed** |

Three mutations, each chained to its own suite run with the mutated region printed before the run:

| mutation | result | kills |
|---|---|---|
| **A** — restore `os_release_fetch`'s own `curl -fsS` dial to `api.github.com` | 2642 / **50** | `every release lookup uses the shared fetch`, `no release lookup dials the API directly any more`, `and names the remedy that actually works` |
| **B** — call it back as `rel=$(os_release_fetch)` | 2643 / **49** | `the appliance os-check does not swallow the hint either`, `and names the remedy that actually works` |
| **C** — delete `socks=""` from `control_os_download`'s `local` | 2691 / **1** | `no dial refers to a socks variable its own function never declares` |

Mutation C is worth reading twice: it killed **only** the new assertion. Dropping the declaration
does not blow up at runtime, because the `else` branch then assigns `socks` as a **global** and every
dial keeps working — right up until a refactor removes that branch, which is exactly what happened in
#1081. A runtime test structurally cannot see this; the static check can, and did.

One assertion of mine was wrong on the first pass and is worth recording: the new "a rate limit is
not reported as a dead Tor circuit" guard barred the word `doctor`, and the correct replacement
message legitimately contains it — *"nothing is wrong with this box, and 'doctor' will say so"*. It
now bars the two **old phrasings**, not the word.

## What was NOT run

- **No bench run.** Nothing under `os/` changed. The `os-check` control verb is exercised at tier 1
  through the real `control-run-pending` drain, not on hardware.
- The Caddy conflict resolutions carry #1134's assertions unchanged; those mutations were run on
  that PR and were not re-run here, because the merge did not change the code they cover.
- The dashboard pytest suite was not run — no Python changed.

## Filed from this work

- #1137 — the compose digest pins assert that *a* digest is present, never which one. A half-done
  version bump is green at every tier. #1129 moves four digest strings.
- #1138 — `scripts/release.sh pin tari` matches the node image only, so a console-wallet bump never
  appears in a release's ingredient list.
- #1139 — appliance refusals still tell the operator to run `./pithead doctor` on a box with no
  shell. Pre-existing, unchanged here, and now reachable from one more verb.

