### PR TITLE
Watch upstream component currency, weekly and report-only — the previous watcher had never run (#1128)

### DIFF
--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -1,0 +1,72 @@
+name: Upstream pin watch
+
+# Weekly upstream-currency report (#1128). It REPORTS and never bumps: a Tari or monerod minor is
+# a data migration to schedule, not a bump to merge (#1129 carries three one-time migrations and a
+# one-way wallet-DB change). RigForge's xmrig-bump.yml opens a build-verified PR instead — same
+# shape, different output, because XMRig is a drop-in binary and its build gate proves the
+# candidate.
+#
+# ONE tracking issue, edited in place. An issue persists, is assignable and milestonable, and lets
+# a human write "held until the bench is free, here's why" in a comment — which a report artifact
+# nobody opens cannot do, and which is the failure mode #1128 was filed about.
+#
+# This file lives on the DEFAULT branch on purpose. The previous pin-watch.yml lived on
+# `develop-v2`, where a `schedule:` can never fire, and so ran exactly zero times — the appliance
+# pins it watched were never checked once. That is the same defect class as #1048 and #1064.
+on:
+  schedule:
+    - cron: "30 6 * * 1" # Mondays 06:30 UTC, after the image sweeps
+  workflow_dispatch:
+
+# Least privilege (#282): issues.write is the job's one output — it never pushes or publishes.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  pin-watch:
+    name: Compare upstream component pins against their latest releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build the currency report
+        id: report
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # NOT `set -e`: a non-zero exit here means "one or more lookups could not run", which is
+          # a result to publish, not a reason to skip publishing it. The exit code is carried to
+          # the last step instead, so a watcher that could not do its job says so in the artefact
+          # a human reads AND fails the run.
+          bash scripts/pin-watch.sh >report.md
+          rc=$?
+          # An empty report is itself a failure to report — never publish silence.
+          [ -s report.md ] || { echo "The pin watcher produced no report at all — see the run log." >report.md; rc=1; }
+          echo "rc=$rc" >>"$GITHUB_OUTPUT"
+      - name: Publish it to the one tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Upstream pin currency (weekly report)"
+        run: |
+          set -Eeuo pipefail
+          body=$(cat report.md)
+          # Exact title match over the open list, NOT `--search`: the search index lags behind
+          # issue creation by minutes, so a search-based dedup files a second issue on the very
+          # next run and then keeps both stale.
+          n=$(gh issue list --state open --limit 200 --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$n" ]; then
+            gh issue edit "$n" --body "$body"
+            echo "updated #$n"
+          else
+            gh issue create --title "$TITLE" --label infra --body "$body"
+          fi
+      - name: Fail the run if any lookup could not be made
+        if: steps.report.outputs.rc != '0'
+        run: |
+          echo "::error::one or more upstream lookups could not run — those pins are UNCHECKED, not current"
+          exit 1

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TITLE: "Upstream pin currency (weekly report)"
+          RC: ${{ steps.report.outputs.rc }}
         run: |
           set -Eeuo pipefail
           body=$(cat report.md)
@@ -59,6 +60,21 @@ jobs:
           # next run and then keeps both stale.
           n=$(gh issue list --state open --limit 200 --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          # A run that could not do its job replaces the report with a failure notice, which would
+          # otherwise DELETE the "last fully successful check" date — and that date is the only
+          # thing separating "failed once this morning" from "has been dead for six weeks". Carry
+          # the previous one forward. A watcher whose own silence is invisible is the exact defect
+          # this watcher exists to catch, so it must not have it.
+          if [ "$RC" != "0" ] && [ -n "$n" ]; then
+            prev=$(gh issue view "$n" --json body --jq .body | grep -a "^_Last fully successful check:" || true)
+            # A real `if`, not `[ -n "$prev" ] && body=...`. The && form is safe HERE (set -e is
+            # ignored for a non-final command in an AND-OR list, checked rather than assumed), but
+            # it evaluates to 1 when $prev is empty — so it only stays safe while something else
+            # follows it. That is a reordering hazard for one saved line.
+            if [ -n "$prev" ]; then
+              body="$body"$'\n\n'"$prev (this run could not complete)"
+            fi
+          fi
           if [ -n "$n" ]; then
             gh issue edit "$n" --body "$body"
             echo "updated #$n"

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -44,6 +44,17 @@ of each product release, not independent releases:
   release: bump the pin → cut a stack patch → re-run the integration gate → ship. The bundle
   ships re-tested.
 
+Noticing that a bump is available is a separate job from making one, and nothing did it until
+`scripts/pin-watch.sh`. It runs weekly from `.github/workflows/pin-watch.yml`, compares each pin
+against the component's latest upstream release, and keeps one tracking issue up to date. It
+reports and never bumps: a Tari or `monerod` minor can carry a one-time data migration, which is
+work to schedule rather than a pull request to merge. Dependabot covers the base images it can see
+and is set to ignore minor and major bumps on the component pins for the same reason.
+
+A lookup that could not be made is reported as unchecked, never as current, and the run fails. The
+report carries the date of the last fully successful check, so a watcher that has stopped looks
+different from one with nothing to say.
+
 ## Published images: GHCR, single-tag model
 
 Images are published to GitHub Container Registry (`ghcr.io/p2pool-starter-stack/*`). Public

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -127,7 +127,6 @@ fi
 
 # Sourcing only defines the functions; release.sh guards its main() behind a BASH_SOURCE check.
 # shellcheck source=/dev/null
-(return 0 2>/dev/null) || true
 set -- # release.sh's arg parser must not see ours
 # shellcheck disable=SC1091
 source "$ROOT/scripts/release.sh"

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -59,7 +59,7 @@ upstream_for() {
 # comparison calls the first two stale every week for ever, and a watcher that cries wolf weekly
 # gets ignored — exactly as useless as one that never runs.
 #
-# Strips, in order: an image name up to the last colon, a digest suffix, a leading `v`, and a
+# Strips, in order: a digest suffix, an image name up to the last colon, a leading `v`, and a
 # `-mainnet`/`-testnet` network suffix.
 norm() {
     local v="$1"
@@ -74,21 +74,7 @@ norm() {
     printf '%s' "$v"
 }
 
-# The digest half of a `tag@sha256:...` image pin; empty for a plain version string.
-pinned_digest() {
-    case "$1" in
-    *@sha256:*) printf '%s' "${1##*@}" ;;
-    esac
-}
-
-# The full image reference minus the digest, e.g. quay.io/tarilabs/minotari_node:v5.3.1-mainnet.
-image_ref() {
-    case "$1" in
-    *@sha256:*) printf '%s' "${1%%@*}" ;;
-    esac
-}
-
-# --- the two lookups. Both are wrapped so a failure is a COUNTED failure, never a quiet "current".
+# The one lookup, wrapped so a failure is a COUNTED failure and never a quiet "current".
 
 latest_release() { # <owner/repo> -> tag on stdout, rc 1 on any failure
     local tag
@@ -99,10 +85,9 @@ latest_release() { # <owner/repo> -> tag on stdout, rc 1 on any failure
     printf '%s' "$tag"
 }
 
-
 # --- self-test -----------------------------------------------------------------------------------
-# The comparison logic is the whole product here; the two lookups are one `gh api` and one
-# `docker` call each. Drives norm() over the real pin spellings and the failure paths over stubs.
+# The comparison logic is the whole product here; the lookup itself is one `gh api` call. Drives
+# norm() over the real pin spellings, and both of the lookup's refusal paths over a stubbed `gh`.
 if [ "${1:-}" = "--self-test" ]; then
     st_fail=0
     st() { # <label> <got> <want>
@@ -123,15 +108,17 @@ if [ "${1:-}" = "--self-test" ]; then
     # And the comparison must still SEE a real gap.
     st "a real gap survives normalisation" \
         "$([ "$(norm 'v5.3.1-mainnet')" = "$(norm 'v5.6.0')" ] && echo same || echo differs)" "differs"
-    # The two halves of an image pin.
-    st "the digest half is extracted" "$(pinned_digest 'caddy:2.11.4@sha256:beef')" "sha256:beef"
-    st "the tag half is extracted" "$(image_ref 'caddy:2.11.4@sha256:beef')" "caddy:2.11.4"
-    st "a plain version pin has no digest half" "$(pinned_digest 'v4.16')" ""
     # UNREACHABLE MUST NOT READ AS CURRENT — the defect this whole script is aimed at.
     st "a release lookup that cannot run fails" \
-        "$(gh() { return 1; }; latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed)" "failed"
+        "$(
+            gh() { return 1; }
+            latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed
+        )" "failed"
     st "a non-version tag is refused, not compared" \
-        "$(gh() { printf 'nightly'; }; latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed)" "failed"
+        "$(
+            gh() { printf 'nightly'; }
+            latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed
+        )" "failed"
     [ "$st_fail" = 0 ] && echo "pin-watch self-test OK"
     exit "$st_fail"
 fi

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Weekly upstream-currency watch (#1128).
+#
+# REPORTS ONLY. It never bumps a pin and never opens a PR. That is deliberate: a Tari or monerod
+# minor is a data migration to schedule, not a bump to merge — #1129 carries three one-time
+# migrations and a one-way wallet-DB change. RigForge's xmrig-bump.yml opens a build-verified PR
+# instead, which is right there and wrong here; the two share this shape, not this output.
+#
+# The pins come from scripts/release.sh's pin(), which is where the release notes read them from.
+# A second list is how the gap this closes opened in the first place.
+#
+# One question per component: is the pinned VERSION behind upstream's latest release?
+#
+# NOT asked here, deliberately: whether an image pinned `tag@sha256:...` still has a digest that
+# corresponds to that tag. The digest is authoritative and the tag is decoration, so a bump that
+# moves the tag and leaves the digest keeps running the old image while every doc says otherwise
+# — but answering it needs a registry client (two different token flows for quay.io and Docker
+# Hub), which is a second source type with its own failure mode. It is its own change.
+#
+# UNREACHABLE IS NOT CURRENT. Every failed lookup increments a counter, the run exits non-zero,
+# and the report names what could not be checked. A watcher that has silently stopped otherwise
+# looks exactly like a watcher with nothing to report — which is how a scheduled workflow in this
+# repo ran zero times without anyone noticing.
+#
+# Usage:
+#   scripts/pin-watch.sh              Print the markdown report on stdout; rc 1 if anything failed.
+#   scripts/pin-watch.sh --self-test  Drive the comparison logic against fixtures. No network.
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Upstream release feed per component. Everything here is compared against
+# `repos/<owner>/<repo>/releases/latest`, which also excludes prereleases — load-bearing, since
+# tari's newest tags are v5.6.0-pre.* and proposing those onto the merge-mining leg would be worse
+# than saying nothing.
+#
+# NOT WATCHED, on purpose, because they have no GitHub release feed: the alpine base in
+# build/tor/Dockerfile, ubuntu:24.04 and python:3.11-slim. Dependabot's docker ecosystem does see
+# those (it reads FROM lines), so they are covered — just not here. They are named in the report so
+# their absence is a statement rather than a silence.
+upstream_for() {
+    case "$1" in
+    monero) echo monero-project/monero ;;
+    p2pool) echo SChernykh/p2pool ;;
+    xmrig-proxy) echo xmrig/xmrig-proxy ;;
+    tari) echo tari-project/tari ;;
+    caddy) echo caddyserver/caddy ;;
+    socket-proxy) echo Tecnativa/docker-socket-proxy ;;
+    compose) echo docker/compose ;;
+    cosign) echo sigstore/cosign ;;
+    esac
+}
+
+# Our pins do not spell versions the way upstream tags them, and this is the part that decides
+# whether the watcher is useful or muted: `caddy:2.11.4` vs `v2.11.4` and `xmrig-proxy 6.26.0` vs
+# `v6.26.0` are CURRENT, and `minotari_node:v5.3.1-mainnet` vs `v5.6.0` is stale. A plain string
+# comparison calls the first two stale every week for ever, and a watcher that cries wolf weekly
+# gets ignored — exactly as useless as one that never runs.
+#
+# Strips, in order: an image name up to the last colon, a digest suffix, a leading `v`, and a
+# `-mainnet`/`-testnet` network suffix.
+norm() {
+    local v="$1"
+    # Digest FIRST: `${v##*:}` cuts to the LAST colon, and a digest suffix carries one — so the
+    # other order turns caddy:2.11.4@sha256:abc into "abc". (Caught by the self-test below on the
+    # first run, which is the only reason it is not shipping that way.)
+    v="${v%%@*}"
+    v="${v##*:}"
+    v="${v#v}"
+    v="${v%-mainnet}"
+    v="${v%-testnet}"
+    printf '%s' "$v"
+}
+
+# The digest half of a `tag@sha256:...` image pin; empty for a plain version string.
+pinned_digest() {
+    case "$1" in
+    *@sha256:*) printf '%s' "${1##*@}" ;;
+    esac
+}
+
+# The full image reference minus the digest, e.g. quay.io/tarilabs/minotari_node:v5.3.1-mainnet.
+image_ref() {
+    case "$1" in
+    *@sha256:*) printf '%s' "${1%%@*}" ;;
+    esac
+}
+
+# --- the two lookups. Both are wrapped so a failure is a COUNTED failure, never a quiet "current".
+
+latest_release() { # <owner/repo> -> tag on stdout, rc 1 on any failure
+    local tag
+    tag=$(gh api "repos/$1/releases/latest" --jq .tag_name 2>/dev/null) || return 1
+    # Third-party input. A tag that is not shaped like a version must not be compared, printed into
+    # an issue body, or otherwise trusted.
+    printf '%s' "$tag" | grep -qE '^v?[0-9]' || return 1
+    printf '%s' "$tag"
+}
+
+
+# --- self-test -----------------------------------------------------------------------------------
+# The comparison logic is the whole product here; the two lookups are one `gh api` and one
+# `docker` call each. Drives norm() over the real pin spellings and the failure paths over stubs.
+if [ "${1:-}" = "--self-test" ]; then
+    st_fail=0
+    st() { # <label> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (got [$2], want [$3])"
+            st_fail=1
+        fi
+    }
+    # The three spellings that would otherwise be reported stale every week for ever.
+    st "a bare image tag normalises to the upstream version" "$(norm 'caddy:2.11.4')" "2.11.4"
+    st "a leading v is not a version difference" "$(norm 'v6.26.0')" "6.26.0"
+    st "tari's network suffix is not a version difference" \
+        "$(norm 'quay.io/tarilabs/minotari_node:v5.3.1-mainnet')" "5.3.1"
+    st "a digest suffix is not part of the version" \
+        "$(norm 'caddy:2.11.4@sha256:aaaa')" "2.11.4"
+    # And the comparison must still SEE a real gap.
+    st "a real gap survives normalisation" \
+        "$([ "$(norm 'v5.3.1-mainnet')" = "$(norm 'v5.6.0')" ] && echo same || echo differs)" "differs"
+    # The two halves of an image pin.
+    st "the digest half is extracted" "$(pinned_digest 'caddy:2.11.4@sha256:beef')" "sha256:beef"
+    st "the tag half is extracted" "$(image_ref 'caddy:2.11.4@sha256:beef')" "caddy:2.11.4"
+    st "a plain version pin has no digest half" "$(pinned_digest 'v4.16')" ""
+    # UNREACHABLE MUST NOT READ AS CURRENT — the defect this whole script is aimed at.
+    st "a release lookup that cannot run fails" \
+        "$(gh() { return 1; }; latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed)" "failed"
+    st "a non-version tag is refused, not compared" \
+        "$(gh() { printf 'nightly'; }; latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed)" "failed"
+    [ "$st_fail" = 0 ] && echo "pin-watch self-test OK"
+    exit "$st_fail"
+fi
+
+# --- the report ----------------------------------------------------------------------------------
+
+# Sourcing only defines the functions; release.sh guards its main() behind a BASH_SOURCE check.
+# shellcheck source=/dev/null
+(return 0 2>/dev/null) || true
+set -- # release.sh's arg parser must not see ours
+# shellcheck disable=SC1091
+source "$ROOT/scripts/release.sh"
+
+# The appliance rootfs COMPILES two more binaries from source, and dependabot has no ecosystem for
+# an ARG consumed by wget — so nothing else can see them. They exist on the appliance lane only,
+# hence the guard: on `develop` this loop is simply shorter, not wrong.
+#
+# BOUNDARY, stated because a silent one is what this whole issue is about: GitHub runs `schedule:`
+# from the DEFAULT branch, so this only ever reads `develop`. The appliance lane's own pins stay
+# unwatched until this script reaches `develop-v2` at the next twin sync. The report says so.
+components="monero p2pool xmrig-proxy tari caddy socket-proxy"
+[ -f "$ROOT/os/rootfs/Dockerfile" ] && components="$components compose cosign"
+
+# release.sh's pin() is the one place pins are read from the tree; the two rootfs binaries have no
+# case there because a release does not bundle them.
+tree_pin() {
+    case "$1" in
+    compose) sed -n 's/^ARG COMPOSE_VERSION=//p' "$ROOT/os/rootfs/Dockerfile" ;;
+    cosign) sed -n 's/^ARG COSIGN_VERSION=//p' "$ROOT/os/rootfs/Dockerfile" ;;
+    *) pin "$1" ;;
+    esac
+}
+
+failed=0
+stale=0
+rows=""
+
+row() { rows="${rows}| $1 | $2 | $3 | $4 |"$'\n'; }
+
+for component in $components; do
+    raw=$(tree_pin "$component" 2>/dev/null) || raw=""
+    if [ -z "$raw" ]; then
+        row "$component" "—" "—" "**could not read the pin from the tree**"
+        failed=$((failed + 1))
+        continue
+    fi
+    repo=$(upstream_for "$component")
+    if ! latest=$(latest_release "$repo"); then
+        row "$component" "\`$(norm "$raw")\`" "—" "**upstream lookup failed — NOT checked**"
+        failed=$((failed + 1))
+        continue
+    fi
+    if [ "$(norm "$raw")" = "$(norm "$latest")" ]; then
+        verdict="current"
+    else
+        verdict="**stale** → \`$latest\`"
+        stale=$((stale + 1))
+    fi
+    row "$component" "\`$(norm "$raw")\`" "\`$(norm "$latest")\`" "$verdict"
+done
+
+printf '%s\n\n' "Upstream currency, checked weekly by \`scripts/pin-watch.sh\`. This never bumps anything."
+printf '| component | pinned | upstream latest | |\n|---|---|---|---|\n%s\n' "$rows"
+printf '%s\n' "Not watched here, because they publish no GitHub release feed: the alpine base image, \`ubuntu:24.04\`, \`python:3.11-slim\`. Dependabot's docker ecosystem reads those \`FROM\` lines and does cover them."
+[ -f "$ROOT/os/rootfs/Dockerfile" ] || printf '%s\n' "The appliance lane's own pins (the rootfs docker-compose and cosign) are NOT in this table: a scheduled workflow only ever reads the default branch, and this script is not on \`develop-v2\` yet."
+printf '%s\n' "Also NOT checked: whether each image pin's digest still corresponds to its tag. The digest is what actually runs, so a half-done bump is invisible to the table above."
+if [ "$failed" -gt 0 ]; then
+    printf '\n%s\n' "**$failed lookup(s) could not run — those rows are unchecked, not current.**"
+else
+    printf '\n%s\n' "_Last fully successful check: $(date -u '+%Y-%m-%d %H:%M UTC')_"
+fi
+printf '\n%s\n' "<!-- pin-watch: stale=$stale failed=$failed -->"
+
+exit "$([ "$failed" -gt 0 ] && echo 1 || echo 0)"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -111,6 +111,16 @@ echo "== unit: lint-operator-strings self-test (#755) =="
 bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
 assert_rc "operator-strings guard self-test passes" "$?" "0"
 
+echo "== unit: pin-watch self-test (#1128) =="
+# The watcher's whole product is the COMPARISON: our pins do not spell versions the way upstream
+# tags them (`caddy:2.11.4` vs `v2.11.4`, `minotari_node:v5.3.1-mainnet` vs `v5.6.0`), so a plain
+# string compare reports two components stale every week for ever and the report gets muted — as
+# useless as the scheduled workflow that lived on a non-default branch and never ran at all. Its
+# --self-test drives the normalisation over the real pin spellings and drives both lookup failure
+# paths, because an upstream lookup that could not run must never read as "current".
+bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
+assert_rc "pin-watch self-test passes" "$?" "0"
+
 echo "== unit: patch-coverage overlap self-test (#1000) =="
 # diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
 # overlap check is what turns that into a loud not-applicable pass or a real failure; its


### PR DESCRIPTION
Closes #1128.

## The thing that reframes this issue: the repo already had a pin watcher, and it had never run

`.github/workflows/pin-watch.yml` existed — on `develop-v2` only. GitHub runs `schedule:` triggers
**from the default branch**, and that is `develop`:

```
$ gh run list --workflow=pin-watch.yml
HTTP 404: workflow pin-watch.yml not found on the default branch
```

Its own header comment knew: *"Runs on the default branch only (schedules always do); until the
appliance tree merges there, the guard below makes every run a quiet no-op."* The appliance tree is
never going to merge to `develop` — that is the twin model.

So the two pins it covered had been checked exactly zero times. Same family as #1048 and #1064: a
gate that reports nothing because it never ran.

This moves it to `develop`, widens it to the pins #1128 is about, and puts the logic in a script so
`make lint-sh` shellchecks it and tier 1 can drive it. (The old file is `develop-v2`-only; it will
conflict at the next twin sync — take this side.)

## Report-only, and why that is not the same answer RigForge got

RigForge's `xmrig-bump.yml` opens a **build-verified PR**, and it has run and succeeded weekly since
July. That is right there: XMRig is a drop-in binary and the build gate genuinely proves the
candidate. It is wrong here: a Tari or monerod minor is a data migration to schedule — #1129 carries
three one-time migrations and a one-way wallet-DB change.

**One shape, two outputs.** Same weekly schedule, same `releases/latest` source, same hard tag-shape
validation, same dedup against the open artefact; a PR there, a tracking issue here.
(rigforge#372 asked for one mechanism across both repos; I have written this up there too — its own
premise turned out to be refuted, the XMRig pin **is** watched.)

## The comparison is the product, not the fetch

Our pins do not spell versions the way upstream tags them:

| pinned as | upstream tags it |
|---|---|
| `caddy:2.11.4` | `v2.11.4` |
| `xmrig-proxy 6.26.0` | `v6.26.0` |
| `minotari_node:v5.3.1-mainnet` | `v5.6.0` |

The old workflow compared with `[ "$latest" = "$pinned" ]`. That reports caddy and xmrig-proxy
**stale every week for ever** — and a watcher that cries wolf weekly gets muted, which is exactly as
useful as one that never runs. `norm()` is the part that had to be tested, and it is the part the
self-test covers.

## Unreachable is not current

Every failed lookup is counted, the run exits non-zero, the report names the rows that could not be
checked, and the `Last fully successful check:` line is written **only** on a clean run. A watcher
that has silently stopped otherwise looks identical to one with nothing to report — which is the
whole reason this issue exists.

## What was run

**The self-test caught a real bug in my own code on its first execution.** `norm()` stripped the
image name before the digest, so `caddy:2.11.4@sha256:abc` normalised to `abc` — `${v##*:}` cuts to
the *last* colon and a digest carries one. Fixed, and the comment says why the order matters.

Live run against the real tree, which independently reproduces the inventory I had derived by hand:

```
| monero      | 0.18.5.0 | 0.18.5.1 | stale |
| p2pool      | 4.16     | 4.18     | stale |
| xmrig-proxy | 6.26.0   | 6.26.0   | current |
| tari        | 5.3.1    | 5.6.0    | stale |
| caddy       | 2.11.4   | 2.11.4   | current |
| socket-proxy| 0.4.2    | 0.5.0    | stale |
```

`make lint-sh` clean. Tier-1 suite: see below.

### Mutations, run

| mutation | result |
|---|---|
| **N** — drop the `v`-prefix strip from `norm()` | **kills** 2 assertions (the two spellings that would be false-positives) |
| **S** — drop the tag-shape validation | **kills** `a non-version tag is refused, not compared` |
| **U** — make a failed `gh api` set `tag=""` instead of returning 1 | **SURVIVED** |
| **U2** — remove *both* the failure return and the shape validation | **kills** both failure assertions |

**U survived, and that is the correct result, not a hole.** With the fetch's `|| return 1` removed,
an empty `tag` still fails the shape validation, so `latest_release` still fails — the two guards
are redundant for this input. Recording it rather than inventing an assertion for a line that is not
independently load-bearing (#1068's convention). U2 proves the pair is covered.

## What was NOT done

- **The digest half of #1137 is not here.** I built it, and cut it. Asking "does this image's
  pinned digest still correspond to its tag" needs a registry client — two different token flows for
  quay.io and Docker Hub — which is a second source type with its own failure mode, and the
  `docker buildx imagetools` shortcut hangs unbounded when the daemon is unreachable. It is its own
  change. The report says so in its own body, so the gap is stated where a human reads it.
  **#1137 stays open and still carries the full analysis.**
- **The appliance lane's own pins are still unwatched.** A schedule only ever reads the default
  branch. The rootfs `docker-compose` and `cosign` pins are wired behind a `[ -f os/rootfs/Dockerfile ]`
  guard, so they start being checked the moment this script reaches `develop-v2` at the next twin
  sync — and until then the report says outright that they are not in the table.
  (For the record: rootfs `docker-compose` is `v5.4.0` against upstream `v5.5.0` today.)
- No bench run. Nothing under `os/` changed.

## Found while doing this, filed separately

- **#1137** — the compose digest pins assert that *a* digest is present, never which one.
- **#1138** — `pin tari` reads the node image only, so a console-wallet bump never reaches the
  release notes.
- Two cosign pins disagree by a major version: `pithead`'s `COSIGN_IMAGE` carries a decorative
  `# v2.6.3` comment while the rootfs pins `COSIGN_VERSION=v3.1.3`. Nothing binds the comment to the
  digest, so the watcher cannot read it without that being fixed first — noted on #1128.
