### PR TITLE
Assert WHICH digest, not that a digest is present — and cover the console wallet at all (#1137)

### DIFF
--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -136,16 +136,6 @@ expect_min "log rotation on every service" "max-size:" 9
 expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476"
 expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
 expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0"
-# The two Tari images are one component and are bumped together, so a tag that moves on one and not
-# the other is a silent split-brain: the node speaks one protocol version and the wallet another.
-# Nothing else in the repo compares them — `scripts/release.sh pin tari` reads the NODE only (#1138),
-# so a wallet left behind is invisible in the release notes too.
-tari_tags=$(grep -oE 'quay\.io/tarilabs/minotari_(node|console_wallet):[^@]+' "$ROOT/docker-compose.yml" |
-    sed 's/.*://' | sort -u | wc -l | tr -d ' ')
-if [ "$tari_tags" = "1" ]; then echo "  ✓ both Tari images carry the same tag"; else
-    echo "  ✗ both Tari images carry the same tag: found $tari_tags distinct tags"
-    fails=$((fails + 1))
-fi
 
 # Per-service precision checks via the JSON render (cleaner than grepping the flat YAML): the
 # Docker socket proxies must stay least-privilege, and the Tari probe must self-match safely.
@@ -320,6 +310,12 @@ jq_assert "tari-wallet healthcheck pattern survives ps CMD truncation (#777)" \
 # is. Whole reference, not the `tag@sha256:` prefix, for the reason given at the other three.
 jq_assert "tari console wallet pinned by digest (#1137)" \
     '.services["tari-wallet"].image == "quay.io/tarilabs/minotari_console_wallet:v5.3.1-mainnet@sha256:31b3cd7b2b390da33c279fd1a5cd457eb254aeea17a5a230ff4c7bfea79a47eb"'
+# The two Tari images are one component, bumped together, so a tag that moves on one and not the
+# other is a silent split-brain — the node speaking one protocol version and the wallet another.
+# Nothing compared them, and `scripts/release.sh pin tari` reads the NODE only (#1138), so a wallet
+# left behind is invisible in the release notes as well.
+jq_assert "both Tari images carry the same tag (#1137)" \
+    '[.services["tari"].image, .services["tari-wallet"].image] | map(split("@")[0] | split(":")[-1]) | unique | length == 1'
 # Compose healthchecks close the #904 gap. `pithead status` and the dashboard's container-health
 # alert (#337) read these states, and a service without a check reports Up even when dead inside —
 # so with every profile active (this render), no service may lack one, and each of the five late

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -126,9 +126,26 @@ expect_absent "no get_info (creds) in compose healthcheck" "get_info"
 expect_min "log rotation on every service" "max-size:" 9
 # Image digest pinning (#135): the externally-pulled images must reference an immutable @sha256
 # digest, not just a mutable tag, so a re-pushed tag can't silently change the running image.
-expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:"
-expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:"
-expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:"
+#
+# The WHOLE reference, not the `tag@sha256:` prefix (#1137). In a `tag@digest` reference the digest
+# is authoritative and the tag is decoration — that is the point of the pin, per the comment on
+# these images in docker-compose.yml. A prefix match therefore passes on the half-done bump that
+# matters: move the tag here and in the compose file, leave the digest, and the stack keeps pulling
+# the old image while the file, this test, the release notes and the docs all announce the new
+# version. Spelling the digest out makes the value a reviewable part of the diff at bump time.
+expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476"
+expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
+expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0"
+# The two Tari images are one component and are bumped together, so a tag that moves on one and not
+# the other is a silent split-brain: the node speaks one protocol version and the wallet another.
+# Nothing else in the repo compares them — `scripts/release.sh pin tari` reads the NODE only (#1138),
+# so a wallet left behind is invisible in the release notes too.
+tari_tags=$(grep -oE 'quay\.io/tarilabs/minotari_(node|console_wallet):[^@]+' "$ROOT/docker-compose.yml" |
+    sed 's/.*://' | sort -u | wc -l | tr -d ' ')
+if [ "$tari_tags" = "1" ]; then echo "  ✓ both Tari images carry the same tag"; else
+    echo "  ✗ both Tari images carry the same tag: found $tari_tags distinct tags"
+    fails=$((fails + 1))
+fi
 
 # Per-service precision checks via the JSON render (cleaner than grepping the flat YAML): the
 # Docker socket proxies must stay least-privilege, and the Tari probe must self-match safely.
@@ -296,6 +313,13 @@ jq_assert "exactly 5 depends_on edges total (#565)" \
 # runs fine (#777). Asserted here because tari-wallet only renders under tari_payout_confirm.
 jq_assert "tari-wallet healthcheck pattern survives ps CMD truncation (#777)" \
     '(.services["tari-wallet"].healthcheck.test | tostring) | contains("[m]inotari_consol") and (contains("[m]inotari_console_wallet") | not)'
+# The console wallet's digest pin had NO assertion anywhere (#1137). It cannot have one where the
+# other three live: $RENDERED is built with COMPOSE_PROFILES=local_node,local_tari and tari-wallet
+# is profiles: ["tari_payout_confirm"], so an expect_present there would pass and fail identically —
+# it is not in that render at all. Here it is, for the same reason the healthcheck assertion above
+# is. Whole reference, not the `tag@sha256:` prefix, for the reason given at the other three.
+jq_assert "tari console wallet pinned by digest (#1137)" \
+    '.services["tari-wallet"].image == "quay.io/tarilabs/minotari_console_wallet:v5.3.1-mainnet@sha256:31b3cd7b2b390da33c279fd1a5cd457eb254aeea17a5a230ff4c7bfea79a47eb"'
 # Compose healthchecks close the #904 gap. `pithead status` and the dashboard's container-health
 # alert (#337) read these states, and a service without a check reports Up even when dead inside —
 # so with every profile active (this render), no service may lack one, and each of the five late


### PR DESCRIPTION
Closes the tier-1 half of #1137. **The registry half stays open** — see the end.

## The defect, shown side by side

The three assertions stopped at `tag@sha256:`. Swap caddy's digest and leave its tag — the exact
half-done bump #1137 is about:

```
NEW form: ✗ caddy pinned by digest: missing [caddy:2.11.4@sha256:df7f1c2fb114...]
OLD form: ✓ PASSES on the mutated digest — could not fail
```

In a `tag@digest` reference **the digest is authoritative and the tag is decoration**, which is the
stated purpose of the pin (`docker-compose.yml`: *"Pinned by digest (#135) so the v5.3.1-mainnet tag
can't be silently re-pointed"*). So the old form passed while the stack pulled the old image and the
compose file, this test, the release notes and the docs all announced the new version.

## Three changes

1. **Assert the whole reference**, digest included, for socket-proxy, caddy and the Tari node. The
   pin value becomes a reviewable part of the diff at bump time rather than a string nobody reads.
2. **The console wallet gets a digest assertion at all** — it had none. It cannot have one where the
   other three live: `$RENDERED` is built with `COMPOSE_PROFILES=local_node,local_tari` and
   `tari-wallet` is `profiles: ["tari_payout_confirm"]`, so an `expect_present` there would pass and
   fail identically. It goes with the profile-enabled JSON, for the same reason the wallet
   healthcheck assertion already sits there.
3. **The two Tari images must carry the same tag.** They are one component bumped together, so a tag
   that moves on one and not the other is a silent split-brain — the node speaking one protocol
   version and the wallet another. Nothing compared them, and `scripts/release.sh pin tari` reads the
   **node only** (#1138), so a wallet left behind is invisible in the release notes too.

## What was run

`bash tests/stack/test_compose.sh` → **0 failing**. `make lint-sh` clean.

ponytail-review on my own diff moved the same-tag check from six lines of `grep|sed|sort|wc` over raw
YAML into a one-line `jq_assert` on the render already in hand. Mutations were **re-run after that
change**, not carried over.

Three mutations, each killing its target:

| mutation | kills |
|---|---|
| caddy's **digest only**, tag untouched | `caddy pinned by digest` — and the old form passes, shown above |
| console wallet's **tag only** | `both Tari images carry the same tag` **and** `tari console wallet pinned by digest` |
| console wallet's **digest only** | `tari console wallet pinned by digest` |

## What this does NOT close, stated plainly

**A tier-1 test cannot catch the fully-consistent-but-wrong pin.** If someone bumps the tag in
`docker-compose.yml` *and* updates this test's literal to match, while leaving the old digest in
both, everything here is green and the stack still runs the old image. Catching that needs resolving
the tag against the registry, which is a network call and belongs in the weekly watcher or a
release-prep step — it was deliberately cut from #1143 because it needs a registry client with two
different token flows.

**So #1137 stays open for that half.** What this PR buys is that the digest is now a value someone
has to look at, an unreviewed edit to `docker-compose.yml` alone goes red, and the console wallet is
covered for the first time.

Relevant right now: #1129 moves four digest strings.
