### PR TITLE
Root-cause leg 4: the bench release server was never proven to bind (#1149)

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -837,8 +837,9 @@ _os_step() { # <json-body> [<deadline-s>]
 # expected the release JSON, `curl -fsS` reported it the same as a dead circuit, and leg 4 blamed
 # Tor for three sessions.
 #
-# The custom handler below 404s on a directory, so the probe must name a real file.
-_serve_update_dir() { # <dir> <port> [probe-file]
+# The custom handler below 404s on a directory, so the probe names a real file — the one the
+# caller has already written before starting the server.
+_serve_update_dir() { # <dir> <port>
     python3 - "$1" "$2" <<'PYEOF' >/dev/null 2>&1 &
 import http.server, os, re, sys
 os.chdir(sys.argv[1])
@@ -875,9 +876,9 @@ class H(http.server.SimpleHTTPRequestHandler):
                     break
 http.server.ThreadingHTTPServer(("0.0.0.0", int(sys.argv[2])), H).serve_forever()
 PYEOF
-    local pid=$! probe="${3:-releases-latest.json}" i
+    local pid=$! i
     for i in $(seq 40); do
-        if curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$2/$probe" 2>/dev/null; then
+        if curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$2/releases-latest.json" 2>/dev/null; then
             printf '%s' "$pid"
             return 0
         fi

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -826,7 +826,19 @@ _os_step() { # <json-body> [<deadline-s>]
 # Serve a directory over HTTP with byte-range support (curl -C - needs 206; python's stock
 # SimpleHTTPRequestHandler answers 200-only, which would silently break the resume leg).
 # Echoes the server PID; caller kills it.
-_serve_update_dir() { # <dir> <port>
+# <dir> <port> [probe-file] -> prints the pid; rc 1 if the port never actually answered.
+#
+# The probe is the point (#1149). This used to background python with `>/dev/null 2>&1` and print
+# `$!` unconditionally, so a FAILED BIND reported a running server: the error went to /dev/null and
+# `$!` is a pid whether or not the process survived. A leaked server from an aborted run is the
+# normal case on a bench — every failure path below kills `$srv_pid`, which is already dead when
+# the bind failed, and `--keep` skips the kill entirely — and that corpse is serving a directory
+# the previous run has since `rm -rf`'d, so every request 404s. The guest then got a 404 where it
+# expected the release JSON, `curl -fsS` reported it the same as a dead circuit, and leg 4 blamed
+# Tor for three sessions.
+#
+# The custom handler below 404s on a directory, so the probe must name a real file.
+_serve_update_dir() { # <dir> <port> [probe-file]
     python3 - "$1" "$2" <<'PYEOF' >/dev/null 2>&1 &
 import http.server, os, re, sys
 os.chdir(sys.argv[1])
@@ -863,7 +875,22 @@ class H(http.server.SimpleHTTPRequestHandler):
                     break
 http.server.ThreadingHTTPServer(("0.0.0.0", int(sys.argv[2])), H).serve_forever()
 PYEOF
-    printf '%s' "$!"
+    local pid=$! probe="${3:-releases-latest.json}" i
+    for i in $(seq 40); do
+        if curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$2/$probe" 2>/dev/null; then
+            printf '%s' "$pid"
+            return 0
+        fi
+        sleep 0.25
+    done
+    # It never answered. Say WHO holds the port — a leftover from an earlier run is the usual
+    # answer, and without this line the next person debugs the guest instead of the bench.
+    # STDERR, not stdout: this function's stdout IS the pid, so the caller reads it through a
+    # command substitution — an `info` here would be captured into the variable and never seen.
+    # Same shape as the swallowed hint in #1081; the diagnostic has to step outside the capture.
+    info "bench update server never answered on :$2 — port holder: $(ss -ltnp "sport = :$2" 2>/dev/null | tail -n +2 | tr -s ' ' | cut -c1-160)" >&2
+    kill "$pid" 2>/dev/null
+    return 1
 }
 
 # Leg 4 — the dashboard OS-update action end-to-end: the user-reachable path over the SAME A/B
@@ -929,7 +956,11 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         "$tag" "$tag" "$size" >"$srv/releases-latest.json"
     host_addr=$(ip -4 -o addr show virbr0 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -1)
     [ -n "$host_addr" ] || host_addr="192.168.122.1"
-    srv_pid=$(_serve_update_dir "$srv" "$port")
+    if ! srv_pid=$(_serve_update_dir "$srv" "$port"); then
+        bad "leg 4: the bench release server never answered on :$port — nothing was checked, and this is the harness, not the product (#1149)"
+        rm -rf "$srv"
+        return
+    fi
     _ssh "printf 'http://$host_addr:$port' > /data/pithead/os-update-test-base" || {
         bad "leg 4: could not plant the update-server seam on the guest"
         kill "$srv_pid" 2>/dev/null


### PR DESCRIPTION
Closes #1149. Root-causes leg 4's `could not reach the release API over Tor`, open across three
sessions and blamed on Tor, on the seam, and on the guest.

## It was none of those, and I checked each on the real machine

The kept KVM guest from the failing run was still defined, so I booted it and drove the actual code:

```
guest -> host:8931                 REACHABLE
/data/pithead/os-update-test-base  present, root-owned, reader uid 0, contents correct
control unit WorkingDirectory      /data/pithead   (and it is in /run, not /etc)
the shipped os_release_fetch       rc=0, correct JSON
```

Everything the previous sessions ruled out really was fine.

## The defect: `_serve_update_dir` reported a server whether or not one was running

```bash
python3 - "$1" "$2" <<'PYEOF' >/dev/null 2>&1 &
...
printf '%s' "$!"
```

`>/dev/null 2>&1` swallows a failed bind and `$!` is a pid regardless. **Nothing checked the port.**

A leaked server from an aborted run holds :8931 — every failure path does `kill "$srv_pid"` on a pid
that is *already dead when the bind failed*, and `--keep` skips the kill entirely — and that corpse
is serving a directory the previous run has since `rm -rf`'d. Every request 404s.

Reproduced on the bench with the helper copied verbatim:

```
RUN 1: pid_a alive=yes  -> serving
       ...run ends, rm -rf's its dir, server survives
RUN 2: pid_b alive=NO   -- bind failed, silently; the harness has a pid and believes it is up
       curl -fsS .../releases-latest.json  ->  rc=22    <- exactly leg 4's symptom
```

Two layers of silence stacked: the harness could not tell "my server is up" from "someone else's
corpse holds the port", and `curl -fsS` reported that 404 identically to a dead Tor circuit — then
named Tor. Layer 2 is already fixed (#1142 gave the seam its own message); this is layer 1.

## The fix, and its own near-miss

It polls a **real file** (the custom handler 404s on a directory) until the port answers, returns
non-zero if it never does, and names who holds the port. The caller refuses the leg instead of
running it against a corpse.

The holder line goes to **stderr on purpose**. This function's stdout *is* the pid, so the caller
reads it through a command substitution — my first version used `info`, and the diagnostic was
captured into the variable and never seen. Same swallowed-hint shape as #1081, and I only found it
because I ran the fix instead of reading it:

```
before: rc=1 refused          (holder line invisible)
after:  rc=1 refused, and the holder line is VISIBLE
        ==> bench update server never answered on :8937 — port holder:
            LISTEN 0 5 0.0.0.0:8937 ... users:(("python3",pid=1570777,fd=3))
```

## What was run — on the bench, as `os/` requires

| | |
|---|---|
| root-cause reproduction on the bench | leaked server → rc=22, leg 4's symptom |
| the fixed helper, happy path | rc=0, pid alive, serving |
| the fixed helper, the race | rc=1, refuses, holder named and **visible** |
| both drivers | extracted **verbatim from the edited file**, not hand-copied |
| `make lint-sh`, `bash -n` | clean |
| full `tests/os/run.sh --phase update` | see the comment below |

## Note for whoever runs the battery next

The bench had leaked servers when I started; I cleared them. If leg 4 fails again, the message will
now tell you whether the bench server or the product is at fault — which is the whole point.
