### PR TITLE
fix(doctor): look for the control units where apply writes them (#1151)

### DIFF
--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -183,6 +183,21 @@ starts. Host identity survives A/B updates and reboots by construction (it never
 system slot to begin with); the reset tiers classify it like everything else on `/data` — a
 keep-everything reinstall keeps it, a fresh-start or full wipe deletes it.
 
+**Fixed — `doctor` looked for the control units in `/etc`, and the appliance puts them in
+`/run` (#1151).** `provision_control_runner` knew the read-only root cannot take that write (#791);
+`check_control_units` and `control_units_owner_dir` did not, and each kept its own `/etc` default.
+On a provisioned box `doctor` therefore reported "no runner units are installed" about units that
+were installed and running. That verdict is the `doctor` half of `pithead-boot`'s health gate, so
+the gate never passed, the A/B slot was never committed, and the dashboard sat on "reboot pending"
+after an update that had in fact succeeded. #1065 makes the first such boot reboot the box; the
+counter is bounded and only a passing gate clears it, so from the second failure on the machine
+deliberately stays up — a healthy, correctly updated appliance parked on an uncommitted slot with
+no way to clear it but a power cycle. Legs 1-3 of the battery cannot see this: they never provision
+the guest, so `pithead-boot` is condition-skipped and the gate never runs at all, and they commit
+with the harness's own `rauc status mark-good`. Leg 4 is the only leg that provisions and then lets
+the boot gate do the committing, and it found this the first time it ran to completion. The
+directory is now one rule, `control_unit_dir`, read by the writer and both readers.
+
 **Fixed — a provisioning failure now surfaces its own reason on the reopened wizard.**
 Setup failures move the config aside as `config.json.failed` and re-mint a token; the
 reopened page used to make an operator dig the reason out of the console. It no longer

--- a/pithead
+++ b/pithead
@@ -4070,7 +4070,7 @@ check_control_units() {
     echo ""
     echo "Dashboard control channel:"
     local unit_dir owner here spool
-    unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}"
+    unit_dir=$(control_unit_dir)
     if [ "$(normalize_bool "$(env_get DASHBOARD_CONTROL_ENABLED)")" != "true" ]; then
         dr_info "Disabled for this install — the dashboard cannot apply config changes or upgrade."
         return 0
@@ -10864,6 +10864,24 @@ control_run_pending() {
     log "Processed $n control request(s)."
 }
 
+# The directory the dashboard control units live in — ONE rule, shared by the writer and both
+# readers. The appliance's root is read-only by design, so /etc/systemd/system cannot take the unit
+# (#791); /run/systemd/system is a first-class unit path, writable, and cleared every boot, which is
+# fine because these units are derived and the boot path re-renders them. A DIY host keeps /etc.
+# This was two rules until #1151: `provision_control_runner` knew about /run and `doctor` did not,
+# so on a PROVISIONED appliance doctor reported "no runner units are installed" about units that
+# were installed and running. That is the half of the boot health gate that never passed, so the
+# slot never committed — and after #1065 the box reboots a healthy, correctly-updated appliance.
+control_unit_dir() {
+    if [ -n "${PITHEAD_UNIT_DIR:-}" ]; then
+        printf '%s' "$PITHEAD_UNIT_DIR"
+    elif is_appliance; then
+        printf '%s' /run/systemd/system
+    else
+        printf '%s' /etc/systemd/system
+    fi
+}
+
 # Physical directory the installed control units name, or "" when there is no service unit or its
 # ExecStart is unparseable. One checkout has two spellings — the `current` symlink and the versioned
 # dir it points at (production units carry the versioned spelling) — so this resolves to a PHYSICAL
@@ -10871,7 +10889,8 @@ control_run_pending() {
 # a directory that no longer exists, so resolve the deepest existing ancestor and keep the rest
 # verbatim: the caller still gets a comparable, printable path instead of an empty answer.
 control_units_owner_dir() {
-    local unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}" owner_dir dir tail
+    local unit_dir owner_dir dir tail
+    unit_dir=$(control_unit_dir)
     owner_dir=$(sed -n 's|^ExecStart=\(/.*\)/pithead control-run-pending$|\1|p' \
         "$unit_dir/pithead-control.service" 2>/dev/null | head -n 1)
     [ -n "$owner_dir" ] || return 0
@@ -10891,14 +10910,11 @@ control_units_owner_dir() {
 provision_control_runner() {
     [ "$OS_TYPE" == "Linux" ] || return 0
     command -v systemctl >/dev/null 2>&1 || return 0
-    local unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}"
-    # The appliance's root is read-only by design, so /etc/systemd/system cannot take the unit
-    # (#791). /run/systemd/system is a first-class unit path, writable, and cleared every boot —
-    # which is fine, because the appliance re-renders derived files on every boot and these
-    # units are derived. Enablement must be --runtime for the same reason: symlinks under /etc
-    # cannot be written either.
+    local unit_dir
+    unit_dir=$(control_unit_dir)
+    # Enablement must be --runtime wherever the units are runtime units: on the appliance's
+    # read-only root, systemd cannot write the /etc symlink a persistent enable needs.
     local -a enable_args=(enable --now)
-    if [ -z "${PITHEAD_UNIT_DIR:-}" ] && is_appliance; then unit_dir=/run/systemd/system; fi
     case "$unit_dir" in /run/*) enable_args=(enable --runtime --now) ;; esac
     if [ "${DASHBOARD_CONTROL_ENABLED:-false}" != "true" ]; then
         if [ -e "$unit_dir/pithead-control.path" ] || [ -e "$unit_dir/pithead-control.service" ]; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -12492,7 +12492,71 @@ assert_contains "superseded rollback dir -> says which dir is live" "$out" "$CCU
 out="$(ccu_run "$CCU/deploy/pithead-v1.19.1" "$CCU/deploy/pithead-v1.19.1/data/control" true \
     "$CCU/deploy/pithead-v1.19.1" "$CCU/deploy/pithead-v1.19.1/data/control")"
 assert_contains "the live install still gets a verdict" "$out" "target this install"
-unset CCU ccu_run out
+unset -f ccu_run
+
+echo "== unit: doctor looks for the control units where apply writes them (#1151) =="
+# The appliance renders host units into /run/systemd/system — its root is read-only, so /etc cannot
+# take the write (#791). `provision_control_runner` knew that; `check_control_units` and
+# `control_units_owner_dir` did not, and hard-coded /etc. On a PROVISIONED appliance doctor
+# therefore reported "no runner units are installed" about units that were installed and running.
+# That is the doctor half of the boot health gate: it never passed, the slot never committed, the
+# dashboard sat on "reboot pending" for ever. Legs 1-3 of the KVM battery cannot see it: they never
+# provision the guest, so pithead-boot.service is condition-skipped and the gate never runs at all
+# (those legs commit with the harness's own `rauc status mark-good`). Leg 4 is the only leg that
+# provisions AND lets the boot gate do the committing.
+#
+# The defect was TWO rules, not a wrong constant, so this asserts the rule has exactly one home.
+assert_eq "appliance -> /run/systemd/system (read-only root, #791)" \
+    "$(PITHEAD_APPLIANCE=1 run_sourced "$SANDBOX" control_unit_dir)" "/run/systemd/system"
+assert_eq "DIY host -> /etc/systemd/system" \
+    "$(PITHEAD_APPLIANCE=0 run_sourced "$SANDBOX" control_unit_dir)" "/etc/systemd/system"
+assert_eq "an explicit PITHEAD_UNIT_DIR wins on the appliance" \
+    "$(PITHEAD_APPLIANCE=1 PITHEAD_UNIT_DIR=/tmp/u run_sourced "$SANDBOX" control_unit_dir)" "/tmp/u"
+assert_eq "an explicit PITHEAD_UNIT_DIR wins on a DIY host" \
+    "$(PITHEAD_APPLIANCE=0 PITHEAD_UNIT_DIR=/tmp/u run_sourced "$SANDBOX" control_unit_dir)" "/tmp/u"
+
+# A SECOND copy of the default is how the two rules drifted apart in the first place, and no runtime
+# test can see a copy that does not exist yet — so this one is static. Every consumer being bound to
+# the rule is covered behaviourally instead: the two readers below, and provision_control_runner by
+# the #791 writer assertion further up. (-F: the pattern carries no regex intent.)
+# Mutation run: put `unit_dir="${PITHEAD_UNIT_DIR:-/etc/systemd/system}"` back in check_control_units
+# -> this goes 0 -> 1 and red.
+assert_eq "no second copy of the /etc default survives outside control_unit_dir" \
+    "$(grep -cF 'PITHEAD_UNIT_DIR:-/etc/systemd/system' "$STACK")" "0"
+
+# The behavioural half: the readers must actually USE what control_unit_dir returns. /run/systemd/
+# system is root-owned, so no tier-1 test can plant a unit in the real appliance directory — the
+# path is proven as two links instead:
+#   link 1 (above) — control_unit_dir answers /run/systemd/system when is_appliance is true;
+#   link 2 (here)  — the readers read whatever it answers, with PITHEAD_UNIT_DIR deliberately
+#                    UNSET, so neither can reach the units by the override arm instead.
+# check_control_units calls control_units_owner_dir, so one run covers both readers: a reader that
+# ignores the helper looks in /etc, finds nothing, and the verdict flips to the "no runner units"
+# FAIL — which is #1151 itself.
+# Mutation run: `[ -n "${PITHEAD_UNIT_DIR:-}" ] || unit_dir=/etc/systemd/system` inserted after the
+# helper call in check_control_units, in control_units_owner_dir, and in both. Each spelling leaves
+# every other assertion in the suite green and goes red only here.
+ccu_bind() { # <install-dir> -> output. Reuses $CCU's stubs and unit dir; PITHEAD_UNIT_DIR never set.
+    printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$CCU/units/pithead-control.service"
+    printf '[Path]\nPathExistsGlob=%s/data/control/requests/*.json\n' "$1" >"$CCU/units/pithead-control.path"
+    printf 'DASHBOARD_CONTROL_ENABLED=true\nCONTROL_DIR=%s/data/control\n' "$1" >"$1/.env"
+    (
+        cd "$1" || exit
+        PATH="$CCU/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        unset PITHEAD_UNIT_DIR
+        # Stands in for the appliance's /run/systemd/system, which this tier cannot write to.
+        control_unit_dir() { printf '%s' "$CCU/units"; }
+        check_control_units 2>&1
+    )
+}
+out="$(ccu_bind "$CCU/install")"
+assert_contains "the readers find units only control_unit_dir knows the directory of" "$out" "target this install"
+assert_not_contains "...and report no fault for units that are correctly installed" "$out" "FAIL"
+unset -f ccu_bind
+unset CCU out
 
 echo "== unit: apply converges the control units even when nothing changed (#33) =="
 # doctor's fix instruction is "run './pithead apply' from this directory". A box whose units point


### PR DESCRIPTION
Closes #1151.

`pithead-boot`'s health gate runs `doctor`. `check_control_units` opened with a hard-coded
`/etc/systemd/system` default, while `provision_control_runner` had known since #791 that the
appliance's read-only root forces those units into `/run/systemd/system`. The reader looked where
the writer never writes, found nothing, and reported a hard failure about units that were
installed, enabled and running. The gate never passed, the slot was never committed, and the
dashboard sat on "reboot pending" after an update that had in fact succeeded.

Two rules, not a wrong constant — so the fix is one rule. `control_unit_dir` resolves the directory
once (explicit `PITHEAD_UNIT_DIR` > appliance `/run/systemd/system` > `/etc/systemd/system`) and the
writer and both readers call it. `control_units_owner_dir` carried the same stale default and is
fixed by the same change.

## Bench evidence — real hardware, A/B on one box

Driven on the kept KVM guest from the leg-4 run (provisioned, cold-booted, running 1.19.2). Same
box, same healthy stack, only the binary differs:

| | `doctor` | control-channel verdict | `doctor --json` |
|---|---|---|---|
| base (`develop-v2`) | 25 OK, 4 warn, **1 FAIL** | ✗ no runner units are installed | **rc=1** |
| this branch | 26 OK, 4 warn, **0 FAIL** | ✓ Control runner units target this install. | **rc=0** |

The base numbers reproduce the issue report exactly. `rc=1` is why the gate's `&&` could never
pass.

End to end, with the fixed binary in place `pithead-boot` went `activating` → `active` in about two
minutes and finished the job it had been looping on for eighteen:

```
rauc status: marked slot rootfs.0 as good
pithead-boot: stack is serving (HTTP 401) and doctor reports healthy — booted slot committed
pithead-boot: OS update to 1.19.2 committed — verdict published to the dashboard
```

Those are the two assertions leg 4 of `tests/os/run.sh --phase update` failed on. Evidence log kept
at `/tmp/1151-bench-evidence.log` on the battery host.

## Tier 1

`bash tests/stack/run.sh` → **2700 passed, 0 failed** (base 2695).

Seven new assertions in two halves, because `/run/systemd/system` is root-owned and this tier cannot
plant a unit in the real appliance directory. The path is proven as two links:

- **link 1, the rule** — `control_unit_dir` answers `/run/systemd/system` when `is_appliance`,
  `/etc/systemd/system` otherwise, and an explicit `PITHEAD_UNIT_DIR` wins over both.
- **link 2, the binding** — `check_control_units` reads whatever the helper answers, with
  `PITHEAD_UNIT_DIR` deliberately **unset** so it cannot reach the units by the override arm
  instead. It calls `control_units_owner_dir`, so one run covers both readers. The third consumer,
  `provision_control_runner`, was already behaviourally bound by the #791 writer assertion.

Plus one static check that no second copy of the `/etc` default survives anywhere in the program —
static because no runtime test can see a copy that does not exist yet, and a second copy is exactly
how the two rules drifted apart.

## Mutations — six named, six run

Baseline 2700/0. Every row measured against the revision being merged.

| # | mutation | result |
|---|---|---|
| M1 | restore `${PITHEAD_UNIT_DIR:-/etc/systemd/system}` in `check_control_units` | 2697/**3** |
| M2 | the same in `control_units_owner_dir` | 2697/**3** |
| M3 | `control_unit_dir`'s appliance arm returns `/etc` | 2697/**3**, incl. both pre-existing #791 writer assertions |
| M4 | `[ -n "${PITHEAD_UNIT_DIR:-}" ] \|\| unit_dir=/etc/systemd/system` after the helper call — `check_control_units` only | 2698/**2** |
| M5 | the same respelling — `control_units_owner_dir` only | 2698/**2** |
| M6 | the same respelling in **both** readers | 2698/**2** |

M4–M6 exist because the adversarial review found them. The first version of this branch bound the
readers with a source-text grep only, and three independent lenses each reproduced a full return of
#1151 — spelled any way other than the one literal the grep looked for — shipping with the whole
suite green. That is this repo's signature defect, in the test written to prevent it. The
behavioural binding (link 2) is what closes it, and M5/M6 now go red printing the exact field
verdict:

```
✗ FAIL The control channel is enabled but no runner units are installed …
```

The review also corrected two claims in the first draft of the docs. Both were re-derived here
before changing:

- **why legs 1-3 miss this.** Not "the control channel is off and the check returns early" — those
  legs never provision the guest, so `pithead-boot.service`'s `ConditionPathExists` is unsatisfied
  and the gate never runs at all; they commit with the harness's own `rauc status mark-good`
  (`tests/os/run.sh:287`, `:715`). Leg 4 is the only leg that provisions **and** lets the boot gate
  commit. It matters because the wrong version implies a cheaper leg could have caught this.
- **what #1065 does.** Not "rolls itself back on every attempt". `fail_boot` is bounded to one
  automatic reboot and only a passing gate clears the counter, so from the second failure the box
  deliberately stays up (`os/overlay/pithead-boot:41-54`) — stranded on an uncommitted slot rather
  than looping. Someone matching a field symptom against the wrong version would look for a reboot
  loop and find a box parked on the new version instead.

A `/ponytail-review` pass after that took 20 lines back out: the three body-grep assertions became
redundant once the readers were bound behaviourally, and the second test sandbox was a copy of one
four lines above it.

## Lint

`make lint` clean through `lint-sh`, `lint-docs-voice` and `lint-operator-strings`. `lint-proto`
needs docker and was **not** run locally — CI covers it.

## Not done

- No new `--phase update` battery run. The fix is proven against the real appliance by the A/B
  above — the same measurement leg 4's two failing assertions were making — but the full ~55 min leg
  has not been re-run on this branch.
- Patch coverage is not meaningful here: the change is bash, so `diff-cover` reports no lines with
  coverage information rather than a real number.
- `develop` is untouched and needs no equivalent — it has no `is_appliance` and no appliance, and
  its three `/etc` defaults are correct for a DIY host.
