### PR TITLE
fix(os): clear the appliance rootfs CVE gate at the source (#1153)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,14 +13,27 @@ CVE-2026-45447
 CVE-2026-23949
 CVE-2026-24049
 
-# Appliance rootfs pinned binaries (docker-compose v5.3.1, cosign v3.1.2 — BOTH already the
-# latest upstream releases, byte-verified): these three sit in Go modules VENDORED inside those
-# binaries, so no pin bump can clear them until upstream cuts releases on the fixed modules.
-# Cleared when pin-watch flags the next compose/cosign releases — bump the pins, drop these.
-# golang.org/x/text norm.Iter infinite loop (both binaries):
-CVE-2026-56852
-# github.com/docker/docker authz bypass, vendored in compose (server-side moby code, and the
-# appliance talks to podman's compat socket, not dockerd — no exposed authz plugin path here):
+# Appliance rootfs Go binaries. This block used to hold three findings on the grounds that the
+# modules were VENDORED inside downloaded release binaries, so "no pin bump can clear them until
+# upstream cuts releases on the fixed modules". That premise is gone: the rootfs COMPILES
+# docker-compose and cosign itself, so the module graph is ours and a finding in it is fixable
+# whether or not upstream has moved. Two of the three are now fixed at the source by the
+# COMPOSE_GO_RAISES / COSIGN_GO_RAISES entries in os/rootfs/Dockerfile and have been deleted from
+# here — golang.org/x/text (CVE-2026-56852) and google.golang.org/grpc (GHSA-hrxh-6v49-42gf).
+# Deleting them is not cosmetic: while a mute is present the scan cannot tell "fixed" from
+# "hidden", so leaving one for a finding you have just fixed destroys the only evidence that the
+# fix landed. Scanned with no ignore file at all after the raises: cosign 0 findings, compose 1.
+#
+# github.com/docker/docker, reached as an indirect dependency of the compiled docker-compose. This
+# one stays, and unlike the other two it genuinely cannot be raised. Trivy names the fix as 29.3.1,
+# but that is a Moby release, not a version of this MODULE — `go list -m -versions` tops out at
+# v28.5.2+incompatible for both github.com/docker/docker and github.com/moby/moby, and the attempt
+# fails the build with "invalid version: unknown revision v29.3.1". Docker 29 lives at a module
+# path compose does not import, so no compose release can carry it either: v5.4.0, v5.5.0 and main
+# all pin v28.5.2+incompatible. The advisory is also a daemon-side authz bypass — compose links the
+# client half, and the appliance talks to podman's compat socket, not dockerd.
+# Clears when compose moves to the docker 29 module path; `go list -m -versions github.com/docker/docker`
+# is the one-line check. The weekly CVE sweep (#833) re-surfaces it regardless (#1153).
 CVE-2026-34040
 # NOTE ON GO STDLIB FINDINGS — there are none listed here on purpose. The appliance rootfs used
 # to download upstream release binaries and inherit whichever Go toolchain built them, so every Go
@@ -28,9 +41,6 @@ CVE-2026-34040
 # COMPILES docker-compose and cosign itself on a pinned, patched toolchain (os/rootfs/Dockerfile,
 # the gobuild stage), so stdlib findings are fixed at the source instead of accepted. If a stdlib
 # CVE appears here again, the answer is to bump the builder image, not to add a line below.
-# google.golang.org/grpc vendored in both pinned binaries (GHSA id — Trivy gates on it like a
-# CVE; same clearing condition as the three above: upstream rebuilds on the fixed module):
-GHSA-hrxh-6v49-42gf
 # util-linux family (bsdutils, libmount1, libuuid1, login, mount, util-linux): the fix is a
 # base-distro point release, 2.41.5-0+deb13u1, and no published python:3.11-slim carries it yet —
 # the newest digest still ships 2.41-5. Same shape as CVE-2026-45447 above: `--ignore-unfixed` hid

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -26,30 +26,63 @@
 #
 # Provenance is not weakened by this, it moves: the old pin was a sha256 of a downloaded binary,
 # this one is an exact upstream COMMIT (never a tag — a tag can be re-pointed, the same reason
-# RIGFORGE_REF below pins a commit) plus Go module integrity from each project's own go.sum. The
-# build flags mirror each project's Makefile so the binaries identify themselves normally:
-# `docker-compose version` and `cosign version` report the release they were built from.
+# RIGFORGE_REF below pins a commit) plus Go module integrity from each project's own go.sum, EXCEPT
+# where GO_RAISES below lifts a module — read that block for what a raise actually costs, which is
+# wider than the modules it names. The build flags mirror each project's Makefile, so
+# `docker-compose version` reports the release it was built from; `cosign version` reports it with a
+# `+dirty` suffix, because raising a module edits go.mod and Go stamps that truthfully. It is also
+# why the tree state below says dirty: this binary IS built from a modified tree, and a build that
+# claimed otherwise would be lying about the provenance this paragraph exists to describe.
 FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS gobuild
 
 ARG COMPOSE_VERSION=v5.4.0
 ARG COMPOSE_COMMIT=ef61d7410a0c816a71705026e638ec256a591d69
 ARG COSIGN_VERSION=v3.1.3
 ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
+# Modules raised above what each project's own go.sum asks for, because upstream has not cut a
+# release carrying the fix and the CVE gate is not optional (#1153). Same reasoning as the patched
+# toolchain above, one level down: we compile from source, so the module graph is ours, and raising
+# the module beats muting the scanner. Per-binary because the findings differ, and EXACT versions
+# because `go get` will happily DOWNGRADE a module that is already newer.
+#
+#   golang.org/x/mod       v0.40.0   CVE-2026-56864 / CVE-2026-56865. Indirect in both: cosign
+#                                    v3.1.3 pins v0.37.0; compose v5.4.0 and v5.5.0 both pin
+#                                    v0.38.0; cosign's own main is still v0.38.0.
+#   google.golang.org/grpc v1.82.1   GHSA-hrxh-6v49-42gf. cosign v3.1.3 pins v1.82.0 — v1.82.1 is
+#                                    where cosign's own main has already moved.
+#
+# WHAT A RAISE ACTUALLY MOVES: `go get X@v Y@v` upgrades the whole closure minimum-version
+# selection needs to satisfy X and Y, not just X and Y. Measured on these exact entries: compose
+# moves 1 module, cosign moves 9 — x/mod pulls x/tools, which pulls x/net, x/sync and x/sys, and
+# x/net pulls x/crypto, x/term and x/text. No formulation avoids that; it is what raising a module
+# in a Go build means. So read a line here as "this module and whatever MVS needs to seat it", and
+# when you add one, run the command and read Go's own upgrade list rather than assuming it is one.
+#
+# Every entry here is debt, not a feature: drop it the moment an upstream release makes it a no-op,
+# and delete its .trivyignore mute in the SAME change — a mute left over a finding you have just
+# fixed means the scan can no longer tell "fixed" from "hidden", which is how two obsolete mutes
+# survived in that file until #1153. Verify by re-running the scan against the built binaries with
+# NO ignore file, never by reading release notes: the first version of this change fixed x/mod and
+# left two other HIGH findings standing.
+ARG COMPOSE_GO_RAISES="golang.org/x/mod@v0.40.0"
+ARG COSIGN_GO_RAISES="golang.org/x/mod@v0.40.0 google.golang.org/grpc@v1.82.1"
 ENV CGO_ENABLED=0
 
 # Blobless clone then detach to the commit: the tag is only a convenience for the version string.
 RUN git clone --filter=blob:none --no-checkout https://github.com/docker/compose /src/compose \
     && git -C /src/compose checkout --detach "${COMPOSE_COMMIT}" \
+    && go -C /src/compose get ${COMPOSE_GO_RAISES} \
     && go build -C /src/compose -trimpath -tags e2e \
         -ldflags "-w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
         -o /out/docker-compose ./cmd
 
 RUN git clone --filter=blob:none --no-checkout https://github.com/sigstore/cosign /src/cosign \
     && git -C /src/cosign checkout --detach "${COSIGN_COMMIT}" \
+    && go -C /src/cosign get ${COSIGN_GO_RAISES} \
     && go build -C /src/cosign -trimpath \
         -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=${COSIGN_VERSION} \
             -X sigs.k8s.io/release-utils/version.gitCommit=${COSIGN_COMMIT} \
-            -X sigs.k8s.io/release-utils/version.gitTreeState=clean" \
+            -X sigs.k8s.io/release-utils/version.gitTreeState=dirty" \
         -o /out/cosign ./cmd/cosign
 
 # Fail the build here rather than shipping a binary that cannot run: a wrong build path or a


### PR DESCRIPTION
Closes #1153.

`OS rootfs scan` has been red on `develop-v2`'s own tip since 2026-08-19 — four runs, with PRs
merged through them. No commit broke it: the branch was untouched between a green run and a red one
and the advisories were published in between.

## Three findings, three different answers

**Raised in the build** — the rootfs compiles both binaries from source, so the module graph is
ours, the same reasoning the patched toolchain above them already uses:

| module | | | |
|---|---|---|---|
| `golang.org/x/mod` | v0.38.0 → **v0.40.0** | CVE-2026-56864, CVE-2026-56865 | both binaries |
| `google.golang.org/grpc` | v1.82.0 → **v1.82.1** | GHSA-hrxh-6v49-42gf | cosign |

Neither is reachable by a pin bump. cosign v3.1.3 *is* the newest release and pins x/mod v0.37.0;
compose v5.4.0 and v5.5.0 both pin v0.38.0; cosign's own main is still v0.38.0.

**Two mutes deleted, not added.** `.trivyignore` already carried CVE-2026-56852 (x/text) and
GHSA-hrxh-6v49-42gf (grpc), on the premise that these modules were vendored inside *downloaded*
release binaries so "no pin bump can clear them". That premise died when the rootfs started
compiling them. Both are fixed at the source now and their entries are gone.

That deletion is load-bearing, not tidiness: **while a mute is present the scan cannot tell "fixed"
from "hidden"**. The first version of this branch verified the grpc raise against grpc's own
still-present mute and proved nothing. Caught in review.

**One accepted, with corrected reasoning** — `github.com/docker/docker` CVE-2026-34040, which
genuinely cannot be raised (see below). It replaces a duplicate: the change had added a second entry
for an ID already accepted at line 24, with a different rationale and a different clearing
condition, so following either comment would have left the other muting.

## Verification — the scan, on the real binaries, twice

Built the gobuild stage on a real machine and scanned the extracted binaries with trivy 0.70.0 and
the gate's own flags.

**With no ignore file at all** (the probative run — nothing can hide behind a mute):

```
cosign          gobinary   0
docker-compose  gobinary   1   <- CVE-2026-34040 only
```

**With the trimmed `.trivyignore`, gate settings, `--exit-code 1`:**

```
cosign          gobinary   0
docker-compose  gobinary   0
TRIVY_EXIT=0
```

`docker-compose version` and `cosign version` both run in the build's own check (exit 0).

## Why CVE-2026-34040 cannot be raised

Trivy names the fix as `29.3.1`. That is a **Moby release, not a version of this module**:

```
go list -m -versions github.com/docker/docker   -> ... v28.5.2+incompatible   (newest)
go list -m -versions github.com/moby/moby       -> ... v28.5.2+incompatible   (newest)
```

Tried it rather than assuming — the build fails with `invalid version: unknown revision v29.3.1`.
Docker 29 lives at a module path compose does not import, so no compose release can carry it
either: v5.4.0, v5.5.0 and main all pin v28.5.2+incompatible. The advisory is also a daemon-side
authz bypass, and compose links the client half.

## Two provenance claims corrected, both found by review

- **A raise moves more than it names.** `go get X@v Y@v` upgrades the whole closure MVS needs to
  seat them — compose moves 1 module, cosign moves **9** (x/mod → x/tools → x/net → x/crypto,
  x/term, x/text, x/sync, x/sys). No formulation avoids that; it is what raising a module in a Go
  build means, so it is written down instead of implied. The reviewer's security framing was
  checked and does not hold: the release-signature verifier is the pinned `ghcr.io/sigstore/cosign`
  **container** (`pithead:542`), not this binary, whose only consumer is an `-x` check in
  `tests/os/verify-image.sh`.
- **`cosign version` now reports `v3.1.3+dirty`.** `go get` edits go.mod, Go stamps `vcs.modified`,
  and release-utils overwrites the `gitVersion` ldflag from the build info — so the ldflag is inert
  and the suffix is truthful. The build was nevertheless still asserting `gitTreeState=clean` about
  a tree Go itself had recorded as modified. It now says `dirty`, so the two agree and both are
  true. Confirmed on the rebuild: `GitVersion: v3.1.3+dirty`, `GitTreeState: dirty`.

Nothing in the repo or the overlay parses either version string — checked.

## Not done

- The local scan covered the two Go binaries, not the whole rootfs image. CI's `OS rootfs scan`
  scans the full image and is the real gate here; this PR's own run is what confirms it.
- No tier-1 test asserts the raises landed, deliberately: the scan is the behavioural gate, and a
  source-text assertion that the ARG contains a version string would be exactly the kind of check
  this repo keeps finding cannot fail.
- The compose currency bump (v5.4.0 → v5.5.0, #1146) is **not** here. It is a separate decision — a
  compose minor is a behaviour change, and it does not move any of these three findings.
