### PR TITLE
fix(boot): ask the dashboard's own site, and tell it apart from the default vhost (#1140)

### DIFF
--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -183,6 +183,19 @@ starts. Host identity survives A/B updates and reboots by construction (it never
 system slot to begin with); the reset tiers classify it like everything else on `/data` — a
 keep-everything reinstall keeps it, a fresh-start or full wipe deletes it.
 
+**Fixed — the boot health gate's other half was accepting Caddy's empty default vhost
+(#1140).** The probe dialled `https://localhost/` and took any status but `000` as proof the
+dashboard was serving, on the stated belief that localhost is always a listed site. It is one only
+while `dashboard.host` is unset: `generate_caddyfile` adds it inside `is_appliance && [ -z
+"$DASHBOARD_HOST" ]`. Pin the host — a documented, supported choice — and the probe reached the
+default vhost, which answers 200 with no body, so "Caddy is running" passed as "the dashboard
+serves" on the gate that decides whether an A/B update lives. Both halves are fixed together,
+because tightening the check alone would have turned the false pass into a permanent failure on
+exactly those machines: the probe now asks for the site the render itself chose, read as `HOST_IP`
+from the `.env` of that same boot and dialled over loopback with `--resolve`, and it accepts only an
+answer the default vhost cannot give — a body, or the `401` a locked dashboard sends. Not a `401`
+check: an empty dashboard password is the documented default, and that machine answers `200`.
+
 **Fixed — `doctor` looked for the control units in `/etc`, and the appliance puts them in
 `/run` (#1151).** `provision_control_runner` knew the read-only root cannot take that write (#791);
 `check_control_units` and `control_units_owner_dir` did not, and each kept its own `/etc` default.

--- a/os/overlay/pithead-boot
+++ b/os/overlay/pithead-boot
@@ -38,6 +38,10 @@ set -uo pipefail
 # which is the whole point of bounding. If it cannot be written, this refuses to reboot at all —
 # an unbounded reboot loop is the one outcome worse than a stranded box.
 BOOT_FAIL_COUNT=.boot-gate-failures
+# Where doctor's verdicts land while this gate is looping: /run, so a gate that never passes leaves
+# the last failing run's exact blocking check behind without wearing /data. A plain variable for the
+# same reason BOOT_FAIL_COUNT is one — the suite points it somewhere writable.
+BOOT_DOCTOR_JSON=/run/pithead-boot-doctor.json
 boot_gate_passed() { rm -f "$BOOT_FAIL_COUNT"; }
 fail_boot() { # <what went wrong>
     echo "pithead-boot: $1 — slot left uncommitted so A/B fallback stays armed" >&2
@@ -61,6 +65,79 @@ fail_boot() { # <what went wrong>
     # this is fixing. Not a deadlock I reproduced — a tail risk the flag costs nothing to remove.
     ${PITHEAD_REBOOT_CMD:-systemctl --no-block reboot}
     exit 1
+}
+
+# The dashboard's own site address, read from the .env this boot has just rendered (#1140).
+#
+# This probe used to dial https://localhost/, and said in a comment that localhost is a listed site
+# so the answer traverses the real dashboard vhost. That is only true while `dashboard.host` is
+# UNSET: generate_caddyfile adds localhost to the site list inside `is_appliance && [ -z
+# "$DASHBOARD_HOST" ]`. Pin the host — a documented, supported choice — and localhost drops out, the
+# probe reaches Caddy's EMPTY DEFAULT VHOST, and that answers 200 with no body. On the gate that
+# decides whether an A/B update lives, "Caddy is running" was passing as "the dashboard serves".
+#
+# HOST_IP is the value the render itself uses as the first site address, so reading it here means
+# the probe and the site list cannot disagree — one rule, not a second copy of the expansion logic.
+# Falls back to localhost rather than to nothing: an unreadable .env must not turn this gate into a
+# permanent RED, which after #1065 reboots a healthy box.
+gate_env_val() { # <key> — last assignment of KEY in ./.env, empty when absent
+    sed -n "s/^$1=//p" .env 2>/dev/null | tail -n 1
+}
+gate_url() { # -> scheme://host:port/ for the dashboard's own site
+    local host port scheme
+    host=$(gate_env_val HOST_IP)
+    [ -n "$host" ] || host=localhost
+    if [ "$(gate_env_val DASHBOARD_SECURE)" = "false" ]; then scheme=http; else scheme=https; fi
+    port=$(gate_env_val HOST_PORT)
+    if [ -z "$port" ]; then [ "$scheme" = https ] && port=443 || port=80; fi
+    printf '%s|%s|%s' "$scheme" "$host" "$port"
+}
+# dashboard.host is validated as "a hostname or IP address — letters, digits, dots, hyphens, and
+# colons", so HOST_IP can be an IPv6 literal, and these two exist because of what curl does with one:
+#   - a URL needs it bracketed, or the port reads as part of the address;
+#   - `--resolve` cannot take one at all — curl rejects the whole option with "Couldn't parse
+#     CURLOPT_RESOLVE entry", which fails the request, which on this gate means a healthy box never
+#     commits and #1065 reboots it. Measured against curl 8.7, bracketed and unbracketed alike.
+# A literal needs no resolution anyway: the box owns the address. So --resolve is for NAMES, where
+# it is what keeps the dial on loopback instead of depending on the machine resolving its own mDNS
+# name — the one lookup a boot-time health probe must not be hostage to.
+gate_target_url() { # <scheme> <host> <port>
+    case "$2" in
+    *:*) printf '%s://[%s]:%s/' "$1" "$2" "$3" ;;
+    *) printf '%s://%s:%s/' "$1" "$2" "$3" ;;
+    esac
+}
+gate_resolve_spec() { # <host> <port> -> a --resolve spec, or empty when the host needs no lookup
+    case "$1" in
+    *:*) ;;                                           # IPv6 literal
+    *[!0-9.]*) printf '%s:%s:127.0.0.1' "$1" "$2" ;;  # a name
+    *) ;;                                             # IPv4 literal
+    esac
+}
+
+# Did that answer come from the DASHBOARD, or from Caddy answering for a Host it has no site for?
+# The default vhost's reply is 200 with a zero-length body. Everything the dashboard vhost produces
+# is either the 401 its login sends or a real page, so require one of those — `!= 000` cannot tell
+# them apart, and that is what let the wrong Host read as success. Belt and braces with gate_url:
+# if the site list and this probe ever disagree again, the gate FAILS instead of lying.
+gate_answer_is_dashboard() { # <http_code> <size_download>
+    [ -n "${1:-}" ] && [ "${1}" != "000" ] || return 1
+    [ "$1" = "401" ] || [ "${2:-0}" -gt 0 ]
+}
+
+# BOTH signals, in the one place they are paired (#852). This lives above the boundary on purpose:
+# while the pairing was a bare `&&` in the commit condition below, the only thing asserting it was a
+# grep of this file — and the doctor half of that grep matched the header COMMENT on line 15, so it
+# stayed green with the doctor call deleted outright. A gate that lies, inside the gate-honesty
+# machinery. As a function it is driven at tier 1 with a stubbed `pithead`, and deleting either half
+# turns an assertion red.
+#
+# doctor's verdicts land in /run (volatile, no /data wear): when this gate never passes, the LAST
+# failing run names the exact blocking check — without it a deadlock here was undiagnosable (the
+# battery hit exactly that).
+gate_ready() { # <http_code> <size_download>
+    gate_answer_is_dashboard "$1" "$2" || return 1
+    ./pithead doctor --json >"$BOOT_DOCTOR_JSON" 2>/dev/null
 }
 
 # Sourceable for the test suite: everything above is definitions, so a `source` stops here and the
@@ -156,19 +233,23 @@ else
     ./pithead up || fail_boot "the stack could not be brought up"
 fi
 
+IFS='|' read -r gate_scheme gate_host gate_port <<<"$(gate_url)"
+gate_target=$(gate_target_url "$gate_scheme" "$gate_host" "$gate_port")
+gate_resolve_args=()
+gate_rs=$(gate_resolve_spec "$gate_host" "$gate_port")
+[ -n "$gate_rs" ] && gate_resolve_args=(--resolve "$gate_rs")
 for _ in $(seq 90); do
-    # localhost, not 127.0.0.1: the bare IP is not in the Caddyfile's site list, so it hits
-    # Caddy's empty default vhost — an empty 200 that proves only that Caddy runs. localhost IS
-    # a listed site, so this answer traverses the real dashboard vhost (TLS + auth + proxy).
-    code=$(curl -kso /dev/null -w '%{http_code}' --max-time 5 https://localhost/ 2>/dev/null) || code=000
-    # Both gates, cheapest first: the curl is fast and gates entry to the slow doctor run, so an
-    # unhealthy or still-booting stack just loops here without paying for a full diagnostic. doctor
-    # only has to pass ONCE — a chain node that is still 'starting' fails a pass and the loop retries
-    # it, so the gate waits out a slow start without ever committing on partial evidence.
-    # doctor's verdicts land in /run (volatile, no /data wear): when this gate never passes, the
-    # LAST failing run names the exact blocking check — without it a deadlock here was
-    # undiagnosable (the battery hit exactly that).
-    if [ "${code:-000}" != "000" ] && ./pithead doctor --json >/run/pithead-boot-doctor.json 2>/dev/null; then
+    # SNI and the Host header carry the site's real name, so Caddy vhost-matches it; for a name the
+    # --resolve above sends the connection to loopback, which the appliance binds unconditionally.
+    # `read` clears both when curl prints nothing, so a silent curl cannot leave the previous
+    # round's success standing.
+    read -r code size <<<"$(curl -kso /dev/null -w '%{http_code} %{size_download}' --max-time 5 \
+        "${gate_resolve_args[@]}" "$gate_target" 2>/dev/null)"
+    # Cheapest first, inside gate_ready: the probe is fast and gates entry to the slow doctor run, so
+    # an unhealthy or still-booting stack just loops here without paying for a full diagnostic.
+    # doctor only has to pass ONCE — a chain node that is still 'starting' fails a pass and the loop
+    # retries it, so the gate waits out a slow start without ever committing on partial evidence.
+    if gate_ready "${code:-000}" "${size:-0}"; then
         command -v rauc >/dev/null 2>&1 && rauc status mark-good
         boot_gate_passed
         echo "pithead-boot: stack is serving (HTTP $code) and doctor reports healthy — booted slot committed"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -10372,15 +10372,132 @@ echo "== unit: the A/B commit gate consumes doctor --json, not just the curl (#8
 # The gate that used to be a bare curl to https://localhost/ committed any slot whose dashboard
 # answered — even one whose mining services had crashed. The fix pairs the curl with doctor's
 # exit code. Assert the wiring: both signals gate the same mark-good, curl first (cheap).
-BOOTSCRIPT="$ROOT/os/overlay/pithead-boot"
-# The curl fills $code from https://localhost/; the commit condition then requires BOTH a non-000
-# code AND a clean 'doctor --json' before mark-good runs.
-grep -qE 'curl.*https://localhost/' "$BOOTSCRIPT" &&
-    grep -qE '\$\{?code[:}].*!=.*000.*&&.*pithead doctor --json' "$BOOTSCRIPT" &&
-    ok "pithead-boot gates mark-good on the localhost curl AND 'pithead doctor --json'" ||
-    bad "pithead-boot gates mark-good on the localhost curl AND 'pithead doctor --json'" \
-        "the commit condition does not pair the curl result with 'doctor --json'"
-unset BOOTSCRIPT
+# BOTH signals must gate mark-good (#852): a slot whose dashboard answers but whose mining
+# containers have crashed must NOT commit. This was a grep of the boot script until #1140, and the
+# doctor half of that grep matched the file's own HEADER COMMENT — it stayed green with the doctor
+# call deleted from the commit condition outright. The pairing now lives in gate_ready and is
+# driven here with a stubbed `pithead`, so deleting either half goes red.
+# Mutation run: drop the doctor call from gate_ready -> "a crashed stack does not commit" goes red;
+# drop the gate_answer_is_dashboard call -> "the default vhost does not commit" goes red.
+GR="$SANDBOX/gate-ready"
+mkdir -p "$GR"
+gr_run() { # <doctor-exit> <code> <size> -> ready|held
+    printf '#!/usr/bin/env bash\nexit %s\n' "$1" >"$GR/pithead"
+    chmod +x "$GR/pithead"
+    (
+        cd "$GR" || exit 1
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+        BOOT_DOCTOR_JSON="$GR/doctor.json"
+        gate_ready "$2" "$3" && echo ready || echo held
+    )
+}
+assert_eq "dashboard serving AND doctor clean -> commit" "$(gr_run 0 200 4096)" "ready"
+# #852 itself: the mining-dead-but-serving slot a curl-only gate used to mark-good.
+assert_eq "a crashed stack does not commit, however well the dashboard answers" "$(gr_run 1 200 4096)" "held"
+# #1140 itself: Caddy's empty default vhost must not open the door to the doctor run either.
+assert_eq "the default vhost does not commit, even with doctor clean" "$(gr_run 0 200 0)" "held"
+assert_eq "nothing answering does not commit" "$(gr_run 0 000 0)" "held"
+assert_eq "a locked dashboard (401) with doctor clean -> commit" "$(gr_run 0 401 0)" "ready"
+unset -f gr_run
+unset GR
+
+echo "== unit: the boot health probe asks the dashboard's own site, and can tell it apart (#1140) =="
+# The probe used to dial https://localhost/ and accept any status but 000, on the stated belief
+# that localhost is always a listed site. generate_caddyfile only adds localhost while
+# dashboard.host is UNSET — pin the host and the probe reached Caddy's EMPTY DEFAULT VHOST, which
+# answers 200 with no body. On the gate that decides whether an A/B update lives, and that #1065
+# reboots on, "Caddy is running" was passing as "the dashboard serves".
+# Two halves, both driven here: ask the right site, and recognise the right answer.
+GU="$SANDBOX/gateurl"
+mkdir -p "$GU"
+gu_run() { # <env-body> -> "scheme|host|port"
+    printf '%s\n' "$1" >"$GU/.env"
+    (
+        cd "$GU" || exit 1
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+        gate_url
+    )
+}
+# THE #1140 CASE: a pinned dashboard.host. The site list holds that name and NOT localhost, so the
+# probe has to carry it or it is talking to the default vhost.
+assert_eq "a pinned host is what the probe asks for" \
+    "$(gu_run 'HOST_IP=panel.example
+DASHBOARD_SECURE=true')" "https|panel.example|443"
+# Unpinned: HOST_IP is whatever resolve_dashboard_host chose, and it is still the first site.
+assert_eq "an unpinned host still comes from the render, not a literal" \
+    "$(gu_run 'HOST_IP=pithead.local
+DASHBOARD_SECURE=true')" "https|pithead.local|443"
+assert_eq "dashboard.secure:false -> the site is http, so the probe is too" \
+    "$(gu_run 'HOST_IP=panel.example
+DASHBOARD_SECURE=false')" "http|panel.example|80"
+assert_eq "a custom host port is honoured" \
+    "$(gu_run 'HOST_IP=panel.example
+DASHBOARD_SECURE=true
+HOST_PORT=8443')" "https|panel.example|8443"
+# Fail SAFE, not closed: an unreadable .env must not make this gate a permanent RED, because after
+# #1065 a gate that never passes reboots a healthy box. Falling back to localhost is the old
+# behaviour, and gate_answer_is_dashboard below still refuses to call the default vhost a success.
+assert_eq "an .env with no HOST_IP falls back rather than dialling nothing" \
+    "$(gu_run 'DASHBOARD_SECURE=true')" "https|localhost|443"
+unset -f gu_run
+unset GU
+
+gad() { # <code> <size> -> accept|reject
+    (
+        cd "$SANDBOX" || exit 1
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+        gate_answer_is_dashboard "$1" "$2" && echo accept || echo reject
+    )
+}
+# The whole point: Caddy's empty default vhost answers 200 with a zero-length body. That is the
+# answer #1140 was accepting as a healthy dashboard.
+assert_eq "200 with an empty body is the default vhost -> REJECT" "$(gad 200 0)" "reject"
+assert_eq "200 with a real page is the dashboard -> accept" "$(gad 200 4096)" "accept"
+# Auth on: the login's 401 has no body of its own, so size alone would reject a healthy locked box.
+assert_eq "401 (a healthy, locked dashboard) -> accept" "$(gad 401 0)" "accept"
+# Auth OFF is supported — an empty dashboard password is the documented default — so the box that
+# answers 200 with a page must pass. That is why this is not a 401 check.
+assert_eq "no connection at all -> reject" "$(gad 000 0)" "reject"
+assert_eq "an empty code -> reject" "$(gad '' 0)" "reject"
+assert_eq "a 502 from a dead upstream -> reject" "$(gad 502 0)" "reject"
+assert_eq "a redirect carrying a body -> accept" "$(gad 308 120)" "accept"
+unset -f gad
+
+# dashboard.host is validated as "a hostname or IP address" and explicitly allows colons, so HOST_IP
+# can be an IPv6 literal. curl will not take one in --resolve — it rejects the WHOLE option with
+# "Couldn't parse CURLOPT_RESOLVE entry" — and an unbracketed literal in the URL reads the port as
+# part of the address. Either way the request fails, the gate never passes, and #1065 reboots a
+# healthy box: a false RED on this gate is as bad as the false GREEN this issue is about. Measured
+# against curl 8.7 before writing these.
+# Mutation run: drop the *:* arm of gate_target_url -> the bracketing assertion goes red; make
+# gate_resolve_spec answer for every host -> the two literal assertions go red.
+# NOT run_sourced: that sources `pithead`, and these live in the boot overlay. (An assert_eq
+# expecting "" would pass vacuously against a function that was never defined, so the non-empty
+# assertions below are what prove the source landed.)
+boot_fn() { # <function> <args...>
+    (
+        cd "$SANDBOX" || exit 1
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-boot" 2>/dev/null
+        "$@"
+    )
+}
+gtu() { boot_fn gate_target_url "$@"; }
+grs() { boot_fn gate_resolve_spec "$@"; }
+assert_eq "a name goes in the URL as-is" "$(gtu https panel.example 443)" "https://panel.example:443/"
+assert_eq "an IPv6 literal is bracketed, or the port joins the address" \
+    "$(gtu https 2001:db8::1 443)" "https://[2001:db8::1]:443/"
+assert_eq "an IPv4 literal needs no brackets" "$(gtu http 192.0.2.5 80)" "http://192.0.2.5:80/"
+# --resolve is for names only. It is what keeps a name's dial on loopback without the box having to
+# resolve its own mDNS name; a literal is already an address and needs no lookup.
+assert_eq "a name gets a --resolve spec pointing at loopback" \
+    "$(grs panel.example 443)" "panel.example:443:127.0.0.1"
+assert_eq "an IPv6 literal gets NO --resolve (curl cannot parse one)" "$(grs 2001:db8::1 443)" ""
+assert_eq "an IPv4 literal gets no --resolve either" "$(grs 192.0.2.5 80)" ""
+unset -f gtu grs boot_fn
 
 echo "== unit: revenue_container_verdict — commit-gate honesty, syncing vs crashed (#852) =="
 # The pure classifier behind check_revenue_containers, so the commit gate's central judgement is


### PR DESCRIPTION
Closes #1140.

The boot health gate's fast half dialled `https://localhost/` and accepted any status but `000`. Its
comment said localhost is a listed site, so the answer traverses the real dashboard vhost. That
holds only while `dashboard.host` is unset — `generate_caddyfile` adds localhost inside
`is_appliance && [ -z "$DASHBOARD_HOST" ]`. Pin the host, which is documented and supported, and
localhost drops out: the probe reaches Caddy's empty default vhost, which answers **200 with no
body**, and "Caddy is running" passes as "the dashboard serves" — on the gate that decides whether
an A/B update lives, and that #1065 reboots on.

## Both halves change together, and that is the point

Tightening the acceptance alone would convert the false pass into a permanent **failure** on exactly
the machines this issue is about: with the host pinned there is genuinely nothing at localhost to
believe. That is the same false-RED shape as #1151, on the same gate. The issue's own preferred
option had this in it — see [the design comment](https://github.com/p2pool-starter-stack/pithead/issues/1140#issuecomment-5351477616).

- **Ask the right site.** `gate_url` reads `HOST_IP`, `DASHBOARD_SECURE` and `HOST_PORT` from the
  `.env` this boot has just rendered. `HOST_IP` is what the render uses as its first site address,
  so the probe and the site list cannot disagree — one rule, not a second copy of the expansion.
- **Recognise the right answer.** `gate_answer_is_dashboard` accepts a body, or the `401` a locked
  dashboard sends, and rejects the default vhost's empty 200. Deliberately **not** a 401 check: an
  empty dashboard password is the documented default (`# OPT-IN — an empty password (the default)
  leaves it open`), and that machine answers 200, so a 401 gate would fail forever on every
  no-login appliance.
- **Dial it correctly.** `dashboard.host` is validated as "a hostname or IP address" and explicitly
  allows colons, so `HOST_IP` can be an IPv6 literal. Measured against curl 8.7 rather than reasoned
  about: curl refuses one in `--resolve` outright — `Couldn't parse CURLOPT_RESOLVE entry` — and an
  unbracketed literal in the URL reads the port as part of the address. Either way the request
  fails and the gate never passes. So `gate_target_url` brackets a literal, and `gate_resolve_spec`
  emits `--resolve` only for names, where it is what keeps the dial on loopback instead of making a
  boot-time health probe hostage to the box resolving its own mDNS name.
- `code`/`size` are cleared each iteration, so a curl that prints nothing cannot leave the previous
  round's answer standing.

## The review found a gate that lies, inside this change

The first version replaced the old single-line regex with two independent greps. The doctor half,
`grep -qE 'pithead doctor --json'`, matched **this file's own header comment on line 15** — so the
one assertion whose job is "both signals gate the same mark-good" stayed green with the doctor call
deleted from the commit condition outright. That is #852 restored, with the test that exists to
prevent it still passing.

Fixed by moving the pairing itself above the sourceable boundary as `gate_ready`, driven at tier 1
with a stubbed `pithead`. `BOOT_DOCTOR_JSON` becomes a plain variable for the same reason
`BOOT_FAIL_COUNT` is one — the suite points it somewhere writable. All five helpers now live above
the boundary, so they are driven rather than asserted about.

## Tier 1

`bash tests/stack/run.sh` → **2722 passed, 0 failed** (base 2700).

## Mutations — eight named, eight run

| # | mutation | result |
|---|---|---|
| M1 | acceptance widened back to "any status but 000" | 2 red |
| M2 | probe target hard-coded back to `localhost` | 4 red |
| M3 | the fail-safe HOST_IP fallback removed | 1 red |
| M4 | acceptance narrowed to **401-only** (the fix the issue first recommended) | 2 red |
| M5 | IPv6 bracketing dropped from `gate_target_url` | 1 red |
| M6 | `--resolve` emitted for IP literals too | 2 red |
| M7 | **the doctor half deleted from the commit gate** — the #852 regression the old grep could not see | 1 red |
| M8 | the probe half widened back inside `gate_ready` | 1 red |

M4 is worth calling out: the suite goes red on the fix originally recommended, because the no-login
case is now encoded as a requirement.

## Not done

- The `curl` invocation itself is still below the sourceable boundary and has no tier-1 coverage —
  only the values it is built from and the decision it feeds. The honest place for the rest is
  leg 4 of the battery.
- **No `--phase update` battery run on this branch.** This changes `pithead-boot`, which the bench
  is the real gate for, and that has not been run here.
- The render is untouched: `localhost` still leaves the site list when `dashboard.host` is pinned.
  This makes the probe honest about that rather than changing what the box serves — the vhost
  question belongs with #1132, where the certificate SAN list is decided by a different rule.
