### PR TITLE
sync: develop -> develop-v2 (util-linux acceptance, #1156)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -13,10 +13,23 @@ CVE-2026-45447
 CVE-2026-23949
 CVE-2026-24049
 
-# util-linux family (bsdutils, libmount1, libuuid1, login, mount, util-linux): the fix is a
-# base-distro point release, 2.41.5-0+deb13u1, and no published python:3.11-slim carries it yet —
-# the newest digest still ships 2.41-5. Same shape as CVE-2026-45447 above: `--ignore-unfixed` hid
-# this until Debian published a fix, at which point it reddened every branch at once without any
-# change on our side. Cleared when a base bump brings 2.41.5-0+deb13u1 in; the weekly CVE sweep
-# (#833) re-surfaces it regardless, so this cannot rot silently.
+# util-linux family (bsdutils, libblkid1, liblastlog2-2, libmount1, libsmartcols1, libuuid1, login,
+# mount, util-linux) — FOUR advisories now, all with the same fix and the same clearing condition.
+# The fix is a base-distro point release, 2.41.5-0+deb13u1, and no published python:3.11-slim
+# carries it: `docker pull python:3.11-slim` returns the very digest build/dashboard/Dockerfile
+# already pins, and it still ships 2.41-5. So this cannot be closed by dependabot or by a manual
+# base bump — only by upstream rebuilding the image on the fixed Debian packages. Verified by
+# pulling the tag and reading dpkg, not from the release notes (#1156).
+#
+# Same shape as CVE-2026-45447 above: `--ignore-unfixed` hid these until Debian published a fix, at
+# which point they reddened every branch at once with no change on our side. 53615 arrived that way
+# on 2026-08-19 and the other three on 2026-08-20, between one CI run and the next on a branch
+# nobody had touched.
+#
+# Cleared when a base bump brings 2.41.5-0+deb13u1 in — `docker run --rm python:3.11-slim
+# dpkg-query -W util-linux` is the one-line check, and all four go together. The weekly CVE sweep
+# (#833) re-surfaces them regardless, so this cannot rot silently.
+CVE-2026-53612
+CVE-2026-53613
+CVE-2026-53614
 CVE-2026-53615


### PR DESCRIPTION
Twin sync: `develop` → `develop-v2`, carrying #1157 (the util-linux acceptance for #1156).

Two commits, one file, one conflict — in `.trivyignore`, which both lanes edited today for different
reasons. That conflict is the whole content of this PR.

## The conflict, and why neither side could win

- `develop-v2` had #1154: the Go-binaries block rewritten, **two mutes deleted** (x/text and grpc,
  now fixed at the source by the `GO_RAISES` entries), and `CVE-2026-34040` kept with new reasoning.
- `develop` had #1157: the util-linux entry rewritten to hold four advisories instead of one.

They overlap because they are adjacent blocks in the same file, so git presented one large hunk.
Taking `--ours` would have silently dropped the util-linux fix and left this lane's dashboard scan
red; taking `--theirs` would have dropped the entire #1154 rewrite and **re-added two mutes for
findings that are now fixed at the source** — the exact thing #1154 argues against, since a mute
over a fixed finding destroys the evidence the fix landed.

Resolved hunk-by-hunk, keeping this lane's Go-binaries block and the incoming util-linux entry, with
the resolution asserted rather than eyeballed:

```
assert 'COMPOSE_GO_RAISES' survives          # the #1154 rewrite
assert 'CVE-2026-34040' survives             # the docker/docker acceptance
assert 'NOTE ON GO STDLIB' survives          # the note that stops stdlib CVEs being re-accepted
assert the stale util-linux prose is gone    # superseded by the incoming one
assert the incoming block adds exactly 53612, 53613, 53614
```

Result — 8 accepted ids, and **zero** active entries for the two #1154 fixed at the source:

```
CVE-2026-45447  CVE-2026-23949  CVE-2026-24049  CVE-2026-34040
CVE-2026-53612  CVE-2026-53613  CVE-2026-53614  CVE-2026-53615
```

`CVE-2026-56852` and `GHSA-hrxh-6v49-42gf` appear once each, in prose, in the sentence recording
that they were deleted and why.

## Verified

`bash tests/stack/run.sh` → **2722 passed, 0 failed** — the same count as `develop-v2` before the
merge, which is what a docs-and-config-only sync should produce. Run because a twin sync is a
coverage event, not because this one changed code.

## A standing difference this creates

`develop` still carries `CVE-2026-56852` and `GHSA-hrxh-6v49-42gf` as active mutes; this lane no
longer does. That is **correct** — those findings live in the appliance rootfs binaries, which only
exist on `develop-v2`, so on `develop` they are entries for artefacts that lane does not build. But
it means `.trivyignore` now differs between the twins by two lines, and **every future sync of this
file will conflict on the same region**. Worth cleaning up on `develop` (they are dead there
regardless of this change); flagged rather than folded in, since it is a separate decision about a
lane this PR is not targeting.
