### PR TITLE
fix(ci): stop the CVE gate scanning yesterday's advisory database (#1159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       - name: Scan image for CVEs (Trivy)
         # Gate on actionable (fixable) HIGH/CRITICAL only; accepted findings live in .trivyignore.
         # Must stay green before v1.1 images publish (#282).
+        #
+        # cache: false is load-bearing (#1159). The action caches the vulnerability database under
+        # `cache-trivy-$(date +%F)`, and Actions caches are immutable and scoped per ref — so the
+        # first run of the calendar day on a branch freezes that branch's database until midnight.
+        # On 2026-08-20 the identical dashboard image passed on one branch and failed on another 40
+        # seconds apart, because one restored a snapshot written at 00:15 and the other one written
+        # at 13:33. A gate whose answer depends on when its branch last started a run is not a gate.
+        # Measured cost of downloading it every time: 108.49 MiB from mirror.gcr.io/aquasec/trivy-db
+        # in 3.3s, against the 13.9s the ~997 MB cache restore was taking. It also returns ~7.5 GB of
+        # the repo's 10 GB Actions cache budget, which was 92% near-duplicate copies of this one DB.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: pithead-${{ matrix.service }}:ci
@@ -117,6 +127,7 @@ jobs:
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: .trivyignore
+          cache: "false"
 
   hadolint:
     name: Dockerfile lint (hadolint)


### PR DESCRIPTION
Closes #1159.

`trivy-action` caches the vulnerability database under `cache-trivy-$(date +%F)` with
`restore-keys: cache-trivy-`. Actions caches are immutable once written and scoped per ref, so that
one key name is many independent entries, and the first run of the calendar day on a branch freezes
that branch's database until midnight. Which snapshot a scan gets is a function of when its branch
last started a run, not of when the scan runs.

`cache: "false"` makes every scan download a current database, so two scans at the same moment
agree.

## What was run

**The flap, reproduced from the archived runs rather than from reasoning.** Two `Build image
(dashboard)` jobs 40 seconds apart on 2026-08-20:

| | run / job | started | debian findings | verdict |
|---|---|---|---|---|
| A | `32376011956` / `96447462559` | 13:44:44Z | 0 | pass |
| B | `32376038312` / `96447547610` | 13:45:24Z | `Total: 27 (HIGH: 27)` | fail |

Both logs pulled with `gh api repos/.../actions/jobs/<id>/logs`. Both report the same image to the
same depth — `Detected OS family="debian" version="13.6"`, `pkg_num=101`. Neither contains a
database download; both hit their cache key exactly.

**The inputs are byte-identical**, checked as trees rather than by reading the diff:

```
$ git rev-parse 28241e13:build/dashboard 64a8be4b:build/dashboard
bfb38aac66f646e1e4f35a64c24f349b82d2bcaa
bfb38aac66f646e1e4f35a64c24f349b82d2bcaa
$ git rev-parse 28241e13:.trivyignore 64a8be4b:.trivyignore
2ac1259c0ed8d1cecfa8aeccfc5295eff86ed561
2ac1259c0ed8d1cecfa8aeccfc5295eff86ed561
$ git rev-parse 28241e13:.github/workflows/ci.yml 64a8be4b:.github/workflows/ci.yml
e94e9c88727dd3837d625e4cc65f45a27d612262
e94e9c88727dd3837d625e4cc65f45a27d612262
```

Neither of `CVE-2026-53612`/`53613`/`53614` was in `.trivyignore` at either commit, so the pass is
not an acceptance.

**The cache entries explain which database each got**, read from the API:

```
cache-trivy-2026-08-20  ref=refs/pull/1057/merge  created=2026-08-20T00:15:58Z
cache-trivy-2026-08-20  ref=refs/pull/1155/merge  created=2026-08-20T13:33:48Z
```

Run A restored the 00:15:58Z entry — written hours before the three util-linux advisories were
published. Run B restored the 13:33:48Z entry, written after them. That entry is also why PR #1057
was green all day and not only at 13:44: created 00:15:58Z, last read 16:01:25Z.

**The cache budget, measured:** `active_caches=56 total_bytes=8112959593`, of which the 25 trivy
entries are `7483481927` — 92% of the repo's Actions cache, against GitHub's 10 GB limit, in
near-duplicate copies of one database. Six of them are ~997 MB.

**Lint:** `uvx yamllint .github/workflows/ci.yml` clean, `uvx zizmor@1.25.2 --offline
.github/workflows/` reports no findings.

## What was NOT run

- **No test, and none is being added.** `docs/dev/testing-strategy.md` fixes four tiers and none of
  them covers `.github/workflows`; the repo has no assertion over any workflow file today, and the
  existing lint tier for them is the `zizmor` job, which passes. Inventing a fifth tier for one YAML
  value would be worse than the comment that now sits above the line. If `cache: "false"` is ever
  deleted, nothing catches it — that is stated rather than papered over.
- **Not driven on a runner before opening this.** GitHub Actions cannot be run locally, so this PR's
  own five matrix jobs were the first execution. They have since run — see the verification comment
  below, which retires both risks and corrects two figures in this description.

## The two ways this could be wrong, and how to check them on this PR

1. **It may go red.** Every scan now sees a current database, so anything the stale snapshots were
   hiding surfaces on this run. That is the intended behaviour, but a red check here is a finding to
   handle, not a reason to revert.
2. **The database now downloads on every job.** If `trivy`'s registry pull is rate-limited across
   five concurrent matrix jobs, this trades a false green for a flaky red, which would be worse.
   Five clean jobs on this PR is the evidence; it has not been proven any other way. For scale: run
   B spent 13.9s restoring its ~997 MB cache, so the expected cost was near zero or negative.

## What this deliberately does not change

The gate still keys on the outside world, so it will still go red with no commit to blame — three
times on 2026-08-20 alone. That is the gate working. The weekly sweep (#833) is the channel for it.
What changes is that the gate stops disagreeing with itself, which is what made those three
reddenings read as noise.
