### PR TITLE
fix(ci): watch the appliance rootfs pins too, in a second lane (#1146)

### DIFF
--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -6,13 +6,21 @@ name: Upstream pin watch
 # shape, different output, because XMRig is a drop-in binary and its build gate proves the
 # candidate.
 #
-# ONE tracking issue, edited in place. An issue persists, is assignable and milestonable, and lets
-# a human write "held until the bench is free, here's why" in a comment — which a report artifact
-# nobody opens cannot do, and which is the failure mode #1128 was filed about.
+# ONE tracking issue per lane, edited in place. An issue persists, is assignable and milestonable,
+# and lets a human write "held until the bench is free, here's why" in a comment — which a report
+# artifact nobody opens cannot do, and which is the failure mode #1128 was filed about. Two lanes
+# rather than one table because the two trees have different pins and different owners; merging
+# them would mean one lane's rows silently vanishing whenever the other lane could not be read.
 #
 # This file lives on the DEFAULT branch on purpose. The previous pin-watch.yml lived on
 # `develop-v2`, where a `schedule:` can never fire, and so ran exactly zero times — the appliance
 # pins it watched were never checked once. That is the same defect class as #1048 and #1064.
+#
+# Living on the default branch means only `develop`'s tree gets read, and `develop` has no `os/` —
+# so the appliance's own two pins were invisible in a run that looked complete (#1146). The `lane`
+# matrix below fixes that by checking out `develop-v2` explicitly for a second report. It is the
+# same defect as the paragraph above, one level in: the previous watcher never ran, this one ran
+# with a lane missing. Both look identical from the Actions tab.
 on:
   schedule:
     - cron: "30 6 * * 1" # Mondays 06:30 UTC, after the image sweeps
@@ -25,12 +33,30 @@ permissions:
 
 jobs:
   pin-watch:
-    name: Compare upstream component pins against their latest releases
+    name: Compare upstream component pins against their latest releases (${{ matrix.lane }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      # fail-fast: false so a lane that cannot report does not cancel the lane that can — a missing
+      # report is the thing this watcher exists to make loud, not a reason to lose the other one.
+      fail-fast: false
+      matrix:
+        include:
+          # `ref: ""` is checkout's own default: the ref that triggered the run. On the weekly
+          # schedule that is the default branch, which is what this lane has always read.
+          - lane: product
+            ref: ""
+            title: "Upstream pin currency (weekly report)"
+          # The appliance rootfs COMPILES docker-compose and cosign from `ARG` values, so nothing
+          # else can see them: dependabot's docker ecosystem reads `FROM` lines, and `cosign` is the
+          # verifier the whole signed-update chain rests on. They exist on this lane only.
+          - lane: appliance
+            ref: develop-v2
+            title: "Upstream pin currency — appliance rootfs (weekly report)"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ matrix.ref }}
           persist-credentials: false
       - name: Build the currency report
         id: report
@@ -47,10 +73,10 @@ jobs:
           # An empty report is itself a failure to report — never publish silence.
           [ -s report.md ] || { echo "The pin watcher produced no report at all — see the run log." >report.md; rc=1; }
           echo "rc=$rc" >>"$GITHUB_OUTPUT"
-      - name: Publish it to the one tracking issue
+      - name: Publish it to this lane's tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
-          TITLE: "Upstream pin currency (weekly report)"
+          TITLE: ${{ matrix.title }}
           RC: ${{ steps.report.outputs.rc }}
         run: |
           set -Eeuo pipefail

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -136,10 +136,18 @@ source "$ROOT/scripts/release.sh"
 # hence the guard: on `develop` this loop is simply shorter, not wrong.
 #
 # BOUNDARY, stated because a silent one is what this whole issue is about: GitHub runs `schedule:`
-# from the DEFAULT branch, so this only ever reads `develop`. The appliance lane's own pins stay
-# unwatched until this script reaches `develop-v2` at the next twin sync. The report says so.
+# from the DEFAULT branch, so a single-job workflow only ever reads `develop` and these two rows
+# are simply absent from a run that looks complete (#1146). pin-watch.yml therefore runs this
+# script TWICE — once on the triggering ref, once against an explicit `develop-v2` checkout — and
+# publishes the two reports to two separate tracking issues. The report below says which it is.
 components="monero p2pool xmrig-proxy tari caddy socket-proxy"
-[ -f "$ROOT/os/rootfs/Dockerfile" ] && components="$components compose cosign"
+lane="the product stack"
+# A real `if`, for the same reason the publish step in pin-watch.yml uses one: `[ -f X ] && var=…`
+# evaluates to 1 on the develop lane, which is only safe while nothing depends on the exit status.
+if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
+    components="$components compose cosign"
+    lane="the product stack and the appliance rootfs"
+fi
 
 # release.sh's pin() is the one place pins are read from the tree; the two rootfs binaries have no
 # case there because a release does not bundle them.
@@ -179,10 +187,23 @@ for component in $components; do
     row "$component" "\`$(norm "$raw")\`" "\`$(norm "$latest")\`" "$verdict"
 done
 
-printf '%s\n\n' "Upstream currency, checked weekly by \`scripts/pin-watch.sh\`. This never bumps anything."
+printf '%s\n\n' "Upstream currency for $lane, checked weekly by \`scripts/pin-watch.sh\`. This never bumps anything."
 printf '| component | pinned | upstream latest | |\n|---|---|---|---|\n%s\n' "$rows"
 printf '%s\n' "Not watched here, because they publish no GitHub release feed: the alpine base image, \`ubuntu:24.04\`, \`python:3.11-slim\`. Dependabot's docker ecosystem reads those \`FROM\` lines and does cover them."
-[ -f "$ROOT/os/rootfs/Dockerfile" ] || printf '%s\n' "The appliance lane's own pins (the rootfs docker-compose and cosign) are NOT in this table: a scheduled workflow only ever reads the default branch, and this script is not on \`develop-v2\` yet."
+# Both arms, so this file stops being a twin-sync conflict: `develop-v2` had already turned this
+# line into an if/else to carry the _COMMIT warning below, and a competing one-line rewrite here
+# would collide with it on every sync. The appliance arm is dead code on `develop` and correct on
+# `develop-v2`, which is the point.
+if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
+    # The rootfs COMPILES these two from source on a pinned Go toolchain rather than downloading a
+    # release binary, so each carries a paired _COMMIT ARG and the VERSION alone decides nothing.
+    # Bumping the version and leaving the commit still builds the old code — the same half-done bump
+    # #1137 describes for image digests. (This warning came from the appliance-lane watcher this
+    # script replaced; the fact outlived the file.)
+    printf '%s\n' "\`compose\` and \`cosign\` are compiled from source in \`os/rootfs/Dockerfile\`, so each bump is TWO ARGs — the version AND its paired \`_COMMIT\`. Resolve the commit with \`gh api repos/<owner>/<repo>/commits/<tag> --jq .sha\`; bumping the version alone still builds the old code."
+else
+    printf '%s\n' "The appliance rootfs's own pins (its docker-compose and cosign, compiled from \`ARG\` values that no dependabot ecosystem can read) are NOT in this table. They are in the appliance report, which the same workflow run produces from an explicit \`develop-v2\` checkout (#1146)."
+fi
 printf '%s\n' "Also NOT checked: whether each image pin's digest still corresponds to its tag. The digest is what actually runs, so a half-done bump is invisible to the table above."
 if [ "$failed" -gt 0 ]; then
     printf '\n%s\n' "**$failed lookup(s) could not run — those rows are unchecked, not current.**"


### PR DESCRIPTION
Closes #1146.

GitHub fires `schedule:` from the default branch only. The default branch is `develop`, which has no
`os/`, so the weekly currency run read six product pins and never saw the appliance's own two —
`COMPOSE_VERSION` and `COSIGN_VERSION`, compiled from source in the rootfs and invisible to
dependabot because they are `ARG` values rather than `FROM` lines. `cosign` is the verifier the whole
signed-update chain rests on.

The script already handled them behind a `[ -f os/rootfs/Dockerfile ]` guard, so this is a workflow
change and not a script one: a two-entry `lane` matrix runs the same steps twice, once on the
triggering ref and once against an explicit `develop-v2` checkout, publishing to two tracking issues.

## What was run

**Both lanes driven end to end**, against the live release feeds. The develop lane, from this
branch's tree:

```
Upstream currency for the product stack, checked weekly by `scripts/pin-watch.sh`. …
| monero       | 0.18.5.0 | 0.18.5.1 | stale → v0.18.5.1 |
| p2pool       | 4.16     | 4.18     | stale → v4.18     |
| xmrig-proxy  | 6.26.0   | 6.26.0   | current           |
| tari         | 5.3.1    | 5.6.0    | stale → v5.6.0    |
| caddy        | 2.11.4   | 2.11.4   | current           |
| socket-proxy | 0.4.2    | 0.5.0    | stale → v0.5.0    |
…The appliance rootfs's own pins … are NOT in this table. They are in the appliance report…
<!-- pin-watch: stale=4 failed=0 -->     rc=0
```

The appliance lane, driven by planting `develop-v2`'s real `ARG` block at `os/rootfs/Dockerfile` and
re-running (temporary file, removed; `git status` clean afterwards):

```
Upstream currency for the product stack and the appliance rootfs, checked weekly by …
…
| compose | 5.4.0 | 5.5.0 | stale → v5.5.0 |
| cosign  | 3.1.3 | 3.1.3 | current        |
<!-- pin-watch: stale=5 failed=0 -->     rc=0
```

That `compose 5.4.0 → 5.5.0` row is the point of the issue: it is a real stale pin on the appliance's
own supply chain that no scheduled run has ever reported.

**The two reports are distinguishable.** They were not before — with two issues carrying the same
opening sentence, a reader had to count rows to know which tree had been read. The first line now
names it, driven from the same `os/rootfs/Dockerfile` test that decides the component list, so the
two cannot drift apart.

**Lint and self-test:** `bash scripts/pin-watch.sh --self-test` → 7 ok; `uvx yamllint
.github/workflows/pin-watch.yml` clean; `uvx zizmor@1.25.2 --offline .github/workflows/` no findings;
`make lint-sh` (shellcheck + shfmt) clean.

## Two things fixed in passing, because they were already false

- `scripts/pin-watch.sh` carried "the appliance lane's own pins stay unwatched until this script
  reaches `develop-v2` at the next twin sync", in a comment and in the report body. That sync landed
  on 2026-08-19. Both replaced with what is true after this change.
- `[ -f … ] && components=…` became a real `if`. It evaluates to 1 on the develop lane, and is only
  safe while nothing downstream reads the exit status — which is the exact hazard the publish step in
  `pin-watch.yml` already writes three lines of comment about. Same file, same rule.

## What was NOT run, and what could still be wrong

- **The scheduled trigger itself has not fired.** No tier can see a workflow's scheduling —
  `docs/dev/testing-strategy.md` fixes four and none of them covers `.github/workflows`. The
  verification is a `workflow_dispatch` after merge, confirming two tracking issues exist with the
  right two tables. That is the step that caught the equivalent defect in rigforge#376, and it is
  what #1146 itself asks for. It will be run and reported on the issue.
- **`ref: ""` is checkout's documented default** (the ref that triggered the run), so the product
  lane is unchanged — but that is read from the action's contract, not driven. If it were wrong, the
  product lane would check out the wrong tree, and the dispatch above is what would show it.
- **A deliberate trust widening:** the appliance lane executes `develop-v2`'s copy of
  `scripts/pin-watch.sh` under a token with `issues: write`. That is the same trust boundary as
  `develop` and the same one the twin sync already assumes, but it is a widening and is stated
  rather than left implicit.
- **No new guard for a missing script.** If `scripts/pin-watch.sh` were absent on `develop-v2`, the
  existing code already turns that into a published failure notice and a red run: `bash` fails, `rc`
  is non-zero, the `[ -s report.md ]` line replaces the empty report, and the last step exits 1.
  #1146 asked for a file-existence guard; the behaviour it wants is already there, so nothing was
  added.
