### PR TITLE
Sync develop into develop-v2 (#1159, #1146) — and the appliance's own half of the CVE-gate fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,16 @@ jobs:
       - name: Scan image for CVEs (Trivy)
         # Gate on actionable (fixable) HIGH/CRITICAL only; accepted findings live in .trivyignore.
         # Must stay green before v1.1 images publish (#282).
+        #
+        # cache: false is load-bearing (#1159). The action caches the vulnerability database under
+        # `cache-trivy-$(date +%F)`, and Actions caches are immutable and scoped per ref — so the
+        # first run of the calendar day on a branch freezes that branch's database until midnight.
+        # On 2026-08-20 the identical dashboard image passed on one branch and failed on another 40
+        # seconds apart, because one restored a snapshot written at 00:15 and the other one written
+        # at 13:33. A gate whose answer depends on when its branch last started a run is not a gate.
+        # Measured cost of downloading it every time: 108.49 MiB from mirror.gcr.io/aquasec/trivy-db
+        # in 3.3s, against the 13.9s the ~997 MB cache restore was taking. It also returns ~7.5 GB of
+        # the repo's 10 GB Actions cache budget, which was 92% near-duplicate copies of this one DB.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: pithead-${{ matrix.service }}:ci
@@ -117,6 +127,7 @@ jobs:
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: .trivyignore
+          cache: "false"
 
   hadolint:
     name: Dockerfile lint (hadolint)

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -60,6 +60,11 @@ jobs:
         if: steps.tree.outputs.present == 'true'
         # Same gate as ci.yml's image scan: actionable (fixable) HIGH/CRITICAL only; accepted
         # findings live in .trivyignore with a rationale and how they clear.
+        #
+        # cache: false for the reason spelled out over ci.yml's scan (#1159) — this is the repo's
+        # other trivy call site. It matters more here: the appliance's Debian userland is baked and
+        # has no apt at runtime, so this scan is the only eye on podman, netavark, openssl and the
+        # kernel between releases. (#1162: that eye is also shut, for a different reason.)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: pithead-os-rootfs:ci
@@ -68,3 +73,4 @@ jobs:
           ignore-unfixed: true
           exit-code: "1"
           trivyignores: .trivyignore
+          cache: "false"

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -6,13 +6,21 @@ name: Upstream pin watch
 # shape, different output, because XMRig is a drop-in binary and its build gate proves the
 # candidate.
 #
-# ONE tracking issue, edited in place. An issue persists, is assignable and milestonable, and lets
-# a human write "held until the bench is free, here's why" in a comment — which a report artifact
-# nobody opens cannot do, and which is the failure mode #1128 was filed about.
+# ONE tracking issue per lane, edited in place. An issue persists, is assignable and milestonable,
+# and lets a human write "held until the bench is free, here's why" in a comment — which a report
+# artifact nobody opens cannot do, and which is the failure mode #1128 was filed about. Two lanes
+# rather than one table because the two trees have different pins and different owners; merging
+# them would mean one lane's rows silently vanishing whenever the other lane could not be read.
 #
 # This file lives on the DEFAULT branch on purpose. The previous pin-watch.yml lived on
 # `develop-v2`, where a `schedule:` can never fire, and so ran exactly zero times — the appliance
 # pins it watched were never checked once. That is the same defect class as #1048 and #1064.
+#
+# Living on the default branch means only `develop`'s tree gets read, and `develop` has no `os/` —
+# so the appliance's own two pins were invisible in a run that looked complete (#1146). The `lane`
+# matrix below fixes that by checking out `develop-v2` explicitly for a second report. It is the
+# same defect as the paragraph above, one level in: the previous watcher never ran, this one ran
+# with a lane missing. Both look identical from the Actions tab.
 on:
   schedule:
     - cron: "30 6 * * 1" # Mondays 06:30 UTC, after the image sweeps
@@ -25,12 +33,30 @@ permissions:
 
 jobs:
   pin-watch:
-    name: Compare upstream component pins against their latest releases
+    name: Compare upstream component pins against their latest releases (${{ matrix.lane }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      # fail-fast: false so a lane that cannot report does not cancel the lane that can — a missing
+      # report is the thing this watcher exists to make loud, not a reason to lose the other one.
+      fail-fast: false
+      matrix:
+        include:
+          # `ref: ""` is checkout's own default: the ref that triggered the run. On the weekly
+          # schedule that is the default branch, which is what this lane has always read.
+          - lane: product
+            ref: ""
+            title: "Upstream pin currency (weekly report)"
+          # The appliance rootfs COMPILES docker-compose and cosign from `ARG` values, so nothing
+          # else can see them: dependabot's docker ecosystem reads `FROM` lines, and `cosign` is the
+          # verifier the whole signed-update chain rests on. They exist on this lane only.
+          - lane: appliance
+            ref: develop-v2
+            title: "Upstream pin currency — appliance rootfs (weekly report)"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ matrix.ref }}
           persist-credentials: false
       - name: Build the currency report
         id: report
@@ -47,10 +73,10 @@ jobs:
           # An empty report is itself a failure to report — never publish silence.
           [ -s report.md ] || { echo "The pin watcher produced no report at all — see the run log." >report.md; rc=1; }
           echo "rc=$rc" >>"$GITHUB_OUTPUT"
-      - name: Publish it to the one tracking issue
+      - name: Publish it to this lane's tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
-          TITLE: "Upstream pin currency (weekly report)"
+          TITLE: ${{ matrix.title }}
           RC: ${{ steps.report.outputs.rc }}
         run: |
           set -Eeuo pipefail

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -136,10 +136,18 @@ source "$ROOT/scripts/release.sh"
 # hence the guard: on `develop` this loop is simply shorter, not wrong.
 #
 # BOUNDARY, stated because a silent one is what this whole issue is about: GitHub runs `schedule:`
-# from the DEFAULT branch, so this only ever reads `develop`. The appliance lane's own pins stay
-# unwatched until this script reaches `develop-v2` at the next twin sync. The report says so.
+# from the DEFAULT branch, so a single-job workflow only ever reads `develop` and these two rows
+# are simply absent from a run that looks complete (#1146). pin-watch.yml therefore runs this
+# script TWICE — once on the triggering ref, once against an explicit `develop-v2` checkout — and
+# publishes the two reports to two separate tracking issues. The report below says which it is.
 components="monero p2pool xmrig-proxy tari caddy socket-proxy"
-[ -f "$ROOT/os/rootfs/Dockerfile" ] && components="$components compose cosign"
+lane="the product stack"
+# A real `if`, for the same reason the publish step in pin-watch.yml uses one: `[ -f X ] && var=…`
+# evaluates to 1 on the develop lane, which is only safe while nothing depends on the exit status.
+if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
+    components="$components compose cosign"
+    lane="the product stack and the appliance rootfs"
+fi
 
 # release.sh's pin() is the one place pins are read from the tree; the two rootfs binaries have no
 # case there because a release does not bundle them.
@@ -179,10 +187,23 @@ for component in $components; do
     row "$component" "\`$(norm "$raw")\`" "\`$(norm "$latest")\`" "$verdict"
 done
 
-printf '%s\n\n' "Upstream currency, checked weekly by \`scripts/pin-watch.sh\`. This never bumps anything."
+printf '%s\n\n' "Upstream currency for $lane, checked weekly by \`scripts/pin-watch.sh\`. This never bumps anything."
 printf '| component | pinned | upstream latest | |\n|---|---|---|---|\n%s\n' "$rows"
 printf '%s\n' "Not watched here, because they publish no GitHub release feed: the alpine base image, \`ubuntu:24.04\`, \`python:3.11-slim\`. Dependabot's docker ecosystem reads those \`FROM\` lines and does cover them."
-[ -f "$ROOT/os/rootfs/Dockerfile" ] || printf '%s\n' "The appliance lane's own pins (the rootfs docker-compose and cosign) are NOT in this table: a scheduled workflow only ever reads the default branch, and this script is not on \`develop-v2\` yet."
+# Both arms, so this file stops being a twin-sync conflict: `develop-v2` had already turned this
+# line into an if/else to carry the _COMMIT warning below, and a competing one-line rewrite here
+# would collide with it on every sync. The appliance arm is dead code on `develop` and correct on
+# `develop-v2`, which is the point.
+if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
+    # The rootfs COMPILES these two from source on a pinned Go toolchain rather than downloading a
+    # release binary, so each carries a paired _COMMIT ARG and the VERSION alone decides nothing.
+    # Bumping the version and leaving the commit still builds the old code — the same half-done bump
+    # #1137 describes for image digests. (This warning came from the appliance-lane watcher this
+    # script replaced; the fact outlived the file.)
+    printf '%s\n' "\`compose\` and \`cosign\` are compiled from source in \`os/rootfs/Dockerfile\`, so each bump is TWO ARGs — the version AND its paired \`_COMMIT\`. Resolve the commit with \`gh api repos/<owner>/<repo>/commits/<tag> --jq .sha\`; bumping the version alone still builds the old code."
+else
+    printf '%s\n' "The appliance rootfs's own pins (its docker-compose and cosign, compiled from \`ARG\` values that no dependabot ecosystem can read) are NOT in this table. They are in the appliance report, which the same workflow run produces from an explicit \`develop-v2\` checkout (#1146)."
+fi
 printf '%s\n' "Also NOT checked: whether each image pin's digest still corresponds to its tag. The digest is what actually runs, so a half-done bump is invisible to the table above."
 if [ "$failed" -gt 0 ]; then
     printf '\n%s\n' "**$failed lookup(s) could not run — those rows are unchecked, not current.**"


### PR DESCRIPTION
Carries #1159 (PR #1160) and #1146 (PR #1161) to the appliance lane, plus the appliance's own half of
#1159 as a separate commit on top.

Two commits, deliberately not one: the merge is a **pure sync** and carries nothing of its own, so
`git diff develop-v2..HEAD^` is exactly `develop`'s two changes. The appliance-only edit is its own
reviewable commit rather than hidden inside the merge.

## The conflict, and how it was resolved

One file conflicted — `scripts/pin-watch.sh`, two hunks — and it conflicted **by design**. `develop-v2`
had already split the report's final conditional into an `if/else` to carry a real warning: a
compose/cosign bump is two ARGs, and moving the version without its paired `_COMMIT` silently builds
the old code. #1161 deliberately adopted that same `if/else` shape on `develop` rather than rewriting
it, so `develop`'s file is now a strict **superset** and both hunks resolve the same way.

Resolved hunk by hunk, not with `--ours`/`--theirs` on the file, then asserted:

```
develop-v2's _COMMIT warning survives                      OK (1)
the lane variable survives                                 OK (1)
corrected else-arm text present                            OK (1)
old false sentence GONE                                    OK (0)
both if-arms present (components block + report block)     OK (2)
```

and then the check that proves the superset claim rather than assuming it:

```
$ git show origin/develop:scripts/pin-watch.sh > /tmp/dev-pw.sh
$ diff -q /tmp/dev-pw.sh scripts/pin-watch.sh
  (identical)
```

## The appliance half of #1159

`os-rootfs.yml` is the repo's **second** `trivy-action` call site; #1160 only fixed `ci.yml`. Same
defect: the action keys its vulnerability database on the calendar day, Actions caches are immutable
and scoped per ref, so the first run of the day on a branch froze that branch's database until
midnight.

This is the lane where a stale answer costs most — the appliance's Debian userland is baked and has
no apt at runtime, so this scan is the only eye on podman, netavark, openssl and the kernel between
releases.

**And that eye is shut for a different reason, tracked as #1162:** this workflow's weekly sweep has
never fired once, because a `schedule:` runs from the default branch and this file exists only on
`develop-v2`. 96 runs, all `pull_request`. This PR makes the scan honest when it runs; #1162 is what
makes it run.

## What was run

**On this merged tree, not on `develop`:**

- `bash scripts/pin-watch.sh` — the **appliance arm** fires here, because this branch actually has
  `os/rootfs/Dockerfile`. First line reads `Upstream currency for the product stack and the appliance
  rootfs`, and the `_COMMIT` warning prints. That is the assertion that the conflict resolution did
  not quietly drop it.
- `bash scripts/pin-watch.sh --self-test` — 7 ok.
- `make lint-sh` rc=0 (~4 min on this tree), `uvx yamllint` clean on both changed workflows,
  `uvx zizmor@1.25.2 --offline .github/workflows/` no findings.
- Content assertions on the merged tree rather than on the merge succeeding: `.trivyignore` keeps the
  appliance-only `CVE-2026-34040` and still carries exactly 8 active ids, `os/rootfs/Dockerfile` is
  intact, both workflows carry `cache: "false"`.
- `git rev-list --count HEAD..origin/develop` → **0**: twins level once this lands.

## What was NOT run

- **No bench evidence, and none is owed** — nothing here touches `os/` runtime behaviour; the change
  under `os/` is `.github/workflows/os-rootfs.yml`, which is CI configuration.
- **The appliance scan has not been observed downloading a fresh database.** `ci.yml`'s equivalent was
  verified that way on #1160 (`[vulndb] Need to update DB`, 108.49 MiB in 3.3s), and this is the
  identical input on the identical pinned action — but it is inference here, not observation. The
  `OS rootfs scan` job on this PR is the first execution; its log is the evidence.
- **No test.** `docs/dev/testing-strategy.md` fixes four tiers and none covers `.github/workflows`;
  `zizmor` is the only lint over them and it does not check inputs. The load-bearing comments are the
  guard, and they say so.
