### PR TITLE
fix(ci): give the appliance rootfs CVE sweep a schedule that can actually fire (#1162)

### DIFF
--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -1,0 +1,104 @@
+name: OS rootfs scan
+
+# Build the appliance rootfs (os/rootfs/Dockerfile) and Trivy-scan it (#833). The appliance's
+# Debian userland — podman, netavark, openssl, the kernel — is frozen at bake time and has no
+# apt at runtime, so this scan is the eye on the base OS between releases. Runs on PRs that
+# touch os/ and weekly on a schedule; a red scheduled run in the Actions tab is the alert, the
+# lychee.yml posture. It is its own workflow (not a build-images matrix entry in ci.yml)
+# because the xmrig prebuild makes this the slowest image in the repo — the paths filter keeps
+# it off stack-only PRs.
+#
+# THIS FILE LIVES ON THE DEFAULT BRANCH (`develop`) AND MUST STAY THERE, even though everything it
+# scans is on `develop-v2` (#1162). GitHub fires `schedule:` from the default branch only, so while
+# this file was develop-v2-only its weekly sweep never ran once — 96 runs over 18 days, every one a
+# `pull_request`. Living on `develop` is only half of it: a job on `develop` still checks out
+# `develop`, which has no os/, so the checkout below names the appliance branch explicitly for every
+# trigger that is not a PR. Do not "fix" the asymmetry by moving the file back — the rule and the
+# one-command check for it are in CONTRIBUTING.md § The two lanes.
+on:
+  pull_request:
+    paths:
+      - "os/**"
+      - ".github/workflows/os-rootfs.yml"
+      - ".trivyignore"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC, after ci.yml's 05:00 image sweep
+  workflow_dispatch:
+
+# Least privilege (#282): read-only, same as ci.yml.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  rootfs-image:
+    name: Build + scan the appliance rootfs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A PR run scans the PR (the empty string is checkout's default: the triggering ref).
+          # Everything else — the weekly sweep and any manual dispatch — is asking about the
+          # appliance, which lives on develop-v2 whichever branch the trigger fired from. Naming it
+          # here is what makes the sweep real rather than a green skip (#1162). It also means a
+          # dispatch is a true rehearsal of the schedule instead of a different code path.
+          # Written negated on purpose: in an Actions expression `A && B || C` is not a
+          # ternary, it is real boolean logic, and '' is FALSY. `event == 'pull_request' && ''`
+          # would collapse to '' and fall through to 'develop-v2', so every PR would scan
+          # develop-v2 instead of the PR. The truthy value has to be the develop-v2 arm.
+          ref: ${{ github.event_name != 'pull_request' && 'develop-v2' || '' }}
+          persist-credentials: false
+      - name: Check the appliance tree exists
+        # Only a PR may legitimately miss the tree: a PR into `develop` can reach this workflow
+        # through the .trivyignore path filter, and `develop` has no os/. Every other trigger has
+        # just checked out develop-v2 by name, so a miss there means the checkout did not do what
+        # it was asked — and a quiet skip would report a green weekly sweep of nothing, which is
+        # the exact failure #1162 was filed for. Fail instead.
+        id: tree
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ -f os/rootfs/Dockerfile ]; then
+            echo "present=true" >>"$GITHUB_OUTPUT"
+          elif [ "$EVENT" = "pull_request" ]; then
+            echo "present=false" >>"$GITHUB_OUTPUT"
+            echo "os/rootfs/Dockerfile not on this branch; nothing to scan"
+            echo "The appliance rootfs was NOT scanned: os/rootfs/Dockerfile is not on this PR's branch." \
+              >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::checked out develop-v2 but os/rootfs/Dockerfile is missing — the appliance checkout did not do what it was asked, so this run cannot report a scan it did not do"
+            exit 1
+          fi
+      - name: docker build os/rootfs
+        if: steps.tree.outputs.present == 'true'
+        # BUILD_COMMIT is a build artifact (os/build-image.sh stamps it; the Dockerfile COPYs
+        # it), so stamp it here too. PITHEAD_UPDATER=rauc matches build-image.sh's default so
+        # the scan covers the updater packages; the test args stay empty — release variant.
+        # images/ holds only .keep here: the staged wizard image is a separate scan target
+        # (ci.yml builds and scans the dashboard image directly).
+        run: |
+          git rev-parse HEAD > os/rootfs/BUILD_COMMIT
+          docker build -f os/rootfs/Dockerfile -t pithead-os-rootfs:ci \
+            --build-arg PITHEAD_UPDATER=rauc .
+      - name: Scan rootfs for CVEs (Trivy)
+        if: steps.tree.outputs.present == 'true'
+        # Same gate as ci.yml's image scan: actionable (fixable) HIGH/CRITICAL only; accepted
+        # findings live in .trivyignore with a rationale and how they clear.
+        #
+        # cache: false for the reason spelled out over ci.yml's scan (#1159) — this is the repo's
+        # other trivy call site. It matters more here: the appliance's Debian userland is baked and
+        # has no apt at runtime, so this scan is the only eye on podman, netavark, openssl and the
+        # kernel between releases, and since #1162 that eye is finally open on a schedule.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: pithead-os-rootfs:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+          cache: "false"

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -17,6 +17,16 @@ name: OS rootfs scan
 # one-command check for it are in CONTRIBUTING.md § The two lanes.
 on:
   pull_request:
+    # A PR whose BASE has no os/ cannot be scanned, and a green check named "Build + scan the
+    # appliance rootfs" that scanned nothing is the same lie in a smaller font. `.trivyignore` is in
+    # the paths filter below and lives on both lanes, so without this a PR editing it on `develop` —
+    # #1156 added four mutes that way — would report the appliance clean under a mute it never
+    # applied. Excluding the two os/-less long-lived branches keeps the filter honest while leaving
+    # stacked appliance branches covered. The appliance-side sync PR is what scans a `.trivyignore`
+    # change for real.
+    branches-ignore:
+      - "develop"
+      - "main"
     paths:
       - "os/**"
       - ".github/workflows/os-rootfs.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,9 @@ appliance branch explicitly when it needs the appliance tree.** GitHub fires a w
 `schedule:` trigger from the default branch only, and Dependabot reads `.github/dependabot.yml`
 from the default branch only. A scheduled workflow or a Dependabot entry that lives on
 `develop-v2` never runs — and a job that never runs looks exactly like a job that ran and found
-nothing, which is why this went unnoticed four times (#1048, #1146, #1162, #1163).
+nothing, which is why this went unnoticed three times (#1146, #1162, #1163). #1048 is its sibling
+and worth knowing next to it: there the schedule did fire, and the job skipped itself behind an
+unset repository variable, so `main` showed green for a gate that had never run.
 
 Living on `develop` is only half of it. A workflow on `develop` still checks out `develop`, which
 has no `os/`, so the appliance lane is reached by an explicit ref
@@ -100,8 +102,16 @@ gh run list --workflow=<name>.yml --limit 200 --json event \
   --jq '[.[].event] | group_by(.) | map({event: .[0], n: length})'
 ```
 
-No `schedule` key in that breakdown means the schedule has never fired. The Dependabot equivalent
-is to group its PRs by `baseRefName`.
+No `schedule` key in that breakdown means the schedule has never fired. A `schedule` key is
+necessary but not sufficient — #1048's shape passes that test — so open the newest scheduled run and
+check its steps actually ran rather than skipping:
+
+```bash
+gh run view <run-id> --json jobs \
+  --jq '.jobs[].steps[] | "\(.conclusion)  \(.name)"'
+```
+
+The Dependabot equivalent of the first check is to group its PRs by `baseRefName`.
 
 ## Opening a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,35 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
    user-facing change. To see what the suites cover, `make test-inventory` writes a
    generated (git-ignored) inventory you can read locally.
 
+### The two lanes, and what that means for CI config
+
+The stack ships two ways from one repo. `develop` is the integration branch for the Docker Compose
+product and is the repo's **default branch**. `develop-v2` is its twin: everything on `develop`,
+plus the appliance OS tree under `os/`. Appliance work targets `develop-v2`; everything else
+targets `develop`, and `develop` is merged into `develop-v2` to keep the twins level.
+
+**Automation that GitHub reads from a fixed location must live on `develop`, and must name the
+appliance branch explicitly when it needs the appliance tree.** GitHub fires a workflow's
+`schedule:` trigger from the default branch only, and Dependabot reads `.github/dependabot.yml`
+from the default branch only. A scheduled workflow or a Dependabot entry that lives on
+`develop-v2` never runs — and a job that never runs looks exactly like a job that ran and found
+nothing, which is why this went unnoticed four times (#1048, #1146, #1162, #1163).
+
+Living on `develop` is only half of it. A workflow on `develop` still checks out `develop`, which
+has no `os/`, so the appliance lane is reached by an explicit ref
+(`.github/workflows/os-rootfs.yml`) or by `target-branch:` (`.github/dependabot.yml`). Both files
+carry a comment saying why they are deliberately asymmetric; do not "tidy" either onto `develop-v2`.
+
+Check this from run history, never from the file — the file always looks fine:
+
+```bash
+gh run list --workflow=<name>.yml --limit 200 --json event \
+  --jq '[.[].event] | group_by(.) | map({event: .[0], n: length})'
+```
+
+No `schedule` key in that breakdown means the schedule has never fired. The Dependabot equivalent
+is to group its PRs by `baseRefName`.
+
 ## Opening a pull request
 
 - Target the `develop` branch and fill out the PR template.


### PR DESCRIPTION
Closes #1162.

`os-rootfs.yml` declares a weekly CVE sweep over the appliance rootfs and has never run one. GitHub
fires `schedule:` from the default branch only, and this file existed on `develop-v2` alone — the
one workflow that was not on both branches. 96 runs since 2026-08-02, every one a `pull_request`.

The appliance's Debian userland has no apt at runtime, so this scan is the only eye on podman,
netavark, openssl and the kernel between releases. It has been shut the whole time, and looked
exactly like a sweep that ran and found nothing.

## Why moving the file is only half the fix

Copying it to `develop` unchanged makes it worse. `develop` has no `os/`, so `present=false`, both
real steps skip on their `if:`, and the job reports **green every Monday for ever** — a scheduled
false GREEN instead of a schedule that never fires. That is #1048 again.

So two things change alongside the move:

- **The checkout names the tree it is scanning.** A PR scans the PR; `schedule` and
  `workflow_dispatch` scan `develop-v2` by name. A dispatch is therefore a genuine rehearsal of the
  schedule rather than a different code path, which is what makes the verification below worth
  anything.
- **The tree guard stops being the thing that decides whether the sweep happens.** A missing tree is
  legitimate only on a PR (a PR into `develop` can still reach this workflow through the
  `.trivyignore` path filter). Anywhere else it means the explicit checkout did not do what it was
  asked, so the run fails instead of reporting a scan it did not do.

### The expression is written negated on purpose

```yaml
ref: ${{ github.event_name != 'pull_request' && 'develop-v2' || '' }}
```

`A && B || C` in an Actions expression is boolean logic, not a ternary, and the empty string is
**falsy**. The natural-reading form — `github.event_name == 'pull_request' && '' || 'develop-v2'` —
collapses to `''` on the true branch and falls straight through to `'develop-v2'`, so **every PR
would scan `develop-v2` instead of the PR**. The truthy value has to be the `develop-v2` arm. I
wrote it the wrong way round first; it is called out in a comment so the next person does not
"simplify" it back.

## What was actually RUN

- **The guard's five states, driven out-of-tree.** The driver extracts the `run:` block verbatim
  from the YAML (`yaml.safe_load` → the `tree` step), so it cannot drift from the file:

  | EVENT | `os/rootfs/Dockerfile` | rc | output |
  |---|---|---|---|
  | `schedule` | present | 0 | `present=true` |
  | `pull_request` | present | 0 | `present=true` |
  | `pull_request` | absent | 0 | `present=false` + a step-summary line saying it was NOT scanned |
  | `schedule` | absent | **1** | `::error::` |
  | `workflow_dispatch` | absent | **1** | `::error::` |

- **The mutation that proves the driver can fail.** Respelling `elif [ "$EVENT" = "pull_request" ]`
  to `elif true` — the pre-#1162 always-skip — flips the `schedule`+absent state from rc=1 to rc=0
  and brings `present=false` back. The driver sees it.
- **`zizmor 1.25.2 --offline .github/workflows/`** — no findings (7 suppressed, pre-existing).
- **`make lint-yaml lint-md lint-docs-voice`** — pass. The new file is in yamllint's list.
- **The `ref: ""` precedent, checked rather than assumed.** `pin-watch.yml`'s product lane ships
  `ref: ""` and its dispatch on 2026-08-21 produced a correct report, so an empty `ref` really is
  checkout's default here.

## What was NOT run, and what still owes evidence

- **The workflow itself.** Expression evaluation and the paths filter can only be proven by a real
  run. The verification is a `workflow_dispatch` on `develop` after merge, and I will read the log
  for `docker build os/rootfs` actually executing — **a green run is not evidence here**, which is
  the whole point of the issue.
- **This PR's own check cannot scan anything.** It is a PR into `develop`, `develop` has no `os/`,
  so the job takes the skip path by design. That is the change behaving correctly, not evidence for
  it. The skip now writes to the step summary so a green check that scanned nothing says so.
- **No test tier covers `.github/workflows`.** `docs/dev/testing-strategy.md` fixes four tiers and
  none of them covers CI config; `zizmor` is the only lint over these files and it does not check
  step inputs. The comments plus the out-of-tree driver above are the only guards. I did not invent
  a fifth tier.
- **The twin sync is owed.** `develop-v2` still carries the old copy of this file. The sync PR has
  to resolve that add/add to develop's version byte-for-byte, and I will check the merged tree's
  contents rather than trusting a clean merge.

## Attacks that did not land

- *Does a PR into `develop-v2` now scan `develop-v2`'s tip instead of the PR?* No — `pull_request`
  takes the `''` arm.
- *Does the scheduled run read the wrong `.trivyignore`?* No — `trivyignores: .trivyignore` resolves
  inside the checked-out tree, which is `develop-v2`'s, so the appliance-only `CVE-2026-34040` mute
  applies where it should.
- *Does `git rev-parse HEAD > os/rootfs/BUILD_COMMIT` stamp the wrong commit?* No — after the
  explicit checkout, HEAD is `develop-v2`'s tip, which is the tree being built.
- *Does `concurrency` let a dispatch cancel a running sweep?* No — `cancel-in-progress` is true only
  for `pull_request`; a dispatch queues behind it.
- *Is `contents: read` enough to check out another branch?* Yes, same repo.

## Also in this PR

A `CONTRIBUTING.md` section writing the rule down once. Four gates in one week were blind for this
one structural reason (#1048, #1146, #1162, #1163) and each was found separately. The branch model
already lives in that section — `docs/dev/releasing.md` points at it as the authority — and it did
not mention `develop-v2` at all. It now names the two lanes, states the rule, and gives the command
that proves it from run history rather than from the file, because the file always looks fine.
