### PR TITLE
fix(ci): point Dependabot at the appliance rootfs base images (#1163)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,30 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+  # The appliance rootfs base images (#833, #1163). Deliberately asymmetric, and it has to be:
+  # Dependabot reads this file from the DEFAULT branch only, so the entry lives here on `develop`,
+  # while the path it names exists only on `develop-v2`. `target-branch` is the mechanism for
+  # exactly that — Dependabot resolves `directory` against it and opens the PR there. Anyone
+  # applying "the twins are level" mechanically will read this as wrong; moving it to develop-v2
+  # is what makes it stop running, which is how it went unnoticed (CONTRIBUTING.md § The two lanes).
+  #
+  # The stakes here are higher than for build/* above: the appliance's Debian userland has no apt
+  # at runtime, so a base digest bump plus a rebake IS its patch channel. There is no other way for
+  # a fixed openssl or kernel package to reach a flashed box between releases.
+  - package-ecosystem: "docker"
+    directory: "/os/rootfs"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-appliance:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the docker entry above: digest + patch within the pinned tag. A trixie ->
+      # forky move or a golang minor is a deliberate rebake, not a security update.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
   # Third-party image digests pinned directly in docker-compose.yml (Tari node + wallet,
   # docker-socket-proxy, caddy) — outside build/*, so the `docker` entry above never sees them,
   # and they feed both channels: pulled on the DIY stack, baked into the appliance image (#833).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,8 +67,12 @@ updates:
       docker-appliance:
         patterns: ["*"]
     ignore:
-      # Same policy as the docker entry above: digest + patch within the pinned tag. A trixie ->
-      # forky move or a golang minor is a deliberate rebake, not a security update.
+      # Same policy as the docker entry above, and it binds the golang builder tag: a 1.26 -> 1.27
+      # move is a deliberate rebake, not a security update. It does NOT constrain
+      # `debian:trixie-slim` — a single-segment codename tag yields no semver comparison for these
+      # conditions to act on, so what holds the appliance to trixie is the tag written into the
+      # FROM line, not this block. Digest-only bumps, which are the whole point here, carry no
+      # semver change and so pass both entries untouched (see PRs #729 and #1116).
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 


### PR DESCRIPTION
Refs #1163. **Deliberately not closing the issue on merge** — see "What still owes evidence".

Dependabot reads `.github/dependabot.yml` from the **default branch only**. The `/os/rootfs` entry
exists on `develop-v2` alone, so it has never produced anything: 25 dependabot PRs ever, all based
on `develop`, none touching `os/rootfs`.

That matters more than a missed bump. The appliance's Debian userland has no apt at runtime, so a
base digest bump plus a rebake **is** its patch channel — there is no other route for a fixed
openssl or kernel package to reach a flashed box between releases. The config's own comment names
`os-rootfs.yml`'s scan as the compensating control; #1162 shows that sweep has never fired either.
The appliance base image has had two watchers and neither has ever run once.

## The fix

`target-branch` is the mechanism GitHub provides for exactly this shape: the entry lives on the
default branch where Dependabot will read it, and names `develop-v2`, against which it resolves the
directory and opens its PRs. It carries a comment saying why it is deliberately asymmetric, so it
does not get "tidied" onto `develop-v2` and quietly stop working — which is precisely how the
current entry ended up doing nothing.

## What was actually RUN

- **`make lint-yaml`** (yamllint) — pass.
- **The ignore block does not suppress what this entry is for.** The `ignore` on
  `version-update:semver-major`/`minor` mirrors the sibling `docker` entry, and the obvious worry is
  that it also filters out the digest-only bumps that are the whole point. It does not: dependabot
  PR #1116 was literally "bump caddy from 2.11.4 to 2.11.4" — a digest-only move — produced under an
  entry carrying the identical ignore block. Checked against a real merged PR rather than the docs.
- **The directory really is where the entry says.** `os/rootfs/Dockerfile` exists on `develop-v2`
  and is named `Dockerfile` (not `Containerfile`) specifically so Dependabot's docker ecosystem
  reads it — dependabot-core#6067. Its two pinned bases are `golang:1.26.6-trixie@sha256:…` (the
  gobuild stage) and `debian:trixie-slim@sha256:…` (the appliance).

## What still owes evidence — why this does not close #1163

**A green run proves nothing here; the config parses either way.** The evidence the issue asks for
is a Dependabot PR actually appearing against `develop-v2`, or a real "last checked" entry for the
`/os/rootfs` directory. Neither exists yet, and the weekly interval means it may not for several
days. Until one of those exists this is unfixed, so the issue stays open with a comment recording
what landed.

This is the same discipline the sibling issue demanded: #1162's fix is not proven by merging it
either, only by reading a real run's log.

## Owed follow-up, landing with the twin sync

`develop-v2` still carries `/os/rootfs` in its own `directories:` list. That entry cannot run and
never could, but leaving both means one place that works and one that cannot. Dropping it belongs to
the sync commit, not here — editing the same region on both lanes at once is what turns a clean twin
sync into a conflict where either naive resolution destroys something real.

The rule this issue and #1162 share is now written down once, in `CONTRIBUTING.md` § The two lanes
(landing in #1166).
