### PR TITLE
chore(os): bump the appliance docker-compose pin to v5.5.0 (#1165)

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -18,11 +18,11 @@
 # Both projects publish release binaries built on whatever Go toolchain they happened to use, and
 # that toolchain's stdlib CVEs become ours — baked into a read-only appliance image that cannot be
 # patched in place. In August 2026 that was nine fixable HIGH findings the scan gated on, and no
-# pin bump could clear them: cosign v3.1.3 (the newest release) ships built with go1.26.4, the
-# same toolchain as v3.1.2, and docker-compose v5.4.0 ships go1.26.5 — both below the go1.26.6
-# that carries the fixes. Verified by reading the build stamps out of the published binaries, not
-# from release notes. Waiting for upstream to rebuild is not a schedule we control, so we compile
-# them ourselves on a patched toolchain and the findings go away at the source.
+# pin bump could clear them: cosign v3.1.3 (the newest release) ships built with go1.26.4, the same
+# toolchain as v3.1.2, and docker-compose v5.4.0 (the pin then) shipped go1.26.5 — both below the
+# go1.26.6 that carries the fixes. Verified by reading the build stamps out of the published
+# binaries, not from release notes. Waiting for upstream to rebuild is not a schedule we control,
+# so we compile them ourselves on a patched toolchain and the findings go away at the source.
 #
 # Provenance is not weakened by this, it moves: the old pin was a sha256 of a downloaded binary,
 # this one is an exact upstream COMMIT (never a tag — a tag can be re-pointed, the same reason
@@ -35,8 +35,8 @@
 # claimed otherwise would be lying about the provenance this paragraph exists to describe.
 FROM golang:1.26.6-trixie@sha256:b75d466dd608587fd66cca705a307ba65b889827d06ad61d6a75f0482b51b7c7 AS gobuild
 
-ARG COMPOSE_VERSION=v5.4.0
-ARG COMPOSE_COMMIT=ef61d7410a0c816a71705026e638ec256a591d69
+ARG COMPOSE_VERSION=v5.5.0
+ARG COMPOSE_COMMIT=870908cc8f07f5e90acdf5d34dd1b96a4fe51d16
 ARG COSIGN_VERSION=v3.1.3
 ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
 # Modules raised above what each project's own go.sum asks for, because upstream has not cut a

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -69,8 +69,18 @@ ARG COSIGN_GO_RAISES="golang.org/x/mod@v0.40.0 google.golang.org/grpc@v1.82.1"
 ENV CGO_ENABLED=0
 
 # Blobless clone then detach to the commit: the tag is only a convenience for the version string.
+#
+# The `describe --exact-match` line is what makes the pin a PAIR rather than two values that happen
+# to sit next to each other. `${COMPOSE_VERSION}` is only an ldflag, `${COMPOSE_COMMIT}` is what is
+# actually built, so bumping the version alone rebuilds the OLD code and stamps the NEW version on
+# it — and every downstream check agrees it worked: the build succeeds, `docker-compose version`
+# prints the new number, and scripts/pin-watch.sh reads the VERSION ARG and reports the component
+# current for ever. Nothing else in the tree reads `${COMPOSE_COMMIT}` at all. The clone is blobless
+# but not shallow, so the tag objects are present and this costs nothing.
 RUN git clone --filter=blob:none --no-checkout https://github.com/docker/compose /src/compose \
     && git -C /src/compose checkout --detach "${COMPOSE_COMMIT}" \
+    && { [ "$(git -C /src/compose describe --tags --exact-match "${COMPOSE_COMMIT}")" = "${COMPOSE_VERSION}" ] \
+        || { echo "COMPOSE_COMMIT ${COMPOSE_COMMIT} is not tag ${COMPOSE_VERSION} — a compose bump is TWO ARGs; resolve the pair with: gh api repos/docker/compose/commits/${COMPOSE_VERSION} --jq .sha" >&2; exit 1; }; } \
     && go -C /src/compose get ${COMPOSE_GO_RAISES} \
     && go build -C /src/compose -trimpath -tags e2e \
         -ldflags "-w -X github.com/docker/compose/v5/internal.Version=${COMPOSE_VERSION}" \
@@ -78,6 +88,8 @@ RUN git clone --filter=blob:none --no-checkout https://github.com/docker/compose
 
 RUN git clone --filter=blob:none --no-checkout https://github.com/sigstore/cosign /src/cosign \
     && git -C /src/cosign checkout --detach "${COSIGN_COMMIT}" \
+    && { [ "$(git -C /src/cosign describe --tags --exact-match "${COSIGN_COMMIT}")" = "${COSIGN_VERSION}" ] \
+        || { echo "COSIGN_COMMIT ${COSIGN_COMMIT} is not tag ${COSIGN_VERSION} — a cosign bump is TWO ARGs; resolve the pair with: gh api repos/sigstore/cosign/commits/${COSIGN_VERSION} --jq .sha" >&2; exit 1; }; } \
     && go -C /src/cosign get ${COSIGN_GO_RAISES} \
     && go build -C /src/cosign -trimpath \
         -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=${COSIGN_VERSION} \
@@ -85,10 +97,19 @@ RUN git clone --filter=blob:none --no-checkout https://github.com/sigstore/cosig
             -X sigs.k8s.io/release-utils/version.gitTreeState=dirty" \
         -o /out/cosign ./cmd/cosign
 
-# Fail the build here rather than shipping a binary that cannot run: a wrong build path or a
-# broken ldflag produces a file that exists and does nothing useful, which every later stage
-# would happily copy.
-RUN /out/docker-compose version && /out/cosign version
+# Fail the build here rather than shipping a binary that cannot run: a wrong build path produces a
+# file that exists and does nothing useful, which every later stage would happily copy.
+#
+# The version has to be ASSERTED, not merely printed. `go build -ldflags "-X pkg.Var=value"` for a
+# symbol that no longer exists is silently ignored by the linker — no warning, no non-zero exit — so
+# if upstream renames the variable or the module path gains a /v6, the binary builds, reports its
+# built-in default (`dev`), and passes a bare `version` call. Measured on a mimic module built with
+# these exact flags: renaming the symbol changed the output to `dev` and left the exit code 0. That
+# string is a provenance guarantee this file makes further up, so a run that prints it is not the
+# same as a run that checks it. Printed first so the build log still shows the real output.
+RUN /out/docker-compose version && /out/cosign version \
+    && /out/docker-compose version | grep -qF "${COMPOSE_VERSION}" \
+    && /out/cosign version | grep -qF "${COSIGN_VERSION}"
 
 # ---------------------------------------------------------------------------------------------
 # Pinned by digest (#135) so the debian:trixie-slim tag can't be silently re-pointed. The digest


### PR DESCRIPTION
Refs #1165. **Deliberately does not close it** — that is a standing report issue, and closing it
would make the next weekly run file a duplicate. `pin-watch.yml` dedups by exact title over the
**open** issue list (a search-index dedup files a second issue on the very next run, so it uses
`gh issue list --state open` instead). A closed report is therefore invisible to it. #1144, the
product lane's twin, is open for the same reason. Four of its rows are also still stale; this PR
closes the `compose` row only.

The first automated appliance pin report — produced by the new appliance lane #1146 added to
`pin-watch.sh`, on its first ever execution — found `compose` stale at `v5.4.0` against upstream
`v5.5.0`. That pin is on the appliance's own supply chain and no automated run had ever looked at
it.

## Two ARGs, not one

`COMPOSE_VERSION` is only an ldflag; `COMPOSE_COMMIT` is what is actually built. Moving the version
alone silently rebuilds the old code with a new version string on it — the report prints this
warning itself, and it is why the pin is a pair.

```
v5.5.0 = 870908cc8f07f5e90acdf5d34dd1b96a4fe51d16
```

## The two standing claims about compose, re-derived rather than assumed

Bumping compose moves the whole MVS closure, so the two entries elsewhere in the tree that describe
compose's module graph had to be re-checked against `v5.5.0` itself, not against the report:

- **`COMPOSE_GO_RAISES="golang.org/x/mod@v0.40.0"` is still needed and is still a raise.** `v5.5.0`
  pins `golang.org/x/mod v0.38.0`, same as `v5.4.0`. Had it moved past v0.40.0, `go get` would have
  silently *downgraded* it.
- **`.trivyignore`'s `CVE-2026-34040` block is still accurate.** `v5.5.0` still pins
  `github.com/docker/docker v28.5.2+incompatible`, so its rationale — that Trivy's named fix
  `29.3.1` is a Moby release and not a version of this module — still describes the pinned version.

One thing did move on its own: compose raised `google.golang.org/grpc` from `v1.82.1` to `v1.83.0`
between the two tags. That is upstream's change, not a raise of ours, and it produced no finding.

## What was actually RUN — on real amd64 hardware, with no ignore file

`docker build --target gobuild` on the bench, then the binaries extracted with `docker create` +
`docker cp` and scanned directly.

**The binaries' own build stamps** (`go version -m`), which is the answer to "did the pin actually
move" that a diff cannot give:

```
mod  github.com/docker/compose/v5   v5.5.0+dirty
dep  github.com/docker/docker       v28.5.2+incompatible
dep  golang.org/x/mod               v0.40.0        <- the raise landed
dep  google.golang.org/grpc         v1.83.0
```

`docker-compose version` → `Docker Compose version v5.5.0`. Both binaries `go1.26.6`, the patched
toolchain. The build's own `RUN /out/docker-compose version && /out/cosign version` guard passed.

**Trivy, fixable HIGH/CRITICAL, with NO ignore file at all**, current DB (`Need to update DB`,
108.49 MiB fetched — no day-frozen cache, per #1159):

```
out/cosign          0 findings
out/docker-compose  1 finding
  CVE-2026-34040  github.com/docker/docker  v28.5.2+incompatible -> 29.3.1  [HIGH]
```

Identical to the pre-bump result recorded in `.trivyignore` ("cosign 0 findings, compose 1"), and
the single finding is the one that file already documents as genuinely un-raisable. **The bump
changes nothing about the accepted-findings picture** — which is the thing that had to be proven
before trusting it, not assumed from release notes.

## A trap worth naming

My first attempt scanned the two extracted binaries with `trivy fs`. It exited **0** with an empty
report — `Target: -`, `Type: -`. `trivy fs` does not analyse standalone Go binaries that way, so
"no findings" there meant "nothing was scanned", and reporting it as clean would have been this
repo's signature defect committed by its own reviewer. `trivy image` over the build stage does find
them (`out/docker-compose | gobinary | pkgs=190`), which is where the numbers above come from. An
empty scan and a clean scan look the same in the exit code; only the package count tells them apart.

## What was NOT run

- **The full rootfs image build and scan.** `--target gobuild` covers the Go half only; the Debian
  userland half is unchanged by this diff and is what CI's `os-rootfs.yml` job builds and scans on
  this PR, with `.trivyignore` applied.
- **No appliance boot.** Nothing here touches boot, RAUC or the wizard — it is two ARG values — so
  no KVM battery was run for it.
- **The other four stale pins in #1165 are untouched**: `monero 0.18.5.0 → 0.18.5.1`,
  `p2pool 4.16 → 4.18`, `tari 5.3.1 → 5.6.0` (that one is #1129, and it is a one-way wallet-DB
  migration, not a bump), `socket-proxy 0.4.2 → 0.5.0`. This PR closes the compose row only; the
  issue's remaining rows are reported again by the next weekly run, which is the other reason it
  stays open.
