### PR TITLE
sync: develop -> develop-v2 (#1162 sweep schedule, #1163 dependabot half two)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,30 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
+  # The appliance rootfs base images (#833, #1163). Deliberately asymmetric, and it has to be:
+  # Dependabot reads this file from the DEFAULT branch only, so the entry lives here on `develop`,
+  # while the path it names exists only on `develop-v2`. `target-branch` is the mechanism for
+  # exactly that — Dependabot resolves `directory` against it and opens the PR there. Anyone
+  # applying "the twins are level" mechanically will read this as wrong; moving it to develop-v2
+  # is what makes it stop running, which is how it went unnoticed (CONTRIBUTING.md § The two lanes).
+  #
+  # The stakes here are higher than for build/* above: the appliance's Debian userland has no apt
+  # at runtime, so a base digest bump plus a rebake IS its patch channel. There is no other way for
+  # a fixed openssl or kernel package to reach a flashed box between releases.
+  - package-ecosystem: "docker"
+    directory: "/os/rootfs"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-appliance:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the docker entry above: digest + patch within the pinned tag. A trixie ->
+      # forky move or a golang minor is a deliberate rebake, not a security update.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
   # Third-party image digests pinned directly in docker-compose.yml (Tari node + wallet,
   # docker-socket-proxy, caddy) — outside build/*, so the `docker` entry above never sees them,
   # and they feed both channels: pulled on the DIY stack, baked into the appliance image (#833).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,8 +67,12 @@ updates:
       docker-appliance:
         patterns: ["*"]
     ignore:
-      # Same policy as the docker entry above: digest + patch within the pinned tag. A trixie ->
-      # forky move or a golang minor is a deliberate rebake, not a security update.
+      # Same policy as the docker entry above, and it binds the golang builder tag: a 1.26 -> 1.27
+      # move is a deliberate rebake, not a security update. It does NOT constrain
+      # `debian:trixie-slim` — a single-segment codename tag yields no semver comparison for these
+      # conditions to act on, so what holds the appliance to trixie is the tag written into the
+      # FROM line, not this block. Digest-only bumps, which are the whole point here, carry no
+      # semver change and so pass both entries untouched (see PRs #729 and #1116).
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -1,0 +1,104 @@
+name: OS rootfs scan
+
+# Build the appliance rootfs (os/rootfs/Dockerfile) and Trivy-scan it (#833). The appliance's
+# Debian userland — podman, netavark, openssl, the kernel — is frozen at bake time and has no
+# apt at runtime, so this scan is the eye on the base OS between releases. Runs on PRs that
+# touch os/ and weekly on a schedule; a red scheduled run in the Actions tab is the alert, the
+# lychee.yml posture. It is its own workflow (not a build-images matrix entry in ci.yml)
+# because the xmrig prebuild makes this the slowest image in the repo — the paths filter keeps
+# it off stack-only PRs.
+#
+# THIS FILE LIVES ON THE DEFAULT BRANCH (`develop`) AND MUST STAY THERE, even though everything it
+# scans is on `develop-v2` (#1162). GitHub fires `schedule:` from the default branch only, so while
+# this file was develop-v2-only its weekly sweep never ran once — 96 runs over 18 days, every one a
+# `pull_request`. Living on `develop` is only half of it: a job on `develop` still checks out
+# `develop`, which has no os/, so the checkout below names the appliance branch explicitly for every
+# trigger that is not a PR. Do not "fix" the asymmetry by moving the file back — the rule and the
+# one-command check for it are in CONTRIBUTING.md § The two lanes.
+on:
+  pull_request:
+    paths:
+      - "os/**"
+      - ".github/workflows/os-rootfs.yml"
+      - ".trivyignore"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC, after ci.yml's 05:00 image sweep
+  workflow_dispatch:
+
+# Least privilege (#282): read-only, same as ci.yml.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  rootfs-image:
+    name: Build + scan the appliance rootfs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A PR run scans the PR (the empty string is checkout's default: the triggering ref).
+          # Everything else — the weekly sweep and any manual dispatch — is asking about the
+          # appliance, which lives on develop-v2 whichever branch the trigger fired from. Naming it
+          # here is what makes the sweep real rather than a green skip (#1162). It also means a
+          # dispatch is a true rehearsal of the schedule instead of a different code path.
+          # Written negated on purpose: in an Actions expression `A && B || C` is not a
+          # ternary, it is real boolean logic, and '' is FALSY. `event == 'pull_request' && ''`
+          # would collapse to '' and fall through to 'develop-v2', so every PR would scan
+          # develop-v2 instead of the PR. The truthy value has to be the develop-v2 arm.
+          ref: ${{ github.event_name != 'pull_request' && 'develop-v2' || '' }}
+          persist-credentials: false
+      - name: Check the appliance tree exists
+        # Only a PR may legitimately miss the tree: a PR into `develop` can reach this workflow
+        # through the .trivyignore path filter, and `develop` has no os/. Every other trigger has
+        # just checked out develop-v2 by name, so a miss there means the checkout did not do what
+        # it was asked — and a quiet skip would report a green weekly sweep of nothing, which is
+        # the exact failure #1162 was filed for. Fail instead.
+        id: tree
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ -f os/rootfs/Dockerfile ]; then
+            echo "present=true" >>"$GITHUB_OUTPUT"
+          elif [ "$EVENT" = "pull_request" ]; then
+            echo "present=false" >>"$GITHUB_OUTPUT"
+            echo "os/rootfs/Dockerfile not on this branch; nothing to scan"
+            echo "The appliance rootfs was NOT scanned: os/rootfs/Dockerfile is not on this PR's branch." \
+              >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::checked out develop-v2 but os/rootfs/Dockerfile is missing — the appliance checkout did not do what it was asked, so this run cannot report a scan it did not do"
+            exit 1
+          fi
+      - name: docker build os/rootfs
+        if: steps.tree.outputs.present == 'true'
+        # BUILD_COMMIT is a build artifact (os/build-image.sh stamps it; the Dockerfile COPYs
+        # it), so stamp it here too. PITHEAD_UPDATER=rauc matches build-image.sh's default so
+        # the scan covers the updater packages; the test args stay empty — release variant.
+        # images/ holds only .keep here: the staged wizard image is a separate scan target
+        # (ci.yml builds and scans the dashboard image directly).
+        run: |
+          git rev-parse HEAD > os/rootfs/BUILD_COMMIT
+          docker build -f os/rootfs/Dockerfile -t pithead-os-rootfs:ci \
+            --build-arg PITHEAD_UPDATER=rauc .
+      - name: Scan rootfs for CVEs (Trivy)
+        if: steps.tree.outputs.present == 'true'
+        # Same gate as ci.yml's image scan: actionable (fixable) HIGH/CRITICAL only; accepted
+        # findings live in .trivyignore with a rationale and how they clear.
+        #
+        # cache: false for the reason spelled out over ci.yml's scan (#1159) — this is the repo's
+        # other trivy call site. It matters more here: the appliance's Debian userland is baked and
+        # has no apt at runtime, so this scan is the only eye on podman, netavark, openssl and the
+        # kernel between releases, and since #1162 that eye is finally open on a schedule.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: pithead-os-rootfs:ci
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          trivyignores: .trivyignore
+          cache: "false"

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -17,6 +17,16 @@ name: OS rootfs scan
 # one-command check for it are in CONTRIBUTING.md § The two lanes.
 on:
   pull_request:
+    # A PR whose BASE has no os/ cannot be scanned, and a green check named "Build + scan the
+    # appliance rootfs" that scanned nothing is the same lie in a smaller font. `.trivyignore` is in
+    # the paths filter below and lives on both lanes, so without this a PR editing it on `develop` —
+    # #1156 added four mutes that way — would report the appliance clean under a mute it never
+    # applied. Excluding the two os/-less long-lived branches keeps the filter honest while leaving
+    # stacked appliance branches covered. The appliance-side sync PR is what scans a `.trivyignore`
+    # change for real.
+    branches-ignore:
+      - "develop"
+      - "main"
     paths:
       - "os/**"
       - ".github/workflows/os-rootfs.yml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,9 @@ appliance branch explicitly when it needs the appliance tree.** GitHub fires a w
 `schedule:` trigger from the default branch only, and Dependabot reads `.github/dependabot.yml`
 from the default branch only. A scheduled workflow or a Dependabot entry that lives on
 `develop-v2` never runs — and a job that never runs looks exactly like a job that ran and found
-nothing, which is why this went unnoticed four times (#1048, #1146, #1162, #1163).
+nothing, which is why this went unnoticed three times (#1146, #1162, #1163). #1048 is its sibling
+and worth knowing next to it: there the schedule did fire, and the job skipped itself behind an
+unset repository variable, so `main` showed green for a gate that had never run.
 
 Living on `develop` is only half of it. A workflow on `develop` still checks out `develop`, which
 has no `os/`, so the appliance lane is reached by an explicit ref
@@ -100,8 +102,16 @@ gh run list --workflow=<name>.yml --limit 200 --json event \
   --jq '[.[].event] | group_by(.) | map({event: .[0], n: length})'
 ```
 
-No `schedule` key in that breakdown means the schedule has never fired. The Dependabot equivalent
-is to group its PRs by `baseRefName`.
+No `schedule` key in that breakdown means the schedule has never fired. A `schedule` key is
+necessary but not sufficient — #1048's shape passes that test — so open the newest scheduled run and
+check its steps actually ran rather than skipping:
+
+```bash
+gh run view <run-id> --json jobs \
+  --jq '.jobs[].steps[] | "\(.conclusion)  \(.name)"'
+```
+
+The Dependabot equivalent of the first check is to group its PRs by `baseRefName`.
 
 ## Opening a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,35 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
    user-facing change. To see what the suites cover, `make test-inventory` writes a
    generated (git-ignored) inventory you can read locally.
 
+### The two lanes, and what that means for CI config
+
+The stack ships two ways from one repo. `develop` is the integration branch for the Docker Compose
+product and is the repo's **default branch**. `develop-v2` is its twin: everything on `develop`,
+plus the appliance OS tree under `os/`. Appliance work targets `develop-v2`; everything else
+targets `develop`, and `develop` is merged into `develop-v2` to keep the twins level.
+
+**Automation that GitHub reads from a fixed location must live on `develop`, and must name the
+appliance branch explicitly when it needs the appliance tree.** GitHub fires a workflow's
+`schedule:` trigger from the default branch only, and Dependabot reads `.github/dependabot.yml`
+from the default branch only. A scheduled workflow or a Dependabot entry that lives on
+`develop-v2` never runs — and a job that never runs looks exactly like a job that ran and found
+nothing, which is why this went unnoticed four times (#1048, #1146, #1162, #1163).
+
+Living on `develop` is only half of it. A workflow on `develop` still checks out `develop`, which
+has no `os/`, so the appliance lane is reached by an explicit ref
+(`.github/workflows/os-rootfs.yml`) or by `target-branch:` (`.github/dependabot.yml`). Both files
+carry a comment saying why they are deliberately asymmetric; do not "tidy" either onto `develop-v2`.
+
+Check this from run history, never from the file — the file always looks fine:
+
+```bash
+gh run list --workflow=<name>.yml --limit 200 --json event \
+  --jq '[.[].event] | group_by(.) | map({event: .[0], n: length})'
+```
+
+No `schedule` key in that breakdown means the schedule has never fired. The Dependabot equivalent
+is to group its PRs by `baseRefName`.
+
 ## Opening a pull request
 
 - Target the `develop` branch and fill out the PR template.


### PR DESCRIPTION
Routine twin sync carrying #1166 and #1167, plus #1163's develop-v2 half.

**One conflict, add/add on `.github/workflows/os-rootfs.yml`** — expected: #1162 added on `develop` a file that already existed here. Resolved to develop's version, and the invariant is asserted rather than reported as a clean merge: the resolved file is byte-identical to `origin/develop:.github/workflows/os-rootfs.yml`, 6520 bytes. This file stops being a twin conflict source instead of adding to it.

**What taking develop's side destroys, checked before taking it.** `diff` of the two copies shows exactly three develop-v2-only fragments, and all three are what #1162 replaced — the "skip quietly" comment written for a scheduled run that could never happen, the bare `else` that made it a quiet skip, and the parenthetical saying this eye was also shut. Nothing real is lost.

**#1163's second half.** `/os/rootfs` drops out of this branch's own `directories:` list. That entry could never run — Dependabot reads the config from the default branch only — and it is now duplicated by the `target-branch` entry on `develop` that does. One place does this instead of one that works and one that cannot. The comment above the docker entry said os/rootfs coverage "starts when the appliance tree merges"; that is no longer the plan, so it now says where the coverage actually lives.

## Evidence the two fixes work, on the issues rather than asserted here

- **#1162** — run 32440376681, a dispatch on `develop`: `ref: develop-v2`, then a real five-minute build (`naming to docker.io/library/pithead-os-rootfs:ci`) and a Trivy scan against a freshly fetched DB. It compiled compose at `870908cc` = v5.5.0, which only reached develop-v2 51 seconds earlier, so it demonstrably read the current tree.
- **#1163** — PR #1170, the first Dependabot PR ever opened against `develop-v2`, 16 seconds after the merge. It found a real pending base-image digest.

## Not run

No bench battery: this diff is CI configuration only and touches nothing under `os/` that ends up in an image.