### PR TITLE
fix(release): name both Tari images in the ingredient list, and guard the compose pins (#1138, #1137)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -195,7 +195,14 @@ pin() {
     monero) grep -oE '^ARG MONERO_VERSION=.*' build/monero/Dockerfile | cut -d= -f2 ;;
     xmrig-proxy) grep -oE '^ARG XMRIG_PROXY_VERSION=.*' build/xmrig-proxy/Dockerfile | cut -d= -f2 ;;
     tor-base) grep -oE '^FROM [^ ]+' build/tor/Dockerfile | head -1 | awk '{print $2}' ;;
+    # `tari` is the NODE, deliberately, because scripts/pin-watch.sh reads this arm for upstream
+    # currency and both Tari images come from one upstream repo — a second row there would say the
+    # same thing twice. The stack pins two images though (node + view-only console wallet), they are
+    # bumped together, and the release notes have to name both or a wallet-only move reads as
+    # unchanged (#1138). tests/stack/test_compose.sh asserts the two carry the same tag, so the
+    # lockstep this relies on is guarded rather than assumed.
     tari) grep -oE 'quay.io/tarilabs/minotari_node:[^ ]+' docker-compose.yml | head -1 ;;
+    tari-wallet) grep -oE 'quay.io/tarilabs/minotari_console_wallet:[^ ]+' docker-compose.yml | head -1 ;;
     caddy) grep -oE 'caddy:[0-9.]+@sha256:[a-f0-9]+' docker-compose.yml | head -1 ;;
     socket-proxy) grep -oE 'tecnativa/docker-socket-proxy:[^ ]+' docker-compose.yml | head -1 ;;
     esac
@@ -659,7 +666,8 @@ write_manifest() {
         printf -- '- monerod: `%s`\n' "$(pin monero)"
         printf -- '- xmrig-proxy: `%s`\n' "$(pin xmrig-proxy)"
         printf -- '- tor base: `%s`\n' "$(pin tor-base)"
-        printf -- '- tari: `%s`\n' "$(pin tari)"
+        printf -- '- tari node: `%s`\n' "$(pin tari)"
+        printf -- '- tari console wallet: `%s`\n' "$(pin tari-wallet)"
         printf -- '- caddy: `%s`\n' "$(pin caddy)"
         printf -- '- docker-socket-proxy: `%s`\n' "$(pin socket-proxy)"
     } >"$out"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2235,6 +2235,31 @@ for svc in p2pool monero xmrig-proxy; do
         bad "pin $svc resolves to a value in its Dockerfile" "got '$pv'"
     fi
 done
+# The same drift guard for the pins read out of docker-compose.yml and build/tor, which had none
+# (#1138). pin() emits the EMPTY string when its grep stops matching — a renamed image, a moved tag
+# format — and the release notes then print "- caddy: " with nothing after it. The ingredient list's
+# whole job, silently not done, on the exact surface an operator uses to check what they installed.
+# grep -F, not -E: these values contain '/' and '.', and a regex match would accept a value that is
+# merely similar to one in the file.
+for comp in tari tari-wallet caddy socket-proxy tor-base; do
+    case "$comp" in
+    tor-base) pin_src="$ROOT/build/tor/Dockerfile" ;;
+    *) pin_src="$ROOT/docker-compose.yml" ;;
+    esac
+    # shellcheck disable=SC1090
+    pv="$(
+        cd "$ROOT" || exit
+        set --
+        source "$REL" 2>/dev/null
+        set +eu
+        pin "$comp"
+    )"
+    if [ -n "$pv" ] && grep -qF -- "$pv" "$pin_src"; then
+        ok "pin $comp resolves to a value in $(basename "$pin_src")"
+    else
+        bad "pin $comp resolves to a value in $(basename "$pin_src")" "got '$pv'"
+    fi
+done
 # The top-level VERSION file is the single source of truth (#44); the dashboard's Python package
 # metadata must stay in lockstep so a release can't ship two different "stack versions".
 ver_file="$(tr -d ' \t\r\n' <"$ROOT/VERSION")"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2218,6 +2218,14 @@ man_out="$SANDBOX/manifest.md"
     write_manifest "$man_out"
 ) 2>/dev/null
 assert_contains "manifest renders the leading-dash Version line (printf --)" "$(cat "$man_out" 2>/dev/null)" "- **Version:** 9.9.9"
+# #1138's actual deliverable is that the ingredient list names BOTH Tari images. The drift guard
+# below tests pin(), which is a different function — deleting either printf leaves it green while
+# the notes regress to naming one of the two. Assert the rendered manifest, which is the artefact an
+# operator reads. A twin-sync conflict on release.sh is a realistic way to lose one of these lines.
+assert_contains "manifest names the tari NODE pin (#1138)" "$(cat "$man_out" 2>/dev/null)" \
+    "- tari node: \`quay.io/tarilabs/minotari_node:"
+assert_contains "manifest names the tari CONSOLE WALLET pin (#1138)" "$(cat "$man_out" 2>/dev/null)" \
+    "- tari console wallet: \`quay.io/tarilabs/minotari_console_wallet:"
 # The ingredients manifest's component pins must resolve to a real value present in each Dockerfile —
 # a drift guard so a renamed ARG can't silently emit an empty pin in the release notes.
 for svc in p2pool monero xmrig-proxy; do
@@ -2239,13 +2247,27 @@ done
 # (#1138). pin() emits the EMPTY string when its grep stops matching — a renamed image, a moved tag
 # format — and the release notes then print "- caddy: " with nothing after it. The ingredient list's
 # whole job, silently not done, on the exact surface an operator uses to check what they installed.
-# grep -F, not -E: these values contain '/' and '.', and a regex match would accept a value that is
+#
+# Each row also names the identifier the pin MUST contain, and that half is the one that matters.
+# "is $pv present in the file it came from" is a TAUTOLOGY for every arm here — pin() extracts a
+# substring of that same file, so any non-empty answer is present by construction, and the check
+# would only ever have caught the empty case. It would NOT have caught the mistake this issue is
+# about: an arm that greps a SIBLING's image (a copy-paste slip when adding tari-wallet next to
+# tari, or a later edit "de-duplicating" two near-identical regexes) resolves fine, matches the
+# file, and reports ok while the release notes name the same image twice.
+# grep -F throughout: these values carry '/' and '.', and a regex match would accept a value that is
 # merely similar to one in the file.
-for comp in tari tari-wallet caddy socket-proxy tor-base; do
-    case "$comp" in
-    tor-base) pin_src="$ROOT/build/tor/Dockerfile" ;;
-    *) pin_src="$ROOT/docker-compose.yml" ;;
-    esac
+for row in \
+    "tari|docker-compose.yml|quay.io/tarilabs/minotari_node:" \
+    "tari-wallet|docker-compose.yml|quay.io/tarilabs/minotari_console_wallet:" \
+    "caddy|docker-compose.yml|caddy:" \
+    "socket-proxy|docker-compose.yml|tecnativa/docker-socket-proxy:" \
+    "tor-base|build/tor/Dockerfile|:"; do
+    comp="${row%%|*}"
+    rest="${row#*|}"
+    pin_rel="${rest%%|*}"
+    pin_want="${rest#*|}"
+    pin_src="$ROOT/$pin_rel"
     # shellcheck disable=SC1090
     pv="$(
         cd "$ROOT" || exit
@@ -2254,10 +2276,14 @@ for comp in tari tari-wallet caddy socket-proxy tor-base; do
         set +eu
         pin "$comp"
     )"
+    pin_ok=0
     if [ -n "$pv" ] && grep -qF -- "$pv" "$pin_src"; then
-        ok "pin $comp resolves to a value in $(basename "$pin_src")"
+        case "$pv" in *"$pin_want"*) pin_ok=1 ;; esac
+    fi
+    if [ "$pin_ok" = 1 ]; then
+        ok "pin $comp resolves to its own image in $pin_rel"
     else
-        bad "pin $comp resolves to a value in $(basename "$pin_src")" "got '$pv'"
+        bad "pin $comp resolves to its own image in $pin_rel" "got '$pv', expected to contain '$pin_want'"
     fi
 done
 # The top-level VERSION file is the single source of truth (#44); the dashboard's Python package

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -133,7 +133,11 @@ expect_min "log rotation on every service" "max-size:" 9
 # matters: move the tag here and in the compose file, leave the digest, and the stack keeps pulling
 # the old image while the file, this test, the release notes and the docs all announce the new
 # version. Spelling the digest out makes the value a reviewable part of the diff at bump time.
-expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476"
+# A COUNT, not a presence check (#1137's residual). This image runs TWICE — docker-proxy and
+# docker-control — and expect_present is a grep -q, so it matches either line: bumping one proxy and
+# leaving the other was green. The two would then run different socket-proxy builds, which is exactly
+# the split the separate-proxy design exists to prevent.
+expect_min "tecnativa socket-proxy pinned by digest (both proxies)" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476" 2
 expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
 expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0"
 


### PR DESCRIPTION
Closes #1138. Advances #1137 (does **not** close it — see the bottom).

Two v1.19.3 items in the same family: the release's ingredient list and the compose pin assertions
both had a blind spot that made a **half-done bump** read as correct.

## #1138 — the ingredient list named one of the two Tari images

`pin tari` grepped `minotari_node` only. The stack pins two — the base node and the view-only
console wallet — and they are bumped together, so a release that moved the wallet read as unchanged
in the notes. #1129 moves both.

**`tari` stays the NODE rather than being renamed to `tari-node`, and that is the interesting part.**
`scripts/pin-watch.sh` reads this same arm through its `tree_pin()` for the weekly currency report.
Renaming it would have made `tree_pin tari` return empty, and the watcher would report
*"could not read the pin from the tree"* and fail its run — a caller the issue does not mention and
that the obvious fix breaks. A new `tari-wallet` arm feeds the notes instead, which now name both.

Watching one image for currency is only safe if the two really do move together, and that is not
assumed: `tests/stack/test_compose.sh` already asserts both Tari images carry the same tag.

## The half of #1138 the issue did not ask for

Only `p2pool`, `monero` and `xmrig-proxy` had a drift guard. The five pins read out of
`docker-compose.yml` and `build/tor` — `tari`, `tari-wallet`, `caddy`, `socket-proxy`, `tor-base` —
had **none**.

`pin()` emits the empty string when its grep stops matching. A renamed image or a changed tag format
and the release notes print `- caddy: ` with nothing after it: the ingredient list's entire job,
silently not done, on the exact surface an operator uses to check what they installed. All five are
guarded now, with `grep -F` so a value merely *similar* to one in the file cannot pass.

## #1137's residual

Parts 1 and 2 of #1137 already landed in PR #1147 — I verified that rather than taking the issue
body at face value, and confirmed by mutation that both landed assertions genuinely go red. **The
issue body is stale.**

One instance of its own defect survived that pass. `tecnativa/docker-socket-proxy` is pinned on
**two** services, `docker-proxy` and `docker-control`, and `expect_present` is a `grep -q` — it
matches either line. Bumping one proxy and leaving the other was green, and the two would then run
different socket-proxy builds, which is precisely the split the separate-proxy design exists to
prevent (one is read-only; the other is the start/stop control path). Now `expect_min … 2`, and the
literal renders exactly twice, so the count is measured rather than hoped for.

## What was actually RUN

**Full tier-1 suite: 1822 passed, 0 failed**, with the five new pin guards green.

**Three mutations, each isolated, all run:**

| mutation | result |
|---|---|
| `tari-wallet` arm's image respelled | **only** `pin tari-wallet` ✗ — other four ✓ |
| `tari` arm's image respelled (the pre-#1138 blind spot) | **only** `pin tari` ✗ — other four ✓ |
| `docker-compose.yml:865` (docker-control) bumped, `:813` left alone | `✗ … expected >= 2, got 1` |

The socket-proxy mutation is the one that matters: **before this change that same edit was green.**

### A mutation that lied first, and what it cost

My first attempt inserted the `# MUTANT` marker mid-line, which commented out the rest of the `case`
arm, broke the whole `case` block, and made **every** pin empty — all five guards went red for a
reason that had nothing to do with the arm under test. A mutation that breaks the file proves nothing
about the assertion. The marker now goes after `;;`, and each run asserts that only the mutated
component's guard flips, with `bash -n` confirming the file still parses. Recorded because a
mutation that is too blunt reads exactly like a mutation that worked.

## What was NOT run

- **No bench work.** This is `scripts/release.sh` and two tier-1 assertion files; nothing here is
  under `os/` and nothing changes what a container runs. The release-cut path this touches is
  exercised by the tier-1 unit tests around `write_manifest` and `pin`, not by a live cut.
- **No live release cut.** The ingredient list's new second line is proven by the drift guard and by
  reading `write_manifest`, not by cutting a release to look at the notes.
- **#1137 stays open.** Part 3 — resolving each pinned tag against its registry — is the registry
  half, and it needs a client with two different token flows (quay.io and Docker Hub).
  `scripts/pin-watch.sh` already states this in the file. That is the only thing that catches a
  tag/digest pair which is self-consistent in the file but wrong against upstream; every pin was
  checked by hand against its registry today and all five are correct.
