### PR TITLE
fix(e2e): prove the live stack's control channel survives a run (#1085, #1067)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -214,7 +214,17 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    harness-rendered creds while the on-disk `.env` kept the real ones: internally consistent, so
    the stack mined and looked healthy for a day while every host-side RPC probe 401ed. A failed
    proof exits non-zero and names the recovery (`docker compose up -d` from the install dir
-   re-bakes everything from disk).
+   re-bakes everything from disk). The same proof asks the restored install's own `doctor` whether
+   the box-global control-runner units still name it
+   ([#1085](https://github.com/p2pool-starter-stack/pithead/issues/1085)): deploying the branch
+   repoints those units at the e2e checkout, and the hardening phase's teardown removes them when it
+   owns them, so a run can end with the live dashboard's config edits and one-click upgrades queueing
+   into a spool nothing watches — enabled, active and silent. The verdict is read from the install's
+   own `pithead`, run from its own directory, because `pithead` works from the directory of the
+   binary you invoke: the branch's copy would compare the units against the e2e checkout and report
+   all-clear on exactly the stranded box. That needs the live install on v1.19.2 or newer, the
+   release whose `doctor` gained the check; an older one is reported as unproven rather than as a
+   pass.
 
 `--mode`: `targeted` (default, lean) validates the dashboard and the sync logic against the
 already-synced node: `check` + `--lifecycle` (one controlled restart exercises the sync gate /

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -173,6 +173,14 @@ SAFETY_ARCHIVE=""
 MINER_CFG_BACKUP=""
 RESTORED=0
 RESTORE_PROOF_FAILED=0
+# Separate from RESTORE_PROOF_FAILED on purpose (#1085). That flag's message is the #971
+# credential-bake incident's, and its remediation — "re-bake from disk: docker compose up -d" —
+# does nothing whatsoever for a systemd unit. A control-channel fault needs its own words.
+CONTROL_PROOF_FAILED=0
+# What the control units looked like BEFORE the restore's converging apply, recorded so the run log
+# says whether THIS run stranded the box. The post-restore verdict cannot answer that: it runs after
+# the apply that repairs it.
+CONTROL_VERDICT_BEFORE=""
 # Where the LIVE stack actually runs from — resolved in preflight (#454). Defaults to CANONICAL_DIR
 # so the EXIT trap always has a target even if it fires before preflight refines it.
 RESTORE_DIR="$CANONICAL_DIR"
@@ -205,7 +213,7 @@ restore_all() {
             miner_reload
             ok "$MINER_HOST repointed to its original pool(s); backup pruned"
         else
-            warn "FAILED to restore $MINER_HOST config — backup kept at $MINER_CFG_BACKUP"
+            warn "FAILED to restore $MINER_HOST config — the backup should still be at $MINER_CFG_BACKUP, but check: if the connection dropped after the prune, it is already gone and the live config is the restored one."
         fi
     fi
 
@@ -215,6 +223,16 @@ restore_all() {
     #    project locally-built :dev images.
     step "bringing the baseline stack ($RESTORE_DIR) back up"
     on_bench "cd '$E2E_DIR' && ./pithead down >/dev/null 2>&1 || true"
+    # Look at the control units BEFORE the apply below converges them. Without this the run can
+    # never report that it stranded the box — the post-restore proof runs downstream of its own
+    # repair, so on the ordinary #1085 path it is green either way. Observation only: the strand is
+    # expected here, and the restore is what has to put it right.
+    CONTROL_VERDICT_BEFORE="$(control_units_verdict "$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)")"
+    case "$CONTROL_VERDICT_BEFORE" in
+    on-target) step "control units before restore: already pointing at $RESTORE_DIR" ;;
+    stranded) step "control units before restore: STRANDED (expected — the branch deploy repoints them); the apply below must converge them" ;;
+    *) step "control units before restore: $CONTROL_VERDICT_BEFORE" ;;
+    esac
     if on_bench "cd '$RESTORE_DIR' && ./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"; then
         wait_bench_healthy 300 && ok "baseline stack healthy again" || warn "baseline stack came up but isn't reporting healthy yet — check 'pithead status' on $BENCH_HOST"
         # Proof, even when the health wait timed out: a stack running the WRONG creds looks
@@ -231,9 +249,18 @@ restore_all() {
     sync="$(on_bench "curl -fsS --max-time 8 http://127.0.0.1:8000/api/state 2>/dev/null | jq -r '\"\(.sync.monero.state)/\(.sync.tari.state)\"' 2>/dev/null" || true)"
     [ -n "$sync" ] && step "post-restore sync state (monero/tari): $sync"
 
-    if [ "$RESTORE_PROOF_FAILED" = "1" ]; then
-        warn "RESTORE NOT PROVEN: the live stack on $BENCH_HOST did not prove it matches $RESTORE_DIR's on-disk config (see above)."
-        warn "  Re-bake from disk by hand: cd $RESTORE_DIR && docker compose up -d — then verify with a host-side authed get_info."
+    if [ "$CONTROL_PROOF_FAILED" = "1" ]; then
+        warn "CONTROL CHANNEL NOT RESTORED on $BENCH_HOST: the live dashboard's config changes and"
+        warn "  one-click upgrades will queue into a spool nothing reads, with nothing reporting a fault."
+        warn "  This is separate from the credential proof above and needs a different repair — see the lines above."
+        [ "$CONTROL_VERDICT_BEFORE" = "stranded" ] &&
+            warn "  This run DID strand them (verdict before the restore: stranded), and the restore did not put them back."
+    fi
+    if [ "$RESTORE_PROOF_FAILED" = "1" ] || [ "$CONTROL_PROOF_FAILED" = "1" ]; then
+        if [ "$RESTORE_PROOF_FAILED" = "1" ]; then
+            warn "RESTORE NOT PROVEN: the live stack on $BENCH_HOST did not prove it matches $RESTORE_DIR's on-disk config (see above)."
+            warn "  Re-bake from disk by hand: cd $RESTORE_DIR && docker compose up -d — then verify with a host-side authed get_info."
+        fi
         exit 1
     fi
     if [ "$rc" -eq 0 ]; then ok "restore complete."; else warn "restore complete (the run itself failed — see above)."; fi
@@ -333,25 +360,54 @@ PROBE
 
     # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
     #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
+    #
+    #    Note what this check can and cannot see. It runs AFTER restore_all's `apply -y`, and that
+    #    apply converges the units (v1.19.2+), so on the ordinary #1085 path the strand is already
+    #    repaired by the time we look — this arm is a proof that the box was LEFT working, not a
+    #    detector of the strand itself. The strand is caught upstream, by CONTROL_VERDICT_BEFORE
+    #    recorded in restore_all before that apply, and by run.sh's ExecStart assertion. What this
+    #    arm does catch on its own: a pithead too old to converge (no-check), a disabled channel
+    #    where apply leaves stray units alone, and strands this run did not cause.
     local doc verdict_line
     doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
     verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
     case "$(control_units_verdict "$doc")" in
     on-target)
-        ok "restore proof: the control runner units point at $RESTORE_DIR"
+        # The units name the right directory. That is text; `enabled` is behaviour, and
+        # provision_control_runner's `systemctl enable --now` is warn-only, so apply can return 0
+        # with correctly-named units that will never fire.
+        if on_bench "systemctl is-enabled pithead-control.path >/dev/null 2>&1"; then
+            ok "restore proof: the control runner units point at $RESTORE_DIR, and the path unit is enabled"
+        else
+            warn "restore proof: the control units name $RESTORE_DIR but pithead-control.path is NOT enabled — correctly addressed and never fired."
+            warn "  Repair on the box: sudo systemctl enable --now pithead-control.path"
+            CONTROL_PROOF_FAILED=1
+        fi
         ;;
     disabled)
-        warn "restore proof: the control channel is disabled in $RESTORE_DIR's config — no channel to strand."
+        # NOT a pass. `apply` leaves the units alone when control is disabled, so this is the one
+        # state in which a strand SURVIVES the restore. Look for the leftovers directly.
+        if on_bench "grep -qsF 'ExecStart=$E2E_DIR/pithead' /etc/systemd/system/pithead-control.service"; then
+            warn "restore proof: the control channel is disabled in $RESTORE_DIR's config, and the box-global units still name the e2e checkout ($E2E_DIR). A disabled apply does not clean them up."
+            warn "  Repair on the box: sudo rm -f /etc/systemd/system/pithead-control.{path,service} && sudo systemctl daemon-reload"
+            CONTROL_PROOF_FAILED=1
+        else
+            ok "restore proof: control channel disabled in $RESTORE_DIR, and no unit names the e2e checkout"
+        fi
+        ;;
+    not-live)
+        warn "restore proof: $RESTORE_DIR is not the live install by its own reckoning — doctor declined to grade its control channel. Units NOT proven."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
         ;;
     no-check)
-        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. The units were NOT proven; check by hand: systemctl cat pithead-control.service"
-        prc=1
+        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. On a pre-v1.19.2 install the restore's own apply cannot converge the units either, so assume the box IS stranded."
+        warn "  Check by hand: systemctl cat pithead-control.service"
+        CONTROL_PROOF_FAILED=1
         ;;
     *)
         warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
         warn "  doctor said: ${verdict_line:-<no verdict line>}"
-        warn "  Repair on the box: cd $RESTORE_DIR && ./pithead apply -y"
-        prc=1
+        CONTROL_PROOF_FAILED=1
         ;;
     esac
     return "$prc"
@@ -528,12 +584,29 @@ borrow_miner() {
     # the original, every later run restores to it, and the contamination is self-perpetuating with
     # nothing reporting a fault. Observed live on a loaner: 32 backups, 3 distinct contents, and the
     # two most recent already carried a bench pool (#1172-follow-up filed).
-    if [ "$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select(.url | ascii_downcase | contains(\$b))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || echo 0)" != "0" ]; then
-        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST before this run borrowed it."
+    # `.url // ""` and a lowercased needle, because a pool entry with no .url makes `.url |
+    # ascii_downcase` raise and jq exits non-zero for the WHOLE expression — one malformed sibling
+    # entry and the probe reports nothing. And the answer is a three-way, not a boolean: "could not
+    # tell" must not read as "clean". The old spelling ended `2>/dev/null || echo 0`, which failed
+    # open on every error path — a truncated config, a dropped ssh — and those are correlated with
+    # the very fault this probe exists to find: a config left half-written by a run that died before
+    # restoring. A probe that goes quiet exactly when the thing it looks for is present is the
+    # defect class this whole PR is about, one function away from the comment that says so.
+    local bench_pools
+    bench_pools="$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select((.url // \"\") | ascii_downcase | contains(\$b | ascii_downcase))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
+    case "$bench_pools" in
+    "" | *[!0-9]*)
+        warn "could not read $MINER_HOST's pool list to check it is not already borrowed (jq failed, or the config is unreadable/malformed)."
+        warn "  A config left half-written by a run that died before restoring looks exactly like this — do NOT read the silence as clean."
+        ;;
+    0) ;;
+    *)
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools pool(s) before this run borrowed it."
         warn "  Either this rig keeps a permanent bench pool, or a previous e2e did not restore it."
-        warn "  The backup taken next records THAT state as the original, so a later restore returns to it."
+        warn "  The backup taken next records THAT state as the original, so a later restore returns to it (#1178)."
         warn "  Check by hand before trusting a restore: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
-    fi
+        ;;
+    esac
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"
     on_miner "cp -a '$MINER_XMRIG_CONFIG' '$MINER_CFG_BACKUP'" || die "Failed to back up the miner config."
     step "miner config backed up → $MINER_CFG_BACKUP"

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -193,8 +193,17 @@ restore_all() {
     # 1. Miner: put its original pool config back and nudge xmrig to reconnect.
     if [ -n "$MINER_CFG_BACKUP" ]; then
         step "restoring $MINER_HOST xmrig config from $MINER_CFG_BACKUP"
-        if on_miner "cp -a '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG'"; then
-            miner_reload && ok "$MINER_HOST repointed to its original pool(s)" || warn "$MINER_HOST config restored; verify xmrig reconnected"
+        # cmp, then rm (#1067). Every borrowing run minted a timestamped .e2e-orig.<stamp> and
+        # nothing ever removed it, so the loaner accumulated them and recovery became a guess among
+        # candidates where the newest is not necessarily the true pre-borrow state. The backup is
+        # only safe to delete once the bytes are demonstrably back in place, and the proof runs in
+        # the SAME remote call so a dropped ssh cannot land between proving and deleting.
+        # Deliberately NOT gated on miner_reload: that function ends `|| true` and `return 0`, so it
+        # cannot fail — gating on it would delete the backup whatever happened, and it is also why
+        # the `warn` arm it used to guard was unreachable.
+        if on_miner "cp -a '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && cmp -s '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && rm -f '$MINER_CFG_BACKUP'"; then
+            miner_reload
+            ok "$MINER_HOST repointed to its original pool(s); backup pruned"
         else
             warn "FAILED to restore $MINER_HOST config — backup kept at $MINER_CFG_BACKUP"
         fi
@@ -272,7 +281,17 @@ wait_synced() { # <timeout_s>
 #      broke. Only .status is required (sync may still be re-confirming); polled briefly because
 #      the containers were just recreated. The probe script travels over ssh stdin (bash -s), so
 #      the creds stay on the box and the remote command string carries no shell parens.
-# Returns 0 when both hold.
+#   3. The box-global control units still name RESTORE_DIR (#1085). deploy_branch's `pithead
+#      upgrade` repoints them at E2E_DIR, and the hardening phase's teardown deletes them outright
+#      when it owns them — either way the live dashboard's config edits and one-click upgrades
+#      queue into a spool nothing watches, while every other signal here still reads healthy.
+#      The verdict comes from RESTORE_DIR's OWN doctor, run from RESTORE_DIR. That is not a
+#      preference: check_control_units compares the installed units' ExecStart against $PWD, and
+#      `pithead` cd's to the directory of the binary you invoke (SCRIPT_DIR, pithead:100) — so the
+#      BRANCH's copy would compare against E2E_DIR and print the OK verdict on exactly the
+#      stranded box this check exists to catch. It needs RESTORE_DIR on v1.19.2+, the release that
+#      added the check; anything older classifies as no-check and FAILS rather than passing quietly.
+# Returns 0 when all three hold.
 RESTORE_PROOF_VAR="MONERO_NODE_PASSWORD"
 verify_restore_proof() {
     local prc=0 disk cid baked="" verdict
@@ -311,6 +330,30 @@ PROBE
         fi
         sleep 10
     done
+
+    # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
+    #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
+    local doc verdict_line
+    doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
+    verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
+    case "$(control_units_verdict "$doc")" in
+    on-target)
+        ok "restore proof: the control runner units point at $RESTORE_DIR"
+        ;;
+    disabled)
+        warn "restore proof: the control channel is disabled in $RESTORE_DIR's config — no channel to strand."
+        ;;
+    no-check)
+        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. The units were NOT proven; check by hand: systemctl cat pithead-control.service"
+        prc=1
+        ;;
+    *)
+        warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
+        warn "  Repair on the box: cd $RESTORE_DIR && ./pithead apply -y"
+        prc=1
+        ;;
+    esac
     return "$prc"
 }
 
@@ -478,6 +521,19 @@ borrow_miner() {
         return 0
     }
     log "Borrowing $MINER_HOST → pointing it at $BENCH_HOST"
+    # Say so BEFORE the backup is taken, because the backup is what "restore" means afterwards. The
+    # repoint below has an `if any(.pools[]?; .url | contains($b)) then .` arm — written for a rig
+    # that legitimately keeps a bench pool — and that arm also silently absorbs the other case: a
+    # previous run that repointed and never restored. The backup then records the borrowed config as
+    # the original, every later run restores to it, and the contamination is self-perpetuating with
+    # nothing reporting a fault. Observed live on a loaner: 32 backups, 3 distinct contents, and the
+    # two most recent already carried a bench pool (#1172-follow-up filed).
+    if [ "$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select(.url | ascii_downcase | contains(\$b))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || echo 0)" != "0" ]; then
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST before this run borrowed it."
+        warn "  Either this rig keeps a permanent bench pool, or a previous e2e did not restore it."
+        warn "  The backup taken next records THAT state as the original, so a later restore returns to it."
+        warn "  Check by hand before trusting a restore: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
+    fi
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"
     on_miner "cp -a '$MINER_XMRIG_CONFIG' '$MINER_CFG_BACKUP'" || die "Failed to back up the miner config."
     step "miner config backed up → $MINER_CFG_BACKUP"

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -328,6 +328,30 @@ env_bake_verdict() { # <var> <disk-env-lines> <container-env-lines>
     fi
 }
 
+# Restore-proof control-channel verdict (#1085): classify `pithead doctor`'s control-channel section
+# so "the check RAN and the units are on target" reads differently from "the check never ran".
+# Classify the TEXT, never doctor's exit code — it is 1 on ANY failed check, so an unrelated failure
+# would swamp this signal and a 0 would read as "units fine" on a pithead that never looked.
+#   on-target — the units name the install doctor was run from
+#   stranded  — the section is there and says anything else: units naming another directory, no
+#               units at all, a spool nobody writes to, or "this is not the live install"
+#   disabled  — the control channel is off for that install, so there is no channel to strand
+#   no-check  — no section at all: no systemd, or a pithead predating the check (v1.19.2)
+control_units_verdict() { # <doctor-output>
+    case "$1" in
+    *"Dashboard control channel:"*) ;;
+    *)
+        printf 'no-check'
+        return
+        ;;
+    esac
+    case "$1" in
+    *"Control runner units target this install."*) printf 'on-target' ;;
+    *"Disabled for this install"*) printf 'disabled' ;;
+    *) printf 'stranded' ;;
+    esac
+}
+
 # Authoritative "is Monero caught up?" — query monerod's own get_info on the box (creds stay
 # on the box) and trust its `synchronized` flag / target_height 0, exactly like the sync gate.
 # This is the readiness GATE (the source of truth, and it avoids waiting on a dashboard poll cycle).

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -333,9 +333,14 @@ env_bake_verdict() { # <var> <disk-env-lines> <container-env-lines>
 # Classify the TEXT, never doctor's exit code — it is 1 on ANY failed check, so an unrelated failure
 # would swamp this signal and a 0 would read as "units fine" on a pithead that never looked.
 #   on-target — the units name the install doctor was run from
-#   stranded  — the section is there and says anything else: units naming another directory, no
-#               units at all, a spool nobody writes to, or "this is not the live install"
-#   disabled  — the control channel is off for that install, so there is no channel to strand
+#   stranded  — the section is there and reports a fault: units naming another directory, no units
+#               at all, or a spool nobody writes to
+#   disabled  — the control channel is off for that install. NOT a pass on its own: `apply` leaves
+#               the units alone when control is disabled, so a strand SURVIVES the restore in
+#               exactly this state. The caller has to look for leftovers itself.
+#   not-live  — doctor declined to grade: this directory is a superseded version dir and `current`
+#               names another. An explicit "I did not evaluate", graded INFO by doctor and pointing
+#               at where to look. Folding it into `stranded` hard-fails a run with a false claim.
 #   no-check  — no section at all: no systemd, or a pithead predating the check (v1.19.2)
 control_units_verdict() { # <doctor-output>
     case "$1" in
@@ -348,6 +353,7 @@ control_units_verdict() { # <doctor-output>
     case "$1" in
     *"Control runner units target this install."*) printf 'on-target' ;;
     *"Disabled for this install"*) printf 'disabled' ;;
+    *"This is not the live install"*) printf 'not-live' ;;
     *) printf 'stranded' ;;
     esac
 }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1653,6 +1653,15 @@ run_hardening() {
     else
         it_fail "pithead-control.path installed + enabled by apply (#33)" "unit not enabled"
     fi
+    # The unit names are box-global, so on a bench that also hosts a live stack the assertion above
+    # was already true before this phase ran — the LIVE install's units satisfy it, and it stays
+    # green even if our apply installed nothing at all. That is why #1085 went unnoticed for two
+    # releases. Bind it to the ExecStart instead: after our apply the units must name THIS checkout,
+    # in the exact line provision_control_runner writes. Physical path on both sides (pithead cd -P's
+    # to SCRIPT_DIR, rx runs in the checkout), so `current` vs a versioned dir cannot cry wolf.
+    assert_contains "the enabled control units name THIS checkout, not another install (#1085)" \
+        "$(rx "grep -m1 '^ExecStart=' /etc/systemd/system/pithead-control.service 2>/dev/null" || true)" \
+        "ExecStart=$(rx 'pwd -P')/pithead control-run-pending"
 
     local cdir
     cdir="$(env_on_box CONTROL_DIR)"

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -634,6 +634,13 @@ _ccv_off='Dashboard control channel:
   INFO Disabled for this install - the dashboard cannot apply config changes or upgrade.'
 assert_eq "control channel off -> disabled, not a strand" "$(control_units_verdict "$_ccv_off")" "disabled"
 
+# doctor's fourth outcome, and folding it into `stranded` hard-fails a run on a FALSE claim: a
+# superseded version dir whose sibling `current` names another install. doctor grades this INFO and
+# tells you where to look, which is not the same as reporting a fault.
+_ccv_notlive='Dashboard control channel:
+  INFO This is not the live install - /srv/code/current points at /srv/code/pithead-v1.19.3. Run doctor there to check its control channel.'
+assert_eq "superseded version dir -> not-live, not a strand" "$(control_units_verdict "$_ccv_notlive")" "not-live"
+
 # The arm that stops this being another check that cannot fail: a pithead predating the check
 # (< v1.19.2), or a box with no systemd, prints NO control-channel section. Without this arm that
 # output falls through to a pass, and "never looked" reads exactly like "looked and it was fine".

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -606,6 +606,45 @@ case "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" "$_baked_wrong")" in
 *) it_pass "verdict never carries a value" ;;
 esac
 
+echo "== control_units_verdict: the restore proof's control-channel oracle (#1085) =="
+# The #1085 shape: after an e2e the box-global control units name the harness checkout, so the live
+# dashboard writes control requests into a spool nothing watches — enabled, active, and silent.
+# doctor's own words are the oracle, so these fixtures are its literal verdict lines.
+_ccv_ok='Boot persistence:
+  OK   Docker is enabled to start at boot.
+
+Dashboard control channel:
+  OK   Control runner units target this install.
+
+CPU:'
+assert_eq "units on target -> on-target" "$(control_units_verdict "$_ccv_ok")" "on-target"
+
+_ccv_strand='Dashboard control channel:
+  FAIL The control runner units point at /srv/code/pithead-e2e, but this install is /srv/code/pithead-v1.19.2 - the dashboard writes its requests here and nothing reads them.'
+assert_eq "units name the harness checkout -> stranded (the #1085 incident)" \
+    "$(control_units_verdict "$_ccv_strand")" "stranded"
+
+# The QUIETER exit from a run: the teardown reaps the units it owns, and a path unit that does not
+# exist reports nothing at all. It must not classify the same as a healthy box.
+_ccv_gone='Dashboard control channel:
+  FAIL The control channel is enabled but no runner units are installed.'
+assert_eq "teardown deleted the units -> stranded" "$(control_units_verdict "$_ccv_gone")" "stranded"
+
+_ccv_off='Dashboard control channel:
+  INFO Disabled for this install - the dashboard cannot apply config changes or upgrade.'
+assert_eq "control channel off -> disabled, not a strand" "$(control_units_verdict "$_ccv_off")" "disabled"
+
+# The arm that stops this being another check that cannot fail: a pithead predating the check
+# (< v1.19.2), or a box with no systemd, prints NO control-channel section. Without this arm that
+# output falls through to a pass, and "never looked" reads exactly like "looked and it was fine".
+_ccv_old='Boot persistence:
+  OK   Docker is enabled to start at boot.
+
+CPU:
+  OK   8 cores.'
+assert_eq "no control-channel section -> no-check, not a pass" "$(control_units_verdict "$_ccv_old")" "no-check"
+assert_eq "empty doctor output -> no-check" "$(control_units_verdict "")" "no-check"
+
 # --- Tally ------------------------------------------------------------------
 echo ""
 echo "selftest: $IT_PASS passed, $IT_FAIL failed"


### PR DESCRIPTION
Closes #1085. Closes #1067.

Running the e2e leaves the box-global control units pointing at the harness checkout — or deletes
them. Either way the live dashboard's config edits and one-click upgrades queue into a spool nothing
watches: **enabled, active, and silent**, while every other signal in the restore proof still reads
healthy. It stranded the bench during the mandated v1.19.2 pre-cut run and was found only because
someone went looking.

## The design posted on the issue does not work, and it fails as the defect it was written to fix

This is the part worth reading. The three-comment design says to run **the branch's** `pithead
doctor` with cwd set to the live install dir. `pithead` cd's to the directory of the binary you
invoke (`SCRIPT_DIR`, `pithead:100`), so that evaluates `E2E_DIR`, not the live install.

`check_control_units` compares the installed units' `ExecStart` against `$PWD`. And `pithead-e2e`
does **not** match the `^pithead-v[0-9]+\.[0-9]+\.[0-9]+$` regex that would have made doctor bail
out with "this is not the live install". So:

| box state | units name | what the posted design prints |
|---|---|---|
| **stranded** (the incident) | `/srv/code/pithead-e2e` | `✓ OK Control runner units target this install.` |
| correctly restored | `/srv/code/pithead-v1.19.2` | `✗ FAIL` |

**Inverted.** It reports all-clear on exactly the broken box. And the matching repair line —
`cd <live dir> && <e2e checkout>/pithead apply -y` — would have cd'd to `E2E_DIR` and re-installed
the units pointing at the harness: the fix installing the bug on purpose.

## What this does instead

**The verdict comes from `RESTORE_DIR`'s OWN doctor, run from `RESTORE_DIR`.** No cwd trick, no
branch binary, and it also catches strands this run did not cause.

**No repair line, deliberately.** `restore_all`'s existing `cd "$RESTORE_DIR" && ./pithead apply -y`
already converges the units: v1.19.2's `apply` calls `provision_control_runner` *before* its
no-change return, and that is tier-1 asserted — *"a no-change apply still converges the control
units, and recreates nothing"*. So this leans on a guarded behaviour, not an assumed one. The issue
comment's claim that `apply` short-circuits without converging was true of v1.19.1 and is now stale.

**The oracle is a classifier with a `no-check` arm, not a grep.** A `pithead` predating v1.19.2, or
a box with no systemd, prints no control-channel section at all. Without that arm, that output falls
through to a pass and **"never looked" reads exactly like "looked and it was fine"** — which is the
defect family this milestone exists to close. `no-check` fails the proof rather than passing quietly.

Doctor's exit code is never the oracle: it is 1 on any `dr_fail`, so an unrelated failure elsewhere
would swamp this signal.

## Two more members of the family, same function

**#1067 — the miner-config backups were never pruned.** Every borrowing run minted a timestamped
`.e2e-orig.<stamp>` and nothing removed it. Now pruned, but only after `cmp -s` proves the bytes are
back, **in the same remote call** so a dropped ssh cannot land between proving and deleting.
Deliberately *not* gated on `miner_reload`: that function ends `|| true; return 0` and cannot fail —
gating on it would delete the backup whatever happened, and it is also why the `warn` arm it used to
guard was unreachable dead code.

**A third one, found while checking the loaner — and it is live right now.** `borrow_miner` backs up
whatever is there, and its repoint carries `if any(.pools[]?; .url | contains($b)) then .` — an arm
written for a rig that legitimately keeps a bench pool. That arm also silently absorbs *a previous
run that never restored*: the backup then records the **borrowed** config as "the original", every
later run restores to it, and the contamination is self-perpetuating with nothing reporting a fault.

Measured on the loaner, shapes only:

```
32 backups, 3 distinct contents
  content A  n=26  (single pool, no bench)      2026-07-13 … 2026-08-17
  content B  n=4   (two pools, bench present)   2026-07-11 … 2026-08-18   <- the live config today
  content C  n=2                                2026-07-13 … 2026-07-21
```

The **two most recent** backups already carry a bench pool, so "restore from the newest" returns the
rig to a borrowed state. It is currently mining to its normal pool with the bench as a *failover*, so
the harm is small — but the harness put it there and never took it back. It now warns loudly, before
the backup is taken. The deeper fix (tag the injected pool so restore removes exactly what it added)
is filed separately rather than smuggled into this PR.

**The hardening assertion that could not fail.** `tests/integration/run.sh` asserted only that
something called `pithead-control.path` was enabled. The unit names are box-global, so on a bench
that also hosts a live stack that is **already true before the phase runs** — the live install's
units satisfy it, and it stayed green even if our `apply` installed nothing at all. That is why this
went unnoticed for two releases. It is bound to the `ExecStart` now.

## What was actually RUN

- **`tests/integration/selftest.sh`: 207 passed, 0 failed** — six new assertions bound to doctor's
  literal verdict strings. Tier 2, runs in `make test` on every PR, no bench needed.
- **Two mutations, each isolated, both run:**

| mutation | result |
|---|---|
| collapse the `stranded` arm into `on-target` | the two strand assertions ✗, `no-check` arms ✓ |
| delete the `no-check` header guard | the two `no-check` assertions ✗, strand arms ✓ |

  The second is the one that matters: it proves the classifier distinguishes *"doctor never ran the
  check"* from *"doctor ran it and it passed"*.
- **`make lint-sh`, `bash -n`, `make lint-md`, `make lint-docs-voice`** — clean.

## What was NOT run, and what this PR still owes

**The bench e2e itself has not run against this branch yet.** That is the only thing that exercises
`verify_restore_proof`, the new `run.sh` assertion, and the `borrow_miner` warning on real hardware —
nothing in the repo covers `tests/integration/e2e.sh` below tier 3, so `shellcheck` plus a live run is
the whole coverage story for the changed lines. I will post the run's output here, including whether
the `borrow_miner` warning fires on the loaner's current contaminated config, which is the one
prediction this PR makes that a live run can refute.

**The restore-proof arm is not yet mutation-proven on hardware.** Locally the classifier is; the
`e2e.sh` plumbing that feeds it is not. The bench mutation is to strand the units by hand
(`sed` the two unit files at `E2E_DIR`, `daemon-reload`) and confirm the proof goes red and names the
repair — that is repairable with one `apply`, so it is safe to run.
