### PR TITLE
test(tor): sandbox the suite's one host-global fixture path (#1104)

### DIFF
--- a/build/tor/entrypoint.sh
+++ b/build/tor/entrypoint.sh
@@ -9,8 +9,15 @@ set -eu
 # TORRC_TEMPLATE is a test seam so the shell suite can render against build/tor/torrc.template; the
 # container always uses the baked-in default.  # ponytail: default unchanged, only overridden in tests
 : "${TORRC_TEMPLATE:=/etc/tor/torrc.template}"
+# TORRC_OUT is the matching seam for the RENDERED file (#1104). Without it the shell suite's tor
+# stub reads a host-global /tmp/torrc, which is the only unsandboxed path in an ~8000-line suite
+# where every other fixture gets its own mktemp -d — so two concurrent runs race on one file and
+# produce a false RED in the hidden-service assertions, whose natural remedy is "re-run until green".
+# The DEFAULT MUST STAY /tmp/torrc: tier-3 assertions in tests/integration/run.sh read this path
+# inside the running container.  # ponytail: default unchanged, only overridden in tests
+: "${TORRC_OUT:=/tmp/torrc}"
 
-sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
+sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >"$TORRC_OUT"
 
 # Node inbound hidden services (#103): the bundled monerod and Tari containers only start under
 # their compose profiles, so publish each node's onion only then — in remote mode the onion would
@@ -19,7 +26,7 @@ sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
 # Unset (a bare `docker compose` with no .env) means no profiles, so no bundled node and no onion.
 case ",${COMPOSE_PROFILES:-}," in
 *,local_node,*)
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Monero P2P Hidden Service
 HiddenServiceDir /var/lib/tor/monero/
@@ -29,7 +36,7 @@ EOF
 esac
 case ",${COMPOSE_PROFILES:-}," in
 *,local_tari,*)
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Tari Base Node Hidden Service
 HiddenServiceDir /var/lib/tor/tari/
@@ -45,7 +52,7 @@ esac
 # Two ports: 80 (plain HTTP) and 443 (HTTPS, self-signed) — Caddy serves both, so Tor Browser's
 # default http->https upgrade lands on the working :443 instead of a refused connection (#343).
 if [ "${DASHBOARD_ONION_ENABLED:-false}" = "true" ]; then
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Dashboard Hidden Service (#343)
 HiddenServiceDir /var/lib/tor/dashboard/
@@ -54,4 +61,4 @@ HiddenServicePort 443 ${NETWORK_PREFIX}.1:443
 EOF
 fi
 
-exec tor -f /tmp/torrc
+exec tor -f "$TORRC_OUT"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5234,12 +5234,24 @@ TOR_ENTRY="$ROOT/build/tor/entrypoint.sh"
 tor_torrc() { # <DASHBOARD_ONION_ENABLED> [COMPOSE_PROFILES] -> the torrc the entrypoint would hand to `tor -f`
     local d
     d="$(mktemp -d)"
-    printf '#!/bin/sh\ncat /tmp/torrc\n' >"$d/tor" # stub tor: ignore -f, just print the rendered file
+    # The stub cats the SANDBOX path, not /tmp/torrc (#1104). That is what makes the TORRC_OUT seam
+    # load-bearing: if the entrypoint ignored it and wrote the host-global file, this prints nothing
+    # and every assertion below goes red. Catting /tmp/torrc instead would keep passing off a stale
+    # file left by an earlier run — the vacuous version of this check.
+    printf '#!/bin/sh\ncat "%s"\n' "$d/torrc" >"$d/tor" # stub tor: ignore -f, print the rendered file
     chmod +x "$d/tor"
     PATH="$d:$PATH" DASHBOARD_ONION_ENABLED="$1" COMPOSE_PROFILES="${2-local_node,local_tari}" NETWORK_PREFIX=10.9.0 \
-        TORRC_TEMPLATE="$ROOT/build/tor/torrc.template" sh "$TOR_ENTRY"
+        TORRC_TEMPLATE="$ROOT/build/tor/torrc.template" TORRC_OUT="$d/torrc" sh "$TOR_ENTRY"
     rm -rf "$d"
 }
+# The suite's only host-global fixture path, now sandboxed: two concurrent runs used to race on one
+# /tmp/torrc and redden the hidden-service assertions, and the natural remedy for that flake is
+# "re-run until green" — the habit this repo has been removing. The container default is unchanged
+# and MUST stay /tmp/torrc, because tier-3 assertions read that path inside the running container.
+assert_eq "tor entrypoint keeps /tmp/torrc as its container default (#1104)" \
+    "$(grep -c '^: "${TORRC_OUT:=/tmp/torrc}"$' "$TOR_ENTRY")" "1"
+assert_eq "tor entrypoint writes NO bare /tmp/torrc outside that default (#1104)" \
+    "$(grep -vE '^\s*#' "$TOR_ENTRY" | grep -cF '/tmp/torrc')" "1"
 tor_onion_on="$(tor_torrc true)"
 assert_contains "tor entrypoint: dashboard HiddenService appended when enabled (#343)" \
     "$tor_onion_on" "HiddenServiceDir /var/lib/tor/dashboard/"


### PR DESCRIPTION
Closes #1104.

`tests/stack/run.sh` is ~8000 lines and every fixture gets its own `mktemp -d` **except one**: the tor entrypoint renders to `/tmp/torrc` and the suite's stub `tor` cats that same host-global path. Two concurrent runs race on one file and redden the hidden-service assertions — a false RED whose natural remedy is "re-run until green", which is the habit this repo has spent months removing.

`TORRC_OUT` is the seam, alongside the `TORRC_TEMPLATE` seam already there for the input side.

**The container default MUST stay `/tmp/torrc`, and does.** Tier-3 assertions in `tests/integration/run.sh` (:566, :572, :1951) read that path *inside the running container* via `docker exec`, so a seam that moved the default would silently redden three e2e checks. One of the two new assertions exists solely to pin that in place.

## The proof is the stub, not a race test

A concurrency race test would be a flake generator, and an "and `/tmp/torrc` was not written" assertion is **vacuous against a stale file from an earlier run**. So the stub now cats the **sandbox** path: if the entrypoint ignored the seam it prints nothing and every assertion below goes red.

## What was actually RUN

**Full tier-1 suite: 1826 passed, 0 failed.**

**Mutation M5**, run in an isolated clone with a stale host-global `/tmp/torrc` **deliberately planted** first, containing real dashboard hidden-service lines — i.e. the exact condition that makes the naive check vacuous:

```
mutation applied: 5 uses of $TORRC_OUT reverted to the literal /tmp/torrc
  ✓ tor entrypoint keeps /tmp/torrc as its container default
  ✗ tor entrypoint writes NO bare /tmp/torrc outside that default
  ✗ tor entrypoint: dashboard HiddenService appended when enabled (#343)
  ✗ tor entrypoint: onion vhost targets the bridge gateway .1 (#343)
  ✗ tor entrypoint: Monero HS present when local_node is active (#103)
  ✗ tor entrypoint: Tari HS present when local_tari is active (#103)
  ✗ tor entrypoint: P2Pool HS is unconditional (#103)
```

**Under the old stub those first four would have PASSED**, reading the planted stale file. That is the whole point of the mutation.

Note which assertions stay green: every *negative* one ("no dashboard onion when disabled", "no Tari HS with no profiles"). Empty output trivially satisfies an absence check — which is exactly why the positive assertions have to be the oracle here.

## What was NOT run

- **No concurrency test.** Deliberate: proving the seam is honoured is deterministic; proving a race is not.
- **No bench work.** `build/tor/entrypoint.sh` runs in a container, and its behaviour is unchanged — the default resolves to the same path. The tier-3 assertions that read `/tmp/torrc` inside the container are covered by the e2e currently running against `develop` for this milestone, and I will say here if they move.