### PR TITLE
fix(e2e): the Caddyfile scheme assertion reads line 1, which #1123 stopped being the site block

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -793,10 +793,18 @@ assert_running_state() {
         assert_eq "dashboard confirms Tari payout tracking is live (#462/#942)" "$(jq_get "$st" '.earnings.tari_confirmed.enabled')" "true"
     fi
 
-    # 9. Caddy scheme matches dashboard.secure.
-    local scheme
-    [ "$secure" = "false" ] && scheme="http://" || scheme="https://"
-    assert_contains "Caddyfile uses correct scheme" "$(rx 'head -n1 Caddyfile 2>/dev/null')" "$scheme"
+    # 9. Caddy scheme matches dashboard.secure — read from the DASHBOARD's site block, which is
+    #    neither line 1 nor the first scheme in the file. #1123 put a global options block
+    #    (`{ auto_https disable_redirects }`) at the top, and in HTTPS mode an `http:// {` redirect
+    #    block ABOVE the dashboard's own block. So `head -n1` sees `{`, and "the first scheme in the
+    #    file" sees `http://` on a box that is correctly serving HTTPS — both spellings report a
+    #    false RED on a healthy stack, which is how this assertion failed 8 times in one green run.
+    #    The dashboard's block is the one whose address carries a HOST after the scheme; the bare
+    #    redirect is `http:// {`, with a space where the host would be, so `[^ ]` separates them.
+    local want_scheme
+    [ "$secure" = "false" ] && want_scheme='^http://[^ ]' || want_scheme='^https://[^ ]'
+    assert_eq "Caddyfile's dashboard site block uses the correct scheme (#1123)" \
+        "$(rx "grep -qE '$want_scheme' Caddyfile && echo yes || echo no")" "yes"
 
     # 10. Secrets intact (proxy token + onions unchanged vs the baseline we captured).
     assert_eq "secrets intact (token + onions)" "$(secret_fingerprint)" "$BASELINE_SECRET_FP"


### PR DESCRIPTION
Closes #1180.

**Found by running the mandated pre-release e2e for v1.19.3.** Every other assertion passed, the restore proved clean, and the run still exited 1:

```
✓ stratum TLS handshake succeeds on the published port (#261/#942)
✓ live-served cert fingerprint matches the one rigs are told to pin (#261/#942)
✓ PAYOUT_CONFIRM_ENABLED matches config (#381/#942)
✗ Caddyfile uses correct scheme            <- 8 times, on a healthy box
✗ E2E FAILED for 'develop' (harness exit 1)
```

The box was serving HTTPS correctly throughout.

## Why

#1123 (2026-08-18) stopped Caddy's `:80` redirect trusting the `Host` header by emitting a global options block, and in HTTPS mode an `http://` redirect block **above** the dashboard's own site block:

```
{
    auto_https disable_redirects
}

http:// {
    redir https://<host>{uri} 308
}

https://<host> {
```

`head -n1 Caddyfile` is `{`. The assertion has been reading a brace and looking for a scheme in it for three days.

## The obvious repair is also wrong

"Use the first scheme in the file" finds `http://` — the redirect block — on a box correctly serving HTTPS. That turns a false RED for `secure=true` into a false GREEN for `secure=false`.

The dashboard's block is the one whose address carries a **host** after the scheme. The bare redirect is `http:// {`, a space where the host would be, so `[^ ]` separates them.

## What was actually RUN

Against the **real rendered Caddyfile on the bench**, not a fixture:

```
grep -cE '^https://[^ ]' Caddyfile   -> 1     (the dashboard block)
grep -cE '^http://[^ ]'  Caddyfile   -> 0     (the bare redirect correctly excluded)
grep -nE '^http://'      Caddyfile   -> 5:http:// {
```

So on this `secure=true` box the new expression answers yes for https and would answer no for http; the old one answered ✗ for both.

`make lint-sh` and `bash -n` clean.

## What is NOT yet proven

**The re-run.** The proof of a harness fix is the harness going green, and the e2e that found this is the one that has to say so. I am re-running the targeted e2e against `develop` with the borrowed miner after this merges, and will post the result here — including whether anything else was hiding behind this failure, since an exit-1 run stops being informative after its first red.

## Why it belongs in v1.19.3 rather than later

This is the gate mandated before every release cut. An assertion that is red on a correct box teaches the operator that a red e2e is normal, on the one check standing between a bad release and the world — #1082's family. v1.19.3 cannot be cut on a gate that cannot go green.