### PR TITLE
sync: develop -> develop-v2 (the v1.19.3 wave)

### DIFF
--- a/build/tor/entrypoint.sh
+++ b/build/tor/entrypoint.sh
@@ -9,8 +9,15 @@ set -eu
 # TORRC_TEMPLATE is a test seam so the shell suite can render against build/tor/torrc.template; the
 # container always uses the baked-in default.  # ponytail: default unchanged, only overridden in tests
 : "${TORRC_TEMPLATE:=/etc/tor/torrc.template}"
+# TORRC_OUT is the matching seam for the RENDERED file (#1104). Without it the shell suite's tor
+# stub reads a host-global /tmp/torrc, which is the only unsandboxed path in an ~8000-line suite
+# where every other fixture gets its own mktemp -d — so two concurrent runs race on one file and
+# produce a false RED in the hidden-service assertions, whose natural remedy is "re-run until green".
+# The DEFAULT MUST STAY /tmp/torrc: tier-3 assertions in tests/integration/run.sh read this path
+# inside the running container.  # ponytail: default unchanged, only overridden in tests
+: "${TORRC_OUT:=/tmp/torrc}"
 
-sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
+sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >"$TORRC_OUT"
 
 # Node inbound hidden services (#103): the bundled monerod and Tari containers only start under
 # their compose profiles, so publish each node's onion only then — in remote mode the onion would
@@ -19,7 +26,7 @@ sed "s/__NETWORK_PREFIX__/${NETWORK_PREFIX}/g" "$TORRC_TEMPLATE" >/tmp/torrc
 # Unset (a bare `docker compose` with no .env) means no profiles, so no bundled node and no onion.
 case ",${COMPOSE_PROFILES:-}," in
 *,local_node,*)
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Monero P2P Hidden Service
 HiddenServiceDir /var/lib/tor/monero/
@@ -29,7 +36,7 @@ EOF
 esac
 case ",${COMPOSE_PROFILES:-}," in
 *,local_tari,*)
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Tari Base Node Hidden Service
 HiddenServiceDir /var/lib/tor/tari/
@@ -45,7 +52,7 @@ esac
 # Two ports: 80 (plain HTTP) and 443 (HTTPS, self-signed) — Caddy serves both, so Tor Browser's
 # default http->https upgrade lands on the working :443 instead of a refused connection (#343).
 if [ "${DASHBOARD_ONION_ENABLED:-false}" = "true" ]; then
-    cat >>/tmp/torrc <<EOF
+    cat >>"$TORRC_OUT" <<EOF
 
 # Dashboard Hidden Service (#343)
 HiddenServiceDir /var/lib/tor/dashboard/
@@ -54,4 +61,4 @@ HiddenServicePort 443 ${NETWORK_PREFIX}.1:443
 EOF
 fi
 
-exec tor -f /tmp/torrc
+exec tor -f "$TORRC_OUT"

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -214,7 +214,17 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    harness-rendered creds while the on-disk `.env` kept the real ones: internally consistent, so
    the stack mined and looked healthy for a day while every host-side RPC probe 401ed. A failed
    proof exits non-zero and names the recovery (`docker compose up -d` from the install dir
-   re-bakes everything from disk).
+   re-bakes everything from disk). The same proof asks the restored install's own `doctor` whether
+   the box-global control-runner units still name it
+   ([#1085](https://github.com/p2pool-starter-stack/pithead/issues/1085)): deploying the branch
+   repoints those units at the e2e checkout, and the hardening phase's teardown removes them when it
+   owns them, so a run can end with the live dashboard's config edits and one-click upgrades queueing
+   into a spool nothing watches — enabled, active and silent. The verdict is read from the install's
+   own `pithead`, run from its own directory, because `pithead` works from the directory of the
+   binary you invoke: the branch's copy would compare the units against the e2e checkout and report
+   all-clear on exactly the stranded box. That needs the live install on v1.19.2 or newer, the
+   release whose `doctor` gained the check; an older one is reported as unproven rather than as a
+   pass.
 
 `--mode`: `targeted` (default, lean) validates the dashboard and the sync logic against the
 already-synced node: `check` + `--lifecycle` (one controlled restart exercises the sync gate /

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -195,7 +195,14 @@ pin() {
     monero) grep -oE '^ARG MONERO_VERSION=.*' build/monero/Dockerfile | cut -d= -f2 ;;
     xmrig-proxy) grep -oE '^ARG XMRIG_PROXY_VERSION=.*' build/xmrig-proxy/Dockerfile | cut -d= -f2 ;;
     tor-base) grep -oE '^FROM [^ ]+' build/tor/Dockerfile | head -1 | awk '{print $2}' ;;
+    # `tari` is the NODE, deliberately, because scripts/pin-watch.sh reads this arm for upstream
+    # currency and both Tari images come from one upstream repo — a second row there would say the
+    # same thing twice. The stack pins two images though (node + view-only console wallet), they are
+    # bumped together, and the release notes have to name both or a wallet-only move reads as
+    # unchanged (#1138). tests/stack/test_compose.sh asserts the two carry the same tag, so the
+    # lockstep this relies on is guarded rather than assumed.
     tari) grep -oE 'quay.io/tarilabs/minotari_node:[^ ]+' docker-compose.yml | head -1 ;;
+    tari-wallet) grep -oE 'quay.io/tarilabs/minotari_console_wallet:[^ ]+' docker-compose.yml | head -1 ;;
     caddy) grep -oE 'caddy:[0-9.]+@sha256:[a-f0-9]+' docker-compose.yml | head -1 ;;
     socket-proxy) grep -oE 'tecnativa/docker-socket-proxy:[^ ]+' docker-compose.yml | head -1 ;;
     esac
@@ -659,7 +666,8 @@ write_manifest() {
         printf -- '- monerod: `%s`\n' "$(pin monero)"
         printf -- '- xmrig-proxy: `%s`\n' "$(pin xmrig-proxy)"
         printf -- '- tor base: `%s`\n' "$(pin tor-base)"
-        printf -- '- tari: `%s`\n' "$(pin tari)"
+        printf -- '- tari node: `%s`\n' "$(pin tari)"
+        printf -- '- tari console wallet: `%s`\n' "$(pin tari-wallet)"
         printf -- '- caddy: `%s`\n' "$(pin caddy)"
         printf -- '- docker-socket-proxy: `%s`\n' "$(pin socket-proxy)"
     } >"$out"

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -173,6 +173,14 @@ SAFETY_ARCHIVE=""
 MINER_CFG_BACKUP=""
 RESTORED=0
 RESTORE_PROOF_FAILED=0
+# Separate from RESTORE_PROOF_FAILED on purpose (#1085). That flag's message is the #971
+# credential-bake incident's, and its remediation — "re-bake from disk: docker compose up -d" —
+# does nothing whatsoever for a systemd unit. A control-channel fault needs its own words.
+CONTROL_PROOF_FAILED=0
+# What the control units looked like BEFORE the restore's converging apply, recorded so the run log
+# says whether THIS run stranded the box. The post-restore verdict cannot answer that: it runs after
+# the apply that repairs it.
+CONTROL_VERDICT_BEFORE=""
 # Where the LIVE stack actually runs from — resolved in preflight (#454). Defaults to CANONICAL_DIR
 # so the EXIT trap always has a target even if it fires before preflight refines it.
 RESTORE_DIR="$CANONICAL_DIR"
@@ -205,7 +213,7 @@ restore_all() {
             miner_reload
             ok "$MINER_HOST repointed to its original pool(s); backup pruned"
         else
-            warn "FAILED to restore $MINER_HOST config — backup kept at $MINER_CFG_BACKUP"
+            warn "FAILED to restore $MINER_HOST config — the backup should still be at $MINER_CFG_BACKUP, but check: if the connection dropped after the prune, it is already gone and the live config is the restored one."
         fi
     fi
 
@@ -215,6 +223,16 @@ restore_all() {
     #    project locally-built :dev images.
     step "bringing the baseline stack ($RESTORE_DIR) back up"
     on_bench "cd '$E2E_DIR' && ./pithead down >/dev/null 2>&1 || true"
+    # Look at the control units BEFORE the apply below converges them. Without this the run can
+    # never report that it stranded the box — the post-restore proof runs downstream of its own
+    # repair, so on the ordinary #1085 path it is green either way. Observation only: the strand is
+    # expected here, and the restore is what has to put it right.
+    CONTROL_VERDICT_BEFORE="$(control_units_verdict "$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)")"
+    case "$CONTROL_VERDICT_BEFORE" in
+    on-target) step "control units before restore: already pointing at $RESTORE_DIR" ;;
+    stranded) step "control units before restore: STRANDED (expected — the branch deploy repoints them); the apply below must converge them" ;;
+    *) step "control units before restore: $CONTROL_VERDICT_BEFORE" ;;
+    esac
     if on_bench "cd '$RESTORE_DIR' && ./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"; then
         wait_bench_healthy 300 && ok "baseline stack healthy again" || warn "baseline stack came up but isn't reporting healthy yet — check 'pithead status' on $BENCH_HOST"
         # Proof, even when the health wait timed out: a stack running the WRONG creds looks
@@ -231,9 +249,18 @@ restore_all() {
     sync="$(on_bench "curl -fsS --max-time 8 http://127.0.0.1:8000/api/state 2>/dev/null | jq -r '\"\(.sync.monero.state)/\(.sync.tari.state)\"' 2>/dev/null" || true)"
     [ -n "$sync" ] && step "post-restore sync state (monero/tari): $sync"
 
-    if [ "$RESTORE_PROOF_FAILED" = "1" ]; then
-        warn "RESTORE NOT PROVEN: the live stack on $BENCH_HOST did not prove it matches $RESTORE_DIR's on-disk config (see above)."
-        warn "  Re-bake from disk by hand: cd $RESTORE_DIR && docker compose up -d — then verify with a host-side authed get_info."
+    if [ "$CONTROL_PROOF_FAILED" = "1" ]; then
+        warn "CONTROL CHANNEL NOT RESTORED on $BENCH_HOST: the live dashboard's config changes and"
+        warn "  one-click upgrades will queue into a spool nothing reads, with nothing reporting a fault."
+        warn "  This is separate from the credential proof above and needs a different repair — see the lines above."
+        [ "$CONTROL_VERDICT_BEFORE" = "stranded" ] &&
+            warn "  This run DID strand them (verdict before the restore: stranded), and the restore did not put them back."
+    fi
+    if [ "$RESTORE_PROOF_FAILED" = "1" ] || [ "$CONTROL_PROOF_FAILED" = "1" ]; then
+        if [ "$RESTORE_PROOF_FAILED" = "1" ]; then
+            warn "RESTORE NOT PROVEN: the live stack on $BENCH_HOST did not prove it matches $RESTORE_DIR's on-disk config (see above)."
+            warn "  Re-bake from disk by hand: cd $RESTORE_DIR && docker compose up -d — then verify with a host-side authed get_info."
+        fi
         exit 1
     fi
     if [ "$rc" -eq 0 ]; then ok "restore complete."; else warn "restore complete (the run itself failed — see above)."; fi
@@ -333,25 +360,54 @@ PROBE
 
     # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
     #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
+    #
+    #    Note what this check can and cannot see. It runs AFTER restore_all's `apply -y`, and that
+    #    apply converges the units (v1.19.2+), so on the ordinary #1085 path the strand is already
+    #    repaired by the time we look — this arm is a proof that the box was LEFT working, not a
+    #    detector of the strand itself. The strand is caught upstream, by CONTROL_VERDICT_BEFORE
+    #    recorded in restore_all before that apply, and by run.sh's ExecStart assertion. What this
+    #    arm does catch on its own: a pithead too old to converge (no-check), a disabled channel
+    #    where apply leaves stray units alone, and strands this run did not cause.
     local doc verdict_line
     doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
     verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
     case "$(control_units_verdict "$doc")" in
     on-target)
-        ok "restore proof: the control runner units point at $RESTORE_DIR"
+        # The units name the right directory. That is text; `enabled` is behaviour, and
+        # provision_control_runner's `systemctl enable --now` is warn-only, so apply can return 0
+        # with correctly-named units that will never fire.
+        if on_bench "systemctl is-enabled pithead-control.path >/dev/null 2>&1"; then
+            ok "restore proof: the control runner units point at $RESTORE_DIR, and the path unit is enabled"
+        else
+            warn "restore proof: the control units name $RESTORE_DIR but pithead-control.path is NOT enabled — correctly addressed and never fired."
+            warn "  Repair on the box: sudo systemctl enable --now pithead-control.path"
+            CONTROL_PROOF_FAILED=1
+        fi
         ;;
     disabled)
-        warn "restore proof: the control channel is disabled in $RESTORE_DIR's config — no channel to strand."
+        # NOT a pass. `apply` leaves the units alone when control is disabled, so this is the one
+        # state in which a strand SURVIVES the restore. Look for the leftovers directly.
+        if on_bench "grep -qsF 'ExecStart=$E2E_DIR/pithead' /etc/systemd/system/pithead-control.service"; then
+            warn "restore proof: the control channel is disabled in $RESTORE_DIR's config, and the box-global units still name the e2e checkout ($E2E_DIR). A disabled apply does not clean them up."
+            warn "  Repair on the box: sudo rm -f /etc/systemd/system/pithead-control.{path,service} && sudo systemctl daemon-reload"
+            CONTROL_PROOF_FAILED=1
+        else
+            ok "restore proof: control channel disabled in $RESTORE_DIR, and no unit names the e2e checkout"
+        fi
+        ;;
+    not-live)
+        warn "restore proof: $RESTORE_DIR is not the live install by its own reckoning — doctor declined to grade its control channel. Units NOT proven."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
         ;;
     no-check)
-        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. The units were NOT proven; check by hand: systemctl cat pithead-control.service"
-        prc=1
+        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. On a pre-v1.19.2 install the restore's own apply cannot converge the units either, so assume the box IS stranded."
+        warn "  Check by hand: systemctl cat pithead-control.service"
+        CONTROL_PROOF_FAILED=1
         ;;
     *)
         warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
         warn "  doctor said: ${verdict_line:-<no verdict line>}"
-        warn "  Repair on the box: cd $RESTORE_DIR && ./pithead apply -y"
-        prc=1
+        CONTROL_PROOF_FAILED=1
         ;;
     esac
     return "$prc"
@@ -528,12 +584,29 @@ borrow_miner() {
     # the original, every later run restores to it, and the contamination is self-perpetuating with
     # nothing reporting a fault. Observed live on a loaner: 32 backups, 3 distinct contents, and the
     # two most recent already carried a bench pool (#1172-follow-up filed).
-    if [ "$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select(.url | ascii_downcase | contains(\$b))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || echo 0)" != "0" ]; then
-        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST before this run borrowed it."
+    # `.url // ""` and a lowercased needle, because a pool entry with no .url makes `.url |
+    # ascii_downcase` raise and jq exits non-zero for the WHOLE expression — one malformed sibling
+    # entry and the probe reports nothing. And the answer is a three-way, not a boolean: "could not
+    # tell" must not read as "clean". The old spelling ended `2>/dev/null || echo 0`, which failed
+    # open on every error path — a truncated config, a dropped ssh — and those are correlated with
+    # the very fault this probe exists to find: a config left half-written by a run that died before
+    # restoring. A probe that goes quiet exactly when the thing it looks for is present is the
+    # defect class this whole PR is about, one function away from the comment that says so.
+    local bench_pools
+    bench_pools="$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select((.url // \"\") | ascii_downcase | contains(\$b | ascii_downcase))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
+    case "$bench_pools" in
+    "" | *[!0-9]*)
+        warn "could not read $MINER_HOST's pool list to check it is not already borrowed (jq failed, or the config is unreadable/malformed)."
+        warn "  A config left half-written by a run that died before restoring looks exactly like this — do NOT read the silence as clean."
+        ;;
+    0) ;;
+    *)
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools pool(s) before this run borrowed it."
         warn "  Either this rig keeps a permanent bench pool, or a previous e2e did not restore it."
-        warn "  The backup taken next records THAT state as the original, so a later restore returns to it."
+        warn "  The backup taken next records THAT state as the original, so a later restore returns to it (#1178)."
         warn "  Check by hand before trusting a restore: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
-    fi
+        ;;
+    esac
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"
     on_miner "cp -a '$MINER_XMRIG_CONFIG' '$MINER_CFG_BACKUP'" || die "Failed to back up the miner config."
     step "miner config backed up → $MINER_CFG_BACKUP"

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -193,8 +193,17 @@ restore_all() {
     # 1. Miner: put its original pool config back and nudge xmrig to reconnect.
     if [ -n "$MINER_CFG_BACKUP" ]; then
         step "restoring $MINER_HOST xmrig config from $MINER_CFG_BACKUP"
-        if on_miner "cp -a '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG'"; then
-            miner_reload && ok "$MINER_HOST repointed to its original pool(s)" || warn "$MINER_HOST config restored; verify xmrig reconnected"
+        # cmp, then rm (#1067). Every borrowing run minted a timestamped .e2e-orig.<stamp> and
+        # nothing ever removed it, so the loaner accumulated them and recovery became a guess among
+        # candidates where the newest is not necessarily the true pre-borrow state. The backup is
+        # only safe to delete once the bytes are demonstrably back in place, and the proof runs in
+        # the SAME remote call so a dropped ssh cannot land between proving and deleting.
+        # Deliberately NOT gated on miner_reload: that function ends `|| true` and `return 0`, so it
+        # cannot fail — gating on it would delete the backup whatever happened, and it is also why
+        # the `warn` arm it used to guard was unreachable.
+        if on_miner "cp -a '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && cmp -s '$MINER_CFG_BACKUP' '$MINER_XMRIG_CONFIG' && rm -f '$MINER_CFG_BACKUP'"; then
+            miner_reload
+            ok "$MINER_HOST repointed to its original pool(s); backup pruned"
         else
             warn "FAILED to restore $MINER_HOST config — backup kept at $MINER_CFG_BACKUP"
         fi
@@ -272,7 +281,17 @@ wait_synced() { # <timeout_s>
 #      broke. Only .status is required (sync may still be re-confirming); polled briefly because
 #      the containers were just recreated. The probe script travels over ssh stdin (bash -s), so
 #      the creds stay on the box and the remote command string carries no shell parens.
-# Returns 0 when both hold.
+#   3. The box-global control units still name RESTORE_DIR (#1085). deploy_branch's `pithead
+#      upgrade` repoints them at E2E_DIR, and the hardening phase's teardown deletes them outright
+#      when it owns them — either way the live dashboard's config edits and one-click upgrades
+#      queue into a spool nothing watches, while every other signal here still reads healthy.
+#      The verdict comes from RESTORE_DIR's OWN doctor, run from RESTORE_DIR. That is not a
+#      preference: check_control_units compares the installed units' ExecStart against $PWD, and
+#      `pithead` cd's to the directory of the binary you invoke (SCRIPT_DIR, pithead:100) — so the
+#      BRANCH's copy would compare against E2E_DIR and print the OK verdict on exactly the
+#      stranded box this check exists to catch. It needs RESTORE_DIR on v1.19.2+, the release that
+#      added the check; anything older classifies as no-check and FAILS rather than passing quietly.
+# Returns 0 when all three hold.
 RESTORE_PROOF_VAR="MONERO_NODE_PASSWORD"
 verify_restore_proof() {
     local prc=0 disk cid baked="" verdict
@@ -311,6 +330,30 @@ PROBE
         fi
         sleep 10
     done
+
+    # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
+    #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
+    local doc verdict_line
+    doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
+    verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
+    case "$(control_units_verdict "$doc")" in
+    on-target)
+        ok "restore proof: the control runner units point at $RESTORE_DIR"
+        ;;
+    disabled)
+        warn "restore proof: the control channel is disabled in $RESTORE_DIR's config — no channel to strand."
+        ;;
+    no-check)
+        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. The units were NOT proven; check by hand: systemctl cat pithead-control.service"
+        prc=1
+        ;;
+    *)
+        warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
+        warn "  Repair on the box: cd $RESTORE_DIR && ./pithead apply -y"
+        prc=1
+        ;;
+    esac
     return "$prc"
 }
 
@@ -478,6 +521,19 @@ borrow_miner() {
         return 0
     }
     log "Borrowing $MINER_HOST → pointing it at $BENCH_HOST"
+    # Say so BEFORE the backup is taken, because the backup is what "restore" means afterwards. The
+    # repoint below has an `if any(.pools[]?; .url | contains($b)) then .` arm — written for a rig
+    # that legitimately keeps a bench pool — and that arm also silently absorbs the other case: a
+    # previous run that repointed and never restored. The backup then records the borrowed config as
+    # the original, every later run restores to it, and the contamination is self-perpetuating with
+    # nothing reporting a fault. Observed live on a loaner: 32 backups, 3 distinct contents, and the
+    # two most recent already carried a bench pool (#1172-follow-up filed).
+    if [ "$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select(.url | ascii_downcase | contains(\$b))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || echo 0)" != "0" ]; then
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST before this run borrowed it."
+        warn "  Either this rig keeps a permanent bench pool, or a previous e2e did not restore it."
+        warn "  The backup taken next records THAT state as the original, so a later restore returns to it."
+        warn "  Check by hand before trusting a restore: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
+    fi
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"
     on_miner "cp -a '$MINER_XMRIG_CONFIG' '$MINER_CFG_BACKUP'" || die "Failed to back up the miner config."
     step "miner config backed up → $MINER_CFG_BACKUP"

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -328,6 +328,30 @@ env_bake_verdict() { # <var> <disk-env-lines> <container-env-lines>
     fi
 }
 
+# Restore-proof control-channel verdict (#1085): classify `pithead doctor`'s control-channel section
+# so "the check RAN and the units are on target" reads differently from "the check never ran".
+# Classify the TEXT, never doctor's exit code — it is 1 on ANY failed check, so an unrelated failure
+# would swamp this signal and a 0 would read as "units fine" on a pithead that never looked.
+#   on-target — the units name the install doctor was run from
+#   stranded  — the section is there and says anything else: units naming another directory, no
+#               units at all, a spool nobody writes to, or "this is not the live install"
+#   disabled  — the control channel is off for that install, so there is no channel to strand
+#   no-check  — no section at all: no systemd, or a pithead predating the check (v1.19.2)
+control_units_verdict() { # <doctor-output>
+    case "$1" in
+    *"Dashboard control channel:"*) ;;
+    *)
+        printf 'no-check'
+        return
+        ;;
+    esac
+    case "$1" in
+    *"Control runner units target this install."*) printf 'on-target' ;;
+    *"Disabled for this install"*) printf 'disabled' ;;
+    *) printf 'stranded' ;;
+    esac
+}
+
 # Authoritative "is Monero caught up?" — query monerod's own get_info on the box (creds stay
 # on the box) and trust its `synchronized` flag / target_height 0, exactly like the sync gate.
 # This is the readiness GATE (the source of truth, and it avoids waiting on a dashboard poll cycle).

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -333,9 +333,14 @@ env_bake_verdict() { # <var> <disk-env-lines> <container-env-lines>
 # Classify the TEXT, never doctor's exit code — it is 1 on ANY failed check, so an unrelated failure
 # would swamp this signal and a 0 would read as "units fine" on a pithead that never looked.
 #   on-target — the units name the install doctor was run from
-#   stranded  — the section is there and says anything else: units naming another directory, no
-#               units at all, a spool nobody writes to, or "this is not the live install"
-#   disabled  — the control channel is off for that install, so there is no channel to strand
+#   stranded  — the section is there and reports a fault: units naming another directory, no units
+#               at all, or a spool nobody writes to
+#   disabled  — the control channel is off for that install. NOT a pass on its own: `apply` leaves
+#               the units alone when control is disabled, so a strand SURVIVES the restore in
+#               exactly this state. The caller has to look for leftovers itself.
+#   not-live  — doctor declined to grade: this directory is a superseded version dir and `current`
+#               names another. An explicit "I did not evaluate", graded INFO by doctor and pointing
+#               at where to look. Folding it into `stranded` hard-fails a run with a false claim.
 #   no-check  — no section at all: no systemd, or a pithead predating the check (v1.19.2)
 control_units_verdict() { # <doctor-output>
     case "$1" in
@@ -348,6 +353,7 @@ control_units_verdict() { # <doctor-output>
     case "$1" in
     *"Control runner units target this install."*) printf 'on-target' ;;
     *"Disabled for this install"*) printf 'disabled' ;;
+    *"This is not the live install"*) printf 'not-live' ;;
     *) printf 'stranded' ;;
     esac
 }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -793,10 +793,18 @@ assert_running_state() {
         assert_eq "dashboard confirms Tari payout tracking is live (#462/#942)" "$(jq_get "$st" '.earnings.tari_confirmed.enabled')" "true"
     fi
 
-    # 9. Caddy scheme matches dashboard.secure.
-    local scheme
-    [ "$secure" = "false" ] && scheme="http://" || scheme="https://"
-    assert_contains "Caddyfile uses correct scheme" "$(rx 'head -n1 Caddyfile 2>/dev/null')" "$scheme"
+    # 9. Caddy scheme matches dashboard.secure — read from the DASHBOARD's site block, which is
+    #    neither line 1 nor the first scheme in the file. #1123 put a global options block
+    #    (`{ auto_https disable_redirects }`) at the top, and in HTTPS mode an `http:// {` redirect
+    #    block ABOVE the dashboard's own block. So `head -n1` sees `{`, and "the first scheme in the
+    #    file" sees `http://` on a box that is correctly serving HTTPS — both spellings report a
+    #    false RED on a healthy stack, which is how this assertion failed 8 times in one green run.
+    #    The dashboard's block is the one whose address carries a HOST after the scheme; the bare
+    #    redirect is `http:// {`, with a space where the host would be, so `[^ ]` separates them.
+    local want_scheme
+    [ "$secure" = "false" ] && want_scheme='^http://[^ ]' || want_scheme='^https://[^ ]'
+    assert_eq "Caddyfile's dashboard site block uses the correct scheme (#1123)" \
+        "$(rx "grep -qE '$want_scheme' Caddyfile && echo yes || echo no")" "yes"
 
     # 10. Secrets intact (proxy token + onions unchanged vs the baseline we captured).
     assert_eq "secrets intact (token + onions)" "$(secret_fingerprint)" "$BASELINE_SECRET_FP"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1653,6 +1653,15 @@ run_hardening() {
     else
         it_fail "pithead-control.path installed + enabled by apply (#33)" "unit not enabled"
     fi
+    # The unit names are box-global, so on a bench that also hosts a live stack the assertion above
+    # was already true before this phase ran — the LIVE install's units satisfy it, and it stays
+    # green even if our apply installed nothing at all. That is why #1085 went unnoticed for two
+    # releases. Bind it to the ExecStart instead: after our apply the units must name THIS checkout,
+    # in the exact line provision_control_runner writes. Physical path on both sides (pithead cd -P's
+    # to SCRIPT_DIR, rx runs in the checkout), so `current` vs a versioned dir cannot cry wolf.
+    assert_contains "the enabled control units name THIS checkout, not another install (#1085)" \
+        "$(rx "grep -m1 '^ExecStart=' /etc/systemd/system/pithead-control.service 2>/dev/null" || true)" \
+        "ExecStart=$(rx 'pwd -P')/pithead control-run-pending"
 
     local cdir
     cdir="$(env_on_box CONTROL_DIR)"

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -634,6 +634,13 @@ _ccv_off='Dashboard control channel:
   INFO Disabled for this install - the dashboard cannot apply config changes or upgrade.'
 assert_eq "control channel off -> disabled, not a strand" "$(control_units_verdict "$_ccv_off")" "disabled"
 
+# doctor's fourth outcome, and folding it into `stranded` hard-fails a run on a FALSE claim: a
+# superseded version dir whose sibling `current` names another install. doctor grades this INFO and
+# tells you where to look, which is not the same as reporting a fault.
+_ccv_notlive='Dashboard control channel:
+  INFO This is not the live install - /srv/code/current points at /srv/code/pithead-v1.19.3. Run doctor there to check its control channel.'
+assert_eq "superseded version dir -> not-live, not a strand" "$(control_units_verdict "$_ccv_notlive")" "not-live"
+
 # The arm that stops this being another check that cannot fail: a pithead predating the check
 # (< v1.19.2), or a box with no systemd, prints NO control-channel section. Without this arm that
 # output falls through to a pass, and "never looked" reads exactly like "looked and it was fine".

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -606,6 +606,45 @@ case "$(env_bake_verdict MONERO_NODE_PASSWORD "$_disk" "$_baked_wrong")" in
 *) it_pass "verdict never carries a value" ;;
 esac
 
+echo "== control_units_verdict: the restore proof's control-channel oracle (#1085) =="
+# The #1085 shape: after an e2e the box-global control units name the harness checkout, so the live
+# dashboard writes control requests into a spool nothing watches — enabled, active, and silent.
+# doctor's own words are the oracle, so these fixtures are its literal verdict lines.
+_ccv_ok='Boot persistence:
+  OK   Docker is enabled to start at boot.
+
+Dashboard control channel:
+  OK   Control runner units target this install.
+
+CPU:'
+assert_eq "units on target -> on-target" "$(control_units_verdict "$_ccv_ok")" "on-target"
+
+_ccv_strand='Dashboard control channel:
+  FAIL The control runner units point at /srv/code/pithead-e2e, but this install is /srv/code/pithead-v1.19.2 - the dashboard writes its requests here and nothing reads them.'
+assert_eq "units name the harness checkout -> stranded (the #1085 incident)" \
+    "$(control_units_verdict "$_ccv_strand")" "stranded"
+
+# The QUIETER exit from a run: the teardown reaps the units it owns, and a path unit that does not
+# exist reports nothing at all. It must not classify the same as a healthy box.
+_ccv_gone='Dashboard control channel:
+  FAIL The control channel is enabled but no runner units are installed.'
+assert_eq "teardown deleted the units -> stranded" "$(control_units_verdict "$_ccv_gone")" "stranded"
+
+_ccv_off='Dashboard control channel:
+  INFO Disabled for this install - the dashboard cannot apply config changes or upgrade.'
+assert_eq "control channel off -> disabled, not a strand" "$(control_units_verdict "$_ccv_off")" "disabled"
+
+# The arm that stops this being another check that cannot fail: a pithead predating the check
+# (< v1.19.2), or a box with no systemd, prints NO control-channel section. Without this arm that
+# output falls through to a pass, and "never looked" reads exactly like "looked and it was fine".
+_ccv_old='Boot persistence:
+  OK   Docker is enabled to start at boot.
+
+CPU:
+  OK   8 cores.'
+assert_eq "no control-channel section -> no-check, not a pass" "$(control_units_verdict "$_ccv_old")" "no-check"
+assert_eq "empty doctor output -> no-check" "$(control_units_verdict "")" "no-check"
+
 # --- Tally ------------------------------------------------------------------
 echo ""
 echo "selftest: $IT_PASS passed, $IT_FAIL failed"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2235,6 +2235,31 @@ for svc in p2pool monero xmrig-proxy; do
         bad "pin $svc resolves to a value in its Dockerfile" "got '$pv'"
     fi
 done
+# The same drift guard for the pins read out of docker-compose.yml and build/tor, which had none
+# (#1138). pin() emits the EMPTY string when its grep stops matching — a renamed image, a moved tag
+# format — and the release notes then print "- caddy: " with nothing after it. The ingredient list's
+# whole job, silently not done, on the exact surface an operator uses to check what they installed.
+# grep -F, not -E: these values contain '/' and '.', and a regex match would accept a value that is
+# merely similar to one in the file.
+for comp in tari tari-wallet caddy socket-proxy tor-base; do
+    case "$comp" in
+    tor-base) pin_src="$ROOT/build/tor/Dockerfile" ;;
+    *) pin_src="$ROOT/docker-compose.yml" ;;
+    esac
+    # shellcheck disable=SC1090
+    pv="$(
+        cd "$ROOT" || exit
+        set --
+        source "$REL" 2>/dev/null
+        set +eu
+        pin "$comp"
+    )"
+    if [ -n "$pv" ] && grep -qF -- "$pv" "$pin_src"; then
+        ok "pin $comp resolves to a value in $(basename "$pin_src")"
+    else
+        bad "pin $comp resolves to a value in $(basename "$pin_src")" "got '$pv'"
+    fi
+done
 # The top-level VERSION file is the single source of truth (#44); the dashboard's Python package
 # metadata must stay in lockstep so a release can't ship two different "stack versions".
 ver_file="$(tr -d ' \t\r\n' <"$ROOT/VERSION")"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5234,12 +5234,24 @@ TOR_ENTRY="$ROOT/build/tor/entrypoint.sh"
 tor_torrc() { # <DASHBOARD_ONION_ENABLED> [COMPOSE_PROFILES] -> the torrc the entrypoint would hand to `tor -f`
     local d
     d="$(mktemp -d)"
-    printf '#!/bin/sh\ncat /tmp/torrc\n' >"$d/tor" # stub tor: ignore -f, just print the rendered file
+    # The stub cats the SANDBOX path, not /tmp/torrc (#1104). That is what makes the TORRC_OUT seam
+    # load-bearing: if the entrypoint ignored it and wrote the host-global file, this prints nothing
+    # and every assertion below goes red. Catting /tmp/torrc instead would keep passing off a stale
+    # file left by an earlier run — the vacuous version of this check.
+    printf '#!/bin/sh\ncat "%s"\n' "$d/torrc" >"$d/tor" # stub tor: ignore -f, print the rendered file
     chmod +x "$d/tor"
     PATH="$d:$PATH" DASHBOARD_ONION_ENABLED="$1" COMPOSE_PROFILES="${2-local_node,local_tari}" NETWORK_PREFIX=10.9.0 \
-        TORRC_TEMPLATE="$ROOT/build/tor/torrc.template" sh "$TOR_ENTRY"
+        TORRC_TEMPLATE="$ROOT/build/tor/torrc.template" TORRC_OUT="$d/torrc" sh "$TOR_ENTRY"
     rm -rf "$d"
 }
+# The suite's only host-global fixture path, now sandboxed: two concurrent runs used to race on one
+# /tmp/torrc and redden the hidden-service assertions, and the natural remedy for that flake is
+# "re-run until green" — the habit this repo has been removing. The container default is unchanged
+# and MUST stay /tmp/torrc, because tier-3 assertions read that path inside the running container.
+assert_eq "tor entrypoint keeps /tmp/torrc as its container default (#1104)" \
+    "$(grep -c '^: "${TORRC_OUT:=/tmp/torrc}"$' "$TOR_ENTRY")" "1"
+assert_eq "tor entrypoint writes NO bare /tmp/torrc outside that default (#1104)" \
+    "$(grep -vE '^\s*#' "$TOR_ENTRY" | grep -cF '/tmp/torrc')" "1"
 tor_onion_on="$(tor_torrc true)"
 assert_contains "tor entrypoint: dashboard HiddenService appended when enabled (#343)" \
     "$tor_onion_on" "HiddenServiceDir /var/lib/tor/dashboard/"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2218,6 +2218,14 @@ man_out="$SANDBOX/manifest.md"
     write_manifest "$man_out"
 ) 2>/dev/null
 assert_contains "manifest renders the leading-dash Version line (printf --)" "$(cat "$man_out" 2>/dev/null)" "- **Version:** 9.9.9"
+# #1138's actual deliverable is that the ingredient list names BOTH Tari images. The drift guard
+# below tests pin(), which is a different function — deleting either printf leaves it green while
+# the notes regress to naming one of the two. Assert the rendered manifest, which is the artefact an
+# operator reads. A twin-sync conflict on release.sh is a realistic way to lose one of these lines.
+assert_contains "manifest names the tari NODE pin (#1138)" "$(cat "$man_out" 2>/dev/null)" \
+    "- tari node: \`quay.io/tarilabs/minotari_node:"
+assert_contains "manifest names the tari CONSOLE WALLET pin (#1138)" "$(cat "$man_out" 2>/dev/null)" \
+    "- tari console wallet: \`quay.io/tarilabs/minotari_console_wallet:"
 # The ingredients manifest's component pins must resolve to a real value present in each Dockerfile —
 # a drift guard so a renamed ARG can't silently emit an empty pin in the release notes.
 for svc in p2pool monero xmrig-proxy; do
@@ -2239,13 +2247,27 @@ done
 # (#1138). pin() emits the EMPTY string when its grep stops matching — a renamed image, a moved tag
 # format — and the release notes then print "- caddy: " with nothing after it. The ingredient list's
 # whole job, silently not done, on the exact surface an operator uses to check what they installed.
-# grep -F, not -E: these values contain '/' and '.', and a regex match would accept a value that is
+#
+# Each row also names the identifier the pin MUST contain, and that half is the one that matters.
+# "is $pv present in the file it came from" is a TAUTOLOGY for every arm here — pin() extracts a
+# substring of that same file, so any non-empty answer is present by construction, and the check
+# would only ever have caught the empty case. It would NOT have caught the mistake this issue is
+# about: an arm that greps a SIBLING's image (a copy-paste slip when adding tari-wallet next to
+# tari, or a later edit "de-duplicating" two near-identical regexes) resolves fine, matches the
+# file, and reports ok while the release notes name the same image twice.
+# grep -F throughout: these values carry '/' and '.', and a regex match would accept a value that is
 # merely similar to one in the file.
-for comp in tari tari-wallet caddy socket-proxy tor-base; do
-    case "$comp" in
-    tor-base) pin_src="$ROOT/build/tor/Dockerfile" ;;
-    *) pin_src="$ROOT/docker-compose.yml" ;;
-    esac
+for row in \
+    "tari|docker-compose.yml|quay.io/tarilabs/minotari_node:" \
+    "tari-wallet|docker-compose.yml|quay.io/tarilabs/minotari_console_wallet:" \
+    "caddy|docker-compose.yml|caddy:" \
+    "socket-proxy|docker-compose.yml|tecnativa/docker-socket-proxy:" \
+    "tor-base|build/tor/Dockerfile|:"; do
+    comp="${row%%|*}"
+    rest="${row#*|}"
+    pin_rel="${rest%%|*}"
+    pin_want="${rest#*|}"
+    pin_src="$ROOT/$pin_rel"
     # shellcheck disable=SC1090
     pv="$(
         cd "$ROOT" || exit
@@ -2254,10 +2276,14 @@ for comp in tari tari-wallet caddy socket-proxy tor-base; do
         set +eu
         pin "$comp"
     )"
+    pin_ok=0
     if [ -n "$pv" ] && grep -qF -- "$pv" "$pin_src"; then
-        ok "pin $comp resolves to a value in $(basename "$pin_src")"
+        case "$pv" in *"$pin_want"*) pin_ok=1 ;; esac
+    fi
+    if [ "$pin_ok" = 1 ]; then
+        ok "pin $comp resolves to its own image in $pin_rel"
     else
-        bad "pin $comp resolves to a value in $(basename "$pin_src")" "got '$pv'"
+        bad "pin $comp resolves to its own image in $pin_rel" "got '$pv', expected to contain '$pin_want'"
     fi
 done
 # The top-level VERSION file is the single source of truth (#44); the dashboard's Python package

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -133,7 +133,11 @@ expect_min "log rotation on every service" "max-size:" 9
 # matters: move the tag here and in the compose file, leave the digest, and the stack keeps pulling
 # the old image while the file, this test, the release notes and the docs all announce the new
 # version. Spelling the digest out makes the value a reviewable part of the diff at bump time.
-expect_present "tecnativa socket-proxy pinned by digest" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476"
+# A COUNT, not a presence check (#1137's residual). This image runs TWICE — docker-proxy and
+# docker-control — and expect_present is a grep -q, so it matches either line: bumping one proxy and
+# leaving the other was green. The two would then run different socket-proxy builds, which is exactly
+# the split the separate-proxy design exists to prevent.
+expect_min "tecnativa socket-proxy pinned by digest (both proxies)" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476" 2
 expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
 expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0"
 


### PR DESCRIPTION
Routine twin sync carrying #1176, #1177, #1179 and #1181. Clean merge, no conflicts.

**Verified by reading the merged tree, not the exit code** — a merge that silently drops one lane's change reports success identically:

| | in the merged tree |
|---|---|
| `scripts/release.sh` | `tari-wallet` arm present; notes name both Tari images |
| `tests/stack/run.sh` | 5 pin drift rows, each bound to its own image name |
| `tests/stack/test_compose.sh` | socket-proxy asserted on **both** proxies (`expect_min … 2`) |
| `build/tor/entrypoint.sh` | `TORRC_OUT` seam, container default still `/tmp/torrc` |
| `tests/integration/lib.sh` | `control_units_verdict` classifier |
| `tests/integration/run.sh` | the Caddyfile scheme fix (#1180) |
| `os/rootfs/Dockerfile` | **develop-v2's own** compose `v5.5.0` pin and debian digest `3a39a059` both survive |

That last row is the one worth checking on every sync: the appliance lane's changes are not reverted by taking develop's side anywhere.

## Evidence, on the bench

The harness changes in this wave were proven with two targeted e2e runs against `develop` with a borrowed loaner rig:

- **run 1** — 619 ✓ / 9 ✗, exit 1. Found #1180 (a false RED that had been sitting on the mandated release gate for three days) and reproduced the #1085 strand live.
- **run 2**, after #1181 — **632 ✓ / 0 ✗**, `✓ restore complete.`

## Not run

No appliance work: this sync touches no `os/` file except by carrying develop's side, which the table above confirms did not disturb the two appliance-only pins. The KVM battery is not implicated by a CI/harness wave.