### PR TITLE
build: bump monero v0.18.5.1, p2pool v4.18, socket-proxy v0.5.0

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -10,8 +10,8 @@ Version-pinned, sha256-verified, **unmodified** upstream binaries (pin + hash in
 
 | Binary | Version | License | Source |
 |--------|---------|---------|--------|
-| monerod | v0.18.5.0 | BSD-3-Clause | <https://github.com/monero-project/monero> |
-| p2pool | v4.16 | **GPL-3.0-or-later** | <https://github.com/SChernykh/p2pool/releases/tag/v4.16> |
+| monerod | v0.18.5.1 | BSD-3-Clause | <https://github.com/monero-project/monero> |
+| p2pool | v4.18 | **GPL-3.0-or-later** | <https://github.com/SChernykh/p2pool/releases/tag/v4.18> |
 | xmrig-proxy | 6.26.0 | **GPL-3.0-or-later** | <https://github.com/xmrig/xmrig-proxy/releases/tag/v6.26.0> |
 | tor | distro | BSD-3-Clause | <https://gitlab.torproject.org/tpo/core/tor> |
 

--- a/build/dashboard/mining_dashboard/client/docker/docker_control.py
+++ b/build/dashboard/mining_dashboard/client/docker/docker_control.py
@@ -13,7 +13,7 @@ class DockerControl:
 
     Goes through a dedicated `docker-control` socket proxy whose ruleset allows exactly
     `POST /containers/<id>/{start,stop}` and nothing else — not the read-only `docker-proxy`
-    the dashboard uses for stats/logs. (tecnativa/docker-socket-proxy v0.4.2 denies all POST
+    the dashboard uses for stats/logs. (tecnativa/docker-socket-proxy v0.5.0 denies all POST
     unless POST=1, and POST=1 on the read proxy would also open create/kill/exec via its
     CONTAINERS grant — so container control lives on its own minimal proxy instead.)
 

--- a/build/monero/Dockerfile
+++ b/build/monero/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y \
 
 # Define Monero version and SHA256 hash for binary verification
 # Refer to https://www.getmonero.org/downloads/hashes.txt for validation
-ARG MONERO_VERSION=v0.18.5.0
-ARG MONERO_HASH=166ad93036f95f5abeba24c8670061be022c9238dba2e6a7587611a1d759e294
+ARG MONERO_VERSION=v0.18.5.1
+ARG MONERO_HASH=22a7dda7b0cb699fdd6b7674c3b4a4465b337cc98a54983523b759e1e7cc9958
 
 # Download, verify integrity, and install the Monero daemon (monerod) plus monero-wallet-rpc.
 # monero-wallet-rpc ships in the SAME CLI tarball (already verified by the hash above), so the

--- a/build/monero/bitmonero.conf.template
+++ b/build/monero/bitmonero.conf.template
@@ -24,7 +24,7 @@ public-node=1
 # ZeroMQ publisher for block notifications (Required for P2Pool)
 zmq-pub=tcp://0.0.0.0:18083
 
-# Peer Management. P2Pool v4.16 recommends out-peers=32 / in-peers=64 for a clearnet node, where
+# Peer Management. P2Pool v4.18 recommends out-peers=32 / in-peers=64 for a clearnet node, where
 # in-peers=64 is the one that matters: it caps INBOUND connections so they can't grow past ~1000 and
 # hit Linux's open-files limit — we honor it exactly. out-peers defaults to 48 (monero.out_peers)
 # because each peer is roughly one bandwidth-capped Tor circuit, so more peers = more aggregate

--- a/build/monero/entrypoint.sh
+++ b/build/monero/entrypoint.sh
@@ -10,11 +10,11 @@ CONFIG_PATH="${CONFIG_PATH:-/home/ubuntu/.bitmonero/bitmonero.conf}"
 CLEARNET_MARKER="${CLEARNET_MARKER:-/clearnet-state/monero.synced}"
 
 # Optional clearnet initial sync (#183). DEFAULT OFF. For the fast clearnet sync window only, this
-# makes monerod match the connectivity P2Pool v4.16 recommends for a clearnet node:
+# makes monerod match the connectivity P2Pool v4.18 recommends for a clearnet node:
 #   - strip the single `proxy=` line that forces ALL P2P over Tor → monerod dials its compiled-in
 #     clearnet seed nodes (and the priority nodes below) directly, at clearnet speed instead of
 #     crawling over bandwidth-capped Tor circuits.
-#   - out-peers → 32 (P2Pool v4.16's clearnet recommendation; the Tor render uses 48, a circuit-
+#   - out-peers → 32 (P2Pool v4.18's clearnet recommendation; the Tor render uses 48, a circuit-
 #     bandwidth workaround). in-peers stays 64 — the open-files cap, which is the rec we always honor.
 #   - add P2Pool's recommended priority nodes for guaranteed-good peers + block templates. These are
 #     CLEARNET hostnames, so they're added ONLY here: in Tor mode their resolution would leak a
@@ -32,7 +32,7 @@ apply_clearnet_initial_sync() {
     sed -e '/^proxy=/d' -e 's/^out-peers=.*/out-peers=32/' "$cfg" >"$tmp" && mv "$tmp" "$cfg"
     cat >>"$cfg" <<'PRIONODES'
 
-# P2Pool v4.16 recommended priority nodes (clearnet sync window only — removed when flipped to Tor).
+# P2Pool v4.18 recommended priority nodes (clearnet sync window only — removed when flipped to Tor).
 add-priority-node=p2pmd.xmrvsbeast.com:18080
 add-priority-node=nodes.hashvault.pro:18080
 PRIONODES

--- a/build/p2pool/Dockerfile
+++ b/build/p2pool/Dockerfile
@@ -1,8 +1,8 @@
 # Pinned by digest (#135) so the ubuntu:24.04 tag can't be silently re-pointed.
 FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
 
-ARG P2POOL_VERSION=v4.16
-ARG P2POOL_HASH=1b03b2e4d4adfe488b2867eb85b57366fbaf8594a7f84cdbf13a3c8519159280
+ARG P2POOL_VERSION=v4.18
+ARG P2POOL_HASH=893691726b0218fe1883a7a326e2c69db4eb228fc72ba00c8adfa6be85b8a415
 
 # Install runtime dependencies. socat (#278): the entrypoint bridges 127.0.0.1 -> the real monerod
 # (node RPC/ZMQ) and the Tari base node (merge-mine gRPC) so those intra-stack legs stay DIRECT while

--- a/build/p2pool/entrypoint.sh
+++ b/build/p2pool/entrypoint.sh
@@ -8,15 +8,18 @@ set -euo pipefail
 # routing — e.g. "--mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor"). We word-split it HERE
 # because Docker Compose passes a `- ${VAR}` command item as ONE argument (no word-splitting), which
 # would hand p2pool a single mangled flag. An empty value expands to nothing (no stray empty arg).
-# #278: p2pool's --socks5 (#165 Tor sidechain routing) ALSO proxies the monerod RPC/ZMQ connection —
-# unless the node address is LOOPBACK. p2pool exempts only 127.0.0.1/::1/localhost from the SOCKS5
-# proxy (verified vs p2pool v4.16: json_rpc_request.cpp / util.cpp is_localhost), so a private Docker
-# node IP (e.g. 172.28.0.26) gets dialled THROUGH Tor — which can't reach a private IP → "get_info ...
-# empty response", no block template, no mining. There is no per-host proxy-bypass flag. So when the
+# #278: p2pool's --socks5 (#165 Tor sidechain routing) ALSO proxies the monerod RPC/ZMQ connection
+# unless the node address is exempt. Up to v4.16 only LOOPBACK was exempt (json_rpc_request.cpp /
+# util.cpp is_localhost), so a private Docker node IP (e.g. 172.28.0.26) got dialled THROUGH Tor —
+# which can't reach a private IP → "get_info ... empty response", no block template, no mining.
+# v4.18 widened the RPC-leg exemption to any private address (json_rpc_request.cpp:250
+# is_private_address, verified vs p2pool v4.18), which makes this bridge belt-and-braces for the
+# node RPC/ZMQ — kept because the merge-mine leg below still needs its twin, and loopback stays
+# exempt in every version, so the bridge costs nothing and survives an upstream narrowing. When the
 # Tor proxy is on, bridge 127.0.0.1 -> the real node with socat and repoint --host at loopback: the
-# node RPC/ZMQ then stay DIRECT (socat is a plain TCP forward, not p2pool's proxy) while the sidechain
-# P2P still rides --socks5 over Tor. The socat hops (loopback -> node) are intra-stack, allowed by the
-# #270 firewall (subnet -> 172.16/12).
+# node RPC/ZMQ then stay DIRECT (socat is a plain TCP forward, not p2pool's proxy) while the
+# sidechain P2P still rides --socks5 over Tor. The socat hops (loopback -> node) are intra-stack,
+# allowed by the #270 firewall (subnet -> 172.16/12).
 if printf '%s' "${P2POOL_FLAGS:-}" | grep -q -- '--socks5'; then
     _node="" _rpc="18081" _zmq="18083" _prev=""
     for _a in "$@"; do
@@ -45,9 +48,10 @@ if printf '%s' "${P2POOL_FLAGS:-}" | grep -q -- '--socks5'; then
     esac
 
     # Same trap, one leg further (#278 covered monerod only): p2pool's MergeMiningClientTari reaches
-    # the Tari base node via TCPServer::connect_to_peer, which — like the node RPC — only skips the
-    # SOCKS5 proxy for a LOOPBACK IP literal (no_proxy = m_addressType != DomainName && is_localhost();
-    # verified vs p2pool v4.16 src/tcp_server.cpp). So `--merge-mine tari://<private-docker-ip>:18142`
+    # the Tari base node via TCPServer::connect_to_peer, which only skips the SOCKS5 proxy for a
+    # LOOPBACK IP literal (no_proxy = m_addressType != DomainName && is_localhost(); verified vs
+    # p2pool v4.18 src/tcp_server.cpp:425 — v4.18's private-address exemption covers the node RPC
+    # leg only, NOT this one). So `--merge-mine tari://<private-docker-ip>:18142`
     # is dialled THROUGH Tor, which rejects RFC1918 ("Rejecting SOCKS request ... to private address")
     # → the gRPC channel_state sticks at TRANSIENT_FAILURE and no Tari is merge-mined. Same remedy:
     # bridge 127.0.0.1 -> the real node and rewrite the URL host to the 127.0.0.1 IP literal (NOT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -810,7 +810,7 @@ services:
   # POST stays off, so this proxy can never write — container control goes through the
   # separate, tightly-scoped docker-control proxy below.
   docker-proxy:
-    image: tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
+    image: tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
     container_name: docker-proxy
     # Memory ceiling (#132 — see monerod). A tiny socket proxy (~13 MiB observed).
     mem_limit: 128m
@@ -857,12 +857,13 @@ services:
   # A second, minimal proxy used ONLY to stop/start p2pool + xmrig-proxy — node-down worker
   # failover (Issue #31), holding the miner until the nodes finish syncing (Issue #35) — plus
   # tor (#424) and monerod after a tor heal (#972).
-  # With POST=1 but every section (CONTAINERS, EXEC, IMAGES, …) left off, the v0.4.2 ruleset
+  # With POST=1 but every section (CONTAINERS, EXEC, IMAGES, …) left off, the v0.5.0 ruleset
   # allows exactly `POST /containers/<id>/{start,stop}` and denies everything else
-  # (create/kill/exec/reads). Kept separate from the read-only proxy above so opening POST
-  # here can't widen that proxy's container access.
+  # (create/kill/exec/reads — and the pause/unpause routes v0.5.0 added, which sit behind their
+  # own ALLOW_PAUSE/ALLOW_UNPAUSE opt-ins, left off here). Kept separate from the read-only
+  # proxy above so opening POST here can't widen that proxy's container access.
   docker-control:
-    image: tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476
+    image: tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
     container_name: docker-control
     # Memory ceiling (#132 — see monerod). A tiny socket proxy (~13 MiB observed).
     mem_limit: 128m

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -211,7 +211,7 @@ switch, or the exposure banner keeps warning about a sync that isn't happening.
 
 | | Tor-only (default) | Clearnet initial sync (opt-in) |
 |---|---|---|
-| **Monero** P2P | over Tor (`proxy=172.28.0.25:9050`) | **direct to clearnet seed nodes** (proxy line dropped), `out-peers` 48 → **32** + P2Pool v4.16's recommended **priority nodes** (`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`) for fast, reliable sync |
+| **Monero** P2P | over Tor (`proxy=172.28.0.25:9050`) | **direct to clearnet seed nodes** (proxy line dropped), `out-peers` 48 → **32** + P2Pool v4.18's recommended **priority nodes** (`p2pmd.xmrvsbeast.com`, `nodes.hashvault.pro`) for fast, reliable sync |
 | **Monero** tx broadcast | over Tor (`tx-proxy=`) | **still over Tor** — unchanged |
 | **Tari** transport | Tor (`type = "tor"`) | **TCP** (`type = "tcp"`) |
 | **Tari** seeds | onion `peer_seeds`, `dns_seeds = []` | **`dns_seeds = ["seeds.tari.com"]`** (onion seeds are unreachable without Tor), onion `public_addresses` dropped |

--- a/tests/integration/mini-stack/docker-compose.fake.yml
+++ b/tests/integration/mini-stack/docker-compose.fake.yml
@@ -127,7 +127,7 @@ services:
 
   # Read-only socket proxy (stats/logs) — mirrors the production docker-proxy.
   docker-proxy:
-    image: tecnativa/docker-socket-proxy:v0.4.2
+    image: tecnativa/docker-socket-proxy:v0.5.0
     container_name: itest-docker-proxy
     networks: [itestnet]
     environment: ["CONTAINERS=1", "LOGS=1"]
@@ -135,7 +135,7 @@ services:
 
   # Write proxy scoped to start/stop only — mirrors the production docker-control.
   docker-control:
-    image: tecnativa/docker-socket-proxy:v0.4.2
+    image: tecnativa/docker-socket-proxy:v0.5.0
     container_name: itest-docker-control
     networks: [itestnet]
     environment: ["POST=1", "ALLOW_START=1", "ALLOW_STOP=1"]

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -690,7 +690,7 @@ assert_running_state() {
         # 'ubuntu' user or an explicit useradd, are uid 1000) and tari pins 1000 via the compose
         # override (the pulled image ships no non-root user of its own). Caddy and the two Docker
         # socket proxies are the audited exception — verified against the upstream images
-        # (caddy:2.11.4, tecnativa/docker-socket-proxy:v0.4.2): neither ships a non-root user, so
+        # (caddy:2.11.4, tecnativa/docker-socket-proxy:v0.5.0): neither ships a non-root user, so
         # they run as root, mitigated by cap_drop: ALL + read_only rootfs and (the proxies) sitting
         # off mining_net on host-loopback-only ports (#345) rather than by uid. Pin ALL 9 so a
         # silent drift either way — a hardened image reverting to root, or an accepted-root service

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -1267,11 +1267,11 @@ case "$(grep -E '^proxy=' "$MONT" || true)" in
 *) bad "monero clearnet: P2P proxy= line stripped (#183)" "still present" ;;
 esac
 assert_contains "monero clearnet: tx-proxy stays on Tor (#183)" "$(cat "$MONT")" "tx-proxy=tor"
-# P2Pool v4.16 clearnet recommendation: out-peers 32 + the recommended priority nodes (added only in
+# P2Pool v4.18 clearnet recommendation: out-peers 32 + the recommended priority nodes (added only in
 # the clearnet window; the Tor template has neither — the #161 check below guards that).
-assert_contains "monero clearnet: out-peers=32 (p2pool v4.16 rec)" "$(cat "$MONT")" "out-peers=32"
-assert_contains "monero clearnet: xmrvsbeast priority node (v4.16)" "$(cat "$MONT")" "add-priority-node=p2pmd.xmrvsbeast.com:18080"
-assert_contains "monero clearnet: hashvault priority node (v4.16)" "$(cat "$MONT")" "add-priority-node=nodes.hashvault.pro:18080"
+assert_contains "monero clearnet: out-peers=32 (p2pool v4.18 rec)" "$(cat "$MONT")" "out-peers=32"
+assert_contains "monero clearnet: xmrvsbeast priority node (v4.18)" "$(cat "$MONT")" "add-priority-node=p2pmd.xmrvsbeast.com:18080"
+assert_contains "monero clearnet: hashvault priority node (v4.18)" "$(cat "$MONT")" "add-priority-node=nodes.hashvault.pro:18080"
 # The committed template (the Tor-only default) keeps the proxy line + the Tor-tuned out-peers.
 assert_contains "monero default: Tor P2P proxy present (#183)" "$(cat "$ROOT/build/monero/bitmonero.conf.template")" 'proxy=${NETWORK_PREFIX}.25:9050'
 # #595: the template's out-peers is now config-driven (monero.out_peers, default 48 in the render).

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -137,7 +137,7 @@ expect_min "log rotation on every service" "max-size:" 9
 # docker-control — and expect_present is a grep -q, so it matches either line: bumping one proxy and
 # leaving the other was green. The two would then run different socket-proxy builds, which is exactly
 # the split the separate-proxy design exists to prevent.
-expect_min "tecnativa socket-proxy pinned by digest (both proxies)" "tecnativa/docker-socket-proxy:v0.4.2@sha256:1f3a6f303320723d199d2316a3e82b2e2685d86c275d5e3deeaf182573b47476" 2
+expect_min "tecnativa socket-proxy pinned by digest (both proxies)" "tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459" 2
 expect_present "caddy pinned by digest" "caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d"
 expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256:824fd6ec21d618805317d7eede374d6782906eeae17d2fc8aaad4df6205f94e0"
 
@@ -153,7 +153,7 @@ jq_assert() { # <label> <filter>
 # The read proxy must never gain write (POST) access; the control proxy is start/stop ONLY.
 jq_assert "docker-proxy cannot POST (read-only API)" '(.services["docker-proxy"].environment.POST // "0") != "1"'
 jq_assert "docker-control is start/stop only (no exec/image ops)" \
-    '.services["docker-control"].environment | (.POST=="1" and .ALLOW_START=="1" and .ALLOW_STOP=="1" and ((.EXEC // "0") != "1") and ((.IMAGES // "0") != "1"))'
+    '.services["docker-control"].environment | (.POST=="1" and .ALLOW_START=="1" and .ALLOW_STOP=="1" and ((.EXEC // "0") != "1") and ((.IMAGES // "0") != "1") and ((.ALLOW_PAUSE // "0") != "1") and ((.ALLOW_UNPAUSE // "0") != "1"))'
 # Both proxies mount the Docker socket read-only.
 jq_assert "docker socket mounted read-only in both proxies" \
     '[.services["docker-proxy"], .services["docker-control"]] | all((.volumes // []) | any((.source == "/var/run/docker.sock") and (.read_only == true)))'


### PR DESCRIPTION
Bumps the three stale non-Tari rows from the weekly pin report (#1144 — the report issue itself stays open; it is a standing weekly report, not a work item). Tari stays at v5.3.1 deliberately: v5.6.0 carries a one-way wallet-DB migration and is scheduled bench-gated work (#1129), not a patch-day bump.

## What moved

| component | from | to | pin proof |
|---|---|---|---|
| monerod | v0.18.5.0 | v0.18.5.1 | tarball sha256 from getmonero.org `hashes.txt`, and the image **built** against it |
| p2pool | v4.16 | v4.18 | tarball sha256 from the GPG-signed `sha256sums.txt.asc` release asset, agreeing with the GitHub API asset digest; image **built** against it |
| socket-proxy (both proxies) | v0.4.2 | v0.5.0 | Docker Hub multi-arch **index** digest; tier-1 asserts the full `tag@sha256` on both rows (`expect_min … 2`) |

## The two audits a bump owes

**p2pool v4.16 → v4.18 is a minor, so it was read, not just moved.** No `--merge-mine`/gRPC changes across v4.17–v4.18. One behaviour change matters to this stack and was verified against v4.18 source: the SOCKS5 exemption now covers *private addresses* on the node-RPC leg (`json_rpc_request.cpp:250 is_private_address`), so the #278 monerod socat bridge becomes belt-and-braces — while the Tari merge-mine leg still exempts loopback only (`tcp_server.cpp:425` unchanged), so its bridge stays load-bearing. Both bridges kept; the entrypoint comments now state the v4.18 reality instead of a stale v4.16 claim. The `out-peers=32` / priority-node recommendations were re-verified identical in the v4.18 README before respelling those comments.

**socket-proxy v0.4.2 → v0.5.0 widens the upstream surface, so the boundary was re-read.** Upstream diff (Dockerfile, `haproxy.cfg`, entrypoint) is additive only: the new pause/unpause routes sit behind their own `ALLOW_PAUSE`/`ALLOW_UNPAUSE` opt-ins which this stack does not set — with our exact `docker-control` env, `POST /containers/{id}/pause` still falls through to deny. The ENV defaults block is byte-identical; `BIND_CONFIG` is compute-if-unset; HAProxy base 3.2.4 → 3.4.2. The `docker-control` hardening assertion now **also denies `ALLOW_PAUSE`/`ALLOW_UNPAUSE`**, so the exact class of change that happened here (a new endpoint class appearing upstream) is visible to the gate next time.

The new image scans clean: `trivy image` (no ignore file) on the v0.5.0 digest → 0 fixable HIGH/CRITICAL (alpine 3.24.1). No existing `.trivyignore` mute relates to socket-proxy, so nothing goes stale.

## What was RUN

- `tests/stack/run.sh` full suite: **1826 passed, 0 failed**; `test_compose.sh` standalone: 85 passed.
- **Mutation, run and named:** `ALLOW_PAUSE=1` added to the `docker-control` env → exactly `✗ docker-control is start/stop only (no exec/image ops)` went red; restored.
- `docker build` of `build/monero` and `build/p2pool` (linux/amd64): both complete — the in-Dockerfile `sha256sum -c` is the pin gate and it passed against the new tarballs.
- `make lint-sh`, `make lint-docs-voice`: clean.
- NOT run here: the targeted bench e2e — this lands before the v1.19.3 cut and the mandated pre-cut e2e run drives the rebuilt images live (mining, merge-mine, lifecycle) as part of the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
