### PR TITLE
release: resolve every third-party image pin against its registry before a cut (#1137 part 3)

### DIFF
--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -112,3 +112,9 @@ jobs:
         run: |
           echo "::error::one or more upstream lookups could not run — those pins are UNCHECKED, not current"
           exit 1
+      # Digest-level check (#1137): does this lane's own docker-compose.yml pins still match what
+      # each tag resolves to right now. Separate from the report above on purpose — a version can
+      # be current while its digest has drifted, and that half-done-bump case is this step's job,
+      # not the report's. A mismatch or failed lookup fails this step, which fails the run.
+      - name: Check third-party image pins against their registries
+        run: bash scripts/resolve-pins.sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -357,6 +357,9 @@ preflight() {
     resolve_signing
     check_verifier_image
 
+    bash "$REPO_ROOT/scripts/resolve-pins.sh" ||
+        die "A third-party image pin does not match what its registry serves for that tag — see above. The digest is what actually runs, so cutting now would announce a version the stack is not running."
+
     STACK_VERSION="$(tr -d ' \t\r\n' <VERSION)"
     is_semver "$STACK_VERSION" || die "VERSION ('$STACK_VERSION') is not SemVer (expected X.Y.Z)."
     TAG="v$STACK_VERSION"

--- a/scripts/resolve-pins.sh
+++ b/scripts/resolve-pins.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Third-party image pin currency, at the digest level (#1137).
+#
+# pin-watch.sh asks "is the pinned VERSION behind upstream's latest release" and says outright that
+# it does NOT ask whether a pinned `tag@sha256:...` still has a digest that matches its tag. This
+# script asks exactly that second question, for every third-party image docker-compose.yml pins by
+# digest: quay.io/tarilabs' tari node and wallet, tecnativa's socket-proxy, and caddy.
+#
+# The digest is what actually runs. A version bump that moves a tag and leaves the digest behind
+# still runs the OLD image while the pin, the release notes, and every doc claim the new one — the
+# exact half-done bump #1137 is about. Comparing tags (what pin-watch.sh already does) cannot catch
+# it; only asking the registry what a tag resolves to right now can.
+#
+# Pin source is one grep over docker-compose.yml, not a hand-kept list: first-party images use
+# ${PITHEAD_REGISTRY...}/${STACK_VERSION...} and are never digest-pinned, so the `@sha256:` pattern
+# alone is the whole filter. A new third-party pin lands here on the next run with no edit to this
+# file, and a first-party image added the same way is never mistaken for one.
+#
+# UNREACHABLE IS NOT CURRENT. A registry lookup that cannot complete is counted, named, and rc 1 —
+# never silently treated as a match. A pin that could not be checked is UNCHECKED, not current.
+#
+# Usage:
+#   scripts/resolve-pins.sh              Compare every digest-pinned image against its registry.
+#                                         rc 1 on any mismatch OR any failed lookup.
+#   scripts/resolve-pins.sh --self-test  Drive extraction + comparison against fixtures, docker
+#                                         stubbed as a shell function. No network.
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# The one place pins are read from. Prints one "image:tag@sha256:digest" per line, sorted unique.
+extract_pins() { # <compose-file>
+    grep -oE 'image: [a-z0-9./_-]+:[A-Za-z0-9._-]+@sha256:[a-f0-9]{64}' "$1" | sed 's/^image: //' | sort -u
+}
+
+# Ask the registry what a tag resolves to RIGHT NOW. Shape-checked before it is trusted anywhere —
+# a registry error page or an empty response must never be compared as if it were a digest. Retried
+# because a registry hiccup must not fake a red; not retried past 3 tries because a hiccup that
+# outlives three tries with a 2s gap is a real outage, and an outage is exactly the UNCHECKED case.
+resolve_digest() { # <tag-ref> -> sha256:<64 hex> on stdout, rc 1 if never resolved to that shape
+    local ref="$1" out attempt sleep_s="${RESOLVE_PINS_RETRY_SLEEP:-2}"
+    for attempt in 1 2 3; do
+        if out="$(docker buildx imagetools inspect "$ref" --format '{{println .Manifest.Digest}}' 2>/dev/null)"; then
+            out="$(printf '%s' "$out" | tr -d '[:space:]')"
+            if printf '%s' "$out" | grep -qE '^sha256:[a-f0-9]{64}$'; then
+                printf '%s\n' "$out"
+                return 0
+            fi
+        fi
+        if [ "$attempt" -lt 3 ]; then
+            sleep "$sleep_s"
+        fi
+    done
+    return 1
+}
+
+# Every pin, resolved and verdicted. Prints one line per pin as it goes (so a hang on pin 2 of 4
+# does not hide the first result) and returns non-zero if anything failed OR mismatched.
+run_check() { # <compose-file>
+    local compose_file="$1" pin tagref pinned live failed=0 mismatched=0
+    while IFS= read -r pin; do
+        [ -n "$pin" ] || continue
+        tagref="${pin%@*}"
+        pinned="${pin##*@}"
+        if ! live="$(resolve_digest "$tagref")"; then
+            printf 'UNCHECKED: %s — the registry lookup for this tag did not return a usable digest after 3 tries. This pin is unverified, not current.\n' "$tagref"
+            failed=$((failed + 1))
+            continue
+        fi
+        if [ "$live" = "$pinned" ]; then
+            printf 'current: %s\n' "$tagref"
+        else
+            printf 'MISMATCH: %s — the registry resolves this tag to %s, docker-compose.yml pins %s. Either a version bump moved the tag and left the digest (the stack still runs the old image), or upstream re-pointed the tag. Fix the pin before cutting.\n' \
+                "$tagref" "$live" "$pinned"
+            mismatched=$((mismatched + 1))
+        fi
+    done < <(extract_pins "$compose_file")
+    if [ "$((failed + mismatched))" -gt 0 ]; then
+        printf '\n%s\n' "$failed lookup(s) unchecked, $mismatched pin(s) mismatched. Fix before cutting."
+        return 1
+    fi
+    printf '\nEvery third-party image pin matches what its registry resolves that tag to.\n'
+    return 0
+}
+
+# --- self-test -------------------------------------------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+    st_fail=0
+    st() { # <label> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (got [$2], want [$3])"
+            st_fail=1
+        fi
+    }
+    export RESOLVE_PINS_RETRY_SLEEP=0
+
+    fx1="$(mktemp)"
+    fx2="$(mktemp)"
+    trap 'rm -f "$fx1" "$fx2"' EXIT
+
+    cat >"$fx1" <<'EOF'
+    image: ${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-dashboard:${STACK_VERSION:-dev}
+    image: caddy:2.11.4@sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1
+    image: quay.io/tarilabs/minotari_node:v5.3.1-mainnet@sha256:b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2
+EOF
+    st "extraction finds exactly the digest-pinned refs" "$(extract_pins "$fx1" | wc -l | tr -d ' ')" "2"
+    st "a \${VAR} first-party image is skipped" "$(extract_pins "$fx1" | grep -c '\${' || true)" "0"
+
+    printf 'image: caddy:2.11.4@sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1\n' >"$fx2"
+
+    docker() { printf 'sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1\n'; }
+    if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
+    st "a matching digest resolves rc 0" "$rc" "0"
+
+    # THE #1137 MUTATION: the tag now resolves to a NEW digest; docker-compose.yml still pins the
+    # old one. Nothing about the file is malformed — this is exactly the half-done bump #1137
+    # describes, and it MUST go red.
+    docker() { printf 'sha256:c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3\n'; }
+    if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
+    st "a moved tag with the old digest left behind is caught" "$rc" "1"
+    st "the mismatch is named, not swallowed" "$(printf '%s' "$out" | grep -c MISMATCH)" "1"
+
+    docker() { return 1; }
+    if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
+    st "a resolver that cannot run fails, never current" "$rc" "1"
+    st "a failed lookup is never printed as current" "$(printf '%s' "$out" | grep -c '^current:')" "0"
+
+    docker() { printf 'not-a-digest\n'; }
+    if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
+    st "non-sha256 resolver output is refused" "$rc" "1"
+    st "garbage output is never compared as a mismatch" "$(printf '%s' "$out" | grep -c MISMATCH)" "0"
+
+    unset -f docker
+
+    if [ "$st_fail" = 0 ]; then
+        echo "resolve-pins self-test OK"
+    fi
+    exit "$st_fail"
+fi
+
+# --- the check -------------------------------------------------------------------------------
+compose_file="$ROOT/docker-compose.yml"
+[ -f "$compose_file" ] || {
+    echo "resolve-pins: docker-compose.yml not found at $compose_file" >&2
+    exit 1
+}
+command -v docker >/dev/null 2>&1 || {
+    echo "resolve-pins: docker is required to resolve registry digests." >&2
+    exit 1
+}
+
+run_check "$compose_file"

--- a/scripts/resolve-pins.sh
+++ b/scripts/resolve-pins.sh
@@ -59,9 +59,10 @@ resolve_digest() { # <tag-ref> -> sha256:<64 hex> on stdout, rc 1 if never resol
 # Every pin, resolved and verdicted. Prints one line per pin as it goes (so a hang on pin 2 of 4
 # does not hide the first result) and returns non-zero if anything failed OR mismatched.
 run_check() { # <compose-file>
-    local compose_file="$1" pin tagref pinned live failed=0 mismatched=0
+    local compose_file="$1" pin tagref pinned live failed=0 mismatched=0 seen=0
     while IFS= read -r pin; do
         [ -n "$pin" ] || continue
+        seen=$((seen + 1))
         tagref="${pin%@*}"
         pinned="${pin##*@}"
         if ! live="$(resolve_digest "$tagref")"; then
@@ -77,6 +78,14 @@ run_check() { # <compose-file>
             mismatched=$((mismatched + 1))
         fi
     done < <(extract_pins "$compose_file")
+    # Zero pins found is a broken extraction, not a clean bill: this file has carried digest pins
+    # since #135, so an empty result means the pattern no longer matches the compose file (or every
+    # pin was deliberately removed — which also deserves a human). Passing here would be the exact
+    # green-while-checking-nothing failure this script exists to kill.
+    if [ "$seen" -eq 0 ]; then
+        printf 'NO PINS FOUND: %s yielded no tag@sha256 image references. The extraction no longer matches the file, so nothing was checked — this is a broken gate, not a clean one.\n' "$compose_file"
+        return 1
+    fi
     if [ "$((failed + mismatched))" -gt 0 ]; then
         printf '\n%s\n' "$failed lookup(s) unchecked, $mismatched pin(s) mismatched. Fix before cutting."
         return 1
@@ -133,6 +142,14 @@ EOF
     if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
     st "non-sha256 resolver output is refused" "$rc" "1"
     st "garbage output is never compared as a mismatch" "$(printf '%s' "$out" | grep -c MISMATCH)" "0"
+
+    # A fixture with NO digest pins at all: the extraction finding nothing means the gate checked
+    # nothing, and a gate that checked nothing must not pass (#1069's whole genus).
+    printf 'image: ${PITHEAD_REGISTRY:-ghcr.io/x}/pithead-dashboard:${STACK_VERSION:-dev}\n' >"$fx2"
+    docker() { printf 'sha256:a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1\n'; }
+    if out="$(run_check "$fx2" 2>&1)"; then rc=0; else rc=$?; fi
+    st "zero pins found fails loudly, never passes vacuously" "$rc" "1"
+    st "the empty extraction is named" "$(printf '%s' "$out" | grep -c 'NO PINS FOUND')" "1"
 
     unset -f docker
 

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -121,6 +121,13 @@ echo "== unit: pin-watch self-test (#1128) =="
 bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
 assert_rc "pin-watch self-test passes" "$?" "0"
 
+echo "== unit: resolve-pins self-test (#1137) =="
+# pin-watch.sh above compares VERSIONS; it does not ask whether a pinned tag@sha256 digest still
+# matches what its registry serves for that tag. This is the check that does, and its --self-test
+# drives the exact half-done bump #1137 is about (tag moved, old digest left in the file) red.
+bash "$ROOT/scripts/resolve-pins.sh" --self-test >/dev/null 2>&1
+assert_rc "resolve-pins self-test passes" "$?" "0"
+
 echo "== unit: patch-coverage overlap self-test (#1000) =="
 # diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
 # overlap check is what turns that into a loud not-applicable pass or a real failure; its


### PR DESCRIPTION
Part 3 of #1137, the last open piece (#1137 stays open only until this merges): a release-prep check that asks each third-party image pin's registry what its tag resolves to RIGHT NOW and compares that against the pinned digest — the only check that catches a tag/digest pair that is self-consistent in the file but wrong against upstream.

The "two token flows" blocker named in pin-watch.sh's header turned out to be avoidable entirely: `docker buildx imagetools inspect` performs both registries' token dances internally and returns the multi-arch **index** digest — the thing docker pulls by and compose pins. No curl, no jq, no token code.

## Shape

- **`scripts/resolve-pins.sh`** (new): pins read from `docker-compose.yml` by one grep (first-party images are never digest-pinned, so `@sha256:` is the whole filter — a future third-party pin is picked up with no edit here). rc 1 on any mismatch OR any failed lookup — UNREACHABLE IS NOT CURRENT, same rule as pin-watch. **Zero pins found also fails loudly**: an empty extraction means the pattern stopped matching the file, and a gate that checked nothing must not pass.
- **`release.sh` preflight**: called unconditionally (NOT dry-run-guarded — the rehearsal must run the real decision), right after the verifier-image check.
- **`tests/stack/run.sh`**: the `--self-test` (11 cases, no network, docker stubbed) wired beside the pin-watch one.
- **`pin-watch.yml`**: one step at the end of the matrix job, so both lanes get the digest-level check weekly. ⚠ The develop-v2 lane needs this script to exist there — today's develop→develop-v2 sync carries it; until that sync lands the appliance-lane step would fail loudly (not silently) on Monday.

## What was RUN

- `--self-test`: 11/11 green.
- **The #1137 mutation, run twice**: (a) implementation-level — comparison replaced with a tautology → the moved-tag/old-digest self-test case went red; (b) the self-test's own fixture case drives tag-moved-digest-kept red on every run.
- **Live against the real registries** on the post-#1183 tree: all four pins (tari node, tari wallet, socket-proxy v0.5.0, caddy) resolve to exactly the pinned digests — this check validated today's socket-proxy bump end to end.
- Full `tests/stack/run.sh`: 1827 passed, 0 failed. `make lint-sh` clean. Adversarial verifier pass: 10/10 attack angles held (fail-open hunt, retry swallowing, DRY_RUN guard, REPO_ROOT resolution, vacuous self-test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
