### PR TITLE
test(control): pin the security perimeter itself, not just allowlist copy-agreement

### DIFF
--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -438,6 +438,10 @@ def test_perimeter_env_keys_never_committable_from_either_copy():
     py_confirm = set(control_service.CONFIRM_ENV_KEY_PATHS.keys())
 
     for key in NEVER_COMMITTABLE_ENV_KEYS:
+        # A perimeter entry whose spelling no longer exists in the codebase guards nothing: the
+        # real (renamed) key could be added to every allowlist while this list stays green. Anchor
+        # each entry to the pithead text so a rename kills the test, not the protection.
+        assert key in pithead, f"{key} appears nowhere in pithead — dead perimeter entry (key renamed?)"
         assert key not in pithead_editable, f"{key} in pithead's CONTROL_DASHBOARD_EDITABLE_KEYS"
         assert key not in pithead_confirm, f"{key} in pithead's CONTROL_DASHBOARD_CONFIRM_KEYS"
         assert key not in py_editable, f"{key} in control_service.EDITABLE_ENV_KEY_PATHS"

--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -387,6 +387,63 @@ def test_confirm_keys_have_no_intra_repo_drift():
     assert set(control_service.CONFIRM_ENV_KEY_PATHS.keys()) == pithead_keys
 
 
+# The security perimeter (#1094): env keys that must never be dashboard-committable at all — auth,
+# onion exposure, the bind/host, the control channel itself, Tor egress, and wallet/node
+# credentials. The two drift tests above only catch the editable/confirm allowlists' two hand-kept
+# copies disagreeing with EACH OTHER; a key added to BOTH copies at once (#1094's mutation proof:
+# DASHBOARD_AUTH_HASH_B64, or DASHBOARD_HOST, added to pithead's list and EDITABLE_ENV_KEY_PATHS
+# together) leaves them in perfect agreement and both drift tests stay green. This list is the
+# claim those tests can't make: not "do the two copies match" but "is this key committable at all".
+NEVER_COMMITTABLE_ENV_KEYS = frozenset(
+    {
+        "DASHBOARD_AUTH_USER",
+        "DASHBOARD_AUTH_HASH_B64",
+        "DASHBOARD_AUTH_PW_FP",
+        "DASHBOARD_HOST",
+        "DASHBOARD_CONTROL_ENABLED",
+        "DASHBOARD_ONION_ENABLED",
+        "DASHBOARD_ONION_ADDRESS",
+        "DASHBOARD_ONION_CLIENT_AUTH",
+        "TOR_EGRESS_FIREWALL",
+        "MONERO_WALLET_ADDRESS",
+        "MONERO_VIEW_KEY",
+        "MONERO_NODE_USERNAME",
+        "MONERO_NODE_PASSWORD",
+        "WALLET_RPC_PASSWORD",
+        "TARI_VIEW_KEY",
+        "TARI_WALLET_PASSWORD",
+    }
+)
+
+
+def test_perimeter_env_keys_never_committable_from_either_copy():
+    """#1094: names the security perimeter directly and checks each of the four allowlists (pithead's
+    editable + confirm sets, EDITABLE_ENV_KEY_PATHS + CONFIRM_ENV_KEY_PATHS) against it
+    independently, so a key added to every copy at once still fails — unlike the drift tests above,
+    which compare the copies only to each other."""
+    import re
+    from pathlib import Path
+
+    here = Path(__file__).resolve()
+    pithead_path = next((p / "pithead" for p in here.parents if (p / "pithead").is_file()), None)
+    if pithead_path is None:
+        pytest.skip("pithead CLI not present in this test context (dashboard-only image)")
+    pithead = pithead_path.read_text()
+    editable_m = re.search(r"CONTROL_DASHBOARD_EDITABLE_KEYS='([^']*)'", pithead)
+    confirm_m = re.search(r"CONTROL_DASHBOARD_CONFIRM_KEYS='([^']*)'", pithead)
+    assert editable_m and confirm_m, "could not find pithead's editable/confirm allowlists"
+    pithead_editable = set(editable_m.group(1).split())
+    pithead_confirm = set(confirm_m.group(1).split())
+    py_editable = set(control_service.EDITABLE_ENV_KEY_PATHS.keys())
+    py_confirm = set(control_service.CONFIRM_ENV_KEY_PATHS.keys())
+
+    for key in NEVER_COMMITTABLE_ENV_KEYS:
+        assert key not in pithead_editable, f"{key} in pithead's CONTROL_DASHBOARD_EDITABLE_KEYS"
+        assert key not in pithead_confirm, f"{key} in pithead's CONTROL_DASHBOARD_CONFIRM_KEYS"
+        assert key not in py_editable, f"{key} in control_service.EDITABLE_ENV_KEY_PATHS"
+        assert key not in py_confirm, f"{key} in control_service.CONFIRM_ENV_KEY_PATHS"
+
+
 class TestWorkerApply:
     """Worker config-apply spooling + validation (#185). The intent carries only the worker name +
     writable-key changes — never a host, port, or token (those stay host-side, #440)."""


### PR DESCRIPTION
#1094 (a sub-item of #1069 — #1069 stays open): the two existing "no intra-repo drift" tests compare the editable/confirm allowlists' two hand-kept copies only to **each other**, so a never-committable key added to both copies at once passes both. This names the security perimeter directly.

- `NEVER_COMMITTABLE_ENV_KEYS`: 16 keys — dashboard auth, the bind/host, onion exposure, the control channel's own enable, Tor egress, wallet/node credentials — checked independently against all four allowlists (pithead's `CONTROL_DASHBOARD_EDITABLE_KEYS`/`CONFIRM_KEYS`, `control_service.py`'s `EDITABLE_ENV_KEY_PATHS`/`CONFIRM_ENV_KEY_PATHS`), so copy-agreement no longer implies safety.
- Each entry is **anchored to the pithead text**: a perimeter key whose spelling was renamed out of the codebase fails the test as a dead entry rather than silently guarding nothing.

## What was RUN
- `make test-dashboard`: 1722 passed, 97% coverage. `make lint`: clean. Targeted perimeter+drift selection: 5 passed.
- **Mutation 1 (the issue's exact scenario):** `DASHBOARD_AUTH_HASH_B64` added to BOTH copies → the new test red, both drift tests still green (reproducing the blind spot). Reverted, green.
- **Mutation 2 (dead-entry anchor):** `TOR_EGRESS_FIREVALL`-class respelling in the deny list → red ("dead perimeter entry"). Reverted, green. All 16 entries verified present in `pithead` (3–14 occurrences each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
