### PR TITLE
dashboard: stop the Your Stack grid trailing half a section of blank space

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -852,7 +852,11 @@ class EarningsCard extends Component {
     return html`
         <div class="card card-advanced" id="card-earnings">
             <h3>P2Pool Earnings (estimated)</h3>
-            <p class="text-muted text-xs earnings-subtitle">Estimated XMR from P2Pool mining plus the Tari merge-mined alongside it — excludes XvB donations.</p>
+            <details class="earnings-details">
+                <summary>About this estimate</summary>
+                <p class="text-muted text-xs earnings-subtitle">Estimated XMR from P2Pool mining plus the Tari merge-mined alongside it — excludes XvB donations.</p>
+                <p class="earnings-disclaimer text-muted text-xs mt-2">${e.disclaimer}</p>
+            </details>
             <div class="earnings-input">
                 <label for="whatif-hr">Your P2Pool Hashrate</label>
                 <input id="whatif-hr" type="text" inputmode="decimal" spellcheck="false"
@@ -925,7 +929,6 @@ class EarningsCard extends Component {
                 </p>`
                 : null
             }
-            <p class="earnings-disclaimer text-muted text-xs mt-2">${e.disclaimer}</p>
         </div>`;
   }
 }
@@ -1260,6 +1263,12 @@ function DashboardView({
   // Layout by operator relevance (#159): the at-a-glance chart and the rigs themselves lead (this
   // stack may drive many machines), then this stack's own detail cards, then pool-wide and network
   // context as reference at the bottom — "mine" first, "the world" last.
+  // Within "Your Stack" (#991), the advanced-only cards are ordered tall-with-tall / short-with-short:
+  // the auto-fit grid's rows are as tall as their tallest card, so pairing similarly-sized neighbours
+  // (XvBStats+EarningsCard, then NodeStats+ExpectedVsActualCard, then TariCard+CadenceCard) cuts the
+  // blank space shorter cards used to trail. Overview is Simple-view-only (display:none in Advanced,
+  // so its position never affects the Advanced grid) and ExpectedVsActualCard shows in both views —
+  // neither constrains this ordering.
   return html`
     <div id="dashboard-view" class=${advanced ? "mode-advanced" : ""}>
         <div class="view-controls">
@@ -1295,12 +1304,12 @@ function DashboardView({
         <div class="grid">
             <div class="grid-section-label">Your Stack</div>
             <${Overview} state=${state} />
-            <${ExpectedVsActualCard} summary=${state.earnings_summary} />
-            <${NodeStats} state=${state} />
             <${XvBStats} state=${state} />
             <${EarningsCard} earnings=${state.earnings} xvb=${state.xvb_calc} energy=${state.energy} />
-            <${CadenceCard} cadence=${state.cadence} />
+            <${NodeStats} state=${state} />
+            <${ExpectedVsActualCard} summary=${state.earnings_summary} />
             <${TariCard} tari=${state.tari} />
+            <${CadenceCard} cadence=${state.cadence} />
             <div class="grid-section-label">The Wider Pool</div>
             <${GlobalStats} state=${state} />
             <${NetworkCard} state=${state} />

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -316,8 +316,19 @@ h3 {
 }
 
 /* Earnings calculator what-if input (Issue #12) */
-.earnings-subtitle {
+/* The subtitle + disclaimer prose (#991): collapsed by default, same pattern as .egress-details —
+ * these two paragraphs were the single biggest block in the tallest card in the "Your Stack" grid
+ * section, so every shorter neighbour trailed blank space under it. */
+.earnings-details {
   margin: -4px 0 12px 0;
+}
+.earnings-details > summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+.earnings-subtitle {
+  margin: 8px 0 0 0;
   line-height: 1.4;
 }
 .earnings-input {


### PR DESCRIPTION
#991: the "Your Stack" Advanced grid wasted roughly half its height because rows are as tall as their tallest card. Both low-risk shapes the issue itself proposed, nothing else:

1. **The tallest card's prose collapses.** The P2Pool Earnings card's subtitle + disclaimer — its single biggest block — now sit in a collapsed-by-default native `<details>` ("About this estimate"), the same pattern `.egress-details` already uses. Copy is verbatim, only relocated.
2. **Height-aware ordering** within the section (the issue's "zero-risk half-measure"): XvBStats+EarningsCard, NodeStats+ExpectedVsActualCard, TariCard+CadenceCard — tall with tall, short with short. Markup order only; no card changes section; Overview is Simple-view-only and unaffected.

**Measured** (dashboard visual harness, real browser at 1280px, `getBoundingClientRect`, against a fixture with `earnings.available: true` so the full tabbed card renders — the checked-in fixture hides exactly the card this issue is about):

| | section height |
|---|---|
| before | 973px |
| disclosure only | 798px |
| + reorder | **704px (−27.6%)** |

Per-row trailing blank space drops from ~492px to ~210px.

## What was RUN
- Frontend suite: 317 passed. `make lint` (biome, docs-voice, operator-strings, everything before lint-proto): clean.
- `make test-dashboard`: 1721 passed, 97% coverage. `make test-stack test-compose test-integration-selftest test-fakes`: all green.
- Patch coverage: not applicable — JS/CSS only, no Python changed.
- Visual states confirmed live in a browser pane at both steps; the masonry/columns rewrite the issue also sketches stays out (it changes reading order — that's #940's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
