### PR TITLE
style: ruff-format the perimeter anchor assert

### DIFF
--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -441,7 +441,9 @@ def test_perimeter_env_keys_never_committable_from_either_copy():
         # A perimeter entry whose spelling no longer exists in the codebase guards nothing: the
         # real (renamed) key could be added to every allowlist while this list stays green. Anchor
         # each entry to the pithead text so a rename kills the test, not the protection.
-        assert key in pithead, f"{key} appears nowhere in pithead — dead perimeter entry (key renamed?)"
+        assert key in pithead, (
+            f"{key} appears nowhere in pithead — dead perimeter entry (key renamed?)"
+        )
         assert key not in pithead_editable, f"{key} in pithead's CONTROL_DASHBOARD_EDITABLE_KEYS"
         assert key not in pithead_confirm, f"{key} in pithead's CONTROL_DASHBOARD_CONFIRM_KEYS"
         assert key not in py_editable, f"{key} in control_service.EDITABLE_ENV_KEY_PATHS"


### PR DESCRIPTION
Formatter output only: release.sh stage 2 caught one unformatted line (the #1186 follow-up anchor assert, added without a lint-py pass — process miss recorded). `git diff` shows a single assert message wrapped by ruff; the perimeter tests still pass and `ruff format --check .` is clean (103 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
