### PR TITLE
dashboard: column-pack the card sections — a static order cannot be height-aware across render states

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -1263,12 +1263,14 @@ function DashboardView({
   // Layout by operator relevance (#159): the at-a-glance chart and the rigs themselves lead (this
   // stack may drive many machines), then this stack's own detail cards, then pool-wide and network
   // context as reference at the bottom — "mine" first, "the world" last.
-  // Within "Your Stack" (#991), the advanced-only cards are ordered tall-with-tall / short-with-short:
-  // the auto-fit grid's rows are as tall as their tallest card, so pairing similarly-sized neighbours
-  // (XvBStats+EarningsCard, then NodeStats+ExpectedVsActualCard, then TariCard+CadenceCard) cuts the
-  // blank space shorter cards used to trail. Overview is Simple-view-only (display:none in Advanced,
-  // so its position never affects the Advanced grid) and ExpectedVsActualCard shows in both views —
-  // neither constrains this ordering.
+  // Within "Your Stack" (#991, reopened): the section packs into CSS columns now, not CSS grid
+  // rows, so a card's height no longer forces blank space under a shorter neighbour regardless of
+  // which cards a given render state actually shows (XvB disabled, no earnings yet, ...) — the
+  // tall-with-tall/short-with-short pairing this comment used to describe was a workaround for
+  // grid's row-stretch behaviour and is moot under column packing. Order here still sets the
+  // column-major reading order, so it stays "mine" first, "the world" last, same as above.
+  // Overview is Simple-view-only (display:none in Advanced) and ExpectedVsActualCard shows in
+  // both views — neither is constrained by this ordering.
   return html`
     <div id="dashboard-view" class=${advanced ? "mode-advanced" : ""}>
         <div class="view-controls">
@@ -1301,8 +1303,8 @@ function DashboardView({
             <${WorkersTable} workers=${state.workers} summary=${state.proxy_summary} ui=${ui} onSort=${onSort} hostIp=${state.host_ip} stratumPort=${state.stratum_port}
                              onInspect=${state.control_enabled ? onInspect : null} />
         </div>
-        <div class="grid">
-            <div class="grid-section-label">Your Stack</div>
+        <div class="grid-section-label">Your Stack</div>
+        <div class="grid grid-columns">
             <${Overview} state=${state} />
             <${XvBStats} state=${state} />
             <${EarningsCard} earnings=${state.earnings} xvb=${state.xvb_calc} energy=${state.energy} />
@@ -1310,7 +1312,9 @@ function DashboardView({
             <${ExpectedVsActualCard} summary=${state.earnings_summary} />
             <${TariCard} tari=${state.tari} />
             <${CadenceCard} cadence=${state.cadence} />
-            <div class="grid-section-label">The Wider Pool</div>
+        </div>
+        <div class="grid-section-label">The Wider Pool</div>
+        <div class="grid grid-columns">
             <${GlobalStats} state=${state} />
             <${NetworkCard} state=${state} />
             <${ComponentHealth} topology=${state.topology} egress=${state.egress} />

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -112,19 +112,31 @@ body {
   margin-bottom: 20px;
 }
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 20px;
   margin-bottom: 20px;
-  /* Cards hug their content instead of stretching to the row's tallest neighbour (#817) — the
-   * default stretch rendered short cards as mostly-empty bordered boxes across the grid. */
-  align-items: start;
 }
-/* Section label inside the Advanced card grid (#159): the grid itself has no visual grouping, so
- * these mark the "mine" -> "the world" transition the layout comment describes. Spans the full
- * grid row; typography matches .est-heading (the other muted section marker in this stylesheet). */
+/* Column-based packing (#991, reopened): a static card order can't stay height-aware across every
+ * combination of conditionally-rendered cards (XvB disabled, no earnings yet, Tari off, ...) — a
+ * fixed sequence is only optimal for the subset of cards visible when it was tuned, and degrades
+ * back to row-shaped trailing gaps for every other subset. CSS multi-column packs whatever cards
+ * are actually visible tightly, for any subset. The trade the issue accepted: reading order is
+ * column-major within the section, not row-major. column-width (not column-count) mirrors the old
+ * auto-fit/minmax(350px, 1fr) responsiveness — the browser fits as many ~350px columns as the
+ * container allows. Only the Your-Stack/Wider-Pool grids get this (the plain `.grid` above still
+ * wraps the single-card Chart/Workers rows, which must stay full width, not column-width).
+ * Your Stack and Wider Pool are each their OWN `.grid-columns` container (#991: an earlier version
+ * shared one container and pulled the label between them out with `column-span: all` — Safari
+ * clips/slices the first card after a spanning element at the column boundary; Chromium doesn't
+ * reproduce it. Two independent containers sidestep the spanner entirely instead of chasing the
+ * engine bug), with the section label a plain heading in normal flow above each one. */
+.grid-columns {
+  columns: 350px;
+  column-gap: 20px;
+}
+/* Section label above a packed grid (#159): the grid itself has no visual grouping, so this marks
+ * the "mine" -> "the world" transition the layout comment describes. A plain block heading in
+ * normal flow (#991: was `column-span: all` inside a single shared container — see above).
+ * Typography matches .est-heading (the other muted section marker in this stylesheet). */
 .grid-section-label {
-  grid-column: 1 / -1;
   margin-top: 6px;
   font-size: 0.7rem;
   font-weight: 600;
@@ -140,6 +152,15 @@ body {
   display: flex;
   flex-direction: column;
   min-width: 0;
+}
+.grid-columns > .card {
+  /* No explicit width: .card is content-box (no box-sizing rule) and a block-level box (`display:
+   * flex`'s outer display is block) already fills its column at `width: auto` — the browser
+   * solves content-width = column-width - padding - border for auto, but a literal `100%` would
+   * set the CONTENT width to the full column and let padding/border add on top, overflowing the
+   * column by 2 * 20px padding + 2px border. */
+  break-inside: avoid;
+  margin-bottom: 20px;
 }
 
 /* Vertically-stacked cards that aren't in a .grid need their own gap (#505: the Configuration
@@ -578,9 +599,11 @@ tr:last-child td {
   text-align: center;
 }
 /* The wins log is capped at 20 rows of data, but even a dozen rows made the XvB card the tallest
- * thing in its grid row — and grid rows are as tall as their tallest card, so every neighbour
- * trailed white space (#817's align-items:start stops the stretch, not the row height). Cap the
- * list at roughly six rows and scroll the rest. */
+ * thing on the page. Under the CSS grid this section used before #991, that stretched every
+ * neighbour in its row with trailing white space (#817's align-items:start stopped the stretch,
+ * not the row height). Under the column packing #991 replaced it with, a card can't split across
+ * a column break (break-inside: avoid), so an uncapped log would instead set a floor under the
+ * whole section's height. Cap the list at roughly six rows and scroll the rest either way. */
 .raffle-wins-list {
   max-height: 120px;
   overflow-y: auto;


### PR DESCRIPTION
Second half of #991, after the operator inspected v1.19.3 live: the static tall-with-tall card order shipped there degrades whenever a conditional card doesn't render (their box runs XvB disabled — the XvBStats card vanishes and the pairing collapses back to tall+short rows). A static order cannot be height-aware across render states, so the section layout moves to column packing.

## Shape

- `.grid-columns` (multi-column, `columns: 350px`) applied to the two card sections only; plain `.grid` stays a block container for the single-card Chart/Workers panels.
- **One independent column container per section, labels outside as plain block headings.** The first draft used one shared container with `column-span: all` labels — the operator's browser (Safari-engine) sliced and double-painted the first Wider-Pool card at the spanner boundary and shuffled/hid panels as zoom changed the column count. `column-span` is the multicol feature engines disagree on; it is now absent from the codebase, and "The Wider Pool starts below Your Stack" is a property of document flow, not of a spanner.
- Cards: `break-inside: avoid`, no `width:100%` (the codebase is content-box; `width:auto` is the correct column fit — the 100% variant overflowed by padding+border and was caught in verification).

## Measured (real browser, real `build_state()` payloads)

"Your Stack" at 1280px, before → after: XvB on/earnings on 763.5 → 807px (**+3.9% — the one state the old hand-tuned order was optimized for pays for the generality; reported, not hidden**); XvB off/earnings on (the operator's live state) 683.5 → 627px; XvB off/earnings off 650.5 → 501px (−23%).

Width sweep 900/1100/1280/1400/1512/1700 across all three states + 375px mobile: zero clipped, zero fragmented (`getClientRects().length === 1` everywhere), zero overlapping cards, visible-count exact, Wider Pool strictly below Your Stack, mobile a clean single column. Operator additionally inspected before/after side-by-side in the visual harness at their own render state, plus a maximal-data stress fixture (XvB + earnings + Tari on, 14 workers, 25 raffle wins, fat lists): no fragmentation, no overlap, no horizontal scroll.

`make test-frontend` 317/317; `make lint` clean. Known follow-up left deliberately: the stale mobile media-query block (~`dashboard.css:1220`) is now inert (`.grid` is no longer a grid) — cleanup, not behavior.

Rides the next release; the deployed v1.19.3 stays as cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
