### PR TITLE
chore(dashboard): drop the inert mobile .grid override left by column packing

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -1195,13 +1195,13 @@ button.upgrade-btn {
 }
 
 /* ---- Responsive / mobile (Issue #83) --------------------------------------------------
- * The desktop layout above is fluid down to tablet widths via the card grid's auto-fit, but a
- * few fixed sizes break or overflow on phones: the 350px card-track minimum forces a column
- * wider than the screen, the header is a fixed two-up row, the disk bar is a hard 150px, and
- * the body padding is a roomy 20px. These overrides take over at phone widths — tighter
- * padding, a stacked header, a single-column card grid, and a full-width disk bar. The workers
- * table is handled separately by .table-scroll above. One breakpoint is enough: above it the
- * grid's auto-fit already reflows cleanly. */
+ * The desktop layout above is fluid down to tablet widths via the sections' column packing, but
+ * a few fixed sizes break or overflow on phones: the header is a fixed two-up row, the disk bar
+ * is a hard 150px, and the body padding is a roomy 20px. These overrides take over at phone
+ * widths — tighter padding, a stacked header, and a full-width disk bar. Card stacking needs no
+ * override: a phone viewport fits exactly one ~350px column, so the packed sections are already
+ * single-column. The workers table is handled separately by .table-scroll above. One breakpoint
+ * is enough: above it the column packing already reflows cleanly. */
 @media (max-width: 640px) {
   body {
     padding: 12px;
@@ -1220,12 +1220,6 @@ button.upgrade-btn {
     flex-wrap: wrap;
   }
 
-  /* One card per row — the 350px minmax floor overflows a phone, so collapse to a single
-       fluid column. */
-  .grid {
-    grid-template-columns: 1fr;
-    gap: 12px;
-  }
   .card {
     padding: 16px;
   }


### PR DESCRIPTION
The delete-only follow-up #1195 left behind: the mobile media query's `.grid` override is dead since the section layout moved to column packing, so it comes out.

## Why only the rule, not the block

The queue note said "inert mobile media-query block" — that framing is wrong, and this PR deliberately does less. The rest of the block (`body` padding, `.header` stacking, `.card` padding, `.disk-bar` width) still targets classes that render on every phone view; only the `.grid` rule inside it is inert:

- `.grid` is a plain block since #1195 (`margin-bottom` only), so `grid-template-columns: 1fr` is a no-op by CSS semantics.
- `gap: 12px` could only manifest as `column-gap` on the `.grid.grid-columns` multicol sections, and below the 640px breakpoint two ~350px columns need ≥712px of content width — the maximum available is 616px, so a second column (and therefore any rendered gap) is impossible.

The section lead comment is updated to match reality (the old text described the removed auto-fit grid and claimed the override produced the single-column phone layout; single-column now falls out of the column math).

## What was RUN

- `make test-frontend`: 317/317 pass.
- `make lint`: pass.
- NOT run: the visual harness. The deleted rule is provably inert by the two arguments above, both properties of the CSS itself rather than of any fixture; a screenshot diff would compare identical pixels. Flagging it so the omission is a stated decision, not an oversight.
