### PR TITLE
feat(release): fast-forward main to the tag at publish; retire the back-merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
 ## Development workflow
 
 1. Fork the repo and create a branch off `develop` (the integration branch; `main` holds released
-   commits only — how releases move `develop` → `main` and back is in
+   commits only — it fast-forwards to each release's tagged commit, see
    [Releasing › Branch mechanics](docs/dev/releasing.md#branch-mechanics)).
 2. Make your change. Keep it focused: one logical change per PR.
 3. Run the full test suite locally:

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -62,8 +62,11 @@ The safe rule: the keyed server only ever runs code you trust. Concretely:
 
 This is how the workflow ships.
 [`.github/workflows/release-gate.yml`](../../.github/workflows/release-gate.yml) runs only on
-`workflow_dispatch` (and `push` to `main`) on a `[self-hosted, pithead-release]` runner, never
-automatically on a PR.
+`workflow_dispatch`, on a `[self-hosted, pithead-release]` runner, never automatically on a PR
+and never on a push: no runner is registered, and a trigger that arrives before its runner is
+how `main` ends up wearing a gate that never ran (#1048). Since releases fast-forward `main`
+at publish time, a `push` trigger would also fire *after* the release it was meant to gate —
+any future automation belongs on the ref being cut, not on `main`.
 
 ## Provisioning the server
 

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -51,9 +51,10 @@ The safe rule: the keyed server only ever runs code you trust. Concretely:
 
 - Do not trigger tier-4 on `pull_request` (and never on a fork PR). "Require approval" only
   gates starting the run; once it starts, the PR's code still executes on the box.
-- Trigger tier-4 only on trusted code: `workflow_dispatch` (a maintainer manually runs it on a
-  ref they've reviewed) and/or `push` to `main` (post-merge). To E2E a specific fork PR, a
-  maintainer reviews it first, then dispatches the workflow on that ref.
+- Trigger tier-4 only on trusted code: `workflow_dispatch`, on a ref a maintainer has reviewed.
+  A `push`-to-`main` trigger is no longer an alternative — `main` only moves when a release
+  fast-forwards it at publish time, after this gate should already have run. To E2E a specific
+  fork PR, a maintainer reviews it first, then dispatches the workflow on that ref.
 - Register the runner as ephemeral / just-in-time (one job, then auto-removed) in its own runner
   group, isolated from any private repos.
 - Keep the runner least-privilege: a dedicated unprivileged user, the box runs nothing else

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -80,12 +80,29 @@ every gate is green.
 
 ### Branch mechanics
 
-Releases are cut from `main`. Merge `develop` into `main` with a real merge commit — never a
-squash, so the released commits keep their history — and run the pipeline from `main`. After
-publishing, merge `main` back into `develop`: the release's merge commit and tag must be an
-ancestor of `develop`, or the next cut diverges. `release.sh` warns (it does not abort) when the
-working tree is on any other branch. The branch model itself is in
+Releases are cut from `develop`. Land the release-prep commit (`VERSION`, `pyproject.toml`, the
+`CHANGELOG.md` entry) as a normal PR, run the pipeline with that commit checked out, and publish:
+the tag lands on it, and `release.sh` then moves `main` to the tagged commit with a fast-forward
+push. `main` keeps its meaning — the last released commit — and stays an ancestor of `develop` by
+construction, so there is no back-merge and no post-release repair step ([#1076]; releases through
+v1.19.3 instead merged `develop` into `main` and back, and the back-merge was missed on v1.19.0).
+Commits that land on `develop` after the prep commit sit ahead of `main`, the normal state
+between releases — cut with the prep commit checked out, not whatever `develop` has moved on to.
+`release.sh` warns (it does not abort) when the working tree is on any branch other than
+`develop`.
+
+The fast-forward push cannot ride a PR: GitHub merges a PR by merge commit, squash, or rebase,
+each of which mints a new commit, and the point is that `main` gains no object the tag does not
+already name. The Main Branch ruleset requires PRs from everyone except organization admins, so
+`release.sh` relies on the same admin bypass the release's protected tag push already uses. If
+the push is refused, the script says so and prints the command to run by hand; the release
+itself is unaffected — `main` merely lags until an admin runs it.
+
+Release-note prose that once lived in the `main` merge commit's body belongs in the GitHub
+Release notes, where operators actually read it. The branch model itself is in
 [CONTRIBUTING.md](../../CONTRIBUTING.md#development-workflow).
+
+[#1076]: https://github.com/p2pool-starter-stack/pithead/issues/1076
 
 ### Pipeline: stage → smoke-test → promote
 
@@ -117,8 +134,9 @@ working tree is on any other branch. The branch model itself is in
 7. Sign ([#376](https://github.com/p2pool-starter-stack/pithead/issues/376)): cosign-sign each
    promoted manifest-list digest and the install bundle with the key on the release server. See
    [Signed releases](#signed-releases).
-8. Publish GitHub Release: create the git tag `vX.Y.Z`, write the `CHANGELOG.md` entry / release
-   notes, and attach release assets: a pinned `docker-compose.yml` / config bundle referencing
+8. Publish GitHub Release: create the git tag `vX.Y.Z`, fast-forward `main` to the tagged commit
+   (see [Branch mechanics](#branch-mechanics)), write the release notes from the `CHANGELOG.md`
+   entry, and attach release assets: a pinned `docker-compose.yml` / config bundle referencing
    `${STACK_VERSION}=vX.Y.Z`, its detached signature (`pithead.tar.gz.sig`), plus the ingredients
    manifest (exact component versions + promoted image digests).
 9. Post-publish smoke ([#459](https://github.com/p2pool-starter-stack/pithead/issues/459)): run
@@ -173,7 +191,7 @@ tolerated-known-failure habit the flag exists to end.
 
 ### Which gates are automated, and which are not
 
-Every gate below runs at cut time or is run by hand. **Nothing gates a merge to `main`**, and no
+Every gate below runs at cut time or is run by hand. **Nothing gates an update of `main`**, and no
 workflow claims to ([#1048](https://github.com/p2pool-starter-stack/pithead/issues/1048)):
 `release-gate.yml` is dispatch-only, because a self-hosted runner on a key-holding box is not
 registered. It previously carried a `push: [main]` trigger behind a repo variable nobody set, so

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@
 #   5. Smoke          pull the STAGED images back and verify they resolve to the right version
 #   6. Promote        re-tag the smoke-tested digests to :vX.Y.Z + :latest (no rebuild) and push
 #   6b. Sign          cosign-sign the promoted digests + the install bundle with the box's key (#376)
-#   7. Publish        git tag, GitHub Release from CHANGELOG, attach the manifest + bundle + bundle sig
+#   7. Publish        git tag, GitHub Release from CHANGELOG + assets, fast-forward main to the tag
 #
 # Nothing user-facing is published until every gate is green. Promotion is by digest, so the released
 # bundle is bit-for-bit what was smoke-tested. The script NEVER starts the live stack on this host and
@@ -371,7 +371,7 @@ preflight() {
     if [ "$ALLOW_DIRTY" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
         die "Working tree is dirty. Commit/stash first, or pass --allow-dirty."
     fi
-    [ "$GIT_BRANCH" = "main" ] || warn "Releasing from '$GIT_BRANCH', not main."
+    [ "$GIT_BRANCH" = "develop" ] || warn "Releasing from '$GIT_BRANCH', not develop."
 
     if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
         die "Git tag $TAG already exists — bump VERSION before cutting a new release."
@@ -624,7 +624,7 @@ publish() {
         sign_bundle "$bundle" "$bundle_sig"
     fi
 
-    confirm "Create git tag $TAG, push it, and publish the GitHub Release?" ||
+    confirm "Create git tag $TAG, push it, fast-forward main to it, and publish the GitHub Release?" ||
         {
             warn "Publish cancelled. Images are promoted; re-run --resume-promote to finish, or publish by hand."
             return 0
@@ -632,6 +632,14 @@ publish() {
 
     run git tag -a "$TAG" -m "Pithead $TAG"
     run git push origin "$TAG"
+
+    # Move main to the released commit (docs/dev/releasing.md § Branch mechanics). A plain push can
+    # only fast-forward, so main gains no object the tag does not already name — which is what makes
+    # the old post-release back-merge unnecessary (#1076). The Main Branch ruleset admits this via
+    # the same admin bypass the protected tag push above already used.
+    if ! run git push origin "$GIT_COMMIT:refs/heads/main"; then
+        warn "main was not fast-forwarded — run: git push origin $GIT_COMMIT:refs/heads/main  (the release is unaffected; main lags until this runs)."
+    fi
 
     local notes="$WORKDIR/notes.md"
     changelog_notes >"$notes"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -637,9 +637,8 @@ publish() {
     # only fast-forward, so main gains no object the tag does not already name — which is what makes
     # the old post-release back-merge unnecessary (#1076). The Main Branch ruleset admits this via
     # the same admin bypass the protected tag push above already used.
-    if ! run git push origin "$GIT_COMMIT:refs/heads/main"; then
+    run git push origin "$GIT_COMMIT:refs/heads/main" ||
         warn "main was not fast-forwarded — run: git push origin $GIT_COMMIT:refs/heads/main  (the release is unaffected; main lags until this runs)."
-    fi
 
     local notes="$WORKDIR/notes.md"
     changelog_notes >"$notes"


### PR DESCRIPTION
Closes #1076.

Releases stop minting a commit only `main` has. The prep commit lands on `develop` as a normal PR, the pipeline runs with it checked out, and `publish()` fast-forwards `main` to the tagged commit right after the tag push. `main` keeps meaning "the last released commit" and stays an ancestor of `develop` by construction — the back-merge (missed on v1.19.0) and all three runbook merge shapes disappear because the damage they repaired is no longer created.

## What changed

- `scripts/release.sh`: `publish()` pushes `$GIT_COMMIT:refs/heads/main` after the tag push, inside `run` (so `--dry-run` prints it) with a `|| warn` fallback that prints the exact command — a refused push leaves the release intact, `main` merely lags. The preflight branch warning flips `main` → `develop`; the confirm prompt and header say what now happens.
- `docs/dev/releasing.md` § Branch mechanics: rewritten for the fast-forward model, including why the push cannot ride a PR (GitHub merges by merge/squash/rebase, each minting a new commit) and what it relies on instead. Pipeline step 8 and the gates preamble updated to match.
- `CONTRIBUTING.md`: the branch-model parenthetical updated.
- `docs/dev/release-server.md`: corrected while in the area — it claimed `release-gate.yml` runs on `push` to `main`; the workflow is `workflow_dispatch`-only (the push trigger exists only as a commented future step in its header). Also notes that under fast-forward mechanics a push-to-`main` trigger would fire *after* the release it was meant to gate, so future automation belongs on the ref being cut.

## The ruleset dependency, verified

`gh api repos/p2pool-starter-stack/pithead/rulesets/12622005` (Main Branch): `pull_request` (1 approval + code owners) + `non_fast_forward` + `deletion` + required status checks, with a single bypass — OrganizationAdmin, always. So:

- The ff push is only possible for an org admin. That is zero new constraint: the cut already runs on the release box under the operator's auth, which is what pushes the protected release tag today.
- **No ruleset change is made or needed.** The `non_fast_forward` rule is untouched and still blocks force pushes; a plain `git push` can only fast-forward, which is the entire mechanism.
- A non-admin cutter hits the `warn` path and gets the one command to hand to an admin.

## What was RUN

- `bash -n` and `shellcheck` on `release.sh`: clean at the Makefile's `--severity=warning` gate; the only findings are pre-existing SC2016 infos in the untouched manifest heredoc (L667–682).
- `make lint`: pass (including `lint-docs-voice`, which caught and cost one banned word on the first draft).
- `make test`: full suite, pass.
- NOT run: the new push, for real — it executes only inside a real `publish()`. `--dry-run` rehearses it by construction (`run` wrapper), and the next cut is the live proof; the cutter should watch for the "fast-forward main" line in the confirm prompt and the push in the log. Until then this leg is code-reviewed, not release-proven.
