### PR TITLE
fix(doctor): drop issue refs from the egress-firewall operator strings

### DIFF
--- a/pithead
+++ b/pithead
@@ -4181,9 +4181,9 @@ check_egress_firewall_nft() {
     fi
     ruleset=$(sudo -n nft list table inet "$TOR_EGRESS_NFT_TABLE" 2>/dev/null) || ruleset=""
     if printf '%s\n' "$ruleset" | grep -q 'hook forward' && printf '%s\n' "$ruleset" | grep -qw drop; then
-        dr_ok "Tor-only egress firewall is installed (#270) — clearnet dials from the stack are fail-closed via nftables (inet $TOR_EGRESS_NFT_TABLE)."
+        dr_ok "Tor-only egress firewall is installed — clearnet dials from the stack are fail-closed via nftables (inet $TOR_EGRESS_NFT_TABLE)."
     else
-        dr_fail "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them (#270)."
+        dr_fail "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them."
     fi
 }
 


### PR DESCRIPTION
The appliance lane's CI has been red on the Lint per-surface job: the doctor's egress-firewall strings carry an issue reference inside operator-facing output, which `lint-operator-strings` bans. This drops the two references — comments keep theirs, operator output does not — and the lint goes green again.

Found by accident: an unrelated doc-prep task ran the lint on unmodified `develop-v2` and it failed. The two most recent CI runs on the branch are failures on exactly this job while every other job stayed green — the false-RED-hides-work shape: as long as the lane is red for a known cosmetic reason, a new real failure lands invisibly.

## What was RUN

- `bash scripts/lint-operator-strings.sh`: exit 0 after the change (was failing before, reproduced on unmodified `develop-v2`).
- `make lint-sh`: pass.
- Nothing else touched; the diff is the two strings.
