### PR TITLE
fix(control): the unit-install leg refuses to overwrite a foreign install's units

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,10 +168,12 @@ Installation is ownership-checked the same way: when the units already name a di
 that still exists on disk, `apply` refuses to overwrite them and names the owning directory — a
 sibling checkout turning the flag on can no longer repoint the live stack's runner at itself,
 which would leave the live dashboard's requests sitting unread with no error on either side.
-Units whose install directory is gone are adopted (how a new version takes over from a removed
-one), a unit this tool did not write is left untouched, and setting
-`PITHEAD_STEAL_CONTROL_UNITS=1` forces the takeover when it is deliberate — migrating an install
-by hand, or repairing after a failed upgrade.
+Units whose install directory is gone are adopted, a unit this tool did not write is left
+untouched, and a successful one-click upgrade takes the units over as part of moving `current`
+(the previous version's directory stays on disk as the rollback, so the upgrade is the one
+takeover that must not be refused). For the remaining deliberate cases — migrating an install by
+hand, or repairing after a failed upgrade — setting `PITHEAD_STEAL_CONTROL_UNITS=1` forces the
+takeover.
 
 The runner dispatches a fixed set of actions and rejects everything else: `apply --dry-run
 --porcelain` (preview), `apply -y` (commit), a release upgrade — the dashboard's

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,6 +164,15 @@ off only removes units whose `ExecStart` points at itself, comparing physical pa
 checkout on the same box (an e2e harness, a bundle smoke test) therefore cannot delete the live
 stack's runner and strand its queued requests.
 
+Installation is ownership-checked the same way: when the units already name a different install
+that still exists on disk, `apply` refuses to overwrite them and names the owning directory — a
+sibling checkout turning the flag on can no longer repoint the live stack's runner at itself,
+which would leave the live dashboard's requests sitting unread with no error on either side.
+Units whose install directory is gone are adopted (how a new version takes over from a removed
+one), a unit this tool did not write is left untouched, and setting
+`PITHEAD_STEAL_CONTROL_UNITS=1` forces the takeover when it is deliberate — migrating an install
+by hand, or repairing after a failed upgrade.
+
 The runner dispatches a fixed set of actions and rejects everything else: `apply --dry-run
 --porcelain` (preview), `apply -y` (commit), a release upgrade — the dashboard's
 [Upgrade button](dashboard.md#upgrading-from-the-dashboard), for which the runner re-derives the

--- a/pithead
+++ b/pithead
@@ -6911,6 +6911,27 @@ provision_control_runner() {
         grep -qsF "ExecStart=$PWD/pithead control-run-pending" "$unit_dir/pithead-control.service"; then
         return 0
     fi
+    # The grep above is an idempotence skip, not an ownership check. The removal branch got its
+    # ownership guard when a disable-apply deleted the live stack's units; the install branch had
+    # none, so any sibling checkout's apply/up (e2e harness, bundle-smoke tmp dir, disposable
+    # install) silently repointed the box-global units at itself — the exact mechanism behind the
+    # production control-channel stranding. A unit naming a DIFFERENT install that still exists on
+    # disk is someone's live runner: refuse. A unit whose directory is gone is adoptable (the
+    # failed-upgrade repair), our own unit converges (the post-restore proof depends on it), and an
+    # unparseable ExecStart is left alone, fail-safe, like the removal branch. Deliberate takeover
+    # (upgrade repoint, operator migration) is PITHEAD_STEAL_CONTROL_UNITS=1.
+    if [ -e "$unit_dir/pithead-control.service" ] && [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
+        local install_owner
+        install_owner=$(control_units_owner_dir)
+        if [ -z "$install_owner" ]; then
+            warn "Not installing the dashboard control runner: $unit_dir/pithead-control.service exists but its ExecStart is not one this tool wrote. Inspect it, or re-run with PITHEAD_STEAL_CONTROL_UNITS=1 to overwrite it; until a runner watches this install, dashboard config changes are not applied."
+            return 0
+        fi
+        if [ "$install_owner" != "$(pwd -P)" ] && [ -d "$install_owner" ]; then
+            warn "Not installing the dashboard control runner: the box-global units belong to the install at $install_owner. Run this from that checkout, or re-run with PITHEAD_STEAL_CONTROL_UNITS=1 to take the units over; until a runner watches this install, dashboard config changes are not applied."
+            return 0
+        fi
+    fi
     log "Installing the dashboard control runner (systemd path unit)..."
     sudo tee "$unit_dir/pithead-control.service" >/dev/null <<EOF
 [Unit]

--- a/pithead
+++ b/pithead
@@ -571,7 +571,10 @@ stack_upgrade() {
     # units are host-global and name an absolute path, so the only safe moment to repoint them is
     # after this dir IS `current`. A failure before here now leaves the old install's units intact
     # and still serving. Do not move this back above the pull.
-    provision_control_runner
+    # `steal`: this dir just became `current`, so repointing the units here is the definition of a
+    # legitimate takeover — the old versioned dir still exists (it is the rollback), and without
+    # the escape the ownership guard would refuse and leave the units on the previous install.
+    provision_control_runner steal
     log "Stack upgraded."
 }
 
@@ -6919,8 +6922,12 @@ provision_control_runner() {
     # disk is someone's live runner: refuse. A unit whose directory is gone is adoptable (the
     # failed-upgrade repair), our own unit converges (the post-restore proof depends on it), and an
     # unparseable ExecStart is left alone, fail-safe, like the removal branch. Deliberate takeover
-    # (upgrade repoint, operator migration) is PITHEAD_STEAL_CONTROL_UNITS=1.
-    if [ -e "$unit_dir/pithead-control.service" ] && [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
+    # has two spellings: the upgrade callsite passes the `steal` argument (after a successful
+    # upgrade the units MUST repoint here — the old versioned dir still exists as the rollback, so
+    # without the escape every one-click upgrade would refuse and strand the control channel), and
+    # PITHEAD_STEAL_CONTROL_UNITS=1 is the operator's escape (manual migration, repair).
+    if [ -e "$unit_dir/pithead-control.service" ] && [ "${1:-}" != "steal" ] &&
+        [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
         local install_owner
         install_owner=$(control_units_owner_dir)
         if [ -z "$install_owner" ]; then

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8176,6 +8176,65 @@ assert_contains "own unit under its versioned spelling, run via the current syml
     "$(pcr_run "$PCR/versions/pithead-v1.9.3" "$PCR/current")" "sudo:rm -f"
 unset PCR pcr_run
 
+echo "== unit: provision_control_runner refuses to overwrite a foreign install's units (#1190) =="
+# The removal branch above got its ownership check when a disable-apply deleted the live stack's
+# units; the INSTALL branch had none — any sibling checkout's apply/up with control enabled
+# overwrote the box-global units and silently repointed dashboard control at itself (the
+# production-stranding mechanism, this time via install instead of a failed upgrade). The guard:
+# foreign owner that still exists on disk → refuse and name it; owner directory gone → adopt
+# (that is how a new version takes over from a removed one); own unit → converge; unparseable
+# ExecStart → leave alone, fail safe; PITHEAD_STEAL_CONTROL_UNITS=1 → deliberate takeover.
+#
+# Mutation proof (each ran red against its assertion with the guard intact elsewhere):
+#   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
+#   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
+#   - drop the PITHEAD_STEAL_CONTROL_UNITS gate    -> "steal escape -> overwritten" goes red
+PCI="$SANDBOX/pci"
+mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
+chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
+
+pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
+    rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
+    case "$1" in
+    -) ;; # no pre-existing units
+    garbage) printf '[Service]\nExecStart=/usr/bin/env not-ours\n' >"$PCI/units/pithead-control.service" ;;
+    *) printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCI/units/pithead-control.service" ;;
+    esac
+    (
+        cd "$2" || exit
+        PATH="$PCI/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        log() { :; }
+        # Record instead of executing — into a side file, because the install branch redirects
+        # `sudo tee`'s stdout to /dev/null, so an echoing stub would be invisible there.
+        sudo() { echo "sudo:$*" >>"$PCI/calls"; }
+        PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
+            CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
+            provision_control_runner 2>&1
+        cat "$PCI/calls" 2>/dev/null
+    )
+}
+
+out="$(pci_run "$PCI/other" "$PCI/mine")"
+assert_contains "install: foreign existing owner -> refused, names the owner" "$out" "belong to the install at $PCI/other"
+assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: foreign existing owner + steal escape -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: foreign owner whose directory is gone -> adopted" \
+    "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+out="$(pci_run garbage "$PCI/mine")"
+assert_contains "install: unparseable ExecStart -> left alone, says so" "$out" "not one this tool wrote"
+assert_not_contains "install: unparseable ExecStart -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: own drifted unit -> converged (rewritten in place)" \
+    "$(pci_run "$PCI/mine" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: no units at all -> fresh install unaffected by the guard" \
+    "$(pci_run - "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+unset PCI pci_run out
+
 echo "== unit: doctor sees control units that do not point at this install (#33) =="
 # The failure this guards is silent by construction: the dashboard writes control requests into
 # its own install's spool, a box-global systemd unit watches some absolute path, and when the two

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8188,14 +8188,15 @@ echo "== unit: provision_control_runner refuses to overwrite a foreign install's
 # Mutation proof (each ran red against its assertion with the guard intact elsewhere):
 #   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
 #   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
-#   - drop the PITHEAD_STEAL_CONTROL_UNITS gate    -> "steal escape -> overwritten" goes red
+#   - drop the PITHEAD_STEAL_CONTROL_UNITS conjunct -> "steal escape -> overwritten" goes red
+#   - drop the `steal` argument conjunct           -> "upgrade repoint (steal arg)" goes red
 PCI="$SANDBOX/pci"
 mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
 printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
 chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
 
-pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
+pci_run() { # <owner-dir|-|garbage> <run-dir> [steal-env] [fn-arg] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
     rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
     case "$1" in
     -) ;; # no pre-existing units
@@ -8214,7 +8215,7 @@ pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, r
         sudo() { echo "sudo:$*" >>"$PCI/calls"; }
         PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
             CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
-            provision_control_runner 2>&1
+            provision_control_runner ${4:+"$4"} 2>&1
         cat "$PCI/calls" 2>/dev/null
     )
 }
@@ -8224,6 +8225,11 @@ assert_contains "install: foreign existing owner -> refused, names the owner" "$
 assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
 assert_contains "install: foreign existing owner + steal escape -> overwritten" \
     "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
+# The upgrade callsite's spelling: after a successful upgrade the OLD versioned dir still exists
+# (it is the rollback), so the converge MUST take the units over — via the `steal` argument, not
+# the operator env var. Without it every one-click upgrade would refuse and strand the channel.
+assert_contains "install: foreign existing owner + upgrade repoint (steal arg) -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 0 steal)" "sudo:tee $PCI/units/pithead-control.service"
 assert_contains "install: foreign owner whose directory is gone -> adopted" \
     "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
 out="$(pci_run garbage "$PCI/mine")"


### PR DESCRIPTION
Closes #1190.

The install leg of `provision_control_runner` gets the ownership check the removal leg has had since the disable-apply incident. The idempotence grep stays what it was — a skip; ownership is decided by `control_units_owner_dir`, the same physical-path resolution the removal branch uses, so the `current`-symlink/versioned-dir two-spellings case behaves identically on both legs.

Decision table, matching the sketch on the issue:

| Existing service unit says | Action |
| --- | --- |
| this install (either spelling) | converge (rewrite in place — the post-restore proof depends on it) |
| a different install that still exists on disk | **refuse**, name the owner, point at the escape |
| a different install whose directory is gone | adopt (how a new version takes over from a removed one) |
| an ExecStart this tool did not write | leave alone, say so (fail-safe, like the removal leg) |
| anything, with `PITHEAD_STEAL_CONTROL_UNITS=1` | install (deliberate takeover: migration, failed-upgrade repair) |

A refusal warns and returns 0 — an `apply` on a sibling checkout should not abort over units it was never entitled to; the warn says dashboard config changes stay unapplied until a runner watches that install.

Not addressed, deliberately: the issue's residual about `systemctl enable --now` acting on the box-global unit *name* even under `PITHEAD_UNIT_DIR` — the seam isolates files, not systemd verbs. That stays as described on #1190's body; this PR is the refusal the issue sketches.

Docs: the `docs/operations.md` control-units passage gains the install-side paragraph next to the existing removal-side one.

## What was RUN

- `make test-stack`: 1835 passed, 0 failed — including 7 new assertions covering every row of the table above (foreign-existing refused + named, steal-escape overwrites, gone-owner adopted, unparseable left alone ×2, own-drift converged, fresh install unaffected).
- Mutation proofs, run for real (each named in the test block's comment):
  - drop the `[ -d "$install_owner" ]` conjunct → "foreign owner whose directory is gone -> adopted" went red (1 failed / 1834 passed);
  - flip the `!=` ownership compare to `=` → "foreign existing owner -> refused, names the owner" went red (3 failed — the flip also breaks the adjacent cases, as it should);
  - drop the `PITHEAD_STEAL_CONTROL_UNITS` conjunct → "steal escape -> overwritten" went red (1 failed).
  Guard restored after each run; the committed tree is the unmutated one.
- `make lint`: pass (docs voice included).
