### PR TITLE
docs(appliance): release branch mechanics caught up with the fast-forward model

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -320,9 +320,10 @@ the morning.
 
 ## Cutting a release
 
-The branch mechanics are the DIY doc's ([releasing.md](releasing.md#branch-mechanics)):
-`develop` merges to `main` with a real merge and the cut runs from `main`. The steps here
-assume that has happened and both channels share one version and one GitHub Release.
+The branch mechanics are the DIY doc's ([releasing.md](releasing.md#branch-mechanics)): the cut
+runs from the release-prep commit on `develop`, and `main` fast-forwards to the tag only when
+`release.sh` publishes it. The steps here run from that same prep commit; both channels share
+one version and one GitHub Release.
 
 1. The release commit is green: `make lint && make test`, and `tests/os/run.sh --phase all`
    on the bench.
@@ -371,7 +372,9 @@ assume that has happened and both channels share one version and one GitHub Rele
    attached. Published release assets are immutable — v1.18.0 burned its tag this way — so
    the release publishes exactly once, with both channels' artifacts aboard. The bundle's
    signature is what devices verify.
-6. Back-merge `main` → `develop`, per the DIY release rule.
+6. `main` fast-forwards to the tag automatically when `release.sh` publishes; if the push was
+   refused, run the command it prints (see
+   [After publishing](manual-release-checklist.md#after-publishing)).
 
 ## Shipping a bad release
 

--- a/docs/dev/manual-release-checklist.md
+++ b/docs/dev/manual-release-checklist.md
@@ -87,8 +87,9 @@ health-gated commit, the migration hold). They have never been proven on real ha
 
 - Post-publish smoke against the published tag, including the upgrade path from the previous
   release on a box that actually runs it.
-- Back-merge `main` → `develop`, then sync `develop` → the integration branch, so the next cut
-  does not diverge.
+- Confirm `main` fast-forwarded to the tag — `release.sh` does this at publish. If the push was
+  refused, run the command it printed by hand.
+- Sync `develop` → the integration branch, so the next cut does not diverge.
 - Record the per-rig performance baselines you actually re-tagged (see
   [RELEASING.md in RigForge](https://github.com/p2pool-starter-stack/rigforge/blob/main/RELEASING.md)),
   and reset the rigs' checkouts afterwards — a dirty checkout aborts the next tag deploy.


### PR DESCRIPTION
## Summary

Doc-only catch-up for #1076 (fast-forward release mechanics, PR #1197). Two
develop-v2-only docs still described the retired develop-to-main
merge/back-merge model:

- `docs/dev/appliance-release.md` — "Cutting a release" intro now defers to
  releasing.md's new branch mechanics (cut from the prep commit on develop;
  main fast-forwards at publish), and the closing numbered step no longer
  tells the cutter to back-merge — it points at the automatic fast-forward
  and the manual fallback if the push is refused.
- `docs/dev/manual-release-checklist.md` — "After publishing" swaps the
  back-merge bullet for a fast-forward confirmation step; the
  develop → develop-v2 sync bullet is unchanged since it's unrelated to #1076.

No code changes. Text was checked against PR #1197's rewritten "Branch
mechanics" section (now merged to develop) to avoid contradicting it. These
two files are develop-v2-only, so the regular develop → develop-v2 sync can
never correct them — found by the adversarial review of #1197, which flagged
that the sync would leave them contradicting the doc they defer to.

## What was RUN

- `make lint-docs-voice` — pass (house-voice banned-word check)
- `make lint-md` — pass
- `make lint-operator-strings` failed at branch time on a pre-existing
  `pithead` finding, reproduced on unmodified develop-v2 — that was fixed
  separately in PR #1199, which merged first exactly so this PR's CI reads
  honestly.
