### PR TITLE
Sync develop → develop-v2 (post-v1.19.3 wave: #1196/#1197/#1200)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
 ## Development workflow
 
 1. Fork the repo and create a branch off `develop` (the integration branch; `main` holds released
-   commits only — how releases move `develop` → `main` and back is in
+   commits only — it fast-forwards to each release's tagged commit, see
    [Releasing › Branch mechanics](docs/dev/releasing.md#branch-mechanics)).
 2. Make your change. Keep it focused: one logical change per PR.
 3. Run the full test suite locally:

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -1195,13 +1195,13 @@ button.upgrade-btn {
 }
 
 /* ---- Responsive / mobile (Issue #83) --------------------------------------------------
- * The desktop layout above is fluid down to tablet widths via the card grid's auto-fit, but a
- * few fixed sizes break or overflow on phones: the 350px card-track minimum forces a column
- * wider than the screen, the header is a fixed two-up row, the disk bar is a hard 150px, and
- * the body padding is a roomy 20px. These overrides take over at phone widths — tighter
- * padding, a stacked header, a single-column card grid, and a full-width disk bar. The workers
- * table is handled separately by .table-scroll above. One breakpoint is enough: above it the
- * grid's auto-fit already reflows cleanly. */
+ * The desktop layout above is fluid down to tablet widths via the sections' column packing, but
+ * a few fixed sizes break or overflow on phones: the header is a fixed two-up row, the disk bar
+ * is a hard 150px, and the body padding is a roomy 20px. These overrides take over at phone
+ * widths — tighter padding, a stacked header, and a full-width disk bar. Card stacking needs no
+ * override: a phone viewport fits exactly one ~350px column, so the packed sections are already
+ * single-column. The workers table is handled separately by .table-scroll above. One breakpoint
+ * is enough: above it the column packing already reflows cleanly. */
 @media (max-width: 640px) {
   body {
     padding: 12px;
@@ -1220,12 +1220,6 @@ button.upgrade-btn {
     flex-wrap: wrap;
   }
 
-  /* One card per row — the 350px minmax floor overflows a phone, so collapse to a single
-       fluid column. */
-  .grid {
-    grid-template-columns: 1fr;
-    gap: 12px;
-  }
   .card {
     padding: 16px;
   }

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -62,8 +62,11 @@ The safe rule: the keyed server only ever runs code you trust. Concretely:
 
 This is how the workflow ships.
 [`.github/workflows/release-gate.yml`](../../.github/workflows/release-gate.yml) runs only on
-`workflow_dispatch` (and `push` to `main`) on a `[self-hosted, pithead-release]` runner, never
-automatically on a PR.
+`workflow_dispatch`, on a `[self-hosted, pithead-release]` runner, never automatically on a PR
+and never on a push: no runner is registered, and a trigger that arrives before its runner is
+how `main` ends up wearing a gate that never ran (#1048). Since releases fast-forward `main`
+at publish time, a `push` trigger would also fire *after* the release it was meant to gate —
+any future automation belongs on the ref being cut, not on `main`.
 
 ## Provisioning the server
 

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -51,9 +51,10 @@ The safe rule: the keyed server only ever runs code you trust. Concretely:
 
 - Do not trigger tier-4 on `pull_request` (and never on a fork PR). "Require approval" only
   gates starting the run; once it starts, the PR's code still executes on the box.
-- Trigger tier-4 only on trusted code: `workflow_dispatch` (a maintainer manually runs it on a
-  ref they've reviewed) and/or `push` to `main` (post-merge). To E2E a specific fork PR, a
-  maintainer reviews it first, then dispatches the workflow on that ref.
+- Trigger tier-4 only on trusted code: `workflow_dispatch`, on a ref a maintainer has reviewed.
+  A `push`-to-`main` trigger is no longer an alternative — `main` only moves when a release
+  fast-forwards it at publish time, after this gate should already have run. To E2E a specific
+  fork PR, a maintainer reviews it first, then dispatches the workflow on that ref.
 - Register the runner as ephemeral / just-in-time (one job, then auto-removed) in its own runner
   group, isolated from any private repos.
 - Keep the runner least-privilege: a dedicated unprivileged user, the box runs nothing else

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -80,12 +80,29 @@ every gate is green.
 
 ### Branch mechanics
 
-Releases are cut from `main`. Merge `develop` into `main` with a real merge commit — never a
-squash, so the released commits keep their history — and run the pipeline from `main`. After
-publishing, merge `main` back into `develop`: the release's merge commit and tag must be an
-ancestor of `develop`, or the next cut diverges. `release.sh` warns (it does not abort) when the
-working tree is on any other branch. The branch model itself is in
+Releases are cut from `develop`. Land the release-prep commit (`VERSION`, `pyproject.toml`, the
+`CHANGELOG.md` entry) as a normal PR, run the pipeline with that commit checked out, and publish:
+the tag lands on it, and `release.sh` then moves `main` to the tagged commit with a fast-forward
+push. `main` keeps its meaning — the last released commit — and stays an ancestor of `develop` by
+construction, so there is no back-merge and no post-release repair step ([#1076]; releases through
+v1.19.3 instead merged `develop` into `main` and back, and the back-merge was missed on v1.19.0).
+Commits that land on `develop` after the prep commit sit ahead of `main`, the normal state
+between releases — cut with the prep commit checked out, not whatever `develop` has moved on to.
+`release.sh` warns (it does not abort) when the working tree is on any branch other than
+`develop`.
+
+The fast-forward push cannot ride a PR: GitHub merges a PR by merge commit, squash, or rebase,
+each of which mints a new commit, and the point is that `main` gains no object the tag does not
+already name. The Main Branch ruleset requires PRs from everyone except organization admins, so
+`release.sh` relies on the same admin bypass the release's protected tag push already uses. If
+the push is refused, the script says so and prints the command to run by hand; the release
+itself is unaffected — `main` merely lags until an admin runs it.
+
+Release-note prose that once lived in the `main` merge commit's body belongs in the GitHub
+Release notes, where operators actually read it. The branch model itself is in
 [CONTRIBUTING.md](../../CONTRIBUTING.md#development-workflow).
+
+[#1076]: https://github.com/p2pool-starter-stack/pithead/issues/1076
 
 ### Pipeline: stage → smoke-test → promote
 
@@ -117,8 +134,9 @@ working tree is on any other branch. The branch model itself is in
 7. Sign ([#376](https://github.com/p2pool-starter-stack/pithead/issues/376)): cosign-sign each
    promoted manifest-list digest and the install bundle with the key on the release server. See
    [Signed releases](#signed-releases).
-8. Publish GitHub Release: create the git tag `vX.Y.Z`, write the `CHANGELOG.md` entry / release
-   notes, and attach release assets: a pinned `docker-compose.yml` / config bundle referencing
+8. Publish GitHub Release: create the git tag `vX.Y.Z`, fast-forward `main` to the tagged commit
+   (see [Branch mechanics](#branch-mechanics)), write the release notes from the `CHANGELOG.md`
+   entry, and attach release assets: a pinned `docker-compose.yml` / config bundle referencing
    `${STACK_VERSION}=vX.Y.Z`, its detached signature (`pithead.tar.gz.sig`), plus the ingredients
    manifest (exact component versions + promoted image digests).
 9. Post-publish smoke ([#459](https://github.com/p2pool-starter-stack/pithead/issues/459)): run
@@ -173,7 +191,7 @@ tolerated-known-failure habit the flag exists to end.
 
 ### Which gates are automated, and which are not
 
-Every gate below runs at cut time or is run by hand. **Nothing gates a merge to `main`**, and no
+Every gate below runs at cut time or is run by hand. **Nothing gates an update of `main`**, and no
 workflow claims to ([#1048](https://github.com/p2pool-starter-stack/pithead/issues/1048)):
 `release-gate.yml` is dispatch-only, because a self-hosted runner on a key-holding box is not
 registered. It previously carried a `push: [main]` trigger behind a repo variable nobody set, so

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,10 +168,12 @@ Installation is ownership-checked the same way: when the units already name a di
 that still exists on disk, `apply` refuses to overwrite them and names the owning directory — a
 sibling checkout turning the flag on can no longer repoint the live stack's runner at itself,
 which would leave the live dashboard's requests sitting unread with no error on either side.
-Units whose install directory is gone are adopted (how a new version takes over from a removed
-one), a unit this tool did not write is left untouched, and setting
-`PITHEAD_STEAL_CONTROL_UNITS=1` forces the takeover when it is deliberate — migrating an install
-by hand, or repairing after a failed upgrade.
+Units whose install directory is gone are adopted, a unit this tool did not write is left
+untouched, and a successful one-click upgrade takes the units over as part of moving `current`
+(the previous version's directory stays on disk as the rollback, so the upgrade is the one
+takeover that must not be refused). For the remaining deliberate cases — migrating an install by
+hand, or repairing after a failed upgrade — setting `PITHEAD_STEAL_CONTROL_UNITS=1` forces the
+takeover.
 
 The runner dispatches a fixed set of actions and rejects everything else: `apply --dry-run
 --porcelain` (preview), `apply -y` (commit), a release upgrade — the dashboard's

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -164,6 +164,15 @@ off only removes units whose `ExecStart` points at itself, comparing physical pa
 checkout on the same box (an e2e harness, a bundle smoke test) therefore cannot delete the live
 stack's runner and strand its queued requests.
 
+Installation is ownership-checked the same way: when the units already name a different install
+that still exists on disk, `apply` refuses to overwrite them and names the owning directory — a
+sibling checkout turning the flag on can no longer repoint the live stack's runner at itself,
+which would leave the live dashboard's requests sitting unread with no error on either side.
+Units whose install directory is gone are adopted (how a new version takes over from a removed
+one), a unit this tool did not write is left untouched, and setting
+`PITHEAD_STEAL_CONTROL_UNITS=1` forces the takeover when it is deliberate — migrating an install
+by hand, or repairing after a failed upgrade.
+
 The runner dispatches a fixed set of actions and rejects everything else: `apply --dry-run
 --porcelain` (preview), `apply -y` (commit), a release upgrade — the dashboard's
 [Upgrade button](dashboard.md#upgrading-from-the-dashboard), for which the runner re-derives the

--- a/pithead
+++ b/pithead
@@ -6911,6 +6911,27 @@ provision_control_runner() {
         grep -qsF "ExecStart=$PWD/pithead control-run-pending" "$unit_dir/pithead-control.service"; then
         return 0
     fi
+    # The grep above is an idempotence skip, not an ownership check. The removal branch got its
+    # ownership guard when a disable-apply deleted the live stack's units; the install branch had
+    # none, so any sibling checkout's apply/up (e2e harness, bundle-smoke tmp dir, disposable
+    # install) silently repointed the box-global units at itself — the exact mechanism behind the
+    # production control-channel stranding. A unit naming a DIFFERENT install that still exists on
+    # disk is someone's live runner: refuse. A unit whose directory is gone is adoptable (the
+    # failed-upgrade repair), our own unit converges (the post-restore proof depends on it), and an
+    # unparseable ExecStart is left alone, fail-safe, like the removal branch. Deliberate takeover
+    # (upgrade repoint, operator migration) is PITHEAD_STEAL_CONTROL_UNITS=1.
+    if [ -e "$unit_dir/pithead-control.service" ] && [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
+        local install_owner
+        install_owner=$(control_units_owner_dir)
+        if [ -z "$install_owner" ]; then
+            warn "Not installing the dashboard control runner: $unit_dir/pithead-control.service exists but its ExecStart is not one this tool wrote. Inspect it, or re-run with PITHEAD_STEAL_CONTROL_UNITS=1 to overwrite it; until a runner watches this install, dashboard config changes are not applied."
+            return 0
+        fi
+        if [ "$install_owner" != "$(pwd -P)" ] && [ -d "$install_owner" ]; then
+            warn "Not installing the dashboard control runner: the box-global units belong to the install at $install_owner. Run this from that checkout, or re-run with PITHEAD_STEAL_CONTROL_UNITS=1 to take the units over; until a runner watches this install, dashboard config changes are not applied."
+            return 0
+        fi
+    fi
     log "Installing the dashboard control runner (systemd path unit)..."
     sudo tee "$unit_dir/pithead-control.service" >/dev/null <<EOF
 [Unit]

--- a/pithead
+++ b/pithead
@@ -571,7 +571,10 @@ stack_upgrade() {
     # units are host-global and name an absolute path, so the only safe moment to repoint them is
     # after this dir IS `current`. A failure before here now leaves the old install's units intact
     # and still serving. Do not move this back above the pull.
-    provision_control_runner
+    # `steal`: this dir just became `current`, so repointing the units here is the definition of a
+    # legitimate takeover — the old versioned dir still exists (it is the rollback), and without
+    # the escape the ownership guard would refuse and leave the units on the previous install.
+    provision_control_runner steal
     log "Stack upgraded."
 }
 
@@ -6919,8 +6922,12 @@ provision_control_runner() {
     # disk is someone's live runner: refuse. A unit whose directory is gone is adoptable (the
     # failed-upgrade repair), our own unit converges (the post-restore proof depends on it), and an
     # unparseable ExecStart is left alone, fail-safe, like the removal branch. Deliberate takeover
-    # (upgrade repoint, operator migration) is PITHEAD_STEAL_CONTROL_UNITS=1.
-    if [ -e "$unit_dir/pithead-control.service" ] && [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
+    # has two spellings: the upgrade callsite passes the `steal` argument (after a successful
+    # upgrade the units MUST repoint here — the old versioned dir still exists as the rollback, so
+    # without the escape every one-click upgrade would refuse and strand the control channel), and
+    # PITHEAD_STEAL_CONTROL_UNITS=1 is the operator's escape (manual migration, repair).
+    if [ -e "$unit_dir/pithead-control.service" ] && [ "${1:-}" != "steal" ] &&
+        [ "${PITHEAD_STEAL_CONTROL_UNITS:-0}" != "1" ]; then
         local install_owner
         install_owner=$(control_units_owner_dir)
         if [ -z "$install_owner" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@
 #   5. Smoke          pull the STAGED images back and verify they resolve to the right version
 #   6. Promote        re-tag the smoke-tested digests to :vX.Y.Z + :latest (no rebuild) and push
 #   6b. Sign          cosign-sign the promoted digests + the install bundle with the box's key (#376)
-#   7. Publish        git tag, GitHub Release from CHANGELOG, attach the manifest + bundle + bundle sig
+#   7. Publish        git tag, GitHub Release from CHANGELOG + assets, fast-forward main to the tag
 #
 # Nothing user-facing is published until every gate is green. Promotion is by digest, so the released
 # bundle is bit-for-bit what was smoke-tested. The script NEVER starts the live stack on this host and
@@ -371,7 +371,7 @@ preflight() {
     if [ "$ALLOW_DIRTY" -eq 0 ] && [ -n "$(git status --porcelain)" ]; then
         die "Working tree is dirty. Commit/stash first, or pass --allow-dirty."
     fi
-    [ "$GIT_BRANCH" = "main" ] || warn "Releasing from '$GIT_BRANCH', not main."
+    [ "$GIT_BRANCH" = "develop" ] || warn "Releasing from '$GIT_BRANCH', not develop."
 
     if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
         die "Git tag $TAG already exists — bump VERSION before cutting a new release."
@@ -624,7 +624,7 @@ publish() {
         sign_bundle "$bundle" "$bundle_sig"
     fi
 
-    confirm "Create git tag $TAG, push it, and publish the GitHub Release?" ||
+    confirm "Create git tag $TAG, push it, fast-forward main to it, and publish the GitHub Release?" ||
         {
             warn "Publish cancelled. Images are promoted; re-run --resume-promote to finish, or publish by hand."
             return 0
@@ -632,6 +632,14 @@ publish() {
 
     run git tag -a "$TAG" -m "Pithead $TAG"
     run git push origin "$TAG"
+
+    # Move main to the released commit (docs/dev/releasing.md § Branch mechanics). A plain push can
+    # only fast-forward, so main gains no object the tag does not already name — which is what makes
+    # the old post-release back-merge unnecessary (#1076). The Main Branch ruleset admits this via
+    # the same admin bypass the protected tag push above already used.
+    if ! run git push origin "$GIT_COMMIT:refs/heads/main"; then
+        warn "main was not fast-forwarded — run: git push origin $GIT_COMMIT:refs/heads/main  (the release is unaffected; main lags until this runs)."
+    fi
 
     local notes="$WORKDIR/notes.md"
     changelog_notes >"$notes"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -637,9 +637,8 @@ publish() {
     # only fast-forward, so main gains no object the tag does not already name — which is what makes
     # the old post-release back-merge unnecessary (#1076). The Main Branch ruleset admits this via
     # the same admin bypass the protected tag push above already used.
-    if ! run git push origin "$GIT_COMMIT:refs/heads/main"; then
+    run git push origin "$GIT_COMMIT:refs/heads/main" ||
         warn "main was not fast-forwarded — run: git push origin $GIT_COMMIT:refs/heads/main  (the release is unaffected; main lags until this runs)."
-    fi
 
     local notes="$WORKDIR/notes.md"
     changelog_notes >"$notes"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8176,6 +8176,65 @@ assert_contains "own unit under its versioned spelling, run via the current syml
     "$(pcr_run "$PCR/versions/pithead-v1.9.3" "$PCR/current")" "sudo:rm -f"
 unset PCR pcr_run
 
+echo "== unit: provision_control_runner refuses to overwrite a foreign install's units (#1190) =="
+# The removal branch above got its ownership check when a disable-apply deleted the live stack's
+# units; the INSTALL branch had none — any sibling checkout's apply/up with control enabled
+# overwrote the box-global units and silently repointed dashboard control at itself (the
+# production-stranding mechanism, this time via install instead of a failed upgrade). The guard:
+# foreign owner that still exists on disk → refuse and name it; owner directory gone → adopt
+# (that is how a new version takes over from a removed one); own unit → converge; unparseable
+# ExecStart → leave alone, fail safe; PITHEAD_STEAL_CONTROL_UNITS=1 → deliberate takeover.
+#
+# Mutation proof (each ran red against its assertion with the guard intact elsewhere):
+#   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
+#   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
+#   - drop the PITHEAD_STEAL_CONTROL_UNITS gate    -> "steal escape -> overwritten" goes red
+PCI="$SANDBOX/pci"
+mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
+chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
+
+pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
+    rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
+    case "$1" in
+    -) ;; # no pre-existing units
+    garbage) printf '[Service]\nExecStart=/usr/bin/env not-ours\n' >"$PCI/units/pithead-control.service" ;;
+    *) printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCI/units/pithead-control.service" ;;
+    esac
+    (
+        cd "$2" || exit
+        PATH="$PCI/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        log() { :; }
+        # Record instead of executing — into a side file, because the install branch redirects
+        # `sudo tee`'s stdout to /dev/null, so an echoing stub would be invisible there.
+        sudo() { echo "sudo:$*" >>"$PCI/calls"; }
+        PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
+            CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
+            provision_control_runner 2>&1
+        cat "$PCI/calls" 2>/dev/null
+    )
+}
+
+out="$(pci_run "$PCI/other" "$PCI/mine")"
+assert_contains "install: foreign existing owner -> refused, names the owner" "$out" "belong to the install at $PCI/other"
+assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: foreign existing owner + steal escape -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: foreign owner whose directory is gone -> adopted" \
+    "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+out="$(pci_run garbage "$PCI/mine")"
+assert_contains "install: unparseable ExecStart -> left alone, says so" "$out" "not one this tool wrote"
+assert_not_contains "install: unparseable ExecStart -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: own drifted unit -> converged (rewritten in place)" \
+    "$(pci_run "$PCI/mine" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: no units at all -> fresh install unaffected by the guard" \
+    "$(pci_run - "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+unset PCI pci_run out
+
 echo "== unit: doctor sees control units that do not point at this install (#33) =="
 # The failure this guards is silent by construction: the dashboard writes control requests into
 # its own install's spool, a box-global systemd unit watches some absolute path, and when the two

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -8188,14 +8188,15 @@ echo "== unit: provision_control_runner refuses to overwrite a foreign install's
 # Mutation proof (each ran red against its assertion with the guard intact elsewhere):
 #   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
 #   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
-#   - drop the PITHEAD_STEAL_CONTROL_UNITS gate    -> "steal escape -> overwritten" goes red
+#   - drop the PITHEAD_STEAL_CONTROL_UNITS conjunct -> "steal escape -> overwritten" goes red
+#   - drop the `steal` argument conjunct           -> "upgrade repoint (steal arg)" goes red
 PCI="$SANDBOX/pci"
 mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
 printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
 printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
 chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
 
-pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
+pci_run() { # <owner-dir|-|garbage> <run-dir> [steal-env] [fn-arg] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
     rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
     case "$1" in
     -) ;; # no pre-existing units
@@ -8214,7 +8215,7 @@ pci_run() { # <owner-dir|-|garbage> <run-dir> [steal] — seed a service unit, r
         sudo() { echo "sudo:$*" >>"$PCI/calls"; }
         PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
             CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
-            provision_control_runner 2>&1
+            provision_control_runner ${4:+"$4"} 2>&1
         cat "$PCI/calls" 2>/dev/null
     )
 }
@@ -8224,6 +8225,11 @@ assert_contains "install: foreign existing owner -> refused, names the owner" "$
 assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
 assert_contains "install: foreign existing owner + steal escape -> overwritten" \
     "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
+# The upgrade callsite's spelling: after a successful upgrade the OLD versioned dir still exists
+# (it is the rollback), so the converge MUST take the units over — via the `steal` argument, not
+# the operator env var. Without it every one-click upgrade would refuse and strand the channel.
+assert_contains "install: foreign existing owner + upgrade repoint (steal arg) -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 0 steal)" "sudo:tee $PCI/units/pithead-control.service"
 assert_contains "install: foreign owner whose directory is gone -> adopted" \
     "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
 out="$(pci_run garbage "$PCI/mine")"


### PR DESCRIPTION
Twin sync: brings today's develop merges onto the appliance lane — the #991 residue cleanup (#1196), the fast-forward release mechanics (#1197), and the control-unit install ownership guard (#1200).

One conflict, in `tests/stack/run.sh`: both lanes had inserted test blocks at the same anchor (develop's new `provision_control_runner` install-guard block vs the appliance lane's installer-gate/headless-setup/ssh blocks), and git interleaved them. Resolved by taking the appliance lane's file and re-inserting the develop-side block verbatim from `origin/develop` at its anchor — both sides' tests are present, nothing was dropped. Everything else auto-merged.

## What was RUN

- `make test-stack` on the merge result: 2741 passed, 0 failed (the appliance suite plus the new install-guard assertions, together).
- `make lint`: pass. (First run failed on `lint-proto` only because the Docker daemon was down after a host restart — rerun clean once it was up; not a merge artifact.)
