### PR TITLE
chore(appliance): the socket-proxy pin's Quadlet mirror catches up (v0.5.0, digest-pinned)

### DIFF
--- a/os/quadlet/docker-control.container
+++ b/os/quadlet/docker-control.container
@@ -2,7 +2,7 @@
 Description=pithead control socket proxy
 [Container]
 ContainerName=docker-control
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 POST=1 ALLOW_START=1 ALLOW_STOP=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/os/quadlet/docker-proxy.container
+++ b/os/quadlet/docker-proxy.container
@@ -2,7 +2,7 @@
 Description=pithead read socket proxy
 [Container]
 ContainerName=docker-proxy
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 LOGS=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/os/quadlet/local/docker-control.container
+++ b/os/quadlet/local/docker-control.container
@@ -2,7 +2,7 @@
 Description=pithead control socket proxy
 [Container]
 ContainerName=docker-control
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 POST=1 ALLOW_START=1 ALLOW_STOP=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/os/quadlet/local/docker-proxy.container
+++ b/os/quadlet/local/docker-proxy.container
@@ -2,7 +2,7 @@
 Description=pithead read socket proxy
 [Container]
 ContainerName=docker-proxy
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 LOGS=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/os/quadlet/payout/docker-control.container
+++ b/os/quadlet/payout/docker-control.container
@@ -2,7 +2,7 @@
 Description=pithead control socket proxy
 [Container]
 ContainerName=docker-control
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 POST=1 ALLOW_START=1 ALLOW_STOP=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/os/quadlet/payout/docker-proxy.container
+++ b/os/quadlet/payout/docker-proxy.container
@@ -2,7 +2,7 @@
 Description=pithead read socket proxy
 [Container]
 ContainerName=docker-proxy
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 LOGS=1
 Volume=/run/podman/podman.sock:/var/run/docker.sock:ro

--- a/pithead
+++ b/pithead
@@ -7854,7 +7854,7 @@ EOF
 Description=pithead read socket proxy
 [Container]
 ContainerName=docker-proxy
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 LOGS=1
 Volume=$proxy_sock:/var/run/docker.sock:ro
@@ -7875,7 +7875,7 @@ EOF
 Description=pithead control socket proxy
 [Container]
 ContainerName=docker-control
-Image=docker.io/tecnativa/docker-socket-proxy:v0.4.2
+Image=docker.io/tecnativa/docker-socket-proxy:v0.5.0@sha256:1f5038b54f06c3e18422902cf00ba21803d1c97805aae032e5e6673d532d3459
 Network=proxy.network
 Environment=CONTAINERS=1 POST=1 ALLOW_START=1 ALLOW_STOP=1
 Volume=$proxy_sock:/var/run/docker.sock:ro


### PR DESCRIPTION
The actionable half of #1165, which turned out to be smaller and different than the report table suggested: the rootfs ARG bumps it lists (monero 0.18.5.1, p2pool 4.18, socket-proxy 0.5.0, compose 5.5.0 + `_COMMIT`) were **already on `develop-v2`** — #1183's sync plus the appliance-only compose commits. What nothing had caught: the **Quadlet runtime mirror** of the socket-proxy pin. `os/quadlet/{,local/,payout/}{docker-proxy,docker-control}.container` and the `render_quadlet_units()` function that generates them were still at `v0.4.2` with **no digest at all** — that path is not wired to `docker-compose.yml`, so a compose-side bump never reaches it. All 7 places now carry `v0.5.0@sha256:1f5038…`, the same index digest compose pins.

Tari stays at 5.3.1 deliberately — the standing operator scheduling call (one-way wallet-DB migration), not a patch-day bump.

## Audits, independently re-derived (none copied from #1183)

- monero 0.18.5.1: hash re-fetched from getmonero hashes.txt, matches the pin.
- p2pool 4.18: hash via the GPG-signed sha256sums *and* the release-API asset digest, both agree; the v4.18 SOCKS5 one-leg-only exemption change re-confirmed (Tari merge-mine bridge stays load-bearing).
- socket-proxy 0.5.0: digest re-derived from the registry with an OCI-index Accept header — confirmed it is the multi-arch **index** digest, not the amd64 child.
- compose 5.5.0: `_COMMIT` re-resolved from the tag; **fresh changelog audit** (this one existed nowhere yet): v5.5.0 overhauls image-digest reconciliation and may recreate containers once on first `up` — inert for this stack, whose images are all `tag@sha256`-pinned and which passes pull policy by CLI flag, never a compose-file `pull_policy:` key. Worst case is a one-time self-healing recreation.
- xmrig-proxy and cosign verified current, digests/commits match.

## What was RUN

- `make lint`: pass. `bash -n pithead`: pass.
- Quadlet render parity verified by sourcing `pithead` and diffing `render_quadlet_units()` output byte-for-byte against all three fixture sets — the same comparison the suite's parity test makes (run manually because sibling sessions held the suite; CI runs the real test on this PR).
- NOT run: a rootfs image build and the KVM battery — the bench gate for `os/` changes, owed after merge and noted below.
