### PR TITLE
fix(tests): the restored-identity and reseeded-dirs assertions can fail now

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1848,18 +1848,26 @@ phase_install() {
     else
         bad "restore leg: restored machine's config does not carry the original wallet"
     fi
-    local new_onion=""
+    local new_onion="" tor_hostname=""
     local odeadline
     odeadline=$(($(date +%s) + 600))
     while [ "$(date +%s)" -lt "$odeadline" ]; do
         new_onion=$(_ssh "grep MONERO_ONION_ADDRESS /data/pithead/.env 2>/dev/null" | cut -d= -f2 | tr -d '\r')
-        [ -n "$new_onion" ] && break
+        tor_hostname=$(_ssh "podman exec tor cat /var/lib/tor/monero/hostname 2>/dev/null" | tr -d '\r')
+        [ -n "$new_onion" ] && [ -n "$tor_hostname" ] && break
         sleep 15
     done
-    if [ -n "$new_onion" ] && [ "$new_onion" = "$orig_onion" ]; then
+    # .env is itself an archive member that load_preserved_state replays verbatim whenever it is
+    # already non-empty (pithead:6155-6166) — new_onion == orig_onion here proves only that the
+    # CONFIG FILE made the round trip, which holds even if the Tor data dir (the actual onion
+    # PRIVATE KEYS) was dropped from the backup: the stale address string rides along in .env while
+    # Tor silently mints a fresh, unrelated hidden service underneath it (#1090). The only
+    # comparison that proves the keys themselves came back is against Tor's OWN hostname file,
+    # sourced from the restored key material rather than from the archived config.
+    if [ -n "$new_onion" ] && [ -n "$tor_hostname" ] && [ "$new_onion" = "$orig_onion" ] && [ "$tor_hostname" = "$orig_onion" ]; then
         ok "restore leg: restored machine kept the ORIGINAL Tor identity, not a regenerated one"
     else
-        bad "restore leg: onion address changed ($orig_onion -> ${new_onion:-none}) — identity was not restored"
+        bad "restore leg: onion identity not restored (.env: $orig_onion -> ${new_onion:-none}, Tor's own hostname: ${tor_hostname:-none})"
     fi
     rm -f "$target_disk" "$restore_archive" "$restore_target"
 }
@@ -3046,10 +3054,14 @@ phase_fault() {
 #          reimplementation of it — which arms the `pithead-reset` marker on the ESP
 #          ($PRESEED_DIR/pithead-reset, default /boot/efi) and reboots. pithead-data-reset picks
 #          the marker up before /data mounts, reformats it, and consumes the marker. Assert the
-#          machine comes back to the wizard, the provisioned config and old container images are
-#          gone, the seeded dirs are back, and — the reset-tier rule — host identity (SSH
-#          host-key fingerprint, machine-id) is FRESH, not carried over: a handed-over box must
-#          not keep the old owner's identity (os/overlay/pithead-data-reset).
+#          machine comes back to the wizard without bricking, the provisioned config and old
+#          container images are gone, and — the reset-tier rule — host identity (SSH host-key
+#          fingerprint, machine-id) is FRESH, not carried over: a handed-over box must not keep
+#          the old owner's identity (os/overlay/pithead-data-reset). The reseed directive itself
+#          (systemd-repart's MakeDirectories= for the overlay/var upperdirs and /pithead) is
+#          proven statically against the built image in tests/os/verify-image.sh (#1092) — a
+#          post-boot dir check here cannot observe a dropped entry honestly (see the comment at
+#          the assertion site below).
 #   leg 2  the OTHER trigger: a data partition that will not mount even after fsck. Corrupt the
 #          ext4 magic on partition 4 (the fixed data slot) from the HOST, on the powered-off
 #          disk, then boot and assert the box self-heals into the wizard instead of bricking.
@@ -3170,11 +3182,17 @@ phase_reset() {
     else
         ok "the provisioned config is gone"
     fi
-    if _ssh "test -d /data/overlay/var && test -d /data/overlay/var-work && test -d /data/pithead"; then
-        ok "the /var overlay + /pithead dirs were reseeded on the fresh partition"
-    else
-        bad "reseeded dirs missing after factory-reset (/data/overlay/var, /data/overlay/var-work, /data/pithead)"
-    fi
+    # #1092: a post-boot `test -d` here is true by construction, not a check of the reseed. The
+    # overlay/var + var-work upperdirs cannot be observed missing at this point — with no `nofail`
+    # on that fstab line (os/rauc/populate-slot.sh), a missing upperdir fails local-fs.target on
+    # this read-only root and the box never answers SSH, so the leg would already have bailed
+    # above at "guest never returned after factory-reset — BRICKED". And /data/pithead is
+    # recreated by pithead-sync's own `mkdir -p` on every boot (os/overlay/pithead-sync) whether
+    # or not repart seeded it, so its presence here proves the sync script ran, not that the seed
+    # worked. The seeding mechanism itself — systemd-repart's MakeDirectories= for all three dirs
+    # — is asserted statically against the built image in tests/os/verify-image.sh, the one place
+    # that can actually observe a dropped entry. What THIS leg proves is the pair above: the
+    # reformat+reboot cycle didn't brick, and it landed back at an unprovisioned wizard.
     # The dashboard image is BAKED into the OS image (the wizard archive) and legitimately
     # reloaded onto the fresh store by the post-reset wizard boot — its presence proves nothing.
     # The wipe probe is an image that only ever arrives by PULL at provision time: monerod.

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -154,6 +154,17 @@ chk "fstab carries no LABEL= mounts" '! grep -q "LABEL=" "$ROOT/etc/fstab"'
 chk "fstab still overlays /var" 'grep -q "overlay /var" "$ROOT/etc/fstab"'
 chk "repart declares 4 GiB slots" 'grep -q "SizeMaxBytes=4G" "$ROOT/usr/lib/repart.d/20-system-a.conf"'
 chk "repart declares the data partition" '[ -s "$ROOT/usr/lib/repart.d/40-data.conf" ]'
+# The seeding mechanism itself (#1092): systemd-repart's MakeDirectories= only runs the moment it
+# FORMATS the partition, so this is the one place that can actually observe a dropped seed — a
+# post-boot check on a running system cannot, because pithead-sync's own `mkdir -p /data/pithead`
+# recreates that directory every boot regardless of what repart seeded, and a missing overlay
+# upperdir fails local-fs.target on this read-only root, bricking the boot before any check runs.
+chk "repart seeds /overlay/var on first format" \
+    'grep -qxF "MakeDirectories=/overlay/var" "$ROOT/usr/lib/repart.d/40-data.conf"'
+chk "repart seeds /overlay/var-work on first format" \
+    'grep -qxF "MakeDirectories=/overlay/var-work" "$ROOT/usr/lib/repart.d/40-data.conf"'
+chk "repart seeds /pithead on first format" \
+    'grep -qxF "MakeDirectories=/pithead" "$ROOT/usr/lib/repart.d/40-data.conf"'
 
 echo "==> the appliance can run the product"
 chk "podman" '[ -e "$ROOT/usr/bin/podman" ]'


### PR DESCRIPTION
## What

Both #1090 and #1092 are "this check cannot go red" defects in `tests/os/run.sh`'s appliance battery. This PR fixes both assertions so they discriminate the real failure they were written to catch, and does nothing else.

**#1090 — restored-Tor-identity check compared `.env` against itself.** `phase_install`'s restore leg compared `MONERO_ONION_ADDRESS` read from the restored machine's `/data/pithead/.env` against the same field read from the original's `.env` before backup. But `.env` is itself an archive member that `load_preserved_state` replays verbatim whenever it's already non-empty (`pithead:6155-6166`) — both sides trace back to the same carried string. Drop the Tor data directory (the actual onion **private keys**) from the backup set and the check stays green: the stale address string rides along in `.env` while Tor silently mints a fresh, unrelated hidden service underneath it.

Fix: also read Tor's own `hostname` file from the restored key material (`podman exec tor cat /var/lib/tor/monero/hostname`) and require it to match the pre-restore address too. That's the only comparison sourced from outside the archived config, so it's the only one that can catch dropped keys.

**#1092 — reseeded-dirs check was true by construction.** `phase_reset` asserted `/data/overlay/var`, `/data/overlay/var-work`, and `/data/pithead` existed post-boot as proof `systemd-repart`'s `MakeDirectories=` seeding ran. All three conjuncts are unfalsifiable at that point: the two overlay dirs back a `/var` overlay mount with no `nofail` on this read-only root (`os/rauc/populate-slot.sh`) — a missing upperdir fails `local-fs.target` and the box never answers SSH, so the leg already bails earlier at "guest never returned after factory-reset — BRICKED" before this line runs. `/data/pithead` is independently recreated by `pithead-sync`'s own `mkdir -p` on every boot regardless of what repart seeded.

Fix: moved the seeding check to where it can actually be observed — a static grep of the shipped `os/rootfs/repart.d/40-data.conf` for all three `MakeDirectories=` lines in `tests/os/verify-image.sh` (the release gate's static-verification phase, which mounts the built image read-only). The vacuous post-boot `test -d` block is removed from `run.sh` entirely, replaced by a comment naming what that leg can honestly still prove: the reformat+reboot cycle didn't brick, and it landed back at an unprovisioned wizard (both already asserted separately, just above).

## What I ran (I am the evidence — the branch's own author is unavailable, report lost)

Scope check:
- `git diff` from the develop-v2 merge-base to this branch's tip touches only `tests/os/run.sh` and `tests/os/verify-image.sh`, one commit, and matches #1090 + #1092 exactly — no extraneous changes.

Lint:
- `shellcheck --severity=warning tests/os/run.sh tests/os/verify-image.sh` → clean, exit 0 (re-verified after the box's shellcheck upgrade to 0.11.0).
- `make lint-sh` on this branch exits 137 at the shellcheck memory cap — that is #1206, not this branch: the blowup file is `tests/stack/run.sh` (unmodified here; the develop-v2 copy alone exceeds the cap, data posted on #1206). The two files this branch touches lint clean at the enforced severity.

**#1092 red/green proof**, at script level — no image build / loop mount / root required, since the fix is a static grep against a text file:
- Extracted the three real `chk()` lines from `verify-image.sh` verbatim into a harness, pointed at a synthetic `$ROOT/usr/lib/repart.d/40-data.conf` seeded from the real `os/rootfs/repart.d/40-data.conf`.
- **GREEN**: all three pass against the honest fixture.
- **Mutation** (the issue's own named mutation — drop `/pithead` from the seed set): removed the `MakeDirectories=/pithead` line → the `/pithead` check goes **RED**, the other two stay green. Restored the line → **GREEN** again.
- Vacuous-pass trap check: commented out the `/pithead` directive instead of deleting it, to confirm `grep -qxF` (exact whole-line match) doesn't false-pass on a disabled directive via substring matching → correctly **RED**.
- Confirmed the three checks fail independently: dropped both `/overlay/var` and `/overlay/var-work` with `/pithead` intact → both go RED while `/pithead` stays green.

**#1090 red/green proof**, at script level — the full end-to-end path is KVM-only (`virt-install`, a live guest, a running Tor container over SSH), so I extracted the exact new conditional and fed it synthetic `orig_onion` / `new_onion` / `tor_hostname` values instead of running the real guest:
- **GREEN**: genuine matching restore (all three values equal) → passes.
- **Mutation** (the issue's own named mutation — Tor data dir dropped from the backup): `new_onion == orig_onion` (the stale `.env` string carried through) but `tor_hostname` is a different, freshly-minted address → **RED**. Restored matching values → **GREEN** again.
- **Counterfactual**: ran the *old* pre-fix conditional (`new_onion == orig_onion` only, no `tor_hostname` check) against the same dropped-Tor-dir mutation values → confirmed it prints `ok` / stays green, reproducing the exact vacuity #1090 reported. This proves the new `tor_hostname` comparison is the discriminating change, not incidental to it.

**Not run — bench/KVM-deferred to the post-merge combined gate:**
- `tests/os/run.sh` end-to-end (`phase_install`, `phase_reset`) — requires `virt-install`/KVM guests and a live Tor container.
- `tests/os/verify-image.sh` against a real built appliance image — requires root + loop mount + an actual built image.
- The full combined test suite (`tests/stack/run.sh` and friends) — out of scope for this targeted change per the four-tier testing model; deferred to the single post-merge combined gate along with the bench legs above. `make lint` was not run in full (fails locally at `lint-proto` without docker); `lint-sh`'s crash on an unrelated file is a known environment issue, not this branch's problem.

## Result

Both assertions now demonstrably discriminate the exact failure their issue describes — reintroducing either named mutation turns the corresponding check red, and both go green on the honest case. Scope matches #1090 and #1092 with nothing extra.

Closes #1090
Closes #1092
