### PR TITLE
fix(appliance): os-update surfaces rauc's own diagnosis instead of a bare abort

### DIFF
--- a/pithead
+++ b/pithead
@@ -2957,7 +2957,14 @@ os_bundle_meta() { # $1: bundle, $2: [meta.pithead] key — echoes its value or 
     # tier-4 migration leg). Verification still runs: rauc info checks the bundle signature
     # against the system keyring before printing anything. Anything unparseable degrades to
     # empty, which every consumer treats as fail-closed "unstamped".
-    rauc info --output-format=shell "$1" 2>/dev/null |
+    #
+    # `|| true` on rauc's own leg: under `set -o pipefail` a signature failure makes rauc info
+    # exit nonzero, and that alone — with sed/head both still succeeding on empty input — fails
+    # the whole pipe. In a bare `var=$(os_bundle_meta ...)` assignment that trips `set -e` right
+    # here, before any caller sees a result, which is exactly this function's own "never fails"
+    # contract broken by pipefail (#1041: the actual mechanism behind the ERR trap's contentless
+    # "aborted unexpectedly" — os_update's callers below never got a chance to run at all).
+    { rauc info --output-format=shell "$1" 2>/dev/null || true; } |
         sed -n "s/^RAUC_META_PITHEAD_$(printf '%s' "$2" | tr '[:lower:]' '[:upper:]')='\(.*\)'\$/\1/p" |
         head -1
 }
@@ -3093,6 +3100,20 @@ os_update() {
         error "rauc is not available here — OS updates apply to the appliance image, not a checkout install."
     [ -f "$bundle" ] || error "No such bundle: $bundle"
 
+    # Verify the bundle explicitly, before anything reads its metadata (#1041). `rauc info`
+    # checks the signature against the system keyring before it prints anything, so a bad
+    # signature fails right here with RAUC's own precise diagnosis on stderr (e.g. "signature
+    # verification failed: Verify error: self-signed certificate" — a bundle signed by a chain
+    # this machine doesn't trust). Captured explicitly rather than left to whatever later reads
+    # the bundle: the dashboard's os-verify/os-install doors already run this same check
+    # (os_verify_bundle_reason) before this CLI path ever runs, but the CLI's own os-update had
+    # nothing playing that role, so its ERR trap fired with no diagnosis to show for it.
+    local rauc_info_err rauc_rc=0
+    rauc_info_err=$(rauc info "$bundle" 2>&1 >/dev/null) || rauc_rc=$?
+    if [ "$rauc_rc" -ne 0 ]; then
+        error "rauc could not verify this bundle.${rauc_info_err:+ rauc said: $(printf '%s' "$rauc_info_err" | tail -1 | tr -d '[:cntrl:]' | head -c 300)}"
+    fi
+
     # Version floor + data-migration guards — the exact refusals the dashboard's os-verify/
     # os-install verbs run (os_update_version_guard, shared so the two doors never drift).
     local bundle_version bundle_min bundle_migrates running_version guard_reason
@@ -3136,7 +3157,25 @@ os_update() {
         fi
     fi
     log "Installing OS update bundle: $bundle (running: $running, bundle: $target)"
-    rauc install "$bundle"
+    # Tee'd like the wizard's fatal path (#1028's idiom): a bare `rauc install` let RAUC's own
+    # diagnosis (a signature mismatch, an incompatible bundle) vanish, leaving only the ERR
+    # trap's generic "aborted unexpectedly" — undiagnosable on a shell-less box where the
+    # console is the only output there is. The tee keeps rauc's progress on this process's own
+    # stdout (the dashboard's install poller reads the percentage off that same stream) while a
+    # copy lands in a scratch file this function can inspect on failure. No bundle path in the
+    # error text on purpose — that is a host staging detail, and the dashboard door whitelists
+    # this exact line straight into the container-visible result.
+    local rauc_log
+    rauc_log=$(mktemp)
+    if rauc install "$bundle" 2>&1 | tee "$rauc_log"; then
+        rm -f "$rauc_log"
+    else
+        local rauc_detail
+        rauc_detail=$(grep -aE '^LastError: |^\[ERROR\] |[Ff]ailed' "$rauc_log" 2>/dev/null |
+            tail -1 | tr -d '[:cntrl:]' | head -c 300) || rauc_detail=""
+        rm -f "$rauc_log"
+        error "rauc install failed.${rauc_detail:+ rauc said: $rauc_detail}"
+    fi
 
     # A data_migration bundle raises the /data floor so a later rollback below it is refused. Armed
     # at install (conservative: before the migration actually runs on the new slot's next boot) —

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -10933,13 +10933,23 @@ assert_rc "unstamped system + release bundle passes — stays shell-less, no cha
 OUSB=$(mktemp -d)
 mkdir -p "$OUSB/bin"
 # A fake rauc: logs every call, answers `info` with a canned shell-format body —
-# the format the real os_bundle_meta parses (RAUC 1.11's JSON output omits [meta.*]).
+# the format the real os_bundle_meta parses (RAUC 1.11's JSON output omits [meta.*]). Two escape
+# hatches for #1041's error-surfacing tests: RAUC_INFO_RC/RAUC_INFO_ERR fail `info` (a signature
+# verdict) with a chosen message on stderr, RAUC_INSTALL_RC/RAUC_INSTALL_ERR do the same for
+# `install`. Both default to a clean 0/no-output — every test above this one never sets them.
 cat >"$OUSB/bin/rauc" <<'EOF'
 #!/usr/bin/env bash
 echo "[rauc] $*" >>"${RAUC_LOG:?}"
 case "$1" in
-info) [ -s "${RAUC_INFO_OUT:-}" ] && cat "$RAUC_INFO_OUT" ;;
-install) exit 0 ;;
+info)
+    [ -s "${RAUC_INFO_OUT:-}" ] && cat "$RAUC_INFO_OUT"
+    [ -n "${RAUC_INFO_ERR:-}" ] && echo "$RAUC_INFO_ERR" >&2
+    exit "${RAUC_INFO_RC:-0}"
+    ;;
+install)
+    [ -n "${RAUC_INSTALL_ERR:-}" ] && echo "$RAUC_INSTALL_ERR" >&2
+    exit "${RAUC_INSTALL_RC:-0}"
+    ;;
 esac
 exit 0
 EOF
@@ -11010,6 +11020,69 @@ assert_rc "release -> release installs with no prompt" "$?" "0"
 assert_contains "rauc install ran unprompted" "$(cat "$RAUC_LOG")" "install bundle.raucb"
 out=$(ourun "$OUSB/variant-debug" "$OUSB/info-release.txt" 2>&1)
 assert_rc "a missing bundle path is an error, not an install" "$?" "1"
+
+echo "== unit: os_bundle_meta degrades to empty instead of aborting the caller (#1041) =="
+# run_sourced (used everywhere above) disables errexit right after sourcing, which would hide
+# the exact bug #1041 traces to: under `set -o pipefail`, `rauc info | sed | head` returns rauc's
+# own nonzero exit even though sed/head both succeed, and a bare `var=$(os_bundle_meta ...)`
+# assignment then trips `set -e` — silently, since the diagnostic went to `2>/dev/null`. This
+# check keeps errexit ON (the real pithead script's own posture) so a regression here reproduces
+# the actual failure: the subshell would abort before ever reaching the second echo.
+: >"$RAUC_LOG"
+ombm_out=$(
+    cd "$OUSB" || exit 1
+    PATH="$OUSB/bin:$PATH"
+    export RAUC_INFO_RC=1 RAUC_INFO_OUT="" RAUC_INFO_ERR="signature verification failed: self-signed certificate"
+    # shellcheck disable=SC1090
+    source "$STACK"
+    echo "before"
+    v=$(os_bundle_meta bundle.raucb version)
+    echo "after:[$v]"
+)
+ombm_rc=$?
+assert_rc "a failing rauc info does not abort the caller under errexit+pipefail" "$ombm_rc" "0"
+assert_contains "execution continues past the failed call" "$ombm_out" "after:[]"
+
+echo "== integration: os-update surfaces rauc's own diagnosis instead of a bare abort (#1041) =="
+# The bug as filed: a signature failure inside a command substitution (os_bundle_meta, above)
+# tripped the ERR trap with nothing to show for it — three bare "aborted unexpectedly" lines and
+# no clue rauc had already diagnosed it precisely on its own stderr. Runs the REAL script as a
+# subprocess (not sourced) so the ERR trap this bug lives in is actually armed.
+OUB=$(mktemp -d)
+mkdir -p "$OUB/bin"
+cp "$STACK" "$OUB/pithead"
+chmod +x "$OUB/pithead"
+cp "$OUSB/bin/rauc" "$OUB/bin/rauc"
+chmod +x "$OUB/bin/rauc"
+touch "$OUB/bundle.raucb"
+: >"$OUB/calls"
+out=$(cd "$OUB" && PATH="$OUB/bin:$PATH" RAUC_LOG="$OUB/calls" \
+    RAUC_INFO_RC=1 RAUC_INFO_ERR="signature verification failed: Verify error: self-signed certificate" \
+    ./pithead os-update bundle.raucb --yes 2>&1)
+rc=$?
+assert_rc "a bad-signature bundle refuses the update" "$rc" "1"
+assert_contains "rauc's own diagnosis reaches the operator" "$out" "self-signed certificate"
+assert_not_contains "the generic contentless abort does not ALSO fire" "$out" "aborted unexpectedly"
+assert_not_contains "rauc install is never reached on a bad signature" "$(cat "$OUB/calls")" "install"
+rm -rf "$OUB"
+
+echo "== unit: os-update surfaces rauc install's own stderr, not just a bare failure (#1041) =="
+: >"$RAUC_LOG"
+out=$(
+    cd "$OUSB" || exit 1
+    PATH="$OUSB/bin:$PATH"
+    export RAUC_INFO_OUT="$OUSB/info-release.txt" PITHEAD_VARIANT_FILE="$OUSB/variant-release"
+    export PITHEAD_MIGRATION_MARKER_FILE="$OUSB/marker-scratch"
+    export RAUC_INSTALL_RC=1 RAUC_INSTALL_ERR="LastError: mounting slot failed: no such device"
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    os_update bundle.raucb --yes </dev/null 2>&1
+)
+rc=$?
+assert_rc "an install-time rauc failure is refused, not silently ignored" "$rc" "1"
+assert_contains "rauc's install-time diagnosis reaches the operator" "$out" "mounting slot failed"
+unset RAUC_INFO_RC RAUC_INFO_ERR RAUC_INSTALL_RC RAUC_INSTALL_ERR
 
 # --- os-update version floor + data-migration guards (#856 downgrade, #851 migration deadlock) ---
 # A correctly-signed bundle is not automatically a safe one: an OLDER image re-opens fixed holes,


### PR DESCRIPTION
## What changed and why

`pithead os-update BUNDLE` on a bad-signature bundle used to report only the ERR trap's generic `pithead aborted unexpectedly (exit 1)` — three times, nothing above it. Root cause traced and reproduced: `os_bundle_meta`'s `rauc info | sed | head` pipe discards rauc's stderr (`2>/dev/null`), and under `set -o pipefail` a signature failure there fails the whole pipe even though `sed`/`head` both succeed on empty input. A bare `bundle_version=$(os_bundle_meta ...)` assignment then trips `set -e` right there — before `os_update`'s own logic, including the already-tee'd `rauc install` further down, ever runs. Standalone repro of the unpatched pipe printed the generic trap message three times (matching the issue's report verbatim) and never surfaced rauc's real diagnosis (`signature verification failed: Verify error: self-signed certificate`).

Two changes in `os_update`/`os_bundle_meta` (`pithead`):
1. `os_bundle_meta` now honors its own documented "never fails" contract — `|| true` on rauc's leg makes it immune to `pipefail` propagating rauc's exit code.
2. `os_update` runs an explicit `rauc info` verification up front, before any metadata read, so a bad bundle refuses immediately with rauc's own stderr text instead of the caller finding out secondhand (or, per mutation 2 below, not finding out at all — the bundle could reach `rauc install`). The dashboard's os-verify/os-install doors already ran an equivalent check (`os_verify_bundle_reason`) before this CLI path did; the CLI's own `os-update` had nothing playing that role.

Tests added in `tests/stack/run.sh` for both, plus one for the pre-existing tee'd `rauc install` stderr capture (previously untested — the fake `rauc` always exited 0).

The issue's second, separate finding (`mkbundle.sh --dev` regenerating a throwaway signing chain, undocumented) is already covered on `develop-v2` in `docs/dev/appliance-release.md` ("Updating a bench over SSH, and the signing trap that stops you") — no doc change needed there.

## What was RUN, with verdicts

- `bash -n pithead` / `bash -n tests/stack/run.sh` — syntax OK.
- `shellcheck --severity=warning pithead` (matches the Makefile's `lint-sh` invocation) — clean, 0 findings.
- `shfmt -i 4 -d pithead tests/stack/run.sh` — clean, no diff.
- `bash scripts/lint-operator-strings.sh` — clean ("no issue/PR numbers in pithead output... no bare docs/ paths").
- Full committed suite, `tests/stack/run.sh` via the required `flock /tmp/pithead-suite.lock` wrapper — completed once: **`pithead tests: 2769 passed, 0 failed`** (exit 0), including the 3 new `#1041` test blocks (8 assertions), with no regressions elsewhere.
- Mutation battery (see below) — run via a standalone lock-free harness extracted verbatim from the committed test file (rationale below), all 3 mutations produced exactly the predicted RED assertions, isolated to their own test; restored to 8/8 green after each.

## What was NOT run

- `shellcheck` directly on `tests/stack/run.sh` itself: hit the known 6G cgroup cap (`shellcheck: exceeded the 6G cgroup cap`) — the documented, expected condition for this specific file, not a defect in this change. `shfmt` covered its formatting instead (clean).
- A **second** full-suite confirmation run and the **in-suite** mutation battery: both attempted through the mandated `/tmp/pithead-suite.lock` wrapper but could not acquire the lock within the session's time budget. `fuser`/`ps` showed 10–14 processes concurrently competing for the same lock from sibling wave agents' worktrees; one foreign holder (confirmed via `/proc`, a different worktree) held it 8+ minutes with negligible CPU time (sleeping, not progressing quickly). Two wait attempts (540s, 560s) timed out with the suite never starting. As a substitute, the exact 3 new test blocks were extracted verbatim from the committed `tests/stack/run.sh` into a small standalone harness (same `ok`/`bad`/`assert_*` helpers, same test bodies) that touches neither docker nor the shared lock, confirmed safe since these tests use none of either — run against the real fixed code (8/8 pass) and against each one-line-reverted mutation. This is reported precisely as what it is: a mutation proof of the committed test bodies, run outside the congested shared harness, not a second in-suite run.
- `make lint` (full) / `make test` (dashboard): out of scope — no Python/dashboard files touched.
- Full combined test suite + KVM/bench battery: deferred to the post-merge combined gate per wave policy. Nothing under `os/` was touched by this change, so no bench-only gate applies here, but the full battery is deferred regardless per standing policy.

## Mutations (each on the real committed code, proven via the standalone harness described above)

1. **`os_bundle_meta`**: reverted the `|| true` pipefail-immunity fix. Result: the 2 assertions in "os_bundle_meta degrades to empty instead of aborting the caller" went RED — `rc 1` instead of `0`, execution stopped at `before` instead of reaching `after:[]`. Restored — same 2 assertions green again.
2. **`os_update`**: removed the explicit upfront `rauc info` verification. Result: 3 of 4 assertions in "os-update surfaces rauc's own diagnosis instead of a bare abort" went RED — and critically, `rauc install` was actually invoked (the `assert_not_contains ... "install"` check failed) on a bundle that had just failed its signature check, i.e. without this check a bad-signature bundle could reach install. Restored — 4/4 green again.
3. **`os_update`**: reverted the tee'd `rauc install` capture back to a bare `rauc install "$bundle"`. Result: the rc assertion in "os-update surfaces rauc install's own stderr" went RED — `rc 0` instead of `1` (under the test's `set +e`, the failed install was silently swallowed and `os_update` returned success). Restored — 2/2 green again.

Closes #1041
