### PR TITLE
fix(appliance): refusals stop naming a shell the box does not have

### DIFF
--- a/pithead
+++ b/pithead
@@ -6076,19 +6076,29 @@ GH_RELEASE_JSON=""
 # result sat at "running" for ever with a single dial in the log. One derivation, one truth.
 GH_SOCKS=""
 gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE_HINT on failure
-    local repo="$1" prefix out code
+    local repo="$1" prefix out code retry_hint
     prefix=$(env_get NETWORK_PREFIX 2>/dev/null) || true
     [ -n "$prefix" ] || prefix="172.28.0"
     GH_SOCKS="${prefix}.25:9050"
     GH_RELEASE_HINT=""
     GH_RELEASE_JSON=""
+    # Every caller of this fetch is reachable from the dashboard on an appliance (os-check, the
+    # RigForge worker-upgrade) — which has no shell to run 'doctor' from, the product's defining
+    # property (#1139). The one caller that DOES want the CLI hint (the DIY one-click upgrade)
+    # already refuses before it ever dials on an appliance host, so keying this off is_appliance
+    # — a fact about the machine, not the caller — gets every call site right with one seam.
+    if is_appliance; then
+        retry_hint="Retry from the dashboard in a few minutes."
+    else
+        retry_hint="Check './pithead doctor' and retry."
+    fi
     # -w appends the status on its own line, so a non-2xx keeps its BODY — which is where GitHub
     # says the limit was exceeded. Without -f, curl's own non-zero exit now means only a transport
     # failure, which is exactly the distinction that was missing.
     if ! out=$(curl -sS --max-time 60 --max-filesize "$CURL_CAP_SMALL" -w '\n%{http_code}' \
         --socks5-hostname "$GH_SOCKS" -H 'Accept: application/vnd.github+json' \
         "https://api.github.com/repos/$repo/releases/latest" 2>/dev/null); then
-        GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. Check './pithead doctor' and retry."
+        GH_RELEASE_HINT="could not reach the GitHub release API over Tor — nothing was changed. $retry_hint"
         return 1
     fi
     code=${out##*$'\n'}
@@ -6099,7 +6109,7 @@ gh_release_fetch() { # <owner/repo>; sets GH_RELEASE_JSON on success, GH_RELEASE
     case "$code" in
     [0-9][0-9][0-9]) ;;
     *)
-        GH_RELEASE_HINT="the GitHub release API answered in a shape this cannot read — nothing was changed. Check './pithead doctor' and retry."
+        GH_RELEASE_HINT="the GitHub release API answered in a shape this cannot read — nothing was changed. $retry_hint"
         return 1
         ;;
     esac
@@ -8396,7 +8406,16 @@ describe_change() {
             msg="Stratum access-password DISABLED — any rig that can reach :3333 may mine again."
         elif [ -z "$old" ]; then
             flag=DEST
-            msg="Stratum access-password ENABLED — rigs must now send the matching 'pass' (find it in .env / './pithead status') or they're rejected; the xmrig-proxy container is recreated."
+            # The DIY hint points at .env / 'status' to recover an auto-generated password; the
+            # appliance has neither a shell nor a dashboard surface that reveals a secret value
+            # (#33's own trust boundary — masked config never round-trips a secret to the
+            # container), so there is no remedy to name here. Drop the instruction rather than
+            # invent one (#1139).
+            if is_appliance; then
+                msg="Stratum access-password ENABLED — rigs must now send the matching 'pass' or they're rejected; the xmrig-proxy container is recreated."
+            else
+                msg="Stratum access-password ENABLED — rigs must now send the matching 'pass' (find it in .env / './pithead status') or they're rejected; the xmrig-proxy container is recreated."
+            fi
         else
             flag=DEST
             msg="Stratum access-password CHANGED — update every rig's 'pass' to match or they're rejected; the xmrig-proxy container is recreated."
@@ -8551,6 +8570,11 @@ describe_change() {
     TOR_AUTO_HEAL)
         if [ "$new" == "true" ]; then
             msg="Tor guard self-heal ENABLED — when clearnet egress through Tor stays broken for 15 min (a failing guard), the dashboard restarts the tor container to pick fresh guards (max 3 restarts per outage, 30-min cooldown; each restart drops ALL Tor circuits, mining onions included, which then rebuild); the dashboard container is recreated."
+        # The DIY fix names 'doctor' + a scoped tor restart, both CLI-only; the appliance has no
+        # shell to run either from, and there is no dashboard control that restarts tor alone
+        # (#1139) — so this side just states the fact instead of a remedy it cannot offer.
+        elif is_appliance; then
+            msg="Tor guard self-heal DISABLED — a stuck guard is back to WARN-only, with no dashboard control to restart Tor manually; the dashboard container is recreated."
         else
             msg="Tor guard self-heal DISABLED — a stuck guard is back to WARN-only ('./pithead doctor', fix with './pithead restart tor'); the dashboard container is recreated."
         fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -573,6 +573,23 @@ esac
 # INFO — and the secret value must NEVER appear in the change preview.
 assert_contains "stratum pw enable is DEST" "$(run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD '' s3cr3t)" "DEST"
 assert_contains "stratum pw disable is INFO" "$(run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD s3cr3t '')" "INFO"
+# Appliance (#1139): the DIY hint points at .env / './pithead status' to recover the password —
+# neither exists without a shell, and the dashboard never round-trips a secret value either (#33),
+# so there is no remedy to name. The appliance-lane message drops the instruction instead of
+# inventing one.
+#
+# MUTATION PROOF: drop the is_appliance branch (always emit the DIY message) and the "names no CLI
+# verb" assertion below goes red; force the appliance branch unconditionally and the unchanged-DIY
+# assertion at line ~574's sibling below goes red — neither direction passes both.
+stratum_pw_appliance="$(PITHEAD_APPLIANCE=1 run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD '' s3cr3t)"
+assert_contains "appliance stratum pw enable is still DEST" "$stratum_pw_appliance" "DEST"
+case "$stratum_pw_appliance" in
+*"./pithead"* | *".env"*) bad "appliance stratum pw enable names no CLI verb or .env" "still says: $stratum_pw_appliance" ;;
+*) ok "appliance stratum pw enable names no CLI verb or .env" ;;
+esac
+assert_contains "DIY stratum pw enable advice is unchanged" \
+    "$(PITHEAD_APPLIANCE=0 run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD '' s3cr3t)" \
+    "find it in .env / './pithead status'"
 case "$(run_sourced "$SANDBOX" describe_change PROXY_STRATUM_PASSWORD oldpw newpw)" in
 *oldpw* | *newpw*) bad "stratum pw change hides the secret" "value leaked into the change preview" ;;
 *DEST*) ok "stratum pw change hides the secret (DEST, no value shown)" ;;
@@ -582,6 +599,22 @@ esac
 assert_contains "tor auto-heal enable is INFO" "$(run_sourced "$SANDBOX" describe_change TOR_AUTO_HEAL false true)" "INFO"
 assert_contains "tor auto-heal enable names the cost" "$(run_sourced "$SANDBOX" describe_change TOR_AUTO_HEAL false true)" "drops ALL Tor circuits"
 assert_contains "tor auto-heal disable names the manual fix" "$(run_sourced "$SANDBOX" describe_change TOR_AUTO_HEAL true false)" "restart tor"
+# Appliance (#1139): 'doctor' and a scoped tor restart are both CLI-only, and no dashboard control
+# restarts tor alone — the appliance-lane message states the fact instead of naming a remedy that
+# does not exist on that lane.
+#
+# MUTATION PROOF: drop the is_appliance branch (always emit the DIY message) and the "names no CLI
+# verb" assertion below goes red; force the appliance branch unconditionally and the unchanged-DIY
+# assertion right above (checked again explicitly below) goes red — neither direction passes both.
+tor_heal_appliance="$(PITHEAD_APPLIANCE=1 run_sourced "$SANDBOX" describe_change TOR_AUTO_HEAL true false)"
+assert_contains "appliance tor auto-heal disable is still INFO" "$tor_heal_appliance" "INFO"
+case "$tor_heal_appliance" in
+*"./pithead"*) bad "appliance tor auto-heal disable names no CLI verb" "still says: $tor_heal_appliance" ;;
+*) ok "appliance tor auto-heal disable names no CLI verb" ;;
+esac
+assert_contains "DIY tor auto-heal disable advice is unchanged" \
+    "$(PITHEAD_APPLIANCE=0 run_sourced "$SANDBOX" describe_change TOR_AUTO_HEAL true false)" \
+    "'./pithead doctor', fix with './pithead restart tor'"
 # Fail-closed miner hold (#490): INFO either way (like TARI_REQUIRED) — it's on the dashboard
 # control-channel allowlist, so a DEST flag here would make control_approval_gate refuse every
 # commit that touches it, defeating the allowlisting.
@@ -7593,6 +7626,56 @@ undeclared_socks="$(awk '
     /--socks5-hostname "\$socks"/ && !declared { print FNR " in " fn }
 ' "$STACK")"
 assert_eq "no dial refers to a socks variable its own function never declares" "$undeclared_socks" ""
+
+echo "== unit: appliance-lane release-fetch hints name no shell the box does not have (#1139) =="
+# The transport-failure and unparseable-response hints told the operator to run './pithead doctor'
+# — reachable from the dashboard's os-check (and the RigForge worker-upgrade) on an appliance,
+# which has no shell to run it from. gh_release_fetch now keys the retry hint off is_appliance, a
+# fact about the machine rather than the caller, so every caller gets it right for free.
+#
+# MUTATION PROOF: hardcode retry_hint to the DIY string (drop the is_appliance branch) and both
+# "names no CLI verb" assertions below go red; hardcode it to the appliance string instead and the
+# DIY-lane assertions (both here and in the block above) go red — neither direction can pass alone.
+gh_tf_appliance=$(PITHEAD_APPLIANCE=1 gh_fetch 000 '' 1)
+assert_eq "appliance transport failure is still a failure" "${gh_tf_appliance%%|*}" "1"
+assert_contains "and still reads as a dial that did not land" "$gh_tf_appliance" "could not reach the GitHub release API"
+assert_contains "and points at the dashboard instead of a shell" "$gh_tf_appliance" "Retry from the dashboard"
+case "$gh_tf_appliance" in
+*"./pithead"*) bad "appliance transport-failure hint names no CLI verb" "still says: $gh_tf_appliance" ;;
+*) ok "appliance transport-failure hint names no CLI verb" ;;
+esac
+
+gh_nocode_appliance=$(
+    cd "$GHR" || exit 1
+    # shellcheck disable=SC1090  # STACK path is dynamic by design
+    source "$STACK" 2>/dev/null
+    set +e
+    export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1 PITHEAD_APPLIANCE=1
+    gh_release_fetch p2pool-starter-stack/pithead
+    printf '%s|%s' "$?" "$GH_RELEASE_HINT"
+)
+assert_eq "appliance unparseable response is still a failure" "${gh_nocode_appliance%%|*}" "1"
+assert_contains "and reads as an unreadable shape" "$gh_nocode_appliance" "answered in a shape this cannot read"
+assert_contains "and points at the dashboard instead of a shell" "$gh_nocode_appliance" "Retry from the dashboard"
+case "$gh_nocode_appliance" in
+*"./pithead"*) bad "appliance unparseable-response hint names no CLI verb" "still says: $gh_nocode_appliance" ;;
+*) ok "appliance unparseable-response hint names no CLI verb" ;;
+esac
+
+# DIY-lane advice is untouched: 'doctor' is exactly right when the operator has a shell to run it
+# from — same fetch, same call, only the machine fact differs.
+gh_tf_diy=$(PITHEAD_APPLIANCE=0 gh_fetch 000 '' 1)
+assert_contains "DIY transport-failure advice is unchanged" "$gh_tf_diy" "Check './pithead doctor' and retry."
+gh_nocode_diy=$(
+    cd "$GHR" || exit 1
+    # shellcheck disable=SC1090  # STACK path is dynamic by design
+    source "$STACK" 2>/dev/null
+    set +e
+    export PATH="$GHR/bin:$PATH" GH_STUB_BODY='{"message":"Not Found"}' GH_STUB_NOCODE=1 PITHEAD_APPLIANCE=0
+    gh_release_fetch p2pool-starter-stack/pithead
+    printf '%s' "$GH_RELEASE_HINT"
+)
+assert_contains "DIY unparseable-response advice is unchanged" "$gh_nocode_diy" "Check './pithead doctor' and retry."
 
 echo "== black-box: control upgrade verb (#59) =="
 # A RELEASE install (no build/*/Dockerfile → is_source_checkout false) with the control channel


### PR DESCRIPTION
## What changed and why

Issue #1139: several operator-facing refusal strings told the operator to run `./pithead doctor` or check `.env` — dead ends on the Pithead OS appliance, which by design has no shell. Both were reachable from the dashboard on that lane (the os-check verb and the config apply-preview).

Fixed four sites, all keyed off the existing `is_appliance` fact-about-the-machine helper (not the caller), matching the project's established pattern:

- **`gh_release_fetch`** (shared by os-check and the RigForge worker-upgrade): the transport-failure and unparseable-response hints now say "Retry from the dashboard in a few minutes." on an appliance instead of "Check './pithead doctor' and retry." — one seam covers every caller.
- **`describe_change PROXY_STRATUM_PASSWORD`** (enable case): the appliance-lane preview drops the "find it in .env / './pithead status'" instruction rather than inventing a remedy the dashboard can't offer — masked config never round-trips a secret value back to the operator (#33's own trust boundary).
- **`describe_change TOR_AUTO_HEAL`** (disable case): the appliance-lane preview states the fact ("no dashboard control to restart Tor manually") instead of naming the CLI-only `'./pithead doctor'` / `'./pithead restart tor'` remedy.

DIY-lane wording is byte-for-byte unchanged in all four spots — verified explicitly by the tests.

The rate-limit hint (a pre-existing sibling of the two `gh_release_fetch` hints touched here) already named a real dashboard-agnostic remedy ("restart tor" — the one CLI-only action the issue calls out as already correct) and needed no change.

Scope note: doctor's own `dr_fail`/`dr_warn` diagnostic strings (e.g. "run './pithead apply'") were left alone — there is no `doctor` verb in the control-channel action list (`pithead:10806`), so nothing currently surfaces that text through the dashboard on the appliance. Filed as a finding for a follow-up audit if that ever changes, per "finish the issue's actual scope, no more."

## What was RUN, with verdicts

- **Targeted tests** — the exact 16 new assertions added to `tests/stack/run.sh` (stratum-password preview ×3, tor-auto-heal preview ×3, gh_release_fetch transport-failure ×4, gh_release_fetch unparseable-response ×4, DIY-unchanged sanity ×2), reproduced verbatim in a standalone harness sourcing the real `pithead` binary (same stub curl, same `run_sourced` pattern) because the shared suite lock was contended by other parallel wave agents (see "not run"): **16/16 passed**.
- **Mutations** — three, one per changed code path, each committed-state clean before mutating:
  1. `gh_release_fetch`'s `if is_appliance` → `if false` (retry_hint always DIY) → **RED**: 4 assertions failed (appliance transport-failure and unparseable-response hints reverted to the CLI-only wording). Restored → 16/16 green.
  2. `describe_change PROXY_STRATUM_PASSWORD`'s `if is_appliance` → `if false` (appliance branch always DIY) → **RED**: 1 assertion failed. Restored → 16/16 green.
  3. `describe_change TOR_AUTO_HEAL`'s `elif is_appliance` → `elif false` (appliance branch never taken) → **RED**: 1 assertion failed. Restored → 16/16 green.
- **shellcheck** — direct invocation (bypassing the box's memory-capped wrapper, which OOMs on `tests/stack/run.sh` per a known, documented cap) at `--severity=warning` (the flag `make lint-sh` actually uses): `pithead` exits 0; `tests/stack/run.sh` has exactly one pre-existing warning (`SC2034` on `BOOT_DOCTOR_JSON`, line ~10544, unrelated to this diff, confirmed present in the pre-change file at the equivalent offset). No new warnings or errors from this diff. Uncapped-severity info findings (SC2016, SC2030/2031, etc.) were also diffed against the base file — the only deltas are 7 new SC2030/2031 info hits on the two new `export PATH=...` lines this diff added, matching an existing pattern already present in the same file (line 7579) and thus consistent with house convention, not a regression.
- **shfmt** — `shfmt -i 4 -d pithead tests/stack/run.sh`: clean, no diff.
- **lint-operator-strings** — `make lint-operator-strings`: self-test OK, full scan OK (no issue numbers, no bare docs/ paths in any operator-facing string, including the four new/changed messages).
- **Docs** — checked `docs/appliance.md` and the CHANGELOG for anything describing this wording; neither documents message text at this granularity (confirmed by precedent: the sibling fix `bb6b3e8` for the same class of appliance operator-string issue touched no docs either). No doc changes needed.

## What was NOT run

- **Full combined suite** (`tests/stack/run.sh`, ~2748 tests) — deferred to the post-merge combined gate per standing wave discipline. Queued under `flock` as instructed but the shared lock was contended by several other parallel wave agents already queued on it; rather than add contention or burn the turn waiting, targeted coverage above (verbatim reproduction of the new assertions, run directly, with full mutation proof) stands in for it. This PR's own prior CI run reportedly went green (2748/0) before a host crash destroyed that log — not cited as evidence here, only mentioned for context.
- **KVM/bench battery** — out of scope for this appliance-refusal-wording change; anything under `os/` is bench-gated per project convention, but this change touches only `pithead` (shared CLI) and its unit tests, not `os/`. Deferred to the post-merge combined gate regardless, per standing instructions.
- **`make lint` (full target)** — fails locally at `lint-proto` without docker (documented, expected). Ran the relevant non-docker pieces individually instead (see above).

Closes #1139
