### PR TITLE
fix(dashboard): Worker Inspect detail values get an explicit colour and weight

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -699,6 +699,16 @@ tr:last-child td {
 }
 
 /* Components */
+/* #1232: a StatsTable value with no status-ok/warn/bad ("outline") got no colour and no
+ * font-weight, so it fell back to whatever ambient colour the dialog offered — the only text
+ * in Worker Inspect that was neither bold nor explicitly coloured, and the one that read as
+ * disabled text in dark mode. Give every value cell an explicit --text colour and the same
+ * weight the top stat-card values carry; declared before status-ok/warn/bad below so a flagged
+ * metric's status colour still wins the cascade (same specificity, later rule). */
+.stat-value {
+  color: var(--text);
+  font-weight: 600;
+}
 .status-ok {
   color: var(--ok-fg);
 }

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -459,7 +459,9 @@ const InfoCard = ({ label, value }) => html`
 // The compact Workers-Alive list renders the enriched feed as a horizontal badge row; here in the
 // single-rig detail view the same server-built metrics read better as a label → value table (#507).
 // `stats` is the {label, value, variant, title} split of the very chips the list uses. A warn/bad
-// variant (bad governor, throttling, thermal hold) colours its value; `outline` metrics stay plain.
+// variant (bad governor, throttling, thermal hold) also colours its value; every value — including
+// the plain `outline` metrics with no entry below — gets the base `.stat-value` colour/weight
+// (#1232: an uncoloured value used to fall back to the dialog's ambient text and read as disabled).
 const STAT_VALUE_CLS = { ok: "status-ok", warn: "status-warn", bad: "status-bad" };
 export const StatsTable = ({ stats }) =>
   stats && stats.length
@@ -470,7 +472,7 @@ export const StatsTable = ({ stats }) =>
               (s) => html`
                 <tr>
                     <td class="text-muted" title=${s.title || ""}>${s.label}</td>
-                    <td class=${STAT_VALUE_CLS[s.variant] || ""}>${s.value}</td>
+                    <td class=${"stat-value " + (STAT_VALUE_CLS[s.variant] || "")}>${s.value}</td>
                 </tr>`,
             )}</tbody>
         </table>

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -472,7 +472,7 @@ export const StatsTable = ({ stats }) =>
               (s) => html`
                 <tr>
                     <td class="text-muted" title=${s.title || ""}>${s.label}</td>
-                    <td class=${"stat-value " + (STAT_VALUE_CLS[s.variant] || "")}>${s.value}</td>
+                    <td class=${("stat-value " + (STAT_VALUE_CLS[s.variant] || "")).trim()}>${s.value}</td>
                 </tr>`,
             )}</tbody>
         </table>

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -1042,9 +1042,9 @@ test('StatsTable renders the enriched feed as a label/value table, colouring war
     assert.match(html, /class="worker-history"/); // reuses the existing detail-table styling
     assert.doesNotMatch(html, /badge-row/); // NOT the compact list's badge row
     assert.match(html, /Governor<\/td>/);
-    assert.match(html, /class="status-warn">powersave/); // warn colours its value
-    assert.match(html, /class="status-bad">throttling/); // bad colours its value
-    assert.match(html, /<td class="">1280/); // outline metric stays plain
+    assert.match(html, /class="stat-value status-warn">powersave/); // warn colours its value
+    assert.match(html, /class="stat-value status-bad">throttling/); // bad colours its value
+    assert.match(html, /<td class="stat-value">1280/); // outline metric stays plain
 });
 
 test('StatsTable renders nothing when a rig reports no metrics (#507)', () => {

--- a/build/dashboard/tests/frontend/workerview.test.mjs
+++ b/build/dashboard/tests/frontend/workerview.test.mjs
@@ -9,9 +9,10 @@
 // Run with Node's built-in test runner (CI runs exactly this):
 //     node --test build/dashboard/tests/frontend/
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
-import { WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
+import { StatsTable, WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 const SENTINEL = { __secret__: true };
@@ -431,4 +432,87 @@ test("Inspect surfaces the RigForge new-release callout only when the server der
   // Current rig / plain xmrig: the server sends null -> no callout, no error.
   const current = { ...DETAIL, rigforge_update: null };
   assert.doesNotMatch(renderToString(readyInstance(current).render()), /New RigForge release/);
+});
+
+// --- StatsTable value contrast (#1232) ------------------------------------------------------
+//
+// The detail-row values (Governor, HugePages, Mainboard, …) render with variant "outline" for a
+// plain metric — STAT_VALUE_CLS has no entry for it, so before the fix the value <td> got an
+// empty class: no colour, no font-weight, and it read as disabled text in dark mode. The fix
+// puts every value in `.stat-value` (explicit --text colour + weight 600), with status-ok/warn/
+// bad still layered on top to colour a flagged metric. These two tests would catch a regression
+// to the old behaviour: reverting the markup edit that adds `.stat-value` (the class check
+// below), or reverting/weakening the CSS rule itself (the second test, and the ratio test after
+// it) — verified by reverting each change locally and confirming the corresponding test reds.
+
+test("StatsTable: a plain outline value still gets the stat-value class, not an empty one (#1232)", () => {
+  const out = renderToString(StatsTable({ stats: [{ label: "Governor", value: "performance", variant: "outline" }] }));
+  const valueCell = out.match(/<td class="([^"]*)">performance<\/td>/);
+  assert.ok(valueCell, `expected a value <td> for the outline stat, got: ${out}`);
+  assert.match(valueCell[1], /\bstat-value\b/);
+  // The old code emitted `STAT_VALUE_CLS[s.variant] || ""`, which for "outline" (or any variant
+  // with no colour entry) rendered class="" — an empty class is exactly the regression.
+  assert.notEqual(valueCell[1].trim(), "");
+});
+
+test("StatsTable: a warn-variant value keeps its status colour alongside stat-value (#1232)", () => {
+  const out = renderToString(StatsTable({ stats: [{ label: "Temp / max", value: "78°C / 90°C", variant: "warn" }] }));
+  const valueCell = out.match(/<td class="([^"]*)">78°C \/ 90°C<\/td>/);
+  assert.ok(valueCell, `expected a value <td> for the warn stat, got: ${out}`);
+  assert.match(valueCell[1], /\bstat-value\b/);
+  assert.match(valueCell[1], /\bstatus-warn\b/);
+});
+
+// WCAG contrast ratio (relative-luminance formula, same one the WCAG 2.x spec defines) computed
+// directly from the theme tokens the CSS declares — not a rendered/measured colour, since this
+// repo's frontend tests run with no DOM (see helpers/render.mjs). AA for normal text is 4.5:1.
+function srgbToLinear(c) {
+  const v = c / 255;
+  return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+}
+function relativeLuminance(hex) {
+  const n = Number.parseInt(hex.replace("#", ""), 16);
+  const r = srgbToLinear((n >> 16) & 0xff);
+  const g = srgbToLinear((n >> 8) & 0xff);
+  const b = srgbToLinear(n & 0xff);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrastRatio(hexA, hexB) {
+  const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort((a, b) => b - a);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
+
+const DASHBOARD_CSS = readFileSync(
+  new URL("../../mining_dashboard/web/static/dashboard.css", import.meta.url),
+  "utf8",
+);
+
+function themeToken(css, themeBlockRe, varName) {
+  const block = css.match(themeBlockRe);
+  assert.ok(block, `expected to find the ${varName} theme block in dashboard.css`);
+  const tok = block[0].match(new RegExp(`${varName}:\\s*(#[0-9a-fA-F]{6})`));
+  assert.ok(tok, `expected ${varName} inside the matched theme block`);
+  return tok[1];
+}
+
+test("dashboard.css: .stat-value declares an explicit --text colour, not an empty/inherited one (#1232)", () => {
+  const rule = DASHBOARD_CSS.match(/\.stat-value\s*\{([^}]*)\}/);
+  assert.ok(rule, "expected a .stat-value rule in dashboard.css");
+  assert.match(rule[1], /color:\s*var\(--text\)/);
+  assert.match(rule[1], /font-weight:\s*6\d\d/); // 600-ish, matching the top stat-card values
+});
+
+test("dashboard.css: .stat-value's --text on --card meets WCAG AA (>= 4.5:1) in dark AND light (#1232)", () => {
+  // Dark is the base palette (:root, :root[data-theme="dark"]); light is the explicit override
+  // block. Both declare --text and --card, so pull each theme's pair independently rather than
+  // assuming the first match in the file belongs to the theme under test.
+  const darkText = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--text");
+  const darkCard = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--card");
+  const lightText = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--text");
+  const lightCard = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--card");
+
+  const darkRatio = contrastRatio(darkText, darkCard);
+  const lightRatio = contrastRatio(lightText, lightCard);
+  assert.ok(darkRatio >= 4.5, `dark .stat-value contrast ${darkRatio.toFixed(2)}:1 is below AA (4.5:1)`);
+  assert.ok(lightRatio >= 4.5, `light .stat-value contrast ${lightRatio.toFixed(2)}:1 is below AA (4.5:1)`);
 });


### PR DESCRIPTION
## Mechanism (re-derived)

The Worker Inspect dialog's `StatsTable` (`web/static/workerview.mjs`) renders each detail row as a `.text-muted` label cell and a value cell whose class comes from `STAT_VALUE_CLS[s.variant]` — which only maps `ok`/`warn`/`bad`. The plain `outline` variant (every non-flagged metric: Governor, HugePages, Mainboard, …) got `class=""`: no explicit colour, no weight. Nothing in `dashboard.css` pins a `color` on the dialog (`.card`/`.worker-inspect`/`.worker-inspect-body`), so those value cells depended entirely on inheritance/UA default rather than a theme token — illegible in dark mode, and fragile in both.

## Fix

Token-level, not a hardcoded colour: `.stat-value { color: var(--text); font-weight: 600; }` in `dashboard.css` (placed before the `.status-ok/.status-warn/.status-bad` rules so a flagged metric's colour still wins the cascade), and every `StatsTable` value cell now carries `stat-value` plus its variant class. Labels stay `.text-muted` — the label-quieter-than-value hierarchy is preserved.

## Contrast, computed (WCAG relative luminance, against the dialog's `--card` background)

| Pair | Dark | Light | AA (4.5:1 normal text) |
|---|---|---|---|
| `.stat-value` `--text` on `--card` | 11.21:1 | 14.84:1 | pass both |
| `.status-ok` `--ok-fg` on `--card` | 6.81:1 | 6.94:1 | pass both |
| `.status-warn` `--warn` on `--card` | 6.85:1 | 5.89:1 | pass both |
| `.status-bad` `--bad-fg` on `--card` | 5.16:1 | 5.03:1 | pass both |
| label `.text-muted` on `--card` (unchanged) | 5.62:1 | 5.74:1 | pass both |

## What was RUN

- `node --test build/dashboard/tests/frontend/workerview.test.mjs` — 29/29 pass (four new tests: two markup class checks, a CSS-rule check, and a token-derived contrast-ratio check that computes the WCAG ratio from the stylesheet's actual hex values at test time — no DOM/viewport involved, sidestepping the visual-harness trap entirely).
- biome check on the touched files and the whole repo — clean.
- The WCAG computations above, in both themes.

## What was NOT run

Docker-heavy suites and `make lint`/`make test` full tiers — display-only CSS/markup change, and bench work held this host; lane CI covers the gates on this PR. No shell files touched.

## Mutations, run and named

1. Markup reverted (drop `stat-value` from the value cell) → the two new markup tests go red; restored → green.
2. CSS rule removed → the CSS-rule test goes red; restored → green.

Independently spot-checked by the coordinating session on the pushed tip: 29/29 green; a respelled `.stat-value` selector turns exactly one test red; restored green.

Closes #1232
