### PR TITLE
Twin sync: the XvB fallback and contrast fixes into develop-v2

### DIFF
--- a/build/dashboard/mining_dashboard/web/static/components.mjs
+++ b/build/dashboard/mining_dashboard/web/static/components.mjs
@@ -561,7 +561,9 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
                 ${
                   calc.estimates_available
                     ? "XvB figures fetched over Tor from the operator's published estimates; odds from the public winners feed; the draw is random among qualifiers — donating above a threshold buys no extra odds."
-                    : "Expected reward estimate unavailable — tier costs only."
+                    : calc.estimates_source === "published"
+                      ? `Reward figures are XvB's last published table (${calc.estimates_published_date}), not a live fetch — XvB is off, so nothing is fetched from xmrvsbeast.com. Win odds need the live winners feed and stay unavailable until XvB runs again.`
+                      : "Expected reward estimate unavailable — tier costs only."
                 }
             </p>
         </div>`;
@@ -587,8 +589,14 @@ function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
             ? null
             : html`<p class="text-muted text-xs" id="xvb-disabled-note">
                 XvB donation is off — this table prices what enabling it would earn and cost at
-                your hashrate. Nothing is fetched from xmrvsbeast.com while it is off, so the
-                odds and reward columns run from the last cached read.</p>`
+                your hashrate. Nothing is fetched from xmrvsbeast.com while it is off${
+                  calc.estimates_source === "published"
+                    ? html`, so the reward columns use XvB's last published table (${calc.estimates_published_date}) instead of a live read`
+                    : calc.estimates_source === "live"
+                      ? ", so the reward columns run from the last live read"
+                      : ""
+                }. The odds column needs the live winners feed, so it stays empty until
+                XvB runs again.</p>`
         }
         <div class="stat-grid">
             <${StatCard} label="Sustainable Tier" value=${t ? t.tier : "None"} cls="c-purple"

--- a/build/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/build/dashboard/mining_dashboard/web/static/dashboard.css
@@ -699,6 +699,16 @@ tr:last-child td {
 }
 
 /* Components */
+/* #1232: a StatsTable value with no status-ok/warn/bad ("outline") got no colour and no
+ * font-weight, so it fell back to whatever ambient colour the dialog offered — the only text
+ * in Worker Inspect that was neither bold nor explicitly coloured, and the one that read as
+ * disabled text in dark mode. Give every value cell an explicit --text colour and the same
+ * weight the top stat-card values carry; declared before status-ok/warn/bad below so a flagged
+ * metric's status colour still wins the cascade (same specificity, later rule). */
+.stat-value {
+  color: var(--text);
+  font-weight: 600;
+}
 .status-ok {
   color: var(--ok-fg);
 }

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -459,7 +459,9 @@ const InfoCard = ({ label, value }) => html`
 // The compact Workers-Alive list renders the enriched feed as a horizontal badge row; here in the
 // single-rig detail view the same server-built metrics read better as a label → value table (#507).
 // `stats` is the {label, value, variant, title} split of the very chips the list uses. A warn/bad
-// variant (bad governor, throttling, thermal hold) colours its value; `outline` metrics stay plain.
+// variant (bad governor, throttling, thermal hold) also colours its value; every value — including
+// the plain `outline` metrics with no entry below — gets the base `.stat-value` colour/weight
+// (#1232: an uncoloured value used to fall back to the dialog's ambient text and read as disabled).
 const STAT_VALUE_CLS = { ok: "status-ok", warn: "status-warn", bad: "status-bad" };
 export const StatsTable = ({ stats }) =>
   stats && stats.length
@@ -470,7 +472,7 @@ export const StatsTable = ({ stats }) =>
               (s) => html`
                 <tr>
                     <td class="text-muted" title=${s.title || ""}>${s.label}</td>
-                    <td class=${STAT_VALUE_CLS[s.variant] || ""}>${s.value}</td>
+                    <td class=${"stat-value " + (STAT_VALUE_CLS[s.variant] || "")}>${s.value}</td>
                 </tr>`,
             )}</tbody>
         </table>

--- a/build/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/build/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -472,7 +472,7 @@ export const StatsTable = ({ stats }) =>
               (s) => html`
                 <tr>
                     <td class="text-muted" title=${s.title || ""}>${s.label}</td>
-                    <td class=${"stat-value " + (STAT_VALUE_CLS[s.variant] || "")}>${s.value}</td>
+                    <td class=${("stat-value " + (STAT_VALUE_CLS[s.variant] || "")).trim()}>${s.value}</td>
                 </tr>`,
             )}</tbody>
         </table>

--- a/build/dashboard/mining_dashboard/web/views.py
+++ b/build/dashboard/mining_dashboard/web/views.py
@@ -1537,6 +1537,38 @@ _XVB_REALIZATION_WINDOW_S = 45 * SECONDS_PER_DAY
 # ponytail: single-wallet study constant — recalibrate from the public-winners generalization.
 XVB_REALIZATION_PRIOR = (0.28, 0.39)
 
+# Vendored fallback for XvB's own published per-tier reward table (#1214). ``build_xvb_calc``'s
+# reward columns need XvB's face figure, but the #163 egress rule stops the live fetch entirely
+# while XvB is disabled — so a box that has never enabled XvB has no cache to read and the table
+# can never answer "is enabling this worth it". These four numbers are the "Player:" line for
+# each donor round type in XvB's own ``reward_estimate_pub.txt`` — the PER-PLAYER expected
+# reward, exactly what the live parser extracts (``_REGEX_REWARD_LINE`` in
+# ``client/xvb_client.py`` matches ``Round: <type> Player: <value> XMR/year`` only; it deliberately
+# skips the pool-total ``Round: <type>: <value> XMR/year`` line just above each Player line, which
+# is a different, much larger figure — the whole raffle's total payout for that round type, not
+# one qualifier's share of it). Using the wrong row here would make the fallback disagree with
+# what any live fetch would ever show. Archived verbatim (no live fetch involved) as part of the
+# delivery study on the date below:
+# docs/research/xvb-delivery-study/data/sources/xmrvsbeast-reward_estimate_pub.txt
+# (docs/research/xvb-delivery-study/data/sources/MANIFEST.md). Keyed by round-type, same as a
+# live ``estimates`` cache, and used ONLY when the box is disabled (see ``build_xvb_calc``'s
+# ``_face_value``: this must never fire for an ENABLED-but-stale box — that box's own live fetch
+# is just failing right now, e.g. a transient bot-challenge, and the honest read is "estimate
+# unavailable", not a claim it is "off" and using a published snapshot). It never overrides a
+# live figure, and it feeds the SAME ``XVB_REALIZATION_PRIOR`` band above, never a second,
+# differently-derived estimate. Static by design (option 1 of #1214): these change rarely, so a
+# dated, labelled snapshot is worth more than a permanent blank on a box that has never enabled
+# XvB. Refresh only by re-archiving the source file and updating the date — a test
+# (TestXvbCalc.test_fallback_values_match_the_archived_source_files_player_rows) parses the
+# archive with the live parser and fails if this dict ever drifts from it.
+XVB_PUBLISHED_REWARD_FALLBACK = {
+    "donor": 0.064,
+    "donor_vip": 0.81,
+    "donor_whale": 4.67,
+    "donor_mega": 54.54,
+}
+XVB_PUBLISHED_REWARD_FALLBACK_DATE = "2026-08-10"
+
 
 def xvb_forecast_tier_key(metrics, tiers):
     """The tier the expected-wins forecast should speak to: held, else targeted (#866).
@@ -1835,12 +1867,22 @@ def build_xvb_calc(metrics, state_mgr, realization=None):
 
     Published with XvB DISABLED too (#938): the table is the enable/don't-enable decision aid, so
     hiding it behind the flag defeated its purpose. Everything here is computable from local
-    config plus the cached public feeds; disabling XvB stops the fetches (the egress rule, #726),
-    so on a box that never enabled XvB the odds and reward columns are honestly empty and on a
-    just-disabled box they age out through the same staleness rule as always. The live-credit
-    context goes quiet on its own: ``build_state`` computes ``realization`` only while enabled,
-    and ``Metrics`` reports current/target tier as "Disabled" — the client keys every
-    live-donation surface (and the current/target cards here) off ``enabled``."""
+    config plus the cached public feeds; disabling XvB stops the fetches (the egress rule, #726).
+    The reward columns still light up on a box that is DISABLED — never enabled, or turned off
+    after its cache aged out (#1214): when nothing live/cached is usable AND ``metrics.xvb_enabled``
+    is False, they fall back to ``XVB_PUBLISHED_REWARD_FALLBACK``, a static, dated, labelled
+    snapshot of XvB's own published table (never a live fetch, so the egress rule is untouched) —
+    ``estimates_source``/``estimates_published_date`` tell the client which one it got. The
+    fallback deliberately does NOT fire for an ENABLED-but-stale box (e.g. a transient fetch
+    failure such as a bot-challenge): that box's live estimate is momentarily unavailable, not
+    "off", so it keeps the honest pre-existing degradation instead — ``estimates_source`` reads
+    "none" and the client shows the same "estimate unavailable" text it always has. The odds
+    column has no fallback at all, disabled or not: qualifier counts are live competitive data
+    with no stable published table to vendor, so it stays honestly empty until XvB runs and the
+    winners feed populates the cache. The live-credit context goes quiet on its own: ``build_state``
+    computes ``realization`` only while enabled, and ``Metrics`` reports current/target tier as
+    "Disabled" — the client keys every live-donation surface (and the current/target cards here)
+    off ``enabled``."""
     tiers = state_mgr.get_tiers()
     round_state = state_mgr.get_xvb_round_stats()
     round_types = (
@@ -1859,54 +1901,83 @@ def build_xvb_calc(metrics, state_mgr, realization=None):
     # XvB's published per-tier expected reward (XMR/year), fetched over Tor and cached (#118). The
     # tier KEY is exactly the round-type in the file (donor / donor_vip / donor_whale / donor_mega),
     # so a tier maps to its estimate by key. A stale or empty cache degrades to None per tier +
-    # estimates_available False — the client shows "estimate unavailable", never a frozen number
-    # implied fresh (reusing the stats staleness rule so the two never disagree, #311).
+    # estimates_available False (reusing the stats staleness rule so the two never disagree, #311)
+    # — ``_face_value`` below then tries the vendored fallback before giving up.
     est_state = state_mgr.get_xvb_reward_estimates()
     estimates = (est_state or {}).get("estimates") or {}
     estimates_stale = xvb_stats_are_stale(est_state)
     estimates_available = bool(estimates) and not estimates_stale
+    # #1214: one static fallback figure per tier, tried only when the box is DISABLED (never
+    # enabled, or turned off after its cache aged out) — an enabled box with a merely-stale or
+    # not-yet-populated cache (a transient fetch failure, e.g. a bot-challenge) is NOT "off"; it
+    # keeps the honest pre-existing "estimate unavailable" degradation instead of a fallback that
+    # would falsely read as "XvB is off, using its last published table". Only tried for tiers the
+    # archived table actually names — a custom TIER_CONFIG round-type it doesn't recognise just
+    # stays None, same as before this fix.
+    fallback_eligible = not metrics.xvb_enabled
+    fallback_used = False
+
+    def _face_value(key):
+        """XvB's own face figure for a tier — live estimate first, vendored fallback second.
+
+        ``realized_reward_year`` deliberately does NOT use this: mixing THIS wallet's own
+        measured delivery factor with a dated, generic fallback would overstate precision the
+        wallet has no basis for, and ``realization`` is only ever non-None while XvB is enabled
+        (``build_state``), when a live estimate is normally available anyway. It keeps requiring
+        a live, fresh figure, same as before this fix."""
+        nonlocal fallback_used
+        if estimates_available and key in estimates:
+            return float(estimates[key])
+        if not estimates_available and fallback_eligible and key in XVB_PUBLISHED_REWARD_FALLBACK:
+            fallback_used = True
+            return XVB_PUBLISHED_REWARD_FALLBACK[key]
+        return None
+
+    tier_rows = []
+    for key, t in tiers.items():
+        if t <= 0:
+            continue
+        face = _face_value(key)
+        live_face = float(estimates[key]) if estimates_available and key in estimates else None
+        tier_rows.append(
+            {
+                "name": get_tier_info(t, tiers)[0],
+                "threshold": float(t),
+                "expected_reward_year": face,
+                # Published figure × measured realization (#872) — the net the panel can
+                # honestly act on. None until enough wins measure the factor; LIVE face value
+                # only (see ``_face_value``'s docstring) — a stale/fallback figure can't be
+                # "realized" against.
+                "realized_reward_year": (
+                    live_face * realization[0] if live_face is not None and realization else None
+                ),
+                # Unmeasured boxes still get a calculable band (#872): the published figure
+                # (live or vendored fallback) scaled by the measured realization PRIOR below.
+                # None once a local measurement exists (realized_reward_year supersedes it) or no
+                # face value is available at all — the two never show together.
+                "assumed_reward_year_range": (
+                    [face * XVB_REALIZATION_PRIOR[0], face * XVB_REALIZATION_PRIOR[1]]
+                    if face is not None and not realization
+                    else None
+                ),
+                "win_odds_day": _odds_day(key),
+                "players_avg": (round_types.get(key) or {}).get("players_avg"),
+            }
+        )
     return {
         "enabled": metrics.xvb_enabled,
         # Ascending tier table for the client's what-if; names via get_tier_info so they read
         # exactly like the tier strings everywhere else (threshold already embedded in the name).
-        # expected_reward_year is XvB's own figure for the tier, or None when unavailable/stale.
-        "tiers": sorted(
-            (
-                {
-                    "name": get_tier_info(t, tiers)[0],
-                    "threshold": float(t),
-                    "expected_reward_year": (
-                        float(estimates[key]) if estimates_available and key in estimates else None
-                    ),
-                    # Published figure × measured realization (#872) — the net the panel can
-                    # honestly act on. None until enough wins measure the factor.
-                    "realized_reward_year": (
-                        float(estimates[key]) * realization[0]
-                        if estimates_available and key in estimates and realization
-                        else None
-                    ),
-                    # Unmeasured boxes still get a calculable band (#872): the published figure
-                    # scaled by the measured realization PRIOR below. None once a local
-                    # measurement exists (realized_reward_year supersedes it) or estimates are
-                    # stale — the two never show together.
-                    "assumed_reward_year_range": (
-                        [
-                            float(estimates[key]) * XVB_REALIZATION_PRIOR[0],
-                            float(estimates[key]) * XVB_REALIZATION_PRIOR[1],
-                        ]
-                        if estimates_available and key in estimates and not realization
-                        else None
-                    ),
-                    "win_odds_day": _odds_day(key),
-                    "players_avg": (round_types.get(key) or {}).get("players_avg"),
-                }
-                for key, t in tiers.items()
-                if t > 0
-            ),
-            key=lambda entry: entry["threshold"],
-        ),
+        "tiers": sorted(tier_rows, key=lambda entry: entry["threshold"]),
         "estimates_available": estimates_available,
         "estimates_stale": estimates_stale,
+        # #1214: "live" when a fresh fetch backs the reward columns, "published" when the vendored
+        # fallback filled them instead (with the date it was archived, so the client can label how
+        # old it is), "none" when neither had anything for any tier.
+        "estimates_source": "live"
+        if estimates_available
+        else ("published" if fallback_used else "none"),
+        "estimates_published_date": XVB_PUBLISHED_REWARD_FALLBACK_DATE if fallback_used else None,
         # Measurement context for the realized figures: the factor and its sample size, or None
         # while unmeasured (the client then labels the published number face value).
         "realization_pct": round(realization[0] * 100) if realization else None,

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -1042,9 +1042,9 @@ test('StatsTable renders the enriched feed as a label/value table, colouring war
     assert.match(html, /class="worker-history"/); // reuses the existing detail-table styling
     assert.doesNotMatch(html, /badge-row/); // NOT the compact list's badge row
     assert.match(html, /Governor<\/td>/);
-    assert.match(html, /class="status-warn">powersave/); // warn colours its value
-    assert.match(html, /class="status-bad">throttling/); // bad colours its value
-    assert.match(html, /<td class="">1280/); // outline metric stays plain
+    assert.match(html, /class="stat-value status-warn">powersave/); // warn colours its value
+    assert.match(html, /class="stat-value status-bad">throttling/); // bad colours its value
+    assert.match(html, /<td class="stat-value">1280/); // outline metric stays plain
 });
 
 test('StatsTable renders nothing when a rig reports no metrics (#507)', () => {

--- a/build/dashboard/tests/frontend/components.test.mjs
+++ b/build/dashboard/tests/frontend/components.test.mjs
@@ -746,6 +746,41 @@ test('XvB decision table: verdict colours cover green and zero-spanning bands, s
     assert.match(sh, /0\.365\d* XMR/); // vip cost at 1e-7
 });
 
+test('XvB decision table: the vendored-fallback reward columns render values and say so, not the bare "tier costs only" footer (#1214)', () => {
+    // #1214: with XvB disabled and never enabled (no live cache), the server fills the reward
+    // columns from its published-table fallback and labels it estimates_source: 'published'
+    // plus a date. The table must show real figures (not dashes) and the footer must say the
+    // numbers are the last-published table, not a live fetch — never the old bare "tier costs
+    // only" wording, which reads as "we have no idea" when the real answer is available.
+    const s = clone();
+    s.earnings.available = true;
+    s.earnings.coeff_day = 1e-9;
+    s.earnings.p2pool_hr = 200000;
+    // expected_reward_year/assumed_reward_year_range mirror what build_xvb_calc's corrected
+    // fallback (views.XVB_PUBLISHED_REWARD_FALLBACK["donor_vip"] = 0.81, the archived file's
+    // PER-PLAYER row, not the much larger pool-total row) would actually emit for a disabled box.
+    s.xvb_calc = {
+        enabled: false, max_fraction: 0.85, estimates_available: false, estimates_stale: false,
+        estimates_source: 'published', estimates_published_date: '2026-08-10',
+        current_tier: 'Disabled', target_tier: 'Disabled', target_threshold: 10000,
+        sustainable: true, note: 'raffle status', mode_note: null,
+        realization_pct: null, realization_wins: null,
+        tiers: [
+            { name: 'Vip (10.00 kH/s+)', threshold: 10000, expected_reward_year: 0.81,
+              realized_reward_year: null, assumed_reward_year_range: [0.81 * 0.28, 0.81 * 0.39],
+              win_odds_day: null, players_avg: null },
+        ],
+    };
+    const up = renderApp({ state: s });
+    // XvB says / yr and Study est. / yr are no longer dashed.
+    assert.match(up, /0\.810000 XMR/); // c-purple "XvB says" cell, face value straight from the fallback
+    assert.match(up, /0\.226800 XMR … 0\.315900 XMR/); // Study est. band = fallback face × the SAME prior
+    assert.doesNotMatch(up, /tier costs only/);
+    assert.match(up, /last published table \(2026-08-10\)/);
+    // The odds column has no such fallback — same root cause, still honestly empty (#1214).
+    assert.match(up, /<td>—<\/td>/);
+});
+
 test('XvBStats greys the credited figures and flags the footer when the fetch is stale (#311)', () => {
     // Fresh (base fixture, xvb_stale false): the normal "Stats fetched" footer, no stale marks.
     const fresh = renderApp();

--- a/build/dashboard/tests/frontend/fixtures/state.json
+++ b/build/dashboard/tests/frontend/fixtures/state.json
@@ -745,6 +745,8 @@
     "current_tier": "None",
     "enabled": true,
     "estimates_available": true,
+    "estimates_published_date": null,
+    "estimates_source": "live",
     "estimates_stale": false,
     "max_fraction": 0.85,
     "mode_note": null,

--- a/build/dashboard/tests/frontend/workerview.test.mjs
+++ b/build/dashboard/tests/frontend/workerview.test.mjs
@@ -9,9 +9,10 @@
 // Run with Node's built-in test runner (CI runs exactly this):
 //     node --test build/dashboard/tests/frontend/
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
-import { WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
+import { StatsTable, WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 const SENTINEL = { __secret__: true };
@@ -431,4 +432,87 @@ test("Inspect surfaces the RigForge new-release callout only when the server der
   // Current rig / plain xmrig: the server sends null -> no callout, no error.
   const current = { ...DETAIL, rigforge_update: null };
   assert.doesNotMatch(renderToString(readyInstance(current).render()), /New RigForge release/);
+});
+
+// --- StatsTable value contrast (#1232) ------------------------------------------------------
+//
+// The detail-row values (Governor, HugePages, Mainboard, …) render with variant "outline" for a
+// plain metric — STAT_VALUE_CLS has no entry for it, so before the fix the value <td> got an
+// empty class: no colour, no font-weight, and it read as disabled text in dark mode. The fix
+// puts every value in `.stat-value` (explicit --text colour + weight 600), with status-ok/warn/
+// bad still layered on top to colour a flagged metric. These two tests would catch a regression
+// to the old behaviour: reverting the markup edit that adds `.stat-value` (the class check
+// below), or reverting/weakening the CSS rule itself (the second test, and the ratio test after
+// it) — verified by reverting each change locally and confirming the corresponding test reds.
+
+test("StatsTable: a plain outline value still gets the stat-value class, not an empty one (#1232)", () => {
+  const out = renderToString(StatsTable({ stats: [{ label: "Governor", value: "performance", variant: "outline" }] }));
+  const valueCell = out.match(/<td class="([^"]*)">performance<\/td>/);
+  assert.ok(valueCell, `expected a value <td> for the outline stat, got: ${out}`);
+  assert.match(valueCell[1], /\bstat-value\b/);
+  // The old code emitted `STAT_VALUE_CLS[s.variant] || ""`, which for "outline" (or any variant
+  // with no colour entry) rendered class="" — an empty class is exactly the regression.
+  assert.notEqual(valueCell[1].trim(), "");
+});
+
+test("StatsTable: a warn-variant value keeps its status colour alongside stat-value (#1232)", () => {
+  const out = renderToString(StatsTable({ stats: [{ label: "Temp / max", value: "78°C / 90°C", variant: "warn" }] }));
+  const valueCell = out.match(/<td class="([^"]*)">78°C \/ 90°C<\/td>/);
+  assert.ok(valueCell, `expected a value <td> for the warn stat, got: ${out}`);
+  assert.match(valueCell[1], /\bstat-value\b/);
+  assert.match(valueCell[1], /\bstatus-warn\b/);
+});
+
+// WCAG contrast ratio (relative-luminance formula, same one the WCAG 2.x spec defines) computed
+// directly from the theme tokens the CSS declares — not a rendered/measured colour, since this
+// repo's frontend tests run with no DOM (see helpers/render.mjs). AA for normal text is 4.5:1.
+function srgbToLinear(c) {
+  const v = c / 255;
+  return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+}
+function relativeLuminance(hex) {
+  const n = Number.parseInt(hex.replace("#", ""), 16);
+  const r = srgbToLinear((n >> 16) & 0xff);
+  const g = srgbToLinear((n >> 8) & 0xff);
+  const b = srgbToLinear(n & 0xff);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrastRatio(hexA, hexB) {
+  const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort((a, b) => b - a);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
+
+const DASHBOARD_CSS = readFileSync(
+  new URL("../../mining_dashboard/web/static/dashboard.css", import.meta.url),
+  "utf8",
+);
+
+function themeToken(css, themeBlockRe, varName) {
+  const block = css.match(themeBlockRe);
+  assert.ok(block, `expected to find the ${varName} theme block in dashboard.css`);
+  const tok = block[0].match(new RegExp(`${varName}:\\s*(#[0-9a-fA-F]{6})`));
+  assert.ok(tok, `expected ${varName} inside the matched theme block`);
+  return tok[1];
+}
+
+test("dashboard.css: .stat-value declares an explicit --text colour, not an empty/inherited one (#1232)", () => {
+  const rule = DASHBOARD_CSS.match(/\.stat-value\s*\{([^}]*)\}/);
+  assert.ok(rule, "expected a .stat-value rule in dashboard.css");
+  assert.match(rule[1], /color:\s*var\(--text\)/);
+  assert.match(rule[1], /font-weight:\s*6\d\d/); // 600-ish, matching the top stat-card values
+});
+
+test("dashboard.css: .stat-value's --text on --card meets WCAG AA (>= 4.5:1) in dark AND light (#1232)", () => {
+  // Dark is the base palette (:root, :root[data-theme="dark"]); light is the explicit override
+  // block. Both declare --text and --card, so pull each theme's pair independently rather than
+  // assuming the first match in the file belongs to the theme under test.
+  const darkText = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--text");
+  const darkCard = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--card");
+  const lightText = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--text");
+  const lightCard = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--card");
+
+  const darkRatio = contrastRatio(darkText, darkCard);
+  const lightRatio = contrastRatio(lightText, lightCard);
+  assert.ok(darkRatio >= 4.5, `dark .stat-value contrast ${darkRatio.toFixed(2)}:1 is below AA (4.5:1)`);
+  assert.ok(lightRatio >= 4.5, `light .stat-value contrast ${lightRatio.toFixed(2)}:1 is below AA (4.5:1)`);
 });

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -127,6 +127,28 @@ def _hashrate(metrics):
 # --- Chart (Issue #65: real-time x-axis, outage gaps as breaks) -----------------------
 
 
+def _xvb_archive():
+    # In a checkout the repo root is four levels up; inside the dashboard image the
+    # tests live at /app/tests and there is no repo root at all — parents[4] itself
+    # raises there, so the lookup must fail soft for the skipif to see "absent".
+    try:
+        root = Path(__file__).parents[4]
+    except IndexError:
+        return None
+    return (
+        root
+        / "docs"
+        / "research"
+        / "xvb-delivery-study"
+        / "data"
+        / "sources"
+        / "xmrvsbeast-reward_estimate_pub.txt"
+    )
+
+
+_XVB_ARCHIVE = _xvb_archive()
+
+
 class TestChart:
     def _line(self, n, start_ts, step=30):
         return [
@@ -2446,6 +2468,12 @@ class TestXvbCalc:
         assert by_threshold[100_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_whale"]
         assert by_threshold[1_000_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_mega"]
 
+    @pytest.mark.skipif(
+        _XVB_ARCHIVE is None or not _XVB_ARCHIVE.exists(),
+        reason="the delivery-study archive lives outside the dashboard image's build context; "
+        "this parity guard runs in the checkout-based dashboard CI job, which fails loudly "
+        "if the fallback and the archive ever disagree",
+    )
     def test_fallback_values_match_the_archived_source_files_player_rows(self):
         # #1214 guard: the vendored fallback must be the PER-PLAYER row XvB publishes, exactly
         # what the live parser would extract — never the pool-total row just above it (that
@@ -2456,16 +2484,7 @@ class TestXvbCalc:
         # instead of silently drifting from what a live fetch would ever show.
         from mining_dashboard.client.xvb_client import DONOR_ROUND_TYPES, parse_reward_estimates
 
-        archive = (
-            Path(__file__).parents[4]
-            / "docs"
-            / "research"
-            / "xvb-delivery-study"
-            / "data"
-            / "sources"
-            / "xmrvsbeast-reward_estimate_pub.txt"
-        )
-        parsed = parse_reward_estimates(archive.read_text())
+        parsed = parse_reward_estimates(_XVB_ARCHIVE.read_text())
         assert set(parsed) == set(DONOR_ROUND_TYPES)  # the archive still names all four tiers
         assert views.XVB_PUBLISHED_REWARD_FALLBACK == parsed
 

--- a/build/dashboard/tests/web/test_views.py
+++ b/build/dashboard/tests/web/test_views.py
@@ -2402,13 +2402,72 @@ class TestXvbCalc:
         assert by_threshold[100_000] == 6.17  # donor_whale
         assert by_threshold[1_000_000] == 56.9  # donor_mega
 
-    def test_stale_estimates_flagged_and_reward_nulled(self):
-        # A stale fetch must degrade: no per-tier number implied fresh, estimates_available False.
+    def test_enabled_stale_estimates_do_not_use_the_fallback(self):
+        # #1214 regression: an ENABLED box whose fetch is merely failing right now (a transient
+        # bot-challenge, a network blip — the sync loop writes only on success) must NOT get the
+        # vendored fallback. That box isn't "off"; claiming "published, not live because XvB is
+        # off" would be a straight lie. It keeps exactly the pre-#1214 honest degradation: no
+        # per-tier number implied fresh, estimates_available False, estimates_source "none".
         sm = self._sm(last_update=time.time() - XVB_STATS_STALE_AFTER_S - 1)
-        out = build_xvb_calc(_metrics(), sm)
+        out = build_xvb_calc(_metrics(xvb_enabled=True), sm)
         assert out["estimates_available"] is False
         assert out["estimates_stale"] is True
+        assert out["estimates_source"] == "none"
+        assert out["estimates_published_date"] is None
         assert all(t["expected_reward_year"] is None for t in out["tiers"])
+        assert all(t["assumed_reward_year_range"] is None for t in out["tiers"])
+
+    def test_disabled_stale_falls_back_to_the_published_table(self):
+        # A DISABLED box whose cache aged out while off — "just-disabled" in the issue's terms —
+        # gets the vendored fallback: no per-tier number implied FRESH (estimates_available stays
+        # False), but expected_reward_year fills in from XvB's own last-published table (never a
+        # live number, and labelled as such via estimates_source).
+        sm = self._sm(last_update=time.time() - XVB_STATS_STALE_AFTER_S - 1)
+        out = build_xvb_calc(_metrics(xvb_enabled=False), sm)
+        assert out["estimates_available"] is False
+        assert out["estimates_stale"] is True
+        assert out["estimates_source"] == "published"
+        assert out["estimates_published_date"] == views.XVB_PUBLISHED_REWARD_FALLBACK_DATE
+        by_threshold = {t["threshold"]: t["expected_reward_year"] for t in out["tiers"]}
+        assert by_threshold[1_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor"]
+        assert by_threshold[100_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_whale"]
+
+    def test_disabled_never_fetched_falls_back_to_the_published_table(self):
+        # #1214's actual bug report: a box that has NEVER enabled XvB has no cache at all (never
+        # fetched, not merely stale). Same fallback, same labelling.
+        sm = self._sm(estimates={}, last_update=0.0)
+        out = build_xvb_calc(_metrics(xvb_enabled=False), sm)
+        assert out["estimates_available"] is False
+        assert out["estimates_stale"] is False
+        assert out["estimates_source"] == "published"
+        by_threshold = {t["threshold"]: t["expected_reward_year"] for t in out["tiers"]}
+        assert by_threshold[1_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor"]
+        assert by_threshold[10_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_vip"]
+        assert by_threshold[100_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_whale"]
+        assert by_threshold[1_000_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor_mega"]
+
+    def test_fallback_values_match_the_archived_source_files_player_rows(self):
+        # #1214 guard: the vendored fallback must be the PER-PLAYER row XvB publishes, exactly
+        # what the live parser would extract — never the pool-total row just above it (that
+        # figure is the whole round's payout, not one qualifier's share, and is 7-70x larger).
+        # Parses the archived source with the real live parser
+        # (mining_dashboard.client.xvb_client.parse_reward_estimates, the exact regex a live
+        # fetch uses) so a future re-vendor from the wrong column fails this test immediately
+        # instead of silently drifting from what a live fetch would ever show.
+        from mining_dashboard.client.xvb_client import DONOR_ROUND_TYPES, parse_reward_estimates
+
+        archive = (
+            Path(__file__).parents[4]
+            / "docs"
+            / "research"
+            / "xvb-delivery-study"
+            / "data"
+            / "sources"
+            / "xmrvsbeast-reward_estimate_pub.txt"
+        )
+        parsed = parse_reward_estimates(archive.read_text())
+        assert set(parsed) == set(DONOR_ROUND_TYPES)  # the archive still names all four tiers
+        assert views.XVB_PUBLISHED_REWARD_FALLBACK == parsed
 
     def test_round_stats_expose_per_tier_draw_odds(self):
         # #872: the winners file's players column makes the draw knowable — each tier carries its
@@ -2438,17 +2497,26 @@ class TestXvbCalc:
 
     def test_unmeasured_boxes_get_the_prior_band_measured_boxes_do_not(self):
         # #872: no local measurement -> published × the measured prior band, so "should I enable
-        # this" is answerable everywhere. A measured factor supersedes it (never both), and stale
-        # estimates null both — a band cannot resurrect a stale face value.
+        # this" is answerable everywhere. A measured factor supersedes it (never both).
         out = build_xvb_calc(_metrics(), self._sm())
         whale = next(t for t in out["tiers"] if t["threshold"] == 100_000)
         lo, hi = views.XVB_REALIZATION_PRIOR
         assert whale["assumed_reward_year_range"] == pytest.approx([6.17 * lo, 6.17 * hi])
         out = build_xvb_calc(_metrics(), self._sm(), realization=(0.19, 15))
         assert all(t["assumed_reward_year_range"] is None for t in out["tiers"])
+        # A measured factor still wins even on a DISABLED, stale box where #1214's vendored
+        # fallback is otherwise eligible — "yours" always supersedes the band, fallback or not.
         stale = self._sm(last_update=time.time() - XVB_STATS_STALE_AFTER_S - 1)
-        out = build_xvb_calc(_metrics(), stale)
+        out = build_xvb_calc(_metrics(xvb_enabled=False), stale, realization=(0.19, 15))
         assert all(t["assumed_reward_year_range"] is None for t in out["tiers"])
+        # Same DISABLED, stale box with NO measured factor: #1214's fallback fills the band from
+        # the published face value instead of leaving it null — the whole point of the fallback.
+        # (An ENABLED, stale box must NOT do this — see test_enabled_stale_estimates_do_not_use_
+        # the_fallback — the fallback is gated on the box being off, not merely stale.)
+        out = build_xvb_calc(_metrics(xvb_enabled=False), stale)
+        whale = next(t for t in out["tiers"] if t["threshold"] == 100_000)
+        face = views.XVB_PUBLISHED_REWARD_FALLBACK["donor_whale"]
+        assert whale["assumed_reward_year_range"] == pytest.approx([face * lo, face * hi])
 
     def test_no_realization_leaves_realized_none(self):
         # Unmeasured (too few wins / payout confirmation off): realized stays None so the client
@@ -2462,12 +2530,81 @@ class TestXvbCalc:
         assert all(t["realized_reward_year"] is None for t in out["tiers"])
 
     def test_empty_estimates_available_false_no_crash(self):
-        # Never fetched / unparseable cache: available False, not "stale" (last_update 0), rewards None.
+        # Never fetched / unparseable cache on an ENABLED box (e.g. mid cold-start right after
+        # enabling, or persistently-failing fetches — never "off"): available False, not "stale"
+        # (last_update 0), and #1214's fallback must NOT fire here — same gate as the stale case,
+        # see test_enabled_stale_estimates_do_not_use_the_fallback. The never-enabled-XvB box the
+        # issue is actually about is test_disabled_never_fetched_falls_back_to_the_published_table.
         sm = self._sm(estimates={}, last_update=0.0)
-        out = build_xvb_calc(_metrics(), sm)
+        out = build_xvb_calc(_metrics(xvb_enabled=True), sm)
         assert out["estimates_available"] is False
         assert out["estimates_stale"] is False
+        assert out["estimates_source"] == "none"
         assert all(t["expected_reward_year"] is None for t in out["tiers"])
+
+    def test_fallback_never_backs_realized_reward_year(self):
+        # #1214: THIS wallet's own measured delivery factor must never be applied to a dated,
+        # generic fallback figure — that would overstate precision the wallet has no basis for.
+        # realized_reward_year keeps requiring a LIVE, fresh estimate even when realization is
+        # (unusually) supplied alongside a disabled box's empty cache.
+        sm = self._sm(estimates={}, last_update=0.0)
+        out = build_xvb_calc(_metrics(xvb_enabled=False), sm, realization=(0.5, 9))
+        assert all(t["realized_reward_year"] is None for t in out["tiers"])
+        # expected_reward_year still gets the fallback — only realized_reward_year is withheld.
+        assert any(t["expected_reward_year"] is not None for t in out["tiers"])
+
+    def test_fallback_skips_tiers_the_published_table_does_not_name(self):
+        # A custom TIER_CONFIG round-type the archived table never named degrades to None, same
+        # as before this fix — the fallback is a fixed vendored table, never invented per key.
+        sm = self._sm(estimates={}, last_update=0.0)
+        sm.get_tiers.return_value = {"donor": 1_000, "custom_tier": 5_000}
+        out = build_xvb_calc(_metrics(xvb_enabled=False), sm)
+        by_threshold = {t["threshold"]: t["expected_reward_year"] for t in out["tiers"]}
+        assert by_threshold[1_000] == views.XVB_PUBLISHED_REWARD_FALLBACK["donor"]
+        assert by_threshold[5_000] is None
+
+    def test_live_estimates_report_source_live_no_fallback_date(self):
+        # A fresh live fetch must be labelled "live", never "published" — the two must never be
+        # ambiguous to the client, which uses this to decide the disabled-note wording.
+        out = build_xvb_calc(_metrics(), self._sm())
+        assert out["estimates_source"] == "live"
+        assert out["estimates_published_date"] is None
+
+    def test_never_fetched_and_fallback_missing_reports_source_none(self):
+        # A DISABLED box whose future TIER_CONFIG names nothing the fallback recognises must
+        # still report "none" rather than falsely claiming "published" — isolates the "fallback
+        # dict has no matching key" case from the enabled/disabled gate (test above).
+        sm = self._sm(estimates={}, last_update=0.0)
+        sm.get_tiers.return_value = {"custom_tier": 5_000}
+        out = build_xvb_calc(_metrics(xvb_enabled=False), sm)
+        assert out["estimates_source"] == "none"
+        assert out["estimates_published_date"] is None
+
+    def test_disabled_path_never_touches_the_network_layer(self):
+        # #163's no-egress-when-disabled contract, at this tier: filling the decision table's
+        # reward columns from #1214's vendored fallback must never make an outbound HTTP call —
+        # build_xvb_calc only reads state_mgr (local) and the static XVB_PUBLISHED_REWARD_FALLBACK
+        # dict. Patches BOTH the chokepoint every real XvB fetch goes through
+        # (mining_dashboard.helper.http.bounded_get) AND requests' own low-level entry point
+        # (requests.sessions.Session.request, what requests.get ultimately calls), so a
+        # regression that wires an on-demand fetch into this path — through the shared helper or
+        # straight through requests — fails this test immediately rather than passing quietly.
+        import requests
+
+        import mining_dashboard.helper.http as http_mod
+
+        def _dial(*a, **k):
+            raise AssertionError("build_xvb_calc must never dial out while XvB is disabled")
+
+        sm = self._sm(estimates={}, last_update=0.0)
+        with (
+            patch.object(http_mod, "bounded_get", side_effect=_dial),
+            patch.object(requests.sessions.Session, "request", side_effect=_dial),
+        ):
+            out = build_xvb_calc(_metrics(xvb_enabled=False), sm)
+        # And the fallback did its job — the dashes are gone, not just "no crash".
+        assert out["estimates_source"] == "published"
+        assert all(t["expected_reward_year"] is not None for t in out["tiers"])
 
     # --- current-tier reward folded into net profit (#712) ---------------------------
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -667,8 +667,12 @@ XMRvsBeast tier could this hashrate hold, and what would it cost?". It renders w
 too (`xvb.enabled: false`) — the decision table below is exactly the enable/don't-enable aid, so
 it must be readable *before* you enable anything. While disabled, the two live-credit rows
 (Current Tier, Target Tier) disappear, and — because disabling XvB stops every fetch from
-xmrvsbeast.com — the odds and reward columns run from the last cached read: on a box that never
-enabled XvB they show tier costs only. The raffle winner is drawn at random among everyone above
+xmrvsbeast.com — the reward columns run from the last cached read when one exists, or otherwise
+from a bundled snapshot of XvB's own published table, labelled with the date it was captured so
+you can see how old it is; either way nothing is fetched to produce it. The odds column has no
+such stand-in — draw frequency and qualifier counts are live numbers XvB's winners feed alone
+carries, so it stays empty on a box that has never enabled XvB, filling in once XvB runs and that
+feed is read for the first time. The raffle winner is drawn at random among everyone above
 the threshold, so donating more than the threshold buys zero extra win chance — but the odds
 themselves are knowable: XvB's winners file publishes the qualifier count for every round, and
 the comparison below shows them.


### PR DESCRIPTION
Routine twin sync: develop → develop-v2, carrying PR #1230 (#1214, the XvB decision-table published fallback with its enabled/disabled gate) and PR #1234 (#1232, the Worker Inspect stat-value contrast fix) across in one batch. Clean merge, no conflicts.

Verified on the merged result: `scripts/lint-topology-classes.sh` exits 0; the appliance lane's full frontend suite — 400/400 pass (this lane's superset including the wizard tests, exercising both synced changes' components).
