### PR TITLE
tests(integration): the mining-asserts skip gets a tier-1 mutation proof

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -601,6 +601,21 @@ wait_miner_running() { wait_for "${1:-180}" 5 "miner released" _pred_miner_runni
 wait_tari_synced() { wait_for "${1:-300}" 10 "Tari sync complete" _pred_tari_synced; }
 wait_pool_ready() { wait_for "${1:-180}" 5 "pool type determinate (${2})" _pred_pool_ready "$2"; }
 
+# Mining-liveness verdict (#905/#1082), factored out of assert_running_state so selftest can
+# prove --no-mining-asserts is a CONDITIONAL skip, not a permanent one: the two assertions must
+# still run — and be able to go red — every time the flag is unset. Only the caller-set skip
+# flag suppresses them; there is no auto-detection here (a live worker-count of zero from a
+# genuinely fallen-off rig must stay indistinguishable from a parked bench unless the operator
+# says so explicitly — see #1082's fail-open discussion).
+assert_mining_state() { # <skip: 0|1> <workers> <hashes> <expected-workers>
+    if [ "$1" = "1" ]; then
+        it_warn "SKIPPED workers online + stratum total hashes: no miner attached to this box (--no-mining-asserts) — drop the flag (and attach a miner) to make these binding again (#905/#1082)"
+        return 0
+    fi
+    assert_num_ge "workers online (>= $4)" "${2:-0}" "$4"
+    assert_num_gt "stratum total hashes > 0" "${3:-0}" 0
+}
+
 # Ground truth for the sidechain axis (#746): the rendered P2POOL_FLAGS in the box's .env carry
 # --mini / --nano (main carries neither). The dashboard classifies the sidechain by counting
 # connected peers' ports, so right after a pool SWITCH p2pool runs the NEW flags while the

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -628,8 +628,9 @@ assert_running_state() {
     #    timeout.
     if [ "$SKIP_MINING_ASSERTS" = "1" ]; then
         # #905: no miner is connected on purpose (e2e --no-miner), so a live worker/hash count
-        # would fail a healthy stack. Skip these two loudly; every other assertion stays binding.
-        it_warn "SKIPPED mining assertions (workers online, stratum hashes): --no-mining-asserts"
+        # would fail a healthy stack. assert_mining_state (lib.sh) skips these two loudly; every
+        # other assertion in the scenario stays binding.
+        assert_mining_state "1" "" "" "$EXPECTED_WORKERS"
     else
         local workers conns hashes
         wait_stratum_hashes 180 || true
@@ -637,8 +638,7 @@ assert_running_state() {
         workers="$(jq_get "$st" '.proxy_workers')"
         conns="$(jq_get "$st" '.stratum.conns')"
         hashes="$(jq_get "$st" '.stratum.total_hashes')"
-        assert_num_ge "workers online (>= $EXPECTED_WORKERS)" "${workers:-0}" "$EXPECTED_WORKERS"
-        assert_num_gt "stratum total hashes > 0" "${hashes:-0}" 0
+        assert_mining_state "0" "$workers" "$hashes" "$EXPECTED_WORKERS"
         it_step "stratum conns=${conns:-?} (informational)"
     fi
 

--- a/tests/integration/selftest.sh
+++ b/tests/integration/selftest.sh
@@ -400,6 +400,34 @@ assert_num_ge "num_ge passes when equal" 5 5
 assert_num_gt "num_gt passes when greater" 6 5
 [ "$IT_PASS" -gt "$_p" ] && it_pass "passing assertions increment IT_PASS" || it_fail "passing assertions increment IT_PASS" "no increment"
 
+echo "== assert_mining_state: --no-mining-asserts is a CONDITIONAL skip, not permanent (#905/#1082) =="
+# Subshell-stub the emitters so the verdict under test can't touch this selftest's counters.
+mining_verdict() { # <skip> <workers> <hashes> <expected> -> concatenated PASS()/FAIL()/WARN() markers
+    (
+        it_pass() { printf 'PASS(%s) ' "$1"; }
+        it_fail() { printf 'FAIL(%s) ' "$1"; }
+        it_warn() { printf 'WARN(%s) ' "$1"; }
+        assert_mining_state "$1" "$2" "$3" "$4"
+    )
+}
+# The flag set: both assertions are skipped (no PASS/FAIL marker for either) — a WARN with a
+# reason and an un-skip instruction, never a silent unconditional pass.
+_out="$(mining_verdict 1 0 0 2)"
+case "$_out" in
+*PASS* | *FAIL*) it_fail "skip path emits no PASS/FAIL for the two assertions" "got [$_out]" ;;
+*) it_pass "skip path emits no PASS/FAIL for the two assertions" ;;
+esac
+assert_contains "skip reason names the flag" "$_out" "no-mining-asserts"
+assert_contains "skip reason says what un-skips it" "$_out" "drop the flag"
+# The flag unset with a healthy count: both assertions run and go green.
+assert_eq "flag unset + healthy count -> both PASS" "$(mining_verdict 0 3 500 2)" "PASS(workers online (>= 2)) PASS(stratum total hashes > 0) "
+# Mutation proof (break the checked thing -> red): flag unset is BINDING, not defanged. Without
+# this, a skip that silently ate the check whenever no one was looking would read exactly like
+# the assertions above passing — this is the other half of the skip contract.
+assert_eq "flag unset + zero workers/hashes -> both FAIL (mutation proof)" "$(mining_verdict 0 0 0 2)" "FAIL(workers online (>= 2)) FAIL(stratum total hashes > 0) "
+# One-sided mutation: only the broken half reddens, the healthy half still passes.
+assert_eq "flag unset + workers ok, hashes 0 -> only hashes FAILs" "$(mining_verdict 0 3 0 2)" "PASS(workers online (>= 2)) FAIL(stratum total hashes > 0) "
+
 echo "== rig_lock: the shared-bench flock (#430 / rigforge#183) =="
 # The canonical rig lock, exercised in a sandbox via the env-overridable paths — no root, no
 # /var/lock. Holders run as background subshells that acquire, signal readiness, then block on


### PR DESCRIPTION
The substance of #1082 landed before this branch: `--no-mining-asserts` already converts the two post-deploy mining assertions from always-red to a conditional skip-with-reason (#905), `e2e.sh` passes it under `--no-miner`, and the release runbook already requires zero failures with the flag. The operator's own status comment on the issue says as much and rejects the auto-detect alternative as fail-open (a parked bench and a silently fallen-off rig would be indistinguishable).

What remained — and what this PR closes — is the coverage gap: the skip/bind decision lived only in a live-box tier-4 code path with zero coverage below it, which is exactly the false-green shape this repo hunts (a skip that quietly stopped running would look identical to one working correctly).

The decision is factored into `assert_mining_state` (`tests/integration/lib.sh`, taking the skip flag as an explicit argument) and pinned by tier-1 selftest coverage using the file's existing subshell-stub pattern: flag set → no PASS/FAIL emitted, the warn names the flag and what un-skips it; flag unset + healthy → both green; flag unset + zero counts → both RED; one-sided break → only that axis reddens (the two assertions are independently binding). No behavior change — CLI flag, e2e wiring, and runbook text all stand.

**Run**: `tests/integration/selftest.sh` — 214 passed, 0 failed (also via `make test-integration-selftest`); `shellcheck --severity=warning` + `shfmt -i 4 -d` on the three changed files, clean; `--help`/`--list` smoke. **Mutations, run and named**: the four selftest cases above, plus an independent coordinating-session mutation on the pushed tip — skip made unconditional (`if true`) → selftest reddens 3/214 (the run-and-red trio), restored → 214/0.

**Not run**: KVM/live e2e — the battery re-run held the bench; the live skip line's appearance in a real run rides the next e2e. Nothing in tests/stack was touched.

Closes #1082
