### PR TITLE
fix(control): backup guards its required items before touching the stack

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -461,7 +461,9 @@ This prompts for a passphrase, then writes a timestamped, encrypted `tar.gz.enc`
 holding the irreplaceable state: `config.json`, `.env` (secrets), the `Caddyfile` (if present), the
 Tor onion keys, and the dashboard database (hashrate history and settings). Blockchains are
 excluded (they re-sync), so the archive is small. The archive is `chmod 600`, and `pithead` prints
-its path when done. Before writing, `backup` checks free space and prompts if it looks tight. On a
+its path when done. Before touching anything, `backup` checks that `config.json` and `.env` are
+still there as regular files, then checks free space and prompts if it looks tight — either check
+can refuse before the running stack is stopped for an archive that would fail anyway. On a
 source checkout, `backups/` is git-ignored — the archive carries `.env` and the onion private keys,
 and secret scanners can't see inside a tarball.
 

--- a/pithead
+++ b/pithead
@@ -3418,6 +3418,47 @@ factory_reset() {
 # Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, and the Tor
 # data dir (onion service keys). The blockchains and dashboard DB re-sync, so they're excluded
 # by default; pass --with-chains to also fold in the Monero/Tari/P2Pool data dirs.
+#
+# The two files a backup archive cannot be worth taking without (#1059/#1244): config.json and
+# .env carry the node credentials and secrets, unlike every optional item stack_backup adds
+# below them (Caddyfile, the Tor data dir, the dashboard dir all get a plain `[ -f ]`/`[ -d ]`
+# guard already — these two didn't). Called BEFORE the disk-space check and before anything
+# touches the running stack, so a refusal here leaves the box exactly as it was, the same
+# promise the space check already makes. `-f` (not `-e`) so a symlink dangling at this instant
+# refuses too, the same as one dangling at tar time would. A function, not inline, so it is
+# testable at tier 1 without driving the whole backup flow.
+backup_require_items() { # <item>...
+    local _req
+    for _req in "$@"; do
+        [ -f "$_req" ] ||
+            error "Backup needs $_req, and it is not there as a regular file (missing, or a symlink to nowhere) — nothing was touched. Run './pithead status' to check the install, or './pithead setup' if this box is unprovisioned."
+    done
+}
+
+# Turns a tar failure into something the NEXT investigation can read straight off the log,
+# instead of needing another bench boot before anyone can look (#1059/#1244: a genuine
+# occurrence had config.json present and root-owned moments earlier, then unstattable at tar
+# time — twice, across the #970 retry — on a guest that was recycled before the state could be
+# inspected by hand). $1 = the directory tar's `-C` pointed at; the rest = the absolute item
+# paths passed to it, so this prints exactly what an investigator would check by hand next.
+backup_diagnose_items() { # <tar -C dir> <item>...
+    local cwd="$1"
+    shift
+    warn "tar ran with -C \"$cwd\" against these resolved items:"
+    local it
+    for it in "$@"; do
+        if [ -f "$it" ]; then
+            warn "  present: $(ls -ld "$it" 2>&1)"
+        elif [ -L "$it" ]; then
+            warn "  DANGLING SYMLINK: $it -> $(readlink -f "$it" 2>&1)"
+        elif [ -e "$it" ]; then
+            warn "  present but not a regular file: $(ls -ld "$it" 2>&1)"
+        else
+            warn "  MISSING: $it"
+        fi
+    done
+}
+
 stack_backup() {
     local with_chains=0 assume_yes=0 was_running=0 no_encrypt=0
     for arg in "$@"; do
@@ -3475,7 +3516,18 @@ stack_backup() {
     # Collect what exists, as absolute paths. We tar with -C / and strip the leading slash, so
     # restore (extract at /) puts every file back exactly where it came from regardless of where
     # config.json / the data dirs live. config.json/.env/Caddyfile sit in the script dir ($PWD).
-    local items=("$PWD/$CONFIG_FILE" "$PWD/$ENV_FILE")
+    #
+    # CONFIG_FILE (unlike ENV_FILE) is overridable — PITHEAD_CONFIG_FILE points a single
+    # invocation at an absolute candidate path (the control gate's staged-config preview uses
+    # it). A bare "$PWD/$CONFIG_FILE" concatenation is unsound exactly then: prefixing $PWD onto
+    # an already-absolute path produces a doubled, non-existent path like
+    # "/data/pithead//tmp/staged.json" that no file was ever going to be at. Not what #1059's
+    # capture hit — that override was not in play there — but real whenever it is, so resolve it
+    # the way every path join should: only prefix $PWD onto a RELATIVE candidate.
+    local _cfg_path="$CONFIG_FILE"
+    case "$_cfg_path" in /*) ;; *) _cfg_path="$PWD/$_cfg_path" ;; esac
+    local items=("$_cfg_path" "$PWD/$ENV_FILE")
+    backup_require_items "${items[@]}"
     [ -f "Caddyfile" ] && items+=("$PWD/Caddyfile")
 
     if [ -d "$TOR_DATA_DIR" ]; then
@@ -3594,6 +3646,7 @@ stack_backup() {
     done
     if [ "$_backup_ok" -ne 1 ]; then
         [ "$was_running" -eq 1 ] && stack_up
+        backup_diagnose_items "/" "${items[@]}"
         error "Backup failed — the partial archive was removed."
     fi
     sudo chown "$REAL_USER":"$REAL_USER" "$archive"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -4934,6 +4934,91 @@ assert_eq "the retry actually ran (fixture consumed)" "$([ -f "$RB/first-tar-fai
 rbarchive="$(ls "$RB"/backups/pithead-backup-*.tar.gz.enc 2>/dev/null | head -1)"
 { [ -n "$rbarchive" ] && [ -s "$rbarchive" ]; } && ok "retry produced a real archive" || bad "retry produced a real archive" "no .enc archive"
 
+echo "== unit: backup_require_items — refuses a missing/dangling required item before anything is touched (#1244) =="
+# The KVM battery caught tar failing to stat config.json AFTER the stack had already been
+# stopped for the backup (#1059) — a real archive attempt was thrown away and the box paid for
+# a stop/start cycle it didn't need. These two functions are pulled out of stack_backup and
+# sourced directly (the same pattern gate_ready/os_update_rollback_verdict use) so the refusal
+# and the diagnostic dump are provable without driving tar, sudo, or the whole backup flow.
+BRI="$SANDBOX/backup-require-items"
+mkdir -p "$BRI"
+: >"$BRI/present.txt"
+ln -s "$BRI/nowhere" "$BRI/dangling.txt"
+out=$(run_sourced "$BRI" backup_require_items "$BRI/present.txt" "$BRI/missing.txt" 2>&1)
+rc=$?
+assert_rc "a genuinely missing item refuses (nonzero)" "$rc" "1"
+assert_contains "the refusal names the exact resolved path" "$out" "$BRI/missing.txt"
+assert_contains "the refusal says what to do next" "$out" "pithead setup"
+out=$(run_sourced "$BRI" backup_require_items "$BRI/present.txt" "$BRI/dangling.txt" 2>&1)
+rc=$?
+assert_rc "a dangling symlink refuses the same way a missing file does" "$rc" "1"
+assert_contains "the dangling-symlink refusal also names the path" "$out" "$BRI/dangling.txt"
+out=$(run_sourced "$BRI" backup_require_items "$BRI/present.txt" 2>&1)
+rc=$?
+assert_rc "every item present passes silently" "$rc" "0"
+assert_eq "nothing is printed when every required item is present" "$out" ""
+
+echo "== unit: backup_diagnose_items — a tar failure names its cwd and each item's real state (#1244) =="
+# The diagnostic half of the same fix: when tar fails anyway (both #970 retry attempts spent),
+# the failure names the -C directory it ran against and what each resolved item actually was —
+# so the NEXT occurrence of #1059's run-conditional vanish doesn't need another bench boot
+# before anyone can look.
+out=$(run_sourced "$BRI" backup_diagnose_items "/" "$BRI/present.txt" "$BRI/missing.txt" "$BRI/dangling.txt" 2>&1)
+assert_contains "names the -C directory tar ran against" "$out" 'tar ran with -C "/"'
+assert_contains "a present item is reported present with its own listing" "$out" "present: "
+assert_contains "the present item's line names its own path" "$out" "$BRI/present.txt"
+assert_contains "a missing item is called out by name" "$out" "MISSING: $BRI/missing.txt"
+assert_contains "a dangling symlink is distinguished from a plain miss" "$out" "DANGLING SYMLINK: $BRI/dangling.txt"
+unset BRI out rc
+
+echo "== unit: stack_backup — an absolute CONFIG_FILE override is archived at its real path, not a doubled one (#1244) =="
+# PITHEAD_CONFIG_FILE (the control gate's staged-config preview seam) can be an ABSOLUTE path.
+# Before this fix, stack_backup unconditionally prefixed $PWD onto it ("$PWD/$CONFIG_FILE"),
+# which for an absolute override built a doubled, nonexistent path like
+# "$PWD//tmp/staged.json" — tar would fail to stat THAT, the same shape #1059 hunted, just from
+# a cause the live capture ruled out rather than the one that actually happened.
+CJ="$SANDBOX/backup-cfg-override"
+mkdir -p "$CJ/build/tari" "$CJ/data/tor" "$CJ/data/dashboard" "$CJ/bin"
+cp "$STACK" "$CJ/pithead"
+cp "$ROOT/build/tari/config.toml.template" "$CJ/build/tari/"
+cat >"$CJ/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat >"$CJ/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = "chown" ] && exit 0
+exec "$@"
+EOF
+chmod +x "$CJ/bin/docker" "$CJ/bin/sudo"
+cat >"$CJ/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=CJTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+# The override candidate lives OUTSIDE $CJ entirely — a doubled "$CJ/<absolute candidate>" path
+# could never coincidentally resolve to something real, so a pass here can only mean the join
+# is absolute-safe, not a lucky path collision.
+CJALT="$SANDBOX/backup-cfg-override-elsewhere"
+mkdir -p "$CJALT"
+printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"'"$VALID_TARI"'"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$CJALT/candidate.json"
+out=$(cd "$CJ" && PATH="$CJ/bin:$PATH" PITHEAD_CONFIG_FILE="$CJALT/candidate.json" PITHEAD_BACKUP_PASSPHRASE=hunter2 ./pithead backup -y 2>&1)
+rc=$?
+assert_rc "backup succeeds against an absolute CONFIG_FILE override" "$rc" "0"
+cjarchive="$(ls "$CJ"/backups/pithead-backup-*.tar.gz.enc 2>/dev/null | head -1)"
+{ [ -n "$cjarchive" ] && [ -s "$cjarchive" ]; } && ok "override archive was written" || bad "override archive was written" "no .enc archive"
+# The archive's member list is the ground truth for what tar was actually told to stat: the
+# override's OWN absolute path (leading / stripped, same as every other item), never a doubled
+# artifact of the old $PWD-prefix bug.
+cjlist=$(openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 -pass pass:hunter2 -in "$cjarchive" 2>/dev/null | tar -tzf - 2>/dev/null)
+assert_contains "the archive carries the override's real, un-doubled path" "$cjlist" "${CJALT#/}/candidate.json"
+assert_not_contains "the archive never carries a \$PWD-doubled override path" "$cjlist" "${CJ#/}${CJALT}"
+unset CJ CJALT out rc cjarchive cjlist
+
 echo "== unit: install.sh host gate (#77 phase 1) =="
 # The installer hard-fails on the platforms the stack cannot run on, before any download.
 IBIN="$SANDBOX/install-stub-bin"


### PR DESCRIPTION
Two fresh KVM repro attempts of the exact restore leg (`--phase install --keep`, ~16 min each) could not reproduce the run-conditional "tar cannot stat config.json" vanish — both backed up cleanly (42/0 twice). Issue archaeology found #1244 continues #1059 (the same bug, previously investigated): that earlier work had already captured config.json as a real present file moments before the failure, refuted the dangling-symlink hypothesis on a live guest, and localized the vanish to the stack-stop window without finding a cause. The mystery stays open — reported honestly, not papered over — and tracking consolidates on #1059.

What this PR ships regardless (the blast-radius work #1059 itself called out as worth doing):

1. **`backup_require_items()`** — config.json and .env were the ONLY backup items with no existence guard (unlike Caddyfile/Tor-dir/dashboard-dir). The guard now runs before the disk-space check and before the stack is touched, so a refusal leaves the box exactly as it was instead of stopping a healthy stack for an archive that was always going to fail.
2. **Path-join bug** — the config.json item was built as `"$PWD/$CONFIG_FILE"` unconditionally, doubling into a nonexistent path whenever `PITHEAD_CONFIG_FILE` (the control gate's staged-config preview seam, #33) holds an absolute path. Now prefixed only when relative. Not what #1059's capture hit (that override wasn't in play), but a real latent bug closed.
3. **`backup_diagnose_items()`** — on any future tar failure, prints tar's `-C` directory and each item's live state (present / missing / dangling symlink with target), so the next occurrence is diagnosable without another bench boot.

Code-reading audit recorded in the investigation: no path in `stack_backup`, `stack_down`, the egress-firewall teardown, the compose shim, the #33 control channel, `pithead-sync`, or `pithead-media-config` touches config.json in the stop window; the file is never bind-mounted into any container (only its masked/reference derivatives are), and podman's storage root lives elsewhere.

**Bonus evidence**: both KVM runs reached the restored machine successfully — wizard reachable through the restored config, original wallet address AND Tor identity intact (not regenerated). That is the live confirmation #1239's merged fix was owed, now delivered, and the first live pass of #1091's new live-state discrimination path.

**Run**: two full KVM install-phase runs under the bench lock (42/0 each, guests destroyed after); full `tests/stack/run.sh` under the suite flock — **2862 passed, 0 failed**, including 16 new assertions; `tests/inventory.sh` clean; `shellcheck --severity=warning pithead` clean; shfmt no diffs; lint-docs-voice + lint-operator-strings clean; `docs/operations.md`'s backup section updated. **Mutations, run and named**: neutered guard → 5/7 block assertions red; dropped `-C` from the diagnosis → its assertion red; reverted the join fix → 3/4 override assertions red.

**Not run**: `make lint-sh` (#1206 cap); a third repro attempt (the brief caps at two non-repros — looping on a non-repro is not evidence).

Closes #1244 (tracking for the unexplained vanish consolidates on #1059).
