### PR TITLE
lint(file-budget): ratchet against the branch's own twin lane

### DIFF
--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -24,11 +24,21 @@ TARGET_LINES=400
 HARD_CEILING=800
 BUDGET_FILE="docs/dev/file-budget.tsv"
 
-# The branch this PR ratchets against. origin/develop when it's reachable (CI, any normal
-# clone); a bare `develop` as a local-only fallback; if neither resolves (a shallow or
-# origin-less checkout) the monotonic check is skipped with a loud note, never silently.
+# The branch this PR ratchets against — the twin lane it will merge into, NOT a fixed branch.
+# develop-v2 carries develop's whole history plus the appliance code, so the same files are
+# legitimately LARGER there; ratcheting a develop-v2 PR against origin/develop would reject
+# every one of those larger ceilings as an illegal "raise". The lane is detected by ancestry:
+# only a develop-v2-lane branch has origin/develop-v2 as an ancestor (develop's history is an
+# ancestor of BOTH lanes, so it cannot distinguish them). Each candidate falls back to its
+# bare local name; if nothing resolves the monotonic check is skipped with a loud note.
 resolve_base_ref() {
-    if git rev-parse -q --verify origin/develop >/dev/null 2>&1; then
+    if git rev-parse -q --verify origin/develop-v2 >/dev/null 2>&1 &&
+        git merge-base --is-ancestor origin/develop-v2 HEAD 2>/dev/null; then
+        echo origin/develop-v2
+    elif git rev-parse -q --verify develop-v2 >/dev/null 2>&1 &&
+        git merge-base --is-ancestor develop-v2 HEAD 2>/dev/null; then
+        echo develop-v2
+    elif git rev-parse -q --verify origin/develop >/dev/null 2>&1; then
         echo origin/develop
     elif git rev-parse -q --verify develop >/dev/null 2>&1; then
         echo develop


### PR DESCRIPTION
A twin-portability fix to the Phase 0 file-budget gate (#1249, merged earlier today), found the moment I tried to carry it to develop-v2.

`resolve_base_ref()` hardcoded `origin/develop` as the ratchet baseline. But develop-v2 carries develop's whole history PLUS the appliance code, so the same files are legitimately larger there (e.g. `web/server.py` is 562 lines on develop, 645 on develop-v2; `views.py` 2303 vs 2339). Ratcheting a develop-v2 PR against origin/develop rejects every one of those larger ceilings as an illegal "raise — ceilings only go down", making the gate impossible to sync to the appliance lane at all.

Fix: `resolve_base_ref()` detects the lane by ancestry — only a develop-v2-lane branch has `origin/develop-v2` as an ancestor, because develop's history is an ancestor of BOTH lanes and so cannot distinguish them. A develop-v2 PR now ratchets against origin/develop-v2, a develop PR against origin/develop, each with its bare-local-name fallback and the existing loud skip when no base resolves.

Verified: `shellcheck --severity=warning` clean, shfmt clean, `--self-test` 12/12; on a develop-based branch the lane resolves to develop (origin/develop-v2 not an ancestor) and the real-tree gate still passes unchanged; the develop-v2 twin sync (its own PR) carries this script plus develop-v2's regenerated budget and passes there. No behaviour change on develop — this only unblocks the appliance lane.

Part of #1105 (Phase 0 twin portability).
