### PR TITLE
test(stack): extract the shared test harness into tests/stack/lib.sh (#1105 Phase 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
 
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/test_compose.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh
 	shfmt -i 4 -d pithead pithead-completion.bash $(shell git ls-files '*.sh' | grep -v '^docs/research/')
 

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -37,5 +37,5 @@ tests/integration/e2e.sh	766
 tests/integration/lib.sh	677
 tests/integration/run.sh	2551
 tests/integration/selftest.sh	658
-tests/stack/run.sh	8381
+tests/stack/run.sh	8319
 tests/stack/test_compose.sh	454

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -1,0 +1,76 @@
+# shellcheck shell=bash
+#
+# Shared test harness for tests/stack/run.sh (#1105 Phase 1, first extraction).
+#
+# The assertion/reporting primitives, the pass/fail counters, and the common fixtures every
+# test group in run.sh builds on. This file is *sourced*, never executed on its own — it has
+# no shebang and is not marked executable, matching tests/integration/lib.sh's convention.
+#
+# Mechanical move only: this is the SAME code that used to sit at the top of run.sh, moved
+# here verbatim so run.sh can source it. No behaviour changed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STACK="$ROOT/pithead"
+PASS=0
+FAIL=0
+
+ok() {
+    PASS=$((PASS + 1))
+    printf '  \033[1;32m✓\033[0m %s\n' "$1"
+}
+bad() {
+    FAIL=$((FAIL + 1))
+    printf '  \033[1;31m✗\033[0m %s\n      %s\n' "$1" "$2"
+}
+
+assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3], got [$2]"; fi; }
+assert_contains() { case "$2" in *"$3"*) ok "$1" ;; *) bad "$1" "[$2] missing [$3]" ;; esac }
+assert_not_contains() { case "$2" in *"$3"*) bad "$1" "[$2] unexpectedly contains [$3]" ;; *) ok "$1" ;; esac }
+assert_rc() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected rc $3, got $2"; fi; }
+
+# Run a command with pithead sourced (functions available, no cd/main side effects),
+# from a given working directory. Usage: run_sourced <dir> <cmd> [args...]
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+run_sourced() {
+    local dir="$1"
+    shift
+    (
+        cd "$dir" || return
+        source "$STACK"
+        set +e
+        "$@"
+    )
+}
+
+# A throwaway sandbox dir, cleaned on exit. Physical path (#695): pithead canonicalizes its
+# own directory with pwd -P, so a sandbox spelled through a symlink (macOS /var -> /private/var)
+# would render .env paths that no longer string-match the $SANDBOX-based assertions.
+SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# A fake docker that records calls and answers the few queries setup/apply make.
+make_stubs() {
+    local bin="$1"
+    mkdir -p "$bin"
+    cat >"$bin/docker" <<'EOF'
+#!/usr/bin/env bash
+echo "[docker] $*" >> "${DOCKER_LOG:-/dev/null}"
+case "$*" in
+  "compose version"|"info") exit 0 ;;
+  "exec tor test -f "*) exit 0 ;;
+  "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion" ;;
+  "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion" ;;
+  "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion" ;;
+  "exec p2pool cat /proc/1/cmdline") printf '%s' "${P2POOL_PROC1:-}" ;;  # #273: tests set the running p2pool argv
+  *hash-password*)
+    # Fake `caddy hash-password` (#8): a per-password digest so enable/change paths differ, and it
+    # never echoes the plaintext back (real bcrypt doesn't either) — keeps the leak checks honest.
+    _pw="${*##*--plaintext }"
+    _d="$(printf '%s' "$_pw" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-22)"
+    printf '$2y$14$%s\n' "$_d" ;;
+esac
+exit 0
+EOF
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$bin/sudo"
+    chmod +x "$bin/docker" "$bin/sudo"
+}

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -6,71 +6,9 @@
 #
 set -uo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-STACK="$ROOT/pithead"
-PASS=0
-FAIL=0
-
-ok() {
-    PASS=$((PASS + 1))
-    printf '  \033[1;32m✓\033[0m %s\n' "$1"
-}
-bad() {
-    FAIL=$((FAIL + 1))
-    printf '  \033[1;31m✗\033[0m %s\n      %s\n' "$1" "$2"
-}
-
-assert_eq() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3], got [$2]"; fi; }
-assert_contains() { case "$2" in *"$3"*) ok "$1" ;; *) bad "$1" "[$2] missing [$3]" ;; esac }
-assert_not_contains() { case "$2" in *"$3"*) bad "$1" "[$2] unexpectedly contains [$3]" ;; *) ok "$1" ;; esac }
-assert_rc() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected rc $3, got $2"; fi; }
-
-# Run a command with pithead sourced (functions available, no cd/main side effects),
-# from a given working directory. Usage: run_sourced <dir> <cmd> [args...]
-# shellcheck disable=SC1090  # STACK path is dynamic by design
-run_sourced() {
-    local dir="$1"
-    shift
-    (
-        cd "$dir" || return
-        source "$STACK"
-        set +e
-        "$@"
-    )
-}
-
-# A throwaway sandbox dir, cleaned on exit. Physical path (#695): pithead canonicalizes its
-# own directory with pwd -P, so a sandbox spelled through a symlink (macOS /var -> /private/var)
-# would render .env paths that no longer string-match the $SANDBOX-based assertions.
-SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
-trap 'rm -rf "$SANDBOX"' EXIT
-
-# A fake docker that records calls and answers the few queries setup/apply make.
-make_stubs() {
-    local bin="$1"
-    mkdir -p "$bin"
-    cat >"$bin/docker" <<'EOF'
-#!/usr/bin/env bash
-echo "[docker] $*" >> "${DOCKER_LOG:-/dev/null}"
-case "$*" in
-  "compose version"|"info") exit 0 ;;
-  "exec tor test -f "*) exit 0 ;;
-  "exec tor cat /var/lib/tor/monero/hostname") echo "mona.onion" ;;
-  "exec tor cat /var/lib/tor/tari/hostname")   echo "taria.onion" ;;
-  "exec tor cat /var/lib/tor/p2pool/hostname") echo "p2pa.onion" ;;
-  "exec p2pool cat /proc/1/cmdline") printf '%s' "${P2POOL_PROC1:-}" ;;  # #273: tests set the running p2pool argv
-  *hash-password*)
-    # Fake `caddy hash-password` (#8): a per-password digest so enable/change paths differ, and it
-    # never echoes the plaintext back (real bcrypt doesn't either) — keeps the leak checks honest.
-    _pw="${*##*--plaintext }"
-    _d="$(printf '%s' "$_pw" | { sha256sum 2>/dev/null || shasum -a 256; } | cut -c1-22)"
-    printf '$2y$14$%s\n' "$_d" ;;
-esac
-exit 0
-EOF
-    printf '#!/usr/bin/env bash\nexit 0\n' >"$bin/sudo"
-    chmod +x "$bin/docker" "$bin/sudo"
-}
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/stack/lib.sh
+source "$HERE/lib.sh"
 
 # ---------------------------------------------------------------------------
 echo "== unit: resolve_default =="


### PR DESCRIPTION
The first module of the tests/stack/run.sh split (#1105 Phase 1) — a MECHANICAL MOVE ONLY, no behaviour change. The shared harness (`ok`/`bad`/`assert_eq`/`assert_contains`/`assert_not_contains`/`assert_rc`, the PASS/FAIL counters, `run_sourced`, the `SANDBOX` fixture, `make_stubs`) moves verbatim into a new `tests/stack/lib.sh` (76 lines, matching `tests/integration/lib.sh`'s existing convention); `run.sh` sources it near the top. Nothing else moves — individual test groups are later modules, each its own paired PR.

run.sh drops 8381 → 8319 lines; `docs/dev/file-budget.tsv`'s ceiling follows (the ratchet only allows shrinking). `Makefile`'s `lint-sh` now also shellchecks the new lib (run.sh itself stays excluded, #1206).

**Byte-identical execution — proven independently, twice.** The full develop-lane suite runs identically before and after: **1836 passed, 0 failed** on both, with an identical ordered 1996-line sequence of section headers and test verdicts. (1836 is the develop-lane count; the ~2862 seen elsewhere this program is develop-v2's larger appliance suite.) The agent's own before/after (real git worktrees) matched; the coordinating session then re-ran an INDEPENDENT clean before (origin/develop @ a real `git worktree`) and after (this branch) — both 1836/0. A first proof attempt via `git archive` into non-git scratch dirs gave a false 3-failure diff because release-smoke #1068 needs a real `.git` at `$ROOT` — a verification-methodology flaw, corrected, not a regression.

No mutation applies — a pure code move has nothing new to fail; the byte-identical suite proof is the verification.

**Follow-ups**: the paired develop-v2 PR (same boundary) lands next; CI wiring for the file-budget lint is still owed a workflow-scoped push (with #1228). The agent produced a proposed ~22-module boundary map for the rest of Phase 1 — posted as a review comment for the operator to re-cut along whatever functional lines (all-doctor / all-control-channel / all-release) they'd rather review by, since the first pass is size-greedy section adjacency.

Part of #1105 (Phase 1, module 1 of ~22).
