### PR TITLE
test(control): extend the never-committable perimeter to node endpoints and binds (#1069 W9)

### DIFF
--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -428,13 +428,22 @@ def test_confirm_keys_have_no_intra_repo_drift():
     assert set(control_service.CONFIRM_ENV_KEY_PATHS.keys()) == pithead_keys
 
 
-# The security perimeter (#1094): env keys that must never be dashboard-committable at all — auth,
-# onion exposure, the bind/host, the control channel itself, Tor egress, and wallet/node
-# credentials. The two drift tests above only catch the editable/confirm allowlists' two hand-kept
-# copies disagreeing with EACH OTHER; a key added to BOTH copies at once (#1094's mutation proof:
-# DASHBOARD_AUTH_HASH_B64, or DASHBOARD_HOST, added to pithead's list and EDITABLE_ENV_KEY_PATHS
-# together) leaves them in perfect agreement and both drift tests stay green. This list is the
-# claim those tests can't make: not "do the two copies match" but "is this key committable at all".
+# The security perimeter (#1094, #1069 W9): env keys that must never be dashboard-committable at
+# all. SECURITY.md:99-100 is the authority for what belongs here — "wallets and view keys,
+# dashboard auth and onion exposure, the control channel itself, the Tor egress firewall, node
+# endpoints, binds, every credential, and the per-rig hosts and tokens" (the last category is
+# enforced elsewhere: worker descriptors are refused outright, per control_service.py's
+# EDITABLE_ENV_KEY_PATHS docstring, so they never reach this env-key-path list at all). The two
+# drift tests above only catch the editable/confirm allowlists' two hand-kept copies disagreeing
+# with EACH OTHER; a key added to BOTH copies at once (#1094's mutation proof: DASHBOARD_AUTH_HASH_B64,
+# or DASHBOARD_HOST, added to pithead's list and EDITABLE_ENV_KEY_PATHS together) leaves them in
+# perfect agreement and both drift tests stay green. This list is the claim those tests can't make:
+# not "do the two copies match" but "is this key committable at all".
+#
+# THIS LIST AND SECURITY.md:99-100 MUST STAY IN SYNC: a perimeter category added to the doc without
+# a matching entry here is a silent gap; an entry here with no textual basis in SECURITY.md is
+# scope creep on a security-critical list. SECURITY.md's enumeration is prose, not a machine-
+# readable key list, so the sync is manual — re-read both on any change to either.
 NEVER_COMMITTABLE_ENV_KEYS = frozenset(
     {
         "DASHBOARD_AUTH_USER",
@@ -452,16 +461,27 @@ NEVER_COMMITTABLE_ENV_KEYS = frozenset(
         "MONERO_NODE_PASSWORD",
         "WALLET_RPC_PASSWORD",
         "TARI_VIEW_KEY",
+        # Node endpoints (SECURITY.md's "node endpoints"): where the stack points its Monero/Tari
+        # RPC clients. Dashboard-committable, this repoints mining traffic to an attacker's node.
+        "MONERO_NODE_HOST",
+        "MONERO_RPC_PORT",
+        "MONERO_ZMQ_PORT",
+        "TARI_GRPC_ADDRESS",
+        # Binds (SECURITY.md's "binds"): the RPC/gRPC listen addresses. DASHBOARD_HOST (above)
+        # covers the dashboard's own bind; these are the merge-mined services' local listeners.
+        "MONERO_RPC_BIND",
+        "MONERO_ZMQ_BIND",
+        "TARI_GRPC_BIND",
         "TARI_WALLET_PASSWORD",
     }
 )
 
 
 def test_perimeter_env_keys_never_committable_from_either_copy():
-    """#1094: names the security perimeter directly and checks each of the four allowlists (pithead's
-    editable + confirm sets, EDITABLE_ENV_KEY_PATHS + CONFIRM_ENV_KEY_PATHS) against it
-    independently, so a key added to every copy at once still fails — unlike the drift tests above,
-    which compare the copies only to each other."""
+    """#1094 / #1069 W9: names the security perimeter directly (SECURITY.md:99-100) and checks each
+    of the four allowlists (pithead's editable + confirm sets, EDITABLE_ENV_KEY_PATHS +
+    CONFIRM_ENV_KEY_PATHS) against it independently, so a key added to every copy at once still
+    fails — unlike the drift tests above, which compare the copies only to each other."""
     import re
     from pathlib import Path
 


### PR DESCRIPTION
Extends the control-channel security-perimeter test to two categories SECURITY.md:99-100 names but the existing list (from #1094 / PR #1186) did not cover: **node endpoints** and **binds**.

#1069's W9 — "the editable-key perimeter drift guard compares two copies, so a key added to both is invisible" — was already closed by #1186, which added `NEVER_COMMITTABLE_ENV_KEYS` and `test_perimeter_env_keys_never_committable_from_either_copy` (each editable allowlist checked against an explicit perimeter list, independently). This test-only PR fills the remaining gap in that list: `MONERO_NODE_HOST`, `MONERO_RPC_PORT`, `MONERO_ZMQ_PORT`, `TARI_GRPC_ADDRESS` (node endpoints — repointing these would send mining traffic to an attacker's node) and `MONERO_RPC_BIND`, `MONERO_ZMQ_BIND`, `TARI_GRPC_BIND` (binds). All seven are real rendered env keys, correctly host-only today; none was in any editable allowlist, but none had a perimeter guard either — a future PR could add one to both copies and every existing test would stay green. The list's comment now cites SECURITY.md:99-100 and notes the prose↔constant sync is manual.

**Security-reviewed (fresh context, PASS, zero blocking findings).** The load-bearing question — are any of these ever legitimately dashboard-committable? — was answered from the code: `control_approval_gate`'s default-deny regex (the actual dashboard commit authority) never admits them; remote-node values are set only via the setup wizard / host-CLI, never the control channel (matching #103's trusted-network-only decision); `describe_change`'s cases for these keys are host-CLI preview text, not a commit path. So the never-committable invariant is correct, not over-broad. One note: the SECURITY.md↔constant sync is manual (self-documented, no action).

**Mutations, run and named** (author + independent security-review re-run): adding `MONERO_NODE_HOST` (a node-endpoint key) to BOTH editable copies turns the new perimeter assertion RED while the pre-existing intra-repo drift guard stays GREEN — the exact blind spot; a second mutation with `DASHBOARD_AUTH_HASH_B64` (auth/credential) proves it's not hardcoded to one key. Reverted, 38/38 green. `ruff check`/`format --check` clean. No product code changed.

Part of #1069 (W9's remaining coverage). Base develop-v2; a develop-lane pairing follows if the perimeter constant lives there too.
