### PR TITLE
test(control): perimeter node-endpoint + bind keys on develop (#1069 W9 pairing)

### DIFF
--- a/build/dashboard/tests/service/test_control_service.py
+++ b/build/dashboard/tests/service/test_control_service.py
@@ -411,16 +411,27 @@ NEVER_COMMITTABLE_ENV_KEYS = frozenset(
         "MONERO_NODE_PASSWORD",
         "WALLET_RPC_PASSWORD",
         "TARI_VIEW_KEY",
+        # Node endpoints (SECURITY.md's "node endpoints"): where the stack points its Monero/Tari
+        # RPC clients. Dashboard-committable, this repoints mining traffic to an attacker's node.
+        "MONERO_NODE_HOST",
+        "MONERO_RPC_PORT",
+        "MONERO_ZMQ_PORT",
+        "TARI_GRPC_ADDRESS",
+        # Binds (SECURITY.md's "binds"): the RPC/gRPC listen addresses. DASHBOARD_HOST (above)
+        # covers the dashboard's own bind; these are the merge-mined services' local listeners.
+        "MONERO_RPC_BIND",
+        "MONERO_ZMQ_BIND",
+        "TARI_GRPC_BIND",
         "TARI_WALLET_PASSWORD",
     }
 )
 
 
 def test_perimeter_env_keys_never_committable_from_either_copy():
-    """#1094: names the security perimeter directly and checks each of the four allowlists (pithead's
-    editable + confirm sets, EDITABLE_ENV_KEY_PATHS + CONFIRM_ENV_KEY_PATHS) against it
-    independently, so a key added to every copy at once still fails — unlike the drift tests above,
-    which compare the copies only to each other."""
+    """#1094 / #1069 W9: names the security perimeter directly (SECURITY.md:99-100) and checks each
+    of the four allowlists (pithead's editable + confirm sets, EDITABLE_ENV_KEY_PATHS +
+    CONFIRM_ENV_KEY_PATHS) against it independently, so a key added to every copy at once still
+    fails — unlike the drift tests above, which compare the copies only to each other."""
     import re
     from pathlib import Path
 


### PR DESCRIPTION
Develop-lane pairing of PR #1254 (merged to develop-v2). The control-channel security perimeter (`NEVER_COMMITTABLE_ENV_KEYS`, from #1094) lives on BOTH lanes — this test guards core control-channel behaviour, not appliance-specific behaviour — so develop must carry the same node-endpoint + bind additions or the lanes diverge on a security invariant.

Adds the same seven anchored keys with the same SECURITY.md:99-100 citation: `MONERO_NODE_HOST`, `MONERO_RPC_PORT`, `MONERO_ZMQ_PORT`, `TARI_GRPC_ADDRESS` (node endpoints) and `MONERO_RPC_BIND`, `MONERO_ZMQ_BIND`, `TARI_GRPC_BIND` (binds). Byte-identical additions to #1254's; the key set now matches develop-v2's exactly (diffed).

The load-bearing invariant — none of these is dashboard-committable in any mode (remote-node values are wizard/host-CLI only, #103 trusted-network-only) — was established by #1254's fresh-context security review; the test logic here is unchanged, only the perimeter data grew. Targeted `pytest tests/service/test_control_service.py` green; ruff check clean. Test-only.

Part of #1069 (W9), keeping the twins level.
