### PR TITLE
docs(contributing): name the legal growth path for a budgeted file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,13 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      comment), `lint-file-budget` (the file-budget ratchet, issue #1105 Phase 0 — a new tracked
      file has a hard ceiling of 800 lines, target 400; an existing offender's current line count
      is its personal ceiling in `docs/dev/file-budget.tsv`, and a PR may not grow it past that —
-     ceilings only ever move down, and the gate rejects a budget edit that raises one. Generated
+     ceilings only ever move down, and the gate rejects a budget edit that raises one. A
+     deliberate, justified addition to a budgeted file therefore has exactly one legal path:
+     split or shrink the file so the addition fits under a ceiling that stays put or drops —
+     see issue #1258 for the worked example, where a security test that outgrew its file moved
+     into its own — and note the gate runs locally and in `make lint` but is not yet wired into
+     CI (issue #1257), so two same-wave merges can each pass alone and fail together: re-run
+     `make lint` after merging onto the tip. Generated
      code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
      the script — and so is the shipped `pithead` artifact itself, for now: its future `lib/*.sh`
      sources are what the gate will govern once Phase 2 splits it), `lint-proto` (buf),


### PR DESCRIPTION
Closes the CONTRIBUTING half of #1258 (the CI-wiring half stays with #1257).

The ratchet's rules say ceilings only move down; what a justified addition to a budgeted file should do instead was written nowhere, and the incident showed a second unstated fact: the gate enforces locally (`make lint`) but not yet in CI, so two same-wave merges can each pass alone and fail together on the tip. Both facts are now in the `lint-file-budget` entry, with #1258 as the worked example.

**What was RUN:** `make lint-md` and `make lint-docs-voice` clean; topology scan clean. Doc-only change.

develop-v2 pair follows (same wording; that lane's CONTRIBUTING carries the same entry).
