### PR TITLE
test(stack): hoist the cross-domain shared fixtures into lib.sh (#1105 Phase 1, module 1b)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -37,5 +37,5 @@ tests/integration/e2e.sh	766
 tests/integration/lib.sh	677
 tests/integration/run.sh	2551
 tests/integration/selftest.sh	658
-tests/stack/run.sh	8319
+tests/stack/run.sh	8219
 tests/stack/test_compose.sh	454

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -126,15 +126,15 @@ file_uid() { stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null; }
 # $WALLET. Body is the verbatim block run.sh built inline (indentation left untouched so the
 # seed_env heredoc keeps its column-0 terminator).
 build_val_sandbox() {
-V="$SANDBOX/val"
-mkdir -p "$V/build/tari" "$V/build/dashboard"
-: >"$V/build/dashboard/Dockerfile"
-cp "$STACK" "$V/pithead"
-make_stubs "$V/bin"
-cp "$ROOT/build/tari/config.toml.template" "$V/build/tari/"
-mkdir -p "$V/data/monero" "$V/data/tari" "$V/data/p2pool" "$V/data/tor" "$V/data/dashboard" "$V/data/p2pool/stats"
-seed_env() {
-    cat >"$V/.env" <<EOF
+    V="$SANDBOX/val"
+    mkdir -p "$V/build/tari" "$V/build/dashboard"
+    : >"$V/build/dashboard/Dockerfile"
+    cp "$STACK" "$V/pithead"
+    make_stubs "$V/bin"
+    cp "$ROOT/build/tari/config.toml.template" "$V/build/tari/"
+    mkdir -p "$V/data/monero" "$V/data/tari" "$V/data/p2pool" "$V/data/tor" "$V/data/dashboard" "$V/data/p2pool/stats"
+    seed_env() {
+        cat >"$V/.env" <<EOF
 MONERO_ONION_ADDRESS=mona.onion
 TARI_ONION_ADDRESS=taria.onion
 P2POOL_ONION_ADDRESS=p2pa.onion
@@ -143,27 +143,27 @@ HOST_IP=box.lan
 DEPLOYMENT_COMPLETED=true
 COMPOSE_PROFILES=local_node
 EOF
-}
-WALLET="4$(printf 'A%.0s' $(seq 94))" # 95-char mainnet primary (starts with 4); #250 now hard-validates this
+    }
+    WALLET="4$(printf 'A%.0s' $(seq 94))" # 95-char mainnet primary (starts with 4); #250 now hard-validates this
 }
 
 # The control-channel sandbox: builds $C, defines CTRL_LOG, seed_control_env, control_config.
 build_control_sandbox() {
-C="$SANDBOX/control"
-mkdir -p "$C/build/tari" "$C/build/dashboard" \
-    "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"
-: >"$C/build/dashboard/Dockerfile"
-cp "$STACK" "$C/pithead"
-# The control gate reads config.reference.json (the closed schema) from beside the script; it ships
-# in the bundle + checkout root, so mirror it into the sandbox.
-cp "$ROOT/config.reference.json" "$C/config.reference.json"
-make_stubs "$C/bin"
-cp "$ROOT/build/tari/config.toml.template" "$C/build/tari/"
-# The password hash step reads the pinned Caddy image out of docker-compose.yml (#8).
-cp "$ROOT/docker-compose.yml" "$C/docker-compose.yml"
-CTRL_LOG="$C/docker.log"
-seed_control_env() {
-    cat >"$C/.env" <<EOF
+    C="$SANDBOX/control"
+    mkdir -p "$C/build/tari" "$C/build/dashboard" \
+        "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"
+    : >"$C/build/dashboard/Dockerfile"
+    cp "$STACK" "$C/pithead"
+    # The control gate reads config.reference.json (the closed schema) from beside the script; it ships
+    # in the bundle + checkout root, so mirror it into the sandbox.
+    cp "$ROOT/config.reference.json" "$C/config.reference.json"
+    make_stubs "$C/bin"
+    cp "$ROOT/build/tari/config.toml.template" "$C/build/tari/"
+    # The password hash step reads the pinned Caddy image out of docker-compose.yml (#8).
+    cp "$ROOT/docker-compose.yml" "$C/docker-compose.yml"
+    CTRL_LOG="$C/docker.log"
+    seed_control_env() {
+        cat >"$C/.env" <<EOF
 MONERO_ONION_ADDRESS=mona.onion
 TARI_ONION_ADDRESS=taria.onion
 P2POOL_ONION_ADDRESS=p2pa.onion
@@ -172,14 +172,14 @@ HOST_IP=box.lan
 DEPLOYMENT_COMPLETED=true
 COMPOSE_PROFILES=local_node
 EOF
-}
-control_config() { # <pool> [extra dashboard keys...] -> writes $C/config.json
-    printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"},
+    }
+    control_config() { # <pool> [extra dashboard keys...] -> writes $C/config.json
+        printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"},
               "tari":{"wallet_address":"T"}, "p2pool":{"pool":"%s"},
               "dashboard":{"secure":true,"host":"box.lan",
                            "auth":{"username":"admin","password":"a control passphrase"},
                            "control":{"enabled":true}} }\n' "$WALLET" "$1" >"$C/config.json"
-}
+    }
 }
 
 run_pending() { (cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead control-run-pending 2>&1); }

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -74,3 +74,121 @@ EOF
     printf '#!/usr/bin/env bash\nexit 0\n' >"$bin/sudo"
     chmod +x "$bin/docker" "$bin/sudo"
 }
+
+# --- shared test fixtures hoisted from run.sh (#1105 Phase 1, module 1b), verbatim ---------
+# Order-of-two-ops extractor for the firewall-before-compose regressions (#291).
+fw_then_compose() { printf '%s\n' "$1" | grep -xE 'firewall|compose' | tr '\n' ','; }
+
+write_fake_docker() { # <bin-dir> — the containerized verifier's stand-in (#1072)
+    mkdir -p "$1"
+    cat >"$1/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+info | pull) exit 0 ;;
+image) exit 0 ;; # `image inspect` -> pinned verifier already local, nothing pulled
+run)
+    shift
+    # Drop the run flags up to and including the pinned verifier image; what remains is the cosign
+    # argv the caller actually asked for.
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+        *sigstore/cosign*)
+            shift
+            break
+            ;;
+        *) shift ;;
+        esac
+    done
+    echo "[cosign] $*" >>"${COSIGN_LOG:-/dev/null}"
+    exit "${COSIGN_RC:-0}"
+    ;;
+esac
+exit 0
+EOF
+    chmod +x "$1/docker"
+}
+write_unreachable_docker() { # <bin-dir> — docker present, daemon down: the "cannot verify" branch.
+    # Probing the daemon rather than unsetting PATH keeps this deterministic on hosts that ship
+    # /usr/bin/docker, which the pinned PATHs below deliberately still expose.
+    mkdir -p "$1"
+    printf '#!/usr/bin/env bash\n[ "$1" = "info" ] && exit 1\nexit 0\n' >"$1/docker"
+    chmod +x "$1/docker"
+}
+
+# config.json, proving the mode at creation, not just the end state.
+# GNU form first: `stat -c` errors cleanly on BSD/macOS, so the `||` fallback fires there. The
+# reverse order is wrong — on Linux `stat -f` is a VALID flag (filesystem status) that succeeds
+# with the wrong output, so the fallback never runs and CI (Linux) reads garbage.
+file_mode() { stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null; }
+file_uid() { stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null; }
+
+# The config-validation/black-box sandbox: builds $V, defines seed_env and the reference
+# $WALLET. Body is the verbatim block run.sh built inline (indentation left untouched so the
+# seed_env heredoc keeps its column-0 terminator).
+build_val_sandbox() {
+V="$SANDBOX/val"
+mkdir -p "$V/build/tari" "$V/build/dashboard"
+: >"$V/build/dashboard/Dockerfile"
+cp "$STACK" "$V/pithead"
+make_stubs "$V/bin"
+cp "$ROOT/build/tari/config.toml.template" "$V/build/tari/"
+mkdir -p "$V/data/monero" "$V/data/tari" "$V/data/p2pool" "$V/data/tor" "$V/data/dashboard" "$V/data/p2pool/stats"
+seed_env() {
+    cat >"$V/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=ORIGINALTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+}
+WALLET="4$(printf 'A%.0s' $(seq 94))" # 95-char mainnet primary (starts with 4); #250 now hard-validates this
+}
+
+# The control-channel sandbox: builds $C, defines CTRL_LOG, seed_control_env, control_config.
+build_control_sandbox() {
+C="$SANDBOX/control"
+mkdir -p "$C/build/tari" "$C/build/dashboard" \
+    "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"
+: >"$C/build/dashboard/Dockerfile"
+cp "$STACK" "$C/pithead"
+# The control gate reads config.reference.json (the closed schema) from beside the script; it ships
+# in the bundle + checkout root, so mirror it into the sandbox.
+cp "$ROOT/config.reference.json" "$C/config.reference.json"
+make_stubs "$C/bin"
+cp "$ROOT/build/tari/config.toml.template" "$C/build/tari/"
+# The password hash step reads the pinned Caddy image out of docker-compose.yml (#8).
+cp "$ROOT/docker-compose.yml" "$C/docker-compose.yml"
+CTRL_LOG="$C/docker.log"
+seed_control_env() {
+    cat >"$C/.env" <<EOF
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=ORIGINALTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+EOF
+}
+control_config() { # <pool> [extra dashboard keys...] -> writes $C/config.json
+    printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"},
+              "tari":{"wallet_address":"T"}, "p2pool":{"pool":"%s"},
+              "dashboard":{"secure":true,"host":"box.lan",
+                           "auth":{"username":"admin","password":"a control passphrase"},
+                           "control":{"enabled":true}} }\n' "$WALLET" "$1" >"$C/config.json"
+}
+}
+
+run_pending() { (cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead control-run-pending 2>&1); }
+
+# A small helper so tests can drive the whole Q&A -> write in one sourced call, sharing the globals
+# wizard_ask_core/wizard_ask_shape set with wizard_write_config (each function's locals don't
+# survive a return, so they must run in the same invocation).
+run_wizard() {
+    wizard_ask_core
+    wizard_ask_shape
+    wizard_write_config
+}

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -711,7 +711,6 @@ echo "== regression: every command installs the Tor-egress firewall BEFORE compo
 # Each case neutralises the command's preamble and records the order of the two load-bearing ops; the
 # firewall sentinel MUST precede the compose sentinel. fw_then_compose() extracts just those two from
 # whatever else the function prints (warnings, banners) so the assert is exact.
-fw_then_compose() { printf '%s\n' "$1" | grep -xE 'firewall|compose' | tr '\n' ','; }
 
 # up: the reference path #276 fixed — pin it too so a future reorder of stack_up is caught here.
 up_order=$(
@@ -889,41 +888,6 @@ echo "== black-box: verify_release_images fail-closed gate (#376) =="
 # pinned image is already present, and logs the cosign argv that follows the image ref — which keeps
 # every assertion below reading exactly as it did when cosign was a host binary. A release install
 # is a dir without build/dashboard/Dockerfile.
-write_fake_docker() { # <bin-dir> — the containerized verifier's stand-in (#1072)
-    mkdir -p "$1"
-    cat >"$1/docker" <<'EOF'
-#!/usr/bin/env bash
-case "$1" in
-info | pull) exit 0 ;;
-image) exit 0 ;; # `image inspect` -> pinned verifier already local, nothing pulled
-run)
-    shift
-    # Drop the run flags up to and including the pinned verifier image; what remains is the cosign
-    # argv the caller actually asked for.
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-        *sigstore/cosign*)
-            shift
-            break
-            ;;
-        *) shift ;;
-        esac
-    done
-    echo "[cosign] $*" >>"${COSIGN_LOG:-/dev/null}"
-    exit "${COSIGN_RC:-0}"
-    ;;
-esac
-exit 0
-EOF
-    chmod +x "$1/docker"
-}
-write_unreachable_docker() { # <bin-dir> — docker present, daemon down: the "cannot verify" branch.
-    # Probing the daemon rather than unsetting PATH keeps this deterministic on hosts that ship
-    # /usr/bin/docker, which the pinned PATHs below deliberately still expose.
-    mkdir -p "$1"
-    printf '#!/usr/bin/env bash\n[ "$1" = "info" ] && exit 1\nexit 0\n' >"$1/docker"
-    chmod +x "$1/docker"
-}
 VRI="$SANDBOX/verify376"
 write_fake_docker "$VRI/bin"
 write_unreachable_docker "$VRI/nodocker"
@@ -3201,25 +3165,7 @@ assert_rc "apply without .env fails" "$rc" "1"
 assert_contains "apply needs setup" "$out" "setup"
 
 echo "== black-box: config validation =="
-V="$SANDBOX/val"
-mkdir -p "$V/build/tari" "$V/build/dashboard"
-: >"$V/build/dashboard/Dockerfile"
-cp "$STACK" "$V/pithead"
-make_stubs "$V/bin"
-cp "$ROOT/build/tari/config.toml.template" "$V/build/tari/"
-mkdir -p "$V/data/monero" "$V/data/tari" "$V/data/p2pool" "$V/data/tor" "$V/data/dashboard" "$V/data/p2pool/stats"
-seed_env() {
-    cat >"$V/.env" <<EOF
-MONERO_ONION_ADDRESS=mona.onion
-TARI_ONION_ADDRESS=taria.onion
-P2POOL_ONION_ADDRESS=p2pa.onion
-PROXY_AUTH_TOKEN=ORIGINALTOKEN
-HOST_IP=box.lan
-DEPLOYMENT_COMPLETED=true
-COMPOSE_PROFILES=local_node
-EOF
-}
-WALLET="4$(printf 'A%.0s' $(seq 94))" # 95-char mainnet primary (starts with 4); #250 now hard-validates this
+build_val_sandbox
 seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"T"}, "p2pool":{"pool":"banana"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
@@ -4204,12 +4150,6 @@ echo "== unit+black-box: secret files are owner-only from creation (#368) =="
 # The subshell umask must make the secret-bearing files 600 from the FIRST byte — a chmod after
 # the write leaves a world-readable window on a shared host, and a silently failed chmod used to
 # leave them 644 forever. The mv shim captures the credential temp file's mode BEFORE it lands on
-# config.json, proving the mode at creation, not just the end state.
-# GNU form first: `stat -c` errors cleanly on BSD/macOS, so the `||` fallback fires there. The
-# reverse order is wrong — on Linux `stat -f` is a VALID flag (filesystem status) that succeeds
-# with the wrong output, so the fallback never runs and CI (Linux) reads garbage.
-file_mode() { stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1" 2>/dev/null; }
-file_uid() { stat -c %u "$1" 2>/dev/null || stat -f %u "$1" 2>/dev/null; }
 PB="$SANDBOX/perm368"
 mkdir -p "$PB/bin"
 printf '{ "monero": {} }\n' >"$PB/config.json"
@@ -5350,37 +5290,7 @@ echo "== black-box: dashboard control channel (#33) =="
 # A deployed sandbox with the control channel on: config carries a dashboard password (required)
 # and dashboard.control.enabled, docker/sudo stubbed. The runner is exercised end-to-end against
 # real spool files; `apply` inside it runs this same sandboxed pithead.
-C="$SANDBOX/control"
-mkdir -p "$C/build/tari" "$C/build/dashboard" \
-    "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"
-: >"$C/build/dashboard/Dockerfile"
-cp "$STACK" "$C/pithead"
-# The control gate reads config.reference.json (the closed schema) from beside the script; it ships
-# in the bundle + checkout root, so mirror it into the sandbox.
-cp "$ROOT/config.reference.json" "$C/config.reference.json"
-make_stubs "$C/bin"
-cp "$ROOT/build/tari/config.toml.template" "$C/build/tari/"
-# The password hash step reads the pinned Caddy image out of docker-compose.yml (#8).
-cp "$ROOT/docker-compose.yml" "$C/docker-compose.yml"
-CTRL_LOG="$C/docker.log"
-seed_control_env() {
-    cat >"$C/.env" <<EOF
-MONERO_ONION_ADDRESS=mona.onion
-TARI_ONION_ADDRESS=taria.onion
-P2POOL_ONION_ADDRESS=p2pa.onion
-PROXY_AUTH_TOKEN=ORIGINALTOKEN
-HOST_IP=box.lan
-DEPLOYMENT_COMPLETED=true
-COMPOSE_PROFILES=local_node
-EOF
-}
-control_config() { # <pool> [extra dashboard keys...] -> writes $C/config.json
-    printf '{ "monero":{"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"},
-              "tari":{"wallet_address":"T"}, "p2pool":{"pool":"%s"},
-              "dashboard":{"secure":true,"host":"box.lan",
-                           "auth":{"username":"admin","password":"a control passphrase"},
-                           "control":{"enabled":true}} }\n' "$WALLET" "$1" >"$C/config.json"
-}
+build_control_sandbox
 
 # Fail-closed: enabling the control channel without a dashboard password must not validate.
 seed_control_env
@@ -5500,7 +5410,6 @@ REQS="$C/data/control/requests"
 RESULTS="$C/data/control/results"
 STAGED="$C/data/control/staged"
 AUDIT="$C/data/control/audit/control.log"
-run_pending() { (cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead control-run-pending 2>&1); }
 
 # Preview: a valid typed intent (pool main -> mini) → previewed result + a host-side staged copy.
 jq -n --arg w "$WALLET" --arg id "$UUID1" '{id:$id, action:"preview", actor:"admin", config:{
@@ -7899,15 +7808,6 @@ core_reads=$(awk '/^wizard_ask_core\(\) \{/,/^\}/' "$STACK" | grep -c '^\s*read 
 shape_reads=$(awk '/^wizard_ask_shape\(\) \{/,/^\}/' "$STACK" | grep -c '^\s*read -r')
 assert_eq "wizard_ask_core has exactly 12 read prompts (wallets, node config, pool tier, dashboard login)" "$core_reads" "12"
 assert_eq "wizard_ask_shape has exactly 6 read prompts (clearnet-sync, remote-access, alerts cluster, local-miner opt-in)" "$shape_reads" "6"
-
-# A small helper so tests can drive the whole Q&A -> write in one sourced call, sharing the globals
-# wizard_ask_core/wizard_ask_shape set with wizard_write_config (each function's locals don't
-# survive a return, so they must run in the same invocation).
-run_wizard() {
-    wizard_ask_core
-    wizard_ask_shape
-    wizard_write_config
-}
 
 echo "== unit: wizard — Enter-through defaults skip everything but the core answers (#502) =="
 # Local node, every optional prompt left blank. Proves two things at once: the core answers land


### PR DESCRIPTION
Module 1b of #1105 Phase 1 (develop lane; the develop-v2 pair follows) — the fixture hoist the coupling scan on #1252's domain map called for, landed before any domain cut so no cut ever depends on run.sh's internal ordering.

What moves into `tests/stack/lib.sh`, verbatim: `fw_then_compose`, `write_fake_docker`/`write_unreachable_docker`, `file_mode`/`file_uid` (with their GNU-vs-BSD rationale comment), `run_pending`, `run_wizard`, and the two shared sandbox builds — the `$V` (config-validation/black-box) and `$C` (control-channel) blocks — which become `build_val_sandbox`/`build_control_sandbox` with the block bodies unchanged. The only lines that are not a verbatim move are the two function-wrapper declarations and their two call sites in `run.sh`. `run.sh` 8319 → 8219; the budget ceiling follows.

**What was RUN (real git worktrees):**
- Before, at the develop tip: full `tests/stack/run.sh` — **1836 passed, 0 failed**.
- After, on this branch: **1836 passed, 0 failed**.
- Logs line-for-line identical after normalizing ANSI + worktree path + mktemp names; the interleaved bash `readonly variable` warnings shift line number only. Execution order is unchanged by this module, so this is the strict ordered-sequence identity.
- `scripts/lint-file-budget.sh` OK; `shellcheck --severity=warning` clean on the grown lib.
- No mutation applies — pure move plus two wrappers; the identical-suite proof is the verification.
