### PR TITLE
fix(os-harness): the ~60% os-update death was the probe loops' 20s SSH ceiling leaking into the whole phase (#1060)

### DIFF
--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Failure evidence for the battery's os-update leg (#1060). Sourced by tests/os/run.sh; uses
+# its globals (_ssh, SSH_ERR, SERIAL) and prints in its indentation idiom.
+#
+# The ~60% mid-copy death survived four batteries because the evidence of WHO killed the
+# command was discarded at three separate layers: the assertion printed a truncated tail and
+# no exit status; _ssh's client stderr went to a scratch file nothing printed; and the serial
+# console was truncated by the next VM boot before cleanup()'s end-of-phase copy ran. This
+# captures all of it at the moment of failure, from both ends of the transport.
+
+# osupdate_failure_evidence <rc> <full-cli-output>
+# rc 124 is timeout(1)'s kill — the harness's own per-call ceiling, not the guest; rc 255 is
+# ssh transport death. Both look identical in the remote output, which simply stops.
+osupdate_failure_evidence() {
+    printf '     os-update rc=%s (124 = harness timeout kill, 255 = ssh transport death)\n' "$1"
+    printf '     ssh client stderr: %s\n' "$(tr -d '\r' <"$SSH_ERR" 2>/dev/null | tail -3 | tr '\n' ';')"
+    printf '     os-update output:\n'
+    printf '%s\n' "$2" | sed 's/^/     | /'
+    # The console NOW, not at phase end: later boots truncate $SERIAL, which is how every
+    # prior occurrence left no console evidence. cleanup() will not clobber this copy.
+    cp -f "$SERIAL" "$SERIAL.failed" 2>/dev/null || true
+    # The guest's own account, captured before the guest is recycled: the kernel's word on
+    # kills, rauc's own journal, and the memory/writeback picture — the CLI output cannot
+    # distinguish a killed command from a failed one, these can.
+    printf '     --- guest evidence (#1060) ---\n'
+    _ssh "journalctl -k --no-pager 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process' | tail -5
+          echo '-- rauc unit --'; journalctl -u rauc --no-pager -n 8 2>/dev/null
+          echo '-- memory --'; free -m | head -2
+          grep -E 'MemAvailable|HugePages_Total|^Dirty|^Writeback:' /proc/meminfo" 2>/dev/null |
+        tr -d '\r' | sed 's/^/     · /'
+}

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -2062,9 +2062,9 @@ phase_provision() {
     fi
     ok "config validated and installed by the host"
 
-    local deadline=$(($(date +%s) + 1500)) names="" SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
+    local deadline=$(($(date +%s) + 1500)) names=""
     while [ "$(date +%s)" -lt "$deadline" ]; do
-        names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
+        names=$(SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" _ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
         case "$names" in
         *dashboard*caddy* | *caddy*dashboard*) break ;;
         esac
@@ -2601,9 +2601,9 @@ phase_media() {
         bad "the ESP pre-seed never reached the running system — nothing to change from here"
         return
     fi
-    local deadline=$(($(date +%s) + 1500)) names="" SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
+    local deadline=$(($(date +%s) + 1500)) names=""
     while [ "$(date +%s)" -lt "$deadline" ]; do
-        names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
+        names=$(SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" _ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
         case "$names" in *dashboard*caddy* | *caddy*dashboard*) break ;; esac
         sleep 15
     done
@@ -3219,10 +3219,9 @@ phase_reset() {
     fi
     ok "provisioned: config installed by the host"
 
-    local SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" # scoped: later calls in this phase run long
     names="" deadline=$(($(date +%s) + 1500))
     while [ "$(date +%s)" -lt "$deadline" ]; do
-        names=$(_ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
+        names=$(SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" _ssh "podman ps --format '{{.Names}}'" 2>/dev/null | tr '\n' ' ')
         case "$names" in
         *dashboard*caddy* | *caddy*dashboard*) break ;;
         esac

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -45,6 +45,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=tests/os/hugepages-boot-verdict.sh
 . "$SCRIPT_DIR/hugepages-boot-verdict.sh"
+# shellcheck source=tests/os/failure-evidence.sh
+. "$SCRIPT_DIR/failure-evidence.sh"
 # shellcheck source=tests/os/restore-live-state-verdict.sh
 . "$SCRIPT_DIR/restore-live-state-verdict.sh"
 # shellcheck source=tests/os/reinstall-prefill-verdict.sh
@@ -102,6 +104,9 @@ ip=""
 # LAST attempt's error text, so a caller that just gave up can classify why without another round
 # trip. See _ssh_unreachable_reason.
 SSH_ERR="/tmp/pithead-os-ssh.err"
+# A fresh run must not inherit the last run's preserved console: the cleanup copy below is
+# no-clobber (the at-assertion copy is the authoritative one), so clear the slate here.
+rm -f "$SERIAL.failed"
 
 # The wallet every phase submits. It must be checksum-VALID: p2pool refuses a well-formed but
 # checksum-invalid address at startup with a SIGABRT and crash-loops (#829), which killed the
@@ -392,7 +397,9 @@ vm_destroy() {
 cleanup() {
     # Preserve the console on failure. It is deleted with everything else on a green run, which
     # meant the one artefact that explains a boot failure was destroyed by the failure itself.
-    if [ "$FAIL" -gt 0 ] && [ -s "$SERIAL" ]; then
+    if [ "$FAIL" -gt 0 ] && [ -s "$SERIAL" ] && [ ! -f "$SERIAL.failed" ]; then
+        # No-clobber: an assertion that copied the console AT the failure got it before later
+        # boots truncated $SERIAL — this end-of-phase copy would replace it with the wrong boot.
         cp "$SERIAL" "$SERIAL.failed" 2>/dev/null &&
             info "console from the failed run kept at $SERIAL.failed"
     fi
@@ -2429,22 +2436,11 @@ phase_provision() {
     # os-update is the path that writes the pending marker (a bare rauc install does not) — and
     # this is also the first tier-4 exercise of os-update against a REAL bundle: it needs
     # unsquashfs on the appliance to read the manifest back, which CI's stubbed rauc never shows.
-    local ou_out
-    if ! ou_out=$(_ssh "cd /data/pithead && ./pithead os-update /data/update.bundle --yes 2>&1"); then
-        printf '     os-update output: %s\n' "$(printf '%s' "$ou_out" | tail -8)"
-        # Capture the guest's own account BEFORE the assertion, because the guest is recycled
-        # moments later and this failure has outlived three batteries without anyone seeing it
-        # (#1060). It stops dead partway through "Copying image to rootfs.1" with no rauc error,
-        # which is the signature of a KILLED command rather than a failed one — so the kernel log
-        # and the memory picture are the evidence, not the CLI output. This leg runs after
-        # provisioning, so hugepages are already carved out of the guest's RAM before a multi-GB
-        # slot copy starts, which is the standing hypothesis this is here to confirm or kill.
-        printf '     --- guest evidence (#1060) ---\n'
-        _ssh "journalctl -k --no-pager 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process' | tail -5
-              echo '-- rauc unit --'; journalctl -u rauc --no-pager -n 8 2>/dev/null
-              echo '-- memory --'; free -m | head -2
-              grep -E 'MemAvailable|HugePages_Total|^Dirty|^Writeback:' /proc/meminfo" 2>/dev/null |
-            tr -d '\r' | sed 's/^/     · /'
+    local ou_out ou_rc
+    ou_out=$(_ssh "cd /data/pithead && ./pithead os-update /data/update.bundle --yes 2>&1")
+    ou_rc=$?
+    if [ "$ou_rc" -ne 0 ]; then
+        osupdate_failure_evidence "$ou_rc" "$ou_out" # both transport ends + the console, at the moment of death
         bad "pithead os-update failed on the guest — see the guest evidence above, and do not restate the cause without reading it"
         return
     fi


### PR DESCRIPTION
Closes #1060.

## What was killing os-update

`phase_provision` (and `phase_media`, `phase_reset`) declare, for a container-wait probe
loop:

```bash
local deadline=... names="" SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}"
```

bash `local` is dynamically scoped — it lasts to the end of the function and shadows the
5400 s default for every function called from it. Every later `_ssh` in those phases,
including the migration leg's `pithead os-update`, ran under `timeout 20`; the ~4 GiB slot
copy needs roughly twice that, so the SSH client was SIGTERM'd mid-copy. That is the whole
"~60% death": a fixed 20 s cut landing at a time-proportional point of the copy — and why
it never reproduced on real hardware (the manual M7 run uses no `_ssh`) and why battery 4's
raised 5400 s default changed nothing (the `local` shadows it).

## What was RUN

- Red (instrumented, before fix): provision phase on the bench KVM — **28 passed /
  1 failed**, the leg dead with **rc=124** (timeout(1)'s kill), guest memory healthy at
  death (MemAvailable ~5.3 GB, Writeback 0, hugepages pool intact), rauc mid-write. Log on
  the bench: `/tmp/claude-1000/m1060-provision2.log`.
- Green (fix applied, same box/image/phase): **34 passed / 0 failed** — the identical
  invocation survives; migration-marker, chain-hold and commit assertions pass. Log:
  `/tmp/claude-1000/m1060-provision3.log`. The red run is the mutation proof for this fix:
  same harness, fix absent, leg fails.
- The evidence helper's failure path was driven directly with stubbed `_ssh`/`SSH_ERR`/
  `SERIAL` (it only runs on failure, which the green battery never reaches): renders rc,
  client stderr, full output, and copies the console.

## Commits

1. **The fix** — scope the probe ceiling to the probe invocation
   (`SSH_TIMEOUT=... _ssh ...` env-prefix) at the three sites; `_wait_ssh`'s own `local` is
   correct (the probe is that function's whole body) and stays.
2. **Evidence capture** (what #1060's body demanded) — the assertion now reports the exact
   rc and the SSH client's own stderr (previously discarded in `$SSH_ERR`), prints the full
   CLI output (a truncated tail hid the story three times), and preserves the serial
   console at the moment of failure (`cleanup()`'s end-of-phase copy runs after later boots
   have truncated it — it is now no-clobber, with a fresh-run `rm` so it can never keep a
   previous run's console). The capture lives in `tests/os/failure-evidence.sh`;
   `tests/os/run.sh` shrinks net −5 lines, per the file-budget ratchet's intent.

## Not done here

- `make lint-sh` on this box dies at the known #1206 shellcheck memory cap (exit 137,
  pre-existing, unrelated — the single big invocation includes `tests/stack/run.sh`); the
  two changed files were shellcheck'd and shfmt'd individually, clean. CI runs the full
  target.
- The battery's other long `_ssh` calls were audited for further leaked ceilings as part of
  review; only the three declared sites had the pattern.
