### PR TITLE
fix(e2e): monero_caught_up derives the remote endpoint in monero.mode=remote (#1083)

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -358,15 +358,15 @@ control_units_verdict() { # <doctor-output>
     esac
 }
 
-# Authoritative "is Monero caught up?" — query monerod's own get_info on the box (creds stay
-# on the box) and trust its `synchronized` flag / target_height 0, exactly like the sync gate.
-# This is the readiness GATE (the source of truth, and it avoids waiting on a dashboard poll cycle).
-# The dashboard's `.sync.monero.state` now also reaches "done" for a synced node — run.sh asserts
-# that display separately. Returns 0 when synced.
+# Authoritative "is Monero caught up?" — query monerod's own get_info (creds stay on the box)
+# and trust its `synchronized` flag / target_height 0, exactly like the sync gate. "Its own"
+# follows the mode: in monero.mode=remote nothing listens on the box's loopback (the render
+# emits no MONERO_RPC_URL; the in-stack relay is container-local), so the endpoint derives from
+# config.json — found by #1083's first live remote run. Returns 0 when synced.
 monero_caught_up() {
     rx 'u=$(grep -E "^MONERO_NODE_USERNAME=" .env 2>/dev/null | cut -d= -f2-);
         p=$(grep -E "^MONERO_NODE_PASSWORD=" .env 2>/dev/null | cut -d= -f2-);
-        url=$(grep -E "^MONERO_RPC_URL=" .env 2>/dev/null | cut -d= -f2-); [ -n "$url" ] || url="http://127.0.0.1:18081";
+        url=$(grep -E "^MONERO_RPC_URL=" .env 2>/dev/null | cut -d= -f2-); [ -n "$url" ] || url=$(jq -r "if (.monero.mode // \"local\") == \"remote\" and .monero.remote.host then \"http://\" + .monero.remote.host + \":\" + ((.monero.remote.rpc_port // 18081) | tostring) else \"http://127.0.0.1:18081\" end" config.json 2>/dev/null); [ -n "$url" ] || url="http://127.0.0.1:18081";
         if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null);
         else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi;
         printf "%s" "$body" | jq -e "(.status==\"OK\") and ((.synchronized==true) or (.target_height==0))" >/dev/null 2>&1'


### PR DESCRIPTION
Part of #1083 (does not close it).

`monero_caught_up()` probes `http://127.0.0.1:18081` when the rendered `.env` carries no
`MONERO_RPC_URL` — and in `monero.mode=remote` that is always the case, while nothing listens
on the box's loopback (the in-stack relay is container-local). Found by the first live run of
the `remote-main-secure-tari` scenario since remote mode shipped in v1.14.0: the probe failed
against a demonstrably healthy remote-mode stack (its supervisor had already released mining
on the remote nodes' sync state).

The probe now derives the endpoint from the box's own `config.json`
(`monero.remote.host`/`rpc_port`) when `.env` has no URL and the mode is remote; local-mode
behavior and the loopback fallback are unchanged, and creds stay on the box as before.

## What was RUN

- Red (fix absent): scenario run against a loaner-hosted remote-mode stack —
  **29 passed / 1 failed**, the failure being exactly this probe
  (`✗ monerod reports synced (RPC)`).
- Green (this fix): same stack, same invocation — **30 passed / 0 failed / 0 skipped**,
  the scenario's first fully-green live run ever. Run details and the substrate recipe are
  on #1083.
- Verifier pass covered the rx/ssh quoting, local-mode/missing-config fallbacks, and
  string-vs-numeric ports.
- Net-zero lines: the file stays exactly at its file-budget ceiling on both lanes.

Twin: this lands as a pair (develop + develop-v2, same change, both at their own ceilings).
