### PR TITLE
feat(dashboard): steer the XvB loop off the credited average's protective projection

### DIFF
--- a/build/dashboard/mining_dashboard/config/config.py
+++ b/build/dashboard/mining_dashboard/config/config.py
@@ -693,6 +693,19 @@ XVB_WIN_ROUND_HOLD_S = float(os.environ.get("XVB_WIN_ROUND_HOLD_S", 5400))
 # especially if XvB over-credits). 0.03 converges in a few hours and stays stable.
 XVB_CONTROL_GAIN = float(os.environ.get("XVB_CONTROL_GAIN", 0.03))
 
+# Projection horizon of the loop's protective steering. The 1h average the loop
+# steers off lags what we actually route by up to the whole rolling window, so at
+# a margin-riding equilibrium a decaying credited average can reach the round
+# minimum before the reactive loop has moved — measured live: ~19 minutes from a
+# won round's draw to the terminating dip, with the ramp-back landing 4 minutes
+# too late. Each advance the controller also projects the credited trend this
+# many seconds forward and steers off min(measured, projected): projection only
+# ever tightens steering, never slackens it, so its worst case is the reactive
+# loop's behavior plus an earlier ramp. 0 disables projection. Default 20 min —
+# inside the measured decay-to-threshold window, and short enough that a full
+# window turnover never doubles a real trend.
+XVB_PROJECTION_HORIZON_S = float(os.environ.get("XVB_PROJECTION_HORIZON_S", 1200))
+
 # Age past which a frozen XvB stats read is treated as stale (#311). A successful
 # fetch lands every ~10 poll cycles (data_service throttle) and only a real fetch
 # bumps `last_update` (#136), so its age IS the fetch age. When the fetch goes quiet

--- a/build/dashboard/mining_dashboard/service/algo_service.py
+++ b/build/dashboard/mining_dashboard/service/algo_service.py
@@ -17,6 +17,7 @@ from mining_dashboard.config.config import (
     XVB_MIN_TIME_SEND_MS,
     XVB_P2POOL_RESERVE_FACTOR,
     XVB_POOL_URL,
+    XVB_PROJECTION_HORIZON_S,
     XVB_STALE_DECAY_AFTER_S,
     XVB_STATS_STALE_AFTER_S,
     XVB_SWITCH_OVERHEAD_MS,
@@ -43,6 +44,17 @@ logger = logging.getLogger("AlgoService")
 XVB_STALE_DECAY_FACTOR = 0.5
 XVB_STALE_DECAY_FLOOR = 0.005
 
+# Protective projection of the credited 1h average (see XVB_PROJECTION_HORIZON_S).
+# The trend is measured across genuine fetches only, needs at least MIN_SPAN of
+# history before it says anything (two adjacent noisy samples make a wild slope),
+# forgets samples older than MAX_LOOKBACK (the trend that matters is the fresh
+# one; a long tail of pre-decay samples dilutes it), and may lower the effective
+# reading by at most MAX_DROP_FRACTION of the measured value (a pathological
+# sample must not slam the loop).
+XVB_PROJECTION_MIN_SPAN_S = 600.0
+XVB_PROJECTION_MAX_LOOKBACK_S = 1500.0
+XVB_PROJECTION_MAX_DROP_FRACTION = 0.25
+
 
 class AlgoService:
     def __init__(self, state_manager, proxy_client, data_service):
@@ -60,6 +72,9 @@ class AlgoService:
         # Advanced once per real cycle by the calibration loop (not in _smart_sleep).
         # None until the first decision seeds it from the feedforward estimate.
         self.donation_fraction = None
+        # (fetch-timestamp, avg_1h) history for the protective projection — appended
+        # only when a genuine fetch lands (last_update moved), pruned to the lookback.
+        self._avg1h_trend = []
 
     async def switch_miners(self, mode, state_label=None):
         """
@@ -196,6 +211,7 @@ class AlgoService:
                         avg_1h,
                     )
             else:
+                self._record_avg1h_sample(xvb_stats)
                 self._advance_controller(current_hr, target_hr, avg_1h, max_fraction)
 
         fraction = min(self.donation_fraction or 0.0, max_fraction)
@@ -255,6 +271,48 @@ class AlgoService:
         last_update = (xvb_stats or {}).get("last_update", 0) or 0
         return time.time() - last_update if last_update else 0.0
 
+    def _record_avg1h_sample(self, xvb_stats):
+        """Remember (fetch time, avg_1h) for the trend projection. Only a genuine
+        fetch appends (``last_update`` moved — the same signal the staleness guard
+        trusts), so a frozen read repeated across cycles adds nothing."""
+        last_update = (xvb_stats or {}).get("last_update", 0) or 0
+        if not last_update:
+            return
+        if self._avg1h_trend and self._avg1h_trend[-1][0] >= last_update:
+            return
+        self._avg1h_trend.append((float(last_update), float(xvb_stats.get("avg_1h", 0) or 0)))
+        cutoff = last_update - XVB_PROJECTION_MAX_LOOKBACK_S
+        self._avg1h_trend = [(t, v) for t, v in self._avg1h_trend if t >= cutoff]
+
+    def _projected_avg_1h(self, avg_1h):
+        """Where the credited 1h average is HEADING, never above where it IS.
+
+        The reactive loop steers off a reading that lags the routed rate by up to
+        the whole rolling window; at a margin-riding equilibrium that lag is how a
+        decaying credited average sags through a live round's minimum before the
+        loop reacts. Extrapolate the measured trend one horizon forward and steer
+        off ``min(measured, projected)`` — a falling trend tightens steering early,
+        a rising trend changes nothing (never slacken on a forecast). Needs a real
+        baseline (span >= the minimum) and caps the drop, so noise cannot slam the
+        loop; disabled entirely when the horizon is 0."""
+        if XVB_PROJECTION_HORIZON_S <= 0 or len(self._avg1h_trend) < 2:
+            return avg_1h
+        t_new, v_new = self._avg1h_trend[-1]
+        t_old, v_old = self._avg1h_trend[0]
+        span = t_new - t_old
+        if span < XVB_PROJECTION_MIN_SPAN_S:
+            return avg_1h
+        slope = (v_new - v_old) / span
+        projected = avg_1h + slope * XVB_PROJECTION_HORIZON_S
+        floor = avg_1h * (1.0 - XVB_PROJECTION_MAX_DROP_FRACTION)
+        effective = max(min(avg_1h, projected), floor)
+        if effective < avg_1h:
+            logger.info(
+                "Credited 1h average trending down: steering off projected "
+                f"{effective:.0f} H/s instead of measured {avg_1h:.0f} H/s"
+            )
+        return effective
+
     def _reference_hr(self, target_hr):
         """Hashrate the controller holds XvB's 1h average at: the tier threshold
         plus a noise-covering cushion (capped in absolute H/s). The raffle
@@ -307,7 +365,10 @@ class AlgoService:
 
         Because it steers off XvB's authoritative number rather than assuming
         ``credited == fraction * current_hr``, it holds the tier no matter how XvB
-        scales our donation — and it can't wind up: the gain is small and the
+        scales our donation. The number it steers off is the protective projection
+        (``_projected_avg_1h``): the measured 1h average, lowered — never raised —
+        by its own recent trend, so a credited decay is answered before it reaches
+        the round minimum instead of after — and it can't wind up: the gain is small and the
         fraction is clamped to ``[0, max_fraction]`` (the VIP reserve), so a
         still-ramping or stale 1h read can only drift it slowly within bounds.
 
@@ -325,7 +386,7 @@ class AlgoService:
             )
             return
 
-        error = self._reference_hr(target_hr) - avg_1h
+        error = self._reference_hr(target_hr) - self._projected_avg_1h(avg_1h)
         step = self.control_gain * error / current_hr
         if step < 0 and self._won_round_live():
             # A won round is (possibly) live: easing off now is how the credited 1h

--- a/build/dashboard/mining_dashboard/sim/donation_model.py
+++ b/build/dashboard/mining_dashboard/sim/donation_model.py
@@ -76,7 +76,7 @@ class _FixedTiers:
         return []
 
 
-def make_algo_controller(algo, p2pool_difficulty=0) -> Controller:
+def make_algo_controller(algo, p2pool_difficulty=0, stamp_updates=False) -> Controller:
     """Adapt a real `AlgoService` into a `decide(...) -> fraction` callable.
 
     Routes through the actual `get_decision` path (with ``advance=True``, so the
@@ -84,11 +84,24 @@ def make_algo_controller(algo, p2pool_difficulty=0) -> Controller:
     the shipping behaviour — the integral controller, the VIP/PPLNS reserve, the
     minimum dwell, and the short-remainder rule — not an idealised model of it.
     ``p2pool_difficulty`` feeds the reserve; 0 leaves it on the flat fallback cap.
+
+    ``stamp_updates`` marks every cycle's stats as a genuine fetch on the SIM
+    clock (one cycle = 3600/CYCLES_PER_HOUR seconds), which is what arms the
+    protective trend projection — without a moving ``last_update`` the projection
+    records no samples and the loop is purely reactive. Sim timestamps would read
+    as ancient to the wall-clock staleness guard, so that check is stubbed out on
+    the adapted service; the staleness paths have their own dedicated tests.
     """
     pool_stats = {"pplns_window": _PPLNS_WINDOW, "difficulty": p2pool_difficulty}
+    sim_clock = [1_000_000.0]
+    if stamp_updates:
+        algo._stats_are_stale = lambda _stats: False
 
     def decide(current_hr, stable_hr, avg_1h, avg_24h):
         xvb_stats = {"avg_1h": avg_1h, "avg_24h": avg_24h, "fail_count": 0}
+        if stamp_updates:
+            sim_clock[0] += 3600.0 / CYCLES_PER_HOUR
+            xvb_stats["last_update"] = sim_clock[0]
         mode, dur_ms = algo.get_decision(
             current_hr, stable_hr, pool_stats, _P2P_MAIN, xvb_stats, _RECENT_SHARES
         )

--- a/build/dashboard/tests/service/test_algo_service.py
+++ b/build/dashboard/tests/service/test_algo_service.py
@@ -837,3 +837,71 @@ class TestWonRoundHold:
                 RECENT_SHARES,
             )
         assert algo.donation_fraction < 0.4  # decayed despite the live round
+
+
+class TestProjectedSteering:
+    """The protective trend projection (#892's steering half): the loop steers off
+    min(measured 1h, projected 1h) so a credited decay is answered before it
+    reaches the round minimum — and a rising trend changes nothing."""
+
+    T0 = 1_000_000.0
+
+    def _with_trend(self, algo, points):
+        algo._avg1h_trend = [(self.T0 + dt, v) for dt, v in points]
+
+    def test_no_projection_without_history(self, algo):
+        assert algo._projected_avg_1h(100_000.0) == 100_000.0
+        self._with_trend(algo, [(0, 110_000.0)])
+        assert algo._projected_avg_1h(100_000.0) == 100_000.0
+
+    def test_no_projection_below_min_span(self, algo):
+        self._with_trend(algo, [(0, 110_000.0), (300, 101_000.0)])
+        assert algo._projected_avg_1h(100_000.0) == 100_000.0
+
+    def test_falling_trend_lowers_effective(self, algo):
+        # -10 H/s per second over 900s; horizon 1200s -> 12k below measured.
+        self._with_trend(algo, [(0, 110_000.0), (900, 101_000.0)])
+        assert algo._projected_avg_1h(100_000.0) == pytest.approx(88_000.0)
+
+    def test_rising_trend_never_raises(self, algo):
+        self._with_trend(algo, [(0, 90_000.0), (900, 99_000.0)])
+        assert algo._projected_avg_1h(100_000.0) == 100_000.0
+
+    def test_drop_is_capped(self, algo):
+        # Absurd decay projects far below the floor; the cap holds at 25% down.
+        self._with_trend(algo, [(0, 200_000.0), (900, 100_000.0)])
+        assert algo._projected_avg_1h(100_000.0) == pytest.approx(75_000.0)
+
+    def test_horizon_zero_disables(self, algo):
+        self._with_trend(algo, [(0, 110_000.0), (900, 101_000.0)])
+        with patch("mining_dashboard.service.algo_service.XVB_PROJECTION_HORIZON_S", 0):
+            assert algo._projected_avg_1h(100_000.0) == 100_000.0
+
+    def test_recording_appends_only_fresh_fetches(self, algo):
+        ts = self.T0
+        algo._record_avg1h_sample({"avg_1h": 100_000.0, "last_update": ts})
+        algo._record_avg1h_sample({"avg_1h": 90_000.0, "last_update": ts})  # frozen read
+        assert algo._avg1h_trend == [(ts, 100_000.0)]
+        algo._record_avg1h_sample({"avg_1h": 95_000.0, "last_update": ts + 300})
+        assert len(algo._avg1h_trend) == 2
+        algo._record_avg1h_sample({"avg_1h": 95_000.0, "last_update": 0})  # never-fetched
+        assert len(algo._avg1h_trend) == 2
+
+    def test_recording_prunes_old_samples(self, algo):
+        algo._record_avg1h_sample({"avg_1h": 100_000.0, "last_update": self.T0})
+        algo._record_avg1h_sample({"avg_1h": 99_000.0, "last_update": self.T0 + 3000})
+        assert [v for _, v in algo._avg1h_trend] == [99_000.0]
+
+    def test_falling_trend_steps_up_where_reactive_stepped_down(self, algo):
+        # Measured 1h sits just ABOVE the reference (reactive would ease off);
+        # the recorded decay projects it below (protective ramps instead).
+        algo.donation_fraction = 0.5
+        target_hr = 100_000.0
+        avg_1h = algo._reference_hr(target_hr) + 1_000.0
+        reactive = AlgoService(algo.state_manager, MagicMock(), MagicMock())
+        reactive.donation_fraction = 0.5
+        reactive._advance_controller(200_000.0, target_hr, avg_1h, 0.85)
+        assert reactive.donation_fraction < 0.5
+        self._with_trend(algo, [(0, avg_1h + 9_000.0), (900, avg_1h)])
+        algo._advance_controller(200_000.0, target_hr, avg_1h, 0.85)
+        assert algo.donation_fraction > 0.5

--- a/build/dashboard/tests/sim/test_donation_model.py
+++ b/build/dashboard/tests/sim/test_donation_model.py
@@ -20,6 +20,7 @@ from mining_dashboard.sim.donation_model import (
     make_algo_controller,
     run_actuated,
     run_algo,
+    run_simulation,
 )
 
 # A real-ish p2pool-main sidechain difficulty so the VIP reserve is exercised.
@@ -235,3 +236,76 @@ class TestDisturbanceRecovery:
         r = run_algo(sc)
         # Re-qualified on the 1h average by the final cycles (24h lags a full day).
         assert min(r.credited_1h[-CYCLES_PER_HOUR:]) >= sc.target_hr * 0.98
+
+class TestProjectedSteering:
+    """The protective trend projection (#892's steering half), closed-loop: at a
+    margin-riding equilibrium a mild credited decay is answered one horizon
+    earlier, which is measurably fewer cycles under the tier threshold — the
+    cycles that terminate a live won round. Projection may only ever tighten
+    steering (min(measured, projected)), so the reactive run bounds it from
+    below by construction; these tests pin that dominance in the loop.
+    ``stamp_updates`` arms the projection: without a moving ``last_update`` no
+    trend samples are recorded and the loop is purely reactive."""
+
+    def _run(self, horizon_s):
+        from unittest.mock import patch
+
+        with patch(
+            "mining_dashboard.service.algo_service.XVB_PROJECTION_HORIZON_S", horizon_s
+        ):
+            algo = build_controller()
+            controller = make_algo_controller(
+                algo, p2pool_difficulty=DIFFICULTY, stamp_updates=True
+            )
+            sc = Scenario(
+                name=f"projected-{horizon_s}",
+                target_hr=10_000,
+                current_hr=46_300,
+                warm_avg=11_200,
+                measurement="fixed",
+                p2pool_difficulty=DIFFICULTY,
+                cycles=10 * CYCLES_PER_HOUR,
+                report_lag_cycles=2,
+                drop_at=4 * CYCLES_PER_HOUR,
+                drop_factor=0.93,
+            )
+            return run_simulation(controller, sc)
+
+    def test_mild_decay_spends_fewer_cycles_below_threshold(self):
+        drop = 4 * CYCLES_PER_HOUR
+        reactive = self._run(0)
+        projected = self._run(1200)
+        below = lambda r: sum(1 for v in r.credited_1h[drop:] if v < 10_000)  # noqa: E731
+        assert below(projected) < below(reactive)
+        assert min(projected.credited_1h[drop:]) >= min(reactive.credited_1h[drop:])
+
+    def test_projection_never_worse_at_steady_state(self):
+        # No disturbance: both settle to the same reference; projection must not
+        # oscillate or over-donate relative to reactive.
+        from unittest.mock import patch
+
+        results = {}
+        for h in (0, 1200):
+            with patch("mining_dashboard.service.algo_service.XVB_PROJECTION_HORIZON_S", h):
+                algo = build_controller()
+                controller = make_algo_controller(
+                    algo, p2pool_difficulty=DIFFICULTY, stamp_updates=True
+                )
+                sc = Scenario(
+                    name=f"steady-{h}",
+                    target_hr=10_000,
+                    current_hr=46_300,
+                    warm_avg=10_500,
+                    measurement="fixed",
+                    p2pool_difficulty=DIFFICULTY,
+                    cycles=8 * CYCLES_PER_HOUR,
+                    report_lag_cycles=2,
+                )
+                results[h] = run_simulation(controller, sc)
+        tail = 2 * CYCLES_PER_HOUR
+        steady_reactive = results[0].credited_1h[-tail:]
+        steady_projected = results[1200].credited_1h[-tail:]
+        # Same equilibrium within 2%, and no extra overshoot from projection.
+        assert max(steady_projected) <= max(steady_reactive) * 1.02
+        assert min(steady_projected) >= min(steady_reactive) * 0.98
+

--- a/build/dashboard/tests/sim/test_donation_model.py
+++ b/build/dashboard/tests/sim/test_donation_model.py
@@ -237,6 +237,7 @@ class TestDisturbanceRecovery:
         # Re-qualified on the 1h average by the final cycles (24h lags a full day).
         assert min(r.credited_1h[-CYCLES_PER_HOUR:]) >= sc.target_hr * 0.98
 
+
 class TestProjectedSteering:
     """The protective trend projection (#892's steering half), closed-loop: at a
     margin-riding equilibrium a mild credited decay is answered one horizon
@@ -250,9 +251,7 @@ class TestProjectedSteering:
     def _run(self, horizon_s):
         from unittest.mock import patch
 
-        with patch(
-            "mining_dashboard.service.algo_service.XVB_PROJECTION_HORIZON_S", horizon_s
-        ):
+        with patch("mining_dashboard.service.algo_service.XVB_PROJECTION_HORIZON_S", horizon_s):
             algo = build_controller()
             controller = make_algo_controller(
                 algo, p2pool_difficulty=DIFFICULTY, stamp_updates=True
@@ -275,7 +274,10 @@ class TestProjectedSteering:
         drop = 4 * CYCLES_PER_HOUR
         reactive = self._run(0)
         projected = self._run(1200)
-        below = lambda r: sum(1 for v in r.credited_1h[drop:] if v < 10_000)  # noqa: E731
+
+        def below(r):
+            return sum(1 for v in r.credited_1h[drop:] if v < 10_000)
+
         assert below(projected) < below(reactive)
         assert min(projected.credited_1h[drop:]) >= min(reactive.credited_1h[drop:])
 
@@ -308,4 +310,3 @@ class TestProjectedSteering:
         # Same equilibrium within 2%, and no extra overshoot from projection.
         assert max(steady_projected) <= max(steady_reactive) * 1.02
         assert min(steady_projected) >= min(steady_reactive) * 0.98
-

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -703,6 +703,10 @@ round minimum; and collecting any win needs a share in the P2Pool PPLNS window (
 being a "VIP"). So the optimum donation is the minimum that clears your tier — never more. A tier
 is raffle status, not an XMR payout, and the card says so. The tier thresholds come from the
 server's tier table — the same one the donation controller steers by — so the two can't disagree.
+Because the credited 1h average lags what the controller actually routes, the controller also
+watches that average's own trend: when it is falling, steering switches to the projected value —
+never the other way around — so a decay toward the round minimum is answered before it lands
+rather than after. A rising trend changes nothing.
 
 NOTE: on the mini/nano sidechains the block adds a reminder that switching the P2Pool sidechain
 resets your PPLNS shares — and with them XvB win collectability until a new share lands.


### PR DESCRIPTION
Closes #892 — the steering half (the detection half shipped earlier as the adaptive winners-sync gate).

The calibration loop steered off a credited 1h average that lags what it routes by up to the whole rolling window. At a margin-riding equilibrium that lag is the incident's mechanism: the controller kept easing off while the true credited value was already falling, the average sagged through the round minimum 19 minutes after a whale-round draw, and the ramp-back landed 4 minutes too late.

**The change.** Each advance the controller records the (fetch-time, avg_1h) trend — genuine fetches only, the same `last_update` signal the staleness guard trusts — and steers off `min(measured, projected)`, where projected extrapolates the recent trend one horizon (`XVB_PROJECTION_HORIZON_S`, default 20 min, 0 disables) forward. A falling trend flips the error sign one horizon early (halting down-steps and starting the ramp before the threshold is reached, which the in-round hold then locks); a rising trend changes nothing — the projection can only ever tighten steering, so its worst case is the reactive loop's behavior. Guards: minimum 10-minute trend baseline, 25-minute lookback (a long tail of pre-decay samples dilutes the fresh trend), drop capped at 25% of measured, frozen reads record nothing.

**What was RUN:**
- Dashboard suite full: all pass; total coverage 97.03% (≥80 gate); patch coverage: all changed files measured.
- New unit tests (9): trend recording/dedup/pruning, span guard, drop cap, horizon-0 disable, rising-trend no-op, and the discriminating pair — with a recorded decay the controller steps UP where the reactive one stepped down.
- New closed-loop sim tests (2), via a new `stamp_updates` mode on the sim's controller adapter (arms the projection under sim time; the wall-clock staleness check is stubbed there, and keeps its own dedicated tests): at a margin-riding equilibrium with a mild decay, the projected loop spends **14 vs 17** ten-minute cycles under the tier threshold (30 minutes less round-killing exposure per event) with an equal-or-higher floor; at steady state the two loops settle identically within 2%.
- **Mutation, run:** neutering the projection (always return the measured value) turns the discriminating sim test red; reverted, green.
- Docs: the dashboard's raffle-mechanics passage gains the trend-steering sentence; voice/markdown/operator-strings lints clean.

**Honest bound:** the projection fixes the *timing* (the late sign-flip); recovery *depth* after a large disturbance stays limited by the deliberately low integral gain — the sim shows a small floor improvement there, not a rescue. If live soaks show threshold dips surviving the earlier ramp, the follow-up knob is error-proportional gain near the threshold, which is a separate, oscillation-risk change.
