### PR TITLE
test(stack): split the harness-tooling self-tests into their own file (#1105 Phase 1, module 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
 
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test_compose.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh
 	shfmt -i 4 -d pithead pithead-completion.bash $(shell git ls-files '*.sh' | grep -v '^docs/research/')
 

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -37,5 +37,5 @@ tests/integration/e2e.sh	766
 tests/integration/lib.sh	677
 tests/integration/run.sh	2551
 tests/integration/selftest.sh	658
-tests/stack/run.sh	8192
+tests/stack/run.sh	8191
 tests/stack/test_compose.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -37,5 +37,5 @@ tests/integration/e2e.sh	766
 tests/integration/lib.sh	677
 tests/integration/run.sh	2551
 tests/integration/selftest.sh	658
-tests/stack/run.sh	8219
+tests/stack/run.sh	8192
 tests/stack/test_compose.sh	454

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -45,7 +45,6 @@ assert_rc "allows mount subfolder" "$?" "0"
 # shellcheck source=tests/stack/test-harness-tooling.sh
 source "$HERE/test-harness-tooling.sh"
 
-
 echo "== unit: is_public_ip classifier (#113) =="
 # Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.
 for ip in 8.8.8.8 1.1.1.1 172.15.0.1 172.32.0.1 100.128.0.1 169.1.1.1 2606:4700:4700::1111 2001:db8::1; do

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -42,36 +42,9 @@ assert_rc "rejects ':' (compose volume-mount injection)" "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/mnt/disk/monero" >/dev/null 2>&1
 assert_rc "allows mount subfolder" "$?" "0"
 
-echo "== unit: lint-operator-strings self-test (#755) =="
-# The operator-strings guard's frontend scanner is non-trivial awk (comment-stripping + CSS-hex-colour
-# skip); a silent break would make it stop catching leaks. Its --self-test drives fixtures through the
-# real scanners and fails if a planted #NNN is missed or a hex colour/comment is wrongly flagged.
-bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
-assert_rc "operator-strings guard self-test passes" "$?" "0"
+# shellcheck source=tests/stack/test-harness-tooling.sh
+source "$HERE/test-harness-tooling.sh"
 
-echo "== unit: pin-watch self-test (#1128) =="
-# The watcher's whole product is the COMPARISON: our pins do not spell versions the way upstream
-# tags them (`caddy:2.11.4` vs `v2.11.4`, `minotari_node:v5.3.1-mainnet` vs `v5.6.0`), so a plain
-# string compare reports two components stale every week for ever and the report gets muted — as
-# useless as the scheduled workflow that lived on a non-default branch and never ran at all. Its
-# --self-test drives the normalisation over the real pin spellings and drives both lookup failure
-# paths, because an upstream lookup that could not run must never read as "current".
-bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
-assert_rc "pin-watch self-test passes" "$?" "0"
-
-echo "== unit: resolve-pins self-test (#1137) =="
-# pin-watch.sh above compares VERSIONS; it does not ask whether a pinned tag@sha256 digest still
-# matches what its registry serves for that tag. This is the check that does, and its --self-test
-# drives the exact half-done bump #1137 is about (tag moved, old digest left in the file) red.
-bash "$ROOT/scripts/resolve-pins.sh" --self-test >/dev/null 2>&1
-assert_rc "resolve-pins self-test passes" "$?" "0"
-
-echo "== unit: patch-coverage overlap self-test (#1000) =="
-# diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
-# overlap check is what turns that into a loud not-applicable pass or a real failure; its
-# --self-test drives fixtures through both branches plus the file-present quiet pass.
-bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
-assert_rc "patch-coverage wrapper self-test passes" "$?" "0"
 
 echo "== unit: is_public_ip classifier (#113) =="
 # Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -1,0 +1,34 @@
+# shellcheck shell=bash
+#
+# Repo-tooling self-tests (#1105 Phase 1 domain: harness core). Sourced by tests/stack/run.sh
+# after lib.sh — the harness (ok/bad/assert_*, SANDBOX) is already loaded.
+echo "== unit: lint-operator-strings self-test (#755) =="
+# The operator-strings guard's frontend scanner is non-trivial awk (comment-stripping + CSS-hex-colour
+# skip); a silent break would make it stop catching leaks. Its --self-test drives fixtures through the
+# real scanners and fails if a planted #NNN is missed or a hex colour/comment is wrongly flagged.
+bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
+assert_rc "operator-strings guard self-test passes" "$?" "0"
+
+echo "== unit: pin-watch self-test (#1128) =="
+# The watcher's whole product is the COMPARISON: our pins do not spell versions the way upstream
+# tags them (`caddy:2.11.4` vs `v2.11.4`, `minotari_node:v5.3.1-mainnet` vs `v5.6.0`), so a plain
+# string compare reports two components stale every week for ever and the report gets muted — as
+# useless as the scheduled workflow that lived on a non-default branch and never ran at all. Its
+# --self-test drives the normalisation over the real pin spellings and drives both lookup failure
+# paths, because an upstream lookup that could not run must never read as "current".
+bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
+assert_rc "pin-watch self-test passes" "$?" "0"
+
+echo "== unit: resolve-pins self-test (#1137) =="
+# pin-watch.sh above compares VERSIONS; it does not ask whether a pinned tag@sha256 digest still
+# matches what its registry serves for that tag. This is the check that does, and its --self-test
+# drives the exact half-done bump #1137 is about (tag moved, old digest left in the file) red.
+bash "$ROOT/scripts/resolve-pins.sh" --self-test >/dev/null 2>&1
+assert_rc "resolve-pins self-test passes" "$?" "0"
+
+echo "== unit: patch-coverage overlap self-test (#1000) =="
+# diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
+# overlap check is what turns that into a loud not-applicable pass or a real failure; its
+# --self-test drives fixtures through both branches plus the file-present quiet pass.
+bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
+assert_rc "patch-coverage wrapper self-test passes" "$?" "0"


### PR DESCRIPTION
Module 2 of #1105 Phase 1 (develop; the develop-v2 pair follows once its lane's 1b pair lands) — the first domain cut per the map on the module-1 PR.

The four repo-tooling self-test sections (operator-strings, pin-watch, resolve-pins, patch-coverage overlap) move verbatim into `tests/stack/test-harness-tooling.sh`, sourced by `run.sh` at the exact position the block vacated. The sections are contiguous, so execution order is unchanged — this cut is held to the strict ordered-identity standard, not the sorted-multiset relaxation. `lint-sh` gains the `tests/stack/test-*.sh` glob every later domain file lands under; the new file follows lib.sh's sourced-not-executed convention (`# shellcheck shell=bash`, mode 644). `run.sh` 8219 → 8192; ceiling follows.

**What was RUN (real git worktrees):**
- Before, at the develop tip: **1836 passed, 0 failed.** After, on this branch: **1836 passed, 0 failed.**
- Logs line-for-line identical after normalizing ANSI/`line N:`/worktree paths — the only residual diff is one mktemp path.
- `scripts/lint-file-budget.sh` OK; `shellcheck` + `shfmt` clean on the new file.
- No mutation applies — pure move; the identical-suite proof is the verification.
