### PR TITLE
test(stack): split the harness-tooling self-tests into their own file (#1105 Phase 1, module 2, develop-v2 pair)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
 
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test_compose.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh \
 		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot \
 		os/overlay/pithead-data-reset os/overlay/pithead-mount-generator os/overlay/pithead-ssh-host-keys \

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -45,6 +45,6 @@ tests/integration/e2e.sh	766
 tests/integration/lib.sh	692
 tests/integration/run.sh	2551
 tests/integration/selftest.sh	686
-tests/os/run.sh	3447
-tests/stack/run.sh	13782
+tests/os/run.sh	3442
+tests/stack/run.sh	13735
 tests/stack/test_compose.sh	462

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -42,55 +42,8 @@ assert_rc "rejects ':' (compose volume-mount injection)" "$?" "1"
 run_sourced "$SANDBOX" assert_safe_dir "/mnt/disk/monero" >/dev/null 2>&1
 assert_rc "allows mount subfolder" "$?" "0"
 
-echo "== unit: lint-operator-strings self-test (#755) =="
-# The operator-strings guard's frontend scanner is non-trivial awk (comment-stripping + CSS-hex-colour
-# skip); a silent break would make it stop catching leaks. Its --self-test drives fixtures through the
-# real scanners and fails if a planted #NNN is missed or a hex colour/comment is wrongly flagged.
-bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
-assert_rc "operator-strings guard self-test passes" "$?" "0"
-
-echo "== unit: pin-watch self-test (#1128) =="
-# The watcher's whole product is the COMPARISON: our pins do not spell versions the way upstream
-# tags them (`caddy:2.11.4` vs `v2.11.4`, `minotari_node:v5.3.1-mainnet` vs `v5.6.0`), so a plain
-# string compare reports two components stale every week for ever and the report gets muted — as
-# useless as the scheduled workflow that lived on a non-default branch and never ran at all. Its
-# --self-test drives the normalisation over the real pin spellings and drives both lookup failure
-# paths, because an upstream lookup that could not run must never read as "current".
-bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
-assert_rc "pin-watch self-test passes" "$?" "0"
-
-echo "== unit: resolve-pins self-test (#1137) =="
-# pin-watch.sh above compares VERSIONS; it does not ask whether a pinned tag@sha256 digest still
-# matches what its registry serves for that tag. This is the check that does, and its --self-test
-# drives the exact half-done bump #1137 is about (tag moved, old digest left in the file) red.
-bash "$ROOT/scripts/resolve-pins.sh" --self-test >/dev/null 2>&1
-assert_rc "resolve-pins self-test passes" "$?" "0"
-
-echo "== unit: verify-healthcheck-scripts self-test (#1098) =="
-# #1098: docker-compose.yml named a healthcheck script (xmrig-proxy-healthcheck.sh) that the
-# pinned appliance images predated — the container reported unhealthy forever with nothing
-# actually broken. This is the narrower, permanent guard: does each service's OWN Dockerfile
-# actually place a file where compose's healthcheck looks for it. The self-test drives the
-# parsers (WORKDIR resolution, COPY --from=, multi-source directory COPYs) against fixtures and
-# reproduces the issue's own named mutation end to end: rename the script in a Dockerfile without
-# touching compose, and the check must go red.
-bash "$ROOT/scripts/verify-healthcheck-scripts.sh" --self-test >/dev/null 2>&1
-assert_rc "verify-healthcheck-scripts self-test passes" "$?" "0"
-
-echo "== unit: verify-healthcheck-scripts against the real tree (#1098) =="
-# The self-test above proves the parsers; this proves the CURRENT docker-compose.yml and build/*
-# Dockerfiles actually agree right now — the same real-tree pass release.sh and CI both get, so a
-# healthcheck rename that forgets the compose side (or vice versa) fails here before it ever
-# reaches an appliance.
-bash "$ROOT/scripts/verify-healthcheck-scripts.sh" >/dev/null 2>&1
-assert_rc "every real healthcheck script exists where its own Dockerfile promises (#1098)" "$?" "0"
-
-echo "== unit: patch-coverage overlap self-test (#1000) =="
-# diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
-# overlap check is what turns that into a loud not-applicable pass or a real failure; its
-# --self-test drives fixtures through both branches plus the file-present quiet pass.
-bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
-assert_rc "patch-coverage wrapper self-test passes" "$?" "0"
+# shellcheck source=tests/stack/test-harness-tooling.sh
+source "$HERE/test-harness-tooling.sh"
 
 echo "== unit: is_public_ip classifier (#113) =="
 # Globally-routable -> rc 0 (public). Includes boundaries just OUTSIDE each excluded range.

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+#
+# Repo-tooling self-tests (#1105 Phase 1 domain: harness core). Sourced by tests/stack/run.sh
+# after lib.sh — the harness (ok/bad/assert_*, SANDBOX) is already loaded.
+echo "== unit: lint-operator-strings self-test (#755) =="
+# The operator-strings guard's frontend scanner is non-trivial awk (comment-stripping + CSS-hex-colour
+# skip); a silent break would make it stop catching leaks. Its --self-test drives fixtures through the
+# real scanners and fails if a planted #NNN is missed or a hex colour/comment is wrongly flagged.
+bash "$ROOT/scripts/lint-operator-strings.sh" --self-test >/dev/null 2>&1
+assert_rc "operator-strings guard self-test passes" "$?" "0"
+
+echo "== unit: pin-watch self-test (#1128) =="
+# The watcher's whole product is the COMPARISON: our pins do not spell versions the way upstream
+# tags them (`caddy:2.11.4` vs `v2.11.4`, `minotari_node:v5.3.1-mainnet` vs `v5.6.0`), so a plain
+# string compare reports two components stale every week for ever and the report gets muted — as
+# useless as the scheduled workflow that lived on a non-default branch and never ran at all. Its
+# --self-test drives the normalisation over the real pin spellings and drives both lookup failure
+# paths, because an upstream lookup that could not run must never read as "current".
+bash "$ROOT/scripts/pin-watch.sh" --self-test >/dev/null 2>&1
+assert_rc "pin-watch self-test passes" "$?" "0"
+
+echo "== unit: resolve-pins self-test (#1137) =="
+# pin-watch.sh above compares VERSIONS; it does not ask whether a pinned tag@sha256 digest still
+# matches what its registry serves for that tag. This is the check that does, and its --self-test
+# drives the exact half-done bump #1137 is about (tag moved, old digest left in the file) red.
+bash "$ROOT/scripts/resolve-pins.sh" --self-test >/dev/null 2>&1
+assert_rc "resolve-pins self-test passes" "$?" "0"
+
+echo "== unit: verify-healthcheck-scripts self-test (#1098) =="
+# #1098: docker-compose.yml named a healthcheck script (xmrig-proxy-healthcheck.sh) that the
+# pinned appliance images predated — the container reported unhealthy forever with nothing
+# actually broken. This is the narrower, permanent guard: does each service's OWN Dockerfile
+# actually place a file where compose's healthcheck looks for it. The self-test drives the
+# parsers (WORKDIR resolution, COPY --from=, multi-source directory COPYs) against fixtures and
+# reproduces the issue's own named mutation end to end: rename the script in a Dockerfile without
+# touching compose, and the check must go red.
+bash "$ROOT/scripts/verify-healthcheck-scripts.sh" --self-test >/dev/null 2>&1
+assert_rc "verify-healthcheck-scripts self-test passes" "$?" "0"
+
+echo "== unit: verify-healthcheck-scripts against the real tree (#1098) =="
+# The self-test above proves the parsers; this proves the CURRENT docker-compose.yml and build/*
+# Dockerfiles actually agree right now — the same real-tree pass release.sh and CI both get, so a
+# healthcheck rename that forgets the compose side (or vice versa) fails here before it ever
+# reaches an appliance.
+bash "$ROOT/scripts/verify-healthcheck-scripts.sh" >/dev/null 2>&1
+assert_rc "every real healthcheck script exists where its own Dockerfile promises (#1098)" "$?" "0"
+
+echo "== unit: patch-coverage overlap self-test (#1000) =="
+# diff-cover exits 0 on "No lines with coverage information" — a vacuous pass. The wrapper's
+# overlap check is what turns that into a loud not-applicable pass or a real failure; its
+# --self-test drives fixtures through both branches plus the file-present quiet pass.
+bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
+assert_rc "patch-coverage wrapper self-test passes" "$?" "0"


### PR DESCRIPTION
## Summary

develop-v2 pair of the develop-lane module 2 PR (#1277), part of the #1105
Phase 1 split of `tests/stack/run.sh` into per-domain files. Branch:
`feat/1105-p2-harness-tooling-v2` (base: `develop-v2`, commit `2b90ba7`).

The same four repo-tooling self-test sections #1277 moved
(lint-operator-strings, pin-watch, resolve-pins, patch-coverage overlap) move
verbatim into `tests/stack/test-harness-tooling.sh`, sourced by `run.sh` at
the exact position the block vacated — one contiguous source point, execution
order unchanged.

This lane also carries two appliance-only self-tests
(`verify-healthcheck-scripts`, #1098 — a self-test plus a real-tree pass) in
the *same contiguous cluster*, immediately between resolve-pins and
patch-coverage. They follow the identical pattern as the four mirrored tests
(drive a `scripts/*.sh --self-test`, `assert_rc`), so they move with the
domain too. **Moved: 6 sections total (4 mirrored + 2 develop-v2-only)**, no
sections left behind unsure for this module.

`Makefile`'s `lint-sh` gains the `tests/stack/test-*.sh` glob (same one-line
change as the develop twin). `run.sh` 13782 → 13735.

`docs/dev/file-budget.tsv` was regenerated with `scripts/lint-file-budget.sh
--generate` (never hand-edited). Besides the expected `tests/stack/run.sh`
ceiling drop, the regeneration also honestly reported a **pre-existing,
unrelated** stale ceiling for `tests/os/run.sh` (3447 → 3442) — that file was
already smaller on disk than its recorded ceiling before this PR touched
anything (confirmed via `git status`/`git log` on it: no local changes, no
commit of mine). Lowering a ceiling is always a legal ratchet-down, so it's
included as part of the honest regeneration rather than hand-suppressed.

## What was run (exact)

- **Before-proof** (untouched `develop-v2` tip, full `tests/stack/run.sh`):
  `pithead tests: 2880 passed, 0 failed` (rc 0).
- **After-proof** (with this module's changes): `pithead tests: 2880 passed,
  0 failed` (rc 0) — counts match the baseline exactly.
- **Lint**: full `make lint-sh` **cannot run locally on this lane** — it dies
  at the pre-existing #1206 6G shellcheck memory cap on this lane's
  ~13.7k-line `run.sh` (known, structural; this split is the eventual fix,
  not a new regression). Per this module's scope:
  - `shellcheck --severity=warning tests/stack/test-harness-tooling.sh` (the
    only new file) → clean, rc 0. `run.sh` itself is **excluded** from local
    shellcheck runs on this lane (the known #1206 hog).
  - `shfmt -i 4 -d tests/stack/run.sh tests/stack/test-harness-tooling.sh` →
    clean, rc 0 (no formatting delta).
  - **CI's shellcheck job is the whole-set arbiter for this lane** — it
    passed on the same-size `run.sh` for the prior develop-v2 pair PR
    (#1272), and must be green here before merge.

## Test plan

- [ ] CI's "Shell tests (shellcheck + pithead suite)" job is green on this PR
      (the required whole-set shellcheck check, since local `make lint-sh`
      structurally cannot run on this lane yet).
- [x] Full stack suite run before this change: 2880 passed, 0 failed.
- [x] Full stack suite run after this change: 2880 passed, 0 failed.
- [x] `docs/dev/file-budget.tsv` regenerated via the repo's own tool; gate
      (`scripts/lint-file-budget.sh`) passes.
