### PR TITLE
ci(lint): run lint-topology in the lint-surfaces job (#1228, #1257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,6 @@ jobs:
           export UV_INSTALL_DIR="$HOME/.local/bin"
           curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
-      - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings
+      - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings, topology classes
         # Single source of truth: the Makefile targets. Tools run via npx/uvx/docker (preinstalled).
-        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings
+        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology


### PR DESCRIPTION
The staged two-line wiring from #1228, pushed now that the workflow scope is granted (#1257): the lint-surfaces step's name and `run:` line each gain `lint-topology`, mirroring exactly how the operator-strings lint is invoked — the Makefile target stays the single source of truth, and the guard checks generic classes only, so CI output teaches nothing about any real setup.

Run locally on this branch: `make lint-yaml` and `make lint-topology` both pass. The honest proof is this PR's own CI: the lint-surfaces job now runs the target on the merged tree.

Per #1228, develop first; the periodic develop→develop-v2 sync carries the identical ci.yml change to the appliance lane. Second of the three #1257 boxes.
