### PR TITLE
ci(trivyignore): wire the weekly obsolete-mute watch (#1174, #1257)

### DIFF
--- a/.github/workflows/trivyignore-watch.yml
+++ b/.github/workflows/trivyignore-watch.yml
@@ -1,0 +1,92 @@
+name: Trivyignore mute watch
+
+# Weekly obsolete-mute report (#1174). REPORT-ONLY — the pin-watch.sh posture: never a gate,
+# because a cleared mute is housekeeping, not a build failure. The script never edits
+# `.trivyignore` and never opens a PR; this workflow's one output is a tracking issue.
+#
+# Why this exists at all: the weekly CVE sweep (#833) scans WITH `.trivyignore` applied, so a
+# muted finding is invisible to it by construction — a mute that outlives its finding rots
+# silently. scripts/trivyignore-watch.sh rebuilds every covered image exactly the way the gate
+# does, scans them with NO ignore file, and names an ID obsolete only when it is absent from ALL
+# of them (a per-image check confidently deletes live mutes — the trap in the script header).
+#
+# This file lives on the DEFAULT branch on purpose: a `schedule:` is read from the default branch
+# only — pin-watch.yml's header carries the history of learning that the hard way (#1048, #1064,
+# #1146). The JOB checks out `develop-v2` explicitly: the script and two of its covered images
+# (the appliance rootfs, and the `.trivyignore` block that documents it) exist only on that lane,
+# while every dashboard/monero/p2pool/xmrig-proxy/tor mute is shared — so the appliance lane's
+# tree is the one place the whole covered set can be built and the union check is honest.
+on:
+  schedule:
+    # Registration proof first (#1257): a near-term daily slot until one schedule-triggered run
+    # is on record in `gh run list --json event` — the YAML existing proves nothing (the
+    # false-green trap above). Moved to the steady weekly slot, Mondays 07:00 UTC after the
+    # 05:00/06:00/06:30 sweeps, in the follow-up recorded on #1257.
+    - cron: "30 23 * * *"
+  workflow_dispatch:
+
+# Least privilege (#282): issues.write is the job's one output — it never pushes or publishes.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  mute-watch:
+    name: Scan every covered image with no ignore file — report mutes nothing still reports
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The appliance lane: the one tree holding the script AND every image the shared
+          # `.trivyignore` covers (see the header). NOT the ref that triggered the run.
+          ref: develop-v2
+          persist-credentials: false
+      - name: Build and scan the covered images, no ignore file applied
+        id: report
+        run: |
+          set -uo pipefail
+          # NOT `set -e`: a broken run is a result to publish, not a reason to skip publishing
+          # it. The script itself refuses to name anything obsolete off an incomplete run and
+          # exits 1; the exit code is carried to the last step so the run still fails loudly.
+          bash scripts/trivyignore-watch.sh >report.md
+          rc=$?
+          # An empty report is itself a failure to report — never publish silence.
+          [ -s report.md ] || { echo "The mute watch produced no report at all — see the run log." >report.md; rc=1; }
+          echo "rc=$rc" >>"$GITHUB_OUTPUT"
+      - name: Publish it to the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Obsolete .trivyignore mutes (weekly report)"
+          RC: ${{ steps.report.outputs.rc }}
+        run: |
+          set -Eeuo pipefail
+          body=$(cat report.md)
+          # The report table carries no date of its own, so the liveness line lives here: a
+          # successful run stamps today, a failed run carries the previous stamp forward — that
+          # date is the only thing separating "failed once this morning" from "dead for six
+          # weeks" (the pin-watch pattern, same reasoning).
+          # Exact title match over the open list, NOT `--search`: the search index lags issue
+          # creation by minutes, so a search-based dedup files a second issue on the very next
+          # run and then keeps both stale.
+          n=$(gh issue list --state open --limit 200 --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ "$RC" = "0" ]; then
+            body="$body"$'\n\n'"_Last fully successful check: $(date -u +%F)_"
+          elif [ -n "$n" ]; then
+            prev=$(gh issue view "$n" --json body --jq .body | grep -a "^_Last fully successful check:" || true)
+            if [ -n "$prev" ]; then
+              body="$body"$'\n\n'"$prev (this run could not complete)"
+            fi
+          fi
+          if [ -n "$n" ]; then
+            gh issue edit "$n" --body "$body"
+            echo "updated #$n"
+          else
+            gh issue create --title "$TITLE" --label infra --body "$body"
+          fi
+      - name: Fail the run if the scan could not do its job
+        if: steps.report.outputs.rc != '0'
+        run: |
+          echo "::error::the mute watch could not scan every covered image — the mutes are UNCHECKED, not clean"
+          exit 1

--- a/.trivyignore
+++ b/.trivyignore
@@ -27,8 +27,12 @@ CVE-2026-24049
 # nobody had touched.
 #
 # Cleared when a base bump brings 2.41.5-0+deb13u1 in — `docker run --rm python:3.11-slim
-# dpkg-query -W util-linux` is the one-line check, and all four go together. The weekly CVE sweep
-# (#833) re-surfaces them regardless, so this cannot rot silently.
+# dpkg-query -W util-linux` is the one-line check, and all four go together. Nothing re-surfaces
+# these on its own: the weekly CVE sweep (#833) scans WITH this file applied, so a muted finding
+# never reaches it (#1174). The weekly mute watch checks whether an ID like these still shows up
+# in any image this file covers: its workflow (.github/workflows/trivyignore-watch.yml) lives on
+# THIS branch, the default one, so its schedule can fire — while the scripts/trivyignore-watch.sh
+# it runs lives on the appliance lane, which the workflow checks out to run it.
 CVE-2026-53612
 CVE-2026-53613
 CVE-2026-53614


### PR DESCRIPTION
Wires the #1174 obsolete-mute watch (script merged in #1253, hand-run only since) as a scheduled workflow — the third #1257 box, and the one the default-branch trap applies to.

Design, all stated in the file's header too:

- **The YAML lives on develop** because `schedule:` is read from the default branch only — the pin-watch.yml header carries the history (#1048/#1064/#1146) of learning that twice.
- **The job checks out `develop-v2`** — the script and the appliance rootfs it must scan exist only on that lane, while every other covered image's mute is shared. A develop checkout could not run the union check at all (no `os/rootfs`), and a partial scan is exactly what the script refuses to call clean.
- **Report-only, pin-watch posture**: one tracking issue, edited in place, exact-title dedup (never `--search` — the index lags). The workflow stamps `Last fully successful check` on a green run and carries it forward on a broken one, because that date is what separates "failed this morning" from "dead for six weeks". A broken run still fails loudly.
- **The first cron is a near-term registration proof** — the YAML existing proves nothing. Once one `schedule`-triggered run is on record in `gh run list --json event`, a follow-up moves it to the steady slot (Mondays 07:00 UTC, after the 05:00/06:00/06:30 sweeps) and the evidence lands on #1257.

Also fixes develop's `.trivyignore` prose, which still claimed the weekly sweep re-surfaces muted findings — the false sentence #1174 was filed about (the sweep scans WITH the file applied; a muted finding never reaches it).

Run on the bench: `scripts/trivyignore-watch.sh --self-test` — 12/12 including the union trap and the fail-loud guards; `make lint-yaml` passes. The real end-to-end (build + scan all six images, publish) runs post-merge via `workflow_dispatch` before the schedule proof.
