### PR TITLE
ci(lint): run the file-budget gate in the lint-surfaces job (#1105 P0, #1257)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,6 @@ jobs:
           export UV_INSTALL_DIR="$HOME/.local/bin"
           curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
-      - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings, topology classes
+      - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings, topology classes, file budget
         # Single source of truth: the Makefile targets. Tools run via npx/uvx/docker (preinstalled).
-        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology
+        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology lint-file-budget


### PR DESCRIPTION
~~DO NOT MERGE until the #1285 shrink lands on develop.~~ **Un-held**: #1285 is closed, the shrink is on develop, and `make lint-file-budget` passes on this branch's rebased tree (run locally; this PR's own CI now runs the gate on the merged tree as the honest proof).

The wiring is the same two-line shape as every other lint surface (#1105 Phase 0's CI half, first #1257 box): the lint-surfaces step gains `lint-file-budget`, Makefile target as the single source of truth. The gap this closes already cost once — #1276's growth was caught by an agent reading the tree, not by CI, exactly the same-wave trap the gate exists for.

Rebased over #1287's merge of the same two lines; the step now carries both suffixes (`topology classes, file budget`).