### PR TITLE
ci(tests): run the real-image data-reset suite on every PR (#1062)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,10 @@ jobs:
         run: make lint-sh
       - name: Run pithead test suite
         run: bash tests/stack/run.sh
+      - name: Run real-image data-reset suite
+        # Real ext4 damage against the product's own repair escalation (#1062). Unprivileged —
+        # e2fsprogs on plain files — and it hard-fails rather than skips when CI lacks the tools.
+        run: bash tests/stack/test_data_reset.sh
       - name: Test-inventory drift check
         # The inventory generator is grep-based; it exits non-zero when any suite it
         # enumerates counts zero — i.e. a suite moved or changed shape and the inventory


### PR DESCRIPTION
The one-line CI step #1280's body declared owed, now that the workflow scope is granted: CI runs tests/stack/run.sh directly, so without this the real-image data-reset suite guards only local make test-stack. The suite itself merged with #1280 and is green on this branch's own CI run (the step executes it on the merged tree). Cherry-picked onto the post-sync develop-v2 tip.