### PR TITLE
fix(appliance): refuse miner co-location on the reduced hugepages tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
         # Real ext4 damage against the product's own repair escalation (#1062). Unprivileged —
         # e2fsprogs on plain files — and it hard-fails rather than skips when CI lacks the tools.
         run: bash tests/stack/test_data_reset.sh
+      - name: Run appliance hugepages suite
+        # #1103 co-location refusal on the reduced tier; standalone suite wired here because the shell-tests job runs each
+        # standalone file explicitly (Makefile test-stack alone never runs in CI).
+        run: bash tests/stack/test_appliance_hugepages.sh
       - name: Test-inventory drift check
         # The inventory generator is grep-based; it exits non-zero when any suite it
         # enumerates counts zero — i.e. a suite moved or changed shape and the inventory

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test-patch-coverage: ## diff-cover (#286) minus its vacuous pass (#1000): >=90% 
 test-stack: ## pithead shell test suite
 	bash tests/stack/run.sh
 	bash tests/stack/test_data_reset.sh
+	bash tests/stack/test_appliance_hugepages.sh
 
 test-compose: ## Validate docker-compose.yml interpolation + hardening invariants (#90)
 	bash tests/stack/test_compose.sh
@@ -42,7 +43,7 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
 
 lint-sh: ## shellcheck + shfmt over the CLI, build/* container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh tests/stack/test_data_reset.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh tests/stack/test_data_reset.sh tests/stack/test_appliance_hugepages.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh \
 		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot \
 		os/overlay/pithead-data-reset os/overlay/pithead-mount-generator os/overlay/pithead-ssh-host-keys \

--- a/pithead
+++ b/pithead
@@ -1030,6 +1030,18 @@ check_hugepages_degraded() {
     dr_warn "$(head -n 1 "$marker" | tr '\t' ' ')"
 }
 
+# #1103: on the REDUCED tier, render_local_miner_config and provision_local_miner both refuse to
+# co-locate the built-in miner even though local_miner.enabled is on (see the comment above
+# local_miner_hugepages_blocked for why no headroom value could make that safe). Say so here too,
+# the same way the reduced reservation itself is announced above — an operator staring at an empty
+# Workers view otherwise has nothing telling them the opt-in was refused rather than just slow.
+check_local_miner_hugepages_blocked() {
+    is_appliance || return 0
+    [ "$(config_bool '.local_miner.enabled' false 2>/dev/null || echo false)" = "true" ] || return 0
+    local_miner_hugepages_blocked || return 0
+    dr_warn "Local mining opt-in is ON, but this machine's reduced HugePages reservation cannot also fit a co-located miner — the built-in RigForge worker is not started. Use a 16 GB machine for the built-in miner."
+}
+
 # True (rc 0) when the host CPU advertises AVX2 — RandomX wants it, but it's performance-only,
 # not fatal. Linux reads /proc/cpuinfo; macOS reads sysctl's machdep CPU features.
 cpu_has_avx2() {
@@ -1191,6 +1203,7 @@ doctor() {
             dr_warn "HugePages_Total is 0 — RandomX mining is slower. Run './pithead setup' (kernel optimization) to reserve them."
         fi
         check_hugepages_degraded
+        check_local_miner_hugepages_blocked
 
         # Runtime counterpart to setup's capacity pre-flight: preflight_resources checks MemTotal
         # (does the host have enough RAM at all), this checks MemAvailable (is enough free right
@@ -2778,7 +2791,13 @@ announce_local_miner() {
     # On the appliance the miner is built in: pithead renders RigForge's config and the boot path
     # runs its setup, so there is nothing to install and no values to copy.
     if is_appliance; then
-        log "Local mining is ON: this machine also mines with its own CPU. The built-in RigForge worker points at the stack's own stratum and appears in the dashboard's Workers view."
+        if local_miner_hugepages_blocked; then
+            # #1103: opted in, but reduced HugePages means the built-in miner never actually
+            # starts (provision_local_miner refuses it) — say that instead of claiming it runs.
+            warn "Local mining is opted in, but this machine's reduced HugePages reservation cannot also fit a co-located miner — the built-in RigForge worker is not started. Use a 16 GB machine for the built-in miner."
+        else
+            log "Local mining is ON: this machine also mines with its own CPU. The built-in RigForge worker points at the stack's own stratum and appears in the dashboard's Workers view."
+        fi
         return 0
     fi
     local bind port host secret
@@ -2849,6 +2868,24 @@ rigforge_dir() { printf '%s' "${PITHEAD_RIGFORGE_DIR:-/data/rigforge}"; }
 # `apply` re-renders after RigForge has already grown the pool, and handing the grown pool
 # back as headroom would ratchet it up on every apply. Healthy hardware has no marker, so the
 # declared value is the same 6144 MB it has always been.
+
+# #1103's product decision: on the REDUCED tier, do not co-locate the built-in miner at all.
+# The tier's 2560 pages were budgeted for the stack's own two RandomX datasets alone, with no
+# co-resident miner in the sum, and no headroom value declared here can fix that — RigForge's
+# grow-only pool write counts the stack's already-held pages as unavailable while this same
+# headroom sits inside its own requirement, so the co-resident's pages are counted twice and the
+# result is unbounded (see the comment above render_local_miner_config for the arithmetic). The
+# RELEASED tier (0 pages) is not affected: it declares zero headroom, so there is nothing left to
+# double-count, and the full tier is the measured, supported case this was never wrong for.
+# Blocking co-location is therefore scoped to exactly the tier where the double-count is real —
+# never the two tiers either side of it, so a normal 16 GB box keeps its full reservation and a
+# released box keeps mining solo exactly as it does today.
+local_miner_hugepages_blocked() {
+    local pages
+    pages=$(hugepages_decision_pages)
+    [ "$pages" -gt 0 ] && [ "$pages" -lt "$PITHEAD_HUGEPAGES" ]
+}
+
 render_local_miner_config() {
     is_appliance || return 0
     # Not on a rig, ever. This function's "switched off" branch DELETES the miner's config, and
@@ -2860,6 +2897,13 @@ render_local_miner_config() {
     if [ "$(config_bool '.local_miner.enabled' false 2>/dev/null || echo false)" != "true" ]; then
         # Derived means derived: switched off, the config goes away — the boot leg then has
         # nothing to start, and a stale stratum password does not linger on /data.
+        rm -f "$dir/config.json"
+        return 0
+    fi
+    if local_miner_hugepages_blocked; then
+        # Same treatment as switched off (#1103): a reduced-RAM box cannot also fit a co-located
+        # miner without double-counting the stack's own reservation. provision_local_miner is
+        # the one that warns the operator; this only keeps the derived file from existing.
         rm -f "$dir/config.json"
         return 0
     fi
@@ -2919,6 +2963,15 @@ provision_local_miner() {
         # Switched off: stop a still-running miner now rather than waiting for the reboot that
         # would drop its runtime unit anyway. Best-effort — absent unit, absent systemctl (tests)
         # and DIY hosts all land in the same quiet no-op.
+        systemctl stop xmrig.service >/dev/null 2>&1 || true
+        return 0
+    fi
+    if local_miner_hugepages_blocked; then
+        # #1103: this machine's reduced HugePages reservation cannot also fit a co-located
+        # miner without double-counting the stack's own share — refuse to start it, the same
+        # way a switched-off opt-in does, rather than let RigForge's grow-only sysctl chase an
+        # unbounded target on hardware already running squeezed.
+        warn "Local mining opt-in is ON, but this machine's reduced HugePages reservation cannot also fit a co-located miner without risking the stack itself — the built-in miner is not started. Use a 16 GB machine for the built-in miner."
         systemctl stop xmrig.service >/dev/null 2>&1 || true
         return 0
     fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -9168,13 +9168,13 @@ assert_eq "no stratum password -> no pass key at all" \
     "$(jq -r '.pools[0] | has("pass")' "$LMR/rigforge/config.json")" "false"
 assert_eq "no degrade marker -> the full budget is declared as headroom (3072 pages -> 6144 MB)" \
     "$(jq -r '.hugepages_reserve_extra_mb' "$LMR/rigforge/config.json")" "6144"
-# Degraded box (#977): the boot-time sizing recorded a smaller reservation in the marker, and
-# the render declares THAT — a constant 6144 here had RigForge's grow-only sysctl size the pool
-# to miner-need + 6 GiB on the low-RAM machine, every boot.
+# #1103 superseded this: it used to assert the recorded reservation as headroom (2560 pages ->
+# 5120 MB), the double-count #1103 removes — co-location is now refused outright on this
+# REDUCED tier (no config); the rest of the gate is proven in test_appliance_hugepages.sh.
 printf 'reduced-reservation words\npages=2560\n' >"$LMR/marker"
 PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMR/marker" run_sourced "$LMR" render_local_miner_config >/dev/null 2>&1
-assert_eq "degrade marker -> headroom follows the recorded reservation (2560 pages -> 5120 MB)" \
-    "$(jq -r '.hugepages_reserve_extra_mb' "$LMR/rigforge/config.json")" "5120"
+[ -f "$LMR/rigforge/config.json" ] && bad "reduced tier -> co-location refused, no config rendered (#1103)" "file exists" ||
+    ok "reduced tier -> co-location refused, no config rendered (#1103)"
 printf 'released-reservation words\npages=0\n' >"$LMR/marker"
 PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMR/marker" run_sourced "$LMR" render_local_miner_config >/dev/null 2>&1
 assert_eq "released reservation -> zero headroom (RigForge sizes for the miner alone)" \

--- a/tests/stack/test_appliance_hugepages.sh
+++ b/tests/stack/test_appliance_hugepages.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Tier-1 proof for #1103: a reduced-RAM appliance must not co-locate the built-in RigForge
+# miner with a headroom declaration that double-counts the stack's own HugePages reservation.
+#
+# tests/stack/run.sh already proves render_local_miner_config's DERIVATION (pool URL, secret,
+# the full/released headroom values) — this file is a sibling, not a duplicate: it proves the
+# NEW #1103 gate that sits in front of that derivation, so it lives on its own rather than
+# growing a file mid-split (#1105 Phase 1). See tests/os/hugepages-boot-verdict.sh /
+# os/overlay/pithead-hugepages for where the marker this gate reads comes from — a real KVM
+# boot on reduced -m proves the marker itself; this proves what pithead does once it exists.
+#
+# The math this exists to stop (from the issue): RigForge's grow-only pool write is
+# required = 1168*numa + 128 + threads + 10 + (extra_mb+1)/2, and avail excludes pages the
+# stack already holds. On the REDUCED tier (2560 pages, sized for the stack's own two RandomX
+# datasets with no co-resident miner in the budget) any nonzero extra_mb the render declares is
+# added to required while the same pages are subtracted from avail — a real machine's numbers
+# put that at ~12 GiB requested on an 8 GiB box. No declared value bounds it, so the fix refuses
+# co-location on exactly that tier: the RELEASED tier (0 pages) already declares zero headroom
+# and has nothing to double-count, and the FULL tier is the measured, supported case — neither
+# changes.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/stack/lib.sh
+source "$HERE/lib.sh"
+
+echo "== unit: local_miner_hugepages_blocked — exactly the reduced tier is blocked =="
+HG="$SANDBOX/hg"
+mkdir -p "$HG"
+assert_eq "no marker (healthy/DIY) -> not blocked" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$HG/no-marker" run_sourced "$HG" local_miner_hugepages_blocked && echo yes || echo no)" "no"
+printf 'reduced\npages=2560\n' >"$HG/reduced-marker"
+assert_eq "reduced tier (2560 pages) -> blocked" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$HG/reduced-marker" run_sourced "$HG" local_miner_hugepages_blocked && echo yes || echo no)" "yes"
+printf 'released\npages=0\n' >"$HG/released-marker"
+assert_eq "released tier (0 pages) -> NOT blocked (nothing left to double-count)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$HG/released-marker" run_sourced "$HG" local_miner_hugepages_blocked && echo yes || echo no)" "no"
+printf 'full\npages=3072\n' >"$HG/full-marker"
+assert_eq "marker present but at the full budget -> NOT blocked" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$HG/full-marker" run_sourced "$HG" local_miner_hugepages_blocked && echo yes || echo no)" "no"
+
+echo "== unit: render_local_miner_config refuses the reduced tier (#1103) =="
+LMH="$SANDBOX/lmh"
+mkdir -p "$LMH/rigforge"
+printf '{"local_miner":{"enabled":true}}' >"$LMH/config.json"
+printf 'STRATUM_PORT=3333\n' >"$LMH/.env"
+export PITHEAD_RIGFORGE_DIR="$LMH/rigforge"
+printf 'reduced\npages=2560\n' >"$LMH/reduced-marker"
+PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/reduced-marker" run_sourced "$LMH" render_local_miner_config >/dev/null 2>&1
+[ -f "$LMH/rigforge/config.json" ] && bad "reduced tier -> no derived config (was blocked)" "file exists" ||
+    ok "reduced tier -> no derived config (was blocked)"
+# The full tier is untouched: this is the regression a sloppy fix would introduce (blocking
+# everything, or shrinking the healthy-box declaration).
+PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/no-marker" run_sourced "$LMH" render_local_miner_config >/dev/null 2>&1
+assert_eq "full tier -> headroom is UNCHANGED at 6144 MB (no regression on a normal box)" \
+    "$(jq -r '.hugepages_reserve_extra_mb' "$LMH/rigforge/config.json")" "6144"
+rm -f "$LMH/rigforge/config.json"
+# The released tier is untouched too: it already declares zero headroom, so there is nothing
+# for this gate to refuse.
+printf 'released\npages=0\n' >"$LMH/released-marker"
+PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/released-marker" run_sourced "$LMH" render_local_miner_config >/dev/null 2>&1
+assert_eq "released tier -> still renders, zero headroom (unchanged)" \
+    "$(jq -r '.hugepages_reserve_extra_mb' "$LMH/rigforge/config.json")" "0"
+unset PITHEAD_RIGFORGE_DIR
+
+echo "== unit: provision_local_miner stops/refuses the miner on the reduced tier (#1103) =="
+LMP="$SANDBOX/lmp"
+mkdir -p "$LMP/bin" "$LMP/rigforge"
+cat >"$LMP/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+echo "systemctl $*" >>"${SYSTEMCTL_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "$LMP/bin/systemctl"
+cat >"$LMP/rigforge/rigforge.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "rigforge.sh $*" >>"${RIGFORGE_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "$LMP/rigforge/rigforge.sh"
+printf '{"local_miner":{"enabled":true}}' >"$LMP/config.json"
+printf 'reduced\npages=2560\n' >"$LMP/reduced-marker"
+export PITHEAD_RIGFORGE_DIR="$LMP/rigforge" SYSTEMCTL_LOG="$LMP/systemctl.log" RIGFORGE_LOG="$LMP/rigforge.log"
+lmp_out=$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMP/reduced-marker" PATH="$LMP/bin:$PATH" \
+    run_sourced "$LMP" provision_local_miner 2>&1)
+assert_rc "blocked -> rc 0 (refusing is not a failure)" "$?" "0"
+assert_contains "blocked -> the operator is told why" "$lmp_out" "reduced HugePages reservation"
+assert_contains "blocked -> any running miner is stopped" "$(cat "$LMP/systemctl.log" 2>/dev/null)" "stop xmrig.service"
+assert_not_contains "blocked -> RigForge's own setup never runs" "$(cat "$LMP/rigforge.log" 2>/dev/null)" "setup"
+[ -f "$LMP/rigforge/config.json" ] && bad "blocked -> no derived config left behind" "file exists" ||
+    ok "blocked -> no derived config left behind"
+unset PITHEAD_RIGFORGE_DIR SYSTEMCTL_LOG RIGFORGE_LOG
+
+echo "== unit: announce_local_miner (appliance) states the refusal instead of claiming the worker runs =="
+LMA="$SANDBOX/lma"
+mkdir -p "$LMA"
+printf '{"local_miner":{"enabled":true}}' >"$LMA/config.json"
+printf 'reduced\npages=2560\n' >"$LMA/reduced-marker"
+lma_out=$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMA/reduced-marker" run_sourced "$LMA" announce_local_miner 2>&1)
+assert_contains "blocked -> announcement names the reduced reservation" "$lma_out" "reduced HugePages reservation"
+assert_not_contains "blocked -> announcement does not claim the worker is on" "$lma_out" "is ON: this machine"
+
+echo "== unit: doctor's check_local_miner_hugepages_blocked (#1103) =="
+DLB="$SANDBOX/dlb"
+mkdir -p "$DLB"
+printf 'reduced\npages=2560\n' >"$DLB/reduced-marker"
+printf '{"local_miner":{"enabled":true}}' >"$DLB/config.json"
+out=$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$DLB/reduced-marker" \
+    run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)
+assert_contains "enabled + blocked -> WARNs" "$out" "reduced HugePages reservation"
+printf '{"local_miner":{"enabled":false}}' >"$DLB/config.json"
+assert_eq "disabled -> silent even on the reduced tier" \
+    "$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$DLB/reduced-marker" run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)" ""
+printf '{"local_miner":{"enabled":true}}' >"$DLB/config.json"
+assert_eq "enabled + full tier -> silent (nothing to warn about)" \
+    "$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$DLB/no-marker" run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)" ""
+assert_eq "off the appliance -> silent regardless" \
+    "$(PITHEAD_APPLIANCE=0 PITHEAD_HUGEPAGES_MARKER="$DLB/reduced-marker" run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)" ""
+
+echo ""
+printf 'appliance-hugepages tests: \033[1;32m%d passed\033[0m, ' "$PASS"
+if [ "$FAIL" -gt 0 ]; then
+    printf '\033[1;31m%d failed\033[0m\n' "$FAIL"
+    exit 1
+fi
+printf '0 failed\n'


### PR DESCRIPTION
# fix(hugepages): refuse to co-locate the built-in miner on a reduced-RAM box

Closes #1103

Branch: `fix/1103-hugepages-colocate`
SHA: `267791a21392cca3921ca874aca8f2cfd46cc4d7`

## Root cause

`pithead:2852` `render_local_miner_config` (and `pithead:8413` `hugepages_decision_pages`,
`pithead:1027` `check_hugepages_degraded`, `os/overlay/pithead-hugepages`).

On the REDUCED HugePages tier (a box below the supported 16 GB floor: 7-15 GB RAM, boot-time
sizing reserves 2560 pages / 5 GiB instead of the full 3072 / 6 GiB), the appliance still
declared the co-located RigForge miner's headroom as `hugepages_reserve_extra_mb` = the tier's
own reservation (5120 MB). RigForge's grow-only pool write is:

```
required = 1168 * numa_nodes + 128 + threads + 10 + (extra_mb + 1) / 2
```

and it grows the pool by `required - avail`, where `avail` counts free pages plus pages the
miner itself already holds — excluding pages the STACK already holds. Since the declared
headroom (`extra_mb`) is inside `required` while the stack's matching pages are excluded from
`avail`, the same pages are counted twice. With 1 NUMA node, 4 threads and the stack holding
~2336 of the tier's 2560 pages, this worked out to requesting roughly 12 GiB of locked memory
on an 8 GB machine — the exact defect #1103 reports. No declared value fixes this (it is the
arithmetic double-counting, not the number); the RELEASED tier (0 pages reserved) already
declares zero headroom and has nothing to double-count, and the FULL tier (16 GB, 3072 pages)
is the measured, supported case — this is a REDUCED-tier-only defect.

## Fix

Per the issue's own framing, this is a product decision needing a pithead-only mitigation
(Option 1 in the issue: refuse to co-locate on a degraded box) since Option 3 (a new
RigForge-side ceiling contract) needs a cross-repo change out of scope here, and Option 2
(declare zero headroom but still colocate) only reduces, does not eliminate, the
over-reservation.

- `pithead:local_miner_hugepages_blocked()` (new): true only when the boot marker records a
  reservation strictly between 0 and the full budget — i.e. exactly the REDUCED tier. Does not
  touch sizing at all.
- `render_local_miner_config`, `provision_local_miner`, `announce_local_miner`: all treat
  "enabled but blocked" the same as switched off — no derived RigForge config, any running
  miner is stopped, and the operator is told why (not silently shown an empty Workers view).
- `doctor` gained `check_local_miner_hugepages_blocked` — a WARN alongside the existing
  degraded-hugepages check, visible the same way the reduced reservation itself already is.

## Tests run

**Tier 1 (unit, new file `tests/stack/test_appliance_hugepages.sh`, 18 assertions):**
- `local_miner_hugepages_blocked` — full/reduced/released/exactly-full-budget-with-marker, all
  four combinations.
- `render_local_miner_config` — reduced tier writes no config; full and released tiers are
  BYTE-FOR-BYTE unchanged (the explicit no-regression check for the "must not shrink
  reservations on normal boxes" requirement).
- `provision_local_miner` — blocked case stops any running miner, never runs RigForge's setup,
  leaves no derived config, and returns rc 0 (a refusal is not a failure).
- `announce_local_miner` (appliance) — blocked case names the reduced reservation and does NOT
  claim the worker is on.
- `check_local_miner_hugepages_blocked` — WARNs only when enabled AND blocked; silent when
  disabled, at full tier, or off the appliance.

Regression-verified: stashing the fix and re-running the new suite fails exactly the 1
assertion the fix addresses per scenario (confirmed manually before commit).

**Mutation coverage, by test:**
- "full tier -> headroom is UNCHANGED at 6144 MB" catches any respell that shrinks the full-tier
  declaration (the load-bearing "must not shrink on normal boxes" invariant).
- "released tier -> still renders, zero headroom (unchanged)" catches a respell that widens the
  refusal to the wrong tier.
- "reduced tier -> no derived config" + the provision/announce/doctor assertions together catch
  a respell that inverts `local_miner_hugepages_blocked`'s boundary (`-gt 0` vs `-ge 0`, `-lt`
  vs `-le` against `PITHEAD_HUGEPAGES`).

**KVM (tier 4) — RUN, with a real verdict.** Combined build (this branch + #1050 + #1030
merged into a throwaway `kvm-combined-1103-1050-1030` branch off the same base commit, per the
"build/boot at most once, reuse across all three bugs" instruction): `os/build-image.sh`
(PITHEAD_UPDATER=rauc, dev SSH key baked) → `os/rauc/mkimage.sh --dev` →
`tests/os/verify-image.sh --test` (100/100 static checks, including this fix's own doctor/
render/provision code shipping correctly). Booted manually via `virt-install --memory 8192`
(the REDUCED tier's real RAM range — `tests/os/run.sh`'s own phases hardcode 16384 and assert
the FULL tier via `hugepages-boot-verdict.sh`, so this had to be a direct boot outside that
harness). KVM lock held for the guest/battery portion only, released immediately after.

Verdict, read live over SSH against the REAL boot-produced marker (not a fixture):

```
MemTotal:        8133520 kB
HugePages_Total:    2560
HugePages_Free:     2560
pithead-hugepages.service: active (RC=0)
/run/pithead-hugepages-degraded: "This machine has 7.8 GiB of RAM — below the supported 16 GB.
  The mining reservation is reduced from 6 GiB to 5 GiB..." / pages=2560

render_local_miner_config (sourced from the ON-BOX /data/pithead/pithead, real marker):
  RENDER_RC=0  BLOCKED=yes
  /data/rigforge/config.json: NO SUCH FILE (correctly refused, not just unit-tested)

provision_local_miner:
  [WARNING] Local mining opt-in is ON, but this machine's reduced HugePages reservation
  cannot also fit a co-located miner without risking the stack itself — the built-in miner is
  not started. Use a 16 GB machine for the built-in miner.
  PROVISION_RC=0

check_local_miner_hugepages_blocked (the new doctor check):
  ⚠ WARN Local mining opt-in is ON, but this machine's reduced HugePages reservation cannot
  also fit a co-located miner — the built-in RigForge worker is not started. Use a 16 GB
  machine for the built-in miner.
```

Every line matches the fix's coded messages exactly, on a real guest boot, not a sandbox
fixture. Full log (incl. #1030's journal-persistence verdict from the same guest/boot) is on
the session record; ask the coordinator for the combined-branch worktree at
you want to re-run or extend the battery without rebuilding.

## NOT proven

- The FULL RigForge co-location interaction (an actual RigForge process computing its
  grow-only sysctl write against the declared headroom) was NOT run — RigForge lives in a
  separate repo and is not available to drive from this session. The fix is verified at the
  pithead side of the contract (no headroom declared, miner not started) via both unit tests
  and the real on-box marker read above; the RigForge-side arithmetic that originally produced
  the ~12 GiB figure is quoted from the issue, not independently re-derived here.
- The RELEASED tier (<7 GB, 0 pages) was not separately KVM-booted — only unit-tested. The
  REDUCED tier (the one this bug is about) is what was booted.
- A full wizard-driven provision with `local_miner=true` (the real end-user path) was not run;
  the KVM leg instead wrote `/data/pithead/config.json` directly over SSH and called the
  functions, which exercises the same code paths but skips the wizard's own HTTP flow.
