### PR TITLE
fix(e2e): the matrix profile gates test membership, not the literal profile string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,9 @@ jobs:
         # Pure-logic checks for the tests/integration/ harness (config rendering, matrix
         # coverage, redaction). The LIVE matrix (tests/integration/run.sh) needs a real test
         # server and runs as a gated/manual release gate (#54), not on every PR.
-        run: bash tests/integration/selftest.sh
+        run: |
+          bash tests/integration/selftest.sh
+          bash tests/integration/selftest-compose-profiles.sh
 
   compose:
     name: Compose config + security hardening

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test-compose: ## Validate docker-compose.yml interpolation + hardening invariant
 
 test-integration-selftest: ## Integration harness pure-logic self-test (no server needed)
 	bash tests/integration/selftest.sh
+	bash tests/integration/selftest-compose-profiles.sh
 
 test-fakes: ## Fake-daemon contract test — real dashboard clients vs controllable fakes (no docker)
 	uv run --locked --project build/dashboard --extra test python -m pytest tests/integration/fakes -q

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1120,7 +1120,7 @@ run_lifecycle() {
     # Piggybacks the pool-flip apply below, which always runs ensure_directories -> ensure_owner.
     # Local mode only (has data dirs); a stub can't create a foreign-uid inode, so this is tier-4.
     local own_dir own_probe=""
-    if [ "$(env_on_box COMPOSE_PROFILES)" = "local_node" ]; then
+    if has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         own_dir="$(env_on_box DASHBOARD_DATA_DIR)"
         if [ -n "$own_dir" ]; then
             own_probe="$own_dir/.itest-owner-probe"
@@ -1145,7 +1145,7 @@ run_lifecycle() {
 
     # Node-down failover (#31): stop monerod -> status non-zero (node down), dashboard rejects
     # workers (xmrig-proxy stopped) -> start monerod -> readmitted -> status 0 again.
-    if [ "$(env_on_box COMPOSE_PROFILES)" = "local_node" ]; then
+    if has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         it_step "stopping monerod to exercise node-down failover…"
         rx "docker compose stop monerod" >/dev/null 2>&1
         wait_for 120 5 "status to report node down" _pred_status_down || true
@@ -1427,7 +1427,7 @@ run_fault_injection() {
     IT_CURRENT_SCENARIO="fault-injection"
     echo ""
     it_log "── fault-injection phase ───────────────────────────"
-    if [ "$(env_on_box COMPOSE_PROFILES)" != "local_node" ]; then
+    if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         it_warn "skipping fault injection (remote mode: no local monerod to break)"
         return 0
     fi
@@ -1588,7 +1588,7 @@ run_hardening() {
     echo ""
     it_log "── v1.4 hardening phase (#377/#33/#424) ────────────"
 
-    if [ "$(env_on_box COMPOSE_PROFILES)" != "local_node" ]; then
+    if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         it_warn "skipping hardening phase (remote mode: no local containers/systemd to exercise)"
         return 0
     fi
@@ -2009,7 +2009,7 @@ run_subnet_scenario() {
         it_warn "skipping moved-subnet phase (needs local mode: it brings the stack down/up and inspects the live docker network)"
         return 0
     fi
-    if [ "$(env_on_box COMPOSE_PROFILES)" != "local_node" ]; then
+    if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         it_warn "skipping moved-subnet phase (remote mode: monerod's moved-prefix proxy is one of the named checks)"
         return 0
     fi
@@ -2104,7 +2104,7 @@ run_rigforge_control() {
         it_warn "skipping rigforge-control (needs local mode: it edits config.json + dials the rig on the mining LAN)"
         return 0
     fi
-    if [ "$(env_on_box COMPOSE_PROFILES)" != "local_node" ]; then
+    if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
         it_warn "skipping rigforge-control (remote mode: no local dashboard container to drive)"
         return 0
     fi

--- a/tests/integration/scenarios.sh
+++ b/tests/integration/scenarios.sh
@@ -119,3 +119,21 @@ scenario_names() {
         [ -n "$name" ] && printf '%s\n' "$name"
     done < <(scenario_matrix)
 }
+
+# Pure membership test on a comma-separated Compose profiles list (#1301) — the runtime
+# counterpart of this file's monero.mode/tari.mode axes: render_env (pithead's env writer) turns
+# the local/remote choice above into COMPOSE_PROFILES by APPENDING tokens (local_node, then
+# local_tari/payout_confirm/tari_payout_confirm as those features turn on), so a standard local
+# box's COMPOSE_PROFILES reads "local_node,local_tari,payout_confirm", never the bare token
+# alone. A strict string-equality comparison against one literal token therefore only ever
+# matches when that token is the ONLY active profile — not a configuration run.sh's six
+# local-mode gates were ever meant to require, so they silently read every standard local box as
+# remote mode. Mirrors pithead's own membership idiom (remove_deactivated_profile_containers in
+# the `pithead` CLI). Sourced (via this file) by run.sh; selftest-compose-profiles.sh proves the
+# mutation this guards against: reverting to a literal `[ "$1" = "$2" ]` comparison must go red.
+has_compose_profile() { # <profiles-csv> <token>
+    case ",$1," in
+    *",$2,"*) return 0 ;;
+    *) return 1 ;;
+    esac
+}

--- a/tests/integration/selftest-compose-profiles.sh
+++ b/tests/integration/selftest-compose-profiles.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Self-test for has_compose_profile (#1301): the COMPOSE_PROFILES membership test run.sh's six
+# local-mode gates (rigforge-control, hardening, moved-subnet, plus two lifecycle assertions) use
+# instead of a literal string comparison. Standalone (not sourced by selftest.sh) so it never
+# touches selftest.sh's own file-budget ceiling — see CONTRIBUTING.md's file-budget-gate entry,
+# the #1258 "moved into its own file" precedent. Run directly, or via
+# `make test-integration-selftest` (which runs this after selftest.sh). No server needed.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+# shellcheck source=tests/integration/scenarios.sh
+source "$HERE/scenarios.sh"
+
+echo "== has_compose_profile: COMPOSE_PROFILES membership, not string equality (#1301) =="
+# This is the load-bearing assertion for #1301: reverting has_compose_profile's body to the old
+# `[ "$1" = "$2" ]` comparison flips this from PASS to FAIL on exactly this fixture — the real
+# shape a standard local box renders (render_env appends local_tari/payout_confirm alongside
+# local_node), not a synthetic one — because strict equality only matches when local_node is the
+# ONLY active profile. That's the mutation this assertion is proving it still catches.
+if has_compose_profile "local_node,local_tari,payout_confirm" local_node; then
+    it_pass "membership matches local_node inside a multi-profile list (the #1301 shape)"
+else
+    it_fail "membership matches local_node inside a multi-profile list (the #1301 shape)" \
+        "false negative — reverts to the #1301 literal-equality bug"
+fi
+# The simple case (no other feature on) must keep working — the fix must not regress it.
+if has_compose_profile "local_node" local_node; then
+    it_pass "membership matches a bare single-token list"
+else
+    it_fail "membership matches a bare single-token list" "false negative on the simplest case"
+fi
+# A genuinely remote stack (local_node absent, other profiles still present) must still skip —
+# the gate must not flip into matching everything.
+if has_compose_profile "payout_confirm" local_node; then
+    it_fail "genuinely remote profile set is not treated as local_node" \
+        "false positive on a remote-mode profile list"
+else
+    it_pass "genuinely remote profile set is not treated as local_node"
+fi
+# Membership is token-exact, not a raw substring match — a profile name that merely CONTAINS
+# "local_node" must not false-positive (guards a naive unanchored `case *local_node*` rewrite).
+if has_compose_profile "some_local_node_variant" local_node; then
+    it_fail "membership is token-exact, not a substring match" \
+        "false positive on 'some_local_node_variant'"
+else
+    it_pass "membership is token-exact, not a substring match"
+fi
+# An empty profiles string (COMPOSE_PROFILES unset/absent) must not crash or match.
+if has_compose_profile "" local_node; then
+    it_fail "empty profiles list is not treated as local_node" "false positive on an empty string"
+else
+    it_pass "empty profiles list is not treated as local_node"
+fi
+
+echo ""
+echo "selftest-compose-profiles: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Six sites in `tests/integration/run.sh` decided "is this a local-node stack" by comparing the
raw `COMPOSE_PROFILES` value against the literal string `local_node` (`run.sh:1123`, `1148`
[`=`], `1430`, `1591`, `2012`, `2107` [`!=`]). `render_env` (the `pithead` CLI's single env-file
writer) builds `COMPOSE_PROFILES` by **appending** tokens — `local_node`, then
`local_tari`/`payout_confirm`/`tari_payout_confirm` as those features turn on — so a standard
local box renders `local_node,local_tari,payout_confirm`, never the bare token alone. The strict
comparison therefore never matched on a normally configured box, and the `rigforge-control`,
`hardening`, and `moved-subnet` phases (plus two `run_lifecycle` assertions) silently
self-skipped as "remote mode" — including on the v1.20.0 pre-cut gate (610 passed / 5 skipped /
0 failed, with the skip lines proving it).

## Root cause

`tests/integration/run.sh` (six call sites, now converted) called `env_on_box COMPOSE_PROFILES`
and compared the result with `[ = "local_node" ]` / `[ != "local_node" ]` instead of testing
list membership.

## Fix

- Added `has_compose_profile "<profiles-csv>" "<token>"` — a pure comma-list membership test —
  to `tests/integration/scenarios.sh` (mirrors `pithead`'s own
  `remove_deactivated_profile_containers` idiom). Placed in `scenarios.sh` rather than `lib.sh`
  or `run.sh` deliberately: both of those are already at their `docs/dev/file-budget.tsv`
  ceiling with zero slack, and `scenarios.sh` isn't budget-tracked (well under the 400-line
  target even after this addition), so the fix doesn't force an unrelated ceiling bump.
- Swapped all six `run.sh` call sites to `has_compose_profile "$(env_on_box COMPOSE_PROFILES)"
  local_node` (or `! has_compose_profile ...`) — net zero line-count change in `run.sh`.
- Added `tests/integration/selftest-compose-profiles.sh`, a standalone self-test (not sourced by
  `selftest.sh`, for the same budget-slack reason) wired into `make test-integration-selftest`
  and `.github/workflows/ci.yml` alongside `selftest.sh`.

## Mutation kill (stated + verified)

The self-test's load-bearing assertion feeds `has_compose_profile` the real standard-box shape
(`"local_node,local_tari,payout_confirm"`, `local_node`) and asserts it matches. Reverting
`has_compose_profile`'s body to the old literal comparison (`[ "$1" = "$2" ]`) flips that
assertion from PASS to FAIL — verified locally: with the literal comparison restored,
`selftest-compose-profiles.sh` reports `4 passed, 1 failed` (rc 1); with the real fix, `5
passed, 0 failed`. Additional assertions guard: the simple single-token case still matches (no
regression), a genuinely remote profile set still does NOT match (the gate must still skip real
remote stacks), membership is token-exact (not an unanchored substring match), and an empty
profiles string doesn't false-positive.

## What ran (this PR)

- `bash tests/integration/selftest.sh` — 214 passed, 0 failed (unchanged; this file was not
  modified).
- `bash tests/integration/selftest-compose-profiles.sh` — 5 passed, 0 failed.
- Manual mutation test: reverted `has_compose_profile` to the old literal-equality bug in a
  scratch copy, re-ran `selftest-compose-profiles.sh` → 4 passed, 1 failed (rc 1), confirming
  the assertion is load-bearing; restored the fix and re-ran green.
- `shellcheck --severity=warning` and `shfmt -i 4 -d` on every touched shell file (`run.sh`,
  `scenarios.sh`, `selftest-compose-profiles.sh`) — clean.
- `bash scripts/lint-file-budget.sh --self-test` and `bash scripts/lint-file-budget.sh` — both
  pass; no ceiling raised, no file grew past its recorded ceiling.
- `bash scripts/lint-topology-classes.sh` — clean (no real-looking hostnames/paths introduced).
- Did NOT run `tests/stack/run.sh`, `make lint` (whole), or the live matrix e2e — out of scope
  for this task per the coordinator's instructions.

## Owed (separate follow-up, on the coordinator)

**The live matrix e2e run is owed.** This PR is verified at the unit/self-test level only —
proving the membership logic is correct in isolation. It has NOT been proven against a real
bench: that the `rigforge-control`, `hardening`, and `moved-subnet` phases actually now RUN
(rather than skip) on a real local-mode box's rendered `COMPOSE_PROFILES`, and that they behave
correctly once running (the `rigforge-control` phase separately has known-stale assertions,
tracked in #1309). The coordinator is scheduling that live-rig proof leg (`tests/integration/
e2e.sh <ref> --mode matrix` on a borrowed rig) as a follow-up; this PR should not be treated as
closing the coverage gap end-to-end until that run comes back green with the three previously-
skipped phases visibly executing (not skipped) in the log.

Closes #1301
