### PR TITLE
fix(e2e): worker-apply legs settle an async accepted response before asserting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,9 @@ jobs:
         # Pure-logic checks for the tests/integration/ harness (config rendering, matrix
         # coverage, redaction). The LIVE matrix (tests/integration/run.sh) needs a real test
         # server and runs as a gated/manual release gate (#54), not on every PR.
-        run: bash tests/integration/selftest.sh
+        run: |
+          bash tests/integration/selftest.sh
+          bash tests/integration/selftest-rigforge-apply-settle.sh
 
   compose:
     name: Compose config + security hardening

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test-compose: ## Validate docker-compose.yml interpolation + hardening invariant
 
 test-integration-selftest: ## Integration harness pure-logic self-test (no server needed)
 	bash tests/integration/selftest.sh
+	bash tests/integration/selftest-rigforge-apply-settle.sh
 
 test-fakes: ## Fake-daemon contract test — real dashboard clients vs controllable fakes (no docker)
 	uv run --locked --project build/dashboard --extra test python -m pytest tests/integration/fakes -q

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -1,0 +1,39 @@
+# shellcheck shell=bash
+#
+# Settle a dashboard-mediated RigForge worker-apply intent past its dial-time "accepted" (#1309).
+#
+# RigForge #344: the rig now answers "accepted" immediately and applies async. pithead's own host
+# runner (control_worker_apply in the `pithead` CLI) caps its post-dial /status poll at 20s and,
+# past that, writes an "accepted … outcome not yet observed" result verbatim — its own words: "the
+# container can keep polling the rig via the next read." That next read is the dashboard's regular
+# per-rig poll (data_service.py's run loop), which on the SAME poll tick both:
+#   (a) refreshes the enriched feed's live watchdog value (served at /api/state, read by
+#       _pred_feed_maxt in run.sh), and
+#   (b) reconciles a still-"accepted" #185 worker-config history row to its real terminal status
+#       (storage_service.py:reconcile_worker_config_status, #579/#604) — step 3a in that poll,
+#       strictly BEFORE the enriched-feed merge at step 3b.
+# So observing the feed converge to the requested max_temp_c is proof the requested key (the only
+# key in a max_temp_c change) is what changed, and the #185 history row for that change_id is
+# already reconciled to "applied" by the time run.sh reads it back — no direct rig dial needed
+# (IT_RIG_TOKEN/RIG_HOST bench flags aren't always set: the live-box case uses the baseline's own
+# workers.list[] descriptor without them), and no reliance on the dial-time result ever changing.
+# Fails loudly (leaves status/ckeys at their dial-time "accepted"/empty) on a real
+# rejected/failed/timeout, exactly like a "the change never actually happened" bug would.
+#
+# Sourced by run.sh, which supplies wait_for (lib.sh) and _pred_feed_maxt (run.sh). Fields are
+# '|'-joined, not tab — `read` with IFS=tab (an IFS-whitespace character) SQUASHES an empty
+# middle field instead of preserving it, misaligning every field after it; '|' can't appear in
+# any of the three values, so it splits correctly even when ckeys/change_id come back empty.
+_settle_worker_apply_maxt() { # <rig> <want-max_temp_c> <dial-result-json> -> "<status>|<ckeys>|<change_id>"
+    local rig="$1" want="$2" res="$3" status ckeys change_id
+    status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
+    ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
+    change_id="$(printf '%s' "$res" | jq -r '.change_id // empty' 2>/dev/null)"
+    if [ "$status" = "accepted" ] &&
+        wait_for 90 5 "the rig to report max_temp_c=$want applied (RigForge #344 async apply, #1309)" \
+            _pred_feed_maxt "$rig" "$want"; then
+        status="applied"
+        ckeys="max_temp_c"
+    fi
+    printf '%s|%s|%s' "$status" "$ckeys" "$change_id"
+}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -24,6 +24,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/lib.sh"
 # shellcheck source=tests/integration/scenarios.sh
 source "$HERE/scenarios.sh"
+source "$HERE/rigforge-apply-settle.sh"
 
 # --- Defaults / globals -----------------------------------------------------
 IT_MODE="ssh"
@@ -2194,7 +2195,7 @@ run_rigforge_control() {
     # enriched feed echoes (watchdog Temp/max), so read the current ceiling from the feed FIRST — if
     # the rig's watchdog isn't reporting it we can't safely restore it, so skip the write rather than
     # leave the rig mis-tuned.
-    local orig_maxt new_maxt res status ckeys
+    local orig_maxt new_maxt res status ckeys change_id
     orig_maxt="$(printf '%s' "$st" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .rigforge.stats[]? | select(.label=="Temp / max") | .value) // empty' 2>/dev/null | sed -n 's#.*/ *\([0-9][0-9]*\).*#\1#p')"
     if [ -z "$orig_maxt" ]; then
         it_warn "rig '$rig' watchdog isn't reporting a max_temp_c in the feed — skipping the reversible write leg (can't read the original to restore it) (#513)"
@@ -2202,17 +2203,16 @@ run_rigforge_control() {
         new_maxt=$((orig_maxt + 1))
         it_step "Worker Inspect edit: max_temp_c $orig_maxt -> $new_maxt via /api/control/worker-apply…"
         res="$(_worker_apply "$rig" "{\"max_temp_c\":$new_maxt}")"
-        status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
-        ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
+        IFS='|' read -r status ckeys change_id <<<"$(_settle_worker_apply_maxt "$rig" "$new_maxt" "$res")"
         assert_eq "Worker Inspect edit applied on the rig (#513)" "$status" "applied"
         assert_contains "the rig's /status confirms max_temp_c changed (#513)" "$ckeys" "max_temp_c"
-        # The dashboard recorded it in the per-worker config history (#185).
+        # Matched by change_id, not "the newest row" — #579/#604's reconciler (rigforge-apply-settle.sh).
         assert_eq "worker-apply recorded in the per-worker history (#185)" \
-            "$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/worker?name=$rig")" 2>/dev/null | jq -r 'first(.history[]?) | .status // empty' 2>/dev/null)" "applied"
+            "$(rx "curl -fsS --max-time 10 $(quote_arg "http://127.0.0.1:8000/api/worker?name=$rig")" 2>/dev/null | jq -r --arg c "$change_id" 'first(.history[]? | select(.change_id==$c)) | .status // empty' 2>/dev/null)" "applied"
         it_step "reverting max_temp_c $new_maxt -> $orig_maxt…"
         res="$(_worker_apply "$rig" "{\"max_temp_c\":$orig_maxt}")"
-        assert_eq "reversible edit reverted on the rig (#513)" \
-            "$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)" "applied"
+        IFS='|' read -r status _ _ <<<"$(_settle_worker_apply_maxt "$rig" "$orig_maxt" "$res")"
+        assert_eq "reversible edit reverted on the rig (#513)" "$status" "applied"
     fi
 
     # ---- #1002b: a second writable key (pools) proves the edit isn't max_temp_c-specific ----

--- a/tests/integration/selftest-rigforge-apply-settle.sh
+++ b/tests/integration/selftest-rigforge-apply-settle.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Self-test for _settle_worker_apply_maxt (#1309): the worker-apply "accepted" (RigForge #344
+# async apply) settle-to-terminal logic run.sh's #513 reversible-edit legs use. Standalone (not
+# sourced by selftest.sh) so it never touches selftest.sh's own file-budget ceiling — same
+# reasoning as selftest-compose-profiles.sh (#1301). Run directly, or via
+# `make test-integration-selftest` (which runs this after selftest.sh). No server needed.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+# shellcheck source=tests/integration/rigforge-apply-settle.sh
+source "$HERE/rigforge-apply-settle.sh"
+
+echo "== _settle_worker_apply_maxt: fast path (already terminal) =="
+res='{"status":"applied","changed_keys":["max_temp_c"],"change_id":"c1"}'
+out="$(_settle_worker_apply_maxt rig1 101 "$res")"
+assert_eq "an immediate 'applied' passes through untouched" "$out" "applied|max_temp_c|c1"
+
+echo "== _settle_worker_apply_maxt: RigForge #344 async apply (#1309) =="
+# This is the load-bearing mutation-kill: if the "accepted is terminal" bug (#1309) were
+# reintroduced — treating status verbatim instead of polling for it to settle — this would still
+# read "accepted|" with no changed_keys, exactly the 4 reds the issue documents.
+res='{"status":"accepted","change_id":"c2"}'
+wait_for() { return 0; }
+out="$(_settle_worker_apply_maxt rig1 101 "$res")"
+assert_eq "'accepted' that converges settles to 'applied' + the requested key" "$out" "applied|max_temp_c|c2"
+
+echo "== _settle_worker_apply_maxt: timeout / real failure must NOT read as success =="
+# Mutation proof, the other half: a change that genuinely never lands (broken apply path, or the
+# #579 feed/reconciler regressed) must fail loudly, not silently pass as "applied" because we saw
+# a "the change is at least accepted" event once.
+res='{"status":"accepted","change_id":"c3"}'
+wait_for() { return 1; }
+out="$(_settle_worker_apply_maxt rig1 101 "$res")"
+assert_eq "'accepted' that never converges stays 'accepted' (fails the caller's assert_eq)" "$out" "accepted||c3"
+
+echo "== _settle_worker_apply_maxt: a pre-dial reject carries no change_id/changed_keys =="
+res='{"status":"rejected","error":"nope"}'
+out="$(_settle_worker_apply_maxt rig1 101 "$res")"
+assert_eq "rejected passes through with both trailing fields genuinely empty" "$out" "rejected||"
+
+echo "== _settle_worker_apply_maxt: '|'-joined output survives an empty MIDDLE field =="
+# The regression this delimiter choice guards: IFS=tab is bash's IFS-WHITESPACE class, so `read`
+# SQUASHES a run of tabs instead of treating an empty middle field as a real field — a change_id
+# with no changed_keys (exactly the "accepted"/"rejected" shapes above) would shift change_id into
+# the ckeys variable instead of leaving it empty. Splits the REAL function's output with the SAME
+# `IFS='|' read` run.sh's call sites use, so reverting the function to a tab-joined output (no '|'
+# to split on at all) fails this: the whole string lands in rstatus instead of just "rejected".
+IFS='|' read -r rstatus rckeys rchange_id <<<"$(_settle_worker_apply_maxt rig1 101 "$res")"
+assert_eq "empty middle field (ckeys) does not shift change_id left" "$rstatus,$rckeys,$rchange_id" "rejected,,"
+
+echo ""
+echo "selftest-rigforge-apply-settle: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

RigForge changed its control API (rigforge#344): a rig now answers `"accepted"` immediately on
`POST /apply` and applies asynchronously; its own `/status` flips to `"applied"` with
`changed_keys` populated seconds later. `pithead`'s host runner (`control_worker_apply`) caps its
own post-dial `/status` poll at 20s and, past that, honestly writes `"accepted" — outcome not yet
observed` as the request's terminal-for-now result. Four `#513` assertions in
`tests/integration/run.sh` treated that dial-time snapshot as final and went red against a
**working** v1.20.0 deploy:

```
✗ Worker Inspect edit applied on the rig (#513)      expected [applied], got [accepted]
✗ the rig's /status confirms max_temp_c changed      [] missing [max_temp_c]
✗ worker-apply recorded in the per-worker history     expected [applied], got [accepted]
✗ reversible edit reverted on the rig (#513)         expected [applied], got [accepted]
```

## Root cause

`tests/integration/run.sh` (`run_rigforge_control`, around the old lines 2205-2215) asserted the
dashboard's `/api/control/worker-apply` response's `.status`/`.changed_keys` fields directly,
with no allowance for `"accepted"` (in-flight) as a legitimate, non-terminal outcome.

## Fix — re-derived from the product code, not just the issue's suggestion

Read `pithead`'s `control_worker_apply` (the host-side runner) and the dashboard's
`data_service.py`/`storage_service.py`/`xmrig_client.py`. Findings that shaped the fix:

- `control_worker_apply`'s own comment: after its 20s post-dial poll lapses, "the container can
  keep polling the rig via **the next read**." That next read is the dashboard's regular per-rig
  poll cycle (`data_service.py`'s `run()` loop).
- That SAME poll cycle, on the SAME tick, both (a) refreshes the enriched feed's live watchdog
  value (`/api/state`, what `_pred_feed_maxt` already reads for the sibling `#516` leg) and (b)
  reconciles a still-`"accepted"` `#185` history row to its real terminal status
  (`storage_service.py:reconcile_worker_config_status`, `#579`/`#604`) — step 3a in that poll,
  strictly **before** the enriched-feed merge at step 3b (`data_service.py:1259-1384`).
- So polling the feed for the requested `max_temp_c` to land is a **credentials-free** oracle
  (`IT_RIG_TOKEN`/`RIG_HOST` bench flags aren't always set — the live-box case uses the baseline's
  own `workers.list[]` descriptor without them) that proves BOTH "applied" and "the right key
  changed" together, and by the time it converges the `#185` history row for that `change_id` is
  guaranteed already reconciled — direct verification confirms `#579`/`#604` (the reconciler) is
  present in the deployed v1.20.0 tag itself, so this isn't a future-only fix.

Implementation:

- Added `_settle_worker_apply_maxt` in a new file, `tests/integration/rigforge-apply-settle.sh`
  (kept out of `lib.sh`/`run.sh` deliberately — both are already at their
  `docs/dev/file-budget.tsv` ceiling with zero slack; the new file is unbudgeted). It takes the
  dial-time result JSON, and if `.status == "accepted"`, polls `_pred_feed_maxt` for up to 90s
  before reporting the settled `status`/`changed_keys`.
- Swapped it into all four `#513` assertions plus the per-worker-history assertion, which is now
  matched by `change_id` (not "the newest row") — a small correctness improvement alongside the
  main fix.
- `run.sh` itself is a **net zero** line change (verified against `docs/dev/file-budget.tsv`).

## Mutation kills (stated + verified)

- **The core #1309 bug** (treating `"accepted"` as terminal): removing the settle-poll `if` block
  entirely makes `_settle_worker_apply_maxt` return `"accepted"` unconditionally — verified: the
  self-test's "accepted that converges" assertion flips from PASS to FAIL when this is reverted.
- **A genuine failure/timeout must NOT read as success**: the "never converges" self-test case
  (stubs `wait_for` to fail) asserts the result STAYS `"accepted"` — if the polling logic were
  changed to optimistically report `"applied"` regardless of the poll outcome, this goes red.
- **The `'|'` output delimiter** (found by hand while building this — an earlier draft used a tab
  delimiter, which bash's `read` silently SQUASHES as IFS-whitespace, shifting `change_id` into
  the `ckeys` field whenever `ckeys` is empty — exactly the shape of both the `"accepted"` and
  `"rejected"` cases): reverting the delimiter back to tab makes 5/5 of the new self-test's
  assertions go red (verified locally).

Ran each mutation locally against `tests/integration/selftest-rigforge-apply-settle.sh` and
confirmed red, then restored the fix and confirmed green (5 passed, 0 failed each time).

## What ran (this PR)

- `bash tests/integration/selftest.sh` — 214 passed, 0 failed (unchanged; not modified).
- `bash tests/integration/selftest-rigforge-apply-settle.sh` (new) — 5 passed, 0 failed.
- Manual functional test of `_settle_worker_apply_maxt` against 4 hand-built response shapes
  (immediate `applied`, `accepted`→converges, `accepted`→timeout, pre-dial `rejected` with no
  `change_id`/`changed_keys`) — all behaved as designed.
- `shellcheck --severity=warning` and `shfmt -i 4 -d` on every touched/new shell file
  (`run.sh`, `rigforge-apply-settle.sh`, `selftest-rigforge-apply-settle.sh`) — clean.
- `bash scripts/lint-file-budget.sh --self-test` and `bash scripts/lint-file-budget.sh` — both
  pass; `run.sh` is a net-zero line change against its recorded ceiling.
- `bash scripts/lint-topology-classes.sh` — clean.
- Did NOT run `tests/stack/run.sh`, `make lint` (whole), or the live matrix e2e — out of scope
  for this task per the coordinator's instructions.

## Owed (separate follow-up, on the coordinator)

**The live matrix e2e run is owed.** This fix is verified at the unit/self-test level only, against
hand-built response fixtures reasoned from reading the actual product code (`pithead`'s
`control_worker_apply`, and the dashboard's `data_service.py`/`storage_service.py`/
`xmrig_client.py`) — it has NOT been re-run against a real borrowed RigForge rig. The coordinator
is scheduling that live-rig proof leg (`tests/integration/e2e.sh <ref> --mode matrix
--rigforge-control` against a borrowed rig) as a follow-up; this PR should not be treated as
closing the `#513` write-path coverage gap until that run comes back green with the previously-red
worker-apply legs now passing for real (not just against fixtures). Also worth noting: this fix
depends on `#1301`'s profile-gate fix to ever actually START the `rigforge-control` phase on a
standard local box (`run_rigforge_control`'s own local-node gate is one of the six sites `#1301`
fixes) — the two PRs are independent commits but the live-rig proof leg needs both merged to run
this phase at all.

Closes #1309
