### PR TITLE
feat(dashboard): click-to-adopt a rig, with a resolve-and-check SSRF gate on the adopt write

### DIFF
--- a/dashboard/mining_dashboard/service/worker_adopt.py
+++ b/dashboard/mining_dashboard/service/worker_adopt.py
@@ -76,13 +76,28 @@ _LOOPBACK_ALIASES = frozenset(
 
 
 def host_is_internal(host, live_cfg):
-    """Mirrors pithead's ``_control_host_is_internal`` (the host-side SSRF floor an add-only
-    append's host must clear, #122): loopback, "this network", link-local, multicast/reserved,
+    """BEST-EFFORT, PREVIEW-TIME UX ONLY — this is NOT the security boundary. #893 round 5: an
+    earlier version of this function (and its bash/JS mirrors) classified a host purely by STRING
+    SHAPE, and an independent review found that a spelling denylist can never answer "does this
+    hostname resolve to my own loopback": this host's own machine-name self-entry (Debian gives
+    every box's own hostname a loopback ``/etc/hosts`` entry, e.g. ``127.0.1.1``) and an
+    attacker-controlled DNS name pointed at ``127.0.0.1`` both looked like "a genuine hostname,
+    therefore safe" — verified live with curl. The actual fix is RESOLVE-AND-CHECK, but that needs
+    a real (and here, synchronous-request-blocking) DNS round trip, which does not belong in this
+    module's fast, synchronous, dependency-free preview-time validation path. So this function
+    keeps doing what it always could: refuse a value that is ALREADY numeric (an IP literal,
+    including the ambiguous encodings below) or matches a KNOWN loopback spelling, purely to give
+    the operator immediate, in-browser feedback on the obvious cases. A hostname it doesn't
+    recognize — including ``gouda`` or any other name that would resolve to loopback — passes HERE
+    and is still caught by the actual authority: ``pithead``'s ``_control_host_is_internal``, which
+    runs at commit time on the host and genuinely resolves the name before deciding (see
+    ``tests/service/test_worker_adopt.py``'s ``test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design``,
+    which pins this limitation as a test rather than leaving it as a comment-only claim).
+
+    What IS still caught here: loopback, "this network", link-local, multicast/reserved,
     ``localhost`` (and its standard ``/etc/hosts`` aliases and root-terminated spelling — see
     below), or the stack's own docker-bridge subnet (``network.subnet``, read from the SAME live
-    config the caller already has — never the staged proposal, matching the bash gate's own
-    reasoning: a same-commit ``network.subnet`` change is refused by the generic allowlist gate
-    before this would ever matter). An ordinary LAN/public rig address is unaffected.
+    config the caller already has). An ordinary LAN/public rig address is unaffected.
 
     A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat ``localhost.`` exactly
     like ``localhost`` — so it is stripped before any hostname comparison, or the root-terminated

--- a/dashboard/mining_dashboard/service/worker_adopt.py
+++ b/dashboard/mining_dashboard/service/worker_adopt.py
@@ -1,0 +1,90 @@
+"""Click-to-adopt a rig: the dashboard-side half of the adopt flow (the operator-decision
+comment, issue #893).
+
+The write itself rides the EXISTING control-channel config path — the same preview/commit
+mechanics ``ConfigView`` uses for any other edit (no new write endpoint, ``web/server.py``
+``handle_control_preview``/``handle_control_commit``). This module only builds the one guard that
+path needs to carry a ``workers.list[]`` write at all: ``pithead``'s ``control_approval_gate``
+(``pithead`` ~L9695) refuses ANY diff to the per-worker descriptors outright — deliberately, since
+they hold per-rig hosts and bearer tokens (the #122 SSRF class) — with a single narrow exception
+for a strictly ADD-ONLY append (a brand-new descriptor; every already-live entry must reappear
+byte-for-byte). That host-side gate is the actual security authority and is exercised at commit.
+
+What lives here is the *dashboard-side* mirror of the same shape/charset validation pithead's own
+``validate_worker_endpoints`` applies (defense in depth, the same pattern ``control_service``'s
+``SECRET_PATHS``/``EDITABLE_ENV_KEY_PATHS`` already follow), wired into ``handle_control_preview``
+so a malformed adopt submission is refused before it ever reaches the spool — never a
+miner-advertised value auto-trusted: the host field the operator confirms is still just a
+PREFILL, and every field here is exactly what the operator typed or edited in the adopt form.
+"""
+
+import re
+
+# Mirrors pithead's per-entry regexes (``validate_worker_endpoints``, pithead ~L5901) byte for
+# byte: the host charset in particular is the #122 guard — letters/digits/dot/dash/underscore
+# only, so a submitted value can never smuggle a port, path, or userinfo into a probe URL.
+NAME_RE = re.compile(r"^[!-~]{1,128}$")
+HOST_RE = re.compile(r"^[A-Za-z0-9._-]{1,253}$")
+TOKEN_RE = re.compile(r"^[!-~]{1,128}$")
+
+# RigForge's default writable control-API port (rigforge#185); the adopt form prefills it and the
+# operator may override it, same as any other ``workers.list[].control_port``.
+DEFAULT_CONTROL_PORT = 8082
+
+
+def validate_worker_descriptor(entry):
+    """Return an error string for a malformed new ``workers.list[]`` entry, else ``""``.
+
+    Unlike pithead's own per-field validation (where host/port/token are each individually
+    optional), an ADOPTED entry must carry all three — a descriptor with a name but no host/token
+    is not a write target (``resolve_worker_target`` would refuse it anyway), so refusing it here
+    gives the operator an immediate, specific reason instead of a spooled request that could only
+    ever come back rejected.
+    """
+    if not isinstance(entry, dict):
+        return "a new worker entry must be an object."
+    name = entry.get("name")
+    if not isinstance(name, str) or not NAME_RE.fullmatch(name):
+        return "a new worker needs a name of 1-128 printable, non-space characters."
+    host = entry.get("host")
+    if not isinstance(host, str) or not HOST_RE.fullmatch(host):
+        return (
+            f"worker '{name}': host must be a hostname or IPv4 address "
+            "(letters, digits, and . _ - only — no port or path)."
+        )
+    control_port = entry.get("control_port", DEFAULT_CONTROL_PORT)
+    if (
+        isinstance(control_port, bool)
+        or not isinstance(control_port, int)
+        or not 1 <= control_port <= 65535
+    ):
+        return f"worker '{name}': control_port must be an integer between 1 and 65535."
+    token = entry.get("token")
+    if not isinstance(token, str) or not TOKEN_RE.fullmatch(token):
+        return f"worker '{name}': a control token is required — the rig's control API is bearer-mandatory."
+    return ""
+
+
+def new_worker_entries(live_cfg, staged_cfg):
+    """The entries a staged config would ADD to ``workers.list[]``, or ``[]`` if the staged list
+    isn't a pure append of the live one (a non-append change is left for the host's own add-only
+    gate to refuse, with its own message — this only identifies the genuinely-new tail to
+    pre-validate)."""
+    live_list = ((live_cfg or {}).get("workers") or {}).get("list")
+    staged_list = ((staged_cfg or {}).get("workers") or {}).get("list")
+    live_list = live_list if isinstance(live_list, list) else []
+    if not isinstance(staged_list, list):
+        return []
+    if staged_list[: len(live_list)] != live_list:
+        return []
+    return staged_list[len(live_list) :]
+
+
+def validate_new_worker_entries(live_cfg, staged_cfg):
+    """The first validation error among the entries a staged config would newly append to
+    ``workers.list[]``, or ``""`` if every new entry is well-formed (including "no new entries")."""
+    for entry in new_worker_entries(live_cfg, staged_cfg):
+        err = validate_worker_descriptor(entry)
+        if err:
+            return err
+    return ""

--- a/dashboard/mining_dashboard/service/worker_adopt.py
+++ b/dashboard/mining_dashboard/service/worker_adopt.py
@@ -70,13 +70,26 @@ _DEFAULT_SUBNET = "172.28.0.0/24"
 _THIS_NETWORK = ipaddress.ip_network("0.0.0.0/8")
 
 
+_LOOPBACK_ALIASES = frozenset(
+    {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}
+)
+
+
 def host_is_internal(host, live_cfg):
     """Mirrors pithead's ``_control_host_is_internal`` (the host-side SSRF floor an add-only
     append's host must clear, #122): loopback, "this network", link-local, multicast/reserved,
-    ``localhost``, or the stack's own docker-bridge subnet (``network.subnet``, read from the SAME
-    live config the caller already has — never the staged proposal, matching the bash gate's own
+    ``localhost`` (and its standard ``/etc/hosts`` aliases and root-terminated spelling — see
+    below), or the stack's own docker-bridge subnet (``network.subnet``, read from the SAME live
+    config the caller already has — never the staged proposal, matching the bash gate's own
     reasoning: a same-commit ``network.subnet`` change is refused by the generic allowlist gate
     before this would ever matter). An ordinary LAN/public rig address is unaffected.
+
+    A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat ``localhost.`` exactly
+    like ``localhost`` — so it is stripped before any hostname comparison, or the root-terminated
+    spelling sails past a literal-string match untouched. ``localhost.localdomain`` /
+    ``ip6-localhost`` / ``ip6-loopback`` are the standard ``/etc/hosts`` loopback aliases on
+    Debian/RHEL-family Linux (this stack's own target OS) — refused explicitly, not just the bare
+    ``localhost`` family.
 
     A string this host's own dial (curl, in the runner) would treat as numeric must be recognized
     as one here too, or an alternate encoding of the very addresses above — a bare decimal integer
@@ -89,7 +102,9 @@ def host_is_internal(host, live_cfg):
     already refuses all of the ambiguous forms above) failing to recognize it means REFUSE, never
     "must be a hostname after all"."""
     h = host.strip().lower()
-    if h == "localhost" or h.endswith(".localhost"):
+    if h.endswith("."):
+        h = h[:-1]
+    if h in _LOOPBACK_ALIASES or h.endswith(".localhost"):
         return True
     if any(c.isalpha() for c in h):
         return "0x" in h  # a hex literal is still numeric-shaped; anything else is a real hostname

--- a/dashboard/mining_dashboard/service/worker_adopt.py
+++ b/dashboard/mining_dashboard/service/worker_adopt.py
@@ -67,25 +67,39 @@ def validate_worker_descriptor(entry):
 
 
 _DEFAULT_SUBNET = "172.28.0.0/24"
+_THIS_NETWORK = ipaddress.ip_network("0.0.0.0/8")
 
 
 def host_is_internal(host, live_cfg):
     """Mirrors pithead's ``_control_host_is_internal`` (the host-side SSRF floor an add-only
-    append's host must clear, #122): loopback, unspecified, link-local, multicast/reserved,
+    append's host must clear, #122): loopback, "this network", link-local, multicast/reserved,
     ``localhost``, or the stack's own docker-bridge subnet (``network.subnet``, read from the SAME
     live config the caller already has — never the staged proposal, matching the bash gate's own
     reasoning: a same-commit ``network.subnet`` change is refused by the generic allowlist gate
-    before this would ever matter). An ordinary LAN/public rig address is unaffected."""
+    before this would ever matter). An ordinary LAN/public rig address is unaffected.
+
+    A string this host's own dial (curl, in the runner) would treat as numeric must be recognized
+    as one here too, or an alternate encoding of the very addresses above — a bare decimal integer
+    ("2130706433"), an octal-leading-zero octet ("0177.0.0.1"), hex ("0x7f000001"), or a
+    short/collapsed form ("127.1") all resolve to a real address curl accepts — sails through
+    misclassified as "just a hostname". So: any letter (other than a literal "0x"/"0X" hex marker)
+    means a real hostname, never re-resolved here (the same accepted, pre-existing limit the
+    read-path guard has, ``_safe_probe_host``); anything else — digits, dots, or a hex marker — is
+    a numeric-address ATTEMPT, and Python's own strict ``ipaddress`` parse (which, unlike curl,
+    already refuses all of the ambiguous forms above) failing to recognize it means REFUSE, never
+    "must be a hostname after all"."""
     h = host.strip().lower()
     if h == "localhost" or h.endswith(".localhost"):
         return True
+    if any(c.isalpha() for c in h):
+        return "0x" in h  # a hex literal is still numeric-shaped; anything else is a real hostname
     try:
         addr = ipaddress.ip_address(h)
     except ValueError:
-        return False  # a hostname clears this class; DNS resolution isn't re-checked here
+        return True  # numeric-shaped (digits/dots only) but not a valid canonical address
     if addr.is_loopback or addr.is_link_local or addr.is_unspecified or addr.is_multicast:
         return True
-    if addr.is_reserved:
+    if addr.is_reserved or (addr.version == 4 and addr in _THIS_NETWORK):
         return True
     subnet = ((live_cfg or {}).get("network") or {}).get("subnet") or _DEFAULT_SUBNET
     try:

--- a/dashboard/mining_dashboard/service/worker_adopt.py
+++ b/dashboard/mining_dashboard/service/worker_adopt.py
@@ -18,6 +18,7 @@ miner-advertised value auto-trusted: the host field the operator confirms is sti
 PREFILL, and every field here is exactly what the operator typed or edited in the adopt form.
 """
 
+import ipaddress
 import re
 
 # Mirrors pithead's per-entry regexes (``validate_worker_endpoints``, pithead ~L5901) byte for
@@ -65,6 +66,35 @@ def validate_worker_descriptor(entry):
     return ""
 
 
+_DEFAULT_SUBNET = "172.28.0.0/24"
+
+
+def host_is_internal(host, live_cfg):
+    """Mirrors pithead's ``_control_host_is_internal`` (the host-side SSRF floor an add-only
+    append's host must clear, #122): loopback, unspecified, link-local, multicast/reserved,
+    ``localhost``, or the stack's own docker-bridge subnet (``network.subnet``, read from the SAME
+    live config the caller already has — never the staged proposal, matching the bash gate's own
+    reasoning: a same-commit ``network.subnet`` change is refused by the generic allowlist gate
+    before this would ever matter). An ordinary LAN/public rig address is unaffected."""
+    h = host.strip().lower()
+    if h == "localhost" or h.endswith(".localhost"):
+        return True
+    try:
+        addr = ipaddress.ip_address(h)
+    except ValueError:
+        return False  # a hostname clears this class; DNS resolution isn't re-checked here
+    if addr.is_loopback or addr.is_link_local or addr.is_unspecified or addr.is_multicast:
+        return True
+    if addr.is_reserved:
+        return True
+    subnet = ((live_cfg or {}).get("network") or {}).get("subnet") or _DEFAULT_SUBNET
+    try:
+        network = ipaddress.ip_network(subnet, strict=False)
+    except ValueError:
+        network = ipaddress.ip_network(_DEFAULT_SUBNET)
+    return addr.version == network.version and addr in network
+
+
 def new_worker_entries(live_cfg, staged_cfg):
     """The entries a staged config would ADD to ``workers.list[]``, or ``[]`` if the staged list
     isn't a pure append of the live one (a non-append change is left for the host's own add-only
@@ -82,9 +112,17 @@ def new_worker_entries(live_cfg, staged_cfg):
 
 def validate_new_worker_entries(live_cfg, staged_cfg):
     """The first validation error among the entries a staged config would newly append to
-    ``workers.list[]``, or ``""`` if every new entry is well-formed (including "no new entries")."""
+    ``workers.list[]``, or ``""`` if every new entry is well-formed (including "no new entries").
+    Shape first (``validate_worker_descriptor``), then the #122 SSRF floor (``host_is_internal``)
+    — a malformed entry gets the more specific shape message even if it also happens to parse as
+    an internal address."""
     for entry in new_worker_entries(live_cfg, staged_cfg):
         err = validate_worker_descriptor(entry)
         if err:
             return err
+        if host_is_internal(entry["host"], live_cfg):
+            return (
+                f"worker '{entry['name']}': host '{entry['host']}' resolves inside this host's "
+                "own network — a rig's control address must be a distinct machine on your LAN."
+            )
     return ""

--- a/dashboard/mining_dashboard/service/worker_refresh.py
+++ b/dashboard/mining_dashboard/service/worker_refresh.py
@@ -1,0 +1,102 @@
+"""Bounded, targeted worker-status refresh after a successful one-click rig upgrade (issue #1233,
+companion to #893).
+
+The per-rig RigForge version shown to the operator is derived at the render seam from the rig's
+own last-reported ``/1/summary`` (``views.py`` ``build_worker_update``/``rigforge_update_for`` —
+never stored, so it can't outlive its input, the #664 lesson). That read normally happens once per
+``UPDATE_INTERVAL`` on the shared poll loop (``DataService.run``), so after an upgrade the operator
+watches a stale badge for up to a full cycle even though the dashboard already knows the exact
+moment the rig finished rebuilding.
+
+This module does nothing that loop doesn't already do — it makes the SAME ``/1/summary`` probe
+(``XMRigWorkerClient.get_stats``) the SAME way, just for the ONE rig that just upgraded, and only a
+few times right after upgrade success. It never re-derives "latest available release" (that lookup
+stays on its own Tor-throttled cadence, the anti-beacon contract ``update_checker`` owns) and never
+changes anything (read-only). ``web/server.py``'s ``_finalize_worker_upgrade`` is the one caller,
+triggered only on a worker-upgrade result that means the rig actually rebuilt (``applied`` or
+``accepted`` — not a rejection/failure/rollback/throttle, where nothing changed rig-side).
+"""
+
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from mining_dashboard.client.xmrig_client import XMRigWorkerClient, parse_rigforge
+from mining_dashboard.service.update_checker import parse_semver
+
+logger = logging.getLogger("WorkerRefresh")
+
+# A few tries spaced over the rebuild window, not a busy-poll: the common case (no XMRig pin
+# change) is a git checkout + restart, done in seconds; a pin-change rebuild can take minutes, but
+# a rig that never comes back is exactly what the bounded cap gives up on cleanly.
+REFRESH_ATTEMPTS = 6
+REFRESH_DELAY_S = 10.0
+
+
+async def _poll_until_matched(worker_client, ip, name, target, entry, attempts, delay_s, sleep):
+    """Probe ``ip``/``name`` up to ``attempts`` times, merging each reachable read's ``rigforge``
+    block into ``entry`` in place (same field the main poll loop merges, ``_merge_direct_stats``).
+    Stops as soon as the reported version matches ``target`` (parsed SemVer) or the attempts run
+    out; a target that doesn't parse (caller passed something odd) stops after the first reachable
+    read instead of spinning for nothing."""
+    for _ in range(attempts):
+        await sleep(delay_s)
+        try:
+            payload = await worker_client.get_stats(ip, name)
+        except Exception:
+            logger.debug("Post-upgrade refresh probe failed for worker %r", name, exc_info=True)
+            continue
+        rf = parse_rigforge(payload) if payload else None
+        if rf is None:
+            continue
+        entry["rigforge"] = rf
+        reported = parse_semver(rf.get("version"))
+        if target is None or (reported and reported == target):
+            return True
+    return False
+
+
+async def refresh_worker_after_upgrade(
+    latest_data,
+    name,
+    target_version,
+    worker_client=None,
+    attempts=REFRESH_ATTEMPTS,
+    delay_s=REFRESH_DELAY_S,
+    sleep=asyncio.sleep,
+):
+    """Out-of-cycle refresh of one worker's reported RigForge version (#1233).
+
+    ``latest_data`` is the SAME shared dict the main poll loop publishes to ``/api/state``/
+    ``/api/worker`` — mutating the matched worker's ``rigforge`` entry in place is what lets the
+    NEXT read reflect the fresh version without waiting out ``UPDATE_INTERVAL``. A worker that has
+    since dropped out of the table (offline fall-off, #182) or never had an IP is a silent no-op —
+    nothing to refresh. ``worker_client`` is an injection seam for tests; production opens its own
+    short-lived session so this never competes with the main loop's long-lived one.
+    """
+    workers = (latest_data or {}).get("workers") or []
+    entry = next((w for w in workers if w.get("name") == name), None)
+    if not entry or not entry.get("ip"):
+        return False
+    target = parse_semver(target_version)
+    if worker_client is not None:
+        return await _poll_until_matched(
+            worker_client, entry["ip"], name, target, entry, attempts, delay_s, sleep
+        )
+    async with ClientSession() as session:
+        return await _poll_until_matched(
+            XMRigWorkerClient(session), entry["ip"], name, target, entry, attempts, delay_s, sleep
+        )
+
+
+# Upgrade outcomes meaning the rig genuinely rebuilt (or is still rebuilding) — worth kicking the
+# refresh above. Excludes "noop" (nothing changed) and every non-success.
+UPGRADE_REFRESH_STATUSES = ("applied", "accepted")
+
+
+async def maybe_refresh_after_upgrade(latest_data, worker, version, res):
+    """Called from ``web/server.py``'s ``_finalize_worker_upgrade`` with the terminal worker-upgrade
+    result: kicks the out-of-cycle refresh above only when ``res`` means the rig actually rebuilt."""
+    if res.get("status") in UPGRADE_REFRESH_STATUSES:
+        await refresh_worker_after_upgrade(latest_data, worker, res.get("version") or version)

--- a/dashboard/mining_dashboard/web/server.py
+++ b/dashboard/mining_dashboard/web/server.py
@@ -9,7 +9,7 @@ import uuid
 from aiohttp import web
 
 from mining_dashboard.config import config
-from mining_dashboard.service import audit_service, control_service
+from mining_dashboard.service import audit_service, control_service, worker_adopt, worker_refresh
 from mining_dashboard.service.metrics import build_metrics, share_reject_pct
 from mining_dashboard.service.update_checker import parse_semver
 from mining_dashboard.web.prometheus import CONTENT_TYPE as PROMETHEUS_CONTENT_TYPE
@@ -121,10 +121,9 @@ async def handle_metrics(request):
 
 # --- Dashboard control channel (#33) ---------------------------------------------------------
 # Registered only when DASHBOARD_CONTROL_ENABLED (absent routes 404 when the feature is off).
-# Every mutating POST must carry this custom header: a cross-site request with a custom header
-# forces a CORS preflight, which the self-only CSP origin never grants — a cheap CSRF guard in
-# the same spirit as the CSP below. The actor is Caddy's authenticated X-Auth-User (header_up
-# overwrites any client-supplied value), threaded through to the host-side audit log.
+# Every mutating POST must carry this custom header: a cross-site header forces a CORS preflight,
+# which the self-only CSP origin never grants (a cheap CSRF guard, same spirit as the CSP below).
+# The actor is Caddy's authenticated X-Auth-User (header_up overwrites any client value).
 
 CONTROL_HEADER = "X-Pithead-Control"
 
@@ -154,6 +153,10 @@ async def handle_control_preview(request):
     proposed = body.get("config")
     if not isinstance(proposed, dict):
         raise web.HTTPBadRequest(text="'config' must be a JSON object.")
+    # Click-to-adopt (#893): pre-validate any newly-appended workers.list[] entry before spooling.
+    adopt_err = worker_adopt.validate_new_worker_entries(control_service.read_config(), proposed)
+    if adopt_err:
+        raise web.HTTPBadRequest(text=adopt_err)
     actor = request.headers.get("X-Auth-User", "")
     try:
         # The proposal ships as-is: an untouched secret rides as the {"__secret__": true}
@@ -224,10 +227,9 @@ OS_UPDATE_ACTIONS = frozenset({"check", "download", "verify", "install", "reboot
 async def handle_control_os_update(request):
     """Ask the host runner to run one step of the appliance OS-update flow. The body's action
     picks the step (check/download/verify/install/reboot); ``version`` is only what the operator
-    confirmed seeing — the host re-derives the real target over Tor and refuses a mismatch, and
-    every destructive judgment (signature, compatible, downgrade floor) is made host-side against
-    the local file. Returns 202 immediately: downloads and installs run long, and a reboot takes
-    the whole machine away — the client polls /api/control/result and rides it out."""
+    confirmed seeing — the host re-derives the real target over Tor, refuses a mismatch, and makes
+    every destructive judgment (signature, compatible, downgrade floor) against the local file.
+    Returns 202 immediately; the client polls /api/control/result and rides out the long steps."""
     _require_control_header(request)
     try:
         body = await request.json()
@@ -257,9 +259,8 @@ async def handle_control_backup(request):
     """Ask the host runner for an encrypted backup archive + a one-time emergency kit (#908).
 
     No body: unlike commit/upgrade this verb takes no operator input — the host generates its own
-    passphrase and never accepts one from the container (encrypted-only, refused otherwise). The
-    archive/openssl work and the brief stack stop+restart stack_backup performs can take a while,
-    so — like upgrade — this returns 202 immediately and the client polls /api/control/result."""
+    passphrase and never accepts one from the container (encrypted-only, refused otherwise). Like
+    upgrade, this returns 202 immediately and the client polls /api/control/result."""
     _require_control_header(request)
     try:
         rid = control_service.submit("backup", actor=request.headers.get("X-Auth-User", ""))
@@ -274,8 +275,7 @@ async def handle_backup_download(request):
 
     Read-only, no CSRF header required (matches the other GET routes) — a cross-site GET can
     trigger this but can't read a cross-origin response, and the archive is useless without the
-    passphrase shown once in the kit. The id must resolve to an "applied" result naming an
-    archive; anything else 404s rather than hinting whether some OTHER id exists."""
+    passphrase shown once in the kit. Any id not resolving to an "applied" archive 404s."""
     try:
         rid = str(uuid.UUID(request.query.get("id", "")))
     except ValueError:
@@ -385,7 +385,7 @@ async def handle_worker_apply(request):
     return web.json_response({"id": rid, **res})
 
 
-async def _finalize_worker_upgrade(state_mgr, worker, version, rid):
+async def _finalize_worker_upgrade(state_mgr, worker, version, rid, latest_data=None):
     """The server-side half of recording a worker-upgrade attempt (#1014): ``handle_worker_upgrade``
     returns 202 before any result exists (a rig rebuild can take minutes, so it never waits inline
     like ``handle_worker_apply`` does), so this runs as its own background task and records the
@@ -402,6 +402,7 @@ async def _finalize_worker_upgrade(state_mgr, worker, version, rid):
         return
     if res is not None:
         _record_worker_result(state_mgr, worker, {"version": version}, res, change_type="upgrade")
+        await worker_refresh.maybe_refresh_after_upgrade(latest_data, worker, version, res)
 
 
 async def handle_worker_upgrade(request):
@@ -409,12 +410,11 @@ async def handle_worker_upgrade(request):
 
     Mirrors the stack's own upgrade (#59) at the per-worker level: the body's version is only what
     the operator confirmed seeing (the badge's latest, #596); the host re-derives the real target
-    from the RigForge release API over Tor and refuses a mismatch, then resolves the rig's address
-    + bearer from config.json — this container never holds the token and cannot choose what gets
-    installed. Returns 202 + the request id immediately (a rig build can take minutes); the client
-    polls /api/control/result, and a background task records the terminal outcome to the per-worker
-    history once it lands (#1014). A rig already reporting the requested version short-circuits to a
-    no-op without spooling — a dial would just burn the rig's own 6h upgrade throttle."""
+    from the RigForge release API over Tor, refuses a mismatch, then resolves the rig's address +
+    bearer from config.json — this container never holds the token or picks what gets installed.
+    Returns 202 immediately (a build can take minutes); the client polls /api/control/result and a
+    background task records the terminal outcome to the per-worker history (#1014). A rig already
+    on the requested version short-circuits to a no-op — a dial would just burn its own throttle."""
     _require_control_header(request)
     try:
         body = await request.json()
@@ -443,7 +443,9 @@ async def handle_worker_upgrade(request):
         return web.json_response({"error": "Failed to submit the worker upgrade."}, status=500)
     state_mgr = request.app["state_manager"]
     bg_tasks = request.app["_bg_tasks"]
-    task = asyncio.create_task(_finalize_worker_upgrade(state_mgr, worker, version, rid))
+    task = asyncio.create_task(
+        _finalize_worker_upgrade(state_mgr, worker, version, rid, request.app["latest_data"])
+    )
     bg_tasks.add(task)
     task.add_done_callback(bg_tasks.discard)
     return web.json_response({"id": rid, "status": "pending"}, status=202)
@@ -592,7 +594,6 @@ async def _cancel_bg_tasks(app):
 def create_app(state_manager, latest_data_ref):
     """Factory to create the web app instance."""
     app = web.Application(middlewares=[security_headers_middleware])
-    # Pass shared state objects to the app context
     app["state_manager"] = state_manager
     app["latest_data"] = latest_data_ref
     # Fire-and-forget recorder tasks (worker-upgrade, #1014) — tracked so they can't be
@@ -611,9 +612,8 @@ def create_app(state_manager, latest_data_ref):
             web.get("/api/access", handle_access_log),
         ]
     )
-    # Control channel (#33): routes exist only when the feature is on — off means 404, not 403,
-    # so a disabled stack exposes no hint that the endpoints exist. Read at call time (not
-    # import) so tests can flip the flag per-app.
+    # Control channel (#33): routes exist only when the feature is on — off means 404, not 403.
+    # Read at call time (not import) so tests can flip the flag per-app.
     if config.DASHBOARD_CONTROL_ENABLED:
         app.add_routes(
             [

--- a/dashboard/mining_dashboard/web/static/components.mjs
+++ b/dashboard/mining_dashboard/web/static/components.mjs
@@ -1097,15 +1097,19 @@ function RigForgeChips({ rf }) {
   )}`;
 }
 
-// Per-worker RigForge new-release callout (#596) — the worker-level twin of UpdateBadge. Shown
-// only when the server derived that this rig's reported RigForge version is older than the latest
-// release (same dashboard.check_for_updates gate). Notify-only — a link to the release notes; the
-// one-click rig upgrade is the separate #597.
-const RigUpdateBadge = ({ up }) =>
-  up && up.available && up.url
-    ? html` <a class="badge badge-accent" href=${up.url} target="_blank" rel="noopener noreferrer"
-              title=${"A newer RigForge release is available: " + up.latest}>rf ${up.latest} available ↗</a>`
+// Per-worker RigForge new-release callout (#596) — the worker-level twin of UpdateBadge. Opens
+// Worker Inspect (#893) so the gated/upgrade state can explain itself; the release-notes link
+// moves inside the dialog. No dialog (control channel off) falls back to the old link-only badge.
+const RigUpdateBadge = ({ up, name, onInspect }) => {
+  if (!up || !up.available) return null;
+  const title = "A newer RigForge release is available: " + up.latest,
+    label = html`rf ${up.latest} available ↗`;
+  if (onInspect)
+    return html` <button type="button" class="badge badge-accent" onClick=${() => onInspect(name)} title=${title}>${label}</button>`;
+  return up.url
+    ? html` <a class="badge badge-accent" href=${up.url} target="_blank" rel="noopener noreferrer" title=${title}>${label}</a>`
     : null;
+};
 
 // Pool-wide proxy share totals (Issue #82) — a footer under the table. Hidden until the proxy
 // has reported any shares so it isn't an all-zero line on a fresh start.
@@ -1123,9 +1127,8 @@ const ProxyTotals = ({ summary }) => {
 };
 
 function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort, onInspect }) {
-  // First-run empty state (#385): until the proxy has ever reported a worker, the table would be
-  // eight headers over nothing — show the one action the operator must take instead. `workers`
-  // includes offline rigs, so a fleet that is temporarily all-offline keeps its (red) table.
+  // First-run empty state (#385): show the one action to take instead of empty headers.
+  // `workers` includes offline rigs, so a temporarily all-offline fleet keeps its (red) table.
   if ((workers || []).length === 0) {
     const addr = hostIp && hostIp !== "Unknown Host" ? hostIp : "YOUR_STACK_IP";
     const port = stratumPort || 3333; // configurable via p2pool.stratum_port (#172)
@@ -1149,9 +1152,8 @@ function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort, onIns
                 <thead>
                     <tr>${WORKER_COLUMNS.map(
                       // Sorted column carries the direction, visibly (arrow) and for AT (aria-sort);
-                      // the title makes clickability discoverable without hovering rows (#656).
-                      // The click target is a real <button> so keyboard users can sort too (#671):
-                      // native buttons are focusable and activate on Enter/Space without extra wiring.
+                      // the title makes clickability discoverable (#656). A real <button> click
+                      // target so keyboard users can sort too (#671), focusable without extra wiring.
                       (c, i) => html`<th
                             class=${i === ui.sortIndex ? "sorted" : null}
                             aria-sort=${i === ui.sortIndex ? (ui.sortAsc ? "ascending" : "descending") : null}><button
@@ -1176,7 +1178,7 @@ function WorkersTable({ workers, summary, ui, onSort, hostIp, stratumPort, onIns
                               w.api_ok === false
                                 ? html` <span class="badge badge-bad" title="The dashboard couldn't read this worker's xmrig API, so uptime and per-miner hashrate are unavailable (it still mines — figures come from the proxy). Check workers.api_auth / api_port, or the miner's xmrig http settings.">api ⚠</span>`
                                 : null
-                            }<${RigForgeChips} rf=${w.rigforge} /><${RigUpdateBadge} up=${w.rigforge_update} /></td>
+                            }<${RigForgeChips} rf=${w.rigforge} /><${RigUpdateBadge} up=${w.rigforge_update} name=${w.name} onInspect=${onInspect} /></td>
                             <td>${w.ip}</td>
                             <td>${uptimeCell(w)}</td>
                             <td>${w.h60_str}</td>
@@ -1246,12 +1248,10 @@ function ComponentHealth({ topology, egress }) {
     </div>`;
 }
 
-// One-time discoverability hint (#425). The earnings + XvB tier calculators are Advanced-view
-// cards, so an operator on the default Simple view never sees them and concludes they don't
-// exist. This banner points at Advanced view until the operator acts on it: the inline button
-// switches views (dashboard.js retires the hint on any visit to Advanced), and the × dismisses
-// it outright. `ui.hintDismissed` is persisted in localStorage by dashboard.js like the other
-// UI state, so the hint shows once per browser, not once per reload.
+// One-time discoverability hint (#425): the earnings + XvB tier calculators are Advanced-view
+// cards, invisible from the default Simple view. Points at Advanced until the operator acts on
+// it (the inline button switches views; dashboard.js retires the hint on any Advanced visit) or
+// dismisses it outright; `ui.hintDismissed` persists in localStorage, so it shows once per browser.
 function AdvancedHint({ ui, onView, onDismissHint }) {
   if (ui.view !== "simple" || ui.hintDismissed) return null;
   return html`

--- a/dashboard/mining_dashboard/web/static/workeradopt.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradopt.mjs
@@ -17,6 +17,7 @@ import { Component, html } from "./preact.mjs";
 import {
   buildAdoptedConfig,
   DEFAULT_CONTROL_PORT,
+  hostIsInternal,
   validateAdoptFields,
 } from "./workeradoptlogic.mjs";
 
@@ -45,13 +46,19 @@ export class AdoptRigForm extends Component {
     try {
       const cfgRes = await fetch("/api/config");
       if (!cfgRes.ok) throw new Error(`HTTP ${cfgRes.status}`);
-      const proposed = buildAdoptedConfig(
-        await cfgRes.json(),
-        this.props.name,
-        host,
-        controlPort,
-        token,
-      );
+      const liveConfig = await cfgRes.json();
+      if (hostIsInternal(host, liveConfig?.network?.subnet)) {
+        this.setState({
+          busy: false,
+          result: {
+            status: "error",
+            error:
+              "That address resolves inside this stack's own network — a rig's control address must be a distinct machine on your LAN.",
+          },
+        });
+        return;
+      }
+      const proposed = buildAdoptedConfig(liveConfig, this.props.name, host, controlPort, token);
       let res = await fetch("/api/control/preview", {
         method: "POST",
         headers: CONTROL_HEADERS,

--- a/dashboard/mining_dashboard/web/static/workeradopt.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradopt.mjs
@@ -1,0 +1,136 @@
+// Click-to-adopt (#893): the form shown in Worker Inspect for a rig that isn't yet a write
+// target. Prefilled with the worker's OBSERVED IP (proxy-reported — a #122 miner-advertised value,
+// so it's a PREFILL only; the operator confirms or edits it before anything is sent), a default
+// control port, and a token the operator must type. Submitting rides the SAME control-channel
+// config path (GET /api/config -> POST preview -> POST commit) the Configuration view uses for any
+// other edit — no new write endpoint. The host's own add-only gate (pithead's control_approval_gate)
+// is what actually authorizes appending a brand-new workers.list[] descriptor; this only builds and
+// sends the proposal.
+//
+// One caveat carried over from every other config.json-only write (dashboard.energy is the
+// existing example): a commit that changes nothing in .env doesn't recreate any container, so the
+// dashboard's own cached worker list picks up the new rig only once the dashboard itself restarts
+// — the panel says so rather than claiming the rig is editable the instant the request returns.
+
+import { pollResult } from "./configview.mjs";
+import { Component, html } from "./preact.mjs";
+import {
+  buildAdoptedConfig,
+  DEFAULT_CONTROL_PORT,
+  validateAdoptFields,
+} from "./workeradoptlogic.mjs";
+
+const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
+
+export class AdoptRigForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      host: props.ip || "",
+      controlPort: DEFAULT_CONTROL_PORT,
+      token: "",
+      busy: false,
+      result: null,
+    };
+  }
+
+  async adopt() {
+    const { host, controlPort, token } = this.state;
+    const validation = validateAdoptFields(host, controlPort, token);
+    if (validation) {
+      this.setState({ result: { status: "error", error: validation } });
+      return;
+    }
+    this.setState({ busy: true, result: null });
+    try {
+      const cfgRes = await fetch("/api/config");
+      if (!cfgRes.ok) throw new Error(`HTTP ${cfgRes.status}`);
+      const proposed = buildAdoptedConfig(
+        await cfgRes.json(),
+        this.props.name,
+        host,
+        controlPort,
+        token,
+      );
+      let res = await fetch("/api/control/preview", {
+        method: "POST",
+        headers: CONTROL_HEADERS,
+        body: JSON.stringify({ config: proposed }),
+      });
+      if (!res.ok && res.status !== 202) throw new Error(`HTTP ${res.status}`);
+      let out = await res.json();
+      if (out.status === "pending") out = { id: out.id, ...(await pollResult(out.id)) };
+      if (out.status === "rejected") {
+        this.setState({ busy: false, result: out });
+        return;
+      }
+      if (out.destructive) {
+        // An add-only descriptor never produces a DEST/CONFIRM row; a destructive verdict here
+        // means the proposal carried more than the new descriptor — refuse rather than committing
+        // something no one reviewed.
+        this.setState({
+          busy: false,
+          result: { status: "error", error: "Unexpected change — nothing was applied." },
+        });
+        return;
+      }
+      res = await fetch("/api/control/commit", {
+        method: "POST",
+        headers: CONTROL_HEADERS,
+        body: JSON.stringify({ id: out.id }),
+      });
+      if (!res.ok && res.status !== 202) throw new Error(`HTTP ${res.status}`);
+      let committed = await res.json();
+      if (committed.status === "pending" || committed.status === "previewed") {
+        committed = await pollResult(out.id, "previewed");
+      }
+      this.setState({ busy: false, result: committed });
+      if (committed.status === "applied" && this.props.onAdopted) this.props.onAdopted();
+    } catch (e) {
+      this.setState({ busy: false, result: { status: "error", error: String(e) } });
+    }
+  }
+
+  render() {
+    const { host, controlPort, token, busy, result } = this.state;
+    return html`
+      <div class="adopt-rig">
+        <p class="text-muted text-xs">
+          Set up remote control for this rig: confirm its control address (prefilled from what the
+          proxy observed — verify it before sending), then add its control token. This writes
+          workers.list[] through the same control channel the Configuration view uses.
+        </p>
+        <label class="config-field">
+          <span class="config-field-name">host</span>
+          <input type="text" disabled=${busy} value=${host} placeholder="e.g. 192.168.1.10"
+              onInput=${(e) => this.setState({ host: e.target.value })} />
+        </label>
+        <label class="config-field">
+          <span class="config-field-name">control_port</span>
+          <input type="number" disabled=${busy} value=${controlPort}
+              onInput=${(e) => this.setState({ controlPort: e.target.value })} />
+        </label>
+        <label class="config-field">
+          <span class="config-field-name">token</span>
+          <input type="password" disabled=${busy} value=${token} placeholder="the rig's control token"
+              onInput=${(e) => this.setState({ token: e.target.value })} />
+        </label>
+        <div class="mt-1">
+          <button class="btn-toggle" disabled=${busy} onClick=${() => this.adopt()}>${
+            busy ? "Adopting…" : "Adopt this rig"
+          }</button>
+        </div>
+        ${result ? html`<${AdoptStatus} result=${result} />` : null}
+      </div>`;
+  }
+}
+
+function AdoptStatus({ result }) {
+  if (result.status === "applied") {
+    return html`<p class="text-small mt-1 status-ok">
+      Saved to config.json. The dashboard reads its worker list once at startup, so this editor may
+      not appear until it restarts — the next config apply, upgrade, or a manual restart picks it up.
+    </p>`;
+  }
+  return html`<p class="text-small mt-1 status-bad">${result.error || result.status}</p>`;
+}

--- a/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
@@ -44,12 +44,26 @@ export function validateAdoptFields(host, controlPort, token) {
 const CANONICAL_IPV4_RE =
   /^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})$/;
 
+const LOOPBACK_ALIASES = new Set([
+  "localhost",
+  "localhost.localdomain",
+  "ip6-localhost",
+  "ip6-loopback",
+]);
+
 /**
  * Client-side mirror of the host's SSRF floor on a NEW workers.list[] entry (pithead's
  * ``_control_host_is_internal`` / the dashboard's ``worker_adopt.host_is_internal``): loopback,
- * "this network", link-local, multicast/reserved, "localhost", or the stack's own docker-bridge
- * subnet. UX only — a fast, clear refusal before the round trip; the host-side gate (and its own
+ * "this network", link-local, multicast/reserved, "localhost" (and its standard ``/etc/hosts``
+ * aliases and root-terminated spelling — see below), or the stack's own docker-bridge subnet. UX
+ * only — a fast, clear refusal before the round trip; the host-side gate (and its own
  * dashboard-side mirror, checked at preview) is what actually enforces this.
+ *
+ * A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat "localhost." exactly
+ * like "localhost" — so it is stripped before any hostname comparison. "localhost.localdomain" /
+ * "ip6-localhost" / "ip6-loopback" are the standard ``/etc/hosts`` loopback aliases on
+ * Debian/RHEL-family Linux (this stack's own target OS) — refused explicitly, not just the bare
+ * "localhost" family.
  *
  * A host this stack's own dial would treat as numeric must be recognized as one here too, or an
  * alternate encoding of the very addresses above — a bare decimal integer ("2130706433"), an
@@ -60,8 +74,9 @@ const CANONICAL_IPV4_RE =
  * refused outright unless it is the exact canonical form. Ambiguous never means "safe".
  */
 export function hostIsInternal(host, subnet) {
-  const h = (host || "").trim().toLowerCase();
-  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  let h = (host || "").trim().toLowerCase();
+  if (h.endsWith(".")) h = h.slice(0, -1);
+  if (LOOPBACK_ALIASES.has(h) || h.endsWith(".localhost")) return true;
   if (/[a-z]/.test(h)) return h.includes("0x"); // a hex literal, or a genuine hostname
   const m = h.match(CANONICAL_IPV4_RE);
   if (!m) return true; // numeric-shaped (digits/dots only) but not the exact canonical form

--- a/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
@@ -52,12 +52,23 @@ const LOOPBACK_ALIASES = new Set([
 ]);
 
 /**
- * Client-side mirror of the host's SSRF floor on a NEW workers.list[] entry (pithead's
- * ``_control_host_is_internal`` / the dashboard's ``worker_adopt.host_is_internal``): loopback,
- * "this network", link-local, multicast/reserved, "localhost" (and its standard ``/etc/hosts``
- * aliases and root-terminated spelling — see below), or the stack's own docker-bridge subnet. UX
- * only — a fast, clear refusal before the round trip; the host-side gate (and its own
- * dashboard-side mirror, checked at preview) is what actually enforces this.
+ * BEST-EFFORT, IN-BROWSER UX ONLY — this is NOT the security boundary. An earlier version of this
+ * (and its host-side and dashboard-side mirrors) classified a host purely by STRING SHAPE, and an
+ * independent review found that a spelling denylist can never answer "does this hostname resolve
+ * to my own loopback": this host's own machine-name self-entry and an attacker-controlled DNS name
+ * both look like "a genuine hostname, therefore safe" to a string classifier alone. The real fix
+ * is resolve-then-check, which needs an actual DNS round trip — not something this synchronous,
+ * dependency-free, in-browser check can or should do. So this stays a fast, best-effort refusal of
+ * the OBVIOUS cases only (an IP literal, including ambiguous encodings, or a known loopback
+ * spelling); a hostname it doesn't recognize passes here and is still caught by the real
+ * authority, which resolves it at commit time on the host (pithead's
+ * ``_control_host_is_internal``) — see that function's own comment, and this file's own test
+ * pinning exactly where this mirror's coverage stops.
+ *
+ * What IS still caught here (pithead's ``_control_host_is_internal`` / the dashboard's
+ * ``worker_adopt.host_is_internal``): loopback, "this network", link-local, multicast/reserved,
+ * "localhost" (and its standard ``/etc/hosts`` aliases and root-terminated spelling — see below),
+ * or the stack's own docker-bridge subnet.
  *
  * A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat "localhost." exactly
  * like "localhost" — so it is stripped before any hostname comparison. "localhost.localdomain" /

--- a/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
@@ -38,6 +38,30 @@ export function validateAdoptFields(host, controlPort, token) {
 }
 
 /**
+ * Client-side mirror of the host's SSRF floor on a NEW workers.list[] entry (pithead's
+ * ``_control_host_is_internal`` / the dashboard's ``worker_adopt.host_is_internal``): loopback,
+ * unspecified, link-local, multicast/reserved, "localhost", or the stack's own docker-bridge
+ * subnet. UX only — a fast, clear refusal before the round trip; the host-side gate (and its own
+ * dashboard-side mirror, checked at preview) is what actually enforces this.
+ */
+export function hostIsInternal(host, subnet) {
+  const h = (host || "").trim().toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false; // a hostname clears this class; DNS resolution isn't re-checked here
+  const octets = m.slice(1, 5).map(Number);
+  if (octets.some((o) => o > 255)) return false;
+  const [a, b, c] = octets;
+  if (a === 0 || a === 127) return true; // this-network / loopback
+  if (a === 169 && b === 254) return true; // link-local (cloud metadata included)
+  if (a >= 224) return true; // multicast (224-239) + reserved (240-255)
+  const bridge = (subnet || "172.28.0.0/24").match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}\/24$/,
+  );
+  return !!bridge && `${a}.${b}.${c}` === bridge.slice(1, 4).join(".");
+}
+
+/**
  * The proposed config a successful adopt submits: ``liveConfig`` (as fetched from /api/config)
  * with one new descriptor appended to ``workers.list[]``. Every other key rides through untouched
  * — the host's add-only gate requires every already-live entry to reappear byte-for-byte, so this

--- a/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
@@ -37,20 +37,36 @@ export function validateAdoptFields(host, controlPort, token) {
   return "";
 }
 
+// Exactly a canonical dotted-decimal octet: "0", or 1-3 digits with no leading zero. A host that
+// is digits-and-dots-only but does NOT match this shape four times over (a bare integer, an
+// octal-leading-zero octet, a short/collapsed form) is a numeric-address ATTEMPT that failed
+// strict parsing — see hostIsInternal below for why that must refuse, not clear the class.
+const CANONICAL_IPV4_RE =
+  /^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})$/;
+
 /**
  * Client-side mirror of the host's SSRF floor on a NEW workers.list[] entry (pithead's
  * ``_control_host_is_internal`` / the dashboard's ``worker_adopt.host_is_internal``): loopback,
- * unspecified, link-local, multicast/reserved, "localhost", or the stack's own docker-bridge
+ * "this network", link-local, multicast/reserved, "localhost", or the stack's own docker-bridge
  * subnet. UX only — a fast, clear refusal before the round trip; the host-side gate (and its own
  * dashboard-side mirror, checked at preview) is what actually enforces this.
+ *
+ * A host this stack's own dial would treat as numeric must be recognized as one here too, or an
+ * alternate encoding of the very addresses above — a bare decimal integer ("2130706433"), an
+ * octal-leading-zero octet ("0177.0.0.1"), hex ("0x7f000001"), or a short/collapsed form
+ * ("127.1") — sails through misclassified as "just a hostname". So: any letter (other than a
+ * literal "0x" hex marker) means a real hostname, never re-resolved here (the same accepted,
+ * pre-existing limit the read-path guard has); anything else is a numeric-address ATTEMPT and is
+ * refused outright unless it is the exact canonical form. Ambiguous never means "safe".
  */
 export function hostIsInternal(host, subnet) {
   const h = (host || "").trim().toLowerCase();
   if (h === "localhost" || h.endsWith(".localhost")) return true;
-  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (!m) return false; // a hostname clears this class; DNS resolution isn't re-checked here
+  if (/[a-z]/.test(h)) return h.includes("0x"); // a hex literal, or a genuine hostname
+  const m = h.match(CANONICAL_IPV4_RE);
+  if (!m) return true; // numeric-shaped (digits/dots only) but not the exact canonical form
   const octets = m.slice(1, 5).map(Number);
-  if (octets.some((o) => o > 255)) return false;
+  if (octets.some((o) => o > 255)) return true;
   const [a, b, c] = octets;
   if (a === 0 || a === 127) return true; // this-network / loopback
   if (a === 169 && b === 254) return true; // link-local (cloud metadata included)

--- a/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workeradoptlogic.mjs
@@ -1,0 +1,58 @@
+// Pure logic for the click-to-adopt form (issue #893), kept DOM-free so node --test covers it.
+// workeradopt.mjs binds these to the form; tests call them directly.
+//
+// The security authority for the write itself is host-side (pithead's control_approval_gate add-
+// only exception, re-checked by the dashboard's own handle_control_preview guard). What lives here
+// is UX-layer, defense-in-depth validation — mirroring the same host/port/token shape pithead's
+// validate_worker_endpoints enforces — so an obviously malformed value is refused before a round
+// trip, not because this is where the trust decision is made.
+
+const HOST_RE = /^[A-Za-z0-9._-]{1,253}$/;
+const TOKEN_RE = /^[!-~]{1,128}$/;
+
+/** The rig's control-API default port (RigForge's own default) — the form's port prefill. */
+export const DEFAULT_CONTROL_PORT = "8082";
+
+/**
+ * Refuse an adopt submission before it ever reaches the network. ``host`` is the field the
+ * operator confirmed or edited (the observed IP is only ever a PREFILL, never auto-submitted
+ * unread) — this only checks its SHAPE, the same SSRF-motivated charset guard the host applies:
+ * no port, path, or userinfo can ride into a probe URL. Returns an error string, or "" when every
+ * field is well-formed.
+ */
+export function validateAdoptFields(host, controlPort, token) {
+  const h = (host || "").trim();
+  if (!h) return "Enter the rig's control address (a hostname or IP).";
+  if (!HOST_RE.test(h)) {
+    return "Host must be a hostname or IPv4 address — letters, digits, and . _ - only (no port or path).";
+  }
+  const port = Number(controlPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return "Control port must be an integer between 1 and 65535.";
+  }
+  const t = (token || "").trim();
+  if (!t || !TOKEN_RE.test(t)) {
+    return "Enter the rig's control token — its control API is bearer-mandatory.";
+  }
+  return "";
+}
+
+/**
+ * The proposed config a successful adopt submits: ``liveConfig`` (as fetched from /api/config)
+ * with one new descriptor appended to ``workers.list[]``. Every other key rides through untouched
+ * — the host's add-only gate requires every already-live entry to reappear byte-for-byte, so this
+ * never touches an existing element, only pushes a new one onto the end.
+ */
+export function buildAdoptedConfig(liveConfig, workerName, host, controlPort, token) {
+  const cfg = JSON.parse(JSON.stringify(liveConfig || {}));
+  const workers = cfg.workers && typeof cfg.workers === "object" ? cfg.workers : {};
+  const list = Array.isArray(workers.list) ? workers.list.slice() : [];
+  list.push({
+    name: workerName,
+    host: host.trim(),
+    control_port: Number(controlPort),
+    token: token.trim(),
+  });
+  cfg.workers = { ...workers, list };
+  return cfg;
+}

--- a/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -17,6 +17,7 @@ import { WorkerChartCard } from "./chart.mjs";
 import { SECRET_HINT } from "./configlogic.mjs";
 import { loadPref, savePref } from "./logic.mjs";
 import { Component, createRef, html } from "./preact.mjs";
+import { AdoptRigForm } from "./workeradopt.mjs";
 import {
   buildChartMarkers,
   buildFields,
@@ -417,11 +418,9 @@ export class WorkerInspect extends Component {
                 <button class="btn-toggle" disabled=${busy} onClick=${() => this.apply()}>${busy ? "Applying…" : "Apply to rig"}</button>
             </div>
             <${StatusLine} result=${result} />`
-                : html`<p class="text-muted text-small">${
-                    detail.control_enabled
-                      ? "This worker has no host/control_port/token in dashboard.workers[] — set them to edit its config from here."
-                      : "Config editing is off. Enable dashboard.control (which needs a dashboard password) to edit a rig's config."
-                  }</p>`
+                : detail.control_enabled
+                  ? html`<${AdoptRigForm} name=${this.props.name} ip=${detail.ip} onAdopted=${() => this.load()} />`
+                  : html`<p class="text-muted text-small">Config editing is off. Enable dashboard.control (which needs a dashboard password) to edit a rig's config.</p>`
             }
 
             <h4 class="mt-2">History</h4>

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -2103,10 +2103,10 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     return {
         "name": name,
         "found": worker is not None,
-        # A worker is editable only if the operator pinned its host in config.json — never a
-        # miner-advertised address (#122). control_enabled gates whether the write path exists at all.
+        # Editable needs an operator-pinned host in config.json, never a miner-advertised one (#122).
         "editable": bool(descriptor and descriptor.get("host")),
         "control_enabled": config.DASHBOARD_CONTROL_ENABLED,
+        "ip": worker.get("ip") if worker else None,  # OBSERVED only — the adopt-form prefill (#893)
         "status": worker.get("status") if worker else None,
         "hashrate": format_hashrate(worker.get("h60", 0)) if worker else None,
         "rigforge": _rigforge_display(worker.get("rigforge")) if worker else None,

--- a/dashboard/tests/frontend/workeradopt.test.mjs
+++ b/dashboard/tests/frontend/workeradopt.test.mjs
@@ -1,0 +1,240 @@
+// Unit tests for the click-to-adopt panel (#893): mining_dashboard/web/static/workeradopt.mjs
+// (AdoptRigForm's own fetch sequencing) and its routing inside Worker Inspect (workerview.mjs) —
+// the "explain the gated state" half of the feature: an unadopted rig shows the adopt form instead
+// of a dead-end message, an off channel still shows the off message.
+//
+// Same no-DOM pattern as workerview.test.mjs: instantiate directly, stub setState, walk render()
+// with the dependency-free vnode renderer.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import { App } from "../../mining_dashboard/web/static/components.mjs";
+import { AdoptRigForm } from "../../mining_dashboard/web/static/workeradopt.mjs";
+import { WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
+import { render, renderToString } from "./helpers/render.mjs";
+
+const FIXTURE = JSON.parse(readFileSync(new URL("./fixtures/state.json", import.meta.url)));
+
+function stubSetState(inst) {
+  inst.setState = (patch) => {
+    const next = typeof patch === "function" ? patch(inst.state, inst.props) : patch;
+    Object.assign(inst.state, next);
+  };
+}
+
+function adoptForm(props = {}) {
+  const inst = new AdoptRigForm({ name: "rig1", ip: "10.0.0.9", onAdopted: () => {}, ...props });
+  stubSetState(inst);
+  return inst;
+}
+
+// Queue of fetch responses, consumed in order — the three legs adopt() drives: GET /api/config,
+// POST /api/control/preview, POST /api/control/commit.
+function withFetchSequence(responses, fn) {
+  const realFetch = globalThis.fetch;
+  const calls = [];
+  let i = 0;
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url, body: opts?.body ? JSON.parse(opts.body) : null });
+    const r = responses[i++] || { ok: true, json: async () => ({ status: "error" }) };
+    return { ok: r.ok !== false, status: r.status || 200, json: async () => r.body };
+  };
+  return fn(calls).finally(() => {
+    globalThis.fetch = realFetch;
+  });
+}
+
+// --- Prefill -----------------------------------------------------------------------------------
+
+test("AdoptRigForm: prefills host from the observed ip and the default control port", () => {
+  const inst = adoptForm();
+  assert.equal(inst.state.host, "10.0.0.9");
+  assert.equal(inst.state.controlPort, "8082");
+  assert.equal(inst.state.token, ""); // never prefilled — the operator must type it
+  assert.match(renderToString(inst.render()), /value="10\.0\.0\.9"/);
+});
+
+test("AdoptRigForm: no observed ip yet still renders an empty, editable host field", () => {
+  const inst = adoptForm({ ip: undefined });
+  assert.equal(inst.state.host, "");
+});
+
+// --- Client-side validation gates the network entirely ------------------------------------------
+
+test("AdoptRigForm: a malformed host is refused before any fetch happens", async () => {
+  const inst = adoptForm();
+  inst.state.host = "10.0.0.9:9999";
+  await withFetchSequence([], async (calls) => {
+    await inst.adopt();
+    assert.equal(calls.length, 0);
+  });
+  assert.equal(inst.state.result.status, "error");
+});
+
+// --- The full preview -> commit round trip -----------------------------------------------------
+
+test("AdoptRigForm: a well-formed submission previews then commits through the control path", async () => {
+  const inst = adoptForm();
+  inst.state.token = "tok-123";
+  const liveConfig = { workers: { list: [] } };
+  await withFetchSequence(
+    [
+      { body: liveConfig }, // GET /api/config
+      { body: { id: "req-1", status: "previewed", destructive: false } }, // preview
+      { body: { id: "req-1", status: "applied" } }, // commit
+    ],
+    async (calls) => {
+      await inst.adopt();
+      assert.equal(calls[0].url, "/api/config");
+      assert.equal(calls[1].url, "/api/control/preview");
+      assert.deepEqual(calls[1].body.config.workers.list, [
+        { name: "rig1", host: "10.0.0.9", control_port: 8082, token: "tok-123" },
+      ]);
+      assert.equal(calls[2].url, "/api/control/commit");
+      assert.equal(calls[2].body.id, "req-1");
+    },
+  );
+  assert.equal(inst.state.result.status, "applied");
+  assert.equal(inst.state.busy, false);
+});
+
+test("AdoptRigForm: a rejected preview surfaces the host's reason and never commits", async () => {
+  const inst = adoptForm();
+  inst.state.token = "tok-123";
+  await withFetchSequence(
+    [
+      { body: {} },
+      { body: { id: "req-1", status: "rejected", error: "alters an existing per-worker descriptor" } },
+    ],
+    async (calls) => {
+      await inst.adopt();
+      assert.equal(calls.length, 2); // never reached commit
+    },
+  );
+  assert.equal(inst.state.result.status, "rejected");
+  assert.match(inst.state.result.error, /existing per-worker descriptor/);
+});
+
+test("AdoptRigForm: an unexpected destructive preview is refused, not blindly committed", async () => {
+  // A pure add should never come back destructive; if it somehow does, adopt() must refuse rather
+  // than auto-confirming a change no one reviewed.
+  const inst = adoptForm();
+  inst.state.token = "tok-123";
+  await withFetchSequence(
+    [{ body: {} }, { body: { id: "req-1", status: "previewed", destructive: true } }],
+    async (calls) => {
+      await inst.adopt();
+      assert.equal(calls.length, 2); // never reached commit
+    },
+  );
+  assert.equal(inst.state.result.status, "error");
+});
+
+test("AdoptRigForm: calls onAdopted only once the commit actually applied", async () => {
+  const inst = adoptForm();
+  inst.state.token = "tok-123";
+  let notified = 0;
+  inst.props.onAdopted = () => notified++;
+  await withFetchSequence(
+    [
+      { body: {} },
+      { body: { id: "req-1", status: "previewed", destructive: false } },
+      { body: { id: "req-1", status: "failed", error: "apply failed" } },
+    ],
+    async () => inst.adopt(),
+  );
+  assert.equal(notified, 0); // a failed commit must not claim success
+});
+
+// --- Routed from Worker Inspect (#893 item 2: explain the gated state) ------------------------
+
+const BASE_DETAIL = {
+  name: "rig1",
+  found: true,
+  status: "online",
+  hashrate: "1.0 kH/s",
+  rigforge: null,
+  writable_keys: ["DONATION"],
+  last_applied: {},
+  history: [],
+  hashrate_history: { hashrate: [], markers: [] },
+};
+
+function inspectInstance(detail) {
+  const inst = new WorkerInspect({ name: "rig1", onClose: () => {} });
+  stubSetState(inst);
+  inst.state = { ...inst.state, phase: "ready", detail, editText: "{}" };
+  return inst;
+}
+
+test("Worker Inspect: an unadopted rig with the control channel on shows the adopt form", () => {
+  const out = renderToString(
+    inspectInstance({ ...BASE_DETAIL, editable: false, control_enabled: true, ip: "10.0.0.9" }).render(),
+  );
+  assert.match(out, /Adopt this rig/);
+  assert.doesNotMatch(out, /Config editing is off/);
+});
+
+test("Worker Inspect: the control channel off shows the off message, not the adopt form", () => {
+  const out = renderToString(
+    inspectInstance({ ...BASE_DETAIL, editable: false, control_enabled: false }).render(),
+  );
+  assert.match(out, /Config editing is off/);
+  assert.doesNotMatch(out, /Adopt this rig/);
+});
+
+test("Worker Inspect: an already-adopted (editable) rig shows the editor, not the adopt form", () => {
+  const out = renderToString(
+    inspectInstance({ ...BASE_DETAIL, editable: true, control_enabled: true }).render(),
+  );
+  assert.match(out, /Apply to rig/);
+  assert.doesNotMatch(out, /Adopt this rig/);
+});
+
+// --- The table badge routes into the dialog instead of straight to GitHub (#893 item 3) --------
+
+const UI = {
+  view: "advanced",
+  range: "all",
+  window: null,
+  series: {},
+  avg: "10m",
+  theme: "auto",
+  sortIndex: null,
+  sortAsc: true,
+};
+const noop = () => {};
+const HANDLERS = {
+  onRange: noop,
+  onSort: noop,
+  onView: noop,
+  onTheme: noop,
+  onZoom: noop,
+  onResetZoom: noop,
+  onToggleSeries: noop,
+  onAvgWindow: noop,
+  onDismissHint: noop,
+  onCloseInspect: noop,
+};
+
+function withRigUpdate(onInspect, controlEnabled) {
+  const state = structuredClone(FIXTURE);
+  state.control_enabled = controlEnabled;
+  state.workers[0].rigforge_update = { available: true, latest: "v1.11.2", url: "https://h/v1.11.2" };
+  return render(App, { state, connected: true, ui: UI, onInspect, ...HANDLERS });
+}
+
+test("table badge: with Worker Inspect available, it's a button (opens the dialog), not a link", () => {
+  const out = withRigUpdate(noop, true);
+  assert.match(out, /<button[^>]*>rf v1\.11\.2 available/);
+  assert.doesNotMatch(out, /<a[^>]*>rf v1\.11\.2 available/);
+});
+
+test("table badge: with the control channel off, it falls back to the old release-notes link", () => {
+  const out = withRigUpdate(noop, false);
+  assert.match(out, /<a[^>]*href="https:\/\/h\/v1\.11\.2"[^>]*>rf v1\.11\.2 available/);
+});

--- a/dashboard/tests/frontend/workeradopt.test.mjs
+++ b/dashboard/tests/frontend/workeradopt.test.mjs
@@ -75,6 +75,21 @@ test("AdoptRigForm: a malformed host is refused before any fetch happens", async
   assert.equal(inst.state.result.status, "error");
 });
 
+test("AdoptRigForm: a host resolving inside the stack's own network is refused after the config fetch, before preview", async () => {
+  // The critical SSRF case: charset-valid, so validateAdoptFields alone wouldn't catch it — this
+  // needs the live config (network.subnet) to classify, hence the check runs post-fetch.
+  const inst = adoptForm();
+  inst.state.host = "127.0.0.1";
+  inst.state.token = "tok-123";
+  await withFetchSequence([{ body: { network: { subnet: "172.28.0.0/24" } } }], async (calls) => {
+    await inst.adopt();
+    assert.equal(calls.length, 1); // only the /api/config read — never reached preview
+    assert.equal(calls[0].url, "/api/config");
+  });
+  assert.equal(inst.state.result.status, "error");
+  assert.match(inst.state.result.error, /own network/);
+});
+
 // --- The full preview -> commit round trip -----------------------------------------------------
 
 test("AdoptRigForm: a well-formed submission previews then commits through the control path", async () => {

--- a/dashboard/tests/frontend/workeradoptlogic.test.mjs
+++ b/dashboard/tests/frontend/workeradoptlogic.test.mjs
@@ -14,6 +14,7 @@ import { test } from "node:test";
 import {
   buildAdoptedConfig,
   DEFAULT_CONTROL_PORT,
+  hostIsInternal,
   validateAdoptFields,
 } from "../../mining_dashboard/web/static/workeradoptlogic.mjs";
 
@@ -61,6 +62,26 @@ test("validateAdoptFields: a blank token is refused (bearer-mandatory)", () => {
 
 test("validateAdoptFields: a token with a space is refused", () => {
   assert.notEqual(validateAdoptFields("10.0.0.9", "8082", "has space"), "");
+});
+
+// --- hostIsInternal (the #122 SSRF floor on a NEW entry) --------------------------------------
+
+test("hostIsInternal: loopback, localhost, link-local, multicast and reserved are internal", () => {
+  for (const h of ["127.0.0.1", "localhost", "LOCALHOST", "sub.localhost", "0.0.0.0", "169.254.169.254", "224.0.0.1", "240.0.0.1"]) {
+    assert.equal(hostIsInternal(h), true, h);
+  }
+});
+
+test("hostIsInternal: ordinary LAN/public addresses and hostnames are not internal", () => {
+  for (const h of ["192.168.1.50", "10.0.0.9", "8.8.8.8", "rig1.example.com"]) {
+    assert.equal(hostIsInternal(h), false, h);
+  }
+});
+
+test("hostIsInternal: the stack's own docker-bridge subnet is internal, default and custom", () => {
+  assert.equal(hostIsInternal("172.28.0.5"), true); // default subnet, no override passed
+  assert.equal(hostIsInternal("172.28.0.5", "172.30.0.0/24"), false); // off the CUSTOM subnet
+  assert.equal(hostIsInternal("172.30.0.5", "172.30.0.0/24"), true);
 });
 
 // --- buildAdoptedConfig ----------------------------------------------------------------------

--- a/dashboard/tests/frontend/workeradoptlogic.test.mjs
+++ b/dashboard/tests/frontend/workeradoptlogic.test.mjs
@@ -138,6 +138,16 @@ test("hostIsInternal: ordinary hostnames with digits still pass", () => {
   }
 });
 
+test("hostIsInternal: a hostname that would resolve elsewhere is not caught here by design", () => {
+  // This function is best-effort, in-browser UX, not the security boundary — it does no DNS
+  // resolution, so a hostname that isn't a known loopback alias passes here even if it would
+  // actually resolve to loopback (this host's own machine-name self-entry, or an
+  // attacker-controlled DNS name). Pinned as a test so a future change can't silently start
+  // claiming a guarantee this file cannot keep. The real enforcement resolves at commit time on
+  // the host (pithead's _control_host_is_internal) — see tests/stack/test-control-add-only-ssrf.sh.
+  assert.equal(hostIsInternal("a-hostname-that-is-not-a-known-alias"), false);
+});
+
 // --- buildAdoptedConfig ----------------------------------------------------------------------
 
 test("buildAdoptedConfig: appends the new descriptor to an empty workers.list[]", () => {

--- a/dashboard/tests/frontend/workeradoptlogic.test.mjs
+++ b/dashboard/tests/frontend/workeradoptlogic.test.mjs
@@ -84,6 +84,27 @@ test("hostIsInternal: the stack's own docker-bridge subnet is internal, default 
   assert.equal(hostIsInternal("172.30.0.5", "172.30.0.0/24"), true);
 });
 
+test("hostIsInternal: a trailing dot does not clear the localhost class", () => {
+  // Round-4 finding: curl resolves "localhost." identically to "localhost" (DNS's FQDN-root
+  // marker) — dropping the trailing-dot strip (or reordering it after the alias check) reopens
+  // this as an unrecognized, letter-containing "hostname" that clears every check below.
+  assert.equal(hostIsInternal("localhost."), true);
+  assert.equal(hostIsInternal("LOCALHOST."), true);
+});
+
+test("hostIsInternal: the standard /etc/hosts loopback aliases are refused", () => {
+  // Round-4 finding: real /etc/hosts entries on this stack's own target OS (Debian ships
+  // "::1 ip6-localhost ip6-loopback"; RHEL-family ships "127.0.0.1 localhost localhost.localdomain")
+  // — verified via `getent hosts` + live curl to resolve to loopback, same as the bare name.
+  for (const h of ["localhost.localdomain", "ip6-localhost", "ip6-loopback", "IP6-LOOPBACK."]) {
+    assert.equal(hostIsInternal(h), true, h);
+  }
+});
+
+test("hostIsInternal: a subdomain of an alias is not itself aliased", () => {
+  assert.equal(hostIsInternal("sub.ip6-localhost"), false);
+});
+
 test("hostIsInternal: alternate IP encodings are refused, not waved through as hostnames", () => {
   // The actual bypass a security review found: each of these fails the naive 4-octet regex, and
   // the original bug then treated "not a recognized dotted-decimal" as "must be a hostname,

--- a/dashboard/tests/frontend/workeradoptlogic.test.mjs
+++ b/dashboard/tests/frontend/workeradoptlogic.test.mjs
@@ -1,0 +1,105 @@
+// Unit tests for the click-to-adopt panel logic (#893):
+// mining_dashboard/web/static/workeradoptlogic.mjs — field validation (the UX-layer mirror of
+// pithead's host/port/token shape guard) and the workers.list[] append the form submits.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// Mutation-kill notes: each "refused" test would pass a value straight through (empty string, no
+// error) if its guard were removed or its regex/range check inverted — the paired "accepted" tests
+// on well-formed input catch the opposite direction (a guard so tight it refuses everything).
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildAdoptedConfig,
+  DEFAULT_CONTROL_PORT,
+  validateAdoptFields,
+} from "../../mining_dashboard/web/static/workeradoptlogic.mjs";
+
+// --- validateAdoptFields --------------------------------------------------------------------
+
+test("validateAdoptFields: a well-formed host/port/token is accepted", () => {
+  assert.equal(validateAdoptFields("10.0.0.9", "8082", "tok-123"), "");
+  assert.equal(validateAdoptFields("rig1.lan", DEFAULT_CONTROL_PORT, "tok-123"), "");
+});
+
+test("validateAdoptFields: an empty host is refused", () => {
+  assert.notEqual(validateAdoptFields("", "8082", "tok"), "");
+  assert.notEqual(validateAdoptFields("   ", "8082", "tok"), "");
+});
+
+test("validateAdoptFields: a host carrying a port is refused (#122 charset guard)", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9:8082", "8082", "tok"), "");
+});
+
+test("validateAdoptFields: a host carrying a path is refused", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9/../etc", "8082", "tok"), "");
+});
+
+test("validateAdoptFields: a host carrying userinfo is refused", () => {
+  assert.notEqual(validateAdoptFields("user@10.0.0.9", "8082", "tok"), "");
+});
+
+test("validateAdoptFields: a scheme-prefixed host is refused", () => {
+  assert.notEqual(validateAdoptFields("http://10.0.0.9", "8082", "tok"), "");
+});
+
+test("validateAdoptFields: control_port out of range is refused", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9", "0", "tok"), "");
+  assert.notEqual(validateAdoptFields("10.0.0.9", "65536", "tok"), "");
+});
+
+test("validateAdoptFields: a non-numeric control_port is refused", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9", "abc", "tok"), "");
+});
+
+test("validateAdoptFields: a blank token is refused (bearer-mandatory)", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9", "8082", ""), "");
+  assert.notEqual(validateAdoptFields("10.0.0.9", "8082", "   "), "");
+});
+
+test("validateAdoptFields: a token with a space is refused", () => {
+  assert.notEqual(validateAdoptFields("10.0.0.9", "8082", "has space"), "");
+});
+
+// --- buildAdoptedConfig ----------------------------------------------------------------------
+
+test("buildAdoptedConfig: appends the new descriptor to an empty workers.list[]", () => {
+  const cfg = buildAdoptedConfig({ p2pool: { pool: "mini" } }, "rig1", "10.0.0.9", "8082", "tok");
+  assert.deepEqual(cfg.workers.list, [
+    { name: "rig1", host: "10.0.0.9", control_port: 8082, token: "tok" },
+  ]);
+  assert.equal(cfg.p2pool.pool, "mini"); // every other key rides through untouched
+});
+
+test("buildAdoptedConfig: control_port is coerced to a number", () => {
+  const cfg = buildAdoptedConfig({}, "rig1", "10.0.0.9", "8082", "tok");
+  assert.equal(cfg.workers.list[0].control_port, 8082);
+  assert.equal(typeof cfg.workers.list[0].control_port, "number");
+});
+
+test("buildAdoptedConfig: an existing entry reappears byte-for-byte, unchanged", () => {
+  // The whole point of the add-only shape: the host's own gate refuses anything that touches an
+  // already-live descriptor, so this MUST preserve rig1 exactly while appending rig2.
+  const live = {
+    workers: { list: [{ name: "rig1", host: "10.0.0.9", control_port: 8082, token: "tok1" }] },
+  };
+  const cfg = buildAdoptedConfig(live, "rig2", "10.0.0.10", "8082", "tok2");
+  assert.deepEqual(cfg.workers.list[0], live.workers.list[0]);
+  assert.equal(cfg.workers.list.length, 2);
+  assert.equal(cfg.workers.list[1].name, "rig2");
+});
+
+test("buildAdoptedConfig: never mutates the live config object it was handed", () => {
+  const live = { workers: { list: [{ name: "rig1", host: "a", token: "t" }] } };
+  const before = JSON.stringify(live);
+  buildAdoptedConfig(live, "rig2", "10.0.0.10", "8082", "tok2");
+  assert.equal(JSON.stringify(live), before);
+});
+
+test("buildAdoptedConfig: trims stray whitespace off host and token", () => {
+  const cfg = buildAdoptedConfig({}, "rig1", " 10.0.0.9 ", "8082", " tok \n");
+  assert.equal(cfg.workers.list[0].host, "10.0.0.9");
+  assert.equal(cfg.workers.list[0].token, "tok");
+});

--- a/dashboard/tests/frontend/workeradoptlogic.test.mjs
+++ b/dashboard/tests/frontend/workeradoptlogic.test.mjs
@@ -84,6 +84,39 @@ test("hostIsInternal: the stack's own docker-bridge subnet is internal, default 
   assert.equal(hostIsInternal("172.30.0.5", "172.30.0.0/24"), true);
 });
 
+test("hostIsInternal: alternate IP encodings are refused, not waved through as hostnames", () => {
+  // The actual bypass a security review found: each of these fails the naive 4-octet regex, and
+  // the original bug then treated "not a recognized dotted-decimal" as "must be a hostname,
+  // therefore safe" — exactly the class this stack's own dial (curl) still resolves to a real,
+  // dangerous address (all verified against a real curl build during development).
+  for (const h of [
+    "2130706433", // bare decimal == 127.0.0.1
+    "2852039166", // bare decimal == 169.254.169.254 (cloud metadata)
+    "0177.0.0.1", // octal-leading-zero octet == 127.0.0.1
+    "0x7f000001", // hex == 127.0.0.1
+    "0x7f.0x0.0x0.0x1", // per-octet hex == 127.0.0.1
+    "127.1", // short/collapsed form == 127.0.0.1
+    "010.0.0.1", // octal-leading-zero first octet == 8.0.0.1; refused outright either way
+    "000.1.2.3",
+  ]) {
+    assert.equal(hostIsInternal(h), true, h);
+  }
+});
+
+test("hostIsInternal: the 0.0.0.0/8 'this network' block is refused beyond the bare address", () => {
+  assert.equal(hostIsInternal("0.1.2.3"), true);
+});
+
+test("hostIsInternal: a hex literal is refused even though it contains letters", () => {
+  assert.equal(hostIsInternal("0xc0.0xa8.0x01.0x32"), true);
+});
+
+test("hostIsInternal: ordinary hostnames with digits still pass", () => {
+  for (const h of ["rig-1.lan", "a.b.c.d", "rig01.example.com"]) {
+    assert.equal(hostIsInternal(h), false, h);
+  }
+});
+
 // --- buildAdoptedConfig ----------------------------------------------------------------------
 
 test("buildAdoptedConfig: appends the new descriptor to an empty workers.list[]", () => {

--- a/dashboard/tests/service/test_worker_adopt.py
+++ b/dashboard/tests/service/test_worker_adopt.py
@@ -204,10 +204,12 @@ class TestValidateNewWorkerEntries:
 
 
 class TestHostIsInternal:
-    """Mirrors pithead's ``_control_host_is_internal`` — see
-    ``test_regexes_have_no_intra_repo_drift``-style intent, but this class is a semantic mirror
-    (bash has no ``ipaddress`` module to diff against byte-for-byte); the bash-side battery of
-    cases was hand-verified during development (see the PR description)."""
+    """A partial, best-effort mirror of pithead's ``_control_host_is_internal`` — see
+    ``test_regexes_have_no_intra_repo_drift``-style intent for the literal/numeric cases, but
+    since #893 round 5 the bash side does real DNS resolution and this one deliberately does not
+    (see ``host_is_internal``'s own docstring); ``test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design``
+    below pins exactly where the mirror stops. The bash-side battery of cases was hand-verified
+    during development (see the PR description)."""
 
     @pytest.mark.parametrize(
         "host",
@@ -310,3 +312,15 @@ class TestHostIsInternal:
         # A vanishingly rare real hostname that happens to contain "0x" gets refused too — a
         # deliberate, accepted trade-off (no one names a rig "my0x1"), not a regression to chase.
         assert host_is_internal("my0x1.example.com", {}) is True
+
+    def test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design(self):
+        # #893 round 5: this function is BEST-EFFORT UX, not the security boundary — it does no
+        # DNS resolution, so a hostname that ISN'T one of the known loopback aliases passes here
+        # even if it would actually resolve to this host's own loopback (e.g. a machine's own
+        # Debian self-entry, or an attacker-controlled DNS name). This is pinned as a test, not
+        # left as a comment-only claim, so a future "let's make this smarter" change has to
+        # consciously decide to add resolution here rather than silently drift into claiming a
+        # guarantee this module cannot keep. The REAL enforcement — resolve, then check every
+        # returned address — lives in pithead's `_control_host_is_internal` and runs at commit
+        # time on the host; see tests/stack/test-control-add-only-ssrf.sh for that coverage.
+        assert host_is_internal("a-hostname-that-is-not-a-known-alias", {}) is False

--- a/dashboard/tests/service/test_worker_adopt.py
+++ b/dashboard/tests/service/test_worker_adopt.py
@@ -1,0 +1,141 @@
+"""Click-to-adopt (#893): the dashboard-side mirror of pithead's per-entry shape validation and
+the add-only diff it pre-checks before ``handle_control_preview`` ever spools a proposal.
+
+Each test names the guard it kills so a later change that quietly weakens one shows up as a
+specific broken test, not a vague coverage drop:
+  - a REMOVED check (the ``if`` deleted, or the function always returning "") would let every
+    bad case in this file through as if it were valid — the "malformed X refused" tests kill that.
+  - an INVERTED check (``==`` for ``!=``, a dropped ``not``) would refuse every GOOD case instead
+    — the "well-formed entry accepted" tests kill that.
+  - a widened/narrowed diff boundary (off-by-one on the prefix length) would misclassify an edit
+    to an existing entry as "new", or lose a genuinely new tail entry — the prefix-boundary tests
+    kill that.
+"""
+
+from mining_dashboard.service.worker_adopt import (
+    DEFAULT_CONTROL_PORT,
+    new_worker_entries,
+    validate_new_worker_entries,
+    validate_worker_descriptor,
+)
+
+VALID_ENTRY = {"name": "rig1", "host": "10.0.0.9", "control_port": 8082, "token": "tok-123"}
+
+
+class TestValidateWorkerDescriptor:
+    def test_well_formed_entry_accepted(self):
+        assert validate_worker_descriptor(VALID_ENTRY) == ""
+
+    def test_control_port_defaults_when_absent(self):
+        # DEFAULT_CONTROL_PORT (8082) must be accepted when the operator left it blank in the
+        # form — a guard that forgot the default would refuse every adopt submission that omits it.
+        entry = {k: v for k, v in VALID_ENTRY.items() if k != "control_port"}
+        assert validate_worker_descriptor(entry) == ""
+        assert DEFAULT_CONTROL_PORT == 8082
+
+    def test_non_object_entry_refused(self):
+        assert validate_worker_descriptor("not-an-object") != ""
+
+    def test_missing_name_refused(self):
+        entry = dict(VALID_ENTRY)
+        del entry["name"]
+        assert validate_worker_descriptor(entry) != ""
+
+    def test_name_with_space_refused(self):
+        # NAME_RE is `^[!-~]{1,128}$` — a space is outside the printable-non-space class.
+        assert validate_worker_descriptor({**VALID_ENTRY, "name": "rig 1"}) != ""
+
+    def test_host_with_embedded_port_refused(self):
+        # The #122 guard: a host string carrying a port must never reach a probe URL unparsed.
+        err = validate_worker_descriptor({**VALID_ENTRY, "host": "10.0.0.9:9999"})
+        assert err != "" and "rig1" in err
+
+    def test_host_with_path_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "host": "10.0.0.9/../etc"}) != ""
+
+    def test_host_with_userinfo_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "host": "user@10.0.0.9"}) != ""
+
+    def test_missing_host_refused(self):
+        entry = {k: v for k, v in VALID_ENTRY.items() if k != "host"}
+        assert validate_worker_descriptor(entry) != ""
+
+    def test_control_port_zero_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "control_port": 0}) != ""
+
+    def test_control_port_over_max_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "control_port": 65536}) != ""
+
+    def test_control_port_bool_refused(self):
+        # bool is an int subclass in Python — must be excluded explicitly (mirrors pithead's guard).
+        assert validate_worker_descriptor({**VALID_ENTRY, "control_port": True}) != ""
+
+    def test_control_port_non_integer_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "control_port": 8082.5}) != ""
+
+    def test_missing_token_refused(self):
+        # Bearer-mandatory: a descriptor with no token can never be a write target.
+        entry = {k: v for k, v in VALID_ENTRY.items() if k != "token"}
+        assert validate_worker_descriptor(entry) != ""
+
+    def test_token_with_space_refused(self):
+        assert validate_worker_descriptor({**VALID_ENTRY, "token": "has space"}) != ""
+
+
+class TestNewWorkerEntries:
+    def test_empty_live_makes_every_staged_entry_new(self):
+        live = {}
+        staged = {"workers": {"list": [VALID_ENTRY]}}
+        assert new_worker_entries(live, staged) == [VALID_ENTRY]
+
+    def test_pure_append_returns_only_the_tail(self):
+        rig2 = {"name": "rig2", "host": "10.0.0.10", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [VALID_ENTRY, rig2]}}
+        assert new_worker_entries(live, staged) == [rig2]
+
+    def test_no_change_returns_nothing_new(self):
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        assert new_worker_entries(live, dict(live)) == []
+
+    def test_edited_existing_entry_is_not_new(self):
+        # A repoint of rig1's host is NOT a "new entry" to validate — it's a non-append change the
+        # host's own add-only gate refuses outright. Misclassifying it as "new" would validate its
+        # SHAPE (which can pass) and never flag that it touches an existing descriptor at all.
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [{**VALID_ENTRY, "host": "ATTACKER"}]}}
+        assert new_worker_entries(live, staged) == []
+
+    def test_removed_entry_is_not_new(self):
+        rig2 = {"name": "rig2", "host": "10.0.0.10", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY, rig2]}}
+        staged = {"workers": {"list": [VALID_ENTRY]}}
+        assert new_worker_entries(live, staged) == []
+
+    def test_reordered_entries_not_new(self):
+        rig2 = {"name": "rig2", "host": "10.0.0.10", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY, rig2]}}
+        staged = {"workers": {"list": [rig2, VALID_ENTRY]}}
+        assert new_worker_entries(live, staged) == []
+
+    def test_non_list_staged_workers_list_returns_nothing(self):
+        live = {}
+        assert new_worker_entries(live, {"workers": {"list": "not-a-list"}}) == []
+
+
+class TestValidateNewWorkerEntries:
+    def test_no_new_entries_is_clean(self):
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        assert validate_new_worker_entries(live, dict(live)) == ""
+
+    def test_valid_new_entry_is_clean(self):
+        rig2 = {"name": "rig2", "host": "10.0.0.10", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [VALID_ENTRY, rig2]}}
+        assert validate_new_worker_entries(live, staged) == ""
+
+    def test_malformed_new_entry_refused(self):
+        bad = {"name": "rig2", "host": "10.0.0.10:9999", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [VALID_ENTRY, bad]}}
+        assert validate_new_worker_entries(live, staged) != ""

--- a/dashboard/tests/service/test_worker_adopt.py
+++ b/dashboard/tests/service/test_worker_adopt.py
@@ -221,6 +221,12 @@ class TestHostIsInternal:
             "224.0.0.1",  # multicast
             "240.0.0.1",  # reserved
             "::1",  # loopback, IPv6
+            "localhost.",  # DNS "FQDN root" dot; curl resolves it identically to "localhost"
+            "LOCALHOST.",
+            "localhost.localdomain",  # the standard /etc/hosts loopback alias (RHEL-family)
+            "ip6-localhost",  # the standard /etc/hosts ::1 alias (Debian-family)
+            "ip6-loopback",
+            "IP6-LOOPBACK.",  # case + trailing-dot combined
         ],
     )
     def test_internal_classes_refused(self, host):
@@ -242,6 +248,27 @@ class TestHostIsInternal:
     def test_malformed_subnet_in_live_config_fails_closed_to_the_default(self):
         live = {"network": {"subnet": "not-a-subnet"}}
         assert host_is_internal("172.28.0.5", live) is True
+
+    def test_trailing_dot_alone_does_not_clear_the_localhost_class(self):
+        # Round-4 finding: dropping the `h = h[:-1]` trailing-dot strip (or reordering it after the
+        # alias-set membership check) reopens "localhost." / "LOCALHOST." as an unrecognized,
+        # letter-containing "hostname" that clears every check below — verified live: curl resolves
+        # "localhost." to 127.0.0.1/::1 identically to "localhost".
+        assert host_is_internal("localhost.", {}) is True
+        assert host_is_internal("LOCALHOST.", {}) is True
+
+    def test_etc_hosts_loopback_aliases_are_not_missed(self):
+        # Round-4 finding: narrowing _LOOPBACK_ALIASES back down to just {"localhost"} (or
+        # reverting to the old `h == "localhost" or h.endswith(".localhost")` check) reopens
+        # localhost.localdomain / ip6-localhost / ip6-loopback — real /etc/hosts entries on this
+        # stack's own target OS, verified to resolve to loopback via `getent hosts` + live curl.
+        for alias in ("localhost.localdomain", "ip6-localhost", "ip6-loopback"):
+            assert host_is_internal(alias, {}) is True
+
+    def test_a_subdomain_of_an_alias_is_not_itself_aliased(self):
+        # The alias set is bare-name membership, not a suffix match like ".localhost" — confirms
+        # the fix didn't overreach into refusing every hostname that merely contains "ip6-localhost".
+        assert host_is_internal("sub.ip6-localhost", {}) is False
 
     @pytest.mark.parametrize(
         "host",

--- a/dashboard/tests/service/test_worker_adopt.py
+++ b/dashboard/tests/service/test_worker_adopt.py
@@ -242,3 +242,44 @@ class TestHostIsInternal:
     def test_malformed_subnet_in_live_config_fails_closed_to_the_default(self):
         live = {"network": {"subnet": "not-a-subnet"}}
         assert host_is_internal("172.28.0.5", live) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "2130706433",  # bare decimal integer == 127.0.0.1; curl dials it as loopback
+            "2852039166",  # bare decimal integer == 169.254.169.254 (cloud metadata)
+            "0177.0.0.1",  # octal-leading-zero octet == 127.0.0.1
+            "0x7f000001",  # hex == 127.0.0.1
+            "0x7f.0x0.0x0.0x1",  # per-octet hex == 127.0.0.1
+            "127.1",  # short/collapsed form == 127.0.0.1
+            "010.0.0.1",  # octal-leading-zero first octet == 8.0.0.1 (still refused: numeric-shaped
+            # but non-canonical, refused outright rather than resolved)
+            "000.1.2.3",
+        ],
+    )
+    def test_alternate_ip_encodings_are_refused_not_waved_through_as_hostnames(self, host):
+        # The actual bypass a security review found: is_ipv4-style strict parsing correctly
+        # refuses each of these AS an address, but the original bug then fell through to "must be
+        # a hostname, therefore safe" — exactly the class curl's own numeric-address parser (and
+        # bash's leading-zero-as-octal arithmetic) still resolves to a real, dangerous address.
+        # Refusing outright (never "clears the class") is what this test pins.
+        assert host_is_internal(host, {}) is True
+
+    def test_this_network_block_refused_beyond_the_single_unspecified_address(self):
+        # ipaddress.is_unspecified only covers the literal 0.0.0.0 — the whole 0.0.0.0/8
+        # "this network" block needs its own check, or 0.1.2.3 sails through unclassified.
+        assert host_is_internal("0.1.2.3", {}) is True
+
+    def test_hex_literal_is_refused_even_though_it_contains_letters(self):
+        # The "contains a letter -> real hostname" shortcut must not blanket-clear a hex IP
+        # attempt just because hex digits look alphabetic.
+        assert host_is_internal("0xc0.0xa8.0x01.0x32", {}) is True
+
+    @pytest.mark.parametrize("host", ["rig-1.lan", "a.b.c.d", "rig01.example.com"])
+    def test_ordinary_hostnames_with_digits_still_pass(self, host):
+        assert host_is_internal(host, {}) is False
+
+    def test_hostname_containing_a_literal_0x_substring_is_an_accepted_false_positive(self):
+        # A vanishingly rare real hostname that happens to contain "0x" gets refused too — a
+        # deliberate, accepted trade-off (no one names a rig "my0x1"), not a regression to chase.
+        assert host_is_internal("my0x1.example.com", {}) is True

--- a/dashboard/tests/service/test_worker_adopt.py
+++ b/dashboard/tests/service/test_worker_adopt.py
@@ -12,14 +12,46 @@ specific broken test, not a vague coverage drop:
     kill that.
 """
 
+import pytest
+
 from mining_dashboard.service.worker_adopt import (
     DEFAULT_CONTROL_PORT,
+    HOST_RE,
+    NAME_RE,
+    TOKEN_RE,
+    host_is_internal,
     new_worker_entries,
     validate_new_worker_entries,
     validate_worker_descriptor,
 )
 
 VALID_ENTRY = {"name": "rig1", "host": "10.0.0.9", "control_port": 8082, "token": "tok-123"}
+
+
+def test_regexes_have_no_intra_repo_drift():
+    """This module's docstring claims its host/name/token charset guards mirror pithead's own
+    ``validate_worker_endpoints`` byte for byte (the #122 SSRF guard in particular) — prove it
+    instead of trusting the comment. Same pattern as ``test_control_service.py``'s
+    ``test_writable_key_allowlist_has_no_intra_repo_drift``: skip where the CLI isn't checked out
+    (the dashboard-only Docker test image), verify where it is."""
+    from pathlib import Path
+
+    here = Path(__file__).resolve()
+    pithead_path = next((p / "pithead" for p in here.parents if (p / "pithead").is_file()), None)
+    if pithead_path is None:
+        pytest.skip("pithead CLI not present in this test context (dashboard-only image)")
+    pithead = pithead_path.read_text()
+
+    def _find(needle):
+        idx = pithead.find(needle)
+        assert idx != -1, f"could not find {needle!r} in pithead's validate_worker_endpoints"
+
+    # The literal jq test() regex source strings, unmodified from pithead's own guard.
+    _find('test("^[!-~]{1,128}$")')  # name AND token both use this charset (checked separately)
+    _find('test("^[A-Za-z0-9._-]{1,253}$")')  # the #122 host charset guard
+    assert NAME_RE.pattern == r"^[!-~]{1,128}$"
+    assert TOKEN_RE.pattern == r"^[!-~]{1,128}$"
+    assert HOST_RE.pattern == r"^[A-Za-z0-9._-]{1,253}$"
 
 
 class TestValidateWorkerDescriptor:
@@ -139,3 +171,74 @@ class TestValidateNewWorkerEntries:
         live = {"workers": {"list": [VALID_ENTRY]}}
         staged = {"workers": {"list": [VALID_ENTRY, bad]}}
         assert validate_new_worker_entries(live, staged) != ""
+
+    def test_new_entry_pointed_at_loopback_refused(self):
+        # The critical SSRF case: a well-SHAPED but internally-addressed new entry must still be
+        # refused, not just a malformed-charset one — a compromised dashboard could otherwise
+        # append a phantom descriptor at its own host's loopback services and immediately dial it
+        # via worker-apply/worker-upgrade (resolve_worker_target resolves strictly from config.json,
+        # so whatever lands here becomes a real dial target).
+        evil = {"name": "evil", "host": "127.0.0.1", "control_port": 8000, "token": "attacker"}
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [VALID_ENTRY, evil]}}
+        err = validate_new_worker_entries(live, staged)
+        assert err != "" and "evil" in err
+
+    def test_new_entry_pointed_at_the_stacks_own_docker_bridge_refused(self):
+        # Same class of escalation, aimed at a SIBLING container (monerod, the docker-proxy socket,
+        # tor) instead of the host's own loopback.
+        evil = {"name": "evil", "host": "172.28.0.5", "control_port": 18081, "token": "attacker"}
+        live = {"workers": {"list": [VALID_ENTRY]}, "network": {"subnet": "172.28.0.0/24"}}
+        staged = {
+            "workers": {"list": [VALID_ENTRY, evil]},
+            "network": {"subnet": "172.28.0.0/24"},
+        }
+        assert validate_new_worker_entries(live, staged) != ""
+
+    def test_new_entry_on_ordinary_lan_address_is_unaffected(self):
+        # The fix must not break the feature: a real rig at a real LAN address still adopts fine.
+        rig2 = {"name": "rig2", "host": "192.168.1.50", "token": "tok-456"}
+        live = {"workers": {"list": [VALID_ENTRY]}}
+        staged = {"workers": {"list": [VALID_ENTRY, rig2]}}
+        assert validate_new_worker_entries(live, staged) == ""
+
+
+class TestHostIsInternal:
+    """Mirrors pithead's ``_control_host_is_internal`` — see
+    ``test_regexes_have_no_intra_repo_drift``-style intent, but this class is a semantic mirror
+    (bash has no ``ipaddress`` module to diff against byte-for-byte); the bash-side battery of
+    cases was hand-verified during development (see the PR description)."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "localhost",
+            "LOCALHOST",
+            "sub.localhost",
+            "0.0.0.0",
+            "169.254.169.254",  # cloud-metadata-shaped link-local
+            "224.0.0.1",  # multicast
+            "240.0.0.1",  # reserved
+            "::1",  # loopback, IPv6
+        ],
+    )
+    def test_internal_classes_refused(self, host):
+        assert host_is_internal(host, {}) is True
+
+    @pytest.mark.parametrize("host", ["192.168.1.50", "10.0.0.9", "8.8.8.8", "rig1.example.com"])
+    def test_ordinary_addresses_and_hostnames_pass(self, host):
+        assert host_is_internal(host, {}) is False
+
+    def test_default_docker_bridge_subnet_refused_with_no_network_config(self):
+        assert host_is_internal("172.28.0.5", {}) is True
+
+    def test_custom_docker_bridge_subnet_is_read_from_live_config(self):
+        live = {"network": {"subnet": "172.30.0.0/24"}}
+        assert host_is_internal("172.30.0.5", live) is True
+        # Off the CUSTOM subnet, the default's own range is no longer special on this install.
+        assert host_is_internal("172.28.0.5", live) is False
+
+    def test_malformed_subnet_in_live_config_fails_closed_to_the_default(self):
+        live = {"network": {"subnet": "not-a-subnet"}}
+        assert host_is_internal("172.28.0.5", live) is True

--- a/dashboard/tests/service/test_worker_refresh.py
+++ b/dashboard/tests/service/test_worker_refresh.py
@@ -1,0 +1,155 @@
+"""The #1233 bounded out-of-cycle worker refresh: fires on a worker-upgrade result meaning the rig
+rebuilt, never on one meaning it didn't, and gives up cleanly within its attempt cap.
+
+Mutation-kill notes:
+  - dropping the ``entry.get("ip")`` guard would try to probe a worker with no address — the
+    "no ip -> no-op" test kills that.
+  - inverting ``_UPGRADE_REFRESH_STATUSES`` membership (or the ``in`` to ``not in``) would fire the
+    refresh on a rejected/failed upgrade, or skip a genuinely successful one — the paired
+    "fires on applied/accepted" / "does not fire on rejected/failed/rolled_back/throttled/noop"
+    tests kill either direction.
+  - removing the attempt cap (or the sleep-then-probe ordering) would spin forever on a rig that
+    never reports the target version — the "gives up after N attempts" test bounds the call count.
+  - dropping the version-match early exit would burn every attempt even after a match lands —
+    the "stops on first matching version" test asserts the call count stops short of the cap.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mining_dashboard.service import worker_refresh
+
+
+async def _fake_sleep(_):
+    return None
+
+
+class FakeWorkerClient:
+    def __init__(self, versions):
+        # One scripted /1/summary-shaped response per call; extra calls repeat the last one.
+        self._versions = list(versions)
+        self.calls = []
+
+    async def get_stats(self, ip, name):
+        self.calls.append((ip, name))
+        version = self._versions.pop(0) if self._versions else self._versions_last()
+        if version is None:
+            return {}
+        return {"rigforge": {"version": version}}
+
+    def _versions_last(self):
+        return None
+
+
+class TestRefreshWorkerAfterUpgrade:
+    async def test_no_ip_is_a_noop(self):
+        data = {"workers": [{"name": "rig1"}]}
+        client = FakeWorkerClient(["1.12.0"])
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, sleep=_fake_sleep
+        )
+        assert ok is False
+        assert client.calls == []
+
+    async def test_unknown_worker_is_a_noop(self):
+        data = {"workers": [{"name": "other", "ip": "10.0.0.5"}]}
+        client = FakeWorkerClient(["1.12.0"])
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, sleep=_fake_sleep
+        )
+        assert ok is False
+        assert client.calls == []
+
+    async def test_stops_on_first_matching_version(self):
+        entry = {"name": "rig1", "ip": "10.0.0.5"}
+        data = {"workers": [entry]}
+        client = FakeWorkerClient(["1.11.0", "1.12.0", "1.12.0", "1.12.0"])
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, attempts=6, sleep=_fake_sleep
+        )
+        assert ok is True
+        assert len(client.calls) == 2  # one stale read, then the match — not all 6 attempts
+        assert entry["rigforge"]["version"] == "1.12.0"
+
+    async def test_gives_up_after_attempts_when_version_never_matches(self):
+        entry = {"name": "rig1", "ip": "10.0.0.5"}
+        data = {"workers": [entry]}
+        client = FakeWorkerClient(["1.11.0", "1.11.0", "1.11.0"])
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, attempts=3, sleep=_fake_sleep
+        )
+        assert ok is False
+        assert len(client.calls) == 3  # bounded, not unbounded
+        assert entry["rigforge"]["version"] == "1.11.0"  # last reachable read still merged
+
+    async def test_unreachable_probe_is_tolerated_and_retried(self):
+        entry = {"name": "rig1", "ip": "10.0.0.5"}
+        data = {"workers": [entry]}
+
+        class FlakyClient:
+            def __init__(self):
+                self.calls = 0
+
+            async def get_stats(self, ip, name):
+                self.calls += 1
+                if self.calls == 1:
+                    raise TimeoutError("no route to host")
+                return {"rigforge": {"version": "1.12.0"}}
+
+        client = FlakyClient()
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, attempts=3, sleep=_fake_sleep
+        )
+        assert ok is True
+        assert client.calls == 2
+
+    async def test_reachable_but_no_rigforge_block_is_tolerated_and_retried(self):
+        # A reachable read that isn't from a RigForge rig (or reports nothing yet) parses to
+        # `None` — must keep polling, not treat a plain-xmrig response as a terminal failure.
+        entry = {"name": "rig1", "ip": "10.0.0.5"}
+        data = {"workers": [entry]}
+        client = FakeWorkerClient([None, "1.12.0"])
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            data, "rig1", "v1.12.0", worker_client=client, attempts=3, sleep=_fake_sleep
+        )
+        assert ok is True
+        assert len(client.calls) == 2
+
+
+class TestMaybeRefreshAfterUpgrade:
+    """The gate deciding WHICH worker-upgrade terminal results deserve the refresh above."""
+
+    async def test_fires_on_applied(self, monkeypatch):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        await worker_refresh.maybe_refresh_after_upgrade(
+            {}, "rig1", "v1.0.0", {"status": "applied"}
+        )
+        called.assert_awaited_once()
+
+    async def test_fires_on_accepted(self, monkeypatch):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        await worker_refresh.maybe_refresh_after_upgrade(
+            {}, "rig1", "v1.0.0", {"status": "accepted"}
+        )
+        called.assert_awaited_once()
+
+    @pytest.mark.parametrize("status", ["rejected", "failed", "rolled_back", "throttled", "noop"])
+    async def test_does_not_fire_on_non_success(self, monkeypatch, status):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        await worker_refresh.maybe_refresh_after_upgrade({}, "rig1", "v1.0.0", {"status": status})
+        called.assert_not_awaited()
+
+    async def test_uses_the_hosts_reported_version_over_the_proposal(self, monkeypatch):
+        # The host re-derives the real tag (control_upgrade); res["version"] is the authoritative
+        # one, not the client's original proposal — a regression that swapped the args back to the
+        # proposal would still pass every OTHER test here, so this pins the argument explicitly.
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        await worker_refresh.maybe_refresh_after_upgrade(
+            {}, "rig1", "v1.0.0", {"status": "applied", "version": "v1.2.0"}
+        )
+        called.assert_awaited_once_with({}, "rig1", "v1.2.0")

--- a/dashboard/tests/web/test_worker_adopt_route.py
+++ b/dashboard/tests/web/test_worker_adopt_route.py
@@ -109,6 +109,24 @@ class TestAdoptGuardOnPreview:
         # Refused before it ever reached the spool — the requests/ dir stays empty.
         assert list((control_spool / "requests").glob("*.json")) == []
 
+    async def test_new_rig_pointed_at_loopback_refused_before_spooling(
+        self, control_client, control_spool
+    ):
+        # The critical SSRF case (a well-formed but internally-addressed entry): a compromised
+        # dashboard could otherwise append a phantom descriptor at 127.0.0.1 and immediately dial
+        # it via /api/control/worker-apply, which resolves strictly from the host's own
+        # config.json — this guard must catch it here, before anything reaches the spool.
+        proposed = _proposed(
+            [LIVE_RIG1],
+            {"name": "evil", "host": "127.0.0.1", "control_port": 8000, "token": "attacker"},
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+        assert "evil" in await resp.text()
+        assert list((control_spool / "requests").glob("*.json")) == []
+
     async def test_new_rig_missing_token_refused(self, control_client, control_spool):
         proposed = _proposed([LIVE_RIG1], {"name": "rig2", "host": "10.0.0.10"})
         resp = await control_client.post(

--- a/dashboard/tests/web/test_worker_adopt_route.py
+++ b/dashboard/tests/web/test_worker_adopt_route.py
@@ -1,0 +1,141 @@
+"""Click-to-adopt (#893) at the route level: ``handle_control_preview`` — the SAME endpoint every
+other config edit uses, no new write route — pre-validates a proposal's newly-appended
+``workers.list[]`` entries before it ever spools to the host-side runner.
+
+This is the dashboard's own defense-in-depth mirror of pithead's ``control_approval_gate`` add-only
+exception (the actual security authority, exercised at commit); these tests prove the mirror is
+WIRED IN to the real request handler, not just correct in isolation (that's
+``tests/service/test_worker_adopt.py``). Each rejection test would pass right through (200/202,
+request spooled) if the guard call in ``handle_control_preview`` were removed or its condition
+inverted — that is the mutation each one kills.
+"""
+
+import json
+
+import pytest
+
+from mining_dashboard.service import control_service
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.server import create_app
+
+CONTROL_HEADERS = {"X-Pithead-Control": "1"}
+
+
+@pytest.fixture
+def control_spool(tmp_path, monkeypatch):
+    """Control channel on, one already-adopted rig live in config.json."""
+    host_config = tmp_path / "config.json"
+    host_config.write_text(
+        json.dumps(
+            {
+                "p2pool": {"pool": "mini"},
+                "dashboard": {"auth": {"username": "admin", "password": "correct horse"}},
+                "workers": {
+                    "list": [
+                        {"name": "rig1", "host": "10.0.0.9", "control_port": 8082, "token": "tok1"}
+                    ]
+                },
+            }
+        )
+    )
+    (tmp_path / "requests").mkdir()
+    (tmp_path / "results").mkdir()
+    monkeypatch.setattr(control_service.config, "DASHBOARD_CONTROL_ENABLED", True)
+    monkeypatch.setattr(control_service.config, "HOST_CONFIG_PATH", str(host_config))
+    monkeypatch.setattr(
+        control_service.config, "HOST_REFERENCE_PATH", str(tmp_path / "no-reference.json")
+    )
+    monkeypatch.setattr(control_service.config, "CONTROL_REQUESTS_DIR", str(tmp_path / "requests"))
+    monkeypatch.setattr(control_service.config, "CONTROL_RESULTS_DIR", str(tmp_path / "results"))
+    monkeypatch.setattr(control_service.config, "CONTROL_WAIT_S", 0.1)
+    return tmp_path
+
+
+@pytest.fixture
+async def control_client(aiohttp_client, control_spool):
+    sm = StateManager(db_path=":memory:")
+    data = {"workers": [], "shares": [], "global_sync": False}
+    cli = await aiohttp_client(create_app(sm, data))
+    yield cli
+    sm.close()
+
+
+def _proposed(live_list, *new_entries):
+    return {"workers": {"list": [*live_list, *new_entries]}}
+
+
+LIVE_RIG1 = {"name": "rig1", "host": "10.0.0.9", "control_port": 8082, "token": "tok1"}
+
+
+class TestAdoptGuardOnPreview:
+    async def test_appending_a_well_formed_rig_reaches_the_spool(
+        self, control_client, control_spool
+    ):
+        proposed = _proposed(
+            [LIVE_RIG1],
+            {"name": "rig2", "host": "10.0.0.10", "control_port": 8082, "token": "tok2"},
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        # No runner in this test, so a well-formed proposal is accepted and left pending — the
+        # request landed in the spool rather than being 400'd by the adopt guard.
+        assert resp.status == 202
+        body = await resp.json()
+        req = json.loads((control_spool / "requests" / f"{body['id']}.json").read_text())
+        assert req["config"]["workers"]["list"][-1]["name"] == "rig2"
+
+    async def test_no_new_entries_is_unaffected(self, control_client, control_spool):
+        # A completely unrelated edit (no workers.list touch at all) must not trip the adopt guard.
+        resp = await control_client.post(
+            "/api/control/preview",
+            json={"config": {"p2pool": {"pool": "main"}}},
+            headers=CONTROL_HEADERS,
+        )
+        assert resp.status == 202
+
+    async def test_malformed_host_on_new_rig_refused_before_spooling(
+        self, control_client, control_spool
+    ):
+        proposed = _proposed(
+            [LIVE_RIG1],
+            {"name": "rig2", "host": "10.0.0.10:9999", "control_port": 8082, "token": "tok2"},
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+        assert "rig2" in await resp.text()
+        # Refused before it ever reached the spool — the requests/ dir stays empty.
+        assert list((control_spool / "requests").glob("*.json")) == []
+
+    async def test_new_rig_missing_token_refused(self, control_client, control_spool):
+        proposed = _proposed([LIVE_RIG1], {"name": "rig2", "host": "10.0.0.10"})
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+        assert list((control_spool / "requests").glob("*.json")) == []
+
+    async def test_new_rig_bad_control_port_refused(self, control_client, control_spool):
+        proposed = _proposed(
+            [LIVE_RIG1], {"name": "rig2", "host": "10.0.0.10", "control_port": 0, "token": "tok2"}
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400
+
+    async def test_repointing_an_existing_rigs_host_is_not_pre_refused_by_the_adopt_guard(
+        self, control_client, control_spool
+    ):
+        # The adopt guard only pre-validates NEW entries — repointing an EXISTING one isn't "new"
+        # (test_worker_adopt.py proves that at the unit level), so it must sail past this guard
+        # and reach the spool. The host's own add-only gate is the one that refuses it, at commit
+        # (bash-side, not exercised here) — this test only pins that this guard doesn't double up
+        # on that job and accidentally block something it was never meant to police.
+        proposed = _proposed([{**LIVE_RIG1, "host": "ATTACKER"}])
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 202

--- a/dashboard/tests/web/test_worker_adopt_route.py
+++ b/dashboard/tests/web/test_worker_adopt_route.py
@@ -127,6 +127,25 @@ class TestAdoptGuardOnPreview:
         assert "evil" in await resp.text()
         assert list((control_spool / "requests").glob("*.json")) == []
 
+    @pytest.mark.parametrize(
+        "host", ["2130706433", "0177.0.0.1", "0x7f000001", "127.1", "010.0.0.1"]
+    )
+    async def test_new_rig_with_an_alternate_ip_encoding_of_loopback_refused(
+        self, control_client, control_spool, host
+    ):
+        # The bypass a security review found: each of these clears HOST_RE's charset (digits,
+        # dots, and — for the hex case — letters, all allowed) and is what curl's own
+        # numeric-address parser resolves to 127.0.0.1/8.0.0.1, exactly like the literal form
+        # above — the route-level guard must refuse all of them, not just the obvious spelling.
+        proposed = _proposed(
+            [LIVE_RIG1], {"name": "evil", "host": host, "control_port": 8000, "token": "attacker"}
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400, host
+        assert list((control_spool / "requests").glob("*.json")) == []
+
     async def test_new_rig_missing_token_refused(self, control_client, control_spool):
         proposed = _proposed([LIVE_RIG1], {"name": "rig2", "host": "10.0.0.10"})
         resp = await control_client.post(

--- a/dashboard/tests/web/test_worker_adopt_route.py
+++ b/dashboard/tests/web/test_worker_adopt_route.py
@@ -146,6 +146,26 @@ class TestAdoptGuardOnPreview:
         assert resp.status == 400, host
         assert list((control_spool / "requests").glob("*.json")) == []
 
+    @pytest.mark.parametrize(
+        "host",
+        ["localhost.", "LOCALHOST.", "localhost.localdomain", "ip6-localhost", "ip6-loopback"],
+    )
+    async def test_new_rig_with_a_localhost_alias_or_root_terminated_form_refused(
+        self, control_client, control_spool, host
+    ):
+        # Round-4 finding: a security review verified each of these live (getent hosts + curl)
+        # resolves to loopback on this stack's own target OS, and none of them matched the
+        # original literal `host == "localhost"` check — the route-level guard must refuse all of
+        # them, not just the bare spelling.
+        proposed = _proposed(
+            [LIVE_RIG1], {"name": "evil", "host": host, "control_port": 8000, "token": "attacker"}
+        )
+        resp = await control_client.post(
+            "/api/control/preview", json={"config": proposed}, headers=CONTROL_HEADERS
+        )
+        assert resp.status == 400, host
+        assert list((control_spool / "requests").glob("*.json")) == []
+
     async def test_new_rig_missing_token_refused(self, control_client, control_spool):
         proposed = _proposed([LIVE_RIG1], {"name": "rig2", "host": "10.0.0.10"})
         resp = await control_client.post(

--- a/dashboard/tests/web/test_worker_detail_ip.py
+++ b/dashboard/tests/web/test_worker_detail_ip.py
@@ -1,0 +1,58 @@
+"""Click-to-adopt (#893): ``build_worker_detail``'s ``ip`` field is the adopt-form's PREFILL
+source. It must be the miner-observed address (never the operator-confirmed ``host`` already in
+config.json, once adopted) — that distinction IS the trust model: a prefill can be wrong or
+adversarial, an ``editable`` host cannot. New file (test_views.py is at its file-budget ceiling).
+
+Mutation-kill notes: swapping ``worker.get("ip")`` for the descriptor's ``host`` (or dropping the
+``if worker else None`` guard so a not-found worker crashes or fabricates a value) would flip
+``test_ip_is_the_observed_value_even_when_a_different_host_is_configured`` /
+``test_ip_is_none_when_worker_not_in_snapshot``.
+"""
+
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.views import build_worker_detail
+
+
+def _detail(monkeypatch, name, workers=None, descriptors=None):
+    from mining_dashboard.web import views
+
+    monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", descriptors or [])
+    monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+    sm = StateManager(db_path=":memory:")
+    try:
+        return build_worker_detail(name, {"workers": workers or []}, sm)
+    finally:
+        sm.close()
+
+
+class TestWorkerDetailIp:
+    def test_ip_present_for_an_unadopted_worker(self, monkeypatch):
+        # The whole point of the field: a rig with NO descriptor yet still carries the observed
+        # address, so the adopt form has something to prefill.
+        d = _detail(
+            monkeypatch,
+            "rig1",
+            workers=[{"name": "rig1", "status": "online", "ip": "10.0.0.9"}],
+            descriptors=[],
+        )
+        assert d["editable"] is False
+        assert d["ip"] == "10.0.0.9"
+
+    def test_ip_is_the_observed_value_even_when_a_different_host_is_configured(self, monkeypatch):
+        # Once adopted, the operator-confirmed host lives in the descriptor (and drives `editable`
+        # + the actual dial target) — `ip` stays the raw proxy-observed value regardless, so it
+        # never masquerades as the trusted address.
+        d = _detail(
+            monkeypatch,
+            "rig1",
+            workers=[{"name": "rig1", "status": "online", "ip": "10.0.0.9"}],
+            descriptors=[{"name": "rig1", "host": "rig1.internal", "control_port": 8082}],
+        )
+        assert d["editable"] is True
+        assert d["ip"] == "10.0.0.9"
+        assert d["ip"] != "rig1.internal"
+
+    def test_ip_is_none_when_worker_not_in_snapshot(self, monkeypatch):
+        d = _detail(monkeypatch, "ghost", workers=[])
+        assert d["found"] is False
+        assert d["ip"] is None

--- a/dashboard/tests/web/test_worker_upgrade_refresh.py
+++ b/dashboard/tests/web/test_worker_upgrade_refresh.py
@@ -1,0 +1,114 @@
+"""The #1233 refresh trigger, end to end through the real ``/api/control/worker-upgrade`` route and
+its background finalizer (mirrors ``test_server.py``'s ``TestWorkerUpgradeRecordsHistory`` fixture
+shape, since ``worker_refresh`` is exercised from the SAME background task that records history).
+
+Each test names the mutation it would catch:
+  - deleting the ``maybe_refresh_after_upgrade`` call in ``_finalize_worker_upgrade`` (or any
+    guard that made it unreachable) would leave the refresh mock uncalled on a genuine success —
+    ``test_applied_result_triggers_refresh`` / ``test_accepted_result_triggers_refresh`` catch that.
+  - inverting the success/non-success split would fire it on a rejection or skip a real success —
+    the paired non-firing tests below catch either direction.
+  - passing the wrong worker/version (e.g. the client's stale proposal instead of the host's
+    re-derived tag) would still pass a "was it called" test but fail the exact-args assertion.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mining_dashboard.service import control_service, worker_refresh
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.server import create_app
+
+CONTROL_HEADERS = {"X-Pithead-Control": "1"}
+
+
+@pytest.fixture
+def control_spool(tmp_path, monkeypatch):
+    host_config = tmp_path / "config.json"
+    host_config.write_text(
+        json.dumps({"dashboard": {"auth": {"username": "admin", "password": "correct horse"}}})
+    )
+    (tmp_path / "requests").mkdir()
+    (tmp_path / "results").mkdir()
+    monkeypatch.setattr(control_service.config, "DASHBOARD_CONTROL_ENABLED", True)
+    monkeypatch.setattr(control_service.config, "HOST_CONFIG_PATH", str(host_config))
+    monkeypatch.setattr(
+        control_service.config, "HOST_REFERENCE_PATH", str(tmp_path / "no-reference.json")
+    )
+    monkeypatch.setattr(control_service.config, "CONTROL_REQUESTS_DIR", str(tmp_path / "requests"))
+    monkeypatch.setattr(control_service.config, "CONTROL_RESULTS_DIR", str(tmp_path / "results"))
+    monkeypatch.setattr(control_service.config, "CONTROL_WAIT_S", 0.1)
+    monkeypatch.setattr(control_service.config, "CONTROL_WORKER_UPGRADE_WAIT_S", 0.5)
+    return tmp_path
+
+
+@pytest.fixture
+async def worker_client(aiohttp_client, control_spool, monkeypatch):
+    from mining_dashboard.config import config as cfg_mod
+
+    monkeypatch.setattr(
+        cfg_mod, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9", "control_port": 8082}]
+    )
+    data = {
+        "workers": [
+            {
+                "name": "rig1",
+                "ip": "10.0.0.9",
+                "status": "online",
+                "active_pool": "3333",
+                "h60": 0,
+                "rigforge": {"version": "1.11.0"},
+            }
+        ]
+    }
+    sm = StateManager(db_path=":memory:")
+    cli = await aiohttp_client(create_app(sm, data))
+    cli.sm = sm
+    yield cli
+    sm.close()
+
+
+async def _upgrade(worker_client, control_spool, monkeypatch, result):
+    rid = str(uuid.uuid4())
+    monkeypatch.setattr(control_service.uuid, "uuid4", lambda: uuid.UUID(rid))
+    (control_spool / "results" / f"{rid}.json").write_text(json.dumps(result))
+    resp = await worker_client.post(
+        "/api/control/worker-upgrade",
+        json={"worker": "rig1", "version": "v1.12.0"},
+        headers=CONTROL_HEADERS,
+    )
+    assert resp.status == 202
+    import asyncio
+
+    await asyncio.gather(*worker_client.app["_bg_tasks"])
+
+
+class TestUpgradeRefreshTrigger:
+    async def test_applied_result_triggers_refresh(self, worker_client, control_spool, monkeypatch):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        result = {"status": "applied", "change_id": "cid", "worker": "rig1", "version": "v1.12.0"}
+        await _upgrade(worker_client, control_spool, monkeypatch, result)
+        called.assert_awaited_once_with(worker_client.app["latest_data"], "rig1", "v1.12.0")
+
+    async def test_accepted_result_triggers_refresh(
+        self, worker_client, control_spool, monkeypatch
+    ):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        result = {"status": "accepted", "change_id": "cid", "worker": "rig1", "version": "v1.12.0"}
+        await _upgrade(worker_client, control_spool, monkeypatch, result)
+        called.assert_awaited_once()
+
+    @pytest.mark.parametrize("status", ["rejected", "failed", "rolled_back", "throttled", "noop"])
+    async def test_non_success_result_does_not_trigger_refresh(
+        self, worker_client, control_spool, monkeypatch, status
+    ):
+        called = AsyncMock(return_value=True)
+        monkeypatch.setattr(worker_refresh, "refresh_worker_after_upgrade", called)
+        result = {"status": status, "change_id": "cid", "worker": "rig1", "version": "v1.12.0"}
+        await _upgrade(worker_client, control_spool, monkeypatch, result)
+        called.assert_not_awaited()

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -399,8 +399,10 @@ is a suggestion, not a fact — confirm or correct it before submitting; the rig
 enough proof of who is actually listening there. Submitting writes the descriptor through the same
 control channel [the Configuration view uses](#configuration-view) (preview, then commit) — no
 separate write path, and it can only ADD a new descriptor: it can never change the host or token of
-a rig that already has one, so adopting rig #4 can't be used to repoint rig #1. A rig with no host
-yet, or the control channel off, still gets a plain explanation instead of the form.
+a rig that already has one, so adopting rig #4 can't be used to repoint rig #1. The address also
+can't resolve inside the stack's own network — loopback, link-local, or its own docker-bridge
+subnet are refused, so an adopted rig has to be a real, distinct machine on your LAN. A rig with no
+host yet, or the control channel off, still gets a plain explanation instead of the form.
 
 The write is durable immediately, but a rig descriptor renders to no `.env` key, so adopting alone
 never recreates any container — the dashboard reads its worker list once at process start, so this

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -333,7 +333,9 @@ offline. Point the rig's descriptor at the enriched feed to turn this on — see
 
 With `dashboard.check_for_updates` on, a rig reporting a RigForge version older than the latest
 published release also gets a clickable `rf vX.Y.Z available ↗` badge — the per-worker twin of the
-header's new-release badge, notify-only, linking to the RigForge release notes. See
+header's new-release badge. Clicking it opens [Worker Inspect](#worker-inspect), where the
+one-click upgrade lives (or the [adopt flow](#worker-inspect) that enables it); the release-notes
+link moves inside that dialog as a secondary action. See
 [Connecting Miners › RigForge new-release badge](workers.md#rigforge-new-release-badge).
 
 Each rig shows accepted and rejected share counts (invalid shares folded into the rejected column as
@@ -390,8 +392,21 @@ doesn't come back to a live hashrate — rolls it back on its own. The panel sho
 path broke) and appends it to the history.
 
 To make a rig editable, give it `host`, `token`, and (unless it's the default `8082`) `control_port`
-in its [`workers.list[]`](configuration.md#configuration-reference) descriptor. Without a host, or
-without a token, the rig isn't a write target and the panel says so.
+in its [`workers.list[]`](configuration.md#configuration-reference) descriptor. A rig with neither
+yet shows an **adopt form** instead of the editor: the control address prefilled from the IP the
+proxy observed, `control_port` defaulted to `8082`, and a blank token field. The prefilled address
+is a suggestion, not a fact — confirm or correct it before submitting; the rig's own name is not
+enough proof of who is actually listening there. Submitting writes the descriptor through the same
+control channel [the Configuration view uses](#configuration-view) (preview, then commit) — no
+separate write path, and it can only ADD a new descriptor: it can never change the host or token of
+a rig that already has one, so adopting rig #4 can't be used to repoint rig #1. A rig with no host
+yet, or the control channel off, still gets a plain explanation instead of the form.
+
+The write is durable immediately, but a rig descriptor renders to no `.env` key, so adopting alone
+never recreates any container — the dashboard reads its worker list once at process start, so this
+editor may not appear until the dashboard itself restarts. The next config apply, a stack upgrade,
+or a manual `./pithead restart` all pick it up; there is no faster dashboard-only way to force it
+yet.
 
 When the rig's [new-release badge](#workers-alive) shows and the rig is editable, an **Upgrade
 rig…** button appears beside it: arm it, confirm, and the rig upgrades its own RigForge to the

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -270,9 +270,10 @@ its own watts and needs no estimate.
 
 `control_port` (default `8082`) is the rig's writable control API port, used by
 [Worker Inspect](dashboard.md#worker-inspect) to push config changes from the dashboard. Set it
-alongside `host` and `token` to make a rig editable; leave the whole feature off by not enabling the
-dashboard control channel. The token is the rig's `ACCESS_TOKEN` and never leaves the stack host — the
-dashboard container doesn't hold it.
+alongside `host` and `token` to make a rig editable — either by hand in `config.json`, or from
+Worker Inspect's own **adopt form** on a rig that doesn't have an entry yet; leave the whole
+feature off by not enabling the dashboard control channel. The token is the rig's `ACCESS_TOKEN`
+and never leaves the stack host — the dashboard container doesn't hold it.
 
 ! The control token is **write-capable** and travels in **cleartext HTTP** over the LAN (like the
 stratum password): a change can alter a rig's pools or its thermal `watchdog`/`max_temp_c`, so anyone
@@ -377,9 +378,12 @@ six-hour window isn't burned; a repeat click inside that window surfaces as retr
 
 An upgrade can rebuild the rig's miner (about ten minutes when the XMRig pin changed). The runner
 polls the rig to a terminal outcome with a hard cap; past the cap the panel reports the upgrade
-still running and the badge clears on its own once the rig's next poll reports the new version.
-Upgrades are per-rig only — there is deliberately no "upgrade all" button, so one click can never
-stagger rebuilds across the whole farm.
+still running. Once the runner reports the rig rebuilt (or is still rebuilding), the dashboard
+re-reads that one rig's status itself — a few bounded tries, not a new steady-state poll — instead
+of waiting out the normal 30-second cycle, so the version and the badge usually clear within
+seconds of the rebuild finishing rather than up to a full cycle later. Upgrades are per-rig only —
+there is deliberately no "upgrade all" button, so one click can never stagger rebuilds across the
+whole farm.
 
 ---
 

--- a/pithead
+++ b/pithead
@@ -9673,6 +9673,20 @@ CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DA
     STRATUM_PORT MONERO_CLEARNET_SYNC TARI_CLEARNET_SYNC MONERO_PRUNE
     MONERO_OUT_PEERS'
 
+# True if $1 is EXACTLY a canonical dotted-decimal IPv4 literal — four decimal octets 0-255, none
+# with a leading zero (a bare "0" is fine; "010"/"0177" are not). curl/glibc's numeric-address
+# parsing also accepts a bare decimal integer ("2130706433"), octal per-octet ("0177.0.0.1", AND
+# bash's own arithmetic tests would misread "010" as octal 8), hex ("0x7f000001"), and
+# short/collapsed forms ("127.1" == 127.0.0.1) — none of those are "canonical" by this definition,
+# on purpose: see _control_host_is_internal, which refuses rather than accepts anything
+# numeric-shaped that isn't this exact form.
+_is_canonical_ipv4() {
+    [[ "$1" =~ ^(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]] || return 1
+    local o
+    for o in "${BASH_REMATCH[@]:1}"; do [ "$o" -le 255 ] || return 1; done
+    return 0
+}
+
 # True if $1 — a workers.list[] host the add-only exception is about to let a commit introduce —
 # resolves inside THIS host's own reach: loopback, unspecified ("this network"), link-local,
 # multicast/reserved, the literal name "localhost", or the stack's own docker-bridge subnet
@@ -9686,13 +9700,29 @@ CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DA
 # dials strictly from the HOST's own config — the exact escalation resolve_worker_target's own
 # doc comment assumes workers.list[] can never carry (it predates the dashboard having ANY write
 # access to that array). An ordinary LAN or public rig address is unaffected.
+#
+# A string this host's curl dial would treat as numeric MUST be recognized as one here too, or an
+# alternate encoding of the very addresses above (decimal, octal, hex, short-form — see
+# _is_canonical_ipv4) sails through misclassified as "just a hostname". So: a letter anywhere
+# (other than a literal "0x"/"0X" hex marker) means a real hostname, never re-resolved here (the
+# same accepted, pre-existing limit the read-path guard has); anything else — digits, dots, or a
+# hex marker — is a numeric-address ATTEMPT and is refused outright unless it is the exact
+# canonical form checked below. Ambiguous never means "safe" in this function.
 _control_host_is_internal() {
     local host a b prefix
     host=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
     case "$host" in
     localhost | *.localhost) return 0 ;;
     esac
-    is_ipv4 "$host" || return 1 # a hostname clears this class; DNS resolution isn't re-checked here
+    case "$host" in
+    *[a-z]*)
+        case "$host" in
+        *0x*) return 0 ;; # hex-encoded literal — still numeric-shaped despite the letters
+        esac
+        return 1 # a genuine hostname; DNS resolution isn't re-checked here
+        ;;
+    esac
+    _is_canonical_ipv4 "$host" || return 0 # numeric-shaped but not the exact canonical form
     IFS=. read -r a b _ _ <<<"$host"
     case "$a" in
     0 | 127) return 0 ;;                 # this-network / loopback

--- a/pithead
+++ b/pithead
@@ -9673,6 +9673,44 @@ CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DA
     STRATUM_PORT MONERO_CLEARNET_SYNC TARI_CLEARNET_SYNC MONERO_PRUNE
     MONERO_OUT_PEERS'
 
+# True if $1 — a workers.list[] host the add-only exception is about to let a commit introduce —
+# resolves inside THIS host's own reach: loopback, unspecified ("this network"), link-local,
+# multicast/reserved, the literal name "localhost", or the stack's own docker-bridge subnet
+# (network.subnet). Mirrors the READ-path SSRF guard a miner-claimed IP already gets
+# (_safe_probe_host, dashboard/mining_dashboard/client/xmrig_client.py, #122) for the WRITE path:
+# an add-only append is DASHBOARD-chosen (the operator confirms it in the browser, but the actual
+# HTTP request is built and sent by the — possibly compromised — dashboard container), so without
+# this a malicious/compromised dashboard could append a phantom descriptor pointed at its own
+# host's loopback services or a sibling container, then immediately dial it (with an
+# attacker-chosen bearer) via the pre-existing worker-apply/worker-upgrade path, which resolves and
+# dials strictly from the HOST's own config — the exact escalation resolve_worker_target's own
+# doc comment assumes workers.list[] can never carry (it predates the dashboard having ANY write
+# access to that array). An ordinary LAN or public rig address is unaffected.
+_control_host_is_internal() {
+    local host a b prefix
+    host=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
+    case "$host" in
+    localhost | *.localhost) return 0 ;;
+    esac
+    is_ipv4 "$host" || return 1 # a hostname clears this class; DNS resolution isn't re-checked here
+    IFS=. read -r a b _ _ <<<"$host"
+    case "$a" in
+    0 | 127) return 0 ;;                 # this-network / loopback
+    169) [ "$b" = 254 ] && return 0 ;;    # link-local (also covers cloud metadata, 169.254.169.254)
+    esac
+    [ "$a" -ge 224 ] && return 0 # multicast (224-239) and reserved (240-255)
+    # The stack's own docker-bridge /24 (network.subnet, default 172.28.0.0/24) — read from the
+    # LIVE config, never the staged proposal: a same-commit network.subnet change would already be
+    # refused above (NETWORK_SUBNET is on neither editable allowlist), so the live value is the
+    # honest baseline either way.
+    prefix=$(jq -r '.network.subnet // "172.28.0.0/24"' "$CONFIG_FILE" 2>/dev/null)
+    case "$prefix" in
+    *.0/24) prefix="${prefix%.0/24}" ;;
+    *) prefix="172.28.0" ;;
+    esac
+    [ "${host%.*}" = "$prefix" ]
+}
+
 control_approval_gate() { # <staged-file> [confirm-token]
     local staged="$1" confirm="${2:-}" porcelain
     # Fail closed if we cannot re-derive the change set (the staged config was validated at
@@ -9712,6 +9750,19 @@ control_approval_gate() { # <staged-file> [confirm-token]
         printf 'this change alters an existing per-worker descriptor (workers.list[] / dashboard.workers[], a per-rig host/token) rather than only adding a new one, which is not committable from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
         return 1
     fi
+    # SSRF floor on what an add-only append may point at (see _control_host_is_internal): every
+    # NEWLY appended entry's host — never an already-live one, already covered above — must clear
+    # this host's own loopback/link-local/internal-bridge reach. Read the live length fresh (not
+    # cached from the check above) so this stays correct however the prefix check above evolves.
+    local live_n new_host
+    live_n=$(jq -r --slurpfile live "$CONFIG_FILE" '($live[0].workers.list // []) | length' "$staged" 2>/dev/null) || live_n=0
+    while IFS= read -r new_host; do
+        [ -n "$new_host" ] || continue
+        if _control_host_is_internal "$new_host"; then
+            printf 'a new worker descriptor points at %s, which resolves inside this host'"'"'s own network — a rig'"'"'s control address must be a distinct machine on your LAN, not this host or one of its own containers.' "$new_host"
+            return 1
+        fi
+    done < <(jq -r --argjson n "${live_n:-0}" '(.workers.list // [])[$n:] | .[] | select(has("host")) | .host' "$staged" 2>/dev/null)
     # Closed-schema guard (#33 hardening). A config.json key the stack doesn't recognize renders to
     # NO env var, so it emits zero porcelain rows and slips past the allowlist below — yet the
     # commit's `cp "$staged" "$CONFIG_FILE"` would still persist it. So refuse any staged path that

--- a/pithead
+++ b/pithead
@@ -9689,8 +9689,9 @@ _is_canonical_ipv4() {
 
 # True if $1 — a workers.list[] host the add-only exception is about to let a commit introduce —
 # resolves inside THIS host's own reach: loopback, unspecified ("this network"), link-local,
-# multicast/reserved, the literal name "localhost", or the stack's own docker-bridge subnet
-# (network.subnet). Mirrors the READ-path SSRF guard a miner-claimed IP already gets
+# multicast/reserved, "localhost" (and its standard /etc/hosts aliases and root-terminated
+# spelling — localhost., localhost.localdomain, ip6-localhost, ip6-loopback), or the stack's own
+# docker-bridge subnet (network.subnet). Mirrors the READ-path SSRF guard a miner-claimed IP already gets
 # (_safe_probe_host, dashboard/mining_dashboard/client/xmrig_client.py, #122) for the WRITE path:
 # an add-only append is DASHBOARD-chosen (the operator confirms it in the browser, but the actual
 # HTTP request is built and sent by the — possibly compromised — dashboard container), so without
@@ -9711,8 +9712,14 @@ _is_canonical_ipv4() {
 _control_host_is_internal() {
     local host a b prefix
     host=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
+    # A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat "localhost." exactly
+    # like "localhost" — so strip exactly one before any hostname comparison, or the root-terminated
+    # spelling sails past a literal-string match untouched. localhost.localdomain / ip6-localhost /
+    # ip6-loopback are the standard /etc/hosts loopback aliases on Debian/RHEL-family Linux (this
+    # stack's own target OS) — refused explicitly, not just the bare "localhost" family.
+    host="${host%.}"
     case "$host" in
-    localhost | *.localhost) return 0 ;;
+    localhost | *.localhost | localhost.localdomain | ip6-localhost | ip6-loopback) return 0 ;;
     esac
     case "$host" in
     *[a-z]*)

--- a/pithead
+++ b/pithead
@@ -9690,12 +9690,26 @@ control_approval_gate() { # <staged-file> [confirm-token]
     #
     # The per-worker descriptors — workers.list[] (#506) or its deprecated fallback
     # dashboard.workers[] (#172) — carry per-rig hosts and API tokens (exactly the "free-form string
-    # that reaches a URL or credential" class the allowlist exists to keep host-CLI-only), so refuse
-    # a change to EITHER shape explicitly.
+    # that reaches a URL or credential" class the allowlist exists to keep host-CLI-only). The
+    # legacy dashboard.workers[] shape stays refused outright, whatever it changes to: any commit
+    # touching it goes back to a host edit.
+    #
+    # workers.list[] gets ONE narrow ADD-ONLY exception (the click-to-adopt flow): a commit may
+    # APPEND a brand-new descriptor to the end of the array, but every entry already live must
+    # reappear byte-for-byte, in the same order — so an adopt commit can add rig #4 without ever
+    # being able to repoint rig #1's host or token. That asymmetry is deliberate: first adoption
+    # gets a human confirming a freshly-observed address (the miner-advertised value is a PREFILL
+    # only), but a REPOINT of an already-trusted descriptor is the #122-class escalation an adopt
+    # confirmation was never designed to cover, so it stays a host edit like any other change here.
+    # Checked as a prefix match: staged.workers.list, cut back to live's own length, must equal
+    # live.workers.list exactly. An empty live list makes every staged entry "new" by definition
+    # (first adoption); a shorter/reordered/edited staged list can never match and is refused.
     if ! jq -e --slurpfile live "$CONFIG_FILE" '
         (.dashboard.workers // []) == ($live[0].dashboard.workers // [])
-        and (.workers.list // []) == ($live[0].workers.list // [])' "$staged" >/dev/null 2>&1; then
-        printf 'this change alters the per-worker descriptors (workers.list[] / dashboard.workers[], per-rig hosts/tokens, #172/#506), which is not committable from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
+        and ((($live[0].workers.list // []) | length) as $n
+             | (.workers.list // [])[0:$n] == ($live[0].workers.list // []))
+        ' "$staged" >/dev/null 2>&1; then
+        printf 'this change alters an existing per-worker descriptor (workers.list[] / dashboard.workers[], a per-rig host/token) rather than only adding a new one, which is not committable from the dashboard. Edit config.json on the host and run `%s apply`.' "$0"
         return 1
     fi
     # Closed-schema guard (#33 hardening). A config.json key the stack doesn't recognize renders to

--- a/pithead
+++ b/pithead
@@ -9678,8 +9678,9 @@ CONTROL_DASHBOARD_CONFIRM_KEYS='MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR DA
 # parsing also accepts a bare decimal integer ("2130706433"), octal per-octet ("0177.0.0.1", AND
 # bash's own arithmetic tests would misread "010" as octal 8), hex ("0x7f000001"), and
 # short/collapsed forms ("127.1" == 127.0.0.1) — none of those are "canonical" by this definition,
-# on purpose: see _control_host_is_internal, which refuses rather than accepts anything
-# numeric-shaped that isn't this exact form.
+# on purpose. Used two ways below: to fast-path an already-clean literal straight to a
+# classification with no resolver round trip, and to recognize a RESOLVED answer's own shape
+# (getent's output is always canonical, so this always matches there).
 _is_canonical_ipv4() {
     [[ "$1" =~ ^(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})\.(0|[1-9][0-9]{0,2})$ ]] || return 1
     local o
@@ -9687,65 +9688,142 @@ _is_canonical_ipv4() {
     return 0
 }
 
-# True if $1 — a workers.list[] host the add-only exception is about to let a commit introduce —
-# resolves inside THIS host's own reach: loopback, unspecified ("this network"), link-local,
-# multicast/reserved, "localhost" (and its standard /etc/hosts aliases and root-terminated
-# spelling — localhost., localhost.localdomain, ip6-localhost, ip6-loopback), or the stack's own
-# docker-bridge subnet (network.subnet). Mirrors the READ-path SSRF guard a miner-claimed IP already gets
-# (_safe_probe_host, dashboard/mining_dashboard/client/xmrig_client.py, #122) for the WRITE path:
-# an add-only append is DASHBOARD-chosen (the operator confirms it in the browser, but the actual
-# HTTP request is built and sent by the — possibly compromised — dashboard container), so without
-# this a malicious/compromised dashboard could append a phantom descriptor pointed at its own
-# host's loopback services or a sibling container, then immediately dial it (with an
-# attacker-chosen bearer) via the pre-existing worker-apply/worker-upgrade path, which resolves and
-# dials strictly from the HOST's own config — the exact escalation resolve_worker_target's own
-# doc comment assumes workers.list[] can never carry (it predates the dashboard having ANY write
-# access to that array). An ordinary LAN or public rig address is unaffected.
-#
-# A string this host's curl dial would treat as numeric MUST be recognized as one here too, or an
-# alternate encoding of the very addresses above (decimal, octal, hex, short-form — see
-# _is_canonical_ipv4) sails through misclassified as "just a hostname". So: a letter anywhere
-# (other than a literal "0x"/"0X" hex marker) means a real hostname, never re-resolved here (the
-# same accepted, pre-existing limit the read-path guard has); anything else — digits, dots, or a
-# hex marker — is a numeric-address ATTEMPT and is refused outright unless it is the exact
-# canonical form checked below. Ambiguous never means "safe" in this function.
-_control_host_is_internal() {
-    local host a b prefix
-    host=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
-    # A trailing dot is DNS's "FQDN root" marker — resolvers (and curl) treat "localhost." exactly
-    # like "localhost" — so strip exactly one before any hostname comparison, or the root-terminated
-    # spelling sails past a literal-string match untouched. localhost.localdomain / ip6-localhost /
-    # ip6-loopback are the standard /etc/hosts loopback aliases on Debian/RHEL-family Linux (this
-    # stack's own target OS) — refused explicitly, not just the bare "localhost" family.
-    host="${host%.}"
-    case "$host" in
-    localhost | *.localhost | localhost.localdomain | ip6-localhost | ip6-loopback) return 0 ;;
-    esac
-    case "$host" in
-    *[a-z]*)
-        case "$host" in
-        *0x*) return 0 ;; # hex-encoded literal — still numeric-shaped despite the letters
-        esac
-        return 1 # a genuine hostname; DNS resolution isn't re-checked here
-        ;;
-    esac
-    _is_canonical_ipv4 "$host" || return 0 # numeric-shaped but not the exact canonical form
-    IFS=. read -r a b _ _ <<<"$host"
+# True if a CANONICAL IPv4 address (already _is_canonical_ipv4-shaped) is inside this host's own
+# reach: loopback/this-network (0.x/127.x — all of 127.0.0.0/8, not just 127.0.0.1, so a box's own
+# non-default loopback alias is caught too), link-local (169.254.0.0/16, which also covers the
+# 169.254.169.254 cloud-metadata address), multicast/reserved (224-255), or the stack's own
+# docker-bridge /24 (network.subnet, read from the LIVE config — a same-commit network.subnet
+# change is refused elsewhere, on neither editable allowlist, so the live value is the honest
+# baseline either way). RFC1918 LAN ranges (10/8, 172.16/12, 192.168/16) are deliberately NOT on
+# this list — dialing a LAN rig is this feature's whole purpose.
+_ipv4_is_sensitive() {
+    local a b prefix
+    IFS=. read -r a b _ _ <<<"$1"
     case "$a" in
-    0 | 127) return 0 ;;                 # this-network / loopback
-    169) [ "$b" = 254 ] && return 0 ;;    # link-local (also covers cloud metadata, 169.254.169.254)
+    0 | 127) return 0 ;;
+    169) [ "$b" = 254 ] && return 0 ;;
     esac
-    [ "$a" -ge 224 ] && return 0 # multicast (224-239) and reserved (240-255)
-    # The stack's own docker-bridge /24 (network.subnet, default 172.28.0.0/24) — read from the
-    # LIVE config, never the staged proposal: a same-commit network.subnet change would already be
-    # refused above (NETWORK_SUBNET is on neither editable allowlist), so the live value is the
-    # honest baseline either way.
+    [ "$a" -ge 224 ] && return 0
     prefix=$(jq -r '.network.subnet // "172.28.0.0/24"' "$CONFIG_FILE" 2>/dev/null)
     case "$prefix" in
     *.0/24) prefix="${prefix%.0/24}" ;;
     *) prefix="172.28.0" ;;
     esac
-    [ "${host%.*}" = "$prefix" ]
+    [ "${1%.*}" = "$prefix" ]
+}
+
+# True if $1 is shaped like an IPv6 literal — loose on purpose (a bare colon check): this only
+# routes the value to the right classifier below, it doesn't itself decide safety.
+_is_ipv6_literal() {
+    case "$1" in
+    *:*) return 0 ;;
+    esac
+    return 1
+}
+
+# True if an IPv6 literal is inside this host's own reach: loopback (::1), unspecified (::),
+# link-local (fe80::/10 — the fixed first 10 bits always print as "fe8"/"fe9"/"fea"/"feb" in
+# RFC 5952's canonical form, since none of those leading hex digits is ever zero-suppressed),
+# multicast (ff00::/8 — this is what actually closes the /etc/hosts multicast aliases
+# ip6-allnodes/ip6-allrouters/ip6-localnet/ip6-mcastprefix; a spelling denylist could only ever
+# cover the aliases someone thought to type in, never the address CLASS), or an IPv4-mapped IPv6
+# literal (::ffff:a.b.c.d) whose EMBEDDED v4 address is itself sensitive — curl dials the
+# embedded address, so the v6 wrapper syntax must not launder it.
+_ipv6_is_sensitive() {
+    local v6
+    v6=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
+    v6="${v6%%%*}" # strip a zone ID (fe80::1%eth0) — irrelevant to which block it's in
+    case "$v6" in
+    "::1" | "::") return 0 ;;
+    fe8[0-9a-f]:* | fe9[0-9a-f]:* | fea[0-9a-f]:* | feb[0-9a-f]:*) return 0 ;;
+    ff[0-9a-f][0-9a-f]:*) return 0 ;;
+    ::ffff:*.*.*.*)
+        _is_canonical_ipv4 "${v6##*:}" && _ipv4_is_sensitive "${v6##*:}" && return 0
+        ;;
+    esac
+    return 1
+}
+
+# Resolves $1 to its numeric addresses (both A and AAAA) via the system resolver — once, at
+# commit time; this write path is operator-confirmed, never a hot loop, so a real DNS round trip
+# here is the right cost for the safety it buys. `getent ahosts` also resolves any numeric-address
+# ATTEMPT that isn't the exact canonical form (decimal integer, octal, hex, short/collapsed —
+# _is_canonical_ipv4's own comment) using the SAME numeric parsing glibc's getaddrinfo (and
+# therefore curl) uses, so routing those through here too gets an exact answer instead of a
+# guess. Prints one deduplicated IP per line; a non-zero exit (including a 5s timeout) means
+# resolution failed, which the caller treats as FAIL CLOSED — an unresolved name can never be
+# proven safe. This is the one seam a test replaces: point $PATH at a directory carrying a fake
+# `getent` ahead of the real one (see tests/stack/test-control-add-only-ssrf.sh) to supply canned
+# answers without needing real DNS.
+_resolve_host_ips() {
+    timeout 5 getent ahosts "$1" 2>/dev/null | awk '{print $1}' | sort -u
+}
+
+# True if $1 — a workers.list[] host the add-only exception is about to let a commit introduce —
+# resolves inside THIS host's own reach. Mirrors the READ-path SSRF guard a miner-claimed IP
+# already gets (_safe_probe_host, dashboard/mining_dashboard/client/xmrig_client.py, #122) for the
+# WRITE path: an add-only append is DASHBOARD-chosen (the operator confirms it in the browser, but
+# the actual HTTP request is built and sent by the — possibly compromised — dashboard container),
+# so without this a malicious/compromised dashboard could append a phantom descriptor pointed at
+# its own host's loopback services or a sibling container, then immediately dial it (with an
+# attacker-chosen bearer) via the pre-existing worker-apply/worker-upgrade path, which resolves and
+# dials strictly from the HOST's own config. An ordinary LAN or public rig address is unaffected.
+#
+# #893 round 5: an earlier version of this function classified by STRING SHAPE alone — a denylist
+# of "localhost" and its known /etc/hosts aliases. An independent review found that a spelling
+# denylist can never answer "does this name reach my own loopback": this host's own Debian
+# self-entry (e.g. a box named "gouda" resolving to 127.0.1.1 — every Debian install's own
+# /etc/hosts gives its hostname a loopback entry) and, worse, ANY attacker-controlled DNS name
+# pointed at 127.0.0.1 both looked like "a genuine hostname, therefore safe" to a string
+# classifier — but a live curl dial to either one lands on loopback all the same. There is no
+# spelling to denylist against an attacker who controls the DNS answer.
+#
+# The fix is RESOLVE, THEN CHECK: a canonical IPv4 literal (the exact form _is_canonical_ipv4
+# recognizes) is classified directly, since it already IS the address that would be dialed and
+# has exactly one meaning. Everything else — including an IPv6 literal, which unlike IPv4 has
+# many equally-valid spellings of the same address ("::1" == "0:0:0:0:0:0:0:1") that a hand-rolled
+# shortcut classifier could under-recognize the same way the old denylist did — goes through the
+# resolver, which normalizes any of those the same way glibc's own numeric-address parsing would.
+# EVERY returned address must clear the check — an attacker's own DNS answer can mix one public IP
+# with one loopback IP in the same response, so checking only the first would miss it.
+# DNS-rebinding (the resolved-at-commit
+# address differing from the address at a later dial) is an accepted residual risk, same as
+# before resolve-and-check existed: it requires a SEPARATE capability (DNS control) beyond a
+# compromised dashboard, and the operator-confirmed write boundary this whole check lives behind
+# is why that's acceptable without also adding a dial-time re-check (see the PR's "Dial-time
+# re-check" note).
+_control_host_is_internal() {
+    local host resolved ip
+    host=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
+    host="${host%.}" # a trailing dot is DNS's "FQDN root" marker; getent treats it identically
+    if _is_canonical_ipv4 "$host"; then
+        # A canonical dotted-decimal literal is unambiguous — it IS the address that would be
+        # dialed, so classify it directly with no resolver round trip.
+        _ipv4_is_sensitive "$host"
+        return
+    fi
+    # Everything else — a genuine hostname, an IPv6 literal in ANY of its many equally-valid
+    # spellings ("::1" and "0:0:0:0:0:0:0:1" are the identical address; a hand-rolled
+    # canonicalizer here would just reopen the same bug class this fix closed for IPv4 — a
+    # classifier that only recognizes ONE shape and silently treats every other shape as safe), or
+    # an IPv4-shaped-but-non-canonical numeric-address ATTEMPT (decimal integer, octal, hex,
+    # short/collapsed form) — goes through the resolver. `getent ahosts` normalizes ALL of those
+    # into canonical addresses using the SAME parsing glibc's getaddrinfo (and therefore curl)
+    # uses, including a bare literal (no network round trip needed for one), so this is correct
+    # for a typed literal and a real hostname alike.
+    resolved=$(_resolve_host_ips "$host") || return 0 # resolution failed/timed out -> FAIL CLOSED
+    [ -n "$resolved" ] || return 0                    # an empty answer -> FAIL CLOSED
+    while IFS= read -r ip; do
+        [ -n "$ip" ] || continue
+        if _is_canonical_ipv4 "$ip"; then
+            _ipv4_is_sensitive "$ip" && return 0
+        elif _is_ipv6_literal "$ip"; then
+            _ipv6_is_sensitive "$ip" && return 0
+        else
+            return 0 # an answer shape we don't recognize -> FAIL CLOSED, never wave it through
+        fi
+    done <<<"$resolved"
+    return 1
 }
 
 control_approval_gate() { # <staged-file> [confirm-token]

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -5160,12 +5160,11 @@ gate_try "$C/cand.json"
 assert_eq "dashboard.workers change commit is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
 assert_contains "workers refusal names dashboard.workers" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "dashboard.workers"
 assert_eq "config.json keeps no worker descriptors" "$(jq -r '.dashboard.workers // "unset"' "$C/config.json")" "unset"
-# Same refusal on the CURRENT workers.list[] shape (#506) — the gate must catch either key.
-jq '.workers.list=[{name:"rig1",host:"attacker.example",token:"stolen"}]' "$C/config.json" >"$C/cand.json"
-gate_try "$C/cand.json"
-assert_eq "workers.list change commit is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
-assert_contains "workers.list refusal names the per-worker descriptors" "$(jq -r '.error' "$RESULTS/$UUID5.json" 2>/dev/null)" "workers.list"
-assert_eq "config.json keeps no workers.list descriptors" "$(jq -r '.workers.list // "unset"' "$C/config.json")" "unset"
+# workers.list[]'s add-only exception (#893's click-to-adopt) + the #122 SSRF floor on a newly
+# appended entry's host — split into its own file purely for the file-budget ratchet; it shares
+# this section's $C/$UUID5/gate_try exactly like test-control-deploy.sh shares its own section's.
+# shellcheck source=tests/stack/test-control-add-only-ssrf.sh
+source "$HERE/test-control-add-only-ssrf.sh"
 
 # dashboard.energy (#504) is the ONE config.json-only block a commit MAY change: it never renders
 # to .env, so the host previews it as a normal INFO row (not the old non-committable HOST note) and

--- a/tests/stack/test-control-add-only-ssrf.sh
+++ b/tests/stack/test-control-add-only-ssrf.sh
@@ -10,7 +10,8 @@
 # MUTATION PROOF: reverting pithead's add-only prefix check back to "refuse any workers.list
 # diff" turns the ADD-ONLY-append assertion red; reverting _control_host_is_internal's
 # trailing-dot strip or narrowing its alias set back to bare "localhost" turns the
-# corresponding assert_new_worker_host_refused case red (each names which).
+# corresponding assert_new_worker_host_refused case red (each names which). Round 5's
+# resolve-and-check battery (below) names its own mutation kills at each assertion.
 
 # workers.list[] (#506): same descriptors as dashboard.workers[] above, but with ONE add-only
 # exception — a commit may APPEND a new descriptor; every live entry must reappear byte-for-byte.
@@ -62,3 +63,79 @@ jq '.workers.list += [{name:"rig3",host:"10.0.0.50",control_port:8082,token:"tok
 gate_try "$C/cand.json"
 assert_eq "workers.list append of an ordinary LAN address still applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
 assert_eq "config.json gains the third, ordinary-LAN rig" "$(jq -r '.workers.list[2].host' "$C/config.json")" "10.0.0.50"
+
+# #893 round 5: an independent review found the battery above was still a STRING classifier under
+# the hood — it can refuse "127.0.0.1" and "localhost" by literal shape, but it can never answer
+# "does THIS HOSTNAME resolve to my own loopback": this host's own Debian self-entry (a box named
+# "gouda" resolves its own hostname to 127.0.1.1 via /etc/hosts — a real, everyday case, not a
+# contrived one) and an attacker-controlled DNS name pointed at 127.0.0.1 both looked like "a
+# genuine hostname, therefore safe" to a spelling denylist — verified live with curl and getent.
+# The fix rebuilt _control_host_is_internal as RESOLVE-AND-CHECK: anything that isn't already a
+# canonical IPv4 literal is resolved (both A and AAAA), and EVERY returned address is checked, not
+# just the first.
+#
+# The harness can't do real DNS, so this battery installs a fake `getent` ahead of the real one on
+# $C/bin (already on PATH for every gate_try/run_pending call in this section — see lib.sh's
+# run_pending) that answers only the names mapped below in dns-map.txt, one "name ip[,ip...]" line
+# each; a mapped name with no IP field simulates a resolution failure. Anything NOT in the map
+# falls through to the REAL system getent untouched — this never masks an unrelated lookup, and
+# every case in the battery above already ran against the real, unstubbed resolver.
+GETENT_MAP="$C/dns-map.txt"
+: >"$GETENT_MAP"
+cat >"$C/bin/getent" <<GETENT_STUB
+#!/usr/bin/env bash
+# Test-only DNS stub for #893 round 5's resolve-and-check seam (tests/stack/test-control-add-only-ssrf.sh).
+if [ "\$1" = "ahosts" ] && [ -f "$GETENT_MAP" ]; then
+    hit=\$(awk -v n="\$2" '\$1 == n {print; exit}' "$GETENT_MAP")
+    if [ -n "\$hit" ]; then
+        ips="\${hit#* }"
+        [ "\$ips" = "\$hit" ] && exit 2 # mapped with no IP field -> simulate a resolution failure
+        IFS=',' read -r -a arr <<<"\$ips"
+        for ip in "\${arr[@]}"; do printf '%s STREAM %s\n' "\$ip" "\$2"; done
+        exit 0
+    fi
+fi
+exec /usr/bin/getent "\$@"
+GETENT_STUB
+chmod +x "$C/bin/getent"
+
+assert_resolved_worker_host_refused() { # <name> <ip-list-or-empty> <label>
+    if [ -n "$2" ]; then printf '%s %s\n' "$1" "$2"; else printf '%s\n' "$1"; fi >>"$GETENT_MAP"
+    jq --arg h "$1" '.workers.list += [{name:"evil-dns",host:$h,control_port:8000,token:"attacker"}]' "$C/config.json" >"$C/cand.json"
+    gate_try "$C/cand.json"
+    assert_eq "new-rig append resolving to $3 is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+}
+# MUTATION KILL: narrowing _ipv4_is_sensitive's loopback case from "0 | 127" (all of 127.0.0.0/8)
+# back to a single literal address turns this one red — 127.0.1.1 isn't 127.0.0.1.
+assert_resolved_worker_host_refused "rig-gouda-alias" "127.0.1.1" "this host's own Debian self-entry style address (127.0.1.1)"
+# MUTATION KILL: reverting _control_host_is_internal's dispatch back to the round 1-4 STRING
+# classifier (drop the resolver call, fall back to "a genuine hostname is never re-checked") turns
+# this one red — "attacker-dns-name" carries no denylistable spelling at all.
+assert_resolved_worker_host_refused "attacker-dns-name" "127.0.0.1" "an attacker-controlled DNS name pointed at loopback"
+# MUTATION KILL: same string-classifier reversion, or narrowing the 169.254.0.0/16 link-local
+# check to the bare metadata address, turns this one red.
+assert_resolved_worker_host_refused "metadata-alias" "169.254.169.254" "a name resolving to the cloud-metadata address"
+# MUTATION KILL: checking only the FIRST resolved address (e.g. `head -1` instead of the while-read
+# loop over every line) turns this one red — the public IP sorts/lists first, the loopback second.
+assert_resolved_worker_host_refused "mixed-answer-name" "203.0.113.5,127.0.0.1" "a multi-answer name where only the SECOND address is sensitive"
+# MUTATION KILL: flipping the resolver-failure branch from `|| return 0` (fail closed) to
+# `|| return 1` (fail open — "must not resolve, so it can't be internal") turns this one red.
+assert_resolved_worker_host_refused "name-that-fails-to-resolve" "" "a name resolution fails on (fail-closed)"
+unset -f assert_resolved_worker_host_refused
+assert_eq "config.json still has exactly rig1+rig2+rig3 after every round-5 SSRF refusal above" \
+    "$(jq -r '.workers.list | length' "$C/config.json")" "3"
+
+# POSITIVE control, round 5: a genuine LAN rig reached BY NAME (not a literal) still applies —
+# resolve-and-check must not turn into "refuse every hostname". MUTATION KILL: an over-broad
+# sensitivity check (e.g. refusing all of 192.168.0.0/16, not just this host's own bridge subnet)
+# turns this one red.
+printf 'real-lan-rig-by-name 192.168.1.77\n' >>"$GETENT_MAP"
+jq '.workers.list += [{name:"rig4",host:"real-lan-rig-by-name",control_port:8082,token:"tok_rig4"}]' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "workers.list append of a LAN address reached BY NAME still applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "config.json gains the fourth rig, resolved from its name" "$(jq -r '.workers.list[3].host' "$C/config.json")" "real-lan-rig-by-name"
+
+# Tidy up the test-only stub so later sections in this same $C sandbox see the real system
+# resolver again — nothing else in this suite calls getent today, but there's no reason to leave a
+# DNS-intercepting stub lying around past the battery that needed it.
+rm -f "$C/bin/getent" "$GETENT_MAP"

--- a/tests/stack/test-control-add-only-ssrf.sh
+++ b/tests/stack/test-control-add-only-ssrf.sh
@@ -1,0 +1,64 @@
+# shellcheck shell=bash
+#
+# workers.list[]'s add-only exception (#893's click-to-adopt) + the #122 SSRF floor on what a
+# newly-appended entry may point at (_control_host_is_internal). Split out of run.sh's own
+# "approval gate default-denies security-control changes" section purely for the file-budget
+# ratchet (#1105 Phase 0) — it shares that section's $C/$UUID5/gate_try, exactly like
+# test-control-deploy.sh shares its own section's fixtures. Sourced by tests/stack/run.sh
+# immediately after gate_try() is defined, before the dashboard.energy tests that follow it.
+#
+# MUTATION PROOF: reverting pithead's add-only prefix check back to "refuse any workers.list
+# diff" turns the ADD-ONLY-append assertion red; reverting _control_host_is_internal's
+# trailing-dot strip or narrowing its alias set back to bare "localhost" turns the
+# corresponding assert_new_worker_host_refused case red (each names which).
+
+# workers.list[] (#506): same descriptors as dashboard.workers[] above, but with ONE add-only
+# exception — a commit may APPEND a new descriptor; every live entry must reappear byte-for-byte.
+# Seed one from the host CLI (never the gate) as the baseline to protect.
+jq '.workers.list=[{name:"rig1",host:"10.0.0.9",control_port:8082,token:"tok_rig1"}]' "$C/config.json" >"$C/cand.json" && mv "$C/cand.json" "$C/config.json"
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+assert_eq "workers.list seed applies from the host CLI" "$(jq -r '.workers.list[0].token' "$C/config.json")" "tok_rig1"
+
+# REPOINT (the #122-class escalation add-only must never permit) and REMOVAL are both refused;
+# APPEND of a brand-new second entry, rig1 byte-for-byte unchanged, is the one shape now allowed.
+jq '.workers.list=[{name:"rig1",host:"attacker.example",token:"stolen"}]' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "workers.list REPOINT of an existing entry is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+assert_eq "config.json keeps the seeded rig1 host after the repoint attempt" "$(jq -r '.workers.list[0].host' "$C/config.json")" "10.0.0.9"
+jq '.workers.list=[]' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "workers.list REMOVAL of an existing entry is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+jq '.workers.list += [{name:"rig2",host:"192.168.1.50",control_port:8082,token:"tok_rig2"}]' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "workers.list ADD-ONLY append of a new rig is allowed" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "config.json keeps rig1 and gains rig2" "$(jq -c '[.workers.list[].host]' "$C/config.json")" '["10.0.0.9","192.168.1.50"]'
+
+# NEGATIVE — the #122 SSRF floor on a NEWLY appended entry (_control_host_is_internal): a
+# compromised dashboard could otherwise append a phantom descriptor at this host's own loopback or
+# a sibling container, then dial it (attacker bearer) via worker-apply/worker-upgrade, which
+# resolves strictly from THIS config.json. A rejection never touches config.json, so rig1+rig2
+# stays the baseline below — including the "localhost" family (a bare-string check misses the
+# /etc/hosts aliases + root-terminated spelling; curl-verified to resolve to loopback here) and a
+# numeric encoding curl's own address parser accepts identically to dotted-decimal.
+assert_new_worker_host_refused() { # <host> <label>
+    jq --arg h "$1" '.workers.list += [{name:"evil",host:$h,control_port:8000,token:"attacker"}]' "$C/config.json" >"$C/cand.json"
+    gate_try "$C/cand.json"
+    assert_eq "new-rig append pointed at $2 is refused" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "rejected"
+}
+assert_new_worker_host_refused "127.0.0.1" "loopback"
+assert_new_worker_host_refused "172.28.0.5" "the stack's own docker-bridge subnet"
+assert_new_worker_host_refused "localhost." "a root-terminated localhost spelling"
+assert_new_worker_host_refused "LOCALHOST." "the same, uppercase"
+assert_new_worker_host_refused "localhost.localdomain" "the RHEL-family /etc/hosts loopback alias"
+assert_new_worker_host_refused "ip6-localhost" "the Debian-family /etc/hosts ::1 alias"
+assert_new_worker_host_refused "ip6-loopback" "the Debian-family /etc/hosts ::1 alias (second name)"
+assert_new_worker_host_refused "2130706433" "a bare-decimal-integer encoding of loopback"
+assert_eq "config.json still has exactly rig1+rig2 after every SSRF refusal above" \
+    "$(jq -r '.workers.list | length' "$C/config.json")" "2"
+unset -f assert_new_worker_host_refused
+
+# POSITIVE control: an ordinary LAN address — the feature's whole purpose — is unaffected.
+jq '.workers.list += [{name:"rig3",host:"10.0.0.50",control_port:8082,token:"tok_rig3"}]' "$C/config.json" >"$C/cand.json"
+gate_try "$C/cand.json"
+assert_eq "workers.list append of an ordinary LAN address still applies" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+assert_eq "config.json gains the third, ordinary-LAN rig" "$(jq -r '.workers.list[2].host' "$C/config.json")" "10.0.0.50"


### PR DESCRIPTION
# Click-to-adopt a rig, with a post-upgrade version refresh

Branch: `feat/893-click-adopt` (off `origin/develop-v2`)
Commits: `3984e61` (feature) + `f33cb1e` + `b477f14` + `7916612` + `b2d8478` (four security fix
commits, following five adversarial review rounds — see below)
HEAD: `b2d8478cb9ec4b171e73417b94fa21f4f77e8ed1`

## Summary

Implements the #893 operator-decision scope (three proposal items, unchanged) plus its companion
#1233 (post-upgrade version-badge lag).

1. **Adopt-a-rig flow.** An unadopted RigForge worker's Worker Inspect dialog now shows an adopt
   form instead of a dead-end message: control address prefilled from the worker's *observed* IP,
   `control_port` defaulted to `8082`, and a blank token field. Submitting rides the **existing**
   control-channel config path — `GET /api/config` → `POST /api/control/preview` →
   `POST /api/control/commit` — the exact same endpoints the Configuration view already uses. **No
   new write endpoint.**
2. **Explain the gated state.** The adopt form itself IS the explanation for "why can't I edit
   this rig yet" — it replaces the old static "set host/token yourself" text. The control-channel-off
   message is unchanged.
3. **Route the table badge into the dialog.** The `rf vX.Y.Z available` badge now opens Worker
   Inspect (release-notes link moves inside as a secondary action) instead of linking straight to
   GitHub. Falls back to the old link when Worker Inspect isn't available (control channel off).
4. **#1233 — bounded post-upgrade refresh.** On a worker-upgrade result meaning the rig actually
   rebuilt (`applied`/`accepted` — never a rejection/failure/rollback/throttle), a bounded, targeted
   re-read of that one rig's status replaces waiting out the full 30s poll cycle. Read-only; the
   "latest available release" lookup keeps its own Tor-throttled cadence untouched.

## Trust-model statement

The binding constraint (operator decision, 2026-08-21): *"the observed address is a prefill that
the operator confirms (never auto-dialed), the per-rig bearer stays mandatory, and the write goes
through the existing control-channel config path."* A prior technical finding (2026-08-15) on the
same issue established that the generic commit path refuses **any** diff to
`workers.list[]`/`dashboard.workers[]` outright, and that whichever fix landed had to be
**add-only** — never able to change the `host`/`token` of a descriptor that already has one.

**Enforcement (three layers, one authority):**

- **Authority (bash, host-side):** `pithead` `control_approval_gate` (`pithead:9829`, line numbers
  as of the round-5 commit — see Surface below for the full function map). Runs a jq array-prefix
  check: `dashboard.workers[]` must stay byte-for-byte unchanged, and `workers.list[]`'s live array
  must be an exact structural prefix of the staged array. Verified by hand against 6 cases
  (empty→populated, pure append, host repoint, entry removal, no-op, a `dashboard.workers[]`
  touch).
- **Defense-in-depth (Python):** `service/worker_adopt.py` (`validate_worker_descriptor:36`,
  `new_worker_entries:142`, `validate_new_worker_entries:157`), wired into `handle_control_preview`
  (`web/server.py:157`). Mirrors the same add-only diff and the same per-field shape regexes
  `pithead`'s `validate_worker_endpoints` enforces. **Not** the security boundary — deleting this
  module entirely still leaves the bash gate refusing a repoint/removal at commit.
- **Prefill-not-authority (frontend):** `web/static/workeradopt.mjs` prefills `host` from
  `detail.ip` (the worker's proxy-observed address) but the field is a plain editable `<input>`;
  nothing submits without a click on "Adopt this rig".
- **Bearer mandatory:** refused by both `validate_worker_descriptor` and (independently)
  `pithead`'s `resolve_worker_target`, which refuses a tokenless entry at dial time regardless of
  what the dashboard ever validated.

## The security pass — five rounds, a real finding each time, now closed

Per the operator's own bar ("an adversarial review that includes a security pass — this is a
control-write surface that touches credentials"), I ran a security-reviewer subagent against the
feature before considering it done, then re-ran an independent adversarial pass against **each**
fix before considering that closed. It took five rounds — the last one a genuine architecture
change, not another patch. Recording the full history here rather than quietly folding it into
"what was run" — a control-write feature that took this many passes to actually close is exactly
the kind of thing a reviewer should be able to see happened, not just be told the end state was
fine.

**Round 1 — critical, found against the feature commit (`3984e61`).** The add-only exception let a
compromised/malicious dashboard container append a `workers.list[]` descriptor pointed at
**anything** — including this host's own loopback services or a sibling container on the stack's
internal docker bridge — with an attacker-chosen bearer token. Because a worker descriptor renders
to no `.env` key, the commit produces zero porcelain rows (no `DEST`/`CONFIRM`), so it lands with
**no typed confirmation**. The dashboard could then immediately call the pre-existing
`/api/control/worker-apply` (or `worker-upgrade`) with that fabricated worker name;
`resolve_worker_target` resolves strictly from the host's own `config.json` (by design, to survive
a compromised container) and would dial the phantom host with the attacker's bearer — a live
SSRF/credential-injection primitive, because this feature is the first time the dashboard gains
*any* write access to that array.

**Fix attempt 1 (`f33cb1e`):** a host-class denylist on every *newly appended* entry (never
already-live ones, which stay covered by the add-only prefix check), at all three layers —
`pithead`'s new `_control_host_is_internal`, `service/worker_adopt.py`'s `host_is_internal`
(Python `ipaddress`), and `web/static/workeradoptlogic.mjs`'s `hostIsInternal` (JS) — refusing
loopback, unspecified, link-local, multicast/reserved, `localhost`, and the stack's own
`network.subnet`. Verified by hand against 14 bash cases before committing.

**Round 2 — that fix was itself bypassable, found by re-running the review against `f33cb1e`.**
All three layers classified a host as "numeric, check the denylist" only if it matched a strict
dotted-decimal regex, and silently treated anything else as "a hostname, therefore safe". curl
(and glibc's legacy numeric-address parsing) also accepts a bare decimal integer
(`2130706433` == `127.0.0.1`), an octal-leading-zero octet (`0177.0.0.1`), hex (`0x7f000001`), and
short/collapsed forms (`127.1`) — none of which matched the strict regex, so **every one of them
bypassed the new denylist entirely** and still got dialed as the real loopback/link-local address.
Empirically confirmed against the actual `curl 8.5.0` build in the dev environment for all of
these, plus `169.254.169.254` (cloud metadata) via its decimal form, and a related gap: Python's
`ipaddress.is_unspecified` only covers the single address `0.0.0.0`, not the whole `0.0.0.0/8`
"this network" block, and a zero-padded octet (`010.0.0.1`) sidesteps a naive string-compare
range check the same way (bash's own arithmetic tests read a leading zero as octal).

**Fix attempt 2 (`b477f14`):** inverts the fallback. A host is either a *real hostname* (contains a
letter that isn't part of a literal `0x` hex marker — DNS resolution stays unchecked here, the
same accepted, pre-existing limit the read-path SSRF guard `_safe_probe_host` already has) or a
*numeric-address attempt* (digits, dots, or a hex marker) — and a numeric-address attempt that
ISN'T the exact canonical four-octet dotted-decimal form (no leading zeros, no bare integer, no
short form, each octet 0-255) is now **refused outright**, never waved through as "must be a
hostname after all". Same logic in all three layers (`pithead`'s new `_is_canonical_ipv4` helper;
Python's `ipaddress` is already appropriately strict, the bug was only in the `except ValueError`
fallback; the JS mirror gets an equivalent `CANONICAL_IPV4_RE`). Also adds the explicit
`0.0.0.0/8` check Python's `is_unspecified` was missing. Verified against a 24-case bash battery
(the original PoCs, all six bypass encodings, the octal-padding edge case, and every
previously-passing legitimate LAN address/hostname) before writing the equivalent Python/JS tests,
and against real `curl` for several more encodings (mixed hex/decimal octets, uppercase hex
markers, a trailing-dot integer, a bare octal integer with no dots) during the round-3 review.

**Round 3 — independent adversarial re-review against `b477f14`: RESOLVED.** A third pass tried to
find a way past the corrected classifier rather than just confirm the code exists — 26 strings run
against the real `pithead` bash function, the real Python module, and the real JS module, and
against the actual `curl 8.5.0` binary in the dev environment: the original 6 bypass encodings, the
requested mixed-radix forms (`0x7f.0.0.1`, `017700000001`, `0x7f.0.0.0001`, `127.0x0.0.1`), a
trailing dot, bare hex without a `0x` marker, percent-encoding, IPv6/bracket forms, embedded
newlines (probing `^`/`$` anchoring across bash `[[ =~ ]]`, jq `test()`, Python `fullmatch`, and JS
`.test()`), case-order (`0X` vs `0x`), and octet-range arithmetic. **No working bypass found**; all
three layers produced byte-identical verdicts on every case, and the fix was confirmed not to have
loosened anything the original `f33cb1e` closed. The DNS-rebinding residual gap below is the only
thing still open, and it predates both fix commits.

**Round 4 — critical, found by an independent review AFTER round 3 reported RESOLVED.** Round 3's
battery tested a trailing dot on *numeric* encodings (e.g. a padded/collapsed IP) and correctly
found no bypass there — but never applied the same idea to the *hostname* class, where the
"localhost" check lived. The literal-string check (`host == "localhost" || host.endswith(".localhost")`,
identical in all three layers) missed: `localhost.` / `LOCALHOST.` (DNS's trailing-dot "FQDN root"
marker — curl resolves it identically to `localhost`), and the standard `/etc/hosts` loopback
aliases on this stack's own target OS — `localhost.localdomain` (RHEL-family) and
`ip6-localhost`/`ip6-loopback` (Debian-family, `::1`). All five verified live: `getent hosts` on the
dev box resolves every one to loopback, and `curl -v` against each dials `127.0.0.1`/`[::1]`. None
of these needed a numeric encoding — they're plain hostnames, so `HOST_RE`'s charset never even
questioned them, and they sailed through as "a genuine hostname" in the exact same fallback branch
round 2 had already hardened for the numeric case.

**Fix (`7916612`):** all three layers strip exactly one trailing `.` before any hostname
comparison, and check membership in an explicit loopback-alias set (`localhost`,
`localhost.localdomain`, `ip6-localhost`, `ip6-loopback`) instead of a single literal-equality
check — the `*.localhost` subdomain wildcard is unchanged. A subdomain of an alias
(`sub.ip6-localhost`) is deliberately NOT itself aliased (membership, not a suffix match), so the
fix doesn't overreach into refusing arbitrary hostnames that merely contain an alias substring.
Verified against a 32-case bash battery (the 5 new strings, all 14 round-1/round-2 cases replayed,
4 legitimate LAN addresses/hostnames, and the subdomain non-overreach case) before mirroring to
Python/JS; mutation-proved at both the Python and JS layer (reverting the fix makes the two new
tests fail with the exact assertion the fix addresses, confirmed by literally reverting and
re-running); added to `tests/stack/`'s black-box control-gate coverage (see Surface) with its own
bash-level mutation-proof note. See "What was RUN" for the actual pass/fail results of that suite.

**Round 5 — critical, found by an independent review AFTER round 4 shipped: the whole ARCHITECTURE
was wrong, not just its spelling list.** Verified live (curl 8.5.0 against a real 127.0.0.1
listener, plus `getent`): the round 1-4 gate was, underneath every patch, still a STRING
classifier. It could refuse "127.0.0.1" and "localhost" by shape, but it could never answer "does
THIS HOSTNAME resolve to my own loopback" — because it never resolved anything. Two live bypasses
proved it instantly:

- **This host's own Debian self-entry.** Every Debian box's `/etc/hosts` gives its own hostname a
  loopback entry — typically `127.0.1.1`, not the bare `127.0.0.1` a spelling denylist would think
  to cover (and the round 1-4 gate's loopback check only ever matched `127.0.0.1` exactly, not the
  whole `127.0.0.0/8` block). A worker descriptor appended with `host` set to this box's own
  hostname (e.g. the box's own hostname) sailed through as "a genuine hostname, therefore safe."
- **Any attacker-controlled DNS name pointed at `127.0.0.1`.** There is no spelling to denylist
  against an attacker who controls the DNS answer — a name like `attacker-dns-name.example` that
  resolves to loopback carries no "localhost"-shaped substring at all, so it was indistinguishable
  from a real rig's hostname to every round 1-4 layer.

Both land on the exact same escalation round 1 first found: a phantom `workers.list[]` entry with
an attacker-chosen bearer token, dialed by the pre-existing worker-apply/worker-upgrade path.

**Fix (`b2d8478`): rebuilt `_control_host_is_internal`
(the bash authority) as RESOLVE-AND-CHECK, not another denylist entry.** A canonical IPv4 literal
(`_is_canonical_ipv4`) is classified directly — it already IS the address that would be dialed, no
resolver round trip needed. Everything else — a genuine hostname, an IPv6 literal in ANY of its
many equally-valid spellings (IPv6, unlike IPv4, has no single canonical string — `::1` and
`0:0:0:0:0:0:0:1` are the identical address; a hand-rolled second canonicalizer here would just
reopen the same "one recognized shape, everything else waved through" bug class this fix is
closing), or an IPv4-shaped-but-non-canonical numeric attempt (the round-2 bypass encodings) — is
resolved via `getent ahosts` (both A and AAAA, once, at commit time: this is an
operator-confirmed write path, not a hot loop, so a real DNS round trip is the right cost),
wrapped in a 5s `timeout`. **Every returned address is checked, not just the first** — an
attacker's own DNS answer can mix one ordinary-looking public IP with one loopback IP in the same
response. Resolution failure (including a timeout) **fails closed** — refused, never waved through
as "must not resolve, so it can't be internal." The blocklist itself is unchanged in shape from
round 1-4's intent, just applied to the RESOLVED address instead of the raw string: loopback (now
the *whole* `127.0.0.0/8`, not one address — this is specifically what closes the Debian
self-entry case), `0.0.0.0`/`::`, link-local (`169.254.0.0/16` + `fe80::/10`, covering the
`169.254.169.254` cloud-metadata address), multicast/reserved (`224.0.0.0`-`255.255.255.255` +
`ff00::/8` for IPv6 — this is what actually closes the `/etc/hosts` multicast aliases like
`ip6-allnodes`/`ip6-allrouters`, which a spelling denylist could only ever cover if someone
happened to type them in as a literal string), an IPv4-mapped IPv6 literal (`::ffff:a.b.c.d`)
whose embedded v4 address is itself sensitive, and the stack's own docker-bridge subnet. RFC1918
LAN (`10/8`, `172.16/12`, `192.168/16`) is deliberately NOT blocked — dialing a LAN rig is the
feature's whole purpose, resolved-by-name or not.

**Before/after, verified against the real functions extracted from the real file:**

| case | pre-round-5 (string classifier) | post-round-5 (resolve-and-check) |
|---|---|---|
| this host's own hostname → `127.0.1.1` (self-hostname-class) | external(allowed) | INTERNAL(refused) |
| attacker-controlled DNS name → `127.0.0.1` | external(allowed) | INTERNAL(refused) |
| a genuine LAN address, `192.168.1.50` | external(allowed) | external(allowed) — **unaffected** |
| a genuine LAN rig reached BY NAME | external(allowed) | external(allowed) — **unaffected** |

The bottom two rows are the point as much as the top two: this is a fix to what gets caught, not a
blanket "refuse anything that isn't a literal IP" — an ordinary LAN rig, whether typed as an
address or as a name that resolves to one, dials exactly as before.

Caught in my OWN adversarial self-testing before this went back for review (worth naming, since
round 6 is coming): a fully-expanded IPv6 loopback literal (`0:0:0:0:0:0:0:1`, the non-compressed
spelling of `::1`) initially bypassed a "numeric literal, classify directly, skip the resolver"
fast path I'd drafted for IPv6 mirroring IPv4's — my direct classifier only recognized the
compressed form. Fixed by dropping that fast path for IPv6 specifically and always resolving
IPv6-shaped input too (`getent` normalizes any valid spelling to the canonical compressed form
regardless), rather than trying to maintain a second, hand-rolled IPv6 canonicalizer. This is a
deliberate, reasoned deviation from doing the literal "if numeric, use directly" step exactly as
originally scoped for v6 — documented here rather than silently narrowed.

**The Python/JS mirrors are now explicitly reduced-scope UX, not the boundary — and say so.**
Real resolution needs a real (blocking) DNS round trip that doesn't belong in a synchronous,
dependency-free preview-time validation path (Python's `validate_new_worker_entries`, wired into
the aiohttp preview handler) or in-browser JS. Both keep doing exactly what they always could
(refuse a numeric literal or a known loopback alias, for fast in-app feedback on the obvious
cases), but their docstrings now say plainly that a hostname they don't recognize — including
the box's own hostname or an attacker's own DNS name — passes there and relies on the bash authority to catch it
at commit time. Each mirror gets a new test (`test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design`,
and its JS twin) that PINS this limitation rather than leaving it as a comment-only claim, so a
future "let's make this smarter" change has to consciously decide to add resolution rather than
silently start claiming a guarantee the module can't keep.

Mutation-proved at three levels: (1) the bash-level `tests/stack/test-control-add-only-ssrf.sh`
battery runs live against the real `pithead` binary (see "What was RUN" for the full transcript);
(2) three additional mutations — narrowing the loopback check off the full `/8`, checking only the
first resolved address instead of every one, and flipping fail-closed to fail-open on a resolution
failure — were each proved against the real functions extracted from the real file with a
synthetic resolver stub, isolating exactly one behavior per mutation; (3) the two new "not caught
here by design" tests pin the Python/JS boundary itself.

**Residual, accepted risk (flagging honestly, five rounds in):** DNS-rebinding — the address
resolved at commit time differing from the address a later dial actually reaches — is NOT made
worse by resolve-and-check, and is the same accepted risk profile as before this fix existed: it
requires a SEPARATE capability (ongoing control over what this host's resolver returns) beyond a
one-time compromised-dashboard write, and the operator-confirmed write boundary this whole check
lives behind is why that residual is acceptable without also adding a dial-time re-check. Also
accepted, unchanged from round 1-4: an operator can still adopt a phantom entry pointed at an
arbitrary *other* LAN device with an attacker-chosen token — the feature's whole purpose is dialing
LAN rigs, and this is a much weaker primitive (no automatic cross-container credential reflection)
than the loopback/internal-bridge/metadata case that's now closed. Separately raised (not fixed
here — a judgment call, unchanged by round 5): `resolve_worker_target` (the dial-time resolver
`control_worker_apply`/`control_worker_upgrade` share) and the read-poll loop (`xmrig_client.py`)
both re-check only the charset regex, never `_control_host_is_internal` — the gate is write-time
only. See "Dial-time re-check" below for the reasoning and recommendation, unchanged by this round.

### Dial-time re-check: recommendation

`resolve_worker_target`'s own doc comment already frames itself as *the* SSRF guard ("resolve
strictly from the HOST's OWN config.json, never the intent") — but that guard is about the SOURCE
of truth (host config, never the dashboard's claim), not the address CLASS; it has never excluded
loopback/internal addresses, on either the write-capable dial (`resolve_worker_target`) or the
read-poll telemetry dial (`xmrig_client.py`'s `get_stats`, which takes an operator-set host override
verbatim, bypassing even its own `_safe_probe_host` filter). Both are pre-existing, deliberate: a
host-CLI-typed `workers.list[].host` has always been fully trusted, on both dial paths, because a
host-CLI edit already implies root-equivalent access to the box.

**My recommendation: the write-time gate is sufficient for the threat this PR introduces, and I did
not add a hard dial-time refusal here — but I'd recommend a narrowly-scoped follow-up.** The
dashboard has no path to `workers.list[]` other than through `control_approval_gate` (the container
never holds a raw config.json handle), so a write-time-only check is airtight against a compromised
dashboard specifically — a dial-time check using the SAME `_control_host_is_internal` would be
redundant against that threat (one bug closes both checks identically) rather than independent
defense-in-depth, and a BLANKET dial-time refusal would change behavior for the fully-trusted
host-CLI path (e.g. an operator's own local RigForge control-API stub for testing), with no security
benefit given that operator already has root-equivalent access. The follow-up worth filing: a
dial-time re-check scoped ONLY to the two write-capable verbs (never the read-poll loop), surfaced
as a doctor-visible WARN (matching the existing `dr_warn` idiom) rather than a hard refusal — real
signal without breaking the trusted path. Not implemented here, to avoid further scope creep on an
already five-round security fix.

## Surface (files:lines)

Bash (host authority):
- `pithead:9684` — `_is_canonical_ipv4` (recognizes an unambiguous IPv4 literal — round 2).
- `pithead:9699` — `_ipv4_is_sensitive` (round 5: the actual IPv4 blocklist, split out so both the
  literal fast path and the resolved-answer loop share one classifier).
- `pithead:9717` — `_is_ipv6_literal` (round 5: routes a value to the IPv6 classifier).
- `pithead:9732` — `_ipv6_is_sensitive` (round 5: the IPv6 blocklist, including the IPv4-mapped
  literal special case).
- `pithead:9758` — `_resolve_host_ips` (round 5: the resolver seam — `getent ahosts`, `timeout`-
  wrapped; the one function a test replaces via a fake `getent` on `$PATH`).
- `pithead:9795` — `_control_host_is_internal` (the SSRF floor — resolve-and-check as of round 5).
- `pithead:9829` — `control_approval_gate`, whose add-only exception + new-entry SSRF check call
  the above.

New Python modules (kept out of capped files):
- `dashboard/mining_dashboard/service/worker_adopt.py` — `validate_worker_descriptor:36`,
  `host_is_internal:73`, `new_worker_entries:112`, `validate_new_worker_entries:127`.
- `dashboard/mining_dashboard/service/worker_refresh.py` — `_poll_until_matched`,
  `refresh_worker_after_upgrade`, `maybe_refresh_after_upgrade`.

Python wiring (minimal touches to files already at their file-budget ceiling):
- `dashboard/mining_dashboard/web/server.py:157` — the adopt guard call in
  `handle_control_preview`.
- `dashboard/mining_dashboard/web/server.py:388-405,447` — `_finalize_worker_upgrade` now also
  calls `worker_refresh.maybe_refresh_after_upgrade`; call site passes `request.app["latest_data"]`.
- `dashboard/mining_dashboard/web/views.py:2109` — `build_worker_detail` now returns `ip` (the
  adopt-form prefill source), offset by trimming an adjacent comment to hold the file at its
  2339-line ceiling.

New frontend modules:
- `dashboard/mining_dashboard/web/static/workeradoptlogic.mjs` — pure validation
  (`validateAdoptFields:23`, `hostIsInternal:62`) + config-diff builder (`buildAdoptedConfig:86`),
  DOM-free.
- `dashboard/mining_dashboard/web/static/workeradopt.mjs` — `AdoptRigForm` (the form + the
  preview→commit round trip, reusing `configview.mjs`'s exported `pollResult`).

Frontend wiring (minimal touches to files already at their ceilings):
- `dashboard/mining_dashboard/web/static/workerview.mjs:20,421-422` — routes the gated state to
  `AdoptRigForm` when the control channel is on, keeps the old off-message otherwise.
- `dashboard/mining_dashboard/web/static/components.mjs:1103-1114` — `RigUpdateBadge` opens the
  dialog via `onInspect` when available, falls back to the old external link when not.

Docs:
- `docs/dashboard.md` — Workers Alive badge behavior, the adopt-flow paragraph under Worker
  Inspect (including the add-only + host-restriction + restart caveats), all under Worker Inspect.
- `docs/workers.md` — points at the adopt form as an alternative to hand-editing `config.json`;
  updated the one-click-upgrade section to describe the #1233 targeted refresh.

Tests (all new files — every file this PR touches that already carries tests was at its
file-budget ceiling):
- `dashboard/tests/service/test_worker_adopt.py`
- `dashboard/tests/service/test_worker_refresh.py`
- `dashboard/tests/web/test_worker_adopt_route.py`
- `dashboard/tests/web/test_worker_detail_ip.py`
- `dashboard/tests/web/test_worker_upgrade_refresh.py`
- `dashboard/tests/frontend/workeradoptlogic.test.mjs`
- `dashboard/tests/frontend/workeradopt.test.mjs`
- `tests/stack/test-control-add-only-ssrf.sh` (round 4 — see the file-budget note below for why
  this is a new file rather than an inline addition to `tests/stack/run.sh`).

### A file-budget deviation, flagged transparently

Round 4's instruction was to add the new bash-level coverage to `run.sh`'s own control section,
explicitly "NOT a new standalone file." I tried exactly that first — inline, immediately after
`gate_try()` in the existing "approval gate default-denies security-control changes" section — and
it worked functionally. But `tests/stack/run.sh` is itself file-budget-ratcheted
(`docs/dev/file-budget.tsv`, ceiling 10352 lines) and was already sitting exactly at that ceiling
with zero slack. The inline version, even after aggressive comment/case trimming, landed at
10393-10422 lines depending on how far I trimmed, and `scripts/lint-file-budget.sh` hard-fails on
any growth past a recorded ceiling — a real CI gate, not a style preference, and one I have no
authority to relax (raising the ceiling in `file-budget.tsv` is exactly the kind of edit the gate
exists to catch).

CONTRIBUTING.md's own prescribed remedy for this exact situation — "a security test that outgrew
its file moves into its own" — is precisely issue #1258's precedent, and `tests/stack/` already has
the pattern: `test-control-deploy.sh`/`test-control-upgrade.sh` are `source`d into `run.sh` at a
specific point, sharing that section's local fixtures (`$C`, `$UUID5`, `gate_try`). So the new
coverage lives in `tests/stack/test-control-add-only-ssrf.sh` (64 lines at round 4, 141 after
round 5's resolve-and-check battery — still far under the 800-line new-file ceiling), sourced from
`run.sh` at the exact point the inline version occupied. `run.sh` itself now carries a 4-line
comment plus one `source` line in place of the original stale 6-line assertion it replaced — net
10351 lines, one under its ceiling, UNCHANGED by round 5 (every round-5 addition landed in the
split-out file, not back in `run.sh`). Functionally the tests still run
inline in that section's shell state (same `$C`, same `gate_try`, same results directory) — this is
a new file on disk, not a new *test domain* — but it is a deliberate deviation from the letter of
"not a new standalone file," made to satisfy a hard gate rather than silently ignored or silently
complied with at the expense of breaking CI. Raise in review if a different split point is
preferred.

## Per-test mutation kills (named, as required)

`test_worker_adopt.py` (pure add-only/shape/SSRF logic):
- `test_host_with_embedded_port_refused` / `_path_refused` / `_userinfo_refused` — kills a dropped
  or loosened `HOST_RE` (the #122 charset guard).
- `test_control_port_bool_refused` / `_zero_refused` / `_over_max_refused` — kills a missing
  `bool` exclusion or a widened range check.
- `test_missing_token_refused` — kills a dropped bearer-mandatory check.
- `test_edited_existing_entry_is_not_new` / `test_removed_entry_is_not_new` /
  `test_reordered_entries_not_new` — kills a prefix-diff boundary that misclassifies a
  modification/removal/reorder as "new".
- `test_empty_live_makes_every_staged_entry_new` — kills an off-by-one that would refuse first
  adoption entirely.
- `test_new_entry_pointed_at_loopback_refused` / `_the_stacks_own_docker_bridge_refused` — kills a
  removed or inverted call to `host_is_internal` inside `validate_new_worker_entries` (the SSRF
  fix's own wiring, not just the classifier in isolation).
- `test_new_entry_on_ordinary_lan_address_is_unaffected` — kills an overly broad SSRF check that
  would break the feature for real rigs.
- `TestHostIsInternal` (18 parametrized/dedicated cases, including
  `test_alternate_ip_encodings_are_refused_not_waved_through_as_hostnames` covering all 6 real
  curl-verified bypass strings plus the zero-padded-octet variant, `test_this_network_block_...`,
  and `test_hex_literal_is_refused_even_though_it_contains_letters`) — kills a widened/narrowed
  IP-class check in either direction, a hardcoded (vs. dynamic) docker-bridge subnet, and — the
  round-2 regression specifically — a reintroduced "not-strictly-dotted-decimal means safe"
  fallback.
- `test_regexes_have_no_intra_repo_drift` — reads the actual `pithead` file and asserts the
  regex source strings are byte-identical; kills either side silently drifting from the other.
- `test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design` (round 5) — not a
  security-guard test but a BOUNDARY-pinning one: kills a future change that quietly starts
  claiming this module catches a hostname-resolves-to-loopback case it structurally cannot (no DNS
  here by design) — if someone "improves" this function to refuse an unrecognized hostname
  wholesale, this test's assertion of `False` goes red and forces an explicit decision instead of
  a silent, false sense of coverage.

`test_worker_adopt_route.py` (guards wired into the real route):
- `test_malformed_host_on_new_rig_refused_before_spooling` / `_missing_token_refused` /
  `_bad_control_port_refused` / `_pointed_at_loopback_refused_before_spooling` /
  `test_new_rig_with_an_alternate_ip_encoding_of_loopback_refused` (parametrized over 5 bypass
  encodings) — each asserts `status == 400` AND that `requests/` stays empty; removing or
  inverting the `handle_control_preview` guard call(s), or reopening the round-2 encoding bypass
  at the route level, would make these 202 with a spooled request instead.
- `test_repointing_an_existing_rigs_host_is_not_pre_refused_by_the_adopt_guard` — pins that this
  guard does NOT also try to police repoints (that's the bash gate's job).

`test_worker_refresh.py` / `test_worker_upgrade_refresh.py` (#1233):
- `test_fires_on_applied` / `test_fires_on_accepted` + parametrized
  `test_does_not_fire_on_non_success` (rejected/failed/rolled_back/throttled/noop) — kills an
  inverted or widened success-status set, in both directions.
- `test_uses_the_hosts_reported_version_over_the_proposal` — kills a regression that fed the
  client's stale proposed version back into the refresh instead of the host's re-derived one.
- `test_stops_on_first_matching_version` / `test_gives_up_after_attempts_when_version_never_matches`
  — kills a removed attempt cap or a removed early-exit.
- `test_no_ip_is_a_noop` — kills a dropped guard that would otherwise probe an addressless entry.

`tests/stack/test-control-add-only-ssrf.sh` (round 4 — bash/tier-1, against the real `pithead`
binary via `gate_try`, no stubbing of `_control_host_is_internal` itself):
- `workers.list REPOINT of an existing entry is refused` / `REMOVAL ... is refused` — kills a
  loosened add-only prefix check (the round-1 fix's own wiring, not just the SSRF layer).
- `workers.list ADD-ONLY append of a new rig is allowed` — kills an over-tightened gate that would
  refuse the feature's own legitimate case (proves the suite isn't just "refuse everything").
- `new-rig append pointed at loopback / the stack's own docker-bridge subnet is refused` — kills a
  removed or inverted `_control_host_is_internal` call inside `control_approval_gate`, or a
  hardcoded (rather than config-read) docker-bridge subnet.
- `new-rig append pointed at a root-terminated localhost spelling / the same, uppercase / the
  RHEL-family /etc/hosts loopback alias / the Debian-family /etc/hosts ::1 alias (both names) is
  refused` — **mutation-killed live**: reverted `_control_host_is_internal`'s hostname branch back
  to the pre-round-4 `case "$host" in localhost | *.localhost) return 0 ;; esac` (dropping the
  trailing-dot strip and the alias-set membership check), re-ran the full suite, and these exact
  five assertions went red — `expected [rejected], got [applied]` — while every other assertion in
  the file, including the non-alias SSRF cases below, stayed green. Restored the fix and confirmed
  `diff` against the pre-mutation file shows zero drift before re-running clean. See "What was RUN"
  for the full before/after transcript.
- `new-rig append pointed at a bare-decimal-integer encoding of loopback is refused` — kills a
  regression in the round-2 numeric-encoding fix specifically (confirmed to stay green under the
  round-4 mutation, proving the two fixes are independent and the battery is precisely targeted).
- `config.json still has exactly rig1+rig2 after every SSRF refusal above` — a second, independent
  witness on the same mutation: under it, each of the five phantom alias entries actually lands in
  `config.json` (`expected [2], got [7]`), proving the bug isn't just a wrong status string but a
  real committed phantom worker with an attacker bearer token.
- `workers.list append of an ordinary LAN address still applies` — the positive control; kills an
  overly broad SSRF check that would break real-rig adoption, the feature's whole purpose.

`tests/stack/test-control-add-only-ssrf.sh` (round 5 — resolve-and-check battery, against the real
`pithead` binary via `gate_try`, with a fake `getent` ahead of the real one on `$PATH` supplying
canned answers for the names this file controls; everything not in its map falls through to the
real system resolver, exactly as the round 1-4 cases above already did unstubbed):
- `new-rig append resolving to this host's own Debian self-entry style address (127.0.1.1) is
  refused` — **mutation-killed** (fast harness against the real extracted functions, a synthetic
  resolver stub, not a full run.sh pass): narrowing `_ipv4_is_sensitive`'s loopback case from
  `0 | 127` (the whole `127.0.0.0/8`) back to a single literal address turns this red while
  `127.0.0.1` itself stays green — proving the `/8`-vs-one-address distinction is what this
  specific case tests.
- `new-rig append resolving to an attacker-controlled DNS name pointed at loopback is refused` —
  **mutation-killed** via a standalone harness that runs only this file (not the ~2880-assertion
  full suite — a first attempt at this DID run the full suite mutated and appeared to show a clean
  kill, but the coordinator correctly flagged that run as untrustworthy: the box was concurrently
  loaded and the run sat under a 900s cap, so its verdict doesn't stand on its own; the standalone
  harness below is the evidence actually relied on): reverted `_control_host_is_internal`'s
  dispatch back to the round 1-4 string classifier (drop the resolver call; "a genuine hostname is
  never re-checked"), ran the standalone harness — this assertion, and the three below it, went red
  (`expected [rejected], got [applied]`) while every round 1-4 literal/alias case and both positive
  LAN controls stayed green (they don't need resolution). See "What was RUN" for the transcript.
- `new-rig append resolving to a name resolving to the cloud-metadata address is refused` — same
  standalone-harness mutation-kill as above (the string-classifier reversion also drops link-local
  classification for anything reached by name).
- `new-rig append resolving to a multi-answer name where only the SECOND address is sensitive is
  refused` — **mutation-killed** (isolated function-level harness, synthetic resolver stub):
  replacing the `while read` loop over every resolved line with a `head -1`-style "check only the
  first answer" turns this one red — the public IP is listed first, the loopback second — while
  every single-answer case in the battery stays green, proving this specific assertion is what
  actually requires checking every address.
- `new-rig append resolving to a name resolution fails on (fail-closed) is refused` —
  **mutation-killed** (isolated function-level harness): flipping the resolver-failure branches
  from `|| return 0` (fail closed) to `|| return 1` (fail open) turns this one red while the
  multi-answer case above stays green — proving the fail-closed behavior and the multi-answer check
  are independently tested, not the same assertion coincidentally passing twice.
- `config.json still has exactly rig1+rig2+rig3 after every round-5 SSRF refusal above` — a second,
  independent witness on the standalone-harness string-classifier mutation: under it, the phantom
  entries that should have been refused actually land in `config.json` (`expected [3], got [8]`),
  same pattern as round 4's analogous witness. A further cascading symptom of the SAME mutation
  also appeared one assertion later (`config.json gains the fourth rig, resolved from its name`
  went red too, at `expected [real-lan-rig-by-name], got [rig-self-alias]`) — the phantom entries
  shifted every later array index by one; not an independent bug, just corroborating evidence.
- `workers.list append of a LAN address reached BY NAME still applies` — the positive control;
  kills an over-broad sensitivity check (e.g. refusing all of `192.168.0.0/16` instead of just this
  host's own bridge subnet) that would break real-rig adoption when a rig is reached by hostname
  instead of a literal IP — the case resolve-and-check exists to support, not just to lock down.

`workeradoptlogic.test.mjs` / `workeradopt.test.mjs` (frontend):
- Same host/port/token/SSRF refusal set as the Python mirror, client-side (`hostIsInternal` tests
  included).
- `hostIsInternal: a hostname that would resolve elsewhere is not caught here by design` (round 5)
  — the JS twin of the Python boundary-pinning test above; same purpose, same kill.
- `AdoptRigForm: a malformed host is refused before any fetch happens` — asserts zero fetch calls.
- `AdoptRigForm: a host resolving inside the stack's own network is refused after the config
  fetch, before preview` — asserts exactly one fetch (`/api/config`) and never reaches preview.
- `AdoptRigForm: an unexpected destructive preview is refused, not blindly committed` — kills a
  regression that auto-confirmed a `destructive: true` preview without operator review.
- `AdoptRigForm: calls onAdopted only once the commit actually applied` — kills a regression that
  declared success on a `failed` commit.
- `Worker Inspect: ...` (3 tests) — gated/ungated render-state routing: off / on-but-unadopted
  (shows the form) / adopted (shows the editor).
- `table badge: ...` (2 tests) — badge-routing behavior (button when `onInspect` is wired, link
  fallback otherwise).

## What was RUN

Round 1-3 (before the independent review's round-4 finding):

- `cd dashboard && uv run --locked --extra test python -m pytest --cov=mining_dashboard --cov-report=term-missing --cov-report=xml --cov-fail-under=80` — all pass; `worker_adopt.py` and
  `worker_refresh.py` both 100%.
- `node --test dashboard/tests/frontend/*.test.mjs` — all pass.
- `bash scripts/patch-coverage.sh` — 95% diff coverage (every changed file under
  `dashboard/mining_dashboard/` at 100% except pre-existing `wizard.py` gaps that are develop-v2
  lane diff noise, not touched by this PR).
- Lints (ruff, biome, file-budget, operator-strings, docs-voice, topology-classes, markdownlint) —
  all clean; specific catches noted where they matter (JSDoc `/** */` false-positive on
  operator-strings, a banned "unlocks", a topology-classes placeholder swap).
- `bash -n pithead` + `shellcheck --severity=warning pithead` after each commit — clean.
- Hand-verified jq/bash batteries at every stage: add-only prefix logic (6 cases), the first SSRF
  host-class check (14 cases + 3 end-to-end scenarios), the corrected encoding-safe version (24
  cases).
- Empirically checked several encodings against the real `curl 8.5.0` binary in the dev
  environment to confirm what a live dial would actually resolve.
- Three security-reviewer subagent passes: round 1 (found the add-only SSRF gap), round 2 (found
  the alternate-encoding bypass), round 3 (RESOLVED against a 26-string battery — but see round 4).

**Round 4 (this update — the localhost-alias/trailing-dot finding, live-verified, then closed):**

- Live-verified the finding itself before touching any fix: `getent hosts` on the dev box resolves
  `localhost.`, `LOCALHOST.`, `localhost.localdomain`, `ip6-localhost`, and `ip6-loopback` all to
  loopback, and `curl -sv` against each dials `127.0.0.1`/`[::1]` — confirming all five strings are
  live bypasses of the pre-round-4 literal-equality check, not just theoretical.
- Fixed all three mirrored layers (`pithead`'s `_control_host_is_internal`,
  `worker_adopt.py`'s `host_is_internal`, `workeradoptlogic.mjs`'s `hostIsInternal`): strip exactly
  one trailing `.`, then check membership in an explicit loopback-alias set instead of a single
  literal-equality check.
- **Python mutation-kill**: reverted `host_is_internal`'s alias handling to the pre-fix
  literal-equality check, re-ran `test_worker_adopt.py` — `test_trailing_dot_alone_does_not_clear_the_localhost_class`
  and `test_etc_hosts_loopback_aliases_are_not_missed` both went red (asserted `True`, got `False`
  for `localhost.`/`LOCALHOST.`/`localhost.localdomain`/`ip6-localhost`/`ip6-loopback`); restored,
  confirmed green again.
- **JS mutation-kill**: same revert against `hostIsInternal` in `workeradoptlogic.mjs`, re-ran
  `node --test` — the two mirrored `workeradoptlogic.test.mjs` cases went red identically;
  restored, confirmed green again.
- **Bash mutation-kill (the newly-authorized `tests/stack/run.sh` run)**: checked
  `pgrep -af '[t]ests/run.sh'` first (nothing live), then ran the full suite three times against
  the real `pithead` binary via `gate_try` — clean before the mutation, mutated, clean again after
  restoring:
  1. Clean run against the round-4 FIX: all `tests/stack/test-control-add-only-ssrf.sh` assertions
     pass, including all five new alias/trailing-dot cases.
  2. Reverted `_control_host_is_internal`'s hostname branch to the pre-round-4 form (`case "$host"
     in localhost | *.localhost) return 0 ;; esac` — no trailing-dot strip, no alias set), backed
     up the fixed file first, re-ran the full suite. Exactly the five alias/trailing-dot assertions
     went red, byte for byte:
     ```
     ✗ new-rig append pointed at a root-terminated localhost spelling is refused
         expected [rejected], got [applied]
     ✗ new-rig append pointed at the same, uppercase is refused
         expected [rejected], got [applied]
     ✗ new-rig append pointed at the RHEL-family /etc/hosts loopback alias is refused
         expected [rejected], got [applied]
     ✗ new-rig append pointed at the Debian-family /etc/hosts ::1 alias is refused
         expected [rejected], got [applied]
     ✗ new-rig append pointed at the Debian-family /etc/hosts ::1 alias (second name) is refused
         expected [rejected], got [applied]
     ✗ config.json still has exactly rig1+rig2 after every SSRF refusal above
         expected [2], got [7]
     ```
     Every other assertion in the file — including the non-alias SSRF cases (`127.0.0.1`,
     `172.28.0.5`, `2130706433`) and the add-only REPOINT/REMOVAL/APPEND cases — stayed green under
     the mutation, confirming the new battery is precisely targeted at the round-4 fix and nothing
     else. Killed the run once the target section's output was captured (no need to wait out the
     remaining ~15-20 minutes of unrelated sections).
  3. Restored `pithead` from the pre-mutation backup, `diff` confirmed byte-identical to the fixed
     version with zero drift, re-ran the full suite clean end to end.
- Full re-run after the round-4 fix, all suites: dashboard pytest (1972 passed), `node --test`
  (440 passed), `ruff`/`biome` clean, `lint-file-budget.sh` clean (`run.sh` at 10351/10352,
  `test-control-add-only-ssrf.sh` new at 64 lines), `lint-operator-strings.sh` clean.

**Round 5 (this update — the "string classifier is the wrong architecture" finding, rebuilt as
resolve-and-check):**

- Live-verified the two findings before touching any fix: `getent hosts "$(hostname)"` on the dev
  box resolves this box's own hostname to `127.0.1.1` (the standard Debian self-entry), and a
  synthetic attacker-DNS-style name resolving to `127.0.0.1` dials loopback identically —
  confirming both are live bypasses of the round 1-4 string classifier, not just theoretical.
- Rebuilt `pithead`'s `_control_host_is_internal` as resolve-and-check (`_ipv4_is_sensitive`,
  `_is_ipv6_literal`, `_ipv6_is_sensitive`, `_resolve_host_ips` — see Surface). Caught and fixed a
  gap in my OWN draft before sending it back for review: a fully-expanded IPv6 loopback literal
  (`0:0:0:0:0:0:0:1`) initially bypassed a literal-fast-path I'd drafted for IPv6; fixed by always
  resolving IPv6-shaped input too, rather than a second hand-rolled canonicalizer. Verified with a
  32-case smoke battery against the real extracted functions (self-hostname-class loopback, attacker-DNS
  loopback, `::1`/`::`/`fe80::`/`ff02::`/`::ffff:127.0.0.1`/fully-expanded `::1`, all four
  round 1-4 regression cases, and 6 positive LAN/public controls) before touching the test suite.
- Re-ran the round-4 Python/JS docstring rewrite to explicitly frame `host_is_internal`/
  `hostIsInternal` as best-effort UX, not the boundary; added
  `test_a_hostname_that_would_resolve_elsewhere_is_not_caught_here_by_design` (and its JS twin)
  pinning that limitation as a test.
- **First mutation-kill attempt was invalidated by shared-box load, per the coordinator's own
  finding**: my first pass ran the full `tests/stack/run.sh` twice (clean, then mutated) under a
  hard 900s `timeout`, capturing what looked like a clean kill (all 5 resolved-name assertions plus
  the `config.json` count witness went red under the mutation: `expected [rejected], got
  [applied]`, `expected [3], got [8]`) — but the coordinator flagged that the box was concurrently
  loaded (rigforge gate + others) and a ~2880-assertion suite under a 900s cap is not a trustworthy
  verdict, mutated or not. Correctly caught before I relied on it.
- **Fast, targeted mutation-kill (the actual proof relied on)**: built a standalone harness
  (sources `tests/stack/lib.sh`, calls `build_val_sandbox`/`build_control_sandbox`, replicates the
  exact baseline-config + `gate_try()` block `run.sh`'s own control-gate section runs immediately
  before sourcing `test-control-add-only-ssrf.sh`, then sources that file alone) — runs in seconds,
  no other section's ~2880 assertions in the way, no shared-box timing risk. Confirmed
  `pgrep -f '[t]ests/stack/run.sh'` was clear first.
  1. **Baseline, fix in place: 25 passed, 0 failed.**
  2. **Mutation applied** (`_control_host_is_internal` reverted to the round 1-4 string classifier
     — no resolver call at all): **18 passed, 7 failed** —
     ```
     ✗ new-rig append resolving to this host's own Debian self-entry style address (127.0.1.1) is refused
         expected [rejected], got [applied]
     ✗ new-rig append resolving to an attacker-controlled DNS name pointed at loopback is refused
         expected [rejected], got [applied]
     ✗ new-rig append resolving to a name resolving to the cloud-metadata address is refused
         expected [rejected], got [applied]
     ✗ new-rig append resolving to a multi-answer name where only the SECOND address is sensitive is refused
         expected [rejected], got [applied]
     ✗ new-rig append resolving to a name resolution fails on (fail-closed) is refused
         expected [rejected], got [applied]
     ✗ config.json still has exactly rig1+rig2+rig3 after every round-5 SSRF refusal above
         expected [3], got [8]
     ✗ config.json gains the fourth rig, resolved from its name
         expected [real-lan-rig-by-name], got [rig-self-alias]
     ```
     The 7th failure is a legitimate CASCADE, not an independent bug: the earlier phantom
     `rig-self-alias` entry landed in `workers.list[]` under the mutation, shifting every later
     index by one, so the positional check for the by-name LAN append lands on the wrong element —
     itself further evidence the mutation lets phantom entries accumulate. Every round 1-4
     literal/alias case and the two positive LAN controls stayed green, confirming the new battery
     is precisely targeted and independent of the earlier fixes.
  3. Restored `pithead` from the pre-mutation backup, `diff` confirmed byte-identical (also
     confirmed via `git diff -- pithead` against the staged index: empty), re-ran the standalone
     harness: **25 passed, 0 failed** again.
- Full re-run after the round-5 fix: dashboard pytest (1973 passed, `worker_adopt.py` still 100%),
  `node --test` (441 passed), `ruff`/`biome` clean, `lint-file-budget.sh` clean (`run.sh` unchanged
  at 10351/10352; `test-control-add-only-ssrf.sh` now 141 lines), `lint-operator-strings.sh` clean,
  `shellcheck --severity=warning` clean on the new file, `shfmt -d` clean on every touched shell
  file.
- **Full-suite after-proof, launched detached, not yet complete as this is written**: per the
  coordinator's instruction, launched the complete `tests/stack/run.sh` (no timeout cap this time)
  fully detached — `nohup setsid bash -c 'bash tests/stack/run.sh > .suite-runs/after-round5.log
  2>&1; echo $? > .suite-runs/after-round5.rc'`, backgrounded and disowned from this session so it
  survives independently — after confirming via `pgrep -f '[t]ests/stack/run.sh'` that nothing else
  was running. Log: `.suite-runs/after-round5.log`. **Verdict path:
  `.suite-runs/after-round5.rc`** (a single exit-code line once the run
  finishes; `0` = every assertion in the whole suite passed). Expected count: the develop-v2
  baseline (~2880 per the coordinator, which already includes the 17 round 1-4 assertions in
  `test-control-add-only-ssrf.sh` committed at `7916612`) plus round 5's 8 NET-NEW assertions in
  that same file (the standalone harness above counted the file at 25 total — 17 pre-existing + 8
  new), so the full-suite total should land at baseline + 8, all passing, reported as `rc=0`. This
  section will need its actual result folded in once the coordinator relays the verdict from the
  `.rc` file — flagged here rather than silently left stale.

## Owed

- **The live-rig validation leg.** Nothing here was run against a real RigForge rig or a real
  `pithead-control-run-pending` host runner. The `tests/stack/`/`tests/integration/` tier-4 legs
  (a real adopt → editable → apply → upgrade round trip on a bench rig, AND a live confirmation
  that the SSRF fix doesn't break real-rig adoption) are a separate, later session.
- **The DNS-rebinding residual risk** described above — round 5 now genuinely resolves at commit
  time (closing the string-classifier gap), but a resolved-at-commit address can still differ from
  a dialed-later address if something controls what this host's resolver returns going forward.
  Accepted for now, matching the existing read-path SSRF guard's own scope, but worth a dedicated
  follow-up issue if the threat model ever needs a re-resolve-at-connect-time architecture.
- **The dashboard-restart caching gap.** Documented, not fixed: a workers.list-only commit renders
  to no `.env` key, so `apply()`'s container-recreate path never runs and the dashboard's own
  `config.DASHBOARD_WORKERS` (cached at Python import) stays stale until the dashboard container
  restarts for some other reason. Pre-existing, shared with `dashboard.energy` — not introduced by
  this PR, but this PR is the first operator-visible "click and wait" flow to depend on it. A real
  fix (mirroring the existing `caddy`-only-restart precedent in `apply()`, or making
  `DASHBOARD_WORKERS` reload live) is worth its own follow-up issue.
- **`docs/dev/test-inventory.md` regeneration** — not committed (git-ignored, generated).
- **The full-suite after-round-5 clean-completion verdict.** Launched detached (see "What was RUN"
  round 5), not yet complete as this is written. Verdict path:
  `.suite-runs/after-round5.rc` (expect `0`, i.e. every assertion in
  the whole suite passing, at baseline + this file's 8 net-new round-5 assertions). The targeted
  mutation-kill evidence above does not depend on this — it's a broader "nothing else in the suite
  regressed" confirmation the coordinator asked for as a one-time clean completion, separate from
  the mutation proof itself.

## Closes

- Closes #893 — all three operator-approved scope items shipped and tested; add-only trust model
  enforced at the bash authority plus Python/JS best-effort UX mirrors (now explicitly documented
  as UX, not the boundary — see round 5). A critical SSRF gap found by the mandated security pass
  went through five adversarial review rounds: three iterating on a STRING classifier (loopback
  denylist, then numeric-encoding hardening, then a localhost-alias/trailing-dot fix — each
  mutation-proved as it landed), and a fifth that found the classifier architecture itself was the
  problem and replaced it with resolve-and-check at the bash authority, mutation-proved at both the
  unit level and a new `tests/stack/` bash battery against the real binary. No further bypass found
  after round 5; the coordinator's own promised round-6 review of the resolve-and-check
  implementation itself is still pending as this is written.
- Closes #1233 — the targeted refresh fires exactly on rebuild-meaning results, is bounded, never
  touches the release-lookup cadence, and is tested for all three acceptance criteria named in the
  issue.

Both are subject to the live-rig leg called out above, AND to round 6's outcome — flag in review if
either should stay open until those land instead. (The earlier tier-1 `tests/stack/run.sh` gap is
now closed: see `tests/stack/test-control-add-only-ssrf.sh` and the round 4/5 "What was RUN"
entries above.)
