### PR TITLE
fix(lint): give shellcheck its own invocation for run.sh so it stops inlining its sources (#1333)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,31 @@ test-integration: ## Run the live config-matrix integration suite (requires a te
 
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
 
+# Two shellcheck invocations, not one, and the split is load-bearing. shellcheck resolves a
+# `# shellcheck source=` directive only when the sourced file is ALSO named on the same command
+# line, and it then inlines that file into the sourcing script's analysis. Listing run.sh beside
+# the 18 files it sources therefore built ONE merged root of ~730 KB costing over 6 GB — which is
+# what got the CI step killed (#1333) and what OOMs local dev (#1206). Peak is the largest single
+# ROOT, not the sum: all 17 domain files plus lib.sh together come to 125 MB, while run.sh alone
+# is ~3.8 GB. Holding run.sh out on its own keeps every cross-file resolution that matters and
+# caps the whole target at that one analysis — which now shrinks with every #1105 module instead
+# of being conserved by the split. The file SET is unchanged: every path below was in the old
+# single invocation, and none is listed twice.
 lint-sh: ## shellcheck + shfmt over the CLI, build/* + dashboard/ container scripts, release + test scripts
-	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh dashboard/*.sh tests/stack/run.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh tests/stack/test_data_reset.sh tests/stack/test_os_update_recovery.sh tests/stack/test_firstboot_journal.sh tests/stack/test_appliance_hugepages.sh \
+	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh dashboard/*.sh \
+		tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh tests/stack/test_data_reset.sh \
+		tests/stack/test_os_update_recovery.sh tests/stack/test_firstboot_journal.sh tests/stack/test_appliance_hugepages.sh \
 		tests/inventory.sh tests/integration/*.sh tests/integration/mini-stack/*.sh \
-		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync os/overlay/pithead-boot \
+		os/installer/pithead-install os/build-image.sh os/rauc/*.sh os/overlay/pithead-sync \
 		os/overlay/pithead-data-reset os/overlay/pithead-mount-generator os/overlay/pithead-ssh-host-keys \
 		os/overlay/pithead-machine-id os/overlay/pithead-media-config os/overlay/pithead-hugepages \
 		os/overlay/pithead-journal-persist \
 		tests/os/run.sh tests/os/verify-image.sh tests/os/hugepages-boot-verdict.sh
+# run.sh by itself, keeping company only with the one file outside tests/stack that it sources:
+# os/overlay/pithead-boot, whose gate_ready and os_update_rollback_verdict read three globals
+# run.sh sets for them. Drop pithead-boot from this line and those three report as SC2034 — it
+# costs ~300 lines to keep here, not the 294 KB of domain files.
+	shellcheck --severity=warning tests/stack/run.sh os/overlay/pithead-boot
 	shfmt -i 4 -d pithead pithead-completion.bash os/installer/pithead-install $(shell git ls-files '*.sh' | grep -v '^docs/research/')
 
 lint-py: ## ruff lint + format check on all repo Python (ruff runs via uv from the locked dev extra)


### PR DESCRIPTION
Closes #1333.

`lint-sh` passed every shell file to one `shellcheck` process. That process is now killed in CI
mid-step, which blocks every #1105 split PR. This gives it two invocations instead of one. No file
is added, dropped, or linted twice, and no severity changes.

## The mechanism, measured

shellcheck resolves a `# shellcheck source=` directive **only when the sourced file is also named
on the same command line** — and it then inlines that file into the sourcing script's analysis.
Two probes on a two-file fixture pin it down:

- `shellcheck main.sh` with `sub.sh` present on disk but not on the command line → the directive is
  not followed, and `main.sh`'s cross-file global reports SC2034.
- `shellcheck main.sh sub.sh` → followed, no SC2034.

`tests/stack/run.sh` carries 18 such directives (`lib.sh` plus 17 domain files). So the old single
invocation built one merged root of roughly 730 KB. That is the whole cost.

## The part of the diagnosis that was backwards

The issue proposed waiting the split out, on the theory that a shrinking `run.sh` would drop the
invocation back under the ceiling. It would not have. Moving a block out of `run.sh` into a file
`run.sh` sources brings those bytes straight back through the directive, and adds a new standalone
root on top. The merged root is conserved by the split; the invocation only ever grew. Measured on
one tree, `develop-v2` at `46eb640`:

| invocation | peak RSS | wall | result |
|---|---|---|---|
| `run.sh` **alone** | 3.79 GB | 30 s | 3 SC2034 |
| `run.sh` with its sources inlined (`-x`) | >6 GB | 95 s | killed at the cap |
| whole `tests/stack` group, one invocation | >6 GB | 44 s | killed at the cap |
| all 17 domain files + `lib.sh` together | 125 MB | 8 s | clean |

Peak is the largest single **root**, not the sum — 17 domain files together cost 125 MB. Only
`run.sh` inlining its own sources is expensive. After this change `run.sh` is analysed by itself,
so each remaining #1105 module now genuinely shrinks it.

## The split

Everything except `run.sh` stays in one invocation — each `source=` target there still shares the
list with its consumer (`selftest.sh` → `lib.sh` + `scenarios.sh`, `release-smoke.sh` →
`release.sh`, `mkbundle.sh` → `populate-slot.sh`), and its largest root costs 1.6 GB.

`run.sh` gets its own line, keeping exactly one companion: `os/overlay/pithead-boot`. Its
`gate_ready` and `os_update_rollback_verdict` read three globals `run.sh` sets for them; without it
those three report as SC2034. It costs ~300 lines to keep, not 294 KB.

## Proof, before and after on the same tree

| | result | peak RSS | wall |
|---|---|---|---|
| before — old single invocation, 84 files | **rc=137**, killed at the cap, reports nothing | 6 GB (capped) | 1m27s |
| after — `make lint-sh` | **rc=0**, 0 findings, 0 shfmt diffs | **3.72 GB** | 1m37s |

File-set equality was checked mechanically, not by eye: the old list and the new groups sorted are
both 84 paths, `uniq -d` is empty, and `diff` between them is empty. `make lint` passes.

This is **stricter than before, not weaker**. `run.sh` no longer resolves into `lib.sh` or the 17
domain files, so an assignment there that only a moved file consumes will now be reported — which
is correct, since the split's own recipe has each moved file re-derive what it needs. Today that
set is empty: the invocation reports 0 findings.

Nothing outside the Makefile changed, so no test tier applies; the gate's own before/after above is
the evidence.

## What I did not do

- I did not measure the true peak of the old invocation. The local cgroup cap stops at 6 GB, and an
  uncapped shellcheck is what OOM-killed this box three times (#1206), so I left it capped.
- That the CI kill is memory exhaustion is an **inference**, not a reading of the runner's
  counters. It rests on the signature: the step died with SIGTERM at 1m57s while every sibling job
  in the same run passed, and the two genuine `cancel-in-progress` runs in recent history show a
  different shape (whole run `cancelled`). The fix stands either way — it cuts the largest analysis
  from over 6 GB to 3.72 GB and is semantically equivalent-or-stricter.
- One trade worth naming: make stops at the first failing recipe line, so findings spread across
  both invocations surface one invocation per run.
- I did not touch `develop`. The lane is frozen, its `lint-sh` recipe already differs, and its CI is
  green.
- I have not claimed #1206 is closed. Local `make lint-sh` now completes under the cap for the first
  time, which is that issue's symptom, but the wrapper and its serialisation still earn their keep.
