### PR TITLE
fix(tests): default WALLET at both sandbox builders so control stops depending on val (#1305)

### DIFF
--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -170,11 +170,23 @@ DEPLOYMENT_COMPLETED=true
 COMPOSE_PROFILES=local_node
 EOF
     }
-    WALLET="$VALID_PRIMARY" # checksum-valid mainnet primary (the XMRig donation address) — #250 gates the type, #829 the checksum
+    # Defaulted, not assigned outright, so a domain file that set its own WALLET before calling
+    # this keeps it. See build_control_sandbox for why both builders default it (#1305).
+    WALLET="${WALLET:-$VALID_PRIMARY}" # checksum-valid mainnet primary (the XMRig donation address) — #250 gates the type, #829 the checksum
 }
 
 # The control-channel sandbox: builds $C, defines CTRL_LOG, seed_control_env, control_config.
 build_control_sandbox() {
+    # control_config() below reads $WALLET, but $WALLET was only ever assigned by
+    # build_val_sandbox(). In run.sh the two calls sit hundreds of lines apart in ONE process and
+    # val happens to run first, so control has always worked by accident of ordering. (No exact
+    # distance here on purpose — every #1105 module moves it, and a number nobody re-measures is
+    # how a comment starts lying.) A domain file
+    # that calls this builder without val — or any section that crosses a process boundary into a
+    # bash-invoked file — would abort on an unbound variable under `set -u`. Defaulting it here
+    # makes this builder self-contained and retires the whole class (#1305); it fails loud rather
+    # than writing a broken config.json, but it should not fail at all.
+    WALLET="${WALLET:-$VALID_PRIMARY}"
     C="$SANDBOX/control"
     mkdir -p "$C/build/tari" "$C/dashboard" \
         "$C/data/monero" "$C/data/tari" "$C/data/p2pool/stats" "$C/data/tor" "$C/data/dashboard"

--- a/tests/stack/test-control-upgrade.sh
+++ b/tests/stack/test-control-upgrade.sh
@@ -18,9 +18,9 @@
 # $WALLET, set explicitly: lib.sh's control_config() closure reads it (lib.sh:207) without ever
 # setting it — in run.sh it was already set globally by build_val_sandbox()'s far-earlier
 # config-validation section. Same trap as module 7's onion-report fix: $VALID_PRIMARY is what
-# WALLET equals there, and it's always bound. NOT fixed in lib.sh here (wrong blast radius for a
-# mechanical move) — every future control-sandbox domain file hits this; defaulting WALLET at
-# build_control_sandbox's entry is a candidate one-line follow-up for later sandbox-cluster cuts.
+# WALLET equals there, and it's always bound. Since FIXED in lib.sh (#1305): both sandbox builders
+# default WALLET now, so a future control-sandbox domain file no longer has to set it. The line
+# below is kept because it is correct and harmless, not because anything still requires it.
 build_control_sandbox
 # shellcheck disable=SC2034  # read by lib.sh's control_config() closure, unseen here
 WALLET="$VALID_PRIMARY"


### PR DESCRIPTION
Closes #1305.

`build_control_sandbox()` defines `control_config()`, whose body reads `$WALLET` — but `$WALLET` was
only ever assigned by `build_val_sandbox()`. `run.sh` calls the two ~2000 lines apart (289 and 1441)
in **one** process, val first, so the control sandbox has only ever worked by accident of execution
order.

That accident does not survive consolidation. A domain file that calls `build_control_sandbox`
without val — or any section that crosses a **process** boundary into a `bash`-invoked file rather
than a sourced one — aborts on an unbound variable under `set -u`. It fails loud rather than writing
a broken `config.json`, so it is a tripwire and not corruption, but it should not fail at all.

#1305 records five instances of this class already worked around by hand: `$REL` in release-signing
(the silent `source "$VAR"` no-op that failed 41 assertions), `$WALLET` in the doctor onion-report
section, `$WALLET` in control-upgrade's preamble, and `$WALLET` twice in control-deploy.

## The change

Per #1305's own prescription, both builders now default rather than assign:

```sh
WALLET="${WALLET:-$VALID_PRIMARY}"
```

**Defaulting, not assigning outright, is the load-bearing part.** It is what keeps the domain files'
existing local re-derivations valid — they become redundant rather than wrong — so nothing has to be
unpicked from the modules that already landed.

## Proof

A true in-place A/B: the base `lib.sh` checked out over the fixed one at the same path, calling the
real `build_control_sandbox` **without** `build_val_sandbox`, under `set -u`.

| `lib.sh` | result |
|---|---|
| base (origin/develop-v2) | `lib.sh: line 207: WALLET: unbound variable` |
| this branch | `control_config` writes the checksum-valid `$VALID_PRIMARY` address |

The normal ordering (val, then control) produces the same address on both, so the working path is
unchanged. Full `tests/stack/run.sh`: **2903 passed, 0 failed** — run on the pre-rebase base; CI
re-runs it on the rebased tree, which is what actually merges.

## On scope

I considered the one-line version — defaulting only in `build_control_sandbox`, since that is the
builder with the broken dependency, and no current caller sets `WALLET` before calling val. I kept
both because #1305 specifies both, because symmetry stops the next reader wondering why the two
builders differ, and because an unconditional assignment in val silently clobbers a caller's
`WALLET`, which is the same footgun pointing the other way.

I did **not** remove the now-redundant `WALLET="$VALID_PRIMARY"` lines from `test-backup.sh` and
`test-control-upgrade.sh`, or the "use `$VALID_PRIMARY`, not `$WALLET`" comments in
`test-control-deploy.sh` and `test-doctor.sh`. They are correct, just no longer necessary, and
unpicking them would widen a shared-core diff into four domain files for no behavioural gain.
