### PR TITLE
ci(trivy): one engine version for the CVE gate and the mute watch (#1290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
         # the repo's 10 GB Actions cache budget, which was 92% near-duplicate copies of this one DB.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Explicit on purpose (#1290) — the action's default engine moves whenever the action is
+          # bumped, and scripts/trivyignore-watch.sh's verdicts only mean something when it scans
+          # with the engine the gate runs. `make lint-trivy-parity` holds the two to one value.
+          version: v0.74.0
           image-ref: pithead-${{ matrix.service }}:ci
           scanners: vuln
           severity: HIGH,CRITICAL
@@ -324,4 +328,4 @@ jobs:
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings, topology classes, file budget
         # Single source of truth: the Makefile targets. Tools run via npx/uvx/docker (preinstalled).
-        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology lint-file-budget
+        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -105,6 +105,10 @@ jobs:
         # kernel between releases, and since #1162 that eye is finally open on a schedule.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Explicit on purpose (#1290) — the action's default engine moves whenever the action is
+          # bumped, and scripts/trivyignore-watch.sh's verdicts only mean something when it scans
+          # with the engine the gate runs. `make lint-trivy-parity` holds the two to one value.
+          version: v0.74.0
           image-ref: pithead-os-rootfs:ci
           scanners: vuln
           severity: HIGH,CRITICAL

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,9 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      `make lint` after merging onto the tip. Generated
      code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
      the script — and so is the shipped `pithead` artifact itself, for now: its future `lib/*.sh`
-     sources are what the gate will govern once Phase 2 splits it), `lint-proto` (buf),
+     sources are what the gate will govern once Phase 2 splits it), `lint-trivy-parity` (the CVE
+     gate's two trivy-action steps and `scripts/trivyignore-watch.sh` must name one trivy engine
+     version — issue #1290), `lint-proto` (buf),
      `lint-toml` (taplo). The
      non-Python tools run via `npx`/`uvx`/`docker`, so a contributor needs **Node, uv, and Docker**
      on PATH (plus `shfmt`); `pre-commit` runs the same checks on changed files. Link-checking

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Local test entry points (mirror the GitHub Actions CI jobs).
-.PHONY: test test-dashboard test-frontend test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml lint-topology lint-file-budget release release-smoke
+.PHONY: test test-dashboard test-frontend test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml lint-topology lint-file-budget lint-trivy-parity release release-smoke
 
 test: lint test-dashboard test-frontend test-stack test-compose test-integration-selftest test-fakes ## Run everything that doesn't need a server/docker
 
@@ -44,7 +44,7 @@ test-inventory: ## Write the test coverage inventory to docs/dev/test-inventory.
 test-integration: ## Run the live config-matrix integration suite (requires a test box; pass ARGS=...)
 	bash tests/integration/run.sh $(ARGS)
 
-lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-proto lint-toml ## Lint/format-check every surface
+lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity lint-proto lint-toml ## Lint/format-check every surface
 
 # Two shellcheck invocations, not one, and the split is load-bearing. shellcheck resolves a
 # `# shellcheck source=` directive only when the sourced file is ALSO named on the same command
@@ -100,6 +100,10 @@ lint-topology: ## Fail if a real-looking IPv6/IPv4/hostname/path/user@host liter
 lint-file-budget: ## Fail if a tracked file crosses the 800-line hard ceiling, or an existing offender grows past its docs/dev/file-budget.tsv ceiling (#1105 Phase 0)
 	bash scripts/lint-file-budget.sh --self-test
 	bash scripts/lint-file-budget.sh
+
+lint-trivy-parity: ## Fail if ci.yml's and os-rootfs.yml's trivy-action steps drift from the version scripts/trivyignore-watch.sh scans with (#1290)
+	bash scripts/trivyignore-watch.sh --self-test
+	bash scripts/trivyignore-watch.sh --check-parity
 
 lint-proto: ## buf lint + build on the vendored Tari protos (config: .../tari/proto/buf.yaml)
 	cd dashboard/mining_dashboard/client/tari/proto && \

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -41,6 +41,7 @@ dashboard/tests/web/test_views.py	3576
 dashboard/tests/web/test_wizard.py	974
 os/rootfs/Dockerfile	406
 scripts/release.sh	851
+scripts/trivyignore-watch.sh	599
 tests/integration/e2e.sh	766
 tests/integration/lib.sh	692
 tests/integration/run.sh	2551

--- a/scripts/trivyignore-watch.sh
+++ b/scripts/trivyignore-watch.sh
@@ -432,12 +432,12 @@ EOF
         local path="$1" verline="$2" has="$3"
         {
             printf '%s\n' "name: fixture" "jobs:" "  scan:" "    steps:" \
-                "      - uses: actions/checkout@deadbeef # v7.0.1" \
+                "      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567 # v7.0.1" \
                 "        with:" \
                 "          persist-credentials: false"
             if [ "$has" = "1" ]; then
                 printf '%s\n' "      - name: Scan image for CVEs (Trivy)" \
-                    "        uses: aquasecurity/trivy-action@deadbeef # v0.36.0" \
+                    "        uses: aquasecurity/trivy-action@0123456789abcdef0123456789abcdef01234567 # v0.36.0" \
                     "        with:"
                 [ -n "$verline" ] && printf '          %s\n' "$verline"
                 printf '%s\n' "          image-ref: pithead-example:ci" \
@@ -514,12 +514,12 @@ EOF
     {
         printf '%s\n' "name: fixture" "jobs:" "  scan:" "    steps:" \
             "      - name: Scan image for CVEs (Trivy)" \
-            "        uses: aquasecurity/trivy-action@deadbeef # v0.36.0" \
+            "        uses: aquasecurity/trivy-action@0123456789abcdef0123456789abcdef01234567 # v0.36.0" \
             "        with:" \
             "          image-ref: pithead-example:ci" \
             "          scanners: vuln" \
             "      - name: Unrelated step that happens to also take a version input" \
-            "        uses: some/other-action@deadbeef" \
+            "        uses: some/other-action@0123456789abcdef0123456789abcdef01234567" \
             "        with:" \
             "          version: v0.74.0"
     } >"$ci_f"

--- a/scripts/trivyignore-watch.sh
+++ b/scripts/trivyignore-watch.sh
@@ -39,6 +39,14 @@
 # class the sweep itself has. A broken or partial scan means "unknown", never "clean", so this
 # refuses to name ANY mute obsolete off an incomplete run and exits 1 instead.
 #
+# THE PARITY CONTRACT (#1290). TRIVY_VERSION below is the one place that declares which trivy
+# engine this script's own scan uses. `--check-parity` (wired into `make lint-trivy-parity`) holds
+# ci.yml's and os-rootfs.yml's trivy-action `version:` input, and the pinned image's own measured
+# version, to that one value — it does not prove what trivy-action resolves a declared input to at
+# run time, only that the two workflows and this script all declare the same one; what the action
+# does with a declared input is upstream's contract. A dependabot bump of trivy-action that silently
+# moves the action's own UNDECLARED default is exactly the drift this catches.
+#
 # Usage:
 #   scripts/trivyignore-watch.sh              Build + scan every covered image with NO ignore file
 #                                              applied, print the report, rc 1 only if the run
@@ -46,16 +54,25 @@
 #                                              printed, not a failure — report-only).
 #   scripts/trivyignore-watch.sh --self-test  Drive the union/report logic against fixture scan
 #                                              output. No docker, no network, no image builds.
+#   scripts/trivyignore-watch.sh --check-parity
+#                                              Check that ci.yml's and os-rootfs.yml's trivy-action
+#                                              steps pin `version:` to TRIVY_VERSION (#1290). No
+#                                              docker, no network. Exit code is the check's own rc.
 
 set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IGNOREFILE="$ROOT/.trivyignore"
 
+# The two CVE-gate workflows whose trivy-action steps must stay pinned to TRIVY_VERSION (#1290).
+# Overridable so --self-test can point this at fixture files instead.
+GATE_WORKFLOWS="$ROOT/.github/workflows/ci.yml $ROOT/.github/workflows/os-rootfs.yml"
+
+# The ONE source of truth for the scanning engine (#1290) — the parity contract is in the header.
 # Digest-pinned (repo convention, #135/#373) rather than `:latest`, so a run today and a run next
-# month scan with the same trivy and the same vulnerability-DB client. Bump alongside the
-# aquasecurity/trivy-action pin in ci.yml/os-rootfs.yml when that moves.
-TRIVY_IMAGE="aquasec/trivy@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969" # 0.74.0
+# month scan with the same trivy and the same vulnerability-DB client.
+TRIVY_VERSION="0.74.0"
+TRIVY_IMAGE="aquasec/trivy@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969" # TRIVY_VERSION above
 
 # Same severity/fixability scope as the gate (ci.yml, os-rootfs.yml): .trivyignore only ever holds
 # entries that would otherwise block on THAT scope, so scanning any wider scope here would report
@@ -111,6 +128,127 @@ ignored_ids() {
     grep -vE '^[[:space:]]*(#|$)' "$1" | awk '{print $1}'
 }
 
+# --- engine parity (#1290) --------------------------------------------------------------------
+
+# -> the pinned $TRIVY_IMAGE's own reported version on stdout, rc 1 if docker fails to run it or
+# the output has no `Version: ` line to parse. Real trivy output's first line is exactly
+# "Version: 0.74.0"; only the FIRST matching line counts.
+engine_version() {
+    local out ver
+    out="$(docker run --rm "$TRIVY_IMAGE" --version 2>/dev/null)" || return 1
+    ver="$(printf '%s\n' "$out" | awk '/^Version: /{print $2; exit}')"
+    [ -n "$ver" ] || return 1
+    printf '%s' "$ver"
+}
+
+# $GATE_WORKFLOWS -> one `<basename>\t<version>` line per trivy-action step found, in file order.
+# `<version>` is MISSING when the step has no `version:` key in its `with:` block, or NOFILE when
+# the workflow file itself does not exist. A single awk state machine per file: a line that starts
+# (optional list-item marker aside) with `uses:` naming aquasecurity/trivy-action@ opens a step —
+# anchored to line-start so a commented-out `# uses: ...` cannot open a phantom step; a `version:`
+# key inside it is captured with any trailing inline comment stripped; the next list item
+# (`- ...`, i.e. the next step) or EOF closes the step and emits it.
+gate_versions() {
+    local f base
+    for f in $GATE_WORKFLOWS; do
+        base="$(basename "$f")"
+        if [ ! -f "$f" ]; then
+            printf '%s\tNOFILE\n' "$base"
+            continue
+        fi
+        awk -v file="$base" '
+            function emit() { print file "\t" (ver == "" ? "MISSING" : ver) }
+            /^[[:space:]]*(-[[:space:]]+)?uses:.*aquasecurity\/trivy-action@/ {
+                if (instep) emit()
+                instep = 1; ver = ""
+                next
+            }
+            instep && /^[[:space:]]*version:[[:space:]]*/ {
+                v = $0
+                sub(/^[[:space:]]*version:[[:space:]]*/, "", v)
+                sub(/[[:space:]]*#.*$/, "", v)
+                sub(/[[:space:]]*$/, "", v)
+                ver = v
+                next
+            }
+            instep && /^[[:space:]]*-[[:space:]]/ {
+                emit()
+                instep = 0
+                next
+            }
+            END { if (instep) emit() }
+        ' "$f"
+    done
+}
+
+# -> one line per trivy-action step describing whether its `version:` matches $TRIVY_VERSION, rc 0
+# only if every file in $GATE_WORKFLOWS produced at least one trivy-action step AND every one of
+# those steps' versions is EXACTLY `v$TRIVY_VERSION` — no loose `v`-stripped comparison, because
+# the real chain (trivy-action -> setup-trivy -> trivy's own install.sh) builds its release URL
+# from the declared value verbatim: a bare `0.74.0` 404s where `v0.74.0` resolves, so a bare value
+# is a real mismatch, not a cosmetic one. A file that yields no step at all (missing file, or no
+# trivy-action `uses:` line) is a failure on its own — a parity check that cannot find its target
+# must go red, not silently skip it.
+check_parity() {
+    local gv f base lf lver fail=0 any
+    gv="$(gate_versions)"
+
+    for f in $GATE_WORKFLOWS; do
+        base="$(basename "$f")"
+        any=0
+        while IFS=$'\t' read -r lf lver; do
+            [ "$lf" = "$base" ] || continue
+            [ "$lver" = "NOFILE" ] && continue
+            any=1
+            if [ "$lver" = "MISSING" ]; then
+                echo "$base: MISSING — no version: input, trivy-action installs its own default (that is the #1290 defect)"
+                fail=1
+                continue
+            fi
+            if [ "$lver" = "v$TRIVY_VERSION" ]; then
+                echo "$base: trivy-action version $lver matches the watch ($TRIVY_VERSION)"
+            elif [ "$lver" = "$TRIVY_VERSION" ]; then
+                echo "$base: MISMATCH — trivy-action version $lver is not v$TRIVY_VERSION (setup-trivy resolves the value verbatim; it must carry the v)"
+                fail=1
+            else
+                echo "$base: MISMATCH — trivy-action version $lver, watch scans $TRIVY_VERSION"
+                fail=1
+            fi
+        done <<<"$gv"
+
+        if [ "$any" -eq 0 ]; then
+            echo "$base: NO trivy-action step found — the parity check cannot see the gate"
+            fail=1
+        fi
+    done
+
+    if [ "$fail" -eq 1 ]; then
+        echo "Fix: set every trivy-action version: to exactly v$TRIVY_VERSION (the leading v is required), or bump TRIVY_VERSION (and the pinned digest above) together."
+    fi
+    return "$fail"
+}
+
+# Gate the real run on both halves of the parity contract before it reports anything: the pinned
+# image must measure as the version this script declares, and the gate's own workflows must be
+# pinned to that same version. Either failing means an "obsolete mute" verdict would describe an
+# engine the gate does not actually run — refuse rather than report.
+preflight() {
+    local measured
+    if ! measured=$(engine_version); then
+        echo "trivyignore-watch: BROKEN RUN — could not measure the pinned trivy image's version." >&2
+        return 1
+    fi
+    if [ "$measured" != "$TRIVY_VERSION" ]; then
+        echo "trivyignore-watch: BROKEN RUN — pinned image reports trivy $measured, script declares $TRIVY_VERSION; refusing to report." >&2
+        return 1
+    fi
+    if ! check_parity >/dev/null; then
+        echo "trivyignore-watch: BROKEN RUN — the gate scans with a different trivy than this watch; an obsolete verdict would describe an engine the gate never runs (#1295's caveat). Refusing to report." >&2
+        return 1
+    fi
+    return 0
+}
+
 # --- the report ------------------------------------------------------------------------------------
 
 # <ignorefile> -> markdown report on stdout. rc 1 on a broken run (nothing named obsolete); rc 0
@@ -162,6 +300,7 @@ report() {
 
     printf '%s\n\n' "Obsolete-.trivyignore-mute watch (#1174). Report-only — an obsolete mute is housekeeping, not a build failure."
     printf '%s\n\n' "Images scanned, no ignore file applied: $IMAGES"
+    printf '%s\n\n' "Engine: trivy $TRIVY_VERSION — the version ci.yml and os-rootfs.yml pass to trivy-action (parity checked before this run)."
     printf '| finding ID | seen in any covered image | verdict |\n|---|---|---|\n%s' "$rows"
     if [ "$obsolete" -gt 0 ]; then
         printf '\n%s\n' "$obsolete of $checked mute(s) are OBSOLETE."
@@ -285,11 +424,176 @@ EOF
         )" "1"
     rm -f "$f"
 
+    # --- engine parity (#1290) --------------------------------------------------------------
+    # Fixtures mimic the real step shape: a `- name:` step, the pinned trivy-action `uses:` line,
+    # then a `with:` block with several keys.
+    pt_dir=$(mktemp -d)
+    pt_write() { # <path> <version-line-or-empty, no leading spaces> <has-trivy-step:0|1>
+        local path="$1" verline="$2" has="$3"
+        {
+            printf '%s\n' "name: fixture" "jobs:" "  scan:" "    steps:" \
+                "      - uses: actions/checkout@deadbeef # v7.0.1" \
+                "        with:" \
+                "          persist-credentials: false"
+            if [ "$has" = "1" ]; then
+                printf '%s\n' "      - name: Scan image for CVEs (Trivy)" \
+                    "        uses: aquasecurity/trivy-action@deadbeef # v0.36.0" \
+                    "        with:"
+                [ -n "$verline" ] && printf '          %s\n' "$verline"
+                printf '%s\n' "          image-ref: pithead-example:ci" \
+                    "          scanners: vuln" \
+                    "          severity: HIGH,CRITICAL" \
+                    "          exit-code: \"1\""
+            fi
+            printf '%s\n' "      - name: Another step" "        run: echo done"
+        } >"$path"
+    }
+
+    # (a) both at TRIVY_VERSION -> rc 0
+    ci_a="$pt_dir/ci-a.yml"
+    os_a="$pt_dir/os-a.yml"
+    pt_write "$ci_a" "version: v0.74.0" 1
+    pt_write "$os_a" "version: v0.74.0" 1
+    GATE_WORKFLOWS="$ci_a $os_a"
+    pp_rc=0
+    check_parity >/dev/null || pp_rc=$?
+    st "check_parity: both workflows at TRIVY_VERSION -> rc 0" "$pp_rc" "0"
+
+    # (b) one at v0.70.0 -> rc 1, MISMATCH naming that file
+    ci_b="$pt_dir/ci-b.yml"
+    os_b="$pt_dir/os-b.yml"
+    pt_write "$ci_b" "version: v0.70.0" 1
+    pt_write "$os_b" "version: v0.74.0" 1
+    GATE_WORKFLOWS="$ci_b $os_b"
+    pp_rc=0
+    pp_out=$(check_parity) || pp_rc=$?
+    st "check_parity: one workflow at v0.70.0 -> rc 1" "$pp_rc" "1"
+    st "check_parity: MISMATCH names the mismatched file" \
+        "$(printf '%s' "$pp_out" | grep -c "ci-b.yml: MISMATCH")" "1"
+
+    # (c) one omits version: -> rc 1, MISSING
+    ci_c="$pt_dir/ci-c.yml"
+    os_c="$pt_dir/os-c.yml"
+    pt_write "$ci_c" "" 1
+    pt_write "$os_c" "version: v0.74.0" 1
+    GATE_WORKFLOWS="$ci_c $os_c"
+    pp_rc=0
+    pp_out=$(check_parity) || pp_rc=$?
+    st "check_parity: one workflow omits version: -> rc 1" "$pp_rc" "1"
+    st "check_parity: omitted version reports MISSING" \
+        "$(printf '%s' "$pp_out" | grep -c "ci-c.yml: MISSING")" "1"
+
+    # (d) a fixture with no trivy-action step at all -> rc 1, "NO trivy-action step found"
+    ci_d="$pt_dir/ci-d.yml"
+    os_d="$pt_dir/os-d.yml"
+    pt_write "$ci_d" "" 0
+    pt_write "$os_d" "version: v0.74.0" 1
+    GATE_WORKFLOWS="$ci_d $os_d"
+    pp_rc=0
+    pp_out=$(check_parity) || pp_rc=$?
+    st "check_parity: a workflow with no trivy-action step -> rc 1" "$pp_rc" "1"
+    st "check_parity: names the step-less file" \
+        "$(printf '%s' "$pp_out" | grep -c "ci-d.yml: NO trivy-action step found")" "1"
+
+    # (e) a bare version value (no leading v) is a MISMATCH, not accepted (#1290 fix 3): the real
+    # chain (trivy-action -> setup-trivy -> trivy's install.sh) builds its release URL from the
+    # declared value verbatim, so bare "0.74.0" 404s where "v0.74.0" resolves.
+    ci_e="$pt_dir/ci-e.yml"
+    os_e="$pt_dir/os-e.yml"
+    pt_write "$ci_e" "version: 0.74.0" 1
+    pt_write "$os_e" "version: v0.74.0" 1
+    GATE_WORKFLOWS="$ci_e $os_e"
+    pp_rc=0
+    pp_out=$(check_parity) || pp_rc=$?
+    st "check_parity: a bare version value (no v) -> rc 1" "$pp_rc" "1"
+    st "check_parity: bare-form MISMATCH names the reason" \
+        "$(printf '%s' "$pp_out" | grep -c "must carry the v")" "1"
+
+    # (f) a LATER step's version: must not be attributed to the trivy step
+    ci_f="$pt_dir/ci-f.yml"
+    {
+        printf '%s\n' "name: fixture" "jobs:" "  scan:" "    steps:" \
+            "      - name: Scan image for CVEs (Trivy)" \
+            "        uses: aquasecurity/trivy-action@deadbeef # v0.36.0" \
+            "        with:" \
+            "          image-ref: pithead-example:ci" \
+            "          scanners: vuln" \
+            "      - name: Unrelated step that happens to also take a version input" \
+            "        uses: some/other-action@deadbeef" \
+            "        with:" \
+            "          version: v0.74.0"
+    } >"$ci_f"
+    GATE_WORKFLOWS="$ci_f $os_a"
+    pp_rc=0
+    pp_out=$(check_parity) || pp_rc=$?
+    st "check_parity: a later step's version: is not attributed to the trivy step" \
+        "$(printf '%s' "$pp_out" | grep -c "ci-f.yml: MISSING")" "1"
+    st "check_parity: (f) fails overall" "$pp_rc" "1"
+
+    # (g) preflight, with engine_version stubbed
+    GATE_WORKFLOWS="$ci_a $os_a" # both at TRIVY_VERSION, from case (a)
+
+    engine_version() { printf '0.70.0'; }
+    pf_rc=0
+    preflight >/dev/null 2>&1 || pf_rc=$?
+    st "preflight: measured engine != TRIVY_VERSION -> rc 1" "$pf_rc" "1"
+
+    engine_version() { printf '0.74.0'; }
+    pf_rc=0
+    preflight >/dev/null 2>&1 || pf_rc=$?
+    st "preflight: measured engine matches + parity OK -> rc 0" "$pf_rc" "0"
+
+    engine_version() { return 1; }
+    pf_rc=0
+    preflight >/dev/null 2>&1 || pf_rc=$?
+    st "preflight: engine_version failing -> rc 1" "$pf_rc" "1"
+
+    # The check_parity half of preflight is a real guard, not dead code: engine matches exactly,
+    # but the gate's own workflows are out of parity (ci_b is MISMATCHED at v0.70.0, from case b).
+    engine_version() { printf '%s' "$TRIVY_VERSION"; }
+    GATE_WORKFLOWS="$ci_b $os_a"
+    pf_rc=0
+    preflight >/dev/null 2>&1 || pf_rc=$?
+    st "preflight: engine matches but the gate's own parity is broken -> rc 1" "$pf_rc" "1"
+
+    # Restore the real engine_version (unset -f would remove it outright, since the stubs above
+    # redefined the same top-level function rather than shadowing it) before testing its own
+    # parsing below.
+    engine_version() {
+        local out ver
+        out="$(docker run --rm "$TRIVY_IMAGE" --version 2>/dev/null)" || return 1
+        ver="$(printf '%s\n' "$out" | awk '/^Version: /{print $2; exit}')"
+        [ -n "$ver" ] || return 1
+        printf '%s' "$ver"
+    }
+    rm -rf "$pt_dir"
+
+    # (h) engine_version's own parsing of `docker ... --version` output
+    docker() { printf 'Version: 0.74.0\nVulnerability DB:\n  Version: 2\n'; }
+    st "engine_version parses the first top-level Version: line" \
+        "$(engine_version)" "0.74.0"
+
+    docker() { printf 'Vulnerability DB:\n  Version: 2\n'; }
+    ev_rc=0
+    engine_version >/dev/null 2>&1 || ev_rc=$?
+    st "engine_version: no top-level Version: line -> rc 1" "$ev_rc" "1"
+
+    unset -f docker
+
     [ "$st_fail" = 0 ] && echo "trivyignore-watch self-test OK"
     exit "$st_fail"
 fi
 
+# --- --check-parity mode ------------------------------------------------------------------------
+# Standalone entry point for `make lint-trivy-parity`: just the parity check, no docker, no
+# image builds.
+if [ "${1:-}" = "--check-parity" ]; then
+    check_parity
+    exit $?
+fi
+
 # --- real run ----------------------------------------------------------------------------------
 
+preflight || exit 1
 report "$IGNOREFILE"
 exit $?


### PR DESCRIPTION
Issue #1290 — close by hand after merge; `develop-v2` is not the default branch, so a `Closes` line does not fire here.

## What was wrong

`scripts/trivyignore-watch.sh` (the weekly obsolete-mute report, #1174) scans with a digest-pinned trivy that is 0.74.0. The CVE gate's two `aquasecurity/trivy-action` steps (`ci.yml`, `os-rootfs.yml`) passed no `version:` input, so the action installed its own default — v0.70.0 at the pinned action SHA. The watch was therefore reporting mutes as obsolete against an engine the gate never runs, which is the caveat that left #1295 undecidable. Nothing checked any of this, and a dependabot bump of the action would move the gate's engine again, silently, because the default lives inside the action.

## The fix — one source of truth, held in place two ways

- `TRIVY_VERSION` in `scripts/trivyignore-watch.sh` is the one place that names the engine. The pinned digest sits next to it.
- Both gate workflows now pass `version: v0.74.0` explicitly. The action's default no longer decides anything; a dependabot SHA bump of the action rewrites `uses:` and its pin comment, never the `version:` input (checked against the action's schema).
- **Static half — `make lint-trivy-parity`** (`--check-parity`, in `make lint` and the `lint-surfaces` CI job): parses both workflows and fails on a mismatched value, a missing `version:` key (the original defect), a value without the `v` (setup-trivy resolves the value verbatim into a release URL, so bare `0.74.0` would 404 at install time), or a workflow in which it cannot find a trivy-action step at all — a check that cannot see its target goes red, not green.
- **Runtime half — `preflight()`** on the real run: measures `trivy --version` from the pinned image and runs the parity check, and refuses to publish a report (rc 1) if either disagrees with `TRIVY_VERSION`. The weekly workflow already turns an empty report into a loud failure, so a refusal surfaces as "unchecked", never as "0 obsolete". The report header now names the engine.

Neither half alone closes the defect: the lint cannot see what the pinned image is, and the runtime check cannot see the workflow files. What trivy-action does with a declared `version:` input is upstream's contract; this PR holds the two declarations and the measured image to one value.

## What was RUN

- `bash scripts/trivyignore-watch.sh --self-test`: 29 cases, OK. The parity fixtures mimic the real step shape and include: a `version:` in a later, unrelated step (must not be attributed), a trailing `# comment` after the value, a commented-out `# uses: aquasecurity/trivy-action@…` line (must not open a phantom step), the bare (no-`v`) form, two trivy steps in one file, the inline `- uses:` form.
- `bash scripts/trivyignore-watch.sh --check-parity` on this tree: both files match, rc 0.
- **Mutation proofs, each restored afterwards** — this is what makes it a guard rather than a grep: (i) `ci.yml` `version:` changed to v0.70.0 → rc 1 naming `ci.yml` as MISMATCH; (ii) the `version:` line deleted from `os-rootfs.yml` → rc 1, MISSING; (iii) `TRIVY_VERSION` changed to 0.73.0 → rc 1 on both files; (iv) `preflight`'s parity block deleted → the self-test case that covers it goes red (an adversarial reviewer found that branch was untested; the case was added and the deletion re-run to prove it bites).
- `make lint-trivy-parity lint-file-budget lint-yaml lint-md lint-docs-voice` green. `shfmt -i 4 -d` clean; shellcheck on the script: no new findings versus the previous revision (three pre-existing SC2016 info hits in the old fixtures, untouched). The full local `make lint` (shellcheck included) runs before merge, once the bench's KVM run finishes — shellcheck's peak and a running guest do not fit in this box's RAM together; CI's lint jobs run on the PR now.
- Two independent reviews of the diff (an adversarial pass and an over-engineering pass), findings folded in: trailing-comment and commented-`uses:` parser traps, the bare-version over-acceptance, the untested preflight branch, a duplicated header paragraph, two self-test cases that could only fail together.

## Deliberate: the file's recorded ceiling

The script grew from 295 to 599 lines, 267 of them the `--self-test` block, and `docs/dev/file-budget.tsv` now records that as its ceiling. The fixtures stay inline on purpose: every lint script in this repo carries its own `--self-test` and the Makefile target pattern (`--self-test`, then the real check) depends on it. The ceiling is chosen, not accidental.

## Not done here

- `develop`'s copy of `ci.yml` still has no `version:` input. `develop` is frozen; its `ci.yml` is a default-branch workflow file (the Monday sweep's `schedule:` fires from it), and #1313 has to edit that same job on `develop` anyway, so the `version:` pin for `develop` rides in that PR with the firing proof, then syncs forward. Noted on #1290.
- #1295's verdict is not re-derived here; it needs a rescan with the gate's engine and no ignore file, which is that issue's own next step now that the engine is one value.

## CI found one thing the local run had not

The first push failed the `lint-surfaces` job on `lint-topology`: the self-test fixtures pinned their fake action as `@deadbeef`, which that lint reads as a `user@host` string. Fixed in the second commit by pinning the fixtures with a 40-hex sha, the shape the lint exempts as a SHA-pinned action (`lint-topology-classes.sh:121`) — the fixtures now mimic the real step exactly. Why the local run missed it: the earlier local `make` invocation had aborted at an unrelated target before it reached `lint-topology`, and the abort was hidden by output filtering. It was not a CI-versus-Makefile difference; the same target fails the same way locally on the first commit. All ten surface targets now pass locally with `make`'s own exit code checked, and CI re-runs on the second commit.

## Lane note

`Makefile` and `CONTRIBUTING.md` are outside this lane's owned paths; both edits were granted by the controller for this PR (the `lint-trivy-parity` target, and the one clause naming it in the lint-target list) and committed through the lane-guard's `.lane-override` hatch, which is why they are named here.
