### PR TITLE
chore(trivyignore): drop the obsolete openssl mute CVE-2026-45447 (#1295)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,10 +4,6 @@
 # distro CVEs are reported but don't block. The entries below are the currently-accepted *fixable*
 # findings, each with a rationale and how it clears. Revisit whenever Dependabot bumps a base image.
 
-# openssl: the fix is a base-distro point release (Debian deb13u2 / Ubuntu 3.0.13-0ubuntu3.11) not
-# yet in our digest-pinned bases. Cleared when Dependabot (docker) bumps the base image digests.
-CVE-2026-45447
-
 # Base-image build tooling living in the python:3.11-slim *system* site-packages — NOT in the app's
 # /app/.venv and never invoked at runtime (the entrypoint runs the venv's python). Cleared by a base bump.
 CVE-2026-23949
@@ -53,7 +49,8 @@ CVE-2026-34040
 # base bump — only by upstream rebuilding the image on the fixed Debian packages. Verified by
 # pulling the tag and reading dpkg, not from the release notes (#1156).
 #
-# Same shape as CVE-2026-45447 above: `--ignore-unfixed` hid these until Debian published a fix, at
+# Same shape as the openssl mute this file carried until 2026-08-24 (CVE-2026-45447, cleared once the
+# pinned bases took the fix): `--ignore-unfixed` hid these until Debian published a fix, at
 # which point they reddened every branch at once with no change on our side. 53615 arrived that way
 # on 2026-08-19 and the other three on 2026-08-20, between one CI run and the next on a branch
 # nobody had touched.


### PR DESCRIPTION
Issue #1295 — close by hand after merge; `develop-v2` is not the default branch, so a `Closes` line does not fire here.

## What this is

One mute leaves `.trivyignore`: `CVE-2026-45447` (openssl), with its rationale comment. The comment further down that cited it as a precedent now says what it was instead of pointing at a line that is gone. The other seven mutes are still live and stay.

## The evidence, and why it is trustworthy now

The weekly report (#1295) named this mute obsolete on 2026-08-22, with the operator's caveat that the watch scanned with a different trivy than the gate (#1290). That caveat is closed: #1344 made `TRIVY_VERSION` the one engine for both, and the watch now refuses to report at all unless the pinned image measures as that version and both gate workflows declare it.

The verdict was then re-derived from scratch, not reused: `trivyignore-watch.yml` dispatched on develop-v2 at 33a4e17 (run 32678865045, 2026-08-24 01:17Z). Its report header names the engine (`trivy 0.74.0 — parity checked before this run`), it scanned all six covered images (os-rootfs, dashboard, monero, p2pool, xmrig-proxy, tor) with **no ignore file applied**, and `CVE-2026-45447` was reported by none of them. A mute over a live finding would hide its own evidence, which is why the rescan runs with the ignore file off.

## What proves it does not come back

This PR's own CI: the five image builds and the rootfs scan run the CVE gate with the mute gone. If the finding were still present in any image, that gate goes red here, before merge.

## Not done here

- `develop` and `main` keep the entry, and **nothing will detect that it is obsolete there.** The mute watch's schedule fires from `develop` but checks out `develop-v2` inside, so it audits v2's `.trivyignore` and never develop's own — #1174's exact defect, a dead mute nobody detects, recreated by the lane split rather than by a bug. Not a blocker: `develop` is frozen and v2 replaces it. Whoever runs the next develop→v2 sync should resolve `.trivyignore` toward v2 deliberately (v2 is the audited side), not treat develop's extra line as a claim to keep.
- No other mute is touched: the same run shows the remaining seven still reported by at least one image.
