### PR TITLE
fix(dashboard): prefill Worker Inspect from the rig's own config (#1235)

### DIFF
--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -11,6 +11,12 @@ from mining_dashboard.config.config import (
     XMRIG_API_TOKEN,
 )
 
+# The writable-key allowlist lives with the WRITE path (control_service) and is imported here
+# rather than restated: a second literal would be a third copy of the same list, and the existing
+# drift guard only compares the dashboard's copy against pithead's. control_service imports only
+# `config`, so this does not close an import cycle.
+from mining_dashboard.service.control_service import WORKER_WRITABLE_KEYS
+
 # Per-worker endpoint descriptors (#172): the validated dashboard.workers[] list from config.json.
 # Module-level (not from-import at call sites) so tests can swap it per case. Fleets are small, so
 # the per-poll lookups below are linear scans — no index to keep in sync.
@@ -43,6 +49,12 @@ def parse_rigforge(payload):
     governor read → ``governor`` null — so each access is defaulted. A present-but-miner-down rig
     (``xmrig_api == "unreachable"``, XMRig keys absent) is flagged via ``miner_down`` so the UI can
     show it as up-but-miner-down rather than offline. Returns a compact dict for the UI, or ``None``.
+
+    ``config`` is the rig's EFFECTIVE writable config (rigforge#253, shipped in RigForge v1.10.0),
+    riding this same poll. It is what the Worker Inspect editor prefills from (#1235): the rig's
+    own current values, rather than Pithead's record of what it last pushed — which is empty on a
+    never-edited rig and stale on one changed directly with ``rigforge.sh apply``. A rig older than
+    v1.10.0 sends no ``config`` and this stays ``None``, so the editor falls back to the record.
     """
     rf = payload.get("rigforge") if isinstance(payload, dict) else None
     if not isinstance(rf, dict):
@@ -76,7 +88,58 @@ def parse_rigforge(payload):
             "temp_c": watchdog.get("temp_c") if wd_on else None,
             "max_temp_c": watchdog.get("max_temp_c") if wd_on else None,
         },
+        "config": _rig_writable_config(rf.get("config")),
     }
+
+
+# Pool keys that are a credential and must never reach the dashboard, let alone an editor box that
+# can POST them back. RigForge already deletes both before serving the block (its read is
+# token-OPTIONAL, so it masks at the source), but this is the same defence-in-depth posture
+# ``mask_secrets`` takes with the host config: the rig is remote, and a rig running an older or
+# patched build is exactly the case a single mask would miss.
+_POOL_CREDENTIAL_KEYS = ("pass", "tls-fingerprint")
+
+# How deep the strip below will walk before it stops trusting the value. A real writable config is
+# three deep at most (pools -> a pool -> its fields); anything past this is not a config we can
+# read, and refusing it also keeps a hostile rig from driving the recursion down our own stack.
+_MAX_CONFIG_DEPTH = 6
+
+
+def _strip_credentials(value, depth=0):
+    """Drop the credential keys from ``value`` at ANY depth and in ANY container shape.
+
+    Shape-agnostic deliberately. Stripping only ``pools`` when it arrived as a list of dicts was a
+    filter that assumed the shape of the very input it was defending against: a rig serving
+    ``pools`` as a dict, or nesting the credential one level deeper, walked straight past it with
+    the credential intact. A hostile or patched rig picks its own response shape, so the only
+    assumption safe to make here is none.
+    """
+    if depth > _MAX_CONFIG_DEPTH:
+        return None
+    if isinstance(value, dict):
+        return {
+            k: _strip_credentials(v, depth + 1)
+            for k, v in value.items()
+            if k not in _POOL_CREDENTIAL_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_credentials(v, depth + 1) for v in value]
+    return value
+
+
+def _rig_writable_config(cfg):
+    """The rig's own values for the writable keys, filtered to the keys we would ever write (#1235).
+
+    Filtered rather than passed through: this is remote-supplied data that prefills an editor whose
+    contents can be POSTed straight back at the rig. Anything outside ``WORKER_WRITABLE_KEYS`` would
+    be a key the apply path rejects anyway, so carrying it can only mislead the operator or widen
+    what a compromised rig can put in front of them. Returns ``None`` when the rig sent nothing
+    usable, which the UI must render as "could not read" rather than as an empty value.
+    """
+    if not isinstance(cfg, dict):
+        return None
+    out = {k: v for k, v in cfg.items() if k in WORKER_WRITABLE_KEYS}
+    return _strip_credentials(out) or None
 
 
 # Terminal control outcomes the rig may mirror: applied/rejected/rolled_back/failed from a

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -18,17 +18,33 @@ export { jsonSyntaxError } from "./configlogic.mjs";
 
 // One row per writable key, typed off the current (last-applied) value's JSON shape. A key never
 // applied yet has no value to type off, so it falls back to an empty JSON sub-editor.
-export function buildFields(writableKeys, lastApplied) {
+export function buildFields(writableKeys, lastApplied, rigConfig) {
   const applied = lastApplied || {};
+  const rig = rigConfig || {};
   return (writableKeys || []).map((key) => {
-    const value = applied[key];
-    if (isSecretSentinel(value)) return { key, type: "secret", value: "" };
-    if (typeof value === "boolean") return { key, type: "boolean", value };
-    if (typeof value === "number") return { key, type: "number", value };
-    if (typeof value === "string") return { key, type: "text", value };
-    // pools/autotune/watchdog (arrays/objects) and any never-applied key: a small per-row JSON
-    // sub-editor rather than a bespoke widget per shape (#518 leaves that for later).
-    return { key, type: "json", value: key in applied ? JSON.stringify(value, null, 2) : "" };
+    // Precedence: what the RIG is running, then what WE last pushed, then nothing (#1235). The
+    // rig's own value is the only one that is true on a never-edited rig or one changed directly
+    // with `rigforge.sh apply`; the last-applied record is a record of our writes, not its state.
+    // `source` travels with the field so the editor can say which of the three a box is showing —
+    // an unlabelled empty box reads as "0"/"none" and invites overwriting a good value.
+    const fromRig = key in rig;
+    const source = fromRig ? "rig" : key in applied ? "applied" : "unknown";
+    const value = fromRig ? rig[key] : applied[key];
+    if (isSecretSentinel(value)) return { key, source, type: "secret", value: "" };
+    // A null from the rig is a real answer — "no thermal cutoff set" — not a failed read, so it
+    // keeps source "rig" and renders empty rather than being demoted to unknown. The TYPE stays
+    // json regardless of source: buildTableChanges types the operator's edit off field.type, and
+    // an empty *text* row would hand back "80" where the rig expects 80 — validate_worker_changes
+    // checks key membership only, so a mistyped value would travel all the way to the rig.
+    if (value === null || value === undefined) {
+      return { key, source, type: "json", value: "" };
+    }
+    if (typeof value === "boolean") return { key, source, type: "boolean", value };
+    if (typeof value === "number") return { key, source, type: "number", value };
+    if (typeof value === "string") return { key, source, type: "text", value };
+    // pools/autotune/watchdog (arrays/objects): a small per-row JSON sub-editor rather than a
+    // bespoke widget per shape (#518 leaves that for later).
+    return { key, source, type: "json", value: JSON.stringify(value, null, 2) };
   });
 }
 
@@ -82,6 +98,14 @@ export function parseJsonChanges(text, writableKeys) {
   const bad = Object.keys(changes).filter((k) => !allowed.has(k));
   if (bad.length) return { error: `Not writable: ${bad.join(", ")}` };
   return { changes };
+}
+
+// Where a field's value came from (#1235). An unlabelled empty box reads as "0"/"none" and
+// invites overwriting a good value with a guess, so a value we could not read says so.
+export function fieldNote(source) {
+  if (source === "rig") return null;
+  if (source === "applied") return "last applied from here";
+  return "could not read from the rig";
 }
 
 // Per-worker hashrate chart markers (#1015): one change-history row -> one tooltip label. The

--- a/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -22,6 +22,7 @@ import {
   buildChartMarkers,
   buildFields,
   buildTableChanges,
+  fieldNote,
   jsonSyntaxError,
   parseJsonChanges,
 } from "./workerlogic.mjs";
@@ -143,7 +144,8 @@ function WorkerField({ field, edits, onEdit, busy }) {
     input = html`<input type=${field.type === "number" ? "number" : "text"} disabled=${busy} value=${value}
         onInput=${(e) => onEdit(field.key, e.target.value)} />`;
   }
-  return html`<label class="config-field"><span class="config-field-name">${field.key}</span>${input}</label>`;
+  const note = fieldNote(field.source);
+  return html`<label class="config-field"><span class="config-field-name">${field.key}${note && html` <span class="text-muted text-xs">${note}</span>`}</span>${input}</label>`;
 }
 
 export class WorkerInspect extends Component {
@@ -252,7 +254,7 @@ export class WorkerInspect extends Component {
       }
       changes = out.changes;
     } else {
-      const fields = buildFields(detail.writable_keys, detail.last_applied);
+      const fields = buildFields(detail.writable_keys, detail.last_applied, detail.rig_config);
       try {
         changes = buildTableChanges(fields, tableEdits);
       } catch {
@@ -387,9 +389,7 @@ export class WorkerInspect extends Component {
             ${
               canEdit
                 ? html`
-            <p class="text-muted text-xs">Writable keys: <span class="font-mono">${(detail.writable_keys || []).join(", ")}</span>.
-               Prefilled with the last config applied from the dashboard — the rig's live feed doesn't expose these values.
-               The rig validates and rolls back if the miner doesn't come back live.</p>
+            <p class="text-muted text-xs">Writable keys: <span class="font-mono">${(detail.writable_keys || []).join(", ")}</span>. Prefilled with what the rig is running now, read from its own feed. A box falls back to the last config applied from here, or says so when the value cannot be read at all — a rig that is offline, or one running a RigForge older than the release that started publishing them. The rig validates and rolls back if the miner doesn't come back live.</p>
             <div class="toggle-group mb-1" role="group" aria-label="Worker config mode">
                 <button class=${"btn-toggle" + (mode === "table" ? " active" : "")} aria-pressed=${mode === "table"}
                     title="View the config as a table" onClick=${() => this.setMode("table")}>Table</button>
@@ -399,7 +399,7 @@ export class WorkerInspect extends Component {
             ${
               mode === "table"
                 ? html`<div>
-                    ${buildFields(detail.writable_keys, detail.last_applied).map(
+                    ${buildFields(detail.writable_keys, detail.last_applied, detail.rig_config).map(
                       (f) => html`<${WorkerField} field=${f} edits=${tableEdits} busy=${busy}
                           onEdit=${(k, v) => this.setState({ tableEdits: { ...tableEdits, [k]: v } })} />`,
                     )}

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -2074,15 +2074,13 @@ def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
 
 
 def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
-    """Per-worker Inspect payload (#185): the rig's current enriched telemetry, the writable config
-    the dashboard last applied (the editor prefill — the rig's feed does not expose the writable
-    config values, so Pithead's own last-applied record is the honest source), and the change history
-    (each row's ``changes`` is a diff by construction, since we only ever record deltas we authored).
-    ``hashrate_by_config`` (#492) is that same version timeline with each version's measured
-    hashrate (worker_history) aggregated over its active window, so an operator can compare config
-    versions empirically. ``hashrate_history`` (#1013) is the same rig's hashrate as a chartable
-    time series, honoring the same ``range_arg``/``window`` ``/api/state`` already uses.
-
+    """Per-worker Inspect payload (#185): the rig's current enriched telemetry, the writable config (the editor
+    prefills from the rig's own current values (#1235), falling back to Pithead's last-applied record when the
+    rig has none), and the change history (each row's ``changes`` is a diff by construction, since we only ever
+    record deltas we authored). ``hashrate_by_config`` (#492) is that same version timeline with each version's
+    measured hashrate (worker_history) aggregated over its active window, so an operator can compare config
+    versions empirically. ``hashrate_history`` (#1013) is the same rig's hashrate as a chartable time series,
+    honoring the same ``range_arg``/``window`` ``/api/state`` already uses.
     ``editable`` is whether the worker has an operator-set ``host`` in ``dashboard.workers[]`` — the
     precondition for the host-side write path. The rig's token is masked out of this container (#440),
     so the container cannot verify it; the host runner re-checks it and fails closed if it is missing.
@@ -2113,6 +2111,8 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         # {available, latest, url} | None — this rig runs an older RigForge (#596).
         "rigforge_update": rigforge_update_for(worker, (data or {}).get("rigforge_release")),
         "writable_keys": sorted(WORKER_WRITABLE_KEYS),
+        # Rig's own current writable-key values (#1235); None means "could not read", not empty.
+        "rig_config": (worker.get("rigforge") or {}).get("config") if worker else None,
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,
         "hashrate_by_config": hashrate_by_config,

--- a/dashboard/tests/client/test_rigforge_config.py
+++ b/dashboard/tests/client/test_rigforge_config.py
@@ -1,0 +1,89 @@
+# Covers the rig's own writable config, carried off the enriched RigForge feed for the editor
+# prefill (#1235).
+import json
+
+from mining_dashboard.client.xmrig_client import parse_rigforge
+
+
+class TestRigWritableConfig:
+    """The rig's own writable config, carried off the enriched feed for the editor prefill (#1235)."""
+
+    def _block(self, cfg):
+        payload = {"rigforge": {"version": "1.10.0", "config": cfg}}
+        return parse_rigforge(payload)["config"]
+
+    def test_writable_config_is_carried_through(self):
+        cfg = {
+            "pools": [{"url": "rig:3333", "user": "48edf", "keepalive": True}],
+            "DONATION": 1,
+            "autotune": "performance",
+            "watchdog": "enabled",
+            "watchdog_interval_min": 5,
+            "max_temp_c": 85,
+        }
+        assert self._block(cfg) == cfg
+
+    def test_a_rig_that_sends_no_config_block_yields_none(self):
+        # RigForge older than the release that added it: the editor must fall back, not show empty
+        # boxes as if they were the rig's values.
+        assert parse_rigforge({"rigforge": {"version": "1.10.0"}})["config"] is None
+        assert self._block(None) is None
+        assert self._block({}) is None
+        assert self._block("not-a-dict") is None
+
+    def test_keys_outside_the_writable_allowlist_are_dropped(self):
+        # This prefills an editor whose contents can be POSTed back at the rig. A key the apply
+        # path would reject anyway can only mislead, so it never reaches the UI.
+        out = self._block({"DONATION": 2, "ACCESS_TOKEN": "s3cret", "api_port": 8081, "pools": []})
+        # An empty pools list is a real value the rig is running, so it survives; the two
+        # non-writable keys do not.
+        assert out == {"DONATION": 2, "pools": []}
+        assert "ACCESS_TOKEN" not in out
+        assert "api_port" not in out
+
+    def test_pool_credentials_are_stripped_even_if_the_rig_sends_them(self):
+        # RigForge deletes these before serving, but its read is token-OPTIONAL and the rig is
+        # remote — an older or patched build is exactly what a single mask at the source misses.
+        out = self._block(
+            {
+                "pools": [
+                    {
+                        "url": "rig:3333",
+                        "user": "48edf",
+                        "pass": "hunter2",
+                        "tls-fingerprint": "ab",
+                    },
+                    {"url": "two:3333", "pass": "also-secret"},
+                ]
+            }
+        )
+        assert out["pools"] == [{"url": "rig:3333", "user": "48edf"}, {"url": "two:3333"}]
+        assert "hunter2" not in json.dumps(out)
+        assert "also-secret" not in json.dumps(out)
+
+    def test_a_credential_is_stripped_whatever_shape_the_rig_wraps_it_in(self):
+        # The threat model is a rig that picks its own response shape, so the strip must not assume
+        # one. An earlier version only ran when `pools` arrived as a list of dicts: a rig serving it
+        # as a dict, or nesting the credential a level deeper, walked past the filter intact. Both
+        # shapes were reproduced against the real function before this test was written.
+        for cfg in (
+            {"pools": {"pass": "hunter2", "tls-fingerprint": "ab"}},
+            {"pools": [{"url": "rig:3333", "auth": {"pass": "hunter2"}}]},
+            {"watchdog": {"nested": {"deeper": {"pass": "hunter2"}}}},
+            {"pools": [[{"pass": "hunter2"}]]},
+        ):
+            assert "hunter2" not in json.dumps(self._block(cfg)), cfg
+
+    def test_a_config_nested_past_all_reason_is_refused_rather_than_walked(self):
+        # A hostile rig should not get to drive our recursion down its own stack, and no real
+        # writable config is anywhere near this deep.
+        deep = cur = {}
+        for _ in range(60):
+            cur["watchdog"] = {}
+            cur = cur["watchdog"]
+        cur["pass"] = "hunter2"
+        assert "hunter2" not in json.dumps(self._block({"watchdog": deep}))
+
+    def test_a_malformed_pool_entry_does_not_crash_the_whole_poll(self):
+        out = self._block({"pools": ["not-a-dict", None, {"url": "ok:1", "pass": "x"}]})
+        assert out["pools"] == ["not-a-dict", None, {"url": "ok:1"}]

--- a/dashboard/tests/frontend/workerlogic.test.mjs
+++ b/dashboard/tests/frontend/workerlogic.test.mjs
@@ -11,6 +11,7 @@ import {
   buildChartMarkers,
   buildFields,
   buildTableChanges,
+  fieldNote,
   jsonSyntaxError,
   markerLabel,
   parseJsonChanges,
@@ -175,4 +176,77 @@ test("buildChartMarkers: maps each row to a chart point, quiet only for a non-ap
 test("buildChartMarkers: tolerates a missing/empty marker list", () => {
   assert.deepEqual(buildChartMarkers(undefined), []);
   assert.deepEqual(buildChartMarkers([]), []);
+});
+
+// --- buildFields prefill precedence (#1235) -------------------------------------------------
+
+const WKEYS = ['DONATION', 'autotune', 'max_temp_c', 'pools', 'watchdog', 'watchdog_interval_min'];
+const byKey = (fields) => Object.fromEntries(fields.map((f) => [f.key, f]));
+
+test('buildFields: the rig\'s own value wins over what we last applied (#1235)', () => {
+    // The whole point: the last-applied record is a record of OUR writes. A value changed directly
+    // on the rig, or never set from here at all, is only in the rig's feed.
+    const f = byKey(buildFields(WKEYS, { DONATION: 1 }, { DONATION: 7, autotune: 'efficiency' }));
+    assert.equal(f.DONATION.value, 7);
+    assert.equal(f.DONATION.source, 'rig');
+    assert.equal(f.autotune.value, 'efficiency');
+    assert.equal(f.autotune.source, 'rig');
+});
+
+test('buildFields: falls back to the last-applied record only when the rig sent nothing (#1235)', () => {
+    const f = byKey(buildFields(WKEYS, { DONATION: 3 }, null));
+    assert.equal(f.DONATION.value, 3);
+    assert.equal(f.DONATION.source, 'applied');
+    // A key neither source knows is UNKNOWN, never silently empty — an unlabelled empty box reads
+    // as "0"/"none" and invites overwriting a good value with a guess.
+    assert.equal(f.watchdog.source, 'unknown');
+    assert.equal(f.watchdog.value, '');
+});
+
+test('buildFields: a null from the rig is an answer, not a failed read (#1235)', () => {
+    // max_temp_c null means "no thermal cutoff set" — it must not be demoted to "could not read".
+    const f = byKey(buildFields(WKEYS, {}, { max_temp_c: null }));
+    assert.equal(f.max_temp_c.source, 'rig');
+    assert.equal(f.max_temp_c.value, '');
+});
+
+test('buildFields -> buildTableChanges: a null-valued key still posts its real JSON type (#1235)', () => {
+    // Asserting the label alone let a regression through once: a null value was typed as a TEXT
+    // row, so editing a rig-reported-null max_temp_c posted the string "80" instead of 80. Nothing
+    // downstream catches that — validate_worker_changes checks key membership, not value types —
+    // so the round trip, not the source label, is what this key needs proven.
+    const fields = buildFields(WKEYS, {}, { max_temp_c: null });
+    assert.deepEqual(buildTableChanges(fields, { max_temp_c: '80' }), { max_temp_c: 80 });
+});
+
+test('buildFields: rig-sourced structured values still get the JSON sub-editor (#1235)', () => {
+    const pools = [{ url: 'rig:3333', user: '48edf' }];
+    const f = byKey(buildFields(WKEYS, {}, { pools }));
+    assert.equal(f.pools.type, 'json');
+    assert.equal(f.pools.source, 'rig');
+    assert.deepEqual(JSON.parse(f.pools.value), pools);
+});
+
+test('buildFields: every field carries a source, so no box can render unlabelled (#1235)', () => {
+    for (const f of buildFields(WKEYS, { DONATION: 1 }, { autotune: 'performance' })) {
+        assert.ok(['rig', 'applied', 'unknown'].includes(f.source), `${f.key} -> ${f.source}`);
+    }
+});
+
+// --- fieldNote ------------------------------------------------------------------------------
+
+test('fieldNote: a rig-sourced value needs no explanation (#1235)', () => {
+    assert.equal(fieldNote('rig'), null);
+});
+
+test('fieldNote: an applied value says where it came from (#1235)', () => {
+    assert.equal(fieldNote('applied'), 'last applied from here');
+});
+
+test('fieldNote: an unknown source says the value could not be read (#1235)', () => {
+    assert.equal(fieldNote('unknown'), 'could not read from the rig');
+});
+
+test('fieldNote: any unrecognised source falls back to could-not-read, never null (#1235)', () => {
+    assert.equal(fieldNote('bogus'), 'could not read from the rig');
 });

--- a/dashboard/tests/frontend/workerview.test.mjs
+++ b/dashboard/tests/frontend/workerview.test.mjs
@@ -1,13 +1,8 @@
-// Unit tests for Worker Inspect's editor UI (#518): mining_dashboard/web/static/workerview.mjs —
-// the table editor, the JSON mode (inline parse errors + the file-fill button), and the masked
-// sentinel round-trip shared with the Configuration view (#508/#440).
-//
-// Rendering uses the dependency-free vnode walker (helpers/render.mjs); apply()/onJsonInput/
-// onFilePick are called directly against a WorkerInspect instance, the same pattern
-// configview.test.mjs uses for ConfigView's poll()/save() — no DOM, no npm deps.
-//
-// Run with Node's built-in test runner (CI runs exactly this):
-//     node --test dashboard/tests/frontend/
+// Unit tests for Worker Inspect's editor UI (#518): mining_dashboard/web/static/workerview.mjs — the
+// table editor, the JSON mode (inline parse errors + the file-fill button), and the masked sentinel
+// round-trip shared with the Configuration view (#508/#440). Rendering uses the dependency-free vnode
+// walker (helpers/render.mjs); apply()/onJsonInput/onFilePick are called directly against a
+// WorkerInspect instance — no DOM, no npm deps. Run with: node --test dashboard/tests/frontend/
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
@@ -30,11 +25,9 @@ const DETAIL = {
   hashrate_history: { hashrate: [], markers: [] },
 };
 
-// WorkerInspect is never mounted here (no DOM/jsdom — this repo's frontend tests deliberately run
-// with neither, see helpers/render.mjs). Preact's setState() only takes effect through Preact's
-// own render loop, which never runs for an unmounted instance, so it silently no-ops on `state`.
-// Stub it to merge synchronously, the same net effect a real render would have, so the methods
-// under test (onJsonInput, apply's busy/result bookkeeping) are observable.
+// WorkerInspect is never mounted here (no DOM/jsdom), so Preact's setState() silently no-ops on
+// `state` — its render loop never runs. Stub it to merge synchronously so the methods under test
+// (onJsonInput, apply's bookkeeping) are observable.
 function stubSetState(inst) {
   inst.setState = (patch) => {
     const next = typeof patch === "function" ? patch(inst.state, inst.props) : patch;
@@ -138,8 +131,7 @@ test("table mode: leaving the secret row blank keeps the token untouched", async
 test("JSON mode: an untouched sentinel round-trips verbatim through the textarea", () => {
   const inst = readyInstance();
   inst.state.mode = "json";
-  // editText is prefilled from last_applied at load() time — unmodified, it still carries the
-  // literal sentinel shape (the same "unless replaced" contract the Configuration view uses).
+  // editText is prefilled from last_applied at load() time — unmodified, it still carries the literal sentinel shape (the same "unless replaced" contract the Configuration view uses).
   assert.match(inst.state.editText, /__secret__/);
   const parsed = JSON.parse(inst.state.editText);
   assert.deepEqual(parsed.token, SENTINEL);
@@ -435,23 +427,17 @@ test("Inspect surfaces the RigForge new-release callout only when the server der
 });
 
 // --- StatsTable value contrast (#1232) ------------------------------------------------------
-//
-// The detail-row values (Governor, HugePages, Mainboard, …) render with variant "outline" for a
-// plain metric — STAT_VALUE_CLS has no entry for it, so before the fix the value <td> got an
-// empty class: no colour, no font-weight, and it read as disabled text in dark mode. The fix
-// puts every value in `.stat-value` (explicit --text colour + weight 600), with status-ok/warn/
-// bad still layered on top to colour a flagged metric. These two tests would catch a regression
-// to the old behaviour: reverting the markup edit that adds `.stat-value` (the class check
-// below), or reverting/weakening the CSS rule itself (the second test, and the ratio test after
-// it) — verified by reverting each change locally and confirming the corresponding test reds.
+// A plain metric renders with variant "outline" — STAT_VALUE_CLS has no entry for it, so before the
+// fix the value <td> got an empty class (no colour/weight, reading as disabled text in dark mode).
+// The fix puts every value in `.stat-value`, with status-ok/warn/bad layered on top for a flagged
+// metric; these two tests catch a regression to either the markup or the CSS rule itself.
 
 test("StatsTable: a plain outline value still gets the stat-value class, not an empty one (#1232)", () => {
   const out = renderToString(StatsTable({ stats: [{ label: "Governor", value: "performance", variant: "outline" }] }));
   const valueCell = out.match(/<td class="([^"]*)">performance<\/td>/);
   assert.ok(valueCell, `expected a value <td> for the outline stat, got: ${out}`);
   assert.match(valueCell[1], /\bstat-value\b/);
-  // The old code emitted `STAT_VALUE_CLS[s.variant] || ""`, which for "outline" (or any variant
-  // with no colour entry) rendered class="" — an empty class is exactly the regression.
+  // The old code emitted `STAT_VALUE_CLS[s.variant] || ""`, which for "outline" (or any variant with no colour entry) rendered class="" — an empty class is exactly the regression.
   assert.notEqual(valueCell[1].trim(), "");
 });
 
@@ -463,9 +449,7 @@ test("StatsTable: a warn-variant value keeps its status colour alongside stat-va
   assert.match(valueCell[1], /\bstatus-warn\b/);
 });
 
-// WCAG contrast ratio (relative-luminance formula, same one the WCAG 2.x spec defines) computed
-// directly from the theme tokens the CSS declares — not a rendered/measured colour, since this
-// repo's frontend tests run with no DOM (see helpers/render.mjs). AA for normal text is 4.5:1.
+// WCAG contrast ratio (relative-luminance formula) computed directly from the theme tokens the CSS declares — not a rendered/measured colour, since these tests run with no DOM. AA is 4.5:1.
 function srgbToLinear(c) {
   const v = c / 255;
   return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
@@ -503,9 +487,7 @@ test("dashboard.css: .stat-value declares an explicit --text colour, not an empt
 });
 
 test("dashboard.css: .stat-value's --text on --card meets WCAG AA (>= 4.5:1) in dark AND light (#1232)", () => {
-  // Dark is the base palette (:root, :root[data-theme="dark"]); light is the explicit override
-  // block. Both declare --text and --card, so pull each theme's pair independently rather than
-  // assuming the first match in the file belongs to the theme under test.
+  // Dark is the base palette; light is the explicit override block — pull each theme's pair independently.
   const darkText = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--text");
   const darkCard = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--card");
   const lightText = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--text");
@@ -515,4 +497,22 @@ test("dashboard.css: .stat-value's --text on --card meets WCAG AA (>= 4.5:1) in 
   const lightRatio = contrastRatio(lightText, lightCard);
   assert.ok(darkRatio >= 4.5, `dark .stat-value contrast ${darkRatio.toFixed(2)}:1 is below AA (4.5:1)`);
   assert.ok(lightRatio >= 4.5, `light .stat-value contrast ${lightRatio.toFixed(2)}:1 is below AA (4.5:1)`);
+});
+
+// --- Prefill provenance (#1235) ----------------------------------------------------------------
+
+test("table mode prefills from the rig's own config and labels every other case (#1235)", () => {
+  // Label text is proven at the logic tier (fieldNote, workerlogic.test.mjs); this proves the render.
+  const withRig = { ...DETAIL, rig_config: { DONATION: 9, max_temp_c: 85 } };
+  const out = renderToString(readyInstance(withRig).render());
+  assert.match(out, /value="9"/); // the rig's DONATION
+  assert.match(out, /value="85"/); // the rig's max_temp_c
+  assert.doesNotMatch(out, /value="5"/); // not the last-applied DONATION
+  assert.doesNotMatch(out, /value="70"/); // nor its max_temp_c
+  const noRig = { ...DETAIL, last_applied: { DONATION: 5 }, rig_config: null };
+  const fell = renderToString(readyInstance(noRig).render());
+  assert.match(fell, /last applied from here/);
+  assert.equal((fell.match(/could not read from the rig/g) || []).length, 2); // max_temp_c, token
+  assert.doesNotMatch(out, /the rig's live feed doesn't expose these values/); // stale claim, #1235
+  assert.match(out, /Prefilled with what the rig is running now/);
 });

--- a/dashboard/tests/web/test_worker_detail_ip.py
+++ b/dashboard/tests/web/test_worker_detail_ip.py
@@ -9,6 +9,8 @@ Mutation-kill notes: swapping ``worker.get("ip")`` for the descriptor's ``host``
 ``test_ip_is_none_when_worker_not_in_snapshot``.
 """
 
+import pytest
+
 from mining_dashboard.service.storage_service import StateManager
 from mining_dashboard.web.views import build_worker_detail
 
@@ -56,3 +58,33 @@ class TestWorkerDetailIp:
         d = _detail(monkeypatch, "ghost", workers=[])
         assert d["found"] is False
         assert d["ip"] is None
+
+
+# --- Rig-sourced editor prefill (#1235) ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rigforge,expected",
+    [
+        ({"config": {"DONATION": 9, "max_temp_c": 85}}, {"DONATION": 9, "max_temp_c": 85}),
+        (None, None),  # plain-xmrig rig
+        ({}, None),
+        ({"version": "1.9.0"}, None),  # RigForge too old to publish the block
+    ],
+)
+def test_rig_config_is_surfaced_for_the_editor_prefill(monkeypatch, rigforge, expected):
+    # #1235: the rig's own writable values ride the enriched feed, so the editor can show what
+    # the rig is RUNNING rather than what we last pushed at it. None means the editor must fall
+    # back to the last-applied record, never render empty boxes as if they were rig values.
+    d = _detail(
+        monkeypatch,
+        "rig1",
+        workers=[{"name": "rig1", "status": "online", "h60": 1, "rigforge": rigforge}],
+        descriptors=[{"name": "rig1", "host": "10.0.0.9"}],
+    )
+    assert d["rig_config"] == expected
+
+
+def test_rig_config_is_none_for_a_worker_that_is_not_in_the_snapshot(monkeypatch):
+    d = _detail(monkeypatch, "ghost", workers=[], descriptors=[])
+    assert d["rig_config"] is None


### PR DESCRIPTION
Closes #1235.

## What changed

The Worker Inspect editor prefilled every writable box from Pithead's own record of the last
config it applied. On a rig that has never been edited from the dashboard that record is empty,
so the operator edited blind — and an unlabelled empty box reads as "0"/"none", which invites
overwriting a good value with a guess.

The editor now prefills from the rig's own effective writable config, falling back to the
last-applied record, and saying so per field when neither is available.

Precedence per key, and every field carries its `source` so the box can label itself:

| source | means | note under the box |
|---|---|---|
| `rig` | the rig's own current value | none needed |
| `applied` | our record of what we last pushed | "last applied from here" |
| `unknown` | neither | "could not read from the rig" |

## The finding that redirected this issue

The issue proposed a new bearer-gated `GET /config` read endpoint on RigForge. **That endpoint
is unnecessary and should not be built — RigForge already publishes this.** `_api_rigforge_block()`
emits `config`, `config_meta` and `control`, and `_api_config_json()` deletes `pass` and
`tls-fingerprint` before serving. It shipped in RigForge v1.10.0 (rigforge#253, closed) and it
rides `/1/summary` — the poll Pithead already makes every cycle.

Pithead was simply discarding it: `parse_rigforge()` is an explicit sub-key allowlist and the
string `config` did not appear in it at all. So the consumer side is the whole fix, and no
cross-repo work is owed. A correction comment saying this is posted on the issue.

## Security review — two defects found and fixed

The mandatory adversarial security pass on this diff found two real defects. Both are fixed here,
and each fix ships with a guard that was **confirmed to fail against the code as it stood** — not
merely to pass against the fix.

**1. The credential strip could be walked past (the more serious of the two).** The strip only ran
when `pools` arrived as a list of dicts. That is a filter assuming the shape of the very input it
defends against, and a hostile or patched rig picks its own response shape. Both bypasses were
reproduced against the real function before anything was changed:

| what the rig serves | before | now |
|---|---|---|
| `pools` as a **dict** carrying `pass` | credential passes through | stripped |
| `pools[].auth.pass` (**nested** one level) | credential passes through | stripped |
| `pools[]` as a flat list of dicts | stripped | stripped |

Replaced with a shape-agnostic recursive strip bounded by `_MAX_CONFIG_DEPTH`, which also refuses
to walk a hostile rig's nesting down our own stack. This is net *simpler* than the special-cased
version it replaces.

**2. A rig-reported null was typed as text, so an edit posted the wrong JSON type.** A null means
"no thermal cutoff set" — a real answer, not a failed read — so it keeps `source: "rig"`. But it
must keep the JSON type too: as a text row, editing a null `max_temp_c` posted the string `"80"`
where the rig expects the number `80`. Nothing downstream catches that — `validate_worker_changes`
checks key membership, not value types. Asserting the source label alone is what let this through,
so the guard is now a round trip rather than a label check.

**Checked and clean:** XSS (all rig-derived values reach the DOM as `value` properties on form
controls; no `innerHTML`/`dangerouslySetInnerHTML` anywhere in the tree, and field *keys* are
always the server's own allowlist, never rig-supplied); no silent write-back (`buildTableChanges`
emits only keys the operator actually edited and drops a value that round-trips unchanged, so an
untouched hostile prefill is never POSTed); write-path re-validation (the server re-checks the
allowlist, and the host runner independently re-resolves host/port/token from the host's own
config and re-checks the allowlist before dialing the rig); no topology leak; no new secrets or
dependencies.

**Found but deliberately NOT fixed here:** the rig-supplied config is forwarded to the browser with
no size bound. Depth is bounded at the filter; breadth and total size are not. The honest fix is a
cap on the poll response body, which bounds every consumer of the feed rather than one field, and
it wants a measurement of what a real feed weighs first. Filed as **#1347** rather than bundled.

**Not covered by the review:** whether the persisted config-history store masks credentials before
storage or display (untouched by this diff, not traced); whether any global client-session size cap
exists outside the poll code; and RigForge's own server-side behaviour, which the review treats as
potentially hostile by assumption rather than auditing.

## Layering note

`xmrig_client` imports `WORKER_WRITABLE_KEYS` from `control_service` rather than restating it: a
second literal would be a third copy of the same list, and the existing drift guard only compares
the dashboard's copy against pithead's. This is an unusual client-to-service direction and a
reviewer should question it — it was questioned, and traced: `control_service` imports only
`config`, so there is no cycle and no module-level side effect. The write path is unchanged; this
only makes the current value visible before an edit.

## Deliberately out of scope

`config_meta` (rigforge#254) — telling a change made ON the rig from one made from here — is
dropped by the same allowlist and is the other half of the issue's complaint. Acceptance is met
without it and the change was already fighting the file-budget ratchet, so it is split out as
**#1345** rather than bundled here.

## What was run

- `node --test dashboard/tests/frontend/` — 452 pass, 0 fail
- the dashboard python suite — exit 0, no failures or errors
- `make lint-py` (ruff check + format), `make lint-js`, `make lint-topology`,
  `scripts/lint-file-budget.sh`, `scripts/lint-operator-strings.sh` — all clean

`lint-py` is worth calling out: it was **failing** on this branch and had been missed. It caught an
`import pytest` inserted above a module docstring, which silently demoted that docstring to a dead
string expression. Fixed here.

## What was NOT run — read this before merging

**Nothing has been exercised against a live rig or the bench.** All evidence here is unit-level.
The issue's acceptance asks for validation against the borrowed loaner rig the e2e already uses;
that is bench-gated and belongs to the harness lane, so it is **unmet**, not quietly skipped.

Specifically still assumed: that the operator's rigs run RigForge v1.10.0 or newer. The code
degrades safely if not — `rig_config` is `None`, the editor falls back to the last-applied record
and labels the box — and that fallback path is covered by tests, but only by tests.
