### PR TITLE
feat(dashboard): say whether each node runs here or somewhere else (#1040)

### DIFF
--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -279,6 +279,11 @@ def compute_topology(
     monero_clearnet_sync,
     tari_clearnet_sync,
     remote_monero,
+    # Defaulted, unlike remote_monero: the egress posture does not model a remote Tari
+    # node's gRPC route yet (#1350), so the two functions no longer take identical knobs
+    # and the shared sweep fixtures splat into both. topology_from_config passes it, and
+    # test_topology_graph asserts that it does rather than trusting the signature to.
+    remote_tari=False,
     healthchecks_enabled,
     telegram_enabled,
     price_feed_enabled=False,
@@ -396,7 +401,8 @@ def compute_topology(
         else:
             edge["leak"] = True
 
-    return {"nodes": TOPOLOGY_NODES, "edges": edges, "summary": posture["summary"]}
+    nodes = topology_nodes(remote_monero=remote_monero, remote_tari=remote_tari)
+    return {"nodes": nodes, "edges": edges, "summary": posture["summary"]}
 
 
 def topology_from_config():
@@ -408,7 +414,8 @@ def topology_from_config():
         xvb_tor=config.XVB_TOR_ENABLED,
         monero_clearnet_sync=config.MONERO_CLEARNET_SYNC,
         tari_clearnet_sync=config.TARI_CLEARNET_SYNC,
-        remote_monero=config.MONERO_NODE_HOST != config.LOCAL_MONERO_HOST,
+        remote_monero=not config.monero_is_local(),
+        remote_tari=not config.tari_is_local(),
         healthchecks_enabled=bool(config.HEALTHCHECKS_PING_URL),
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],

--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -27,6 +27,10 @@ import ipaddress
 from urllib.parse import urlsplit
 
 from mining_dashboard.config import config
+from mining_dashboard.service.topology_graph import (  # noqa: F401  (re-exported)
+    TOPOLOGY_NODES,
+    topology_nodes,
+)
 
 TOR = "tor"
 CLEARNET = "clearnet"
@@ -254,28 +258,6 @@ def _notify_knobs():
 # The egress list above answers "is anything leaking?"; the topology answers "how is the whole
 # stack wired?" — every component and the route of each link (ingress, egress, internal). Same
 # config-derived routes, so the two views can never disagree (the summary is shared verbatim).
-
-# Zones, left-to-right by trust: your LAN, the host's container bridge, the Tor hub, the Internet.
-ZONE_LAN = "lan"
-ZONE_HOST = "host"
-ZONE_TOR = "tor"
-ZONE_NET = "internet"
-
-# Nodes bracket the host components with the external actors they actually talk to. ``internal``
-# nodes (the socket proxies) only appear when the operator expands the internal mesh.
-TOPOLOGY_NODES = [
-    {"id": "rigs", "label": "Mining rigs", "zone": ZONE_LAN},
-    {"id": "browser", "label": "Browser", "zone": ZONE_LAN},
-    {"id": "xmrig-proxy", "label": "xmrig-proxy", "zone": ZONE_HOST},
-    {"id": "caddy", "label": "caddy", "zone": ZONE_HOST},
-    {"id": "dashboard", "label": "dashboard", "zone": ZONE_HOST},
-    {"id": "p2pool", "label": "p2pool", "zone": ZONE_HOST},
-    {"id": "monerod", "label": "monerod", "zone": ZONE_HOST},
-    {"id": "tari", "label": "tari", "zone": ZONE_HOST},
-    {"id": "docker", "label": "docker-proxy", "zone": ZONE_HOST, "internal": True},
-    {"id": "tor", "label": "tor", "zone": ZONE_TOR},
-    {"id": "internet", "label": "Tor network", "zone": ZONE_NET},
-]
 
 
 def _edge(src, dst, route, label, kind):

--- a/dashboard/mining_dashboard/service/metrics.py
+++ b/dashboard/mining_dashboard/service/metrics.py
@@ -21,6 +21,8 @@ from mining_dashboard.config.config import (
     MONERO_PRUNE,
     XVB_DONATION_LEVEL,
     XVB_MAX_DONATION_FRACTION,
+    monero_is_local,
+    tari_is_local,
 )
 from mining_dashboard.helper.utils import (
     DEFAULT_PPLNS_WINDOW,
@@ -115,6 +117,11 @@ class Metrics:
     # otherwise be judged against the wrong baseline. History retention (30 days) covers it
     # exactly. Defaulted so direct Metrics(...) constructors needn't set it.
     p2pool_30d: float = 0.0
+    # Does each node run on THIS machine, or somebody else's (#1040)? A remote node's health is
+    # not the operator's to fix, which is the whole reason the UI has to say which it is. Both
+    # default to local — the stock setup — so direct Metrics(...) constructors needn't set them.
+    monero_local: bool = True
+    tari_local: bool = True
 
 
 def build_metrics(latest_data, state_mgr, history=None):
@@ -238,6 +245,8 @@ def build_metrics(latest_data, state_mgr, history=None):
         monero=_sync_metric(data.get("monero_sync", {})),
         tari=_sync_metric(data.get("tari_sync", {})),
         monero_mode=_monero_mode(),
+        monero_local=monero_is_local(),
+        tari_local=tari_is_local(),
         tari_mining=bool(data.get("tari", {}).get("active", False)),
         tari_difficulty=data.get("tari", {}).get("difficulty", 0) or 0,
         tari_reward=data.get("tari", {}).get("reward", 0) or 0,

--- a/dashboard/mining_dashboard/service/topology_graph.py
+++ b/dashboard/mining_dashboard/service/topology_graph.py
@@ -1,0 +1,46 @@
+"""The stack's topology graph: the zones each component sits in, the fixed node list, and the
+per-request marking of which nodes are this machine's own (#1040).
+
+Split out of ``egress.py`` because that module sits at its file-budget ceiling and this is the
+part of it that is data rather than logic. ``egress`` imports back from here; the dependency runs
+one way, and re-exporting ``TOPOLOGY_NODES`` keeps every existing importer working unchanged.
+"""
+
+# Zones, left-to-right by trust: your LAN, the host's container bridge, the Tor hub, the Internet.
+ZONE_LAN = "lan"
+ZONE_HOST = "host"
+ZONE_TOR = "tor"
+ZONE_NET = "internet"
+
+# Nodes bracket the host components with the external actors they actually talk to. ``internal``
+# nodes (the socket proxies) only appear when the operator expands the internal mesh.
+TOPOLOGY_NODES = [
+    {"id": "rigs", "label": "Mining rigs", "zone": ZONE_LAN},
+    {"id": "browser", "label": "Browser", "zone": ZONE_LAN},
+    {"id": "xmrig-proxy", "label": "xmrig-proxy", "zone": ZONE_HOST},
+    {"id": "caddy", "label": "caddy", "zone": ZONE_HOST},
+    {"id": "dashboard", "label": "dashboard", "zone": ZONE_HOST},
+    {"id": "p2pool", "label": "p2pool", "zone": ZONE_HOST},
+    {"id": "monerod", "label": "monerod", "zone": ZONE_HOST},
+    {"id": "tari", "label": "tari", "zone": ZONE_HOST},
+    {"id": "docker", "label": "docker-proxy", "zone": ZONE_HOST, "internal": True},
+    {"id": "tor", "label": "tor", "zone": ZONE_TOR},
+    {"id": "internet", "label": "Tor network", "zone": ZONE_NET},
+]
+
+
+def topology_nodes(*, remote_monero, remote_tari):
+    """``TOPOLOGY_NODES`` with the two relocatable nodes marked local or remote (#1040).
+
+    monerod and tari are the only nodes an operator can run somewhere else; every other node in
+    the graph is always this machine's own, so it carries no ``remote`` key at all rather than a
+    redundant ``False`` the diagram would then have to decide not to draw.
+
+    Returns a COPY. The graph is built per request and the node list is a module-level constant —
+    marking it in place would leak one call's topology into the next.
+    """
+    relocatable = {"monerod": remote_monero, "tari": remote_tari}
+    return [
+        {**n, "remote": bool(relocatable[n["id"]])} if n["id"] in relocatable else n
+        for n in TOPOLOGY_NODES
+    ]

--- a/dashboard/mining_dashboard/web/static/components.mjs
+++ b/dashboard/mining_dashboard/web/static/components.mjs
@@ -39,6 +39,7 @@ import { MineCartTrain } from "./minecart.mjs";
 import { OsUpdateControl, OsVerdictBanner } from "./osupdate.mjs";
 import { Component, Fragment, html } from "./preact.mjs";
 import { SecurityPanel } from "./securityview.mjs";
+import { MoreStats, StatCard, TariStatus } from "./statcards.mjs";
 import { StackTopology } from "./topology.mjs";
 import { WorkerInspect } from "./workerview.mjs";
 
@@ -46,12 +47,6 @@ import { WorkerInspect } from "./workerview.mjs";
 const cVar = (v) => "c-" + v;
 
 // --- Small shared pieces -------------------------------------------------------------
-
-const StatCard = ({ label, value, cls, span, title }) => html`
-    <div class=${"stat-card" + (span ? " col-span-2" : "")} title=${title || ""}>
-        <h5>${label}</h5>
-        <p class=${cls || ""}>${value}</p>
-    </div>`;
 
 // Standardized Day/Month/Year estimate table — the one shape every earnings tab presents its
 // estimate in: coin column in accent, a ≈-fiat column appearing once the coin's price is known
@@ -97,51 +92,6 @@ const SharesStat = ({ sw, label = "Share in Window" }) => html`
         <h5>${label}</h5>
         <p><span class=${sw.ok ? "status-ok" : "status-bad"}>${sw.count}</span></p>
     </div>`;
-
-// Progressive disclosure for a busy stat-grid card ("show more" pattern). A card splits its
-// StatCards into `headline` (always visible — the figures an operator actually glances at) and
-// `detail` (behind the toggle, collapsed by default); both share one `stat-grid` so the layout is
-// identical to the old flat list once expanded. Expansion is persisted per card via
-// loadPref/savePref — the same helpers dashboardEarningsTab already uses — keyed on `prefKey` so
-// each card remembers its own state independently across a reload. The toggle is a real <button>
-// with aria-expanded (not <details>/<summary>): that keeps the expanded/collapsed state explicit
-// for assistive tech and gives the label control ("Show all (N)") the native disclosure triangle
-// doesn't.
-const EXPAND_STATES = ["expanded", "collapsed"];
-class MoreStats extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { expanded: loadPref(props.prefKey, EXPAND_STATES, "collapsed") === "expanded" };
-    this.toggle = () => {
-      const expanded = !this.state.expanded;
-      savePref(this.props.prefKey, expanded ? "expanded" : "collapsed");
-      this.setState({ expanded });
-    };
-  }
-
-  render() {
-    const { headline, detail, count } = this.props;
-    const { expanded } = this.state;
-    return html`
-        <div class="stat-grid">
-            ${headline}
-            ${expanded ? detail : null}
-        </div>
-        <button type="button" class="more-stats-toggle" aria-expanded=${expanded ? "true" : "false"}
-                onClick=${this.toggle}>
-            ${expanded ? "Show less ▴" : `Show all (${count}) ▾`}
-        </button>`;
-  }
-}
-
-// Tari merge-mine status. The ✔ means the gRPC channel is actually up, so it's gated on `connected`
-// (channel_state READY) — NOT on `active` (a chain is merely configured). When configured but the
-// channel is down (e.g. TRANSIENT_FAILURE) we show the raw state in a warn style and no ✔, so a dead
-// channel can never read as "TRANSIENT_FAILURE ✔".
-const TariStatus = ({ tari }) => html`
-    <p class=${tari.connected ? "status-ok" : tari.active ? "status-warn" : ""}>
-        ${tari.status}${tari.connected ? html` <span class="check-inline">✔</span>` : null}
-    </p>`;
 
 const Badges = ({ badges }) => html`
     <div class="badge-row">

--- a/dashboard/mining_dashboard/web/static/components.mjs
+++ b/dashboard/mining_dashboard/web/static/components.mjs
@@ -39,7 +39,7 @@ import { MineCartTrain } from "./minecart.mjs";
 import { OsUpdateControl, OsVerdictBanner } from "./osupdate.mjs";
 import { Component, Fragment, html } from "./preact.mjs";
 import { SecurityPanel } from "./securityview.mjs";
-import { MoreStats, StatCard, TariStatus } from "./statcards.mjs";
+import { MoreStats, nodeLocation, StatCard, TariStatus } from "./statcards.mjs";
 import { StackTopology } from "./topology.mjs";
 import { WorkerInspect } from "./workerview.mjs";
 
@@ -441,6 +441,8 @@ function NetworkCard({ state }) {
             <${StatCard} label="Difficulty" value=${n.diff} />
             <${StatCard} label="Reward" value=${n.reward} />`;
   const detail = html`
+            <${StatCard} label="Node" value=${nodeLocation(state.sync?.monero?.local)}
+                title="Whether this stack runs its own monerod or points at somebody else's" />
             <${StatCard} label="Node Mode" value=${m.mode} />
             <${StatCard} label="DB Size" value=${m.db_size} />
             <div class="stat-card col-span-2"><h5>Current Block Hash</h5><p class="font-mono text-xs">${n.hash}</p></div>
@@ -448,7 +450,7 @@ function NetworkCard({ state }) {
   return html`
     <div class="card card-advanced" id="card-network">
         <h3>XMR Network</h3>
-        <${MoreStats} prefKey="dashboardCardNetwork" headline=${headline} detail=${detail} count=${7} />
+        <${MoreStats} prefKey="dashboardCardNetwork" headline=${headline} detail=${detail} count=${8} />
     </div>`;
 }
 
@@ -1009,7 +1011,7 @@ function CadenceCard({ cadence }) {
     </div>`;
 }
 
-function TariCard({ tari }) {
+function TariCard({ tari, local }) {
   return html`
     <div class="card card-advanced" id="card-tari">
         <h3>Tari Merge-Mining</h3>
@@ -1018,6 +1020,8 @@ function TariCard({ tari }) {
             <${StatCard} label="Reward" value=${tari.reward} />
             <${StatCard} label="Height" value=${tari.height} />
             <${StatCard} label="Difficulty" value=${tari.diff} />
+            <${StatCard} label="Node" value=${nodeLocation(local)}
+                title="Whether this stack runs its own Tari base node or points at somebody else's" />
         </div>
         <div class="wallet-text">Wallet: ${tari.wallet}</div>
     </div>`;
@@ -1278,7 +1282,7 @@ function DashboardView({
             <${EarningsCard} earnings=${state.earnings} xvb=${state.xvb_calc} energy=${state.energy} />
             <${NodeStats} state=${state} />
             <${ExpectedVsActualCard} summary=${state.earnings_summary} />
-            <${TariCard} tari=${state.tari} />
+            <${TariCard} tari=${state.tari} local=${state.sync?.tari?.local} />
             <${CadenceCard} cadence=${state.cadence} />
         </div>
         <div class="grid-section-label">The Wider Pool</div>

--- a/dashboard/mining_dashboard/web/static/statcards.mjs
+++ b/dashboard/mining_dashboard/web/static/statcards.mjs
@@ -1,0 +1,59 @@
+// The shared stat-card primitives every dashboard card is built from: one stat cell, the
+// progressive-disclosure wrapper that splits a busy card into headline + detail, and the Tari
+// merge-mine status line. Split out of components.mjs (#1040) because that file sits at its
+// file-budget ceiling and these three are the pieces with no dependency back on it — the import
+// runs one way, leaf to hub, like chart.mjs and topology.mjs already do.
+
+import { loadPref, savePref } from "./logic.mjs";
+import { Component, html } from "./preact.mjs";
+
+export const StatCard = ({ label, value, cls, span, title }) => html`
+    <div class=${"stat-card" + (span ? " col-span-2" : "")} title=${title || ""}>
+        <h5>${label}</h5>
+        <p class=${cls || ""}>${value}</p>
+    </div>`;
+
+// Progressive disclosure for a busy stat-grid card ("show more" pattern). A card splits its
+// StatCards into `headline` (always visible — the figures an operator actually glances at) and
+// `detail` (behind the toggle, collapsed by default); both share one `stat-grid` so the layout is
+// identical to the old flat list once expanded. Expansion is persisted per card via
+// loadPref/savePref — the same helpers dashboardEarningsTab already uses — keyed on `prefKey` so
+// each card remembers its own state independently across a reload. The toggle is a real <button>
+// with aria-expanded (not <details>/<summary>): that keeps the expanded/collapsed state explicit
+// for assistive tech and gives the label control ("Show all (N)") the native disclosure triangle
+// doesn't.
+const EXPAND_STATES = ["expanded", "collapsed"];
+export class MoreStats extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { expanded: loadPref(props.prefKey, EXPAND_STATES, "collapsed") === "expanded" };
+    this.toggle = () => {
+      const expanded = !this.state.expanded;
+      savePref(this.props.prefKey, expanded ? "expanded" : "collapsed");
+      this.setState({ expanded });
+    };
+  }
+
+  render() {
+    const { headline, detail, count } = this.props;
+    const { expanded } = this.state;
+    return html`
+        <div class="stat-grid">
+            ${headline}
+            ${expanded ? detail : null}
+        </div>
+        <button type="button" class="more-stats-toggle" aria-expanded=${expanded ? "true" : "false"}
+                onClick=${this.toggle}>
+            ${expanded ? "Show less ▴" : `Show all (${count}) ▾`}
+        </button>`;
+  }
+}
+
+// Tari merge-mine status. The ✔ means the gRPC channel is actually up, so it's gated on `connected`
+// (channel_state READY) — NOT on `active` (a chain is merely configured). When configured but the
+// channel is down (e.g. TRANSIENT_FAILURE) we show the raw state in a warn style and no ✔, so a dead
+// channel can never read as "TRANSIENT_FAILURE ✔".
+export const TariStatus = ({ tari }) => html`
+    <p class=${tari.connected ? "status-ok" : tari.active ? "status-warn" : ""}>
+        ${tari.status}${tari.connected ? html` <span class="check-inline">✔</span>` : null}
+    </p>`;

--- a/dashboard/mining_dashboard/web/static/statcards.mjs
+++ b/dashboard/mining_dashboard/web/static/statcards.mjs
@@ -57,3 +57,10 @@ export const TariStatus = ({ tari }) => html`
     <p class=${tari.connected ? "status-ok" : tari.active ? "status-warn" : ""}>
         ${tari.status}${tari.connected ? html` <span class="check-inline">✔</span>` : null}
     </p>`;
+
+// Local vs remote for the two nodes an operator can run somewhere else (#1040). A remote node's
+// health is not theirs to fix, which is the whole reason a card has to say which it is. An absent
+// flag is a payload from before this shipped, NOT a location, so it reads as unknown rather than
+// quietly claiming "Local" — the one answer that would send someone to the wrong machine.
+export const nodeLocation = (local) =>
+  local === true ? "Local" : local === false ? "Remote" : "—";

--- a/dashboard/mining_dashboard/web/static/topology.mjs
+++ b/dashboard/mining_dashboard/web/static/topology.mjs
@@ -7,7 +7,7 @@
 // this file is presentation only — it carries no routing logic of its own (the #61 principle).
 
 import { boxAnchor, loadPref, savePref } from "./logic.mjs";
-import { Component, html } from "./preact.mjs";
+import { Component, Fragment, html } from "./preact.mjs";
 
 // Fixed layout — the stack is a known, fixed set of components, so positions are hand-placed
 // (left→right by trust: your LAN, the host bridge, the Tor hub, the internet) rather than solved.
@@ -113,11 +113,20 @@ export class StackTopology extends Component {
           ${nodes.map((n) => {
             const p = POS[n.id];
             if (!p) return null;
+            // #1040: monerod and tari are the only nodes an operator can run elsewhere, so only
+            // they carry `remote` and only they get a location caption. It rides as a SIBLING of
+            // the node group, not a child: `.topo-node text` outranks `.topo-zone`, so a caption
+            // inside the group would silently render as a second full-size label.
+            const loc = n.remote === true ? "remote" : n.remote === false ? "local" : null;
+            const cx = p.x + p.w / 2;
             return html`
-              <g class=${nodeCls(n.zone)}>
-                <rect x=${p.x} y=${p.y} width=${p.w} height=${p.h} rx="6" />
-                <text x=${p.x + p.w / 2} y=${p.y + p.h / 2 + 4} text-anchor="middle">${n.label}</text>
-              </g>`;
+              <${Fragment}>
+                <g class=${nodeCls(n.zone)}>
+                  <rect x=${p.x} y=${p.y} width=${p.w} height=${p.h} rx="6" />
+                  <text x=${cx} y=${loc ? p.y + 14 : p.y + p.h / 2 + 4} text-anchor="middle">${n.label}</text>
+                </g>
+                ${loc && html`<text x=${cx} y=${p.y + 26} class="topo-zone">${loc}</text>`}
+              <//>`;
           })}
         </svg>
       </div>`;

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -1243,10 +1243,10 @@ def build_sync(metrics, monero_db_size):
             out.update(extra)
         return out
 
-    return {
-        "monero": section(metrics.monero, {"mode": metrics.monero_mode, "db_size": monero_db_size}),
-        "tari": section(metrics.tari),
-    }
+    # `local` (#1040) lives here: sync.* is the only per-node block covering BOTH chains.
+    mono = {"mode": metrics.monero_mode, "db_size": monero_db_size, "local": metrics.monero_local}
+    tari = {"local": metrics.tari_local}
+    return {"monero": section(metrics.monero, mono), "tari": section(metrics.tari, tari)}
 
 
 # How long the "payout wallet changed" banner stays in the top bar after a change (#375).

--- a/dashboard/tests/frontend/components.test.mjs
+++ b/dashboard/tests/frontend/components.test.mjs
@@ -16,25 +16,7 @@ import { App } from '../../mining_dashboard/web/static/components.mjs';
 import { WORKER_COLUMNS } from '../../mining_dashboard/web/static/logic.mjs';
 import { StatsTable } from '../../mining_dashboard/web/static/workerview.mjs';
 import { render } from './helpers/render.mjs';
-
-const BASE = JSON.parse(readFileSync(new URL('./fixtures/state.json', import.meta.url)));
-const clone = () => structuredClone(BASE);
-
-// Default client UI state; the handlers are no-ops (the renderer never invokes them).
-const UI = {
-    view: 'advanced', range: 'all', window: null, series: {}, avg: '10m',
-    theme: 'auto', sortIndex: null, sortAsc: true,
-};
-const noop = () => {};
-const HANDLERS = {
-    onRange: noop, onSort: noop, onView: noop, onTheme: noop,
-    onZoom: noop, onResetZoom: noop, onToggleSeries: noop, onAvgWindow: noop,
-    onDismissHint: noop, onInspect: noop, onCloseInspect: noop,
-};
-
-function renderApp({ state = BASE, connected = true, ui = UI } = {}) {
-    return render(App, { state, connected, ui, ...HANDLERS });
-}
+import { cardSlice, clone, renderApp, UI } from './harness.mjs';
 
 // --- App shell / connection states -----------------------------------------------------
 
@@ -137,14 +119,6 @@ test('operational App renders the remaining advanced cards', () => {
 // until toggled. Several sibling cards reuse the same labels (Overview and My P2Pool Node Stats
 // both have a "Mining Mode" stat, for instance), so `cardSlice` scopes assertions to one card's
 // own markup — from its id up to the next card's id — rather than matching against the whole page.
-function cardSlice(html, id) {
-    const marker = `id="${id}"`;
-    const start = html.indexOf(marker);
-    assert.notEqual(start, -1, `missing ${id}`);
-    const next = html.indexOf('id="card-', start + marker.length);
-    return next === -1 ? html.slice(start) : html.slice(start, next);
-}
-
 test('Global P2Pool Stats collapses to the headline stats by default (progressive disclosure)', () => {
     const card = cardSlice(renderApp(), 'card-global');
     // Headline: the pool's own money/health figures.
@@ -185,7 +159,7 @@ test('XMR Network collapses to the headline stats by default', () => {
     assert.doesNotMatch(card, /Current Block Hash/);
     assert.doesNotMatch(card, /Network Time/);
     assert.match(card, /class="more-stats-toggle" aria-expanded="false"/);
-    assert.match(card, /Show all \(7\)/);
+    assert.match(card, /Show all \(8\)/); // 7 + the node's local/remote location (#1040)
 });
 
 test('MoreStats expands to show every stat when toggled, and persists the choice per card, independently of siblings', () => {

--- a/dashboard/tests/frontend/fixtures/state.json
+++ b/dashboard/tests/frontend/fixtures/state.json
@@ -373,7 +373,8 @@
     "monero": {
       "current": 3000000,
       "db_size": "\u2014",
-      "mode": "Pruned",
+      "local": true,
+    "mode": "Pruned",
       "percent": 100,
       "remaining": 0,
       "state": "done",
@@ -381,7 +382,8 @@
     },
     "tari": {
       "current": 50000,
-      "percent": 100,
+      "local": true,
+    "percent": 100,
       "remaining": 0,
       "state": "done",
       "target": 50000
@@ -616,12 +618,14 @@
       {
         "id": "monerod",
         "label": "monerod",
-        "zone": "host"
+        "remote": false,
+          "zone": "host"
       },
       {
         "id": "tari",
         "label": "tari",
-        "zone": "host"
+        "remote": false,
+          "zone": "host"
       },
       {
         "id": "docker",

--- a/dashboard/tests/frontend/harness.mjs
+++ b/dashboard/tests/frontend/harness.mjs
@@ -1,0 +1,45 @@
+// The shared render harness for the frontend render tests. components.mjs exports only the App
+// root by design, so every card is driven THROUGH App with a real build_state() payload
+// (fixtures/state.json, regenerate with fixtures/_gen_state.py) — the components are therefore
+// exercised against the true server contract. Rendering uses a dependency-free vnode walker
+// (helpers/render.mjs): no DOM, no npm deps.
+//
+// Split out of components.test.mjs so a second render test file can use it without duplicating a
+// fixture and a handler table, and because that file is at its file-budget ceiling.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { App } from '../../mining_dashboard/web/static/components.mjs';
+import { render } from './helpers/render.mjs';
+
+const BASE = JSON.parse(readFileSync(new URL('./fixtures/state.json', import.meta.url)));
+const clone = () => structuredClone(BASE);
+
+// Default client UI state; the handlers are no-ops (the renderer never invokes them).
+const UI = {
+    view: 'advanced', range: 'all', window: null, series: {}, avg: '10m',
+    theme: 'auto', sortIndex: null, sortAsc: true,
+};
+const noop = () => {};
+const HANDLERS = {
+    onRange: noop, onSort: noop, onView: noop, onTheme: noop,
+    onZoom: noop, onResetZoom: noop, onToggleSeries: noop, onAvgWindow: noop,
+    onDismissHint: noop, onInspect: noop, onCloseInspect: noop,
+};
+
+function renderApp({ state = BASE, connected = true, ui = UI } = {}) {
+    return render(App, { state, connected, ui, ...HANDLERS });
+}
+
+export { BASE, clone, renderApp, UI };
+
+// One card's slice of the rendered HTML, so an assertion cannot accidentally match a sibling card.
+function cardSlice(html, id) {
+    const marker = `id="${id}"`;
+    const start = html.indexOf(marker);
+    assert.notEqual(start, -1, `missing ${id}`);
+    const next = html.indexOf('id="card-', start + marker.length);
+    return next === -1 ? html.slice(start) : html.slice(start, next);
+}
+
+export { cardSlice };

--- a/dashboard/tests/frontend/nodelocation.test.mjs
+++ b/dashboard/tests/frontend/nodelocation.test.mjs
@@ -1,0 +1,60 @@
+// Does the dashboard say whether each node runs here or somewhere else (#1040)?
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// The label mapping itself lives in statcards.test.mjs; these cover the WIRING — that each card
+// and the diagram read the right node's flag — which only a render can prove. New file:
+// components.test.mjs is at its file-budget ceiling.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { cardSlice, clone, renderApp } from './harness.mjs';
+
+test('both node cards say whether the node is this machine\'s or somebody else\'s (#1040)', () => {
+    // The wiring, not the mapping (statcards.test.mjs covers that): each card must read its OWN
+    // node's flag out of sync.*, so a remote Tari can never be reported using Monero's answer.
+    const s = clone();
+    s.sync.monero.local = true;
+    s.sync.tari.local = false;
+    const tari = cardSlice(renderApp({ state: s }), 'card-tari');
+    assert.match(tari, /<h5>Node<\/h5><p class="">Remote</);
+
+    s.sync.tari.local = true;
+    assert.match(cardSlice(renderApp({ state: s }), 'card-tari'), /<h5>Node<\/h5><p class="">Local</);
+
+    // An older payload with no flag must not read as Local — see statcards.test.mjs for why.
+    delete s.sync.tari.local;
+    assert.match(cardSlice(renderApp({ state: s }), 'card-tari'), /<h5>Node<\/h5><p class="">—</);
+});
+
+test('the XMR Network card reads Monero\'s own location, not Tari\'s (#1040)', () => {
+    const store = new Map([['dashboardCardNetwork', 'expanded']]);
+    globalThis.localStorage = {
+        getItem: (k) => (store.has(k) ? store.get(k) : null),
+        setItem: (k, v) => store.set(k, String(v)),
+    };
+    try {
+        const s = clone();
+        s.sync.monero.local = false;
+        s.sync.tari.local = true; // the wrong source would flip this assertion
+        assert.match(cardSlice(renderApp({ state: s }), 'card-network'), /<h5>Node<\/h5><p class="">Remote</);
+    } finally {
+        delete globalThis.localStorage;
+    }
+});
+
+test('the diagram captions the two relocatable nodes with their location (#1040)', () => {
+    // The issue: the picture implied everything ran on this box. The caption rides as a SIBLING
+    // of the node group because `.topo-node text` outranks `.topo-zone` — inside the group it
+    // would render as a second full-size label, which is why this asserts the class, not just
+    // the word.
+    const s = clone();
+    s.topology.nodes = s.topology.nodes.map((n) => (n.id === 'tari' ? { ...n, remote: true } : n));
+    const html = renderApp({ state: s });
+    assert.match(html, /class="topo-zone">remote</);
+    assert.match(html, /class="topo-zone">local</);
+    // Nodes that cannot move carry no location at all — no caption, no empty one.
+    const captions = html.match(/class="topo-zone">(local|remote)</g) || [];
+    assert.equal(captions.length, 2, 'only monerod and tari may carry a location');
+});

--- a/dashboard/tests/frontend/statcards.test.mjs
+++ b/dashboard/tests/frontend/statcards.test.mjs
@@ -1,0 +1,25 @@
+// Unit tests for the shared stat-card primitives (mining_dashboard/web/static/statcards.mjs).
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// Only the pure pieces live here; the components themselves are exercised through the rendered
+// app in components.test.mjs, which is the lowest tier that proves they are actually wired up.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { nodeLocation } from "../../mining_dashboard/web/static/statcards.mjs";
+
+test("nodeLocation names each node local or remote (#1040)", () => {
+  assert.equal(nodeLocation(true), "Local");
+  assert.equal(nodeLocation(false), "Remote");
+});
+
+test("nodeLocation never guesses Local when the payload does not say (#1040)", () => {
+  // A dashboard serving a payload from before this shipped has no `local` key. "Local" is the one
+  // answer that would send an operator to the wrong machine to fix a node that is not theirs, so
+  // an absent or unusable flag must read as unknown rather than as the common case.
+  for (const missing of [undefined, null, "", 0, "true", 1]) {
+    assert.equal(nodeLocation(missing), "—", `${JSON.stringify(missing)} must not read as a location`);
+  }
+});

--- a/dashboard/tests/service/test_topology_graph.py
+++ b/dashboard/tests/service/test_topology_graph.py
@@ -1,0 +1,47 @@
+"""The topology graph's node list and its local/remote marking (#1040).
+
+New file: egress.py's own test module is at its file-budget ceiling, and this covers the piece
+split out of it — the graph as data, plus the per-request marking of which nodes are this
+machine's own.
+"""
+
+from mining_dashboard.service import egress
+from mining_dashboard.service.topology_graph import TOPOLOGY_NODES, topology_nodes
+
+_COMBOS = ((False, False), (True, False), (False, True), (True, True))
+
+
+def test_only_the_relocatable_nodes_carry_a_location():
+    # monerod and tari are the only nodes an operator can run somewhere else. Every other node is
+    # always this machine's own, so it carries no `remote` key at all — the diagram then has one
+    # thing to draw rather than a redundant "local" on nine boxes it would have to skip.
+    #
+    # The mixed rows are the point: the failure that matters is not a missing flag, it is one node
+    # reported using the OTHER node's answer, which sends an operator to the wrong machine.
+    for mono, tari in _COMBOS:
+        nodes = {n["id"]: n for n in topology_nodes(remote_monero=mono, remote_tari=tari)}
+        assert nodes["monerod"]["remote"] is mono, (mono, tari)
+        assert nodes["tari"]["remote"] is tari, (mono, tari)
+        assert sorted(i for i, n in nodes.items() if "remote" in n) == ["monerod", "tari"]
+
+
+def test_marking_never_mutates_the_shared_node_list():
+    # The node list is a module-level constant and the graph is rebuilt per request: marking it in
+    # place would leak one caller's topology into the next one's diagram.
+    for mono, tari in _COMBOS:
+        topology_nodes(remote_monero=mono, remote_tari=tari)
+    assert all("remote" not in n for n in TOPOLOGY_NODES)
+
+
+def test_the_served_graph_carries_each_node_s_real_location(monkeypatch):
+    # compute_topology defaults remote_tari, so a signature alone would not catch topology_from_config
+    # forgetting to pass it — the diagram would then call every Tari node local, forever and quietly.
+    # Both helpers are given different answers so a swapped wire-up fails too.
+    # Tari must come out REMOTE here. remote_tari defaults to False, so asserting a local Tari
+    # would pass whether or not the value was ever passed — the assertion has to differ from the
+    # default to mean anything. Monero is given the opposite answer so a swapped wiring fails too.
+    monkeypatch.setattr(egress.config, "monero_is_local", lambda: True)
+    monkeypatch.setattr(egress.config, "tari_is_local", lambda: False)
+    nodes = {n["id"]: n for n in egress.topology_from_config()["nodes"]}
+    assert nodes["monerod"]["remote"] is False
+    assert nodes["tari"]["remote"] is True

--- a/dashboard/tests/web/test_node_location.py
+++ b/dashboard/tests/web/test_node_location.py
@@ -1,0 +1,65 @@
+"""Local vs remote for the Monero and Tari nodes (#1040).
+
+The two nodes an operator can run either on this machine or somebody else's. A remote node's
+health is not theirs to fix, so the dashboard has to say which it is looking at — the diagram and
+both node cards read it from ``/api/state``'s ``sync`` block, the only per-node block that covers
+BOTH chains (``state.monero`` has no Tari twin).
+
+New file: test_views.py is at its file-budget ceiling.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mining_dashboard.service import metrics as metrics_mod
+from mining_dashboard.service.metrics import SyncMetric
+from mining_dashboard.web.views import build_sync
+
+_SYNCED = SyncMetric(
+    percent=100, current=10, target=10, remaining=0, has_target=True, done=True, down=False
+)
+
+
+def _sync(*, monero_local, tari_local):
+    metrics = SimpleNamespace(
+        monero=_SYNCED,
+        tari=_SYNCED,
+        monero_mode="Pruned",
+        monero_local=monero_local,
+        tari_local=tari_local,
+    )
+    return build_sync(metrics, "85.0 GB")
+
+
+def test_each_node_carries_its_own_location():
+    # Asserted as a matrix rather than one happy case: the failure that matters is not "no flag",
+    # it is one node reported using the OTHER node's answer, which sends an operator to the wrong
+    # machine. Only the mixed rows can catch that.
+    for monero_local, tari_local in ((True, True), (True, False), (False, True), (False, False)):
+        out = _sync(monero_local=monero_local, tari_local=tari_local)
+        assert out["monero"]["local"] is monero_local, (monero_local, tari_local)
+        assert out["tari"]["local"] is tari_local, (monero_local, tari_local)
+
+
+def test_the_location_rides_alongside_the_existing_sync_fields():
+    # It is added to the per-node block, not swapped in for it: the gauge still needs its state.
+    out = _sync(monero_local=False, tari_local=True)
+    assert out["monero"]["mode"] == "Pruned"
+    assert out["monero"]["db_size"] == "85.0 GB"
+    for node in ("monero", "tari"):
+        assert out[node]["state"] == "done"
+        assert out[node]["percent"] == 100
+
+
+def test_build_metrics_reads_each_node_from_its_own_config_helper(monkeypatch):
+    # The wiring at the source. A swap here — monero_local fed by the Tari helper or vice versa —
+    # produces a payload that is well-formed and confidently wrong, and every check downstream of
+    # it would still pass. So the two helpers are given DIFFERENT answers on purpose.
+    monkeypatch.setattr(metrics_mod, "monero_is_local", lambda: False)
+    monkeypatch.setattr(metrics_mod, "tari_is_local", lambda: True)
+    mgr = MagicMock()
+    mgr.get_history.return_value = []
+    mgr.get_xvb_stats.return_value = {"current_mode": "P2POOL"}
+    m = metrics_mod.build_metrics({"shares": [], "workers": []}, mgr)
+    assert m.monero_local is False
+    assert m.tari_local is True

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -466,6 +466,14 @@ detail: **My P2Pool Node Stats**, **Global P2Pool Stats**, **XvB Donation Stats*
 **P2Pool Earnings (estimated)** calculator below. The
 expected-vs-actual table stays in both views. The choice is remembered across reloads.
 
+**XMR Network** and **Tari Merge-Mining** each carry a **Node** row saying whether that node runs
+here or somewhere else, and the **Stack Topology & Egress** diagram captions `monerod` and `tari`
+the same way. The difference is operational: a node you run is yours to restart and resync, and a
+node you point at (`monero.mode: remote`, `tari.mode: remote`) is somebody else's to fix, so it is
+the first thing worth knowing when one stalls. It also makes the remote-node setting visible
+without opening `config.json`. A row reads `—` when the dashboard cannot tell — a payload from
+before this shipped, rather than a node it has decided is local.
+
 The what-if earnings calculator and the XvB tier calculator live only in Advanced view. Simple view
 shows a one-time banner pointing there; it goes away once you dismiss it or open Advanced view, and
 stays away across reloads.

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -6,13 +6,13 @@ dashboard/mining_dashboard/service/alert_service.py	928
 dashboard/mining_dashboard/service/algo_service.py	558
 dashboard/mining_dashboard/service/control_service.py	414
 dashboard/mining_dashboard/service/data_service.py	1852
-dashboard/mining_dashboard/service/egress.py	435
+dashboard/mining_dashboard/service/egress.py	424
 dashboard/mining_dashboard/service/storage_service.py	1603
 dashboard/mining_dashboard/service/telegram_commands.py	1023
 dashboard/mining_dashboard/sim/donation_model.py	539
 dashboard/mining_dashboard/web/server.py	645
 dashboard/mining_dashboard/web/static/chart.mjs	681
-dashboard/mining_dashboard/web/static/components.mjs	1400
+dashboard/mining_dashboard/web/static/components.mjs	1354
 dashboard/mining_dashboard/web/static/configview.mjs	591
 dashboard/mining_dashboard/web/static/dashboard.css	1579
 dashboard/mining_dashboard/web/static/logic.mjs	609
@@ -23,7 +23,7 @@ dashboard/mining_dashboard/web/views.py	2339
 dashboard/mining_dashboard/wizard.py	674
 dashboard/tests/client/test_xmrig_client.py	537
 dashboard/tests/config/test_config.py	458
-dashboard/tests/frontend/components.test.mjs	1219
+dashboard/tests/frontend/components.test.mjs	1193
 dashboard/tests/frontend/configview.test.mjs	492
 dashboard/tests/frontend/logic.test.mjs	836
 dashboard/tests/frontend/wizard.test.mjs	765


### PR DESCRIPTION
Closes #1040.

## What the operator gets

The stack can run its Monero and Tari nodes here, or point at a third-party or fleet-shared node.
The dashboard rendered the two identically, so the only way to tell was to read `config.json`.

That is not cosmetic. A node you run is yours to restart and resync; a node you point at is
somebody else's to fix. It is the first thing worth knowing when one stalls.

Both places the issue asks for:

- **The diagram** captions `monerod` and `tari` local or remote.
- **Both node cards** carry a **Node** row saying the same thing.

Only those two nodes carry a location. Every other node in the graph is always this machine's own,
so it gets no caption rather than a redundant "local" on nine boxes the renderer would then have to
decide not to draw.

An absent flag renders `—`, never `Local`. A payload from before this shipped is not a location,
and `Local` is the one answer that would send someone to the wrong machine to fix a node that is
not theirs.

## Where the data comes from

The locality is not new: `config.monero_is_local()` and `tari_is_local()` already exist and already
drive real behaviour (RAM budgeting, and whether the stack scrapes logs or probes RPC). This change
only carries them to the browser. Verified they are sound for every rendered config — `pithead`
renders a local Tari as an address on the same bridge prefix as `LOCAL_MONERO_HOST`, and a remote
one as the operator's own host, so a false "local" would need a remote node placed inside the
operator's own docker bridge subnet.

Probed the edges directly rather than reasoning about them: the bare-compose fallback and both
remote shapes (hostname and IP) all answer correctly. The one wrong answer is an **unset**
`TARI_GRPC_ADDRESS`, whose module default is `127.0.0.1` and so reads as Remote — reachable only
by running the dashboard outside compose, since compose's own fallback sits on the bridge and
`pithead` always renders the value explicitly. No rendered config hits it.

`local` rides in `sync.{monero,tari}` because that is the only per-node block `/api/state` carries
for **both** chains — `state.monero` has no Tari twin.

## The file-budget ratchet shaped this PR

Four of the files this touches sat exactly at their ceiling (`config.py`, `views.py`, `egress.py`,
`components.mjs`), as did `dashboard.css`, `logic.mjs`, `test_views.py`, `test_metrics.py`,
`components.test.mjs` and `test_egress.py`. Ceilings only go down, so the gate's own answer is to
make the files smaller. The first commit does that and is **relocations only**:

| new file | from | why it is a clean cut |
|---|---|---|
| `static/statcards.mjs` | `components.mjs` | `StatCard`/`MoreStats`/`TariStatus` are leaves; the import runs one way, like `chart.mjs` already does |
| `service/topology_graph.py` | `egress.py` | the zones and node list are data, not logic; `egress` re-exports `TOPOLOGY_NODES` so every importer is untouched |
| `tests/frontend/harness.mjs` | `components.test.mjs` | the render harness, so a second render-test file needs no duplicated fixture |

Net effect on the ratchet — three ceilings **lowered**, none raised:

| file | ceiling before | after |
|---|---|---|
| `components.mjs` | 1400 | 1354 |
| `egress.py` | 435 | 424 |
| `components.test.mjs` | 1219 | 1193 |

`views.py` lands back at exactly 2339, its unchanged ceiling. New tests went into new files rather
than growing the two maxed test modules. No CSS was added: the caption reuses `.topo-zone`.

One rendering detail worth knowing, because it is invisible until it bites: the caption is a
**sibling** of the node `<g>`, not a child. `.topo-node text` (0,1,1) outranks `.topo-zone` (0,1,0),
so inside the group the caption would silently have rendered as a second full-size label. The test
asserts the class, not just the word.

## Deliberately not included — filed as #1350

Three edges (`dashboard`→`monerod`, `p2pool`→`tari`, `dashboard`→`tari`) are hardcoded `LOCAL` even
when the far node is remote, while `p2pool`→`monerod` already models it. Making them honest means
flipping them to `CLEARNET` — and the same edge list feeds the egress posture, whose tagging loop
treats a clearnet link from the host-networked dashboard as a **real leak**. Every remote-node
operator would start seeing a leak reported.

That may be the right answer, but a remote node one hop away on the operator's own switch is not
the same exposure as one across the internet, and the route model has no state that says so. It
wants deciding, not bundling. This is also why `compute_topology` **defaults** `remote_tari` rather
than requiring it — and why a test asserts `topology_from_config` actually passes it, instead of
trusting the signature to enforce a wire-up it no longer can.

## Out of lane, disclosed

`docs/dashboard.md`, via a one-shot `.lane-override` (the guard consumed it). At commit time no
role owned `docs/` at all, so there was no session to ask, while the standing bar requires docs to
ship with the change — a gap whose failure mode is quiet: a lane hits the guard, drops the doc
rather than argue with it, and the docs rot while every PR still reads as compliant.

Raised with the controller, who has since put `docs/` into `_shared.paths`, so later changes will
not need the override. The commit here predates that and keeps its disclosure. Its only out-of-lane
file is that one doc.

## What was run

- `node --test dashboard/tests/frontend/` — 457 pass, 0 fail
- the dashboard python suite — exit 0, no failures or errors
- `make lint-py`, `lint-js`, `lint-topology`, `lint-md`, `lint-docs-voice`,
  `scripts/lint-operator-strings.sh`, `scripts/lint-file-budget.sh` — all clean

**Every new guard was confirmed to FAIL against the code as it stood**, not merely to pass against
the fix. Mutations run: marking removed; the shared node list mutated in place; the two config
helpers swapped; the `remote_tari` pass-through dropped; and each card reading the *other* node's
flag.

That last check earned its keep twice. The wire-up test was **defective on its first draft** — it
asserted a local Tari, which is also what `remote_tari`'s default produces, so it passed with the
pass-through deleted. It only became a real test once the expected value differed from the default.
A guard never seen to fail is a grep.

## What was NOT done

- **The diagram's caption geometry has not been looked at in a browser.** It is asserted
  structurally — the class, and that exactly two captions render — not visually. The numbers place
  both lines inside a 32px box, but that is arithmetic, not observation.
- No live rig, bench, or remote-node stack was exercised. A genuinely remote node has not been
  rendered; the remote path is proven by unit tests that inject the flag.