### PR TITLE
ci(trivy): pin both gate workflows' scanner engine on develop (#1290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,12 @@ jobs:
         # the repo's 10 GB Actions cache budget, which was 92% near-duplicate copies of this one DB.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Explicit on purpose (#1290): the action's own default engine moves whenever the action
+          # is bumped, so an unpinned step scans with whatever database that week's action resolved
+          # to. develop-v2 holds both gate workflows to one value with `make lint-trivy-parity`;
+          # that lint and the script it reads from live on that lane only, so on develop the pin is
+          # kept by hand.
+          version: v0.74.0
           image-ref: pithead-${{ matrix.service }}:ci
           scanners: vuln
           severity: HIGH,CRITICAL

--- a/.github/workflows/os-rootfs.yml
+++ b/.github/workflows/os-rootfs.yml
@@ -105,6 +105,12 @@ jobs:
         # kernel between releases, and since #1162 that eye is finally open on a schedule.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Explicit on purpose (#1290), and it matters more here than on ci.yml's step. The weekly
+          # rootfs sweep fires from the DEFAULT branch, so the scan that runs unattended reads THIS
+          # copy while every PR scan of the same rootfs reads develop-v2's, pinned since #1290. One
+          # artifact, two vulnerability databases, invisible from the Actions tab. Kept by hand:
+          # `make lint-trivy-parity` is develop-v2's.
+          version: v0.74.0
           image-ref: pithead-os-rootfs:ci
           scanners: vuln
           severity: HIGH,CRITICAL


### PR DESCRIPTION
Two `version:` lines and their comments. Nothing else.

## The finding

#1290 made `scripts/trivyignore-watch.sh`'s `TRIVY_VERSION` the one source of truth for the scanning engine, pinned both gate workflows to it, and held them there with `make lint-trivy-parity`. All of that landed on `develop-v2`. `develop` got none of it — measured, not read:

| branch | workflow | `version:` |
| --- | --- | --- |
| `origin/develop` | `ci.yml` | none |
| `origin/develop` | `os-rootfs.yml` | none |
| `origin/develop-v2` | `ci.yml` | `v0.74.0` |
| `origin/develop-v2` | `os-rootfs.yml` | `v0.74.0` |

Reproduce with:

```
for b in origin/develop origin/develop-v2; do for f in ci.yml os-rootfs.yml; do
  printf '%-20s %-16s ' "$b" "$f"
  git show $b:.github/workflows/$f | awk '/aquasecurity\/trivy-action@/{i=1} i&&/^[[:space:]]*version:/{print $2; f=1; exit} END{if(!f) print "NO PIN"}'
done; done
```

An unpinned step scans with whatever engine that week's action resolved to by default — `v0.70.0` at the pinned action sha, four minor releases behind what the watch scans with.

## `os-rootfs.yml` is the half that bites

Its weekly rootfs sweep fires from the **DEFAULT** branch, so **the unattended scan of the appliance's baked userland reads `develop`'s unpinned copy while every PR scan of that same artifact reads `develop-v2`'s pinned copy.** One artifact, two vulnerability databases, invisible from the Actions tab.

That is default-branch blindness and engine drift stacked on the one path nobody watches. It matters more here than on `ci.yml` because the appliance userland is frozen at bake time and has no apt at runtime — this sweep is the only eye on podman, netavark, openssl and the kernel between releases.

## Why a `develop`-targeted PR on a frozen branch

Lane-policy exception (b), and for the same reason the drift exists: these scans fire from the default branch, so `develop`'s copy is the one that runs unattended, and no `develop-v2` change can reach it.

## What is *not* fixed here

Nothing on `develop` guards these pins. `make lint-trivy-parity` and the script it reads from exist on `develop-v2` only, so a reviewer should not assume a gate is holding them — each comment says so in the file, so the next person does not have to work it out.

## Evidence

- `uvx yamllint` on both changed files — clean.
- `uvx zizmor@1.25.2 --offline .github/workflows/` — `No findings to report`.
- Both files parse (`yaml.safe_load`).
- Lane: both paths are inside `currency.paths`' named-file grant; the controller was told before either was staged.

## Over-engineering pass

One finding, addressed: the `os-rootfs.yml` comment ran to eight lines for a one-line change. Trimmed to five — the default-branch asymmetry is a fact that exists nowhere else in the tree and earns its space; the restatement of "kept by hand" that `ci.yml`'s comment already makes did not.
