### PR TITLE
ci(sweep): scan the images users run, not a rebuild of develop (#1313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,31 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-  # Weekly CVE sweep (#833): rebuild + Trivy-scan every image even when no PR is open, so a CVE
-  # disclosed during a quiet week — or fixed in the apt archive without a new base digest, which
-  # Dependabot never sees — surfaces here instead of reddening the next unrelated PR. Only
-  # `build-images` runs on the schedule (every other job gates on the event); the run going red
-  # in the Actions tab is the alert, the lychee.yml posture. Scheduled runs use the default
-  # branch (develop).
+  # Two Monday sweeps run off this schedule, answering two different questions. Every other job
+  # gates itself off the event, so only these two run.
+  #
+  #   build-images  (#833) rebuilds every image from THIS branch and scans the rebuild: does what
+  #                 we are about to ship carry a CVE? It is the only sweep that can go red before
+  #                 a release, and the run reddening in the Actions tab is its alert (the
+  #                 lychee.yml posture).
+  #   sweep-shipped (#1313) scans what users are already running — the published ghcr images from
+  #                 `main`, each tag resolved to a digest and the digest scanned as published. A
+  #                 rebuild structurally cannot answer that: it resolves apt at scan time, so it
+  #                 picks up archive fixes the published bytes never got and goes green while the
+  #                 shipped image is still vulnerable. It reports into a tracking issue instead of
+  #                 reddening, because "a shipped image has a fixable CVE" asks for a patch
+  #                 release, which is a decision a person makes.
+  #
+  # Scheduled runs use the default branch (develop).
   schedule:
     - cron: "0 5 * * 1" # Mondays 05:00 UTC
+    # TEMPORARY, and its own follow-up PR removes it the moment it has fired once (#1313). A
+    # `schedule:` is read from the DEFAULT branch only, and a workflow file that merely LOOKS
+    # right proves nothing about registration — #1048, #1064 and #1146 are all the same defect,
+    # a scheduled job that never ran and reported nothing while not running. The only proof is a
+    # run carrying `event: schedule`, and the weekly slot above cannot supply one inside a working
+    # session. This near-term daily slot does, then goes away. Same recipe as #1257's proof cron.
+    - cron: "30 3 * * *" # PROOF SLOT — removed once a scheduled run is on record
 
 # Least privilege (#282): every job here only reads the repo — none push commits, comment, or
 # publish packages. Narrowing the default GITHUB_TOKEN limits the blast radius of a compromised step.
@@ -134,6 +151,177 @@ jobs:
           exit-code: "1"
           trivyignores: .trivyignore
           cache: "false"
+
+  sweep-shipped:
+    # The half of the Monday sweep that reports on what users are running (#1313). `build-images`
+    # above scans a rebuild of this branch; this scans the bytes on the registry.
+    #
+    # Every leg resolves the published TAG to a DIGEST and scans the digest. That is not
+    # ceremony: a tag is a moving pointer, so "we scanned :v1.20.0" stops being a statement about
+    # any particular image the moment it moves, and the digest is the only reference that names
+    # the bytes a user pulled. The digest scanned is printed in the report.
+    #
+    # fail-fast: false so one unreachable image does not hide the other four — and a leg that
+    # fails still shows up, because the report job runs on `always()` and names any image it
+    # received no scan for as UNCHECKED rather than counting it as clean.
+    name: Shipped-image CVE sweep (${{ matrix.service }})
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monero, p2pool, tor, xmrig-proxy, dashboard]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve the shipped tag to a digest, and take main's own .trivyignore
+        id: shipped
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          set -Eeuo pipefail
+          # The scheduled run checks out develop. `main` is a different ref and a shallow clone
+          # does not carry it, so fetch it rather than assume it is here — since #1076 `main` is a
+          # fast-forward pointer to the released tag, and it is the only ref that knows what
+          # shipped.
+          git fetch --no-tags --depth=1 origin main
+          ver="$(git show origin/main:VERSION)"
+          [ -n "$ver" ] || { echo "::error::main carries no VERSION — cannot tell what shipped"; exit 1; }
+          tag="v$ver"
+          # main's OWN .trivyignore, never develop's. A mute added after the cut would otherwise
+          # silence a finding in an image whose review never saw that mute.
+          git show origin/main:.trivyignore >main.trivyignore
+          repo="p2pool-starter-stack/pithead-$SERVICE"
+          # The packages are public, so an anonymous pull token is enough — no registry secret
+          # enters this workflow.
+          token="$(curl -fsS "https://ghcr.io/token?scope=repository:$repo:pull" | jq -er .token)"
+          digest="$(curl -fsSI \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+            "https://ghcr.io/v2/$repo/manifests/$tag" |
+            tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }')"
+          # An unresolved digest must never fall through to a tag scan: the report would then say
+          # "shipped image" about bytes nobody can identify. Fail the leg instead and let it read
+          # UNCHECKED.
+          printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$' ||
+            { echo "::error::could not resolve ghcr.io/$repo:$tag to a digest — got [$digest]"; exit 1; }
+          echo "ref=ghcr.io/$repo@$digest" >>"$GITHUB_OUTPUT"
+          # The tag every leg swept, so the report can refuse to mix two releases if a cut lands
+          # mid-run.
+          printf '%s\n' "$tag" >"sweep-$SERVICE.tag"
+      - name: Scan the published image by digest (Trivy)
+        # Same scope as the gate above, and the same engine — but only because #1290's pin is on
+        # both steps. Read that as a dependency, not a coincidence: comparing this sweep's verdict
+        # against the rebuild's is the whole reason both exist, and two trivy releases apart is
+        # enough to make them disagree for reasons that have nothing to do with the images. If the
+        # step above ever loses its `version:`, this comparison stops meaning anything, and on
+        # develop no lint will say so (`make lint-trivy-parity` is develop-v2's).
+        #
+        # trivy pulls the digest from the registry itself — nothing is built here.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.74.0
+          image-ref: ${{ steps.shipped.outputs.ref }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          # Report-only, deliberately. A fixable CVE in an image that is already published cannot
+          # be fixed by failing this run; it asks for a patch release. The run goes red only when
+          # the sweep itself could not do its job, which the report job decides.
+          exit-code: "0"
+          trivyignores: main.trivyignore
+          cache: "false"
+          format: json
+          output: sweep-${{ matrix.service }}.json
+      - name: Upload this image's scan output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shipped-sweep-${{ matrix.service }}
+          path: |
+            sweep-${{ matrix.service }}.json
+            sweep-${{ matrix.service }}.tag
+          # An empty upload would reach the report job as a scan that found nothing, which is the
+          # one thing this must never say off a leg that did not scan.
+          if-no-files-found: error
+
+  sweep-shipped-report:
+    # One tracking issue, edited in place — the pin-watch.yml / trivyignore-watch.yml posture. An
+    # issue persists, is assignable, and lets a person write "held until the next cut, here's why"
+    # in a comment. A red square in the Actions tab cannot hold that, and this finding's whole
+    # value is the conversation about whether to cut a patch release.
+    name: Shipped-image CVE sweep — tracking issue
+    # always() so a failed scan leg still reports: an image with no scan output is UNCHECKED, and
+    # saying so is the entire point. Skipping the report on a partial sweep would leave the last
+    # good report standing as if it were current.
+    if: always() && github.event_name == 'schedule'
+    needs: sweep-shipped
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Least privilege (#282): issues.write is this job's one output — it never pushes or publishes.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Collect every leg's scan output
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: shipped-sweep-*
+          merge-multiple: true
+          path: shipped-sweep
+      - name: Render the report
+        id: report
+        run: |
+          set -uo pipefail
+          # NOT `set -e`: an incomplete sweep is a result to publish, not a reason to publish
+          # nothing. The script names the images it could not check and exits 1; the rc is
+          # carried to the last step so the run still fails loudly.
+          bash scripts/shipped-image-sweep-report.sh shipped-sweep >report.md
+          rc=$?
+          # An empty report is itself a failure to report — never publish silence.
+          [ -s report.md ] || { echo "The shipped-image sweep produced no report at all — see the run log." >report.md; rc=1; }
+          echo "rc=$rc" >>"$GITHUB_OUTPUT"
+      - name: Publish it to the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC: ${{ steps.report.outputs.rc }}
+        run: |
+          set -Eeuo pipefail
+          # The title is the upsert key and it lives in the script, so there is exactly one
+          # spelling of it anywhere. A second spelling here would file a second issue on the very
+          # next run and then keep both stale.
+          TITLE="$(bash scripts/shipped-image-sweep-report.sh --title)"
+          body=$(cat report.md)
+          # Exact title match over the open list, NOT `--search`: the search index lags issue
+          # creation by minutes, so a search-based dedup files a second issue on the next run.
+          n=$(gh issue list --state open --limit 200 --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          # A run that could not do its job must not DELETE the "last fully successful" date —
+          # that date is the only thing separating "failed once this morning" from "has been dead
+          # for six weeks". Stamp it on success, carry it forward on failure (pin-watch pattern).
+          if [ "$RC" = "0" ]; then
+            body="$body"$'\n\n'"_Last fully successful sweep: $(date -u +%F)_"
+          elif [ -n "$n" ]; then
+            prev=$(gh issue view "$n" --json body --jq .body | grep -a "^_Last fully successful sweep:" || true)
+            if [ -n "$prev" ]; then
+              body="$body"$'\n\n'"$prev (this run could not complete)"
+            fi
+          fi
+          if [ -n "$n" ]; then
+            gh issue edit "$n" --body "$body"
+            echo "updated #$n"
+          else
+            gh issue create --title "$TITLE" --label infra --body "$body"
+          fi
+      - name: Fail the run if the sweep could not cover every shipped image
+        if: steps.report.outputs.rc != '0'
+        run: |
+          echo "::error::the shipped-image sweep did not cover every published image — those images are UNCHECKED, not clean"
+          exit 1
 
   hadolint:
     name: Dockerfile lint (hadolint)

--- a/scripts/shipped-image-sweep-report.sh
+++ b/scripts/shipped-image-sweep-report.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+#
+# Shipped-image CVE sweep report (#1313).
+#
+# The Monday sweep in ci.yml rebuilds every image from the branch and scans the rebuild. That
+# cannot answer the question users care about. A rebuild resolves apt at scan time, so it picks up
+# archive fixes the published image never got — the sweep goes green while the bytes people are
+# running still carry the CVE. It also scans the default branch, not the release. This report
+# covers the other half: the images published at cut time, promoted by digest with no rebuild
+# (release.sh stage 6 is `buildx imagetools create`, a re-tag), scanned exactly as published.
+#
+# REPORT-ONLY, and that posture is deliberate. A CVE in a shipped image is a fact to act on — it
+# means "consider cutting a patch release", a decision a person makes — not a build to fail. The
+# run goes red only when the sweep itself could not do its job.
+#
+# WHAT THIS SCRIPT IS. It does no scanning and touches no network. ci.yml's `sweep-shipped` matrix
+# resolves each published tag to a digest, scans that digest with trivy, and uploads two files per
+# image; this script reads that directory and renders the tracking-issue body. Keeping the render
+# out of the workflow is what makes it testable — `--self-test` drives every failure mode below
+# through fixtures with no docker, no network, and no GitHub.
+#
+# INCOMPLETE IS NEVER CLEAN. Every refusal below exits 1 and says UNCHECKED in the report rather
+# than printing a reassuring zero. This is the defect class the whole currency lane exists for: a
+# watcher with nothing to say and a watcher that has quietly died look identical from the Actions
+# tab, and "0 findings" off a partial run is the most expensive kind of false green.
+#
+#   - the artifact directory is missing, or holds no scan output at all
+#   - an expected image produced no report (its matrix leg failed)
+#   - an unexpected image appeared (ci.yml's matrix and SWEPT_IMAGES below have drifted)
+#   - a report cannot be parsed
+#   - a report names an artifact that is NOT a digest reference, so the run cannot honestly claim
+#     it scanned published bytes rather than a moving tag
+#   - a report's artifact is a different image than the leg it arrived as
+#   - the legs disagree about which release tag they swept (a cut landed mid-run)
+#
+# Usage:
+#   scripts/shipped-image-sweep-report.sh <dir>   Render the report for the artifacts in <dir> on
+#                                                  stdout. rc 1 if the sweep was incomplete.
+#   scripts/shipped-image-sweep-report.sh --title  Print the tracking issue's title, nothing else.
+#   scripts/shipped-image-sweep-report.sh --self-test
+#                                                  Drive the render + every refusal above through
+#                                                  fixtures. No network, no docker, no gh.
+
+set -Eeuo pipefail
+
+# THE TITLE IS A CONSTANT AND MUST NEVER BE EDITED. The workflow upserts the tracking issue by
+# EXACT title match over the open issue list. Change this string and the next run silently files a
+# SECOND issue instead of updating the first, then keeps both — the old one frozen at whatever it
+# last said, which reads as a sweep that found nothing new. Renaming the issue by hand in the web
+# UI breaks it the same way.
+SWEEP_ISSUE_TITLE="Shipped-image CVE sweep (weekly report)"
+
+# The images this report expects to find, which must match ci.yml's `sweep-shipped` matrix. The
+# two lists are checked against each other at run time rather than trusted: a service added to the
+# matrix and not here arrives as an unexpected file, one added here and not to the matrix arrives
+# as a missing leg, and BOTH exit 1. A silently shrinking sweep is the failure this guards.
+SWEPT_IMAGES="monero p2pool tor xmrig-proxy dashboard"
+
+# Only fixable HIGH/CRITICAL are counted, the same scope ci.yml's gate uses (`ignore-unfixed`), and
+# the same scope every `.trivyignore` entry is written against. It is also the only scope that maps
+# to a decision: a patch release can only ship a fix that exists. Unfixed findings are left to the
+# gate's own reporting rather than counted here as if someone could act on them. This is the label
+# the table header prints; the jq filter below spells the same two out literally.
+SEVERITY_LABEL="HIGH/CRITICAL"
+
+usage() {
+    sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- render helpers ---------------------------------------------------------------------------
+
+# Shorten a digest for the summary table; the full value is printed in the per-image section, so
+# nothing is lost. `sha256:5da0208411…` is enough to eyeball against `docker inspect` output.
+short_digest() {
+    printf '%s…' "${1:0:20}"
+}
+
+# Every HIGH/CRITICAL row in a trivy JSON report, as TSV: id, severity, package, installed, fixed.
+# `.Results[]?` and `.Vulnerabilities[]?` are both optional-indexed on purpose — a clean image
+# reports Results with no Vulnerabilities key at all, which is a legitimate zero, not a parse
+# failure. A genuinely unreadable file fails in render_report() before this runs.
+findings_tsv() {
+    jq -r '
+        [ .Results[]? | .Vulnerabilities[]? ]
+        | map(select(.Severity == "HIGH" or .Severity == "CRITICAL"))
+        | sort_by(.Severity, .VulnerabilityID)
+        | .[]
+        | [ .VulnerabilityID, .Severity, .PkgName,
+            (.InstalledVersion // ""), (.FixedVersion // "") ]
+        | @tsv
+    ' "$1"
+}
+
+# --- the report -------------------------------------------------------------------------------
+
+# Reads <dir>, prints the markdown body on stdout, returns 1 if the sweep was incomplete.
+render_report() {
+    local dir="$1"
+    local rc=0
+    local svc file tagfile ref tag
+    local summary="" details="" problems=""
+    local tag_seen="" tag_conflict=0
+    local expected
+
+    if [ ! -d "$dir" ]; then
+        printf 'The sweep produced no artifact directory at all (`%s` does not exist).\n' "$dir"
+        printf '\nEvery shipped image is UNCHECKED. See the run log.\n'
+        return 1
+    fi
+
+    # An unexpected report means ci.yml's matrix grew and SWEPT_IMAGES did not. Catch it before
+    # rendering, because the summary table below is keyed on SWEPT_IMAGES and would simply not
+    # show the new image — a sweep that silently omits an image is exactly what #1313 is about.
+    for file in "$dir"/sweep-*.json; do
+        [ -e "$file" ] || continue
+        svc="$(basename "$file" .json)"
+        svc="${svc#sweep-}"
+        expected=0
+        for s in $SWEPT_IMAGES; do
+            [ "$s" = "$svc" ] && expected=1 && break
+        done
+        if [ "$expected" -eq 0 ]; then
+            problems="${problems}- \`$svc\` was swept but is not in this report's image list — ci.yml's \`sweep-shipped\` matrix and \`SWEPT_IMAGES\` in \`scripts/shipped-image-sweep-report.sh\` have drifted apart.
+"
+            rc=1
+        fi
+    done
+
+    for svc in $SWEPT_IMAGES; do
+        file="$dir/sweep-$svc.json"
+        tagfile="$dir/sweep-$svc.tag"
+
+        if [ ! -s "$file" ]; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\` produced no scan report; its matrix leg did not finish. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        if ! ref="$(jq -er '.ArtifactName' "$file" 2>/dev/null)"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\`'s scan report could not be parsed. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        # The whole point of the change is that we scanned published bytes. A tag reference here
+        # would mean the digest resolve fell through, and reporting it as a shipped-image result
+        # would be a lie of exactly the shape #1313 was filed about.
+        if ! printf '%s' "$ref" | grep -Eq "/pithead-$svc@sha256:[0-9a-f]{64}\$"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\` reports artifact \`$ref\`, which is not a digest reference to \`pithead-$svc\`. Nothing here proves the published image was scanned, so it is UNCHECKED.
+"
+            rc=1
+            continue
+        fi
+
+        if [ -s "$tagfile" ]; then
+            tag="$(tr -d '[:space:]' <"$tagfile")"
+            if [ -z "$tag_seen" ]; then
+                tag_seen="$tag"
+            elif [ "$tag" != "$tag_seen" ]; then
+                tag_conflict=1
+            fi
+        fi
+
+        # Captured, not piped in from a process substitution: a jq failure inside `< <(...)` is
+        # invisible to `set -e`, so a report whose Results array is malformed would render as a
+        # confident zero. Same rule as everywhere else here — unreadable is UNCHECKED.
+        local tsv
+        if ! tsv="$(findings_tsv "$file")"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\`'s findings could not be read out of its scan report. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        local fixable=0 id sev pkg installed fixed rows=""
+        while IFS=$'\t' read -r id sev pkg installed fixed; do
+            [ -n "$id" ] || continue
+            [ -n "$fixed" ] || continue
+            fixable=$((fixable + 1))
+            rows="${rows}| \`$id\` | $sev | \`$pkg\` | \`$installed\` | \`$fixed\` |
+"
+        done <<<"$tsv"
+
+        if [ "$fixable" -eq 0 ]; then
+            summary="${summary}| \`pithead-$svc\` | \`$(short_digest "${ref#*@}")\` | 0 |
+"
+        else
+            summary="${summary}| \`pithead-$svc\` | \`$(short_digest "${ref#*@}")\` | **$fixable** |
+"
+            details="${details}
+### \`pithead-$svc\` — $fixable fixable
+
+Scanned \`$ref\`.
+
+| CVE | severity | package | installed | fixed in |
+| --- | --- | --- | --- | --- |
+${rows}"
+        fi
+    done
+
+    if [ "$tag_conflict" -eq 1 ]; then
+        problems="${problems}- The legs did not sweep the same release tag, so this report mixes two releases. A cut probably landed mid-run; the next run will settle it.
+"
+        rc=1
+    fi
+
+    printf 'The images users actually pull, scanned as published. Each tag is resolved to a digest\n'
+    printf 'first and the digest is what trivy reads, so this reports the bytes on the registry — not\n'
+    printf 'a rebuild, which would resolve apt afresh and hide the very CVEs this exists to find.\n'
+    if [ -n "$tag_seen" ]; then
+        printf '\nRelease swept: **%s** (from `main`, scanned against `main`'"'"'s own `.trivyignore`).\n' "$tag_seen"
+    fi
+    printf '\n| image | digest | fixable %s |\n| --- | --- | --- |\n' "$SEVERITY_LABEL"
+    printf '%s' "$summary"
+
+    if [ -n "$problems" ]; then
+        printf '\n## This sweep did not complete\n\n%s' "$problems"
+    fi
+
+    if [ -n "$details" ]; then
+        printf '%s' "$details"
+        printf '\nA finding here means the published image carries a CVE with a fix available. The\n'
+        printf 'decision it asks for is whether to cut a patch release, so this reports and never\n'
+        printf 'fails the build.\n'
+    elif [ "$rc" -eq 0 ]; then
+        printf '\nNo fixable HIGH/CRITICAL in any shipped image.\n'
+    fi
+
+    return "$rc"
+}
+
+# --- entry points -------------------------------------------------------------------------------
+
+if [ "${1:-}" = "--title" ]; then
+    printf '%s\n' "$SWEEP_ISSUE_TITLE"
+    exit 0
+fi
+
+if [ "${1:-}" = "--self-test" ]; then
+    st_fail=0
+    st() { # <label> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (got [$2], want [$3])"
+            st_fail=1
+        fi
+    }
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    # <dir> <service> <artifact-ref> <vuln-json-array>
+    fixture() {
+        mkdir -p "$1"
+        jq -n --arg a "$3" --argjson v "$4" \
+            '{ArtifactName: $a, Results: [{Target: "t", Vulnerabilities: $v}]}' \
+            >"$1/sweep-$2.json"
+        printf 'v1.20.0\n' >"$1/sweep-$2.tag"
+    }
+    ref_for() { printf 'ghcr.io/p2pool-starter-stack/pithead-%s@sha256:%064d' "$1" "$2"; }
+
+    # A whole clean sweep. The green path has to be REACHABLE — a check that can only ever say
+    # "incomplete" is as useless as one that only ever says "clean".
+    clean="$tmp/clean"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$clean" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    out="$(render_report "$clean")" && rc=0 || rc=$?
+    st "a complete clean sweep passes" "$rc" "0"
+    st "a clean sweep says so" \
+        "$(printf '%s' "$out" | grep -c 'No fixable HIGH/CRITICAL')" "1"
+    st "every image appears in the summary" \
+        "$(printf '%s' "$out" | grep -c '^| `pithead-')" "5"
+
+    # Findings are counted, and only the FIXABLE ones.
+    found="$tmp/found"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        if [ "$s" = dashboard ]; then
+            fixture "$found" "$s" "$(ref_for "$s" "$i")" '[
+                {"VulnerabilityID":"CVE-2026-1","Severity":"HIGH","PkgName":"libfoo",
+                 "InstalledVersion":"1.0","FixedVersion":"1.1"},
+                {"VulnerabilityID":"CVE-2026-2","Severity":"CRITICAL","PkgName":"libbar",
+                 "InstalledVersion":"2.0","FixedVersion":"2.1"},
+                {"VulnerabilityID":"CVE-2026-3","Severity":"HIGH","PkgName":"libbaz",
+                 "InstalledVersion":"3.0"}
+            ]'
+        else
+            fixture "$found" "$s" "$(ref_for "$s" "$i")" '[]'
+        fi
+        i=$((i + 1))
+    done
+    out="$(render_report "$found")" && rc=0 || rc=$?
+    st "a finding is reported, not failed" "$rc" "0"
+    st "only the fixable findings are counted" \
+        "$(printf '%s' "$out" | grep -c '`pithead-dashboard` — 2 fixable')" "1"
+    st "the unfixable finding is not in the table" \
+        "$(printf '%s' "$out" | grep -c 'CVE-2026-3')" "0"
+    st "the finding's own digest is named in full" \
+        "$(printf '%s' "$out" | grep -c "Scanned \`$(ref_for dashboard 5)\`")" "1"
+
+    # Every refusal. Each must exit 1 AND say UNCHECKED — a quiet zero is the bug.
+    miss="$tmp/miss"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        [ "$s" = tor ] || fixture "$miss" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    out="$(render_report "$miss")" && rc=0 || rc=$?
+    st "a leg that did not finish fails the run" "$rc" "1"
+    st "the missing image reads UNCHECKED, never clean" \
+        "$(printf '%s' "$out" | grep -c '`pithead-tor` | — | \*\*UNCHECKED\*\*')" "1"
+    # On the PROBLEM TEXT, not just the UNCHECKED row. The missing-file guard and the
+    # unparseable-report guard below it emit an identical summary row and an identical rc, so an
+    # assertion on either of those passes whichever guard fired — deleting the missing-file check
+    # outright left this whole block green until it was checked by mutation. Each guard is now
+    # named by the one sentence only it writes.
+    st "the missing leg is diagnosed as a leg that did not finish" \
+        "$(printf '%s' "$out" | grep -c 'produced no scan report; its matrix leg did not finish')" "1"
+    st "a missing leg is not misreported as an unparseable one" \
+        "$(printf '%s' "$out" | grep -c 'could not be parsed')" "0"
+
+    extra="$tmp/extra"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$extra" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$extra" newsvc "$(ref_for newsvc 9)" '[]'
+    out="$(render_report "$extra")" && rc=0 || rc=$?
+    st "an image the report does not know about fails the run" "$rc" "1"
+    st "the drift is named" "$(printf '%s' "$out" | grep -c 'drifted apart')" "1"
+
+    bad="$tmp/bad"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$bad" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    printf 'not json at all' >"$bad/sweep-monero.json"
+    out="$(render_report "$bad")" && rc=0 || rc=$?
+    st "an unparseable report fails the run" "$rc" "1"
+    st "an unparseable report reads UNCHECKED" \
+        "$(printf '%s' "$out" | grep -c 'could not be parsed')" "1"
+    st "an unparseable report is not misreported as a missing leg" \
+        "$(printf '%s' "$out" | grep -c 'its matrix leg did not finish')" "0"
+
+    # The load-bearing one. If the digest resolve fell through and trivy scanned a TAG, the run
+    # must not claim it swept published bytes — that is #1313's own defect, one level in.
+    tagref="$tmp/tagref"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$tagref" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$tagref" p2pool "ghcr.io/p2pool-starter-stack/pithead-p2pool:v1.20.0" '[]'
+    out="$(render_report "$tagref")" && rc=0 || rc=$?
+    st "a tag scan is refused, not reported as a shipped-image result" "$rc" "1"
+    st "the tag scan reads UNCHECKED" \
+        "$(printf '%s' "$out" | grep -c 'not a digest reference')" "1"
+
+    swap="$tmp/swap"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$swap" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$swap" tor "$(ref_for monero 3)" '[]'
+    out="$(render_report "$swap")" && rc=0 || rc=$?
+    st "a leg that scanned the wrong image fails the run" "$rc" "1"
+
+    conflict="$tmp/conflict"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$conflict" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    printf 'v1.19.3\n' >"$conflict/sweep-tor.tag"
+    out="$(render_report "$conflict")" && rc=0 || rc=$?
+    st "legs that swept different releases fail the run" "$rc" "1"
+
+    out="$(render_report "$tmp/nothing-here")" && rc=0 || rc=$?
+    st "a missing artifact directory fails the run" "$rc" "1"
+    st "a missing artifact directory does not print a clean table" \
+        "$(printf '%s' "$out" | grep -c 'No fixable')" "0"
+
+    empty="$tmp/empty"
+    mkdir -p "$empty"
+    out="$(render_report "$empty")" && rc=0 || rc=$?
+    st "an empty artifact directory fails the run" "$rc" "1"
+
+    # Every case above calls render_report inside an `&&` list, where bash suppresses `set -e`
+    # for the whole dynamic extent of the call — so none of them can see an error-exit that only
+    # bites the way CI actually invokes this: bare, in its own process. Drive the green path
+    # through a real subprocess once, or the suite is proving the logic and not the script.
+    out="$(bash "${BASH_SOURCE[0]}" "$clean")" && rc=0 || rc=$?
+    st "the clean path survives a real subprocess invocation" "$rc" "0"
+    st "the subprocess renders the same table" \
+        "$(printf '%s' "$out" | grep -c '^| `pithead-')" "5"
+    out="$(bash "${BASH_SOURCE[0]}" "$miss")" && rc=0 || rc=$?
+    st "an incomplete sweep still exits 1 from a real subprocess" "$rc" "1"
+
+    # The title is the upsert key; a change here silently files a second issue for ever.
+    st "--title prints the constant and nothing else" \
+        "$(bash "${BASH_SOURCE[0]}" --title)" "$SWEEP_ISSUE_TITLE"
+
+    [ "$st_fail" = 0 ] && echo "shipped-image-sweep-report self-test OK"
+    exit "$st_fail"
+fi
+
+if [ $# -ne 1 ] || [ "${1:0:2}" = "--" ]; then
+    usage >&2
+    exit 2
+fi
+
+render_report "$1"

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -32,3 +32,11 @@ echo "== unit: patch-coverage overlap self-test (#1000) =="
 # --self-test drives fixtures through both branches plus the file-present quiet pass.
 bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
 assert_rc "patch-coverage wrapper self-test passes" "$?" "0"
+
+echo "== unit: shipped-image sweep report self-test (#1313) =="
+# The weekly sweep of the PUBLISHED images renders its tracking-issue body with this script, and
+# its whole job is refusing to call an image clean when it was never scanned. Every refusal —
+# a missing leg, an unparseable report, an artifact that is a tag rather than a digest — is
+# driven through fixtures here, with no network, no docker and no gh.
+bash "$ROOT/scripts/shipped-image-sweep-report.sh" --self-test >/dev/null 2>&1
+assert_rc "shipped-image sweep report self-test passes" "$?" "0"


### PR DESCRIPTION
Adds a second Monday sweep that scans the images users are actually running, and the script that renders its report. Addresses #1313.

## Why the existing sweep cannot answer this

`build-images` runs `docker build ./build/<service>` and points Trivy at the fresh `pithead-<service>:ci`. Two things follow, either one enough on its own:

- A rebuild resolves apt at scan time, so it silently picks up archive fixes the published image never got. That is the exact case the sweep's own header calls out as its reason for existing — and in that case the rebuild goes green while the image users are running stays vulnerable.
- Scheduled runs use `develop`. What users run is the release, and since #1076 `main` is a fast-forward pointer to the released tag.

Retargeting the existing sweep at `main` fixes the second half only. It would still be scanning a rebuild.

## What `sweep-shipped` does instead

Each leg reads the tag from `main`'s `VERSION`, resolves it against ghcr with an anonymous pull token, and scans the resulting **digest**.

Resolving first is not ceremony. A tag is a moving pointer, so "we scanned `:v1.20.0`" stops naming any particular bytes the moment it moves; the digest is the only reference that names what a user pulled. The digest scanned is printed in the report, so the claim is checkable after the fact.

It applies **`main`'s own** `.trivyignore`, never `develop`'s. A mute added after the cut would otherwise silence a finding in an image whose review never saw that mute.

The packages are public, so an anonymous pull token is enough and no registry secret enters the workflow. Trivy pulls the digest from the registry itself — nothing is built in this job.

## Report-only, deliberately

`exit-code: "0"` on the scan, and the finding lands in one tracking issue rather than reddening the run. A fixable CVE in an image that is already published cannot be fixed by failing a build; it asks whether to cut a patch release, which is a decision a person makes. An issue persists, is assignable, and can hold "held until the next cut, here's why" in a comment. A red square in the Actions tab cannot.

The run goes red on exactly one thing: the sweep itself failing to do its job.

## The part worth reviewing hardest

`scripts/shipped-image-sweep-report.sh` renders the issue body, and its one non-negotiable behaviour is refusing to call an image clean when it was never scanned. Each of these reads UNCHECKED and exits 1, which fails the run:

- a leg produced no scan report
- a report cannot be parsed, or its findings cannot be read out
- an image was swept that the report does not know about (this matrix and the script's list have drifted)
- a report names an artifact that is **not** a digest reference — the run must never claim it scanned published bytes when the resolve fell through to a tag
- a report's artifact is a different image than the leg it arrived as
- the legs disagree about which release they swept (a cut landed mid-run)

Twenty-seven fixture cases drive every refusal plus the clean path, with no network, no docker and no gh. Three of them invoke the script as a real subprocess: the rest call `render_report` inside an `&&` list, where bash suppresses `set -e` for the whole dynamic extent of the call, so they structurally cannot see an error-exit the way CI would.

**The refusals were checked by mutation, not by reading.** Each guard was deleted or weakened in a copy of the script and the suite re-run; all six die:

| mutation | result |
| --- | --- |
| missing-leg guard deleted | killed |
| digest-vs-tag guard deleted | killed |
| wrong-image guard weakened to any digest | killed |
| tag-conflict guard deleted | killed |
| unexpected-image guard deleted | killed |
| fixable-only filter dropped | killed |

The missing-leg one **survived** the first time round, and that is why the mutation pass happened at all. Its assertion checked the shared `UNCHECKED` summary row, which the unparseable-report guard directly below it emits identically — so deleting the missing-file check outright left the suite green, the second guard silently covering for the first. Both are now asserted on the one sentence only each of them writes, and each is asserted *not* to produce the other's.

## The temporary cron

The second `cron:` is temporary and PR-B removes exactly that line and nothing else. A `schedule:` is read from the default branch only, and a workflow file that merely looks right proves nothing about registration — #1048, #1064 and #1146 are all the same defect. The only proof is a run carrying `event: schedule`:

```
gh run list --workflow=ci.yml --event schedule --json event,conclusion,createdAt,databaseId
```

That run URL goes on #1313 and in PR-B's body before the temporary slot is removed. The real Monday slot is in this PR from the start, so removing the proof slot is a pure deletion and cannot strand the sweep on a cron that never fires again.

## Why a `develop`-targeted PR on a frozen branch

Lane-policy exception (b): `schedule:` is read from the DEFAULT branch only, so a sweep added on `develop-v2` would never run once. PR-C hand-ports it to `develop-v2`'s `include:`-matrix `ci.yml` and is a mandatory part of this item, not a follow-up someone may drop — without it the parity lint's coverage of the new step's `version:` never exists on the lane that has a parity lint.

## Depends on #1352

That PR pins `build-images`' Trivy step to `v0.74.0` on `develop`. This one's new scan step is pinned to the same value, and the comment above it says the comparison between the two sweeps only means something while both pins are there. Merge that one first; if this lands alone, the two Monday sweeps read vulnerability databases four minor releases apart and the comment is wrong.

## Out of lane, named as the guard asks

`tests/stack/test-harness-tooling.sh` is outside `currency.paths` and was staged under the repo's one-shot `.lane-override`. It is the repo's one registry for script self-tests, sitting beside `pin-watch`'s and `resolve-pins`' own — and a self-test that nothing calls is decoration. One `echo`, one `bash ... --self-test`, one `assert_rc`.

## Deliberately not here

`os-rootfs.yml`'s weekly sweep has the same shape — it rebuilds the appliance rootfs and never looks at the shipped bundle — and is filed separately as #1353, cross-linked both ways. It is not a line in this PR because the appliance has no published artifact to retarget a scan at, which is a design question rather than a workflow edit.

## Evidence

- `scripts/shipped-image-sweep-report.sh --self-test` — 27/27.
- `bash tests/stack/run.sh` — 1837 passed, 0 failed, rc 0, with the new self-test provably executing (`== unit: shipped-image sweep report self-test (#1313) ==` in the run output), not merely present in the file.
- `shellcheck --severity=warning` and `shfmt -i 4 -d` clean on both changed shell files. `make lint-sh` was not run locally: a KVM guest is up on this box and shellcheck peaks over 7 GB against `tests/stack/run.sh`. CI's Shell tests job is that same shellcheck.
- `uvx yamllint` clean; `uvx zizmor@1.25.2 --offline .github/workflows/` — `No findings to report`.
- `bash scripts/lint-file-budget.sh` — `file budget OK`. The new script is 429 lines; a new file only has to clear the 800 hard ceiling, so no `docs/dev/file-budget.tsv` row is added.
- `lint-operator-strings`, `lint-topology-classes`, `lint-md` — clean.
- Every one of the five published tags resolves anonymously on ghcr today, checked against the live registry rather than assumed.

## Over-engineering pass

One finding, addressed: `findings_tsv` built its jq program by string interpolation from a `SEVERITIES` list, looping to assemble `.Severity == "HIGH" or .Severity == "CRITICAL"` — a generality nothing uses, spelling one fixed filter three different ways (the loop, the interpolated program, and a `${...// //}` expansion to render the table header). Now a literal jq filter and a plain label constant. All six guard mutations still die.

Kept despite being the obvious next candidate: the per-leg `.tag` sidecar and the tag-conflict refusal. Reading `main`'s VERSION once in the report job would be shorter, but it would report the release the report job *believes* was swept rather than the one each leg *did* sweep, and a cut landing mid-run would produce a confident, wrong version line. Eight lines and one fixture case to report a fact instead of an assumption.

## What is not proven yet

That the schedule fires. Nothing in this PR can prove it — that is what the temporary cron and PR-B are for, and no claim of registration will be made from the YAML looking right.
