### PR TITLE
fix(dashboard): bound one rig's /1/summary read (#1347)

### DIFF
--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 import logging
 import time
 
@@ -25,6 +26,18 @@ WORKER_ENDPOINTS = DASHBOARD_WORKERS
 # Longest worker-name we'll ever echo back as a Bearer token (#122). xmrig names/tokens are short;
 # this just bounds a pathological miner-supplied value before it goes into a header.
 _MAX_NAME_TOKEN = 128
+
+# Ceiling on one rig's /1/summary. The poll pulls a device's response straight into the
+# dashboard's memory, and since #1235 part of it is forwarded on to the operator's browser;
+# nothing else bounds it, so aiohttp would buffer whatever the far end chose to send.
+#
+# Measured, not guessed — JSON-serialized /1/summary at real rig shapes, RigForge block included:
+# ~2.8 KiB for an 8-thread rig, 3.6 KiB for a 32-thread workstation, 8.0 KiB for a 192-thread
+# EPYC, and 16.0 KiB for an absurd-but-legitimate 512 threads with 8 pools. The term that actually
+# scales is hashrate.threads — one row per mining thread. 1 MiB is ~64x that absurd case, so the
+# cap cannot plausibly be reached by a rig telling the truth, which is the failure that would
+# matter: a cap set tight enough to bite a real operator is worse than the exhaustion it prevents.
+_MAX_SUMMARY_BYTES = 1024 * 1024
 
 # Re-warn about a worker whose API keeps failing at most this often, so a misconfigured fleet logs
 # one line per worker per interval — not one per poll (the data loop runs every ~30s).
@@ -345,7 +358,26 @@ class XMRigWorkerClient:
         try:
             async with self.session.get(url, headers=headers, timeout=API_TIMEOUT) as response:
                 if response.status == 200:
-                    payload = await response.json()
+                    # Read one byte past the ceiling and refuse on overflow. Deliberately NOT a
+                    # Content-Length check: that header is set by the far end, may be absent under
+                    # chunked encoding, and is exactly what a rig lying about its size would lie
+                    # about. Reading with a bound never trusts it in the first place.
+                    # Accumulate: StreamReader.read(n) is a SHORT read — it returns whatever is
+                    # buffered the moment anything is, NOT n bytes. One call would truncate any
+                    # body that arrives split across TCP reads, which is ordinary for a rig on
+                    # WiFi or any link with latency, and the rig would then read as unreachable
+                    # for a reason with nothing to do with its size. Stop at EOF, or one byte past
+                    # the ceiling — never buffering more than that however the body is framed.
+                    body = b""
+                    while len(body) <= _MAX_SUMMARY_BYTES:
+                        chunk = await response.content.read(_MAX_SUMMARY_BYTES + 1 - len(body))
+                        if not chunk:
+                            break
+                        body += chunk
+                    if len(body) > _MAX_SUMMARY_BYTES:
+                        self._warn(host, name, url, f"body over {_MAX_SUMMARY_BYTES} bytes")
+                        return {"api_ok": False}
+                    payload = json.loads(body)
                     if isinstance(payload, dict):
                         self._warned.pop(host, None)  # recovered — allow the next failure to log
                         payload["api_ok"] = True

--- a/dashboard/tests/client/test_rigforge_config.py
+++ b/dashboard/tests/client/test_rigforge_config.py
@@ -87,3 +87,52 @@ class TestRigWritableConfig:
     def test_a_malformed_pool_entry_does_not_crash_the_whole_poll(self):
         out = self._block({"pools": ["not-a-dict", None, {"url": "ok:1", "pass": "x"}]})
         assert out["pools"] == ["not-a-dict", None, {"url": "ok:1"}]
+
+
+# --- RigForge enriched feed parse (#235) ---------------------------------------------------------
+# The enriched feed is a SUPERSET of /1/summary: the whole XMRig object plus one `rigforge` key.
+# parse_rigforge lifts the display-relevant fields, nullable-safe; a plain-xmrig body → None.
+
+
+def test_parse_rigforge_absent_is_none():
+    # A plain-xmrig worker (no `rigforge` key) parses to None — the UI renders it as today.
+    assert parse_rigforge({"hashrate": {"total": [100]}, "api_ok": True}) is None
+    assert parse_rigforge({}) is None
+    assert parse_rigforge(["not", "a", "dict"]) is None
+
+
+def test_parse_rigforge_miner_down_has_no_xmrig_keys():
+    # Miner-down body: XMRig keys drop, only the rigforge block with xmrig_api unreachable remains.
+    rf = parse_rigforge({"rigforge": {"version": "1.7.0", "xmrig_api": "unreachable"}})
+    assert rf["miner_down"] is True
+    assert rf["version"] == "1.7.0"
+    # Absent sub-objects default cleanly — no chip data, no crash.
+    assert rf["power"] == {"watts": None, "hs_per_watt": None}
+    assert rf["watchdog"]["enabled"] is False
+
+
+def test_parse_rigforge_all_null_fields():
+    # Every enriched field is nullable on the wire (no RAPL, non-root, watchdog disabled).
+    block = {
+        "version": "1.7.0",
+        "tune": {"target": None, "autotune": {"enabled": False, "next": None}},
+        "power": {"watts": None, "hs_per_watt": None},
+        "health": {"governor": None, "throttling": None, "firmware": {}, "hugepages_total": None},
+        "watchdog": {"mode": "disabled"},
+    }
+    rf = parse_rigforge({"rigforge": block})
+    assert rf["power"] == {"watts": None, "hs_per_watt": None}
+    assert rf["health"] == {
+        "governor": None,
+        "throttling": None,
+        "board": None,
+        "hugepages_total": None,
+    }
+    assert rf["tune"] == {"target": None, "autotune_enabled": False, "autotune_next": None}
+    # A disabled watchdog masks its temp fields.
+    assert rf["watchdog"] == {
+        "enabled": False,
+        "thermal_hold": None,
+        "temp_c": None,
+        "max_temp_c": None,
+    }

--- a/dashboard/tests/client/test_summary_size_cap.py
+++ b/dashboard/tests/client/test_summary_size_cap.py
@@ -1,0 +1,124 @@
+"""The ceiling on one rig's ``/1/summary`` (#1347).
+
+The worker poll reads a device's response straight into the dashboard's memory, and since #1235
+part of it is forwarded on to the operator's browser. Nothing else bounds it.
+
+The ceiling has two failure modes and they pull in opposite directions: set too high it does not
+prevent the exhaustion it exists for, and set too low it silently breaks a real operator's rig —
+the worse of the two, because it looks like the rig is broken rather than the dashboard. So these
+pin BOTH ends, with a body of an actual measured size on the accept side.
+
+The fakes are local rather than shared with test_xmrig_client.py: pytest runs with
+``--import-mode=importlib``, so a test module cannot import a sibling, and these need to set the
+body BYTES directly rather than a payload object.
+"""
+
+import pytest
+
+from mining_dashboard.client import xmrig_client as xc
+from mining_dashboard.client.xmrig_client import XMRigWorkerClient
+
+# Measured, JSON-serialized /1/summary with the RigForge block included: ~2.8 KiB for an 8-thread
+# rig, 8.0 KiB for a 192-thread EPYC, and 16.0 KiB for an absurd-but-legitimate 512 threads with
+# 8 pools. The term that scales is hashrate.threads — one row per mining thread.
+LARGEST_REAL_RIG_BYTES = 16 * 1024
+
+
+def body_of(n):
+    """A well-formed JSON object body of exactly ``n`` bytes."""
+    body = b'{"a":"' + b"x" * (n - 8) + b'"}'
+    assert len(body) == n, (len(body), n)
+    return body
+
+
+class FakeResponse:
+    """``read`` is a SHORT read, like aiohttp's StreamReader: it hands back what is buffered, never
+    necessarily ``n`` bytes, and it advances a position. Modelling that is the point — the first
+    version of this fake returned the full slice on every call, which let a client that read ONCE
+    pass every test here while truncating any real body that arrived split across TCP reads."""
+
+    def __init__(self, status, raw, content_length=None, chunk=1024):
+        self.status = status
+        self._raw = raw
+        self._pos = 0
+        self._chunk = chunk
+        # Present so a test can prove the client does NOT consult it.
+        self.content_length = content_length
+        self.content = self
+
+    async def read(self, n=-1):
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, self._chunk))
+        chunk, self._pos = self._raw[self._pos : end], end
+        return chunk
+
+
+class FakeGet:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response):
+        self._response = response
+
+    def get(self, url, headers=None, timeout=None):
+        return FakeGet(self._response)
+
+
+async def _stats(raw, content_length=None, chunk=1024):
+    session = FakeSession(FakeResponse(200, raw, content_length, chunk))
+    return await XMRigWorkerClient(session).get_stats("10.0.0.1", "rig1")
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        pytest.param(LARGEST_REAL_RIG_BYTES, id="largest-real-rig"),
+        pytest.param(xc._MAX_SUMMARY_BYTES, id="exactly-at-the-ceiling"),
+    ],
+)
+async def test_a_body_up_to_the_ceiling_is_accepted(size):
+    # The accept side matters most: a ceiling that rejects a real rig presents as a broken rig.
+    assert (await _stats(body_of(size)))["api_ok"] is True
+
+
+async def test_a_body_past_the_ceiling_is_refused_without_raising():
+    # Refused, not crashed: one oversized rig must not take the poll down for every other worker.
+    result = await _stats(body_of(xc._MAX_SUMMARY_BYTES + 1))
+    assert result == {"api_ok": False}
+
+
+async def test_the_ceiling_does_not_trust_the_rig_s_content_length():
+    # A rig lying about its size is exactly the case this exists for, and Content-Length is what it
+    # would lie WITH — it is also absent under chunked encoding. The client must bound the read
+    # itself rather than believe the header.
+    result = await _stats(body_of(xc._MAX_SUMMARY_BYTES + 1), content_length=10)
+    assert result == {"api_ok": False}
+
+
+async def test_an_oversized_body_is_never_parsed():
+    # The refusal has to happen on the BYTES. Handing json.loads a body we already know is over the
+    # ceiling would do the expensive thing first and check afterwards.
+    huge = b'{"a":"' + b"x" * (xc._MAX_SUMMARY_BYTES * 2) + b'"}'
+    assert (await _stats(huge)) == {"api_ok": False}
+
+
+async def test_a_body_split_across_many_reads_is_still_read_whole():
+    # The regression that a single bounded read would cause, and the reason this fake models a
+    # short read at all. A rig on WiFi, or any link with latency, delivers its body in pieces;
+    # reading once returns only the first piece, json.loads then fails, and a perfectly healthy
+    # rig is reported unreachable for a reason with nothing to do with its size. Verified against
+    # a real aiohttp server: one read(1000) of a 994-byte body returned 100 bytes.
+    result = await _stats(body_of(64 * 1024), chunk=97)  # a deliberately unaligned chunk
+    assert result["api_ok"] is True
+
+
+async def test_an_oversized_body_delivered_in_pieces_is_still_refused():
+    # The other half: trickling an oversized body must not slip past the ceiling either.
+    assert (await _stats(body_of(xc._MAX_SUMMARY_BYTES + 1), chunk=97)) == {"api_ok": False}

--- a/dashboard/tests/client/test_xmrig_client.py
+++ b/dashboard/tests/client/test_xmrig_client.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from mining_dashboard.client import xmrig_client as xc
@@ -46,12 +48,24 @@ RIGFORGE_BLOCK = {
 
 
 class FakeResponse:
+    """Mimics aiohttp's ClientResponse for the one thing the client uses: a BOUNDED read off
+    ``response.content``. It never calls ``.json()`` — reading with a byte limit is the whole
+    point of the size cap (#1347), so a fake offering an unbounded ``.json()`` would test a path
+    that no longer exists. The ceiling's own tests live in test_summary_size_cap.py."""
+
     def __init__(self, status, payload=None):
         self.status = status
-        self._payload = payload if payload is not None else {}
+        self._raw = json.dumps(payload if payload is not None else {}).encode()
+        self._pos = 0
+        self.content = self  # the client reads response.content.read(n)
 
-    async def json(self):
-        return self._payload
+    async def read(self, n=-1):
+        # A SHORT read, like aiohttp's StreamReader: returns what is buffered, never necessarily
+        # n bytes. A fake that always hands back the full slice would let a client that reads
+        # once — and so truncates any split body — pass every test here. See #1347.
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, 8))
+        chunk, self._pos = self._raw[self._pos : end], end
+        return chunk
 
 
 class FakeGet:
@@ -400,18 +414,8 @@ async def test_spoofed_name_cannot_redirect_the_token_to_the_miner_ip_when_host_
     assert session.calls[0][0] == "http://192.168.7.9:8080/1/summary"
 
 
-# --- RigForge enriched feed parse (#235) ---------------------------------------------------------
-# The enriched feed is a SUPERSET of /1/summary: the whole XMRig object plus one `rigforge` key.
-# parse_rigforge lifts the display-relevant fields, nullable-safe; a plain-xmrig body → None.
-
-
-def test_parse_rigforge_absent_is_none():
-    # A plain-xmrig worker (no `rigforge` key) parses to None — the UI renders it as today.
-    assert parse_rigforge({"hashrate": {"total": [100]}, "api_ok": True}) is None
-    assert parse_rigforge({}) is None
-    assert parse_rigforge(["not", "a", "dict"]) is None
-
-
+# Kept here, not with the other parse tests: it shares RIGFORGE_BLOCK with the
+# control-status tests below.
 def test_parse_rigforge_full_block():
     rf = parse_rigforge({"hashrate": {"total": [100]}, "rigforge": RIGFORGE_BLOCK, "api_ok": True})
     assert rf["version"] == "1.7.0"
@@ -429,43 +433,6 @@ def test_parse_rigforge_full_block():
         "thermal_hold": False,
         "temp_c": 62,
         "max_temp_c": 85,
-    }
-
-
-def test_parse_rigforge_miner_down_has_no_xmrig_keys():
-    # Miner-down body: XMRig keys drop, only the rigforge block with xmrig_api unreachable remains.
-    rf = parse_rigforge({"rigforge": {"version": "1.7.0", "xmrig_api": "unreachable"}})
-    assert rf["miner_down"] is True
-    assert rf["version"] == "1.7.0"
-    # Absent sub-objects default cleanly — no chip data, no crash.
-    assert rf["power"] == {"watts": None, "hs_per_watt": None}
-    assert rf["watchdog"]["enabled"] is False
-
-
-def test_parse_rigforge_all_null_fields():
-    # Every enriched field is nullable on the wire (no RAPL, non-root, watchdog disabled).
-    block = {
-        "version": "1.7.0",
-        "tune": {"target": None, "autotune": {"enabled": False, "next": None}},
-        "power": {"watts": None, "hs_per_watt": None},
-        "health": {"governor": None, "throttling": None, "firmware": {}, "hugepages_total": None},
-        "watchdog": {"mode": "disabled"},
-    }
-    rf = parse_rigforge({"rigforge": block})
-    assert rf["power"] == {"watts": None, "hs_per_watt": None}
-    assert rf["health"] == {
-        "governor": None,
-        "throttling": None,
-        "board": None,
-        "hugepages_total": None,
-    }
-    assert rf["tune"] == {"target": None, "autotune_enabled": False, "autotune_next": None}
-    # A disabled watchdog masks its temp fields.
-    assert rf["watchdog"] == {
-        "enabled": False,
-        "thermal_hold": None,
-        "temp_c": None,
-        "max_temp_c": None,
     }
 
 

--- a/dashboard/tests/service/test_data_service.py
+++ b/dashboard/tests/service/test_data_service.py
@@ -1962,7 +1962,7 @@ class _RecordingGet:
     async def __aenter__(self):
         resp = MagicMock()
         resp.status = 200
-        resp.json = AsyncMock(return_value={"ok": True})
+        resp.content.read = AsyncMock(side_effect=[json.dumps({"ok": True}).encode(), b""])
         return resp
 
     async def __aexit__(self, *exc):

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -21,7 +21,7 @@ dashboard/mining_dashboard/web/static/wizard.mjs	889
 dashboard/mining_dashboard/web/static/workerview.mjs	479
 dashboard/mining_dashboard/web/views.py	2339
 dashboard/mining_dashboard/wizard.py	674
-dashboard/tests/client/test_xmrig_client.py	537
+dashboard/tests/client/test_xmrig_client.py	504
 dashboard/tests/config/test_config.py	458
 dashboard/tests/frontend/components.test.mjs	1193
 dashboard/tests/frontend/configview.test.mjs	492


### PR DESCRIPTION
Closes #1347.

## What was wrong

The worker poll read a rig's `/1/summary` with `await response.json()` and nothing bounding it.
The unbounded read is not new — but **#1235 made it reachable from a new direction**. Before, an
oversized feed cost the container some memory and was then discarded. Since #1235, part of that
rig-supplied response is forwarded into `/api/worker/detail` and rendered in a textarea in the
operator's browser. So a rig that is compromised, patched, or simply buggy can now inflate what
the container holds *and* what the browser renders.

The rig is remote and controls its response completely.

## The number is measured, not guessed

The issue asked for the cap to be set from evidence. JSON-serialized `/1/summary` at real rig
shapes, RigForge block included:

| rig | serialized size |
|---|---|
| 8 threads, 1 pool | 2.8 KiB |
| 32-thread workstation, 2 pools | 3.6 KiB |
| 192-thread EPYC, 5 pools | 8.0 KiB |
| absurd-but-legitimate: 512 threads, 8 pools | **16.0 KiB** |

The term that actually scales is `hashrate.threads` — one row per mining thread. The ceiling is
**1 MiB, about 64× the absurd case.**

## Both ends are pinned, because the cap has two opposite failure modes

Too high and it does not prevent the exhaustion it exists for. **Too low and it silently breaks a
real operator's rig — and that is the worse one**, because it presents as a broken *rig*, not a
broken dashboard. So there is a test that a body the size of the largest real rig is still
accepted, not only that an oversized one is refused.

## The security review caught a real bug — read this part

The first version of this fix called `await response.content.read(cap + 1)` **once**. That is
wrong, and wrong in the exact way this PR claims to protect against.

aiohttp's `StreamReader.read(n)` is a **short read**: it returns whatever is buffered the moment
anything is, *not* `n` bytes. So a body arriving split across TCP reads — ordinary for a rig on
WiFi, a loaded rig, or any link with latency — gets truncated mid-JSON, `json.loads` fails, and a
perfectly healthy rig is reported unreachable **for a reason with nothing to do with its size**.

Verified against a real aiohttp server before believing it: a single `read(1000)` of a 994-byte
body returned **100 bytes**.

The reason my tests did not catch it is the part worth carrying: **both fakes modelled `read(n)` as
always returning the full slice**, so a client that read once passed everything. A fake that is
more obliging than the real library tests a world that does not exist. Both fakes now model a short
read with a position, and there is a split-body test that fails against the single-read version.

The fix accumulates until EOF or one byte past the ceiling, so it still never buffers more than the
bound however the body is framed. It cannot spin on a rig that trickles: `API_TIMEOUT` is passed as
a plain number, which aiohttp treats as a **total** timeout covering the body read.

## Design decisions worth reviewing

**It does not trust `Content-Length`.** That header is set by the far end, is absent under chunked
encoding, and is exactly what a rig lying about its size would lie *with*. The client reads one
byte past the ceiling and refuses on overflow, so it never believes the header in the first place.
A test asserts a `Content-Length` that disagrees with the body changes nothing.

**It refuses, it does not raise.** One oversized rig must not take the poll down for every other
worker. It returns `api_ok: False` and warns — the same path an unreachable rig already takes.

## Supporting moves — both forced by the ratchet, both no-ops

`test_xmrig_client.py` was at its ceiling and had to absorb the fake's new shape.

- The RigForge feed-parse tests move to `test_rigforge_config.py`, which #1235 created for exactly
  those. One test stays behind because it shares `RIGFORGE_BLOCK` with the control-status tests.
  537 → 498 lines, and the ceiling **ratchets down** with it.
- `FakeResponse` now serves bytes off `.content`, because `.json()` is no longer the path under
  test — a fake still offering an unbounded `.json()` would exercise a path that no longer exists.
  The same one-line change in `test_data_service.py`'s recording stub, which stays at exactly its
  ceiling.

## Scope — what I found but did not fix

**Correction to an earlier draft of this section.** It claimed `price_feed`, `update_checker`,
`telegram_commands` and the XvB reads were "equally unbounded". They are not: #660 already put all
of them behind `bounded_get` in `helper/http.py`, which streams and cuts at 1 MiB — the same
ceiling this PR arrives at independently. Re-derived by reading every call site, not by trusting
the earlier list.

What #660 did NOT cover is the clients it treated as internal: `xmrig_proxy_client` (four reads),
`collector/logs.py`, `collector/containers.py`, `client/docker/docker_control.py`, and the monerod
and monero-wallet clients. The rig poll this PR fixes was in that same untreated set. Those are a
different trust class from each other and from the rig, so they are filed separately rather than
bundled in here — see the follow-up issue, which ranks them by trust class and names this PR as the
first instance fixed.

## What was run

- the dashboard python suite — exit 0, no failures
- `node --test dashboard/tests/frontend/` — 457 pass
- `make lint-py`, `lint-js`, `lint-topology`, `scripts/lint-operator-strings.sh`,
  `scripts/lint-file-budget.sh` — all clean

**Every guard was confirmed to FAIL against the code as it stood.** Mutations run: the ceiling
removed entirely; the ceiling replaced by a `Content-Length` check; the ceiling set to 8 KiB (the
largest-real-rig test catches it, so the accept-side guard is real and not decoration); and the read
collapsed back to a single call, which three tests now catch including the split-body one.

## What was NOT done

- **No live rig or bench.** The 16.0 KiB figure is a payload synthesized at a real rig's shape, not
  a sample captured from hardware. The in-repo integration fake could not serve as the measurement:
  it is a trimmed 862 bytes and its `rigforge` block carries **no `config` key at all**, so it does
  not exercise what #1235 added either.
- **Not fixed:** dropping `response.json()` loses its `Content-Type` check, so a non-JSON 200 body
  now logs a less specific message. Diagnostics only, and the body fails to parse either way.
- **No doc change.** Nothing operator-facing moves — a real rig sits ~64× under the ceiling, so the
  only new visible behaviour is a log line no real rig can produce.

