### PR TITLE
ci(sweep): port the shipped-image sweep to this lane (#1313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,23 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-  # Weekly CVE sweep (#833): rebuild + Trivy-scan every image even when no PR is open, so a CVE
-  # disclosed during a quiet week — or fixed in the apt archive without a new base digest, which
-  # Dependabot never sees — surfaces here instead of reddening the next unrelated PR. Only
-  # `build-images` runs on the schedule (every other job gates on the event); the run going red
-  # in the Actions tab is the alert, the lychee.yml posture. Scheduled runs use the default
-  # branch (develop).
+  # Two Monday sweeps hang off this schedule, answering two different questions. Every other job
+  # gates itself off the event, so only these two run.
+  #
+  #   build-images  (#833) rebuilds every image from the branch and scans the rebuild: does what
+  #                 we are about to ship carry a CVE? It is the only sweep that can go red before
+  #                 a release, and the run reddening in the Actions tab is its alert.
+  #   sweep-shipped (#1313) scans what users are already running — the published ghcr images from
+  #                 `main`, each tag resolved to a digest and the digest scanned as published. A
+  #                 rebuild structurally cannot answer that: it resolves apt at scan time, so it
+  #                 picks up archive fixes the published bytes never got. It reports into a
+  #                 tracking issue rather than reddening, because "a shipped image has a fixable
+  #                 CVE" asks for a patch release, which is a decision a person makes.
+  #
+  # NEITHER FIRES FROM THIS FILE — `schedule:` is read from the DEFAULT branch only, so both run
+  # from `develop`'s copy and this cron block is inert. It is here so the twins stay level, and so
+  # `make lint-trivy-parity` (this lane only) covers sweep-shipped's trivy step at all. Change the
+  # cadence on `develop`, and prove it fired with `gh run list --json event`.
   schedule:
     - cron: "0 5 * * 1" # Mondays 05:00 UTC
 
@@ -146,6 +157,177 @@ jobs:
           exit-code: "1"
           trivyignores: .trivyignore
           cache: "false"
+
+  sweep-shipped:
+    # The half of the Monday sweep that reports on what users are running (#1313). `build-images`
+    # above scans a rebuild of this branch; this scans the bytes on the registry.
+    #
+    # Every leg resolves the published TAG to a DIGEST and scans the digest. That is not
+    # ceremony: a tag is a moving pointer, so "we scanned :v1.20.0" stops being a statement about
+    # any particular image the moment it moves, and the digest is the only reference that names
+    # the bytes a user pulled. The digest scanned is printed in the report.
+    #
+    # fail-fast: false so one unreachable image does not hide the other four — and a leg that
+    # fails still shows up, because the report job runs on `always()` and names any image it
+    # received no scan for as UNCHECKED rather than counting it as clean.
+    name: Shipped-image CVE sweep (${{ matrix.service }})
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [monero, p2pool, tor, xmrig-proxy, dashboard]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve the shipped tag to a digest, and take main's own .trivyignore
+        id: shipped
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          set -Eeuo pipefail
+          # The scheduled run checks out develop. `main` is a different ref and a shallow clone
+          # does not carry it, so fetch it rather than assume it is here — since #1076 `main` is a
+          # fast-forward pointer to the released tag, and it is the only ref that knows what
+          # shipped.
+          git fetch --no-tags --depth=1 origin main
+          ver="$(git show origin/main:VERSION)"
+          [ -n "$ver" ] || { echo "::error::main carries no VERSION — cannot tell what shipped"; exit 1; }
+          tag="v$ver"
+          # main's OWN .trivyignore, never develop's. A mute added after the cut would otherwise
+          # silence a finding in an image whose review never saw that mute.
+          git show origin/main:.trivyignore >main.trivyignore
+          repo="p2pool-starter-stack/pithead-$SERVICE"
+          # The packages are public, so an anonymous pull token is enough — no registry secret
+          # enters this workflow.
+          token="$(curl -fsS "https://ghcr.io/token?scope=repository:$repo:pull" | jq -er .token)"
+          digest="$(curl -fsSI \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+            "https://ghcr.io/v2/$repo/manifests/$tag" |
+            tr -d '\r' | awk 'tolower($1) == "docker-content-digest:" { print $2 }')"
+          # An unresolved digest must never fall through to a tag scan: the report would then say
+          # "shipped image" about bytes nobody can identify. Fail the leg instead and let it read
+          # UNCHECKED.
+          printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$' ||
+            { echo "::error::could not resolve ghcr.io/$repo:$tag to a digest — got [$digest]"; exit 1; }
+          echo "ref=ghcr.io/$repo@$digest" >>"$GITHUB_OUTPUT"
+          # The tag every leg swept, so the report can refuse to mix two releases if a cut lands
+          # mid-run.
+          printf '%s\n' "$tag" >"sweep-$SERVICE.tag"
+      - name: Scan the published image by digest (Trivy)
+        # Same scope as the gate above, and the same engine — but only because #1290's pin is on
+        # both steps. Read that as a dependency, not a coincidence: comparing this sweep's verdict
+        # against the rebuild's is the whole reason both exist, and two trivy releases apart is
+        # enough to make them disagree for reasons that have nothing to do with the images. If the
+        # step above ever loses its `version:`, this comparison stops meaning anything, and on
+        # develop no lint will say so (`make lint-trivy-parity` is develop-v2's).
+        #
+        # trivy pulls the digest from the registry itself — nothing is built here.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.74.0
+          image-ref: ${{ steps.shipped.outputs.ref }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          # Report-only, deliberately. A fixable CVE in an image that is already published cannot
+          # be fixed by failing this run; it asks for a patch release. The run goes red only when
+          # the sweep itself could not do its job, which the report job decides.
+          exit-code: "0"
+          trivyignores: main.trivyignore
+          cache: "false"
+          format: json
+          output: sweep-${{ matrix.service }}.json
+      - name: Upload this image's scan output
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shipped-sweep-${{ matrix.service }}
+          path: |
+            sweep-${{ matrix.service }}.json
+            sweep-${{ matrix.service }}.tag
+          # An empty upload would reach the report job as a scan that found nothing, which is the
+          # one thing this must never say off a leg that did not scan.
+          if-no-files-found: error
+
+  sweep-shipped-report:
+    # One tracking issue, edited in place — the pin-watch.yml / trivyignore-watch.yml posture. An
+    # issue persists, is assignable, and lets a person write "held until the next cut, here's why"
+    # in a comment. A red square in the Actions tab cannot hold that, and this finding's whole
+    # value is the conversation about whether to cut a patch release.
+    name: Shipped-image CVE sweep — tracking issue
+    # always() so a failed scan leg still reports: an image with no scan output is UNCHECKED, and
+    # saying so is the entire point. Skipping the report on a partial sweep would leave the last
+    # good report standing as if it were current.
+    if: always() && github.event_name == 'schedule'
+    needs: sweep-shipped
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Least privilege (#282): issues.write is this job's one output — it never pushes or publishes.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Collect every leg's scan output
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: shipped-sweep-*
+          merge-multiple: true
+          path: shipped-sweep
+      - name: Render the report
+        id: report
+        run: |
+          set -uo pipefail
+          # NOT `set -e`: an incomplete sweep is a result to publish, not a reason to publish
+          # nothing. The script names the images it could not check and exits 1; the rc is
+          # carried to the last step so the run still fails loudly.
+          bash scripts/shipped-image-sweep-report.sh shipped-sweep >report.md
+          rc=$?
+          # An empty report is itself a failure to report — never publish silence.
+          [ -s report.md ] || { echo "The shipped-image sweep produced no report at all — see the run log." >report.md; rc=1; }
+          echo "rc=$rc" >>"$GITHUB_OUTPUT"
+      - name: Publish it to the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC: ${{ steps.report.outputs.rc }}
+        run: |
+          set -Eeuo pipefail
+          # The title is the upsert key and it lives in the script, so there is exactly one
+          # spelling of it anywhere. A second spelling here would file a second issue on the very
+          # next run and then keep both stale.
+          TITLE="$(bash scripts/shipped-image-sweep-report.sh --title)"
+          body=$(cat report.md)
+          # Exact title match over the open list, NOT `--search`: the search index lags issue
+          # creation by minutes, so a search-based dedup files a second issue on the next run.
+          n=$(gh issue list --state open --limit 200 --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          # A run that could not do its job must not DELETE the "last fully successful" date —
+          # that date is the only thing separating "failed once this morning" from "has been dead
+          # for six weeks". Stamp it on success, carry it forward on failure (pin-watch pattern).
+          if [ "$RC" = "0" ]; then
+            body="$body"$'\n\n'"_Last fully successful sweep: $(date -u +%F)_"
+          elif [ -n "$n" ]; then
+            prev=$(gh issue view "$n" --json body --jq .body | grep -a "^_Last fully successful sweep:" || true)
+            if [ -n "$prev" ]; then
+              body="$body"$'\n\n'"$prev (this run could not complete)"
+            fi
+          fi
+          if [ -n "$n" ]; then
+            gh issue edit "$n" --body "$body"
+            echo "updated #$n"
+          else
+            gh issue create --title "$TITLE" --label infra --body "$body"
+          fi
+      - name: Fail the run if the sweep could not cover every shipped image
+        if: steps.report.outputs.rc != '0'
+        run: |
+          echo "::error::the shipped-image sweep did not cover every published image — those images are UNCHECKED, not clean"
+          exit 1
 
   hadolint:
     name: Dockerfile lint (hadolint)

--- a/scripts/shipped-image-sweep-report.sh
+++ b/scripts/shipped-image-sweep-report.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+#
+# Shipped-image CVE sweep report (#1313).
+#
+# The Monday sweep in ci.yml rebuilds every image from the branch and scans the rebuild. That
+# cannot answer the question users care about. A rebuild resolves apt at scan time, so it picks up
+# archive fixes the published image never got — the sweep goes green while the bytes people are
+# running still carry the CVE. It also scans the default branch, not the release. This report
+# covers the other half: the images published at cut time, promoted by digest with no rebuild
+# (release.sh stage 6 is `buildx imagetools create`, a re-tag), scanned exactly as published.
+#
+# REPORT-ONLY, and that posture is deliberate. A CVE in a shipped image is a fact to act on — it
+# means "consider cutting a patch release", a decision a person makes — not a build to fail. The
+# run goes red only when the sweep itself could not do its job.
+#
+# WHAT THIS SCRIPT IS. It does no scanning and touches no network. ci.yml's `sweep-shipped` matrix
+# resolves each published tag to a digest, scans that digest with trivy, and uploads two files per
+# image; this script reads that directory and renders the tracking-issue body. Keeping the render
+# out of the workflow is what makes it testable — `--self-test` drives every failure mode below
+# through fixtures with no docker, no network, and no GitHub.
+#
+# INCOMPLETE IS NEVER CLEAN. Every refusal below exits 1 and says UNCHECKED in the report rather
+# than printing a reassuring zero. This is the defect class the whole currency lane exists for: a
+# watcher with nothing to say and a watcher that has quietly died look identical from the Actions
+# tab, and "0 findings" off a partial run is the most expensive kind of false green.
+#
+#   - the artifact directory is missing, or holds no scan output at all
+#   - an expected image produced no report (its matrix leg failed)
+#   - an unexpected image appeared (ci.yml's matrix and SWEPT_IMAGES below have drifted)
+#   - a report cannot be parsed
+#   - a report names an artifact that is NOT a digest reference, so the run cannot honestly claim
+#     it scanned published bytes rather than a moving tag
+#   - a report's artifact is a different image than the leg it arrived as
+#   - the legs disagree about which release tag they swept (a cut landed mid-run)
+#
+# Usage:
+#   scripts/shipped-image-sweep-report.sh <dir>   Render the report for the artifacts in <dir> on
+#                                                  stdout. rc 1 if the sweep was incomplete.
+#   scripts/shipped-image-sweep-report.sh --title  Print the tracking issue's title, nothing else.
+#   scripts/shipped-image-sweep-report.sh --self-test
+#                                                  Drive the render + every refusal above through
+#                                                  fixtures. No network, no docker, no gh.
+
+set -Eeuo pipefail
+
+# THE TITLE IS A CONSTANT AND MUST NEVER BE EDITED. The workflow upserts the tracking issue by
+# EXACT title match over the open issue list. Change this string and the next run silently files a
+# SECOND issue instead of updating the first, then keeps both — the old one frozen at whatever it
+# last said, which reads as a sweep that found nothing new. Renaming the issue by hand in the web
+# UI breaks it the same way.
+SWEEP_ISSUE_TITLE="Shipped-image CVE sweep (weekly report)"
+
+# The images this report expects to find, which must match ci.yml's `sweep-shipped` matrix. The
+# two lists are checked against each other at run time rather than trusted: a service added to the
+# matrix and not here arrives as an unexpected file, one added here and not to the matrix arrives
+# as a missing leg, and BOTH exit 1. A silently shrinking sweep is the failure this guards.
+SWEPT_IMAGES="monero p2pool tor xmrig-proxy dashboard"
+
+# Only fixable HIGH/CRITICAL are counted, the same scope ci.yml's gate uses (`ignore-unfixed`), and
+# the same scope every `.trivyignore` entry is written against. It is also the only scope that maps
+# to a decision: a patch release can only ship a fix that exists. Unfixed findings are left to the
+# gate's own reporting rather than counted here as if someone could act on them. This is the label
+# the table header prints; the jq filter below spells the same two out literally.
+SEVERITY_LABEL="HIGH/CRITICAL"
+
+usage() {
+    sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- render helpers ---------------------------------------------------------------------------
+
+# Shorten a digest for the summary table; the full value is printed in the per-image section, so
+# nothing is lost. `sha256:5da0208411…` is enough to eyeball against `docker inspect` output.
+short_digest() {
+    printf '%s…' "${1:0:20}"
+}
+
+# Every HIGH/CRITICAL row in a trivy JSON report, as TSV: id, severity, package, installed, fixed.
+# `.Results[]?` and `.Vulnerabilities[]?` are both optional-indexed on purpose — a clean image
+# reports Results with no Vulnerabilities key at all, which is a legitimate zero, not a parse
+# failure. A genuinely unreadable file fails in render_report() before this runs.
+findings_tsv() {
+    jq -r '
+        [ .Results[]? | .Vulnerabilities[]? ]
+        | map(select(.Severity == "HIGH" or .Severity == "CRITICAL"))
+        | sort_by(.Severity, .VulnerabilityID)
+        | .[]
+        | [ .VulnerabilityID, .Severity, .PkgName,
+            (.InstalledVersion // ""), (.FixedVersion // "") ]
+        | @tsv
+    ' "$1"
+}
+
+# --- the report -------------------------------------------------------------------------------
+
+# Reads <dir>, prints the markdown body on stdout, returns 1 if the sweep was incomplete.
+render_report() {
+    local dir="$1"
+    local rc=0
+    local svc file tagfile ref tag
+    local summary="" details="" problems=""
+    local tag_seen="" tag_conflict=0
+    local expected
+
+    if [ ! -d "$dir" ]; then
+        printf 'The sweep produced no artifact directory at all (`%s` does not exist).\n' "$dir"
+        printf '\nEvery shipped image is UNCHECKED. See the run log.\n'
+        return 1
+    fi
+
+    # An unexpected report means ci.yml's matrix grew and SWEPT_IMAGES did not. Catch it before
+    # rendering, because the summary table below is keyed on SWEPT_IMAGES and would simply not
+    # show the new image — a sweep that silently omits an image is exactly what #1313 is about.
+    for file in "$dir"/sweep-*.json; do
+        [ -e "$file" ] || continue
+        svc="$(basename "$file" .json)"
+        svc="${svc#sweep-}"
+        expected=0
+        for s in $SWEPT_IMAGES; do
+            [ "$s" = "$svc" ] && expected=1 && break
+        done
+        if [ "$expected" -eq 0 ]; then
+            problems="${problems}- \`$svc\` was swept but is not in this report's image list — ci.yml's \`sweep-shipped\` matrix and \`SWEPT_IMAGES\` in \`scripts/shipped-image-sweep-report.sh\` have drifted apart.
+"
+            rc=1
+        fi
+    done
+
+    for svc in $SWEPT_IMAGES; do
+        file="$dir/sweep-$svc.json"
+        tagfile="$dir/sweep-$svc.tag"
+
+        if [ ! -s "$file" ]; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\` produced no scan report; its matrix leg did not finish. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        if ! ref="$(jq -er '.ArtifactName' "$file" 2>/dev/null)"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\`'s scan report could not be parsed. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        # The whole point of the change is that we scanned published bytes. A tag reference here
+        # would mean the digest resolve fell through, and reporting it as a shipped-image result
+        # would be a lie of exactly the shape #1313 was filed about.
+        if ! printf '%s' "$ref" | grep -Eq "/pithead-$svc@sha256:[0-9a-f]{64}\$"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\` reports artifact \`$ref\`, which is not a digest reference to \`pithead-$svc\`. Nothing here proves the published image was scanned, so it is UNCHECKED.
+"
+            rc=1
+            continue
+        fi
+
+        if [ -s "$tagfile" ]; then
+            tag="$(tr -d '[:space:]' <"$tagfile")"
+            if [ -z "$tag_seen" ]; then
+                tag_seen="$tag"
+            elif [ "$tag" != "$tag_seen" ]; then
+                tag_conflict=1
+            fi
+        fi
+
+        # Captured, not piped in from a process substitution: a jq failure inside `< <(...)` is
+        # invisible to `set -e`, so a report whose Results array is malformed would render as a
+        # confident zero. Same rule as everywhere else here — unreadable is UNCHECKED.
+        local tsv
+        if ! tsv="$(findings_tsv "$file")"; then
+            summary="${summary}| \`pithead-$svc\` | — | **UNCHECKED** |
+"
+            problems="${problems}- \`$svc\`'s findings could not be read out of its scan report. This image is UNCHECKED, not clean.
+"
+            rc=1
+            continue
+        fi
+
+        local fixable=0 id sev pkg installed fixed rows=""
+        while IFS=$'\t' read -r id sev pkg installed fixed; do
+            [ -n "$id" ] || continue
+            [ -n "$fixed" ] || continue
+            fixable=$((fixable + 1))
+            rows="${rows}| \`$id\` | $sev | \`$pkg\` | \`$installed\` | \`$fixed\` |
+"
+        done <<<"$tsv"
+
+        if [ "$fixable" -eq 0 ]; then
+            summary="${summary}| \`pithead-$svc\` | \`$(short_digest "${ref#*@}")\` | 0 |
+"
+        else
+            summary="${summary}| \`pithead-$svc\` | \`$(short_digest "${ref#*@}")\` | **$fixable** |
+"
+            details="${details}
+### \`pithead-$svc\` — $fixable fixable
+
+Scanned \`$ref\`.
+
+| CVE | severity | package | installed | fixed in |
+| --- | --- | --- | --- | --- |
+${rows}"
+        fi
+    done
+
+    if [ "$tag_conflict" -eq 1 ]; then
+        problems="${problems}- The legs did not sweep the same release tag, so this report mixes two releases. A cut probably landed mid-run; the next run will settle it.
+"
+        rc=1
+    fi
+
+    printf 'The images users actually pull, scanned as published. Each tag is resolved to a digest\n'
+    printf 'first and the digest is what trivy reads, so this reports the bytes on the registry — not\n'
+    printf 'a rebuild, which would resolve apt afresh and hide the very CVEs this exists to find.\n'
+    if [ -n "$tag_seen" ]; then
+        printf '\nRelease swept: **%s** (from `main`, scanned against `main`'"'"'s own `.trivyignore`).\n' "$tag_seen"
+    fi
+    printf '\n| image | digest | fixable %s |\n| --- | --- | --- |\n' "$SEVERITY_LABEL"
+    printf '%s' "$summary"
+
+    if [ -n "$problems" ]; then
+        printf '\n## This sweep did not complete\n\n%s' "$problems"
+    fi
+
+    if [ -n "$details" ]; then
+        printf '%s' "$details"
+        printf '\nA finding here means the published image carries a CVE with a fix available. The\n'
+        printf 'decision it asks for is whether to cut a patch release, so this reports and never\n'
+        printf 'fails the build.\n'
+    elif [ "$rc" -eq 0 ]; then
+        printf '\nNo fixable HIGH/CRITICAL in any shipped image.\n'
+    fi
+
+    return "$rc"
+}
+
+# --- entry points -------------------------------------------------------------------------------
+
+if [ "${1:-}" = "--title" ]; then
+    printf '%s\n' "$SWEEP_ISSUE_TITLE"
+    exit 0
+fi
+
+if [ "${1:-}" = "--self-test" ]; then
+    st_fail=0
+    st() { # <label> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (got [$2], want [$3])"
+            st_fail=1
+        fi
+    }
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    # <dir> <service> <artifact-ref> <vuln-json-array>
+    fixture() {
+        mkdir -p "$1"
+        jq -n --arg a "$3" --argjson v "$4" \
+            '{ArtifactName: $a, Results: [{Target: "t", Vulnerabilities: $v}]}' \
+            >"$1/sweep-$2.json"
+        printf 'v1.20.0\n' >"$1/sweep-$2.tag"
+    }
+    ref_for() { printf 'ghcr.io/p2pool-starter-stack/pithead-%s@sha256:%064d' "$1" "$2"; }
+
+    # A whole clean sweep. The green path has to be REACHABLE — a check that can only ever say
+    # "incomplete" is as useless as one that only ever says "clean".
+    clean="$tmp/clean"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$clean" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    out="$(render_report "$clean")" && rc=0 || rc=$?
+    st "a complete clean sweep passes" "$rc" "0"
+    st "a clean sweep says so" \
+        "$(printf '%s' "$out" | grep -c 'No fixable HIGH/CRITICAL')" "1"
+    st "every image appears in the summary" \
+        "$(printf '%s' "$out" | grep -c '^| `pithead-')" "5"
+
+    # Findings are counted, and only the FIXABLE ones.
+    found="$tmp/found"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        if [ "$s" = dashboard ]; then
+            fixture "$found" "$s" "$(ref_for "$s" "$i")" '[
+                {"VulnerabilityID":"CVE-2026-1","Severity":"HIGH","PkgName":"libfoo",
+                 "InstalledVersion":"1.0","FixedVersion":"1.1"},
+                {"VulnerabilityID":"CVE-2026-2","Severity":"CRITICAL","PkgName":"libbar",
+                 "InstalledVersion":"2.0","FixedVersion":"2.1"},
+                {"VulnerabilityID":"CVE-2026-3","Severity":"HIGH","PkgName":"libbaz",
+                 "InstalledVersion":"3.0"}
+            ]'
+        else
+            fixture "$found" "$s" "$(ref_for "$s" "$i")" '[]'
+        fi
+        i=$((i + 1))
+    done
+    out="$(render_report "$found")" && rc=0 || rc=$?
+    st "a finding is reported, not failed" "$rc" "0"
+    st "only the fixable findings are counted" \
+        "$(printf '%s' "$out" | grep -c '`pithead-dashboard` — 2 fixable')" "1"
+    st "the unfixable finding is not in the table" \
+        "$(printf '%s' "$out" | grep -c 'CVE-2026-3')" "0"
+    st "the finding's own digest is named in full" \
+        "$(printf '%s' "$out" | grep -c "Scanned \`$(ref_for dashboard 5)\`")" "1"
+
+    # Every refusal. Each must exit 1 AND say UNCHECKED — a quiet zero is the bug.
+    miss="$tmp/miss"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        [ "$s" = tor ] || fixture "$miss" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    out="$(render_report "$miss")" && rc=0 || rc=$?
+    st "a leg that did not finish fails the run" "$rc" "1"
+    st "the missing image reads UNCHECKED, never clean" \
+        "$(printf '%s' "$out" | grep -c '`pithead-tor` | — | \*\*UNCHECKED\*\*')" "1"
+    # On the PROBLEM TEXT, not just the UNCHECKED row. The missing-file guard and the
+    # unparseable-report guard below it emit an identical summary row and an identical rc, so an
+    # assertion on either of those passes whichever guard fired — deleting the missing-file check
+    # outright left this whole block green until it was checked by mutation. Each guard is now
+    # named by the one sentence only it writes.
+    st "the missing leg is diagnosed as a leg that did not finish" \
+        "$(printf '%s' "$out" | grep -c 'produced no scan report; its matrix leg did not finish')" "1"
+    st "a missing leg is not misreported as an unparseable one" \
+        "$(printf '%s' "$out" | grep -c 'could not be parsed')" "0"
+
+    extra="$tmp/extra"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$extra" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$extra" newsvc "$(ref_for newsvc 9)" '[]'
+    out="$(render_report "$extra")" && rc=0 || rc=$?
+    st "an image the report does not know about fails the run" "$rc" "1"
+    st "the drift is named" "$(printf '%s' "$out" | grep -c 'drifted apart')" "1"
+
+    bad="$tmp/bad"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$bad" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    printf 'not json at all' >"$bad/sweep-monero.json"
+    out="$(render_report "$bad")" && rc=0 || rc=$?
+    st "an unparseable report fails the run" "$rc" "1"
+    st "an unparseable report reads UNCHECKED" \
+        "$(printf '%s' "$out" | grep -c 'could not be parsed')" "1"
+    st "an unparseable report is not misreported as a missing leg" \
+        "$(printf '%s' "$out" | grep -c 'its matrix leg did not finish')" "0"
+
+    # The load-bearing one. If the digest resolve fell through and trivy scanned a TAG, the run
+    # must not claim it swept published bytes — that is #1313's own defect, one level in.
+    tagref="$tmp/tagref"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$tagref" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$tagref" p2pool "ghcr.io/p2pool-starter-stack/pithead-p2pool:v1.20.0" '[]'
+    out="$(render_report "$tagref")" && rc=0 || rc=$?
+    st "a tag scan is refused, not reported as a shipped-image result" "$rc" "1"
+    st "the tag scan reads UNCHECKED" \
+        "$(printf '%s' "$out" | grep -c 'not a digest reference')" "1"
+
+    swap="$tmp/swap"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$swap" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    fixture "$swap" tor "$(ref_for monero 3)" '[]'
+    out="$(render_report "$swap")" && rc=0 || rc=$?
+    st "a leg that scanned the wrong image fails the run" "$rc" "1"
+
+    conflict="$tmp/conflict"
+    i=1
+    for s in $SWEPT_IMAGES; do
+        fixture "$conflict" "$s" "$(ref_for "$s" "$i")" '[]'
+        i=$((i + 1))
+    done
+    printf 'v1.19.3\n' >"$conflict/sweep-tor.tag"
+    out="$(render_report "$conflict")" && rc=0 || rc=$?
+    st "legs that swept different releases fail the run" "$rc" "1"
+
+    out="$(render_report "$tmp/nothing-here")" && rc=0 || rc=$?
+    st "a missing artifact directory fails the run" "$rc" "1"
+    st "a missing artifact directory does not print a clean table" \
+        "$(printf '%s' "$out" | grep -c 'No fixable')" "0"
+
+    empty="$tmp/empty"
+    mkdir -p "$empty"
+    out="$(render_report "$empty")" && rc=0 || rc=$?
+    st "an empty artifact directory fails the run" "$rc" "1"
+
+    # Every case above calls render_report inside an `&&` list, where bash suppresses `set -e`
+    # for the whole dynamic extent of the call — so none of them can see an error-exit that only
+    # bites the way CI actually invokes this: bare, in its own process. Drive the green path
+    # through a real subprocess once, or the suite is proving the logic and not the script.
+    out="$(bash "${BASH_SOURCE[0]}" "$clean")" && rc=0 || rc=$?
+    st "the clean path survives a real subprocess invocation" "$rc" "0"
+    st "the subprocess renders the same table" \
+        "$(printf '%s' "$out" | grep -c '^| `pithead-')" "5"
+    out="$(bash "${BASH_SOURCE[0]}" "$miss")" && rc=0 || rc=$?
+    st "an incomplete sweep still exits 1 from a real subprocess" "$rc" "1"
+
+    # The title is the upsert key; a change here silently files a second issue for ever.
+    st "--title prints the constant and nothing else" \
+        "$(bash "${BASH_SOURCE[0]}" --title)" "$SWEEP_ISSUE_TITLE"
+
+    [ "$st_fail" = 0 ] && echo "shipped-image-sweep-report self-test OK"
+    exit "$st_fail"
+fi
+
+if [ $# -ne 1 ] || [ "${1:0:2}" = "--" ]; then
+    usage >&2
+    exit 2
+fi
+
+render_report "$1"

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -51,3 +51,11 @@ echo "== unit: patch-coverage overlap self-test (#1000) =="
 # --self-test drives fixtures through both branches plus the file-present quiet pass.
 bash "$ROOT/scripts/patch-coverage.sh" --self-test >/dev/null 2>&1
 assert_rc "patch-coverage wrapper self-test passes" "$?" "0"
+
+echo "== unit: shipped-image sweep report self-test (#1313) =="
+# The weekly sweep of the PUBLISHED images renders its tracking-issue body with this script, and
+# its whole job is refusing to call an image clean when it was never scanned. Every refusal —
+# a missing leg, an unparseable report, an artifact that is a tag rather than a digest — is
+# driven through fixtures here, with no network, no docker and no gh.
+bash "$ROOT/scripts/shipped-image-sweep-report.sh" --self-test >/dev/null 2>&1
+assert_rc "shipped-image sweep report self-test passes" "$?" "0"


### PR DESCRIPTION
Hand-port of #1354 to this lane. Part of #1313, not a follow-up someone may drop.

The job YAML and `scripts/shipped-image-sweep-report.sh` are **byte-identical** to `develop`'s (`diff` against `origin/develop` is empty for the script; the jobs were lifted verbatim). Only the schedule header differs, and it differs to say something that is true of this lane and false of the other.

## Neither sweep fires from this copy

`schedule:` is read from the DEFAULT branch only, so both Monday sweeps run from `develop`'s `ci.yml` and this file's cron block is inert. The header now says that outright. A reader who assumes otherwise will change a cadence here and watch nothing happen — the same class of mistake as #1048, #1064 and #1146, one level in, and the reason `pin-watch.yml`'s header carries three paragraphs of history about it.

## So why port it at all

Two reasons, neither of them "it might run".

**The parity lint is the real one, and it lives only here.** `make lint-trivy-parity` holds every `trivy-action` step in `ci.yml` and `os-rootfs.yml` to `scripts/trivyignore-watch.sh`'s `TRIVY_VERSION`, and that script exists on this lane only. Until this port, the new scan step's `version: v0.74.0` was pinned by hand on `develop` with nothing anywhere checking it. After it:

```
ci.yml: trivy-action version v0.74.0 matches the watch (0.74.0)
ci.yml: trivy-action version v0.74.0 matches the watch (0.74.0)
os-rootfs.yml: trivy-action version v0.74.0 matches the watch (0.74.0)
```

Three steps, two of them in `ci.yml` — `build-images`' and the new `sweep-shipped`'s. That third line is the coverage this PR exists to create.

**The twins stay level**, so the next `develop` → `develop-v2` sync is a fast-forward rather than a conflict in a file both lanes edit.

## One thing worth knowing for the next port

`tests/stack/test-harness-tooling.sh` is **not** interchangeable between the twins — this lane's copy carries two `#1098` registrations (`verify-healthcheck-scripts`, self-test and real-tree) that `develop`'s does not. Copying `develop`'s version across wholesale deletes them silently, which is what happened on the first attempt here and was caught by reading the diff rather than the file. The registration was appended to this lane's own copy instead: `+8` lines, nothing removed.

That file is outside `currency.paths`; staged under the repo's one-shot `.lane-override`, same as on #1354.

## Evidence

- `make lint-trivy-parity` — OK, with the three matching lines above.
- `bash tests/stack/run.sh` — **2904 passed, 0 failed**, rc 0, with `== unit: shipped-image sweep report self-test (#1313) ==` in the output. Executed, not merely registered.
- `scripts/shipped-image-sweep-report.sh --self-test` — 27/27.
- `uvx yamllint` clean; `uvx zizmor@1.25.2 --offline .github/workflows/` — `No findings to report`.
- `bash scripts/lint-file-budget.sh` — `file budget OK`, generated against **this** lane. No `docs/dev/file-budget.tsv` row: the twins' budgets diverge and neither needs one here, because a new file only has to clear the 800 hard ceiling and this one is 429 lines.
- `lint-operator-strings`, `lint-topology-classes` — clean. `shellcheck --severity=warning` + `shfmt -i 4 -d` clean on both shell files. `make lint-sh` not run locally: a KVM guest is up and shellcheck peaks over 7 GB against `tests/stack/run.sh`; CI's Shell tests job is that same shellcheck.

## Order

#1352 (engine pins on `develop`) → #1354 (the sweep) → PR-B (removes the temporary proof cron, once a run carrying `event: schedule` is on record) → this. PR-B touches `develop` only; nothing in it reaches this lane, so this PR's content is final regardless of when that one lands.

## Over-engineering pass

This is a verbatim port, so the only authored content is the schedule header. One finding, addressed: the "neither fires here" paragraph ran to six lines. Trimmed to four — the fact that the cron block is inert has to be in the file (that ignorance is what #1048, #1064 and #1146 each cost), but the rationale for keeping the copy does not need restating at length when the two reasons are one clause each.
