### PR TITLE
test(os): capture what removes config.json during the restore leg's backup (#1059)

### DIFF
--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -505,14 +505,22 @@ VANISHED at 2026-08-24T01:25:57+00:00"
     # The evidence dump is a /proc sweep: arbitrary cmdlines, which can and do contain this file's
     # own header vocabulary. A real vanish whose process table mentions a RIVAL outcome must still
     # report as exactly one outcome — the vanish — because the captured line is indented as evidence
-    # and only a printf writes a header. Un-anchor the header grep in _fe_case and this case fails
-    # while every other case stays green, which is the whole point of it being here.
+    # and only a printf writes a header.
+    #
+    # The canned cmdline below carries the header's FIVE-SPACE indentation on purpose, and that
+    # detail is the whole assertion. Without it the poison matched neither the anchored pattern nor
+    # an un-anchored one, so this case passed on the indentation baked into the grep pattern rather
+    # than on the anchor — green even with the ^ removed, which is the plausible edit. A case that
+    # proves the guard only against an implausible mutation is a guard proven by nothing, the exact
+    # shape this branch keeps finding. Caught by the reviewer lane, who removed only the caret.
+    # What makes the discrimination real: the marker sits INSIDE the line, while a genuine header
+    # STARTS it. Anchored, this cannot match; drop the ^ and it does.
     _fe_case "a vanish is not confused by its own evidence naming another outcome" \
         "config.json went away during the backup" \
         "WATCHOKALIVE:STARTED at 2026-08-24T01:00:00+00:00 pid=1234
 VANISHED at 2026-08-24T01:25:57+00:00
 -- process table at that instant --
-4711	grep --line-buffered -- --- #1059: WATCHER UNREADABLE — this run collected no evidence either way ---"
+4711	tail -f /tmp/pithead-1059-watch.log | grep -F      --- #1059: WATCHER UNREADABLE — this run collected no evidence either way ---"
 
     printf '== unit: #1059 watcher arming ==\n'
     # pgrep found it: a watcher is on the guest, and arming has nothing to report.

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -82,9 +82,23 @@ backup_failure_evidence() {
 # first two static passes over the backup's own call chain found nothing, because the actor is a
 # concurrent process rather than anything that call chain invokes.
 backup_precapture() {
-    _ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
-        tr -d '\r' | sed 's/^/     · /'
-    _ssh 'cat >/tmp/pithead-1059-watch.sh <<"EOS"
+    # Captured and re-emitted rather than streamed, so the header printed below is GUARANTEED to
+    # start its own line. sed does not terminate a final line that arrived unterminated, and the
+    # guest's last line here is a `readlink` whose termination is not ours to assume — glue the
+    # header onto the tail of an evidence line and every line-anchored reader of the battery
+    # scrollback, this file's own self-test included, stops seeing it. `$()` strips the trailing
+    # newlines, printf puts back exactly one, and empty output still prints nothing.
+    local pre
+    pre=$(_ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
+        tr -d '\r' | sed 's/^/     · /')
+    [ -n "$pre" ] && printf '%s\n' "$pre"
+    # The log is cleared BEFORE the watcher is armed, not by the watcher. The watcher truncates it
+    # too, but only if it starts — and a watcher that never starts is precisely the case the report
+    # reads off an empty log. The restore leg runs on a keep-reinstalled guest, so a log left by an
+    # earlier run can outlive the run that wrote it; without this, "never started" would be reported
+    # against the PREVIOUS run's evidence. Loud and wrong is better than silent, but neither is the
+    # bar here.
+    _ssh 'rm -f /tmp/pithead-1059-watch.log; cat >/tmp/pithead-1059-watch.sh <<"EOS"
 # Paths and ceiling come from the environment so the self-test can drive this exact body
 # unmodified. The heredoc is quoted, so these expand on the GUEST at run time, where nothing sets
 # them and the defaults are what runs. A test that had to sed the constants would be proving a
@@ -225,7 +239,9 @@ backup_watch_report() {
 # silently covers for another's deletion. Delete any branch below and its case goes red rather
 # than falling through to the quiet path.
 _fe_selftest_reply=""
+_fe_selftest_pgrep=""
 _fe_selftest_rc=0
+_fe_ssh_capture=""
 
 # Every outcome's unique sentence. The keys are the assertion vocabulary: a case names the one it
 # wants and is checked against all the others.
@@ -233,6 +249,7 @@ _FE_SENTENCES="WATCHER UNREADABLE
 WATCHER NEVER STARTED
 WATCHER DIED mid-window
 WATCH WINDOW EXPIRED
+WATCHER DID NOT START
 config.json went away during the backup"
 
 _fe_case() { # <label> <want-sentence|QUIET> <canned _ssh reply>
@@ -264,7 +281,17 @@ _fe_case() { # <label> <want-sentence|QUIET> <canned _ssh reply>
     # earlier session was running with "WATCHER UNREADABLE" inside its grep pattern, the sweep
     # captured its cmdline, and a whole-output match called that a second outcome. The header is
     # what NAMES the outcome, so the header is what has to be unambiguous.
-    headers=$(printf '%s\n' "$got" | grep -- '--- #1059:' || true)
+    # ANCHORED, and that anchor is load-bearing. Every header this file writes is a printf that
+    # starts the line at this exact indentation; every line of captured evidence is prefixed
+    # '     | ' (vanish) or '     · ' (precapture) by the sed that renders it. So anchoring makes
+    # the two unconfusable. Unanchored, this grep matched the marker WHEREVER it appeared —
+    # including inside the /proc sweep the vanish branch dumps, whose cmdlines are arbitrary text.
+    # That is not hypothetical twice over: a predecessor session's orphaned `tail -f | grep` held
+    # 'WATCHER UNREADABLE' in its pattern and produced a false failure here, and this very branch's
+    # mutation runs poisoned themselves the same way — the sed rewriting a header string was itself
+    # captured as evidence naming a second outcome. A searcher that can find its own vocabulary in
+    # what it is searching reports confident nonsense.
+    headers=$(printf '%s\n' "$got" | grep -- '^     --- #1059:' || true)
     while IFS= read -r line; do
         [ -n "$line" ] || continue
         [ "$line" = "$want" ] && continue
@@ -276,6 +303,67 @@ _fe_case() { # <label> <want-sentence|QUIET> <canned _ssh reply>
         esac
     done <<<"$_FE_SENTENCES"
     printf 'ok: %s\n' "$label"
+}
+
+# The ARM side. Everything above drives the REPORT; until now nothing drove the one call that puts
+# a watcher on the guest in the first place, and that asymmetry was not theoretical: deleting
+# backup_precapture's confirmation OUTRIGHT left this suite fully green (mutated 2026-08-24, 14/14
+# ok, rc 0). A guard present in the source and unproven by any test is the same defect this file
+# exists to refuse, one call earlier — the reviewer lane made exactly that structural point against
+# an earlier revision of this branch.
+#
+# The launch is `setsid nohup ... & disown` inside `>/dev/null 2>&1 || true`, so its exit status
+# carries no information about whether a watcher is running. Only the pgrep afterwards does, and
+# these two cases are what hold it in place.
+_fe_precapture_case() { # <label> <want-sentence|QUIET> <canned evidence reply> <canned pgrep reply>
+    local label="$1" want="$2" got
+    _fe_selftest_reply="$3"
+    _fe_selftest_pgrep="$4"
+    # Headers only. The first _ssh in precapture echoes the guest's `ls` back through a `· ` prefix,
+    # and under a single canned stub that reply is this case's own sentinel text — matching the whole
+    # output would let the echo satisfy the assertion instead of the branch under test.
+    got=$(backup_precapture | grep -- '^     --- #1059:' || true)
+    if [ "$want" = "QUIET" ]; then
+        if [ -n "$got" ]; then
+            printf 'FAIL: %s — a watcher confirmed running must name no outcome, got: %s\n' "$label" "$got"
+            _fe_selftest_rc=1
+            return
+        fi
+        printf 'ok: %s (silent)\n' "$label"
+        return
+    fi
+    case "$got" in
+    *"$want"*) printf 'ok: %s\n' "$label" ;;
+    *)
+        printf 'FAIL: %s — expected "%s", got: %s\n' "$label" "$want" "${got:-<silence>}"
+        _fe_selftest_rc=1
+        ;;
+    esac
+}
+
+# A stale log outliving the run that wrote it is the one way an empty-log reading can be right about
+# "never started" and still be reported against the previous run's evidence. The clear has to happen
+# before the script is written, not after the spawn, or it races the watcher's own first line.
+#
+# Asserted on the command precapture actually SENDS, which is a text-level check: it dies if the
+# clear is deleted or reordered, and it cannot prove the guest honoured it. That proof is tier 4.
+_fe_precapture_arms_clean() {
+    local sent
+    _fe_selftest_reply=""
+    _fe_selftest_pgrep="UP"
+    _fe_ssh_capture=""
+    backup_precapture >/dev/null
+    sent=$_fe_ssh_capture
+    case "$sent" in
+    *"rm -f /tmp/pithead-1059-watch.log"*"cat >/tmp/pithead-1059-watch.sh"*)
+        printf 'ok: the arm call clears any stale log before writing the watcher\n'
+        ;;
+    *)
+        printf 'FAIL: the arm call does not clear the stale log ahead of the watcher: %s\n' "${sent:0:120}"
+        _fe_selftest_rc=1
+        ;;
+    esac
+    _fe_ssh_capture=""
 }
 
 # The other half of the contract. Everything above drives the REPORT against a canned reply; it
@@ -372,8 +460,20 @@ _fe_watcher_cases() {
 
 _fe_self_test() {
     # The stub transport. backup_watch_report calls _ssh twice — the fetch and the pkill — and
-    # discards the second's output, so one canned reply serves both.
-    _ssh() { printf '%s' "$_fe_selftest_reply"; }
+    # discards the second's output, so one canned reply serves both. It also records what it was
+    # asked to run, which is the only handle tier 1 has on the arm call: that one is fire-and-forget
+    # by design, so nothing about it can be read back from a reply.
+    _ssh() {
+        _fe_ssh_capture="$_fe_ssh_capture$*"
+        # backup_precapture makes two calls with different jobs, and a case needs to drive them
+        # independently: the evidence read, and the arm-check probe. Matched on the probe's own
+        # tail rather than on 'pgrep', because backup_watch_report's fetch contains a pgrep too and
+        # matching that would quietly re-point every report case at the wrong canned reply.
+        case "$*" in
+        *"&& printf UP") printf '%s' "$_fe_selftest_pgrep" ;;
+        *) printf '%s' "$_fe_selftest_reply" ;;
+        esac
+    }
 
     printf '== unit: #1059 watch-report discrimination ==\n'
     # No sentinel at all: ssh failed, the guest is gone, the command died. Nothing is known.
@@ -402,6 +502,33 @@ VANISHED at 2026-08-24T01:25:57+00:00"
     # The ONLY quiet case: started, still watching, nothing seen.
     _fe_case "a fully-watched window with no vanish stays quiet" "QUIET" \
         "WATCHOKALIVE:STARTED at 2026-08-24T01:00:00+00:00 pid=1234"
+    # The evidence dump is a /proc sweep: arbitrary cmdlines, which can and do contain this file's
+    # own header vocabulary. A real vanish whose process table mentions a RIVAL outcome must still
+    # report as exactly one outcome — the vanish — because the captured line is indented as evidence
+    # and only a printf writes a header. Un-anchor the header grep in _fe_case and this case fails
+    # while every other case stays green, which is the whole point of it being here.
+    _fe_case "a vanish is not confused by its own evidence naming another outcome" \
+        "config.json went away during the backup" \
+        "WATCHOKALIVE:STARTED at 2026-08-24T01:00:00+00:00 pid=1234
+VANISHED at 2026-08-24T01:25:57+00:00
+-- process table at that instant --
+4711	grep --line-buffered -- --- #1059: WATCHER UNREADABLE — this run collected no evidence either way ---"
+
+    printf '== unit: #1059 watcher arming ==\n'
+    # pgrep found it: a watcher is on the guest, and arming has nothing to report.
+    _fe_precapture_case "a watcher confirmed running arms quietly" "QUIET" "" "UP"
+    # pgrep found nothing: the detached launch did not take. Said at the START of the window, where
+    # it still reads as a warning — the report will say it again at the end, and the two are
+    # deliberately different sentences so neither can stand in for the other.
+    _fe_precapture_case "a watcher that failed to arm is named immediately" "WATCHER DID NOT START" "" ""
+    # The guest's evidence arriving WITHOUT a trailing newline is the case that broke this: sed does
+    # not terminate an unterminated final line, so the header printed next was glued to the end of an
+    # evidence line and stopped being a header at all. Anchored readers — the battery scrollback, and
+    # the assertion above — then see nothing while the branch is firing correctly. Found by mutation:
+    # with the guard removed, inverting the arm-check no longer failed anything.
+    _fe_precapture_case "the header starts its own line even when the guest evidence does not" \
+        "WATCHER DID NOT START" "/data/pithead/config.json" ""
+    _fe_precapture_arms_clean
 
     printf '== unit: #1059 watcher body, run for real against a sandbox file ==\n'
     _fe_watcher_cases

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -115,12 +115,25 @@ EOS
 setsid nohup bash /tmp/pithead-1059-watch.sh </dev/null >/dev/null 2>&1 & disown' >/dev/null 2>&1 || true
 }
 
-# Report whatever the watcher saw, and stop it. Silent when the file never went away, so a healthy
+# Report whatever the watcher saw, and stop it. Quiet when the file never went away, so a healthy
 # run stays quiet; loud the moment it blinks, pass or fail.
+#
+# The one thing it must NOT do is stay quiet because it could not look. A silent "no vanish" and a
+# silent "the guest never answered" are the same output and opposite meanings, and reading the
+# second as the first is how a run gets recorded as evidence when it collected none. So the log is
+# fetched with a sentinel: no sentinel back means the watcher could not be read, and that is said
+# out loud rather than passed off as a clean result.
 backup_watch_report() {
-    local seen
-    seen=$(_ssh "cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
+    local raw seen
+    raw=$(_ssh "printf WATCHOK; cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
     _ssh "pkill -f pithead-1059-watch.sh" >/dev/null 2>&1 || true
+    case "$raw" in
+    WATCHOK*) seen=${raw#WATCHOK} ;;
+    *)
+        printf '     --- #1059: WATCHER UNREADABLE — this run collected no evidence either way ---\n'
+        return 0
+        ;;
+    esac
     [ -n "$seen" ] || return 0
     printf '     --- #1059: config.json went away during the backup ---\n'
     printf '%s\n' "$seen" | sed 's/^/     | /'

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -29,3 +29,99 @@ osupdate_failure_evidence() {
           grep -E 'MemAvailable|HugePages_Total|^Dirty|^Writeback:' /proc/meminfo" 2>/dev/null |
         tr -d '\r' | sed 's/^/     · /'
 }
+
+# backup_failure_evidence — the restore leg's source backup refused to complete (#1059).
+#
+# The known occurrence was `tar: data/pithead/config.json: Cannot stat` on a machine whose
+# config.json was a present, root-owned regular file seconds earlier, with `.env` beside it
+# archiving fine — and the guest was recycled before anyone could look, twice. What the CLI
+# log alone cannot say is whether the file was RENAMED and by whom.
+#
+# The tree is the discriminator. Every path that removes config.json without touching .env
+# lives in the firstboot wizard loop, and on an INSTALLED machine that has already accepted a
+# config and brought its stack up, one of them is reachable: the setup-failure branch, which
+# does `mv -f config.json config.json.failed` and re-mints a token. (The rest are pre-setup
+# validator rejections, or installer-STICK paths keyed on an install-request and /boot/efi.)
+# `config.json.failed` on disk names that branch outright, and the spool it writes beside it
+# (error.txt, last-attempt.json) carries the reason setup failed. Its ABSENCE proves nothing,
+# though, and that asymmetry is the whole reason this dump exists: the branch is
+# `mv -f config.json config.json.failed 2>/dev/null || rm -f config.json`, so a failed mv
+# discards its own stderr and DELETES the file outright, leaving no artifact at all. Read a
+# missing config.json.failed as "no evidence either way", never as an alibi. A
+# `config.json.tmp` would instead name the credential write-back's atomic sibling.
+backup_failure_evidence() {
+    printf '     --- guest evidence (#1059) ---\n'
+    _ssh "echo '-- backup log --'; cat /tmp/restore-backup.log 2>/dev/null
+          echo '-- /data/pithead tree --'; ls -la /data/pithead/ 2>&1
+          echo '-- config.json now --'; ls -la /data/pithead/config.json 2>&1; readlink -f /data/pithead/config.json 2>&1
+          echo '-- provisioning still in flight? --'
+          systemctl is-active pithead-firstboot.service pithead-boot.service 2>&1
+          echo '-- wizard spool (the reason setup failed, if it did) --'
+          cat /data/pithead/data/firstboot/error.txt 2>/dev/null; echo
+          cat /data/pithead/data/firstboot/last-attempt.json 2>/dev/null | head -c 400; echo
+          echo '-- firstboot journal --'; journalctl -u pithead-firstboot --no-pager -n 30 2>/dev/null" |
+        tr -d '\r' | sed 's/^/     | /'
+    backup_watch_report
+}
+
+# The #1059 watcher. Two static passes over this repo — a 12-candidate adversarial fan-out and a
+# hand trace of every path that removes config.json — agree that NOTHING in the backup's own call
+# chain touches the file: compose never mounts it, remove_tor_egress_firewall only edits nftables,
+# and the one remover reachable on an installed machine is the firstboot wizard loop's
+# `mv config.json config.json.failed`. That branch is NOT ruled out: it is gated on the exit
+# status of `(setup)` (pithead:2746), and under `set -Eeuo pipefail` any failing command,
+# unbound variable or ERR trap exits that subshell — calling error() is one route to a non-zero
+# status, not the gate. So the actor may be in this tree or outside it, and an instrument that
+# can only name this repo's code would miss half the possibilities by construction.
+#
+# Hence a watcher that names ANY actor. The appliance image ships no inotify-tools, no auditd and
+# no lsof (os/rootfs/Dockerfile), so this is a poll plus a /proc sweep — the process table read
+# within ~100ms of the file going away, while whatever did it is still likely to be alive. It
+# also survives the case that has bitten this issue twice: a run where the backup SUCCEEDS but
+# the file still blinked, which every previous capture would have recorded as an uneventful pass.
+backup_precapture() {
+    _ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
+        tr -d '\r' | sed 's/^/     · /'
+    _ssh 'cat >/tmp/pithead-1059-watch.sh <<"EOS"
+f=/data/pithead/config.json
+out=/tmp/pithead-1059-watch.log
+: >"$out"
+end=$((SECONDS + 1800))
+while [ $SECONDS -lt $end ]; do
+    if [ ! -e "$f" ]; then
+        {
+            echo "VANISHED at $(date -Is)"
+            ls -la /data/pithead/ 2>&1
+            echo "-- the wizard loop, which is the only reachable remover --"
+            systemctl is-active pithead-firstboot.service 2>&1
+            journalctl -u pithead-firstboot --no-pager -n 20 2>/dev/null
+            echo "-- process table at that instant --"
+            for p in /proc/[0-9]*; do
+                [ -r "$p/cmdline" ] || continue
+                c=$(tr "\0" " " <"$p/cmdline")
+                [ -n "$c" ] || continue # kernel threads carry no cmdline and no suspicion
+                printf "%s\t%s\n" "${p#/proc/}" "$c"
+            done
+        } >>"$out" 2>&1
+        for _ in $(seq 300); do
+            [ -e "$f" ] && { echo "REAPPEARED at $(date -Is)" >>"$out"; break; }
+            sleep 0.1
+        done
+        exit 0
+    fi
+    sleep 0.1
+done
+EOS
+setsid nohup bash /tmp/pithead-1059-watch.sh </dev/null >/dev/null 2>&1 & disown' >/dev/null 2>&1 || true
+}
+
+# Report whatever the watcher saw, and stop it. Silent when the file never went away, so a healthy
+# run stays quiet; loud the moment it blinks, pass or fail.
+backup_watch_report() {
+    local seen
+    seen=$(_ssh "cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
+    _ssh "pkill -f pithead-1059-watch.sh" >/dev/null 2>&1 || true
+    [ -n "$seen" ] || return 0
+    printf '     --- #1059: config.json went away during the backup ---\n'
+    printf '%s\n' "$seen" | sed 's/^/     | /'
+}

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -524,7 +524,19 @@ VANISHED at 2026-08-24T01:25:57+00:00
 
     printf '== unit: #1059 watcher arming ==\n'
     # pgrep found it: a watcher is on the guest, and arming has nothing to report.
-    _fe_precapture_case "a watcher confirmed running arms quietly" "QUIET" "" "UP"
+    #
+    # The evidence reply is not empty, and that is the assertion rather than scenery. This case is
+    # what holds the anchor on the precapture grep, and an empty reply gives an un-anchored grep
+    # nothing to mistake for a header — the case would then pass on there being no input, not on the
+    # anchor. So the readlink target carries the marker with a real header's five-space indentation
+    # INSIDE the line. Anchored, it cannot match: the rendered line opens with the evidence prefix,
+    # not with the header's indentation. Drop the ^ here and this case fails. Reachability is lower
+    # than on the report side, which renders a /proc sweep and has been poisoned for real twice —
+    # ls -la and readlink output carrying an indented marker is contrived. Same class either way,
+    # and a guard proven only against an implausible mutation is what this branch keeps finding.
+    _fe_precapture_case "a watcher confirmed running arms quietly" "QUIET" \
+        "lrwxrwxrwx 1 root root 42 Aug 24 01:00 /data/pithead/config.json -> /data/pithead/     --- #1059: WATCHER UNREADABLE, and not a header ---" \
+        "UP"
     # pgrep found nothing: the detached launch did not take. Said at the START of the window, where
     # it still reads as a warning — the report will say it again at the end, and the two are
     # deliberately different sentences so neither can stand in for the other.

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -85,10 +85,18 @@ backup_precapture() {
     _ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
         tr -d '\r' | sed 's/^/     · /'
     _ssh 'cat >/tmp/pithead-1059-watch.sh <<"EOS"
-f=/data/pithead/config.json
-out=/tmp/pithead-1059-watch.log
+# Paths and ceiling come from the environment so the self-test can drive this exact body
+# unmodified. The heredoc is quoted, so these expand on the GUEST at run time, where nothing sets
+# them and the defaults are what runs. A test that had to sed the constants would be proving a
+# respelled copy rather than the script the battery ships.
+f=${PITHEAD_1059_WATCH_FILE:-/data/pithead/config.json}
+out=${PITHEAD_1059_WATCH_LOG:-/tmp/pithead-1059-watch.log}
 : >"$out"
-end=$((SECONDS + 1800))
+# Written before any polling, so an EMPTY log means the watcher never ran. That is a different
+# fact from "nothing vanished" and must never be reported as one.
+echo "STARTED at $(date -Is) pid=$$" >>"$out"
+watch_seconds=${PITHEAD_1059_WATCH_SECONDS:-1800}
+end=$((SECONDS + watch_seconds))
 while [ $SECONDS -lt $end ]; do
     if [ ! -e "$f" ]; then
         {
@@ -113,32 +121,300 @@ while [ $SECONDS -lt $end ]; do
     fi
     sleep 0.1
 done
+# The ceiling reached with the file still there. The backup outlasted the watcher, so only part
+# of the window was watched — say so, rather than let a quiet log read as a clean pass.
+echo "WINDOW EXPIRED at $(date -Is): the ${watch_seconds}s watch ceiling was reached with the file still present" >>"$out"
 EOS
 setsid nohup bash /tmp/pithead-1059-watch.sh </dev/null >/dev/null 2>&1 & disown' >/dev/null 2>&1 || true
+    # Confirm it took. The launch is detached, so its exit status says nothing about whether the
+    # watcher is running, and the line above discards output on purpose. A watcher that never
+    # started is the likeliest way this instrument ends up naming nothing while nothing was
+    # watching, so it is named HERE — at the start of the window, when there is still time to
+    # read it as a warning rather than as a result.
+    case "$(_ssh "pgrep -f '[p]ithead-1059-watch.sh' >/dev/null 2>&1 && printf UP" | tr -d '\r')" in
+    *UP*) ;;
+    *) printf '     --- #1059: WATCHER DID NOT START — this run will collect no evidence either way ---\n' ;;
+    esac
 }
 
 # Report whatever the watcher saw, and stop it. Quiet when the file never went away, so a healthy
 # run stays quiet; loud the moment it blinks, pass or fail.
 #
-# The one thing it must NOT do is stay quiet because it could not look. A silent "no vanish" and a
-# silent "the guest never answered" are the same output and opposite meanings, and reading the
-# second as the first is how a run gets recorded as evidence when it collected none. So the log is
-# fetched with a sentinel: no sentinel back means the watcher could not be read, and that is said
-# out loud rather than passed off as a clean result.
+# The one thing it must NOT do is stay quiet because it could not look. Silence has to mean one
+# thing only, and there are FIVE ways to end up with nothing to name against one way of having
+# genuinely seen nothing:
+#
+#   the guest could not be read        -> no sentinel comes back
+#   the watcher never started          -> readable, but the log is empty
+#   the watcher was killed mid-window  -> it started, and it is no longer running
+#   the watch ceiling was reached      -> it started, and it timed out with the file still there
+#   the file went away                 -> the event, reported loudly
+#   it watched the whole window        -> the only case that is allowed to be quiet
+#
+# Reading any of the first four as the last is how a run gets recorded as evidence when it
+# collected none — the exact defect this file exists to prevent, one level up. So the fetch
+# carries two sentinels: WATCHOK proves the guest answered, ALIVE proves the watcher was still
+# running when it was asked, and the log's own STARTED / WINDOW EXPIRED lines carry the rest.
+# Each outcome gets a sentence only it writes, so no two can be confused for one another.
 backup_watch_report() {
-    local raw seen
-    raw=$(_ssh "printf WATCHOK; cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
+    local raw seen alive=0
+    # One round trip for all three facts. The ':' terminates the sentinels — the log's first
+    # character is arbitrary, so the boundary has to be explicit rather than positional.
+    raw=$(_ssh "printf WATCHOK; pgrep -f '[p]ithead-1059-watch.sh' >/dev/null 2>&1 && printf ALIVE; printf ':'; cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
     # Bracketed: the remote `bash -c` running this pkill carries the pattern in its OWN cmdline,
     # so an unbracketed one matches the shell issuing it.
     _ssh "pkill -f '[p]ithead-1059-watch.sh'" >/dev/null 2>&1 || true
     case "$raw" in
-    WATCHOK*) seen=${raw#WATCHOK} ;;
+    WATCHOK*) raw=${raw#WATCHOK} ;;
     *)
         printf '     --- #1059: WATCHER UNREADABLE — this run collected no evidence either way ---\n'
         return 0
         ;;
     esac
-    [ -n "$seen" ] || return 0
-    printf '     --- #1059: config.json went away during the backup ---\n'
-    printf '%s\n' "$seen" | sed 's/^/     | /'
+    case "$raw" in ALIVE*)
+        alive=1
+        raw=${raw#ALIVE}
+        ;;
+    esac
+    seen=${raw#:}
+    # The event first: on a vanish the watcher exits by design, so it is legitimately not ALIVE
+    # here and must not be read as having died.
+    case "$seen" in
+    *"VANISHED at "*)
+        printf '     --- #1059: config.json went away during the backup ---\n'
+        printf '%s\n' "$seen" | sed 's/^/     | /'
+        return 0
+        ;;
+    esac
+    case "$seen" in
+    *"WINDOW EXPIRED at "*)
+        printf '     --- #1059: WATCH WINDOW EXPIRED before the backup finished — this run collected no evidence either way ---\n'
+        return 0
+        ;;
+    esac
+    case "$seen" in
+    *"STARTED at "*) ;;
+    *)
+        printf '     --- #1059: WATCHER NEVER STARTED — this run collected no evidence either way ---\n'
+        return 0
+        ;;
+    esac
+    if [ "$alive" -ne 1 ]; then
+        printf '     --- #1059: WATCHER DIED mid-window — this run collected no evidence either way ---\n'
+        return 0
+    fi
+    # Started, still running, nothing recorded: the only case that has actually watched the whole
+    # window and seen the file stay put. Quiet, so a healthy battery stays readable.
+    return 0
 }
+
+# --- self-test (#1059) -----------------------------------------------------------------------
+#
+# Driven by `tests/os/failure-evidence.sh --self-test`, tier 1, no KVM guest and no transport:
+# `_ssh` is stubbed with a canned reply, which is the whole input this logic has.
+#
+# What it is here to prove is DISCRIMINATION, not that the code runs. The instrument's product is
+# that its silence means exactly one thing, and five of the six outcomes above are "no evidence"
+# rather than "nothing happened". If any two of them printed the same sentence, a run that watched
+# nothing would read as a run that watched cleanly — the defect the instrument exists to detect,
+# reappearing inside the instrument.
+#
+# So every case is asserted twice over: the sentence only that outcome writes must be PRESENT, and
+# every other outcome's sentence must be ABSENT. Asserting on the shared
+# "collected no evidence either way" tail would pass for any of the four, which is how one guard
+# silently covers for another's deletion. Delete any branch below and its case goes red rather
+# than falling through to the quiet path.
+_fe_selftest_reply=""
+_fe_selftest_rc=0
+
+# Every outcome's unique sentence. The keys are the assertion vocabulary: a case names the one it
+# wants and is checked against all the others.
+_FE_SENTENCES="WATCHER UNREADABLE
+WATCHER NEVER STARTED
+WATCHER DIED mid-window
+WATCH WINDOW EXPIRED
+config.json went away during the backup"
+
+_fe_case() { # <label> <want-sentence|QUIET> <canned _ssh reply>
+    local label="$1" want="$2" got line headers
+    _fe_selftest_reply="$3"
+    got=$(backup_watch_report)
+    if [ "$want" = "QUIET" ]; then
+        if [ -n "$got" ]; then
+            printf 'FAIL: %s — a fully-watched clean window must print nothing, got: %s\n' "$label" "$got"
+            _fe_selftest_rc=1
+            return
+        fi
+        printf 'ok: %s (silent)\n' "$label"
+        return
+    fi
+    case "$got" in
+    *"$want"*) ;;
+    *)
+        printf 'FAIL: %s — expected "%s", got: %s\n' "$label" "$want" "${got:-<silence>}"
+        _fe_selftest_rc=1
+        return
+        ;;
+    esac
+    # ...and none of the others, so this case cannot be satisfied by a neighbouring branch.
+    #
+    # Compared against the HEADER lines only. The vanish branch prints its captured evidence
+    # below its header, and that evidence is a process table — arbitrary text, which can contain
+    # anything including this file's own vocabulary. It does: a leftover log-follower from an
+    # earlier session was running with "WATCHER UNREADABLE" inside its grep pattern, the sweep
+    # captured its cmdline, and a whole-output match called that a second outcome. The header is
+    # what NAMES the outcome, so the header is what has to be unambiguous.
+    headers=$(printf '%s\n' "$got" | grep -- '--- #1059:' || true)
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        [ "$line" = "$want" ] && continue
+        case "$headers" in
+        *"$line"*)
+            printf 'FAIL: %s — its header also names another outcome, "%s": %s\n' "$label" "$line" "$headers"
+            _fe_selftest_rc=1
+            ;;
+        esac
+    done <<<"$_FE_SENTENCES"
+    printf 'ok: %s\n' "$label"
+}
+
+# The other half of the contract. Everything above drives the REPORT against a canned reply; it
+# cannot tell whether the watcher actually writes the lines the report keys on. A mismatch there
+# (the watcher writing "STARTED:" while the report looks for "STARTED at ") would leave every
+# clean run reporting NEVER STARTED, and no amount of report-side testing would show it.
+#
+# So this runs the watcher body EXACTLY as backup_precapture ships it — extracted from the
+# heredoc, not retyped — against a sandbox file, and then feeds its real output back through
+# backup_watch_report. The two halves are proven against each other rather than each against my
+# idea of the other.
+_fe_watcher_body() {
+    awk '/cat >\/tmp\/pithead-1059-watch.sh <<"EOS"/{flag = 1; next} flag && /^EOS$/{exit} flag' "${BASH_SOURCE[0]}"
+}
+
+_fe_watcher_cases() {
+    local sandbox body target log out wpid i
+    sandbox=$(mktemp -d)
+    body="$sandbox/watch.sh"
+    _fe_watcher_body >"$body"
+    if [ ! -s "$body" ]; then
+        printf 'FAIL: could not extract the watcher body from the heredoc\n'
+        _fe_selftest_rc=1
+        rm -rf "$sandbox"
+        return
+    fi
+    # A watcher that does not parse never starts, and the run collects nothing. Cheap to check
+    # here; on the guest it would only show up as a silent absence.
+    if ! bash -n "$body" 2>"$sandbox/syntax"; then
+        printf 'FAIL: the shipped watcher body does not parse: %s\n' "$(cat "$sandbox/syntax")"
+        _fe_selftest_rc=1
+        rm -rf "$sandbox"
+        return
+    fi
+    printf 'ok: the shipped watcher body parses\n'
+
+    # --- the file goes away and comes back ---
+    target="$sandbox/config.json"
+    log="$sandbox/vanish.log"
+    : >"$target"
+    PITHEAD_1059_WATCH_FILE="$target" PITHEAD_1059_WATCH_LOG="$log" \
+        PITHEAD_1059_WATCH_SECONDS=30 bash "$body" &
+    wpid=$!
+    i=0
+    while [ ! -s "$log" ] && [ "$i" -lt 200 ]; do
+        sleep 0.05
+        i=$((i + 1))
+    done
+    rm -f "$target"
+    sleep 1 # the poll is 0.1s, so this is detection with margin, not a race
+    : >"$target"
+    wait "$wpid" 2>/dev/null || true
+    out=$(cat "$log" 2>/dev/null)
+    case "$(printf '%s' "$out" | head -1)" in
+    "STARTED at "*) printf 'ok: the watcher announces STARTED before it polls\n' ;;
+    *)
+        printf 'FAIL: the watcher log does not open with STARTED: %s\n' "$(printf '%s' "$out" | head -1)"
+        _fe_selftest_rc=1
+        ;;
+    esac
+    case "$out" in
+    *"VANISHED at "*) printf 'ok: the watcher records a real disappearance\n' ;;
+    *)
+        printf 'FAIL: the watcher missed a file that actually went away\n'
+        _fe_selftest_rc=1
+        ;;
+    esac
+    # The contract, closed: the watcher's OWN output, through the real report.
+    _fe_case "a real vanish log reports as a vanish" "config.json went away during the backup" "WATCHOK:$out"
+
+    # --- the ceiling is reached with the file still there ---
+    log="$sandbox/expired.log"
+    PITHEAD_1059_WATCH_FILE="$target" PITHEAD_1059_WATCH_LOG="$log" \
+        PITHEAD_1059_WATCH_SECONDS=1 bash "$body"
+    out=$(cat "$log" 2>/dev/null)
+    case "$out" in
+    *"WINDOW EXPIRED at "*) printf 'ok: the watcher records its own expiry\n' ;;
+    *)
+        printf 'FAIL: the watcher expired without saying so: %s\n' "${out:-<empty>}"
+        _fe_selftest_rc=1
+        ;;
+    esac
+    case "$out" in
+    *"VANISHED at "*)
+        printf 'FAIL: the watcher reported a vanish for a file that stayed put\n'
+        _fe_selftest_rc=1
+        ;;
+    *) printf 'ok: a file that stayed put produces no vanish\n' ;;
+    esac
+    _fe_case "a real expired log reports as an expired window" "WATCH WINDOW EXPIRED" "WATCHOK:$out"
+
+    rm -rf "$sandbox"
+}
+
+_fe_self_test() {
+    # The stub transport. backup_watch_report calls _ssh twice — the fetch and the pkill — and
+    # discards the second's output, so one canned reply serves both.
+    _ssh() { printf '%s' "$_fe_selftest_reply"; }
+
+    printf '== unit: #1059 watch-report discrimination ==\n'
+    # No sentinel at all: ssh failed, the guest is gone, the command died. Nothing is known.
+    _fe_case "guest unreadable is not a clean run" "WATCHER UNREADABLE" ""
+    # The guest answered and the log is empty: the launch never took.
+    _fe_case "a watcher that never started is not a clean run" "WATCHER NEVER STARTED" "WATCHOK:"
+    # It started, and it is not running now, with nothing recorded: it was killed mid-window.
+    _fe_case "a watcher killed mid-window is not a clean run" "WATCHER DIED mid-window" \
+        "WATCHOK:STARTED at 2026-08-24T01:00:00+00:00 pid=1234"
+    # It started and timed out with the file still present: the backup outlasted the watch.
+    _fe_case "an expired watch window is not a clean run" "WATCH WINDOW EXPIRED" \
+        "WATCHOK:STARTED at 2026-08-24T01:00:00+00:00 pid=1234
+WINDOW EXPIRED at 2026-08-24T01:30:00+00:00: the 1800s watch ceiling was reached with config.json still present"
+    # The event. The watcher exits by design after recording it, so it is legitimately not ALIVE
+    # here — this case is what proves that is not misread as a death.
+    _fe_case "a vanish is reported even though the watcher has exited" \
+        "config.json went away during the backup" \
+        "WATCHOK:STARTED at 2026-08-24T01:00:00+00:00 pid=1234
+VANISHED at 2026-08-24T01:25:57+00:00
+config.json.failed"
+    # ...and the same, with the watcher still in its reappear wait.
+    _fe_case "a vanish is reported while the watcher is still alive" \
+        "config.json went away during the backup" \
+        "WATCHOKALIVE:STARTED at 2026-08-24T01:00:00+00:00 pid=1234
+VANISHED at 2026-08-24T01:25:57+00:00"
+    # The ONLY quiet case: started, still watching, nothing seen.
+    _fe_case "a fully-watched window with no vanish stays quiet" "QUIET" \
+        "WATCHOKALIVE:STARTED at 2026-08-24T01:00:00+00:00 pid=1234"
+
+    printf '== unit: #1059 watcher body, run for real against a sandbox file ==\n'
+    _fe_watcher_cases
+
+    if [ "$_fe_selftest_rc" -ne 0 ]; then
+        printf '#1059 watch-report self-test FAILED\n'
+        return 1
+    fi
+    printf '#1059 watch-report self-test passed\n'
+    return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ] && [ "${1:-}" = "--self-test" ]; then
+    _fe_self_test
+    exit $?
+fi

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -64,21 +64,23 @@ backup_failure_evidence() {
     backup_watch_report
 }
 
-# The #1059 watcher. Two static passes over this repo — a 12-candidate adversarial fan-out and a
-# hand trace of every path that removes config.json — agree that NOTHING in the backup's own call
-# chain touches the file: compose never mounts it, remove_tor_egress_firewall only edits nftables,
-# and the one remover reachable on an installed machine is the firstboot wizard loop's
-# `mv config.json config.json.failed`. That branch is NOT ruled out: it is gated on the exit
-# status of `(setup)` (pithead:2746), and under `set -Eeuo pipefail` any failing command,
-# unbound variable or ERR trap exits that subshell — calling error() is one route to a non-zero
-# status, not the gate. So the actor may be in this tree or outside it, and an instrument that
-# can only name this repo's code would miss half the possibilities by construction.
+# The #1059 watcher. It caught the mechanism on its first instrumented run, and stays as the
+# canary for it: `setup` is still inside `stack_up`'s `compose up -d` when a concurrent
+# `pithead backup` calls `stack_down`, which deletes a container out from under that in-flight
+# `compose up`; it fails, `stack_up` calls error(), the `(setup)` subshell exits non-zero, and
+# the firstboot wizard loop moves config.json aside (pithead:2746 -> :2752). Whether tar then
+# reports `Cannot stat` is pure timing.
 #
-# Hence a watcher that names ANY actor. The appliance image ships no inotify-tools, no auditd and
-# no lsof (os/rootfs/Dockerfile), so this is a poll plus a /proc sweep — the process table read
-# within ~100ms of the file going away, while whatever did it is still likely to be alive. It
-# also survives the case that has bitten this issue twice: a run where the backup SUCCEEDS but
-# the file still blinked, which every previous capture would have recorded as an uneventful pass.
+# It reports on PASSING runs too, and that is the load-bearing part rather than a nicety: the run
+# that produced the capture above was one where the BACKUP SUCCEEDED and the config was moved
+# aside anyway. A failure-only instrument would have printed a green tick. It follows that older
+# greens on this leg are not evidence the vanish did not happen — nothing was looking.
+#
+# The appliance image ships no inotify-tools, no auditd and no lsof (os/rootfs/Dockerfile), so
+# this is a poll plus a /proc sweep, read within ~100ms of the file going away while whatever did
+# it is still likely to be alive. Deliberately names ANY actor, not just this repo's code: the
+# first two static passes over the backup's own call chain found nothing, because the actor is a
+# concurrent process rather than anything that call chain invokes.
 backup_precapture() {
     _ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
         tr -d '\r' | sed 's/^/     · /'
@@ -126,7 +128,9 @@ setsid nohup bash /tmp/pithead-1059-watch.sh </dev/null >/dev/null 2>&1 & disown
 backup_watch_report() {
     local raw seen
     raw=$(_ssh "printf WATCHOK; cat /tmp/pithead-1059-watch.log 2>/dev/null" | tr -d '\r')
-    _ssh "pkill -f pithead-1059-watch.sh" >/dev/null 2>&1 || true
+    # Bracketed: the remote `bash -c` running this pkill carries the pattern in its OWN cmdline,
+    # so an unbracketed one matches the shell issuing it.
+    _ssh "pkill -f '[p]ithead-1059-watch.sh'" >/dev/null 2>&1 || true
     case "$raw" in
     WATCHOK*) seen=${raw#WATCHOK} ;;
     *)

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1732,20 +1732,15 @@ phase_install() {
     local restore_archive="/tmp/pithead-os-restore-test.tar.gz.enc"
     local restore_pass="pithead-os-restore-test-passphrase" # fixture value, not real secret material
     rm -f "$restore_archive"
-    # State of the two files the backup collects unguarded, captured BEFORE the run (#1059). The
-    # backup failed here with `tar: data/pithead/config.json: Cannot stat` on a machine that was
-    # serving a live stack, and the guest is recycled before anyone can look. `tar` reports exactly
-    # that for a DANGLING SYMLINK as well as for a missing file, and `.env` beside it archived
-    # fine, so what the path actually IS matters more than whether `ls` finds something there.
-    _ssh "ls -la /data/pithead/config.json /data/pithead/.env 2>&1; readlink -f /data/pithead/config.json 2>&1" |
-        tr -d '\r' | sed 's/^/     · /'
+    backup_precapture # #1059: state of both collected files, plus a watcher for the run itself
     if _ssh "cd /data/pithead && PITHEAD_BACKUP_PASSPHRASE=$restore_pass ./pithead backup -y >/tmp/restore-backup.log 2>&1"; then
         ok "restore leg: took a real encrypted backup off the live machine"
+        backup_watch_report # a vanish the backup happened to survive is still the #1059 event
     else
         bad "restore leg: could not take the source backup"
-        # The reason lives on the guest — print ALL of it, or this failure is undiagnosable
-        # after the VM is recycled (a 500-char tail cut off the tar/openssl stderr once).
-        _ssh "cat /tmp/restore-backup.log 2>/dev/null" | tr -d '\r' | sed 's/^/     | /'
+        # The reason lives on the guest — capture ALL of it, log AND tree, or this failure is
+        # undiagnosable after the VM is recycled (it has been, twice: #1059).
+        backup_failure_evidence
         rm -f "$target_disk"
         return
     fi

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -59,3 +59,15 @@ echo "== unit: shipped-image sweep report self-test (#1313) =="
 # driven through fixtures here, with no network, no docker and no gh.
 bash "$ROOT/scripts/shipped-image-sweep-report.sh" --self-test >/dev/null 2>&1
 assert_rc "shipped-image sweep report self-test passes" "$?" "0"
+
+echo "== unit: #1059 watch-report discrimination =="
+# The restore leg's config.json watcher reports on PASSING runs, so its SILENCE is the load-bearing
+# output — and five ways of collecting no evidence (guest unreadable, watcher never started,
+# watcher killed mid-window, watch window expired) must not print what a genuinely clean window
+# prints. Its --self-test drives all six outcomes, asserts each on the one sentence only it writes
+# AND on the absence of the others, and runs the shipped watcher body for real against a sandbox
+# file so the watcher and the report are proven against each other rather than each against an
+# assumption. Lives in tests/os/ (appliance lane); driven here because tier 1 is the lowest tier
+# that proves it and it needs no KVM.
+bash "$ROOT/tests/os/failure-evidence.sh" --self-test >/dev/null 2>&1
+assert_rc "#1059 watch-report self-test passes" "$?" "0"


### PR DESCRIPTION
## What this is

Evidence capture for #1059, in the appliance battery's restore leg. It found the root cause on
its first instrumented run.

## Why it existed to be written

#1059 is `tar: data/pithead/config.json: Cannot stat` on a live appliance, seconds after that
same file was captured as a present, root-owned regular file, with `.env` beside it archiving
fine. It had survived two static investigations and had been lost to a recycled guest twice: the
leg printed the backup log and nothing else, and the log cannot say whether the file was removed,
renamed, or by whom.

## What it does

`backup_precapture` records both collected files and starts a guest-side watcher for the length
of the backup. Within ~100ms of `config.json` going away the watcher records the `/data/pithead`
tree, the firstboot unit's state and journal, and the full process table — the acting process is
still likely to be alive at that point. The appliance image ships no `inotify-tools`, no `auditd`
and no `lsof`, so a poll plus a `/proc` sweep is what is available.

`backup_failure_evidence` additionally dumps the backup log in full, the tree, whether
provisioning was still in flight, the wizard spool and the firstboot journal.

**It reports on PASSING runs too**, and that turned out to be the whole point — see below.

## What it found

On its first instrumented run, on a machine where **the backup SUCCEEDED**:

```
01:25:28  containers Starting; tor still "Waiting"
01:25:56  Container tor  Error dependency tor failed to start
01:25:56  no container with name or ID "0494b001..." found: no such container
01:25:56  Error: executing docker-compose up --pull missing -d: exit status 1
01:25:57  config.json VANISHED -> config.json.failed
```

with `pithead firstboot-wizard`, `pithead backup -y` and `podman compose up -d` all alive at that
instant. `setup` was still inside `stack_up`; the concurrent backup's `stack_down` deleted a
container out from under its in-flight `compose up`; `stack_up` called `error()`; the `(setup)`
subshell exited non-zero; and the wizard loop moved the machine's configuration aside.

Every previous capture on this leg would have recorded that run as an uneventful pass. Reporting
on success is what caught it, and it means earlier "could not reproduce" greens on this leg are
not evidence the vanish did not happen — nothing was looking.

Root cause and the two product defects are written up on #1059. **This PR fixes none of them** —
it is the instrument, not the fix.

## Notes for review

- **`run.sh` stays under its recorded file-budget ceiling** (3437 vs 3442). The helpers live in
  the already-sourced `failure-evidence.sh` rather than in `run.sh`, which is the reusable trick
  for any instrumentation change to a budgeted file — the budget gate is otherwise the thing most
  likely to reject one.
- **Silence is never ambiguous.** Six outcomes, six sentences, and only one of them is quiet.
  An earlier revision of this PR claimed this property while only partly having it — see
  "Correction" below, which is the most important thing on this page for a reviewer.
- **A missing `config.json.failed` is not an alibi.** The branch is
  `mv -f ... 2>/dev/null || rm -f config.json`, so a failed `mv` deletes with no artifact. The
  helper says so, because an instrument that can exonerate the wrong line is worse than none.
- Failure-path and watcher output only; a healthy battery is otherwise unchanged.

## What was run

- `make lint` RC=0 (`lint-sh` completed with no OOM), `make test` **2903 passed, 0 failed** —
  matching the develop-v2 baseline.
- `tests/os/run.sh --phase install` on a KVM guest, twice. The first run lost its restore leg to
  my own mid-run edit (the harness rebuilds images from the live tree, so a dirty worktree makes
  `mkimage` refuse); the second ran on a frozen tree and is the one quoted above.
- Watcher logic exercised directly as well: vanish detected and timestamped, process table
  captured, reappearance seen. That exercise is now a committed `--self-test` rather than an
  ad-hoc one — see below.

## Correction: this instrument had the defect it exists to detect

Added in `1b7e87d`, after the reviewer lane asked — without having read the diff — whether
"nothing was removed" and "the watcher did not see it" could produce the same output. They could.

`backup_watch_report`'s `WATCHOK` sentinel proved the **guest answered**. Nothing proved the
**watcher was ever alive**. So three distinct ways of collecting no evidence all fell through to
the same silent `return 0` as a genuinely clean window:

| situation | what it printed before |
|---|---|
| the watcher never started (the launch is detached and its result discarded) | nothing |
| the watcher was killed mid-window | nothing |
| the watcher hit its own 1800s ceiling while the backup ran on | nothing |
| `config.json` genuinely stayed put | nothing |

A run that watched nothing was indistinguishable from a run that watched cleanly — which is
precisely the failure this file was written to catch, reappearing one level up inside the catcher.
Every "could not reproduce" this instrument might have produced would have carried that ambiguity.

**Now:** the watcher writes `STARTED` before it polls and `WINDOW EXPIRED` when its ceiling is
reached; the fetch also asks whether it is still running; `backup_precapture` confirms the launch
took, so a watcher that never started is named at the **start** of the window instead of inferred
from silence at the end. Each outcome gets a sentence only it writes.

### How that is proven, rather than asserted

- A `--self-test` drives all six outcomes. Each is asserted on its own sentence **and on the
  absence of every other outcome's sentence** — asserting on the shared
  "collected no evidence either way" tail would let any one branch silently cover for another's
  deletion, which is a trap this project has already been bitten by.
- **All six discrimination branches were mutated; every mutation goes red.** Deleting a branch
  makes its case fall through to the quiet path, and the test catches exactly that.
- The **watcher body is extracted from its own heredoc and run for real** — parsed, then driven to
  a genuine vanish and a genuine expiry against a sandbox file, with its actual output fed back
  through `backup_watch_report`. So the two halves are proven against each other rather than each
  against my idea of the other; a `STARTED:`/`STARTED at ` mismatch would be caught here and by
  nothing else. Paths and the ceiling read from the environment *only* so this can drive the
  shipped body unmodified rather than a respelled copy.
- One assertion in the first draft of that test was itself wrong, and the run caught it: the vanish
  report embeds a `/proc` process table, which is arbitrary text and can contain this file's own
  vocabulary. It did — a leftover log-follower from an earlier session was running with
  `WATCHER UNREADABLE` inside its grep pattern. The distinctness check now compares **header lines
  only**, since the header is what names the outcome and the body is captured evidence by nature.

### What this does NOT prove

The self-test is tier 1 against a stubbed transport. It does not prove that `pgrep` and the
detached launch behave on the appliance guest as they do on the bench host — that half is tier 4
and needs a battery run. The failure direction is the safe one: a guest-side failure of these new
lines degrades to a **loud wrong-reason** message, never to a false green. Stated rather than
glossed, because the whole point of the change is not overclaiming what was checked.

### Out-of-lane file, disclosed

**`tests/stack/test-harness-tooling.sh`** — owned outright by the `tests` lane, which is not
running. The controller granted the one-shot `.lane-override` for this rather than block a 1.7s
additive assertion behind a lane spawn and rehydrate. The commit is that one file and nothing else,
additive only, and the guard printed `override CONSUMED`. It is the house home for a `--self-test`:
five other scripts are driven there the same way, and tier 1 is the lowest tier that proves this
one — no network, no docker, no KVM.

## Re-run after rebase onto `8f384e3`

The branch was 5 commits behind and has been rebased. Worth recording because the budget gate went
RED on a file this PR does not touch: `lint-file-budget` reported that
`docs/dev/file-budget.tsv` "raises `dashboard/tests/client/test_xmrig_client.py`'s ceiling from
504 to 537". develop-v2 had *lowered* that ceiling, and the inherited older tsv read as a raise.
Rebasing cleared it with no change of mine — a ceiling going DOWN on the base makes every
un-rebased branch look like it is raising one.

Green on the new base, exit codes captured directly rather than read off filtered output:
`lint-file-budget` RC=0 · `shellcheck --severity=warning` RC=0 · `shfmt -i 4 -d` RC=0 ·
`--self-test` RC=0 (14 assertions, 0 failures). The full `make lint` / `make test` / battery
figures above were measured before the rebase.

## Ponytail pass

Run on this diff; two findings applied, two noted.

- **Applied:** the watcher teardown's `pkill -f` pattern matched the shell issuing it (the remote
  `bash -c` carries the pattern in its own cmdline) — bracketed.
- **Applied:** the `backup_precapture` header recited the investigation rather than its result.
  It now states the mechanism, since the root cause is established.
- **Noted, not changed:** on a vanish the failure path prints the `/data/pithead` tree twice, once
  from each helper. Deduping would lose the tree on failures with *no* vanish, which is the more
  expensive side of the trade.
- **Noted, not changed:** the reappear-detection loop covers a case never observed in the wild.
  Kept at 4 lines because it distinguishes a rename that is later restored from a permanent one.




---

## Correction to the figures above — two claims, two registers

Added post-merge at the controller's ask, because the two pre-rebase numbers quoted earlier are not
the same kind of claim and reading them as one overstates this PR's evidence.

**`make test` 2903/0 does NOT carry.** The reason is mechanical, not a labelling problem: the rebase
pulled in ten commits that ADD tests — a 431-line frontend suite, a 124-line size-cap suite, a
49-line config suite, and the tier-1 split. A count measured before the things it should have
counted cannot describe the tree after them. Treat it as void, not as stale.

**The battery's 41-pass-1-fail plausibly DOES carry, but it is an argument, not a measurement.**
Nothing the rebase pulled in touches `tests/os`, and the later commits touch only
`failure-evidence.sh`, which never calls `ok()`/`bad()` — the leg's tally comes from the
`backup -y` exit code alone. That is a mechanism, and it is offered as reasoning rather than as a
figure anyone re-measured. No battery has run on this branch.

**Still unproven, unchanged:** that `pgrep` and the detached launch behave on the appliance guest as
they do on the bench host is tier 4. The failure direction is safe — a loud wrong reason, never a
silent green — which is a mitigation and not evidence.

The distinction is owed to the reviewer lane, which split it rather than treating the two as one
claim.
