### PR TITLE
fix(tests): catch a domain file that nothing sources (#1357)

### DIFF
--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -226,7 +226,13 @@ sudo tests/os/run.sh --image os/rauc/build/system.img
 What gates a merge vs. a release, the standards every test holds to, and the known gaps. For the
 full enumerated coverage, `make test-inventory` generates the list on demand (git-ignored — read it
 locally). The generator is grep-based, so CI runs it on every PR and fails if any suite it
-enumerates counts zero — the drift a moved or reshaped suite would otherwise hide.
+enumerates counts zero — the drift a moved or reshaped suite would otherwise hide. It also holds
+`tests/stack/run.sh` and the per-domain files it sources to each other in both directions: a file
+named by a `source` line has to exist, and a file on disk has to be sourced by something. Either
+mismatch ends the same way — `run.sh` does not stop on a failed `source`, so the suite reports a
+pass having skipped every assertion in that domain. It reads those `source` lines as text, which
+catches one that is absent or commented out but not one that is present and never reached; a
+handful of suites are invoked as their own CI step instead and are listed as exempt in the script.
 
 ### What runs where
 
@@ -239,7 +245,7 @@ enumerates counts zero — the drift a moved or reshaped suite would otherwise h
 | Compose interpolation + **security/hardening** invariants | 1 | every PR | ✅ required |
 | Fake-daemon **contract test** | 2 | every PR | ✅ required |
 | Integration harness **self-test** | 4 | every PR | ✅ required |
-| **Test-inventory drift** check (the generator still enumerates every suite) | — | every PR | ✅ required |
+| **Test-inventory drift** check (every suite still enumerates; every domain file is sourced) | — | every PR | ✅ required |
 | Fake-daemon **docker mini-stack** | 3 | PRs touching the harness/dashboard | ✅ (own workflow) |
 | **Live config matrix** on real nodes | 4 | manual / pre-release | ✅ **release gate** ([#44](https://github.com/p2pool-starter-stack/pithead/issues/44)) |
 | **KVM appliance battery** (`tests/os/run.sh`) | 4 | manual / pre-release | ✅ **release gate for the image** ([appliance-release.md](appliance-release.md)) |

--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -100,25 +100,58 @@ for f in tests/stack/*.sh; do
     fi
 done
 
-# Every domain file run.sh claims to source must exist. This is the only thing standing between a
-# renamed or deleted domain file and a green suite: run.sh's `source` of a missing file does not
-# stop it (see above), and the per-file loop cannot miss what the glob no longer matches. The 18
-# hyphen-named domain files have no standalone CI invocation of their own — the underscore-named
-# test_*.sh suites do, and fail their own step — so for them this check is the whole safety net.
-n_sourced=0
+# run.sh's `source` line and the file it names have to agree, and they can disagree in EITHER
+# direction. Both ways end identically: `source` of a missing file does not stop run.sh (see
+# above), so the suite goes green having skipped every assertion in that domain, and neither the
+# aggregate nor the per-file gate can see it. The hyphen-named domain files have no standalone CI
+# invocation of their own — the underscore-named test_*.sh suites do, and fail their own step — so
+# for them these two checks are the whole safety net. Both read one SOURCED list, so the pattern
+# cannot drift between them, and a pattern that stops matching trips the emptiness guard rather
+# than quietly satisfying both loops at once.
+#
+# The pattern is anchored to the start of the line, and that anchor is load-bearing: without it a
+# commented-out `# source "$HERE/x.sh"` reads here as a live one, so the file counts as sourced
+# while run.sh never runs it — the same silent skip by another route, and the likeliest thing for
+# a conflict resolution to leave behind. What stays out of reach is a line that is live text but
+# dead code: a `source` inside a branch that never runs, or inside a function nothing calls, still
+# reads as present. Telling those apart needs control flow rather than grep, and is not claimed.
+SOURCED=$(grep -oE '^[[:space:]]*source "\$HERE/[A-Za-z0-9_.-]+\.sh"' tests/stack/run.sh |
+    sed -E 's|^[[:space:]]*source "\$HERE/||; s|"$||')
+if [ -z "$SOURCED" ]; then # the grep itself going quiet must not read as "all present"
+    echo "inventory drift: no 'source \"\$HERE/...\"' lines found in run.sh — the split's shape" \
+        "changed; update the pattern in tests/inventory.sh" >&2
+    exit 1
+fi
+
+# Direction 1 (#1336) — every file run.sh claims to source must exist. Catches a domain file
+# deleted or renamed out from under a live `source` line.
 while read -r want; do
-    n_sourced=$((n_sourced + 1))
     if [ ! -f "tests/stack/$want" ]; then
         echo "inventory drift: run.sh sources tests/stack/$want, which does not exist — the file" \
             "was moved or renamed and the suite would still pass, silently skipping it" >&2
         exit 1
     fi
-done < <(grep -oE 'source "\$HERE/[A-Za-z0-9_.-]+\.sh"' tests/stack/run.sh | sed -E 's|source "\$HERE/||; s|"$||')
-if [ "$n_sourced" -eq 0 ]; then # the grep itself going quiet must not read as "all present"
-    echo "inventory drift: no 'source \"\$HERE/...\"' lines found in run.sh — the split's shape" \
-        "changed; update the pattern in tests/inventory.sh" >&2
+done <<<"$SOURCED"
+
+# Direction 2 (#1357) — every domain file on disk must be sourced. The loop above can only examine
+# the `source` lines that are PRESENT, so a line deleted while its file stays on disk is never
+# looked at; the per-file section gate then finds the orphaned file with its headers intact and
+# passes it. Nothing else asks the question in this direction.
+# Not sourced by run.sh, by design — each is invoked as its own CI step and fails there:
+UNSOURCED="test_appliance_hugepages.sh test_compose.sh test_data_reset.sh \
+    test_firstboot_journal.sh test_os_update_recovery.sh"
+for f in tests/stack/*.sh; do
+    base="${f#tests/stack/}"
+    if [ "$base" = "run.sh" ]; then continue; fi # the sourcer itself
+    case " $UNSOURCED " in *" $base "*) continue ;; esac
+    # Matched between newlines, not spaces: a filename containing a space would survive the glob
+    # above (it is iterated directly) only to be split apart by a space-delimited lookup here.
+    case $'\n'"$SOURCED"$'\n' in *$'\n'"$base"$'\n'*) continue ;; esac
+    echo "inventory drift: tests/stack/$base is on disk but nothing sources it — a 'source' line" \
+        "was deleted and the suite would still pass, silently skipping the file's sections;" \
+        "restore the line, or add the file to UNSOURCED with a reason" >&2
     exit 1
-fi
+done
 
 # --- emit -----------------------------------------------------------------
 cat <<EOF


### PR DESCRIPTION
tests/inventory.sh held only one direction of the agreement between
run.sh's source lines and the domain files beside it: every file a
`source` line names must exist. The reverse was open — a `source` line
deleted while its file stays on disk. That loop can only examine the
source lines that are present, so a deleted one is never looked at, and
the per-file section gate then finds the orphaned file with its headers
intact and passes it. run.sh runs under `set -uo pipefail` with no -e
and exits on its failure counter alone, so either shape ends the same
way: a suite that reports a pass having skipped every assertion in that
domain.

Both directions now read one SOURCED list, so the pattern cannot drift
between them, and a pattern that stops matching trips the emptiness
guard rather than quietly satisfying both loops at once.

The extraction is anchored to the start of the line, and that anchor is
the difference between a guard and a grep. Unanchored, a commented-out
`# source "$HERE/x.sh"` still matches, so the file counts as sourced
while run.sh never runs it — the same silent skip by another route, and
the likeliest thing for the rebase or conflict resolution #1357 worries
about to leave behind. C3 below is the control that proves the anchor is
what catches it rather than the surrounding code.

Mutation-tested, because a check that greps for the right text without
failing on the defect closes the issue and leaves the hole open. Every
case asserts on the one sentence only its own guard writes and asserts
the other's is absent — two guards sharing an output string can silently
cover for each other's deletion:

  M0  unmutated tree                    -> rc 0, silent
  M1  source line deleted, file kept    -> rc 1, the new sentence only
  M1c source line commented out         -> rc 1, the new sentence only
  M3  module file deleted, line kept    -> rc 1, the existing sentence
  M4  source pattern broken             -> rc 1, emptiness guard
  M5  source line indented              -> rc 0, anchor allows leading
                                           whitespace, so it does not
                                           over-restrict
  C1  M1  against pre-change code       -> rc 0  <- the hole itself
  C2  M1c against pre-change code       -> rc 0  <- the hole itself
  C3  M1c, anchor removed from new code -> rc 0  <- the anchor is what
                                           catches M1c

What is deliberately not claimed: a `source` line that is live text but
dead code — inside a branch that never runs, or a function nothing calls
— still reads as present. Telling those apart needs control flow rather
than grep. The code comment and docs/dev/testing-strategy.md both say so
rather than leaving the reader to infer the guard is absolute.

The generated inventory output is byte-identical to pre-change, verified
by running both scripts from a tree root in a scratch copy: 3076 lines
each, md5 f7ff7e1eba780f3a1bb96fc138c21c72. This also drops the stale
"18 hyphen-named domain files" count from the comment being rewritten:
it was 22 at this tip, and any count there goes stale on the next cut.

Run: shfmt -i 4 -d and shellcheck on tests/inventory.sh (clean at full
severity apart from two pre-existing intentional SC2016 info notes on
the literal `$HERE` pattern), plus lint-file-budget, lint-docs-voice and
lint-operator-strings — each rc=0. make lint-sh and make test were NOT
run locally; CI runs both.
