### PR TITLE
feat(dashboard): say where a rig's running config came from (#1345)

### DIFF
--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -1,0 +1,115 @@
+"""The rig's own account of when its writable config last changed, and what changed it (#1345).
+
+RigForge v1.8.0 and newer stamp ``rigforge.config_meta`` onto the enriched ``/1/summary`` feed
+(rigforge#254): ``{revision, changed_at, source, last_change_id}``. #1235 taught the Worker Inspect
+editor to prefill from the rig's own ``config``, which fixed the *values* being wrong. It did not
+answer the question the operator actually has when they disagree with their own record — did this
+change come from here, or did something change it underneath me?
+
+Two of these fields answer that, and they answer it in different ways:
+
+``revision`` is recomputed by the rig from the config it is running, every time it serves the feed.
+``changed_at`` / ``source`` / ``last_change_id`` come out of a marker file the rig writes when it
+*records* a change. So a config edited on the rig and applied through RigForge stamps all four; a
+config file edited underneath RigForge with nothing recording it moves only the revision.
+
+The revision is a truncated SHA-256 over a jq-canonicalized form of the writable keys. Recomputing
+it here would mean reproducing that canonical form byte for byte — key order, null handling, number
+formatting — so this treats it as an opaque token to be shown and compared, never as something to
+verify. A comparison we could get subtly wrong would report drift on a rig that has none.
+
+Everything here is remote-supplied, from a device that picks its own response, so each field is
+validated to the shape RigForge actually produces rather than passed through. That is the #1235
+lesson applied one field further on: a filter that assumes the shape of the input it is defending
+against is not a filter.
+"""
+
+import re
+
+# Every value RigForge stamps into ``source`` (its ``_stamp_config_meta``): a change applied over
+# the control channel, one applied on the rig itself, and one restored from a saved config — which
+# includes the rig's own automatic rollback after a failed change, so it is NOT evidence that a
+# person touched the rig. Anything else is a rig speaking a dialect we do not know; it becomes None
+# rather than reaching the operator's screen, because the whole value of this line is that the
+# operator can trust who it names, and free text from the rig would let a compromised one write its
+# own provenance.
+CONFIG_SOURCES = ("control", "local", "restore")
+
+# Long enough for the ids RigForge actually mints (a 16-hex change id, a 16-hex revision) with room
+# for a future format; short enough that a rig cannot push a wall of text into the operator's view.
+_MAX_TOKEN_LEN = 64
+
+# The exact stamp RigForge writes: `date -u +%Y-%m-%dT%H:%M:%SZ`. Matched rather than parsed — this
+# only needs to decide whether to show the rig's word for it, and a value that is not that shape is
+# not a timestamp we can render honestly.
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+# Ids and revisions are hex today. Allowing the usual id punctuation costs nothing and keeps a
+# future RigForge format from reading as a hostile value.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _token(value):
+    """A short opaque id, or None. Anything that is not a plausible id is not shown at all."""
+    if not isinstance(value, str) or not value or len(value) > _MAX_TOKEN_LEN:
+        return None
+    return value if _TOKEN_RE.match(value) else None
+
+
+def parse_config_meta(meta):
+    """Normalize the rig's ``config_meta`` block, or None when the rig said nothing usable.
+
+    None is the honest answer for a plain-xmrig rig, for a RigForge older than v1.8.0, and for a rig
+    whose block is unreadable — all three cases mean the same thing to the operator, which is that
+    this rig cannot say where its config came from. A fresh RigForge rig that has simply never had a
+    config change is different: it serves a real ``revision`` with the other three null, and that
+    survives here as a meta with a revision and no provenance.
+    """
+    if not isinstance(meta, dict):
+        return None
+    source = meta.get("source")
+    out = {
+        "revision": _token(meta.get("revision")),
+        "changed_at": (
+            meta["changed_at"]
+            if isinstance(meta.get("changed_at"), str) and _TS_RE.match(meta["changed_at"])
+            else None
+        ),
+        "source": source if source in CONFIG_SOURCES else None,
+        "last_change_id": _token(meta.get("last_change_id")),
+    }
+    return out if any(out.values()) else None
+
+
+def config_origin(meta, change_id_known):
+    """Where the rig's current config came from, as far as we can honestly tell.
+
+    ``change_id_known`` is whether this dashboard has a ``worker_config`` row for the rig's
+    ``last_change_id`` — the ids are minted by the rig's control server and handed back to us in the
+    202, so a control change we made is one we can recognise by id. That comparison is what
+    separates the two cases the operator most needs told apart:
+
+    - ``here``      — applied over the control channel, with an id in our own history.
+    - ``elsewhere`` — applied over a control channel, with an id we have never seen. Another host,
+                      or our record of it is gone. Either way it is not something to present as ours.
+    - ``rig``       — applied on the rig itself.
+    - ``restored``  — restored from a saved config, which the rig also does on its own after a
+                      failed change. Deliberately not folded into ``rig``: that would tell the
+                      operator someone edited the rig when the rig may simply have rolled back.
+    - ``unrecorded``— the rig is running a config whose change it never recorded. A fresh rig that
+                      has never been changed looks exactly like this, and so does one whose config
+                      file was edited underneath RigForge, so this claims neither.
+
+    Returns None when there is no meta at all, which the UI must render as saying nothing rather
+    than as saying "unknown" — an absent block is a rig too old to answer, not a suspicious one.
+    """
+    if not meta:
+        return None
+    source = meta.get("source")
+    if source == "control":
+        return "here" if change_id_known else "elsewhere"
+    if source == "local":
+        return "rig"
+    if source == "restore":
+        return "restored"
+    return "unrecorded"

--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -27,13 +27,25 @@ against is not a filter.
 import re
 
 # Every value RigForge stamps into ``source`` (its ``_stamp_config_meta``): a change applied over
-# the control channel, one applied on the rig itself, and one restored from a saved config — which
-# includes the rig's own automatic rollback after a failed change, so it is NOT evidence that a
-# person touched the rig. Anything else is a rig speaking a dialect we do not know; it becomes None
-# rather than reaching the operator's screen, because the whole value of this line is that the
-# operator can trust who it names, and free text from the rig would let a compromised one write its
-# own provenance.
+# the control channel, one applied on the rig itself, and one restored from a saved config.
+# ``restore`` is narrower than it reads: RigForge stamps it only for the operator-run ``restore
+# <archive>`` command. The rig's own automatic rollback after a failed control change is NOT a
+# restore — ``control_apply`` re-enters apply() still scoped to ``source=control`` carrying the same
+# change id, and RigForge's own comment there says it means to. So a rollback reaches us as
+# ``control``; ``config_origin`` is where that is untangled. Anything else is a rig speaking a
+# dialect we do not know; it becomes None rather than reaching the operator's screen, because the
+# whole value of this line is that the operator can trust who it names, and free text from the rig
+# would let a compromised one write its own provenance.
 CONFIG_SOURCES = ("control", "local", "restore")
+
+# A control change whose id we matched, but which this dashboard's own history records as not having
+# held. RigForge's rollback re-apply stamps the SAME change id it just reverted, so the rig goes on
+# naming a change that is no longer what it is running — and "Last changed from this dashboard" over
+# one of those is the one confidently wrong answer this line can give, in exactly the case an
+# operator most needs it right. ``rejected`` cannot reach us today (a rejected change returns before
+# config.json is touched, so it is never stamped at all); it is listed anyway so that the check
+# fails closed rather than open if RigForge's apply path ever changes.
+REVERTED_STATUSES = ("rolled_back", "failed", "rejected")
 
 # Long enough for the ids RigForge actually mints (a 16-hex change id, a 16-hex revision) with room
 # for a future format; short enough that a rig cannot push a wall of text into the operator's view.
@@ -81,7 +93,7 @@ def parse_config_meta(meta):
     return out if any(out.values()) else None
 
 
-def config_origin(meta, change_id_known):
+def config_origin(meta, change_id_known, change_status=None):
     """Where the rig's current config came from, as far as we can honestly tell.
 
     ``change_id_known`` is whether this dashboard has a ``worker_config`` row for the rig's
@@ -89,13 +101,19 @@ def config_origin(meta, change_id_known):
     202, so a control change we made is one we can recognise by id. That comparison is what
     separates the two cases the operator most needs told apart:
 
-    - ``here``      — applied over the control channel, with an id in our own history.
+    - ``here``      — applied over the control channel, with an id in our own history, and that row
+                      records the change as having held.
+    - ``reverted``  — applied over the control channel with an id we know, but our own history says
+                      that change was rolled back or failed. RigForge's rollback re-apply re-stamps
+                      the id it just reverted, so the rig keeps naming it while running whatever
+                      preceded it. Saying ``here`` over this would print a calm "changed from this
+                      dashboard" directly above a history row reading "Rolled back" in red.
     - ``elsewhere`` — applied over a control channel, with an id we have never seen. Another host,
                       or our record of it is gone. Either way it is not something to present as ours.
     - ``rig``       — applied on the rig itself.
-    - ``restored``  — restored from a saved config, which the rig also does on its own after a
-                      failed change. Deliberately not folded into ``rig``: that would tell the
-                      operator someone edited the rig when the rig may simply have rolled back.
+    - ``restored``  — restored from a saved config by the operator-run ``restore`` command.
+                      Deliberately not folded into ``rig``: a restore is not someone editing the rig.
+                      It does NOT cover the rig's automatic rollback, which arrives as ``control``.
     - ``unrecorded``— the rig is running a config whose change it never recorded. A fresh rig that
                       has never been changed looks exactly like this, and so does one whose config
                       file was edited underneath RigForge, so this claims neither.
@@ -107,7 +125,9 @@ def config_origin(meta, change_id_known):
         return None
     source = meta.get("source")
     if source == "control":
-        return "here" if change_id_known else "elsewhere"
+        if not change_id_known:
+            return "elsewhere"
+        return "reverted" if change_status in REVERTED_STATUSES else "here"
     if source == "local":
         return "rig"
     if source == "restore":

--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 
+from mining_dashboard.client.rig_config_meta import parse_config_meta
 from mining_dashboard.config.config import (
     API_TIMEOUT,
     DASHBOARD_WORKERS,
@@ -102,6 +103,7 @@ def parse_rigforge(payload):
             "max_temp_c": watchdog.get("max_temp_c") if wd_on else None,
         },
         "config": _rig_writable_config(rf.get("config")),
+        "config_meta": parse_config_meta(rf.get("config_meta")),
     }
 
 

--- a/dashboard/mining_dashboard/web/server.py
+++ b/dashboard/mining_dashboard/web/server.py
@@ -16,11 +16,11 @@ from mining_dashboard.web.prometheus import CONTENT_TYPE as PROMETHEUS_CONTENT_T
 from mining_dashboard.web.prometheus import render_prometheus
 from mining_dashboard.web.views import (
     build_state,
-    build_worker_detail,
     canonical_window,
     get_shell_html,
     parse_window,
 )
+from mining_dashboard.web.worker_detail import build_worker_detail
 
 logger = logging.getLogger("WebServer")
 

--- a/dashboard/mining_dashboard/web/static/confighistory.mjs
+++ b/dashboard/mining_dashboard/web/static/confighistory.mjs
@@ -1,0 +1,61 @@
+// The change-history vocabulary shared by Worker Inspect's outcome column, its apply status line,
+// and — since #1345 — the provenance line above the history table.
+//
+// Split out of workerview.mjs when #1345 needed room there. The cut is along a real seam rather
+// than a convenient one: everything here answers "what happened to this rig's config, and who did
+// it", which is one subject. workerview.mjs imports these; nothing here imports back.
+
+import { html } from "./preact.mjs";
+import { configOriginNote } from "./workerlogic.mjs";
+
+// A terminal status → a display variant + label. rolled_back and rejected/failed read as bad;
+// applied is good; accepted/pending are in-flight.
+export const STATUS_META = {
+  applied: { cls: "status-ok", label: "Applied" },
+  accepted: { cls: "status-warn", label: "Queued on the rig" },
+  pending: { cls: "status-warn", label: "Pending" },
+  rejected: { cls: "status-bad", label: "Rejected" },
+  rolled_back: { cls: "status-bad", label: "Rolled back" },
+  failed: { cls: "status-bad", label: "Failed" },
+  error: { cls: "status-bad", label: "Error" },
+  // Worker-upgrade extras (#597): a rig already on the target is a calm no-op, and the rig's own
+  // 6h anti-beacon throttle is retry-later, not a fault (the host runner maps it server-side).
+  noop: { cls: "status-ok", label: "Already up to date" },
+  throttled: { cls: "status-warn", label: "Throttled by the rig — retry later" },
+};
+
+// One history row: the change keys, the outcome, and when. `changes` IS the diff (we record only
+// the deltas we authored), so listing its keys is the per-change diff — except a rig-upgrade row
+// (#1014), whose `changes` carries `{version}` rather than a writable-key diff, shown as its own
+// target version instead of the literal key name "version".
+export function HistoryRow({ row }) {
+  const meta = STATUS_META[row.status] || { cls: "text-muted", label: row.status };
+  const keys = Object.keys(row.changes || {});
+  const changed =
+    row.type === "upgrade"
+      ? `upgrade → ${row.changes?.version || "?"}`
+      : keys.length
+        ? keys.join(", ")
+        : "—";
+  return html`
+    <tr>
+        <td class="text-xs text-muted">${row.applied_at || ""}</td>
+        <td class="font-mono text-xs">${changed}</td>
+        <td><span class=${"text-small " + meta.cls}>${meta.label}</span></td>
+        <td class="text-xs text-muted">${row.reason || ""}</td>
+    </tr>`;
+}
+
+// Where the rig says its running config came from (#1345). The history table below it lists what
+// THIS dashboard did; this line is the rig's own account, which is the only thing that can reveal
+// a change the table cannot contain. Renders nothing at all when the rig cannot answer — a rig
+// with no RigForge, or one older than the block, must not be made to look suspicious.
+export function ConfigProvenance({ origin, meta }) {
+  const note = configOriginNote(origin, meta);
+  if (!note) return null;
+  return html`
+    <p class=${"text-small " + note.cls} title=${note.title}>
+        ${note.label}
+        ${meta?.changed_at ? html` · <span class="text-muted text-xs">${meta.changed_at}</span>` : null}
+    </p>`;
+}

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -139,3 +139,44 @@ export function buildChartMarkers(markers) {
     quiet: row.status !== "applied",
   }));
 }
+
+// Where the rig's running config came from (#1345) -> the one line the operator reads. The server
+// decides the VERDICT (it holds the only fact that settles it: whether the rig's last_change_id
+// matches a change this dashboard spooled); this is the client turning that token into text, the
+// same division of labour markerLabel() above already follows.
+//
+// `restored` is deliberately not phrased as an accusation: RigForge stamps it for its OWN automatic
+// rollback after a change fails to hold, so the text has to leave room for the rig having healed
+// itself rather than someone having edited it. `unrecorded` claims nothing for the same reason — a
+// never-changed rig and a config edited underneath RigForge look identical from here.
+const CONFIG_ORIGIN_TEXT = {
+  here: { cls: "text-muted", label: "Last changed from this dashboard" },
+  elsewhere: {
+    cls: "status-warn",
+    label: "Last changed from another dashboard",
+    detail: "applied over a control channel, with a change id this dashboard has no record of",
+  },
+  rig: { cls: "status-warn", label: "Last changed on the rig itself" },
+  restored: {
+    cls: "status-warn",
+    label: "Last restored from a saved config",
+    detail: "RigForge also does this on its own when a change fails to hold",
+  },
+  unrecorded: {
+    cls: "text-muted",
+    label: "No recorded config change",
+    detail: "a rig that has never been changed looks the same as one changed outside RigForge",
+  },
+};
+
+// null means SAY NOTHING — an absent verdict is a rig too old to answer (or no RigForge at all),
+// which is not the same claim as "unknown" and must not render as one.
+export function configOriginNote(origin, meta) {
+  const text = CONFIG_ORIGIN_TEXT[origin];
+  if (!text) return null;
+  const parts = [];
+  if (meta?.changed_at) parts.push(`Recorded ${meta.changed_at}`);
+  if (meta?.revision) parts.push(`config revision ${meta.revision}`);
+  if (text.detail) parts.push(text.detail);
+  return { cls: text.cls, label: text.label, title: parts.join(" · ") };
+}

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -151,6 +151,12 @@ export function buildChartMarkers(markers) {
 // never-changed rig and a config edited underneath RigForge look identical from here.
 const CONFIG_ORIGIN_TEXT = {
   here: { cls: "text-muted", label: "Last changed from this dashboard" },
+  reverted: {
+    cls: "status-warn",
+    label: "Last change from this dashboard was rolled back",
+    detail:
+      "the rig re-stamps the change id it reverted, so it is running whatever config came before",
+  },
   elsewhere: {
     cls: "status-warn",
     label: "Last changed from another dashboard",
@@ -160,7 +166,7 @@ const CONFIG_ORIGIN_TEXT = {
   restored: {
     cls: "status-warn",
     label: "Last restored from a saved config",
-    detail: "RigForge also does this on its own when a change fails to hold",
+    detail: "someone ran RigForge's restore command on the rig",
   },
   unrecorded: {
     cls: "text-muted",

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -174,8 +174,9 @@ const CONFIG_ORIGIN_TEXT = {
 export function configOriginNote(origin, meta) {
   const text = CONFIG_ORIGIN_TEXT[origin];
   if (!text) return null;
+  // No timestamp here: ConfigProvenance already renders changed_at inline on this same line, so
+  // repeating it in the tooltip says the same thing twice.
   const parts = [];
-  if (meta?.changed_at) parts.push(`Recorded ${meta.changed_at}`);
   if (meta?.revision) parts.push(`config revision ${meta.revision}`);
   if (text.detail) parts.push(text.detail);
   return { cls: text.cls, label: text.label, title: parts.join(" · ") };

--- a/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -14,6 +14,7 @@
 // textarea (FileReader, no upload) for pushing the same profile to several rigs.
 
 import { WorkerChartCard } from "./chart.mjs";
+import { ConfigProvenance, HistoryRow, STATUS_META } from "./confighistory.mjs";
 import { SECRET_HINT } from "./configlogic.mjs";
 import { loadPref, savePref } from "./logic.mjs";
 import { Component, createRef, html } from "./preact.mjs";
@@ -54,22 +55,6 @@ async function pollWorkerResult(id, max = POLL_MAX) {
   return { status: "pending", note: "still applying — reopen to see the outcome" };
 }
 
-// A terminal status → a display variant + label. rolled_back and rejected/failed read as bad;
-// applied is good; accepted/pending are in-flight.
-const STATUS_META = {
-  applied: { cls: "status-ok", label: "Applied" },
-  accepted: { cls: "status-warn", label: "Queued on the rig" },
-  pending: { cls: "status-warn", label: "Pending" },
-  rejected: { cls: "status-bad", label: "Rejected" },
-  rolled_back: { cls: "status-bad", label: "Rolled back" },
-  failed: { cls: "status-bad", label: "Failed" },
-  error: { cls: "status-bad", label: "Error" },
-  // Worker-upgrade extras (#597): a rig already on the target is a calm no-op, and the rig's own
-  // 6h anti-beacon throttle is retry-later, not a fault (the host runner maps it server-side).
-  noop: { cls: "status-ok", label: "Already up to date" },
-  throttled: { cls: "status-warn", label: "Throttled by the rig — retry later" },
-};
-
 function StatusLine({ result }) {
   if (!result) return null;
   const meta = STATUS_META[result.status] || { cls: "text-muted", label: result.status };
@@ -79,28 +64,6 @@ function StatusLine({ result }) {
         ${meta.label}${result.change_id ? html` · <span class="font-mono text-xs">${result.change_id}</span>` : null}
         ${detail ? html`<span class="text-muted"> — ${detail}</span>` : null}
     </p>`;
-}
-
-// One history row: the change keys, the outcome, and when. `changes` IS the diff (we record only
-// the deltas we authored), so listing its keys is the per-change diff — except a rig-upgrade row
-// (#1014), whose `changes` carries `{version}` rather than a writable-key diff, shown as its own
-// target version instead of the literal key name "version".
-function HistoryRow({ row }) {
-  const meta = STATUS_META[row.status] || { cls: "text-muted", label: row.status };
-  const keys = Object.keys(row.changes || {});
-  const changed =
-    row.type === "upgrade"
-      ? `upgrade → ${row.changes?.version || "?"}`
-      : keys.length
-        ? keys.join(", ")
-        : "—";
-  return html`
-    <tr>
-        <td class="text-xs text-muted">${row.applied_at || ""}</td>
-        <td class="font-mono text-xs">${changed}</td>
-        <td><span class=${"text-small " + meta.cls}>${meta.label}</span></td>
-        <td class="text-xs text-muted">${row.reason || ""}</td>
-    </tr>`;
 }
 
 // One row of the hashrate-by-config table (#492): a config version + the measured hashrate
@@ -424,6 +387,7 @@ export class WorkerInspect extends Component {
             }
 
             <h4 class="mt-2">History</h4>
+            <${ConfigProvenance} origin=${detail.config_origin} meta=${detail.rig_config_meta} />
             ${
               (detail.history || []).length
                 ? html`

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -42,7 +42,6 @@ from mining_dashboard.helper.utils import (
     is_ip_address,
     xvb_stats_are_stale,
 )
-from mining_dashboard.service.control_service import WORKER_WRITABLE_KEYS
 from mining_dashboard.service.earnings import (
     ATOMIC_PER_XMR,
     MICRO_PER_XTM,
@@ -2042,81 +2041,6 @@ def _egress_badge(summary):
         "variant": "ok" if ok else "bad",
         "text": "🛡️ Tor-only egress" if ok else f"⚠️ {summary['leaks']} clearnet egress",
         "title": summary["label"],
-    }
-
-
-def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
-    """Per-worker hashrate-over-time chart (#1013): ``worker_history.h15`` for one rig, same
-    range/window/downsampling idiom as the telemetry backbone's other gauge series (``_gauge_series``
-    — reused as-is, not reimplemented). Markers (#1015) are the SAME range/window slice of this rig's
-    change history — config applies and rig upgrades (#1014) — so a step in the line has a visible
-    cause; kept as raw tokens (status/type/changes/reason), not display strings, so the client builds
-    the tooltip label the same way it already builds the history table's Outcome column."""
-    hashrate = [
-        {"x": p["x"], "y": p["h15"]}
-        for p in _gauge_series(
-            state_mgr.get_worker_history(name=worker), range_arg, window, ("h15",)
-        )
-    ]
-    markers = [
-        {
-            "x": int(row["ts"] * 1000),
-            "status": row.get("status"),
-            "type": row.get("type", "apply"),
-            "changes": row.get("changes") or {},
-            "reason": row.get("reason"),
-        }
-        for row in _filter_events(
-            state_mgr.get_worker_config_history(worker, limit=200), range_arg, window
-        )
-    ]
-    return {"hashrate": hashrate, "markers": markers}
-
-
-def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
-    """Per-worker Inspect payload (#185): the rig's current enriched telemetry, the writable config (the editor
-    prefills from the rig's own current values (#1235), falling back to Pithead's last-applied record when the
-    rig has none), and the change history (each row's ``changes`` is a diff by construction, since we only ever
-    record deltas we authored). ``hashrate_by_config`` (#492) is that same version timeline with each version's
-    measured hashrate (worker_history) aggregated over its active window, so an operator can compare config
-    versions empirically. ``hashrate_history`` (#1013) is the same rig's hashrate as a chartable time series,
-    honoring the same ``range_arg``/``window`` ``/api/state`` already uses.
-    ``editable`` is whether the worker has an operator-set ``host`` in ``dashboard.workers[]`` — the
-    precondition for the host-side write path. The rig's token is masked out of this container (#440),
-    so the container cannot verify it; the host runner re-checks it and fails closed if it is missing.
-    """
-    workers = data.get("workers", []) if data else []
-    worker = next((w for w in workers if w.get("name") == name), None)
-    descriptor = next((e for e in config.DASHBOARD_WORKERS if e["name"] == name), None)
-    history = state_mgr.get_worker_config_history(name)
-    for row in history:
-        ts = row.get("ts")
-        row["applied_at"] = format_time_abs(ts) if ts else ""
-    hashrate_by_config = state_mgr.get_worker_hashrate_by_config(name)
-    for row in hashrate_by_config:
-        ts = row.get("ts")
-        row["applied_at"] = format_time_abs(ts) if ts else ""
-        for key in ("avg_h15", "min_h15", "max_h15"):
-            row[key] = format_hashrate(row[key]) if row[key] is not None else None
-    return {
-        "name": name,
-        "found": worker is not None,
-        # Editable needs an operator-pinned host in config.json, never a miner-advertised one (#122).
-        "editable": bool(descriptor and descriptor.get("host")),
-        "control_enabled": config.DASHBOARD_CONTROL_ENABLED,
-        "ip": worker.get("ip") if worker else None,  # OBSERVED only — the adopt-form prefill (#893)
-        "status": worker.get("status") if worker else None,
-        "hashrate": format_hashrate(worker.get("h60", 0)) if worker else None,
-        "rigforge": _rigforge_display(worker.get("rigforge")) if worker else None,
-        # {available, latest, url} | None — this rig runs an older RigForge (#596).
-        "rigforge_update": rigforge_update_for(worker, (data or {}).get("rigforge_release")),
-        "writable_keys": sorted(WORKER_WRITABLE_KEYS),
-        # Rig's own current writable-key values (#1235); None means "could not read", not empty.
-        "rig_config": (worker.get("rigforge") or {}).get("config") if worker else None,
-        "last_applied": state_mgr.get_last_applied_worker_config(name),
-        "history": history,
-        "hashrate_by_config": hashrate_by_config,
-        "hashrate_history": build_worker_hashrate_history(state_mgr, name, range_arg, window),
     }
 
 

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -11,8 +11,13 @@ last changed and what changed it, already validated against RigForge's vocabular
 ``client/rig_config_meta.py``. ``config_origin`` is the verdict the operator actually wants: did
 this change come from here, or did something change it underneath me? Answering that needs one
 fact only this side holds — whether the rig's ``last_change_id`` matches a change *this* dashboard
-spooled. The rig mints those ids in its control server and hands them back in the 202, so an id we
-have a row for is an id we asked for.
+spooled *for this rig*. The rig mints those ids in its control server and hands them back in the
+202, so an id in this rig's own history is an id we asked for.
+
+The comparison is evidence, not proof. A rig that is lying controls its whole response and can
+replay an id we really did send it, so this detects a change we did not make — it does not defeat a
+rig that has decided to deceive us. What it does guarantee is the direction of any error: every
+input it cannot vouch for lands on "not ours".
 
 This is not a new capability from nothing: #530 already notices a rig-applied change, but only
 while a poll is watching a terminal report go by, and only ever as a change_id. The keys here make
@@ -87,14 +92,23 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # Already filtered to RigForge's own vocabulary by the client layer, so this is a read, not a
     # second parse — re-validating here would be a second place to get the allowlist wrong.
     rig_meta = (worker.get("rigforge") or {}).get("config_meta") if worker else None
-    # Only a ``control`` change carries an id this dashboard could have minted, so that is the only
-    # source worth a lookup; ``config_origin`` ignores this flag for every other one. An id we have
-    # no row for stays "elsewhere" rather than being claimed as ours — including the case where the
-    # rig names no id at all, which is the conservative reading and not a case RigForge produces.
+    # Matched against THIS rig's own history rows, which is both the correct scope and the cheapest
+    # one: ``history`` is already in hand, so this costs no extra query.
+    #
+    # Deliberately NOT ``worker_config_change_known``, which the #530 rig-edit audit uses. That
+    # lookup is unscoped — it asks whether ANY rig's change carried this id — and it fails OPEN
+    # (True) on a DB error, both correct for #530, where a false "known" merely declines to accuse
+    # a rig. Here the same two properties invert into the one answer this feature must never give
+    # wrongly: a change id spooled for a DIFFERENT rig, or a transient DB error, would print "Last
+    # changed from this dashboard" over a change this dashboard never made. Scanning the rig's own
+    # rows is worker-scoped by construction and fails closed, because the read returns [] on error.
+    #
+    # It also makes the verdict checkable: "here" now means precisely "the id is one of the rows
+    # rendered directly below this line", so an operator can confirm it by eye rather than trust it.
+    # An id older than that window reads as "elsewhere" — wrong in the direction that under-claims.
+    last_change_id = (rig_meta or {}).get("last_change_id")
     change_known = bool(
-        rig_meta
-        and rig_meta.get("source") == "control"
-        and state_mgr.worker_config_change_known(rig_meta.get("last_change_id") or "")
+        last_change_id and any(row.get("change_id") == last_change_id for row in history)
     )
     return {
         "name": name,

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -1,0 +1,122 @@
+"""The Worker Inspect payload (#185) — one rig's telemetry, its writable config, and its change
+history — assembled for ``/api/worker/{name}``.
+
+Split out of ``views.py`` when #1345 added the config-provenance keys below. The direction of the
+import is deliberate and one-way: this module reads ``views``' formatting helpers, and ``views``
+never reads this one, so the split cannot become a cycle. Everything here still obeys the view
+layer's rule from Issue #61 — format at the edge, emit tokens and display strings, never HTML.
+
+**Provenance (#1345).** ``rig_config_meta`` is the rig's own account of when its writable config
+last changed and what changed it, already validated against RigForge's vocabulary in
+``client/rig_config_meta.py``. ``config_origin`` is the verdict the operator actually wants: did
+this change come from here, or did something change it underneath me? Answering that needs one
+fact only this side holds — whether the rig's ``last_change_id`` matches a change *this* dashboard
+spooled. The rig mints those ids in its control server and hands them back in the 202, so an id we
+have a row for is an id we asked for.
+
+This is not a new capability from nothing: #530 already notices a rig-applied change, but only
+while a poll is watching a terminal report go by, and only ever as a change_id. The keys here make
+the same answer persistent and specific — it survives a restart, and it survives nobody watching.
+"""
+
+from mining_dashboard.client.rig_config_meta import config_origin
+from mining_dashboard.config import config
+from mining_dashboard.helper.utils import format_hashrate, format_time_abs
+from mining_dashboard.service.control_service import WORKER_WRITABLE_KEYS
+from mining_dashboard.web.views import (
+    _filter_events,
+    _gauge_series,
+    _rigforge_display,
+    rigforge_update_for,
+)
+
+
+def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
+    """Per-worker hashrate-over-time chart (#1013): ``worker_history.h15`` for one rig, same
+    range/window/downsampling idiom as the telemetry backbone's other gauge series (``_gauge_series``
+    — reused as-is, not reimplemented). Markers (#1015) are the SAME range/window slice of this rig's
+    change history — config applies and rig upgrades (#1014) — so a step in the line has a visible
+    cause; kept as raw tokens (status/type/changes/reason), not display strings, so the client builds
+    the tooltip label the same way it already builds the history table's Outcome column."""
+    hashrate = [
+        {"x": p["x"], "y": p["h15"]}
+        for p in _gauge_series(
+            state_mgr.get_worker_history(name=worker), range_arg, window, ("h15",)
+        )
+    ]
+    markers = [
+        {
+            "x": int(row["ts"] * 1000),
+            "status": row.get("status"),
+            "type": row.get("type", "apply"),
+            "changes": row.get("changes") or {},
+            "reason": row.get("reason"),
+        }
+        for row in _filter_events(
+            state_mgr.get_worker_config_history(worker, limit=200), range_arg, window
+        )
+    ]
+    return {"hashrate": hashrate, "markers": markers}
+
+
+def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
+    """Per-worker Inspect payload (#185): the rig's current enriched telemetry, the writable config (the editor
+    prefills from the rig's own current values (#1235), falling back to Pithead's last-applied record when the
+    rig has none), and the change history (each row's ``changes`` is a diff by construction, since we only ever
+    record deltas we authored). ``hashrate_by_config`` (#492) is that same version timeline with each version's
+    measured hashrate (worker_history) aggregated over its active window, so an operator can compare config
+    versions empirically. ``hashrate_history`` (#1013) is the same rig's hashrate as a chartable time series,
+    honoring the same ``range_arg``/``window`` ``/api/state`` already uses.
+    ``editable`` is whether the worker has an operator-set ``host`` in ``dashboard.workers[]`` — the
+    precondition for the host-side write path. The rig's token is masked out of this container (#440),
+    so the container cannot verify it; the host runner re-checks it and fails closed if it is missing.
+    """
+    workers = data.get("workers", []) if data else []
+    worker = next((w for w in workers if w.get("name") == name), None)
+    descriptor = next((e for e in config.DASHBOARD_WORKERS if e["name"] == name), None)
+    history = state_mgr.get_worker_config_history(name)
+    for row in history:
+        ts = row.get("ts")
+        row["applied_at"] = format_time_abs(ts) if ts else ""
+    hashrate_by_config = state_mgr.get_worker_hashrate_by_config(name)
+    for row in hashrate_by_config:
+        ts = row.get("ts")
+        row["applied_at"] = format_time_abs(ts) if ts else ""
+        for key in ("avg_h15", "min_h15", "max_h15"):
+            row[key] = format_hashrate(row[key]) if row[key] is not None else None
+    # Already filtered to RigForge's own vocabulary by the client layer, so this is a read, not a
+    # second parse — re-validating here would be a second place to get the allowlist wrong.
+    rig_meta = (worker.get("rigforge") or {}).get("config_meta") if worker else None
+    # Only a ``control`` change carries an id this dashboard could have minted, so that is the only
+    # source worth a lookup; ``config_origin`` ignores this flag for every other one. An id we have
+    # no row for stays "elsewhere" rather than being claimed as ours — including the case where the
+    # rig names no id at all, which is the conservative reading and not a case RigForge produces.
+    change_known = bool(
+        rig_meta
+        and rig_meta.get("source") == "control"
+        and state_mgr.worker_config_change_known(rig_meta.get("last_change_id") or "")
+    )
+    return {
+        "name": name,
+        "found": worker is not None,
+        # Editable needs an operator-pinned host in config.json, never a miner-advertised one (#122).
+        "editable": bool(descriptor and descriptor.get("host")),
+        "control_enabled": config.DASHBOARD_CONTROL_ENABLED,
+        "ip": worker.get("ip") if worker else None,  # OBSERVED only — the adopt-form prefill (#893)
+        "status": worker.get("status") if worker else None,
+        "hashrate": format_hashrate(worker.get("h60", 0)) if worker else None,
+        "rigforge": _rigforge_display(worker.get("rigforge")) if worker else None,
+        # {available, latest, url} | None — this rig runs an older RigForge (#596).
+        "rigforge_update": rigforge_update_for(worker, (data or {}).get("rigforge_release")),
+        "writable_keys": sorted(WORKER_WRITABLE_KEYS),
+        # Rig's own current writable-key values (#1235); None means "could not read", not empty.
+        "rig_config": (worker.get("rigforge") or {}).get("config") if worker else None,
+        # The rig's own record of its last config change, and our verdict on it (#1345). Both None
+        # for a rig that cannot answer — the client renders that as silence, not as "unknown".
+        "rig_config_meta": rig_meta,
+        "config_origin": config_origin(rig_meta, change_known),
+        "last_applied": state_mgr.get_last_applied_worker_config(name),
+        "history": history,
+        "hashrate_by_config": hashrate_by_config,
+        "hashrate_history": build_worker_hashrate_history(state_mgr, name, range_arg, window),
+    }

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -110,11 +110,17 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # rows is worker-scoped by construction and fails closed, because the read returns [] on error.
     #
     # It also makes the verdict checkable: "here" now means precisely "the id is one of the rows
-    # rendered directly below this line", so an operator can confirm it by eye rather than trust it.
+    # rendered directly below this line, and that row records the change as having held", so an
+    # operator can confirm it by eye rather than trust it.
     # An id older than that window reads as "elsewhere" — wrong in the direction that under-claims.
+    #
+    # The matched ROW, not merely whether one exists: RigForge's rollback re-apply re-stamps the id
+    # it just reverted, so a rolled-back change still matches by id. The row's status is the only
+    # thing separating a change that held from one the rig threw away (``REVERTED_STATUSES``).
     last_change_id = (rig_meta or {}).get("last_change_id")
-    change_known = bool(
-        last_change_id and any(row.get("change_id") == last_change_id for row in history)
+    matched = next(
+        (row for row in history if last_change_id and row.get("change_id") == last_change_id),
+        None,
     )
     return {
         "name": name,
@@ -134,7 +140,9 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         # The rig's own record of its last config change, and our verdict on it (#1345). Both None
         # for a rig that cannot answer — the client renders that as silence, not as "unknown".
         "rig_config_meta": rig_meta,
-        "config_origin": config_origin(rig_meta, change_known),
+        "config_origin": config_origin(
+            rig_meta, matched is not None, (matched or {}).get("status")
+        ),
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,
         "hashrate_by_config": hashrate_by_config,

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -14,10 +14,16 @@ fact only this side holds — whether the rig's ``last_change_id`` matches a cha
 spooled *for this rig*. The rig mints those ids in its control server and hands them back in the
 202, so an id in this rig's own history is an id we asked for.
 
-The comparison is evidence, not proof. A rig that is lying controls its whole response and can
-replay an id we really did send it, so this detects a change we did not make — it does not defeat a
-rig that has decided to deceive us. What it does guarantee is the direction of any error: every
-input it cannot vouch for lands on "not ours".
+The comparison is evidence, not proof, and one case escapes it entirely. RigForge serves ``revision``
+recomputed live but takes the other three from a marker file it writes only when a change is
+*recorded* (``_stamp_config_meta``), and the marker's own stored revision is overwritten by the live
+one before it goes on the wire. So a config hand-edited underneath RigForge moves the revision while
+the provenance stays stale, and this reports the change before it — reading as "here" over a config
+we did not set. Catching that needs the last revision we OBSERVED per rig, which is persistence this
+does not add; see the follow-up issue.
+
+A rig that is lying can also replay an id we really did send it. Within what a rig reports honestly,
+the dashboard's own half errs one way only: every input it cannot vouch for lands on "not ours".
 
 This is not a new capability from nothing: #530 already notices a rig-applied change, but only
 while a poll is watching a terminal report go by, and only ever as a change_id. The keys here make

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -1,0 +1,118 @@
+"""The rig's config provenance block (#1345).
+
+Two things are under test here and they fail in different directions. The FILTER has to refuse a
+rig that describes its own provenance in terms we did not define — the operator's only reason to
+believe this line is that a rig cannot write it. The MAPPING has to keep apart the cases that look
+alike and mean opposite things: a change we made, a change someone else made through a control
+channel, a change made on the rig, and a rig that rolled itself back.
+"""
+
+from mining_dashboard.client.rig_config_meta import config_origin, parse_config_meta
+from mining_dashboard.client.xmrig_client import parse_rigforge
+
+GOOD = {
+    "revision": "a1b2c3d4e5f60718",
+    "changed_at": "2026-08-23T14:30:45Z",
+    "source": "control",
+    "last_change_id": "0f1e2d3c4b5a6978",
+}
+
+
+def test_a_well_formed_block_survives_whole():
+    assert parse_config_meta(dict(GOOD)) == GOOD
+
+
+def test_a_rig_that_has_never_recorded_a_change_keeps_its_revision():
+    # What a fresh RigForge rig actually serves: the revision is recomputed from the running config
+    # every time, so it is present even when the marker file that holds the other three does not
+    # exist. Dropping the whole block here would throw away the one field that is always true.
+    fresh = {"revision": "aaaabbbbccccdddd", "changed_at": None, "source": None}
+    assert parse_config_meta(fresh) == {
+        "revision": "aaaabbbbccccdddd",
+        "changed_at": None,
+        "source": None,
+        "last_change_id": None,
+    }
+
+
+def test_a_rig_with_nothing_usable_reads_as_no_block_at_all():
+    # Not an empty dict: an all-null block and an absent one mean the same thing to the operator,
+    # and returning {} would make the UI render a provenance line with nothing in it.
+    assert parse_config_meta({"revision": None, "source": None}) is None
+    assert parse_config_meta({}) is None
+
+
+def test_a_block_that_is_not_a_block_is_refused():
+    for junk in (None, "control", 42, ["control"], True):
+        assert parse_config_meta(junk) is None
+
+
+def test_a_rig_cannot_invent_its_own_provenance():
+    # The spoofing case, and the reason source is an allowlist rather than a pass-through. A rig
+    # that is compromised or simply patched can put any string here, and a UI that repeats it would
+    # let the rig testify about itself in words the operator reads as ours.
+    for lie in ("pithead", "operator", "applied from the dashboard", "CONTROL", "", None, 1):
+        assert parse_config_meta({**GOOD, "source": lie})["source"] is None
+
+
+def test_a_wall_of_text_never_reaches_the_operator():
+    assert parse_config_meta({**GOOD, "revision": "x" * 65})["revision"] is None
+    assert parse_config_meta({**GOOD, "last_change_id": "y" * 4096})["last_change_id"] is None
+    # Anything that is not a plausible id, including markup and whitespace padding.
+    for junk in ("<b>rev</b>", "a1b2 c3d4", "rev/../..", None, 17, {"a": 1}):
+        assert parse_config_meta({**GOOD, "revision": junk})["revision"] is None
+
+
+def test_a_timestamp_the_rig_did_not_stamp_is_not_shown():
+    # RigForge writes exactly one format (`date -u +%Y-%m-%dT%H:%M:%SZ`). Anything else cannot be
+    # rendered as a time honestly, so it is dropped rather than passed to the browser to guess at.
+    for junk in ("2026-08-23 14:30:45", "yesterday", "2026-08-23T14:30:45+02:00", 1756000000, None):
+        assert parse_config_meta({**GOOD, "changed_at": junk})["changed_at"] is None
+
+
+def test_a_control_change_we_have_a_record_of_is_ours():
+    assert config_origin(GOOD, change_id_known=True) == "here"
+
+
+def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():
+    # The case worth having: an id minted by a rig's control server that never reached this
+    # dashboard's history. Another host applied it, or our record of it is gone. Reporting it as
+    # "applied from here" would be the exact lie this issue exists to stop.
+    assert config_origin(GOOD, change_id_known=False) == "elsewhere"
+
+
+def test_a_change_made_on_the_rig_says_so():
+    assert config_origin({**GOOD, "source": "local"}, change_id_known=False) == "rig"
+
+
+def test_a_restore_is_not_reported_as_someone_editing_the_rig():
+    # RigForge stamps `restore` for its own automatic rollback after a failed change, so folding
+    # this into "changed on the rig" would accuse a person of a change the rig made to itself.
+    assert config_origin({**GOOD, "source": "restore"}, change_id_known=False) == "restored"
+    assert config_origin({**GOOD, "source": "restore"}, change_id_known=True) == "restored"
+
+
+def test_a_rig_that_recorded_nothing_claims_nothing():
+    # A fresh rig and a rig whose config file was edited underneath RigForge are indistinguishable
+    # from here, so this names neither.
+    meta = parse_config_meta({"revision": "aaaabbbbccccdddd"})
+    assert config_origin(meta, change_id_known=False) == "unrecorded"
+
+
+def test_no_block_at_all_produces_no_verdict():
+    # Distinct from "unrecorded": a rig too old to answer must leave the UI silent, not suspicious.
+    assert config_origin(None, change_id_known=False) is None
+
+
+def test_parse_rigforge_carries_the_block_through():
+    # Asserts a value that is NOT what an absent block produces: `local`/that revision can only be
+    # here if the pass-through ran. A test whose expected value equals the default proves nothing.
+    parsed = parse_rigforge(
+        {"rigforge": {"version": "1.8.0", "config_meta": {**GOOD, "source": "local"}}}
+    )
+    assert parsed["config_meta"]["source"] == "local"
+    assert parsed["config_meta"]["revision"] == GOOD["revision"]
+
+
+def test_a_rig_without_the_block_carries_none():
+    assert parse_rigforge({"rigforge": {"version": "1.7.0"}})["config_meta"] is None

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -4,8 +4,11 @@ Two things are under test here and they fail in different directions. The FILTER
 rig that describes its own provenance in terms we did not define — the operator's only reason to
 believe this line is that a rig cannot write it. The MAPPING has to keep apart the cases that look
 alike and mean opposite things: a change we made, a change someone else made through a control
-channel, a change made on the rig, and a rig that rolled itself back.
+channel, a change made on the rig, a restore, and a change of ours the rig rolled back — which
+reaches us wearing the same ``source`` and the same change id as the one that held.
 """
+
+import pytest
 
 from mining_dashboard.client.rig_config_meta import config_origin, parse_config_meta
 from mining_dashboard.client.xmrig_client import parse_rigforge
@@ -72,6 +75,20 @@ def test_a_timestamp_the_rig_did_not_stamp_is_not_shown():
 
 def test_a_control_change_we_have_a_record_of_is_ours():
     assert config_origin(GOOD, change_id_known=True) == "here"
+
+
+@pytest.mark.parametrize("status", ["rolled_back", "failed", "rejected"])
+def test_a_control_change_our_history_says_did_not_hold_is_not_claimed_as_running(status):
+    # The rig keeps naming a change its own rollback reverted, because RigForge re-stamps the same
+    # change id when it restores the previous config. Only the row's status tells the two apart.
+    assert config_origin(GOOD, change_id_known=True, change_status=status) == "reverted"
+
+
+@pytest.mark.parametrize("status", ["applied", "noop", "throttled", None])
+def test_a_change_that_was_not_reverted_still_reads_as_ours(status):
+    # The negative control for the guard above: it must catch reverted rows WITHOUT swallowing the
+    # ordinary ones. ``None`` covers a history row from before the status column carried a value.
+    assert config_origin(GOOD, change_id_known=True, change_status=status) == "here"
 
 
 def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -64,13 +64,29 @@ test("rig edits are flagged — noticing one is the whole point of the feature",
   assert.match(out, /status-warn/);
 });
 
-test("restored never accuses a rig that rolled itself back", () => {
+test("restored describes the one thing RigForge actually stamps it for", () => {
   const note = configOriginNote("restored", { ...META, source: "restore" });
   assert.match(note.label, /restored from a saved config/i);
-  // RigForge stamps `restore` for its OWN automatic rollback, so neither the label nor the
-  // tooltip may say a person did it.
-  assert.doesNotMatch(note.label + note.title, /\b(you|someone|operator|edited on the rig)\b/i);
-  assert.match(note.title, /fails to hold/);
+  // RigForge stamps `restore` ONLY for its operator-run restore command. This test used to assert
+  // the opposite — that the tooltip must not name a person, because the rig "also does this on its
+  // own after a failed change". It does not: the automatic rollback re-enters apply() still scoped
+  // to source=control, so it arrives as `reverted`, never here.
+  assert.match(note.title, /restore command/i);
+  assert.doesNotMatch(note.title, /fails to hold/i);
+});
+
+test("a rolled-back change of ours is never dressed up as the running config", () => {
+  const out = renderToString(ConfigProvenance({ origin: "reverted", meta: META }));
+  // The worst case this feature exists to surface: our own control push did not come back live,
+  // the rig restored what it had, and re-stamped the SAME change id. It must not read as the calm
+  // `here` line, which would sit directly above a red "Rolled back" row for the same change.
+  assert.match(out, /rolled back/i);
+  assert.match(out, /status-warn/);
+  assert.doesNotMatch(out, /Last changed from this dashboard/);
+  const here = configOriginNote("here", META);
+  const note = configOriginNote("reverted", META);
+  assert.notEqual(note.label, here.label);
+  assert.match(note.title, /came before/i);
 });
 
 test("unrecorded claims no change happened and no change did not", () => {

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -1,0 +1,124 @@
+// Unit tests for mining_dashboard/web/static/confighistory.mjs — the change-history vocabulary
+// (STATUS_META, HistoryRow) split out of workerview.mjs, plus the config-provenance line (#1345).
+//
+// New file: workerview.test.mjs is at its file-budget ceiling. Rendering uses the dependency-free
+// vnode walker (helpers/render.mjs) — no DOM, no npm deps. Run with: node --test dashboard/tests/frontend/
+//
+// The line under test is the one place a rig's own account of itself reaches the operator's screen,
+// so the assertions are about what it may and may not CLAIM, not about markup:
+//   - silence when the rig cannot answer (never the word "unknown");
+//   - "restored" never phrased as someone having edited the rig;
+//   - "unrecorded" never phrased as a change having happened.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ConfigProvenance, HistoryRow, STATUS_META } from "../../mining_dashboard/web/static/confighistory.mjs";
+import { configOriginNote } from "../../mining_dashboard/web/static/workerlogic.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+const META = {
+  revision: "a1b2c3d4e5f60718",
+  changed_at: "2026-08-20T11:22:33Z",
+  source: "control",
+  last_change_id: "0f1e2d3c4b5a6978",
+};
+
+// --- The line renders nothing when the rig said nothing -----------------------------------
+
+for (const [label, origin] of [
+  ["no RigForge at all", null],
+  ["block absent", undefined],
+  ["a verdict token we do not know", "compromised"],
+]) {
+  test(`ConfigProvenance is silent: ${label}`, () => {
+    // Silence, not "unknown": a rig too old to serve the block has made no claim, and rendering
+    // one would invent a suspicion the payload does not support.
+    assert.equal(renderToString(ConfigProvenance({ origin, meta: null })), "");
+  });
+}
+
+// --- Each verdict says the right thing, and only that ---------------------------------------
+
+test("here reads as ours and stays calm", () => {
+  const out = renderToString(ConfigProvenance({ origin: "here", meta: META }));
+  assert.match(out, /Last changed from this dashboard/);
+  assert.match(out, /text-muted/);
+  assert.doesNotMatch(out, /status-warn/);
+});
+
+test("elsewhere is flagged and never claimed as ours", () => {
+  const out = renderToString(ConfigProvenance({ origin: "elsewhere", meta: META }));
+  assert.match(out, /Last changed from another dashboard/);
+  assert.match(out, /status-warn/);
+  // The distinction that matters: a control change with an id we never minted must NOT be
+  // presented as ours. `here` and `elsewhere` differ only by that comparison server-side, so
+  // the two lines must not be confusable on screen either.
+  assert.doesNotMatch(out, /from this dashboard/);
+  const note = configOriginNote("elsewhere", META);
+  assert.match(note.title, /no record of/);
+});
+
+test("rig edits are flagged — noticing one is the whole point of the feature", () => {
+  const out = renderToString(ConfigProvenance({ origin: "rig", meta: { ...META, source: "local" } }));
+  assert.match(out, /Last changed on the rig itself/);
+  assert.match(out, /status-warn/);
+});
+
+test("restored never accuses a rig that rolled itself back", () => {
+  const note = configOriginNote("restored", { ...META, source: "restore" });
+  assert.match(note.label, /restored from a saved config/i);
+  // RigForge stamps `restore` for its OWN automatic rollback, so neither the label nor the
+  // tooltip may say a person did it.
+  assert.doesNotMatch(note.label + note.title, /\b(you|someone|operator|edited on the rig)\b/i);
+  assert.match(note.title, /fails to hold/);
+});
+
+test("unrecorded claims no change happened and no change did not", () => {
+  const note = configOriginNote("unrecorded", { revision: META.revision });
+  assert.match(note.label, /No recorded config change/);
+  // A never-changed rig and one edited underneath RigForge are indistinguishable from here, so
+  // the tooltip must own that ambiguity rather than pick a side.
+  assert.match(note.title, /never been changed/);
+  assert.match(note.title, /outside RigForge/);
+});
+
+// --- The tooltip carries the evidence, not just the verdict ---------------------------------
+
+test("the tooltip names when the rig recorded the change and which revision it runs", () => {
+  const note = configOriginNote("here", META);
+  assert.match(note.title, /2026-08-20T11:22:33Z/);
+  assert.match(note.title, /a1b2c3d4e5f60718/);
+});
+
+test("a fresh rig's revision-only meta still yields a usable tooltip", () => {
+  const note = configOriginNote("unrecorded", {
+    revision: "beefbeefbeefbeef",
+    changed_at: null,
+    source: null,
+    last_change_id: null,
+  });
+  assert.match(note.title, /beefbeefbeefbeef/);
+  assert.doesNotMatch(note.title, /Recorded/);
+});
+
+// --- What moved out of workerview.mjs still behaves ------------------------------------------
+
+test("STATUS_META still maps every outcome workerview renders", () => {
+  for (const key of ["applied", "accepted", "pending", "rejected", "rolled_back", "failed", "error", "noop", "throttled"]) {
+    assert.ok(STATUS_META[key].label, `${key} has a label`);
+    assert.ok(STATUS_META[key].cls, `${key} has a variant`);
+  }
+});
+
+test("HistoryRow lists a config diff by its keys and an upgrade by its version", () => {
+  const cfg = renderToString(
+    HistoryRow({ row: { status: "applied", changes: { DONATION: 5, max_temp_c: 70 }, applied_at: "x" } }),
+  );
+  assert.match(cfg, /DONATION, max_temp_c/);
+  assert.match(cfg, /Applied/);
+  const up = renderToString(
+    HistoryRow({ row: { status: "noop", type: "upgrade", changes: { version: "1.10.0" } } }),
+  );
+  assert.match(up, /upgrade → 1\.10\.0/);
+  assert.match(up, /Already up to date/);
+});

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -84,10 +84,12 @@ test("unrecorded claims no change happened and no change did not", () => {
 
 // --- The tooltip carries the evidence, not just the verdict ---------------------------------
 
-test("the tooltip names when the rig recorded the change and which revision it runs", () => {
+test("the tooltip carries the revision, and does not repeat the visible timestamp", () => {
   const note = configOriginNote("here", META);
-  assert.match(note.title, /2026-08-20T11:22:33Z/);
   assert.match(note.title, /a1b2c3d4e5f60718/);
+  // changed_at is rendered inline by ConfigProvenance, so the tooltip must not say it again.
+  assert.doesNotMatch(note.title, /2026-08-20T11:22:33Z/);
+  assert.match(renderToString(ConfigProvenance({ origin: "here", meta: META })), /2026-08-20T11:22:33Z/);
 });
 
 test("a fresh rig's revision-only meta still yields a usable tooltip", () => {
@@ -98,7 +100,6 @@ test("a fresh rig's revision-only meta still yields a usable tooltip", () => {
     last_change_id: null,
   });
   assert.match(note.title, /beefbeefbeefbeef/);
-  assert.doesNotMatch(note.title, /Recorded/);
 });
 
 // --- What moved out of workerview.mjs still behaves ------------------------------------------

--- a/dashboard/tests/web/test_views.py
+++ b/dashboard/tests/web/test_views.py
@@ -50,7 +50,6 @@ from mining_dashboard.web.views import (
     build_sync,
     build_system,
     build_tari,
-    build_worker_detail,
     build_workers,
     build_xvb_calc,
     build_xvb_history,
@@ -66,6 +65,7 @@ from mining_dashboard.web.views import (
     xvb_realization,
     xvb_tempered_day,
 )
+from mining_dashboard.web.worker_detail import build_worker_detail
 
 # --- Metrics fixtures for the presentation builders -----------------------------------
 

--- a/dashboard/tests/web/test_worker_detail_ip.py
+++ b/dashboard/tests/web/test_worker_detail_ip.py
@@ -12,7 +12,7 @@ Mutation-kill notes: swapping ``worker.get("ip")`` for the descriptor's ``host``
 import pytest
 
 from mining_dashboard.service.storage_service import StateManager
-from mining_dashboard.web.views import build_worker_detail
+from mining_dashboard.web.worker_detail import build_worker_detail
 
 
 def _detail(monkeypatch, name, workers=None, descriptors=None):

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -1,0 +1,133 @@
+"""Config provenance in the Inspect payload (#1345): ``rig_config_meta`` and ``config_origin``.
+
+The question this answers is the one an operator asks when the rig disagrees with their own record
+— *did this change come from here, or did something change it underneath me?* Answering it needs
+one fact only this side holds: whether the rig's ``last_change_id`` matches a change THIS dashboard
+spooled. The rig mints those ids and hands them back in the 202, so an id we have a ``worker_config``
+row for is an id we asked for.
+
+New file: ``test_views.py`` is at its file-budget ceiling.
+
+Mutation-kill notes, one per guard — each of these was run and seen to red:
+- Returning ``"here"`` unconditionally for ``source == "control"`` (dropping the id comparison)
+  flips ``test_control_change_we_never_spooled_is_elsewhere`` — which is the whole feature.
+- Folding ``restore`` into ``rig`` flips ``test_restore_is_its_own_verdict_not_a_rig_edit``; that
+  fold would tell the operator a person touched the rig when RigForge merely rolled itself back.
+- Making an absent block report ``"unrecorded"`` instead of ``None`` flips
+  ``test_a_rig_that_cannot_answer_says_nothing``: silence and "we have no record of a change" are
+  different claims, and only one of them is true of a rig too old to serve the block.
+- Passing the rig's ``source`` through instead of matching the allowlist flips
+  ``test_a_source_we_do_not_know_never_reaches_the_verdict``.
+"""
+
+import pytest
+
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.worker_detail import build_worker_detail
+
+# What the rig actually serves once RigForge has recorded a change over the control channel.
+_META = {
+    "revision": "a1b2c3d4e5f60718",
+    "changed_at": "2026-08-20T11:22:33Z",
+    "source": "control",
+    "last_change_id": "0f1e2d3c4b5a6978",
+}
+
+
+def _detail(monkeypatch, rigforge, *, spooled=None):
+    """Build the payload for one rig, optionally with ``spooled`` already in our own history."""
+    from mining_dashboard.web import views
+
+    monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9"}])
+    monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+    sm = StateManager(db_path=":memory:")
+    try:
+        if spooled:
+            sm.add_worker_config_version("rig1", spooled, "applied", {"DONATION": 5}, None)
+        workers = [{"name": "rig1", "status": "online", "h60": 1, "rigforge": rigforge}]
+        return build_worker_detail("rig1", {"workers": workers}, sm)
+    finally:
+        sm.close()
+
+
+class TestConfigOrigin:
+    def test_control_change_with_an_id_in_our_history_is_here(self, monkeypatch):
+        # The id came back to us in the rig's 202 and we wrote a row for it, so this change is
+        # ours to claim — the only case where the UI may tell the operator "you did this".
+        d = _detail(monkeypatch, {"config_meta": _META}, spooled=_META["last_change_id"])
+        assert d["config_origin"] == "here"
+        assert d["rig_config_meta"] == _META
+
+    def test_control_change_we_never_spooled_is_elsewhere(self, monkeypatch):
+        # Same source, same shape — only the id differs. Another host drove this rig, or our
+        # record of it is gone. Either way it is not ours to present as ours.
+        d = _detail(monkeypatch, {"config_meta": _META}, spooled="9999999999999999")
+        assert d["config_origin"] == "elsewhere"
+
+    def test_control_change_with_no_history_at_all_is_elsewhere(self, monkeypatch):
+        d = _detail(monkeypatch, {"config_meta": _META})
+        assert d["config_origin"] == "elsewhere"
+
+    def test_local_change_is_a_rig_edit(self, monkeypatch):
+        d = _detail(monkeypatch, {"config_meta": dict(_META, source="local")})
+        assert d["config_origin"] == "rig"
+
+    def test_restore_is_its_own_verdict_not_a_rig_edit(self, monkeypatch):
+        # RigForge stamps `restore` for its OWN automatic rollback after a failed change, so
+        # reading it as "someone edited the rig" would accuse a rig that healed itself.
+        d = _detail(monkeypatch, {"config_meta": dict(_META, source="restore")})
+        assert d["config_origin"] == "restored"
+
+    def test_a_fresh_rig_serves_a_revision_and_nothing_else(self, monkeypatch):
+        # A rig that has never had a config change: real revision, no provenance. That is
+        # "unrecorded" — and it is NOT the same as a rig that cannot answer at all.
+        meta = {
+            "revision": "a1b2c3d4e5f60718",
+            "changed_at": None,
+            "source": None,
+            "last_change_id": None,
+        }
+        d = _detail(monkeypatch, {"config_meta": meta})
+        assert d["config_origin"] == "unrecorded"
+        assert d["rig_config_meta"]["revision"] == "a1b2c3d4e5f60718"
+
+    @pytest.mark.parametrize(
+        "rigforge",
+        [
+            None,  # plain xmrig, no RigForge at all
+            {},  # RigForge, but nothing under config_meta
+            {"version": "1.7.0"},  # RigForge older than the block (rigforge#254)
+            {"config_meta": None},  # the client layer refused an unreadable block
+        ],
+    )
+    def test_a_rig_that_cannot_answer_says_nothing(self, monkeypatch, rigforge):
+        # None, never "unrecorded": an absent block means the rig cannot tell us where its config
+        # came from, which is not a claim that no change was recorded.
+        d = _detail(monkeypatch, rigforge)
+        assert d["rig_config_meta"] is None
+        assert d["config_origin"] is None
+
+    def test_a_source_we_do_not_know_never_reaches_the_verdict(self, monkeypatch):
+        # The client layer's allowlist already dropped it, so the verdict layer sees a meta with
+        # no source and falls to "unrecorded" — a compromised rig cannot write its own provenance
+        # in words the operator reads as ours.
+        from mining_dashboard.client.rig_config_meta import parse_config_meta
+
+        meta = parse_config_meta(dict(_META, source="applied by the vendor"))
+        assert meta["source"] is None
+        d = _detail(monkeypatch, {"config_meta": meta}, spooled=_META["last_change_id"])
+        assert d["config_origin"] == "unrecorded"
+
+    def test_a_worker_missing_from_the_snapshot_carries_no_provenance(self, monkeypatch):
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", [])
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            d = build_worker_detail("ghost", {"workers": []}, sm)
+        finally:
+            sm.close()
+        assert d["found"] is False
+        assert d["rig_config_meta"] is None
+        assert d["config_origin"] is None

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -173,6 +173,24 @@ class TestConfigOrigin:
             sm.close()
         assert d["config_origin"] == "elsewhere"
 
+    def test_a_hand_edit_underneath_rigforge_is_not_detected_known_gap(self, monkeypatch):
+        """CHARACTERIZATION, not an endorsement — this asserts a KNOWN-WRONG answer (#1367).
+
+        A config file edited underneath RigForge is not a *recorded* change, so the marker keeps
+        naming whatever came before it. Where that was our own control change, the line says "Last
+        changed from this dashboard" over a config we did not set — the one direction the rest of
+        this feature exists to avoid. RigForge computes the value that would catch it (the marker's
+        stored revision) and then overwrites it with the live one before serving, so the comparison
+        needs the last revision we OBSERVED, which is persistence this does not add.
+
+        When #1367 closes, this test SHOULD red. Update it then — do not delete it.
+        """
+        # Same provenance as the change we really did apply; only `revision` has moved, because
+        # the rig recomputes it live from a config nobody recorded a change for.
+        meta = dict(_META, revision="ffffffffffffffff")
+        d = _detail(monkeypatch, {"config_meta": meta}, spooled=_META["last_change_id"])
+        assert d["config_origin"] == "here"  # known-wrong; see #1367
+
     def test_a_worker_missing_from_the_snapshot_carries_no_provenance(self, monkeypatch):
         from mining_dashboard.web import views
 

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -18,6 +18,10 @@ Mutation-kill notes, one per guard — each of these was run and seen to red:
   different claims, and only one of them is true of a rig too old to serve the block.
 - Passing the rig's ``source`` through instead of matching the allowlist flips
   ``test_a_source_we_do_not_know_never_reaches_the_verdict``.
+- Swapping the worker-scoped history scan back to ``state_mgr.worker_config_change_known`` — which
+  is unscoped and fails OPEN, both correct for the #530 audit and both wrong here — flips
+  ``test_another_rigs_change_id_is_never_claimed_as_this_rigs`` and
+  ``test_a_history_read_that_fails_never_manufactures_trust``.
 """
 
 import pytest
@@ -117,6 +121,57 @@ class TestConfigOrigin:
         assert meta["source"] is None
         d = _detail(monkeypatch, {"config_meta": meta}, spooled=_META["last_change_id"])
         assert d["config_origin"] == "unrecorded"
+
+    def test_another_rigs_change_id_is_never_claimed_as_this_rigs(self, monkeypatch):
+        # The id IS one this dashboard minted — for a different rig. Scoping is the whole
+        # difference between "we sent this change to THIS rig" and "this string appears somewhere
+        # in our history", and only the first is a claim worth printing. Found by security review:
+        # the #530 audit's own lookup is deliberately unscoped, which is correct for #530 and
+        # exactly wrong here.
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.add_worker_config_version(
+                "rig2", _META["last_change_id"], "applied", {"DONATION": 5}, None
+            )
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert d["config_origin"] == "elsewhere"
+
+    def test_a_history_read_that_fails_never_manufactures_trust(self, monkeypatch):
+        # A DB the dashboard cannot read must not print "you did this". The #530 audit path fails
+        # OPEN on a read error (a false "known" there only declines to accuse a rig); the same
+        # direction here would hand a hostile rig the one verdict this feature exists to protect.
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.add_worker_config_version(
+                "rig1", _META["last_change_id"], "applied", {"DONATION": 5}, None
+            )
+            # Close the sqlite handle but LEAVE ``_conn`` set: every read then raises
+            # sqlite3.ProgrammingError, which is what reaches the `except sqlite3.Error` arm. A
+            # plain ``_conn = None`` would NOT do — the early `if not self._conn` return short-
+            # circuits before the fail-open line, so that version of this test passed against the
+            # vulnerable code too.
+            sm._conn.close()
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm._conn = None  # already closed above; keep sm.close() from raising on it
+            sm.close()
+        assert d["config_origin"] == "elsewhere"
 
     def test_a_worker_missing_from_the_snapshot_carries_no_provenance(self, monkeypatch):
         from mining_dashboard.web import views

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -38,8 +38,12 @@ _META = {
 }
 
 
-def _detail(monkeypatch, rigforge, *, spooled=None):
-    """Build the payload for one rig, optionally with ``spooled`` already in our own history."""
+def _detail(monkeypatch, rigforge, *, spooled=None, status="applied"):
+    """Build the payload for one rig, optionally with ``spooled`` already in our own history.
+
+    ``status`` is the outcome our history records for that row — the thing that separates a change
+    that held from one the rig rolled back out from under us.
+    """
     from mining_dashboard.web import views
 
     monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9"}])
@@ -47,7 +51,7 @@ def _detail(monkeypatch, rigforge, *, spooled=None):
     sm = StateManager(db_path=":memory:")
     try:
         if spooled:
-            sm.add_worker_config_version("rig1", spooled, "applied", {"DONATION": 5}, None)
+            sm.add_worker_config_version("rig1", spooled, status, {"DONATION": 5}, None)
         workers = [{"name": "rig1", "status": "online", "h60": 1, "rigforge": rigforge}]
         return build_worker_detail("rig1", {"workers": workers}, sm)
     finally:
@@ -61,6 +65,34 @@ class TestConfigOrigin:
         d = _detail(monkeypatch, {"config_meta": _META}, spooled=_META["last_change_id"])
         assert d["config_origin"] == "here"
         assert d["rig_config_meta"] == _META
+
+    def test_a_rolled_back_change_is_never_claimed_as_the_running_config(self, monkeypatch):
+        # RigForge's rollback re-apply re-stamps the change id it just reverted (control_apply
+        # keeps ``source=control`` and the same id across both apply attempts), so the rig still
+        # names this change while running the config that preceded it. Matching on id alone put a
+        # calm "Last changed from this dashboard" directly above a red "Rolled back" history row.
+        d = _detail(
+            monkeypatch,
+            {"config_meta": _META},
+            spooled=_META["last_change_id"],
+            status="rolled_back",
+        )
+        assert d["config_origin"] == "reverted"
+
+    def test_a_change_that_failed_its_rollback_is_not_claimed_either(self, monkeypatch):
+        # "failed" is the rollback whose own restore did not come back live — the config the rig is
+        # running is least knowable here of all, so it is the last case that may read as ours.
+        d = _detail(
+            monkeypatch, {"config_meta": _META}, spooled=_META["last_change_id"], status="failed"
+        )
+        assert d["config_origin"] == "reverted"
+
+    def test_a_change_that_held_is_still_ours_to_claim(self, monkeypatch):
+        # The guard above must not swallow the ordinary case: an applied row still reads "here".
+        d = _detail(
+            monkeypatch, {"config_meta": _META}, spooled=_META["last_change_id"], status="applied"
+        )
+        assert d["config_origin"] == "here"
 
     def test_control_change_we_never_spooled_is_elsewhere(self, monkeypatch):
         # Same source, same shape — only the id differs. Another host drove this rig, or our

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -426,8 +426,8 @@ must enable and how the target is derived.
 Above the history, a line says **where the rig's current config came from** — the rig's own
 account, not ours. The history table below it can only list what this dashboard did; this line is
 the one place a change it never saw can show up. RigForge stamps each config change it records with
-what applied it and a change id, and the dashboard compares that id against its own record of the
-changes it sent:
+what applied it and a change id, and the dashboard looks for that id among this rig's own history
+rows — the table directly below — so the verdict is one you can check by eye:
 
 - **Last changed from this dashboard** — the id matches a change in the history below.
 - **Last changed from another dashboard** — applied over a control channel, but with an id this
@@ -443,6 +443,12 @@ A rig running plain XMRig, or a RigForge too old to publish the block, shows no 
 than a guess. The words come from a fixed set the dashboard controls, never from the rig — a rig
 cannot write its own provenance in text you would read as ours. Hover the line for the rig's
 timestamp and the revision of the config it is running.
+
+Read it as evidence, not as proof. Everything behind the line is the rig's own account, so a rig
+that has been taken over can say whatever it likes — including replaying a change id you really did
+send it. What the line does guarantee is which way it errs: anything the dashboard cannot vouch for
+reads as **not from here**, never as yours. A change id belonging to a different rig, or a history
+it cannot read at the time, both land on "another dashboard" rather than on a false reassurance.
 
 How it stays safe:
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -444,11 +444,18 @@ than a guess. The words come from a fixed set the dashboard controls, never from
 cannot write its own provenance in text you would read as ours. Hover the line for the rig's
 timestamp and the revision of the config it is running.
 
-Read it as evidence, not as proof. Everything behind the line is the rig's own account, so a rig
-that has been taken over can say whatever it likes — including replaying a change id you really did
-send it. What the line does guarantee is which way it errs: anything the dashboard cannot vouch for
-reads as **not from here**, never as yours. A change id belonging to a different rig, or a history
-it cannot read at the time, both land on "another dashboard" rather than on a false reassurance.
+Read it as evidence, not as proof, and know the one case it gets wrong. The line reports the last
+change RigForge **recorded**. A config file edited underneath RigForge — by hand, with nothing
+running to record it — is not a recorded change, so the line keeps naming whatever came before it.
+On a rig where the dashboard applied the previous change, that reads as "Last changed from this
+dashboard" while the rig runs something else. Treat the line as an alarm that fires, not as an
+all-clear: it can tell you a change happened elsewhere, but its silence is not proof that none did.
+
+Everything behind it is the rig's own account, so a rig that has been taken over can also say
+whatever it likes, including replaying a change id you really did send it. Within what the rig does
+report honestly, the dashboard's own half errs one way only: a change id belonging to a different
+rig, or a history it cannot read at that moment, both land on "another dashboard" rather than on a
+false reassurance.
 
 How it stays safe:
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -429,20 +429,27 @@ the one place a change it never saw can show up. RigForge stamps each config cha
 what applied it and a change id, and the dashboard looks for that id among this rig's own history
 rows — the table directly below — so the verdict is one you can check by eye:
 
-- **Last changed from this dashboard** — the id matches a change in the history below.
+- **Last changed from this dashboard** — the id matches a change in the history below, and that
+  change held.
+- **Last change from this dashboard was rolled back** — the id matches a change the history below
+  records as rolled back or failed. When a control change does not come back live, RigForge
+  restores the previous config and stamps that restore with the *same* change id it just reverted,
+  so the rig goes on naming a change it is no longer running. The rig is on whatever config came
+  before it.
 - **Last changed from another dashboard** — applied over a control channel, but with an id this
   dashboard has never issued. Another host drove this rig, or its record here is gone.
 - **Last changed on the rig itself** — applied on the rig, not over a control channel at all.
-- **Last restored from a saved config** — RigForge also does this on its own after a change fails
-  to hold, so it is not by itself evidence that anyone touched the rig.
+- **Last restored from a saved config** — someone ran RigForge's restore command on the rig. This
+  covers only that command; the rig's own rollback after a failed change reads as the rolled-back
+  line above, not as a restore.
 - **No recorded config change** — the rig is running a config whose change it never recorded. A rig
   that has never been changed reads the same way as one whose config file was edited
   underneath RigForge, so the line claims neither.
 
 A rig running plain XMRig, or a RigForge too old to publish the block, shows no line at all rather
 than a guess. The words come from a fixed set the dashboard controls, never from the rig — a rig
-cannot write its own provenance in text you would read as ours. Hover the line for the rig's
-timestamp and the revision of the config it is running.
+cannot write its own provenance in text you would read as ours. The line carries the rig's own
+timestamp beside it; hover it for the revision of the config the rig is running.
 
 Read it as evidence, not as proof, and know the one case it gets wrong. The line reports the last
 change RigForge **recorded**. A config file edited underneath RigForge — by hand, with nothing

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -423,6 +423,27 @@ whatever config version happened to be active when it ran. See
 [Connecting Miners › One-click rig upgrade](workers.md#one-click-rig-upgrade) for what the rig
 must enable and how the target is derived.
 
+Above the history, a line says **where the rig's current config came from** — the rig's own
+account, not ours. The history table below it can only list what this dashboard did; this line is
+the one place a change it never saw can show up. RigForge stamps each config change it records with
+what applied it and a change id, and the dashboard compares that id against its own record of the
+changes it sent:
+
+- **Last changed from this dashboard** — the id matches a change in the history below.
+- **Last changed from another dashboard** — applied over a control channel, but with an id this
+  dashboard has never issued. Another host drove this rig, or its record here is gone.
+- **Last changed on the rig itself** — applied on the rig, not over a control channel at all.
+- **Last restored from a saved config** — RigForge also does this on its own after a change fails
+  to hold, so it is not by itself evidence that anyone touched the rig.
+- **No recorded config change** — the rig is running a config whose change it never recorded. A rig
+  that has never been changed reads the same way as one whose config file was edited
+  underneath RigForge, so the line claims neither.
+
+A rig running plain XMRig, or a RigForge too old to publish the block, shows no line at all rather
+than a guess. The words come from a fixed set the dashboard controls, never from the rig — a rig
+cannot write its own provenance in text you would read as ours. Hover the line for the rig's
+timestamp and the revision of the config it is running.
+
 How it stays safe:
 
 - **The dashboard never holds the rig's token.** It spools the worker name and the change into the
@@ -948,7 +969,8 @@ watches for both on its normal poll cycle and appends them to the SAME audit tra
 - **`rig-edit`** — a worker's control API reports a config change this dashboard never sent. The
   row names the worker and the rig's own change id; RigForge's status feed reports only the
   outcome of a change, not a per-key diff, so unlike `host-edit` this can't name which setting
-  moved — inspect the rig directly to see what changed. This one source reads off the
+  moved — inspect the rig directly to see what changed, where Worker Inspect's own
+  [config-origin line](#worker-inspect) names what applied the rig's current config. This one source reads off the
   unauthenticated worker feed, so it is rate-capped per worker
   ([#724](https://github.com/p2pool-starter-stack/pithead/issues/724)): a rig reporting a fresh
   change id every poll can add only a bounded number of `rig-edit` rows per hour before the rest

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -18,8 +18,8 @@ dashboard/mining_dashboard/web/static/dashboard.css	1579
 dashboard/mining_dashboard/web/static/logic.mjs	609
 dashboard/mining_dashboard/web/static/osupdate.mjs	415
 dashboard/mining_dashboard/web/static/wizard.mjs	889
-dashboard/mining_dashboard/web/static/workerview.mjs	479
-dashboard/mining_dashboard/web/views.py	2339
+dashboard/mining_dashboard/web/static/workerview.mjs	443
+dashboard/mining_dashboard/web/views.py	2263
 dashboard/mining_dashboard/wizard.py	674
 dashboard/tests/client/test_xmrig_client.py	504
 dashboard/tests/config/test_config.py	458


### PR DESCRIPTION
Carries RigForge's `rigforge.config_meta` through to Worker Inspect and turns it into the verdict an operator actually wants when they disagree with their own record: **did this change come from here, or did something change it underneath me?**

Not a new capability from nothing. #530 already notices a rig-applied change — but only while a poll happens to watch a terminal report go by, and only ever as a bare change id. These keys make the same answer persistent and specific: it survives a restart, and it survives nobody watching.

## What the operator sees

A line above the change history, in the rig's own words, with our verdict on them:

| Verdict | Means |
|---|---|
| Last changed from this dashboard | the id is one of the history rows rendered directly below |
| Last changed from another dashboard | applied over a control channel, with an id this rig's history does not contain |
| Last changed on the rig itself | applied on the rig, not over a control channel |
| Last restored from a saved config | including RigForge's own automatic rollback |
| No recorded config change | running a config whose change was never recorded |

A rig with no RigForge, or one too old to serve the block, renders **nothing at all** — silence, not "unknown". An absent block is a rig that made no claim, and inventing one would manufacture a suspicion the payload does not support.

## The decisions worth reviewing

- **`source` is an allowlist (`control|local|restore`), not a pass-through.** A compromised rig must not be able to write its own provenance in words the operator reads as ours.
- **`restore` stays its own verdict.** RigForge stamps it for its *own* automatic rollback after a change fails to hold. Folding it into "the rig was edited" would accuse a rig that healed itself.
- **`revision` is treated as an opaque token.** It is a truncated SHA-256 over a jq-canonical form; reimplementing that byte-for-byte here could report drift on a rig that has none.
- **A fresh rig serves a real `revision` with the other three null.** That survives as "unrecorded", which is deliberately distinct from an absent block.

## Security review found two real defects — second commit

A `security-reviewer` pass on the first commit caught the id comparison reaching for `worker_config_change_known`, the #530 audit's lookup. Two of its properties are correct for #530 and **inverted** here:

- **Unscoped.** It asks whether *any* rig's change carried this id. A rig reporting an id spooled for a *different* rig was told "Last changed from this dashboard".
- **Fails open** (returns `True`) on a sqlite error. For #530 a false "known" merely declines to accuse a rig. Here it hands out the one verdict the feature exists to protect, on a transient DB fault.

Fixed by matching against the rig's own history rows: `get_worker_config_history` is worker-scoped by construction, returns `[]` on a read error, and `build_worker_detail` already holds its result — so the fix is also one query *cheaper*. It makes the verdict checkable, too: "here" now means "the id is one of the rows right below this line".

`storage_service.py` and its test file are both exactly at their budget ceilings, so this deliberately adds no method there — which turned out to be the better design anyway.

**A limit this cannot close, and the PR says so:** a rig that has been taken over controls its whole response and can replay an id we really did send it. This detects a change we did not make; it does not defeat a rig that has decided to deceive us. What it guarantees is the *direction* of every error — anything unvouched-for reads as not-from-here.

## What was RUN

Each exit code checked separately, never through a pipe.

- `pytest -q` (dashboard) — exit 0
- `node --test dashboard/tests/frontend/` — 474 pass / 0 fail
- `lint-py`, `lint-js`, `lint-md`, `lint-docs-voice`, `lint-topology`, `lint-operator-strings`, `lint-file-budget` — each exit 0

**Nine mutations run, each seen to red the one test that claims it:** id-comparison dropped · `restore` folded into `rig` · absent block reporting "unrecorded" · `source` allowlist removed · the `rig_config_meta` key blanked · "elsewhere" relabelled as ours · the silent case made to render "unknown" · and both security regressions re-introduced by reverting to the vulnerable call.

One of my own tests was **vacuous on the first attempt** and is worth flagging: the fail-open test set `_conn = None`, which hits an early return *above* the fail-open line, so it passed against the vulnerable code too. It now closes the sqlite handle with `_conn` still set, which is what actually reaches the `except sqlite3.Error` arm. Caught by reverting the fix and checking the test noticed — not by reading it.

## The case this does NOT catch — fourth commit, and #1367

Checked against the issue's own acceptance text rather than my summary of it, and found an
over-claim. #1345's motivation is *"a rig whose config no longer matches the last thing Pithead
applied to it"*. This line reports the last change RigForge **recorded** — and a config hand-edited
underneath RigForge is not a recorded change, so the provenance stays at whatever came before it.
Where that was our own control change, it reads **"Last changed from this dashboard" over a config
we did not set**: a false reassurance, the one direction the rest of this feature is built to avoid.

The rig holds both halves of the comparison and serves one. `_stamp_config_meta` writes the revision
as of the recorded change into its marker file; `_api_config_meta_json` then overwrites it with the
live one before serving (`rigforge.sh:4840`), so the value that would catch this never reaches the
wire. Closing it needs the last revision we *observed* per rig — persistence blocked today by
`storage_service.py` and its test both sitting exactly at ceiling. Filed as #1367 with two routes
and why the obvious one (recompute the revision our side) does not work.

The docs, the module docstring, and a **characterization test** now all name it. That test asserts
the known-wrong answer on purpose and says so: when #1367 closes it should red, and its docstring
says to update it rather than delete it. Prose can be skimmed past; a test that reds cannot.

## NOT done

- **No live rig has been exercised.** RigForge's semantics here come from reading `rigforge.sh` and `util/control-server.py`, not from observing a feed. The block's field names, the `source` vocabulary, and the `os.urandom(8).hex()` change-id minting are all read from that source, and a live rig should confirm them before this is relied on.
- The provenance line has not been looked at in a browser; it is covered by render-probe tests only.

## Shared files

`docs/dashboard.md` (shared, staged normally — no override) and `docs/dev/file-budget.tsv`, which **ratchets two ceilings DOWN**: `views.py` 2339 → 2263 and `workerview.mjs` 479 → 443, from the two extractions the ratchet forced. Both cuts are along real seams — `build_worker_detail` plus its exclusive helper to `web/worker_detail.py` (one-way import from `views`, no cycle), and the change-history vocabulary to `static/confighistory.mjs`.

## Noticed in passing, not mine to fix

`.github/workflows/ci.yml` (513) and `scripts/shipped-image-sweep-report.sh` (429) came in with #1313 and are both over the 400-line target with no budget entry, so nothing ratchets them until they cross 800. The gate is green either way — flagging for whoever owns those paths.

## Ponytail pass

One finding, applied in the third commit: `configOriginNote`'s tooltip repeated the `changed_at` that `ConfigProvenance` already renders inline on the same line. Dropped — the tooltip keeps the revision and the per-verdict caveat, neither of which is visible elsewhere. The test that asserted the timestamp *was* in the title now asserts it is not, and that the visible line carries it, so the redundancy cannot return unnoticed.

Nothing else was cut. The token filter is a security boundary; the logic/render split matches the `markerLabel`/`buildChartMarkers` pattern already in `workerlogic.mjs`; and the long "why not `worker_config_change_known`" comment in `worker_detail.py` is what stops the next reader reinstating the bug the security pass just found.


---

## Fifth commit — a false "here" over a rolled-back change

The verifier pass this PR was waiting on found a real defect, confirmed against RigForge's source and fixed in `de3d12c`.

**What was wrong.** `change_known` matched the rig's `last_change_id` against this rig's history rows **by id alone, ignoring the row's status**. RigForge's rollback re-apply re-stamps the *same* change id it just reverted: `control_apply()` sets `local RIGFORGE_CONFIG_SOURCE=control RIGFORGE_CONFIG_CHANGE_ID="$cid"` once and both apply attempts run under it, and the comment there says it means to — *"attribute this (and the rollback re-apply) to the control path with its change_id"*. `_stamp_config_meta` fires on the second apply because the restored config's hash differs from the failed one. So a control change that did **not** come back live still matched, and the line printed the calm "Last changed from this dashboard" directly above a red "Rolled back" row for that same change — a self-contradiction on screen, in the one case this feature most needs to be right.

**The fix.** The verdict now reads the matched row's status rather than merely whether a row exists. A row this dashboard records as `rolled_back` or `failed` gets its own verdict, `reverted` → *"Last change from this dashboard was rolled back"*, flagged, with the tooltip explaining that the rig is running whatever config came before.

`rejected` is in `REVERTED_STATUSES` too, although it **cannot reach us today**: `_control_commit` rejects and returns before `config.json` is touched, so a rejected change is never stamped and its id never becomes `last_change_id`. It is listed so the check fails closed rather than open if that apply path ever changes.

**The same wrong belief had spread to four places**, all corrected: the `CONFIG_SOURCES` comment, the `config_origin` docstring, the operator-facing list in `docs/dashboard.md`, and a frontend test that asserted the restore tooltip must *not* name a person "because RigForge also does this on its own after a failed change". It does not — `restore` is stamped only by the operator-run `restore <archive>` command (one call site); the automatic rollback is `control`.

Also corrected: a doc line the tooltip-dedup commit left stale. It promised "Hover the line for the rig's timestamp and the revision"; that commit deliberately removed the timestamp from the tooltip, and it renders inline instead.

**Mutation evidence** — each new guard reverted and seen to red the tests that name it, then restored and re-verified green:

| Mutation | Result |
|---|---|
| `config_origin` drops the status check | 5 red (3 parametrized unit + 2 integration) |
| caller drops the status argument | 2 red |
| frontend `reverted` text collapsed back onto `here` | 1 red |

Gates re-run from the repo root with each exit code checked separately: `pytest` rc=0, `node --test` 475/475, `lint-py` / `lint-js` / `lint-topology` / `lint-md` / `lint-docs-voice` / `lint-operator-strings` / `lint-file-budget` all rc=0. No budgeted ceiling is touched — none of the changed files has a budget entry.

## Still open, not fixed here

**The 50-row history window can flip a true "here" into a false "elsewhere".** `build_worker_detail` matches against `get_worker_config_history(name)` at its default `limit=50`. Every apply attempt writes a row, so 50 recorded changes *after* the one the rig is running push it out of the window; the match fails and the line reads "Last changed from another dashboard" — an alarm, over a change that genuinely came from here. The existing comment calls this "wrong in the direction that under-claims", which understates it: the operator reads that line as a warning, not as "we did not look far enough back".

Fixing it properly needs a worker-scoped exact-id lookup, i.e. a new `StateManager` method — and `storage_service.py` (1603) and `tests/service/test_storage_service.py` (1646) are both exactly at their ceilings, which is the same wall that blocks #1367. Filed as #1369 rather than smuggled in here.
