### PR TITLE
ci(sweep): retire the temporary proof slot now that a scheduled run is on record (#1313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,6 @@ on:
   # Scheduled runs use the default branch (develop).
   schedule:
     - cron: "0 5 * * 1" # Mondays 05:00 UTC
-    # TEMPORARY, and its own follow-up PR removes it the moment it has fired once (#1313). A
-    # `schedule:` is read from the DEFAULT branch only, and a workflow file that merely LOOKS
-    # right proves nothing about registration — #1048, #1064 and #1146 are all the same defect,
-    # a scheduled job that never ran and reported nothing while not running. The only proof is a
-    # run carrying `event: schedule`, and the weekly slot above cannot supply one inside a working
-    # session. This near-term daily slot does, then goes away. Same recipe as #1257's proof cron.
-    - cron: "30 3 * * *" # PROOF SLOT — removed once a scheduled run is on record
 
 # Least privilege (#282): every job here only reads the repo — none push commits, comment, or
 # publish packages. Narrowing the default GITHUB_TOKEN limits the blast radius of a compromised step.


### PR DESCRIPTION
Retires the temporary proof cron added alongside the shipped-image sweep. Seven lines deleted, no
other change.

## The proof it was waiting for

```
run 32689697668   event=schedule   branch=develop   sha=3f88946
created 2026-08-24T04:21:19Z   conclusion=success
```

https://github.com/p2pool-starter-stack/pithead/actions/runs/32689697668

`3f88946` is `develop`'s tip and is the merge of the sweep wiring, so the run **carried** the sweep
rather than predating it. This is the proof slot firing ~51 minutes late, which is ordinary; it cannot
be the Monday slot, which is `0 5 * * 1` and had not come round at 04:21Z.

**Two separate claims, and both are evidenced — read them separately.**

1. **The schedule is registered and fires.** From `event: schedule` in the run history, not from the
   YAML. This is the narrow thing the slot existed to answer, and it is the thing three earlier
   defects in this repo got wrong by reading the file instead of the runs.
2. **The sweep does its job.** All five `Shipped-image CVE sweep` jobs ran green and the reporting job
   opened its tracking issue. A firing run alone would not have shown this, which is why it is stated
   apart from claim 1 rather than folded into one green tick.

The first live sweep also found four fixable HIGH CVEs in the published `pithead-tor` v1.20.0 digest.
Details are on the issue and on the tracking report; the patch-release decision is routed to the
release owner and is not part of this PR.

## Why no companion sync PR — verified, not assumed

`develop-v2` was already carrying only the Monday cron, with a comment saying its block is inert and
exists for twin-levelness. I parsed both `ci.yml` files and compared the schedule lists rather than
eyeballing them:

```
this branch:  [{'cron': '0 5 * * 1'}]
develop-v2:   [{'cron': '0 5 * * 1'}]
```

So this **re-levels** the twins. A sync PR would be a no-op.

## Lane policy

`.github/workflows/ci.yml` is a shared file and this lane's named-file grant. Targeting the frozen
`develop` is lane-policy exception (b): a workflow that must fire from the DEFAULT branch lands there,
is proven firing from `gh run list --json event`, then syncs forward. Removing the proof slot is the
tail of that same exception, and was cleared by the controller in advance. Naming it here so the next
reader does not have to re-derive it.

## Review pass

The repo's PR gate did not prompt on this branch. That is a known defect in the gate rather than a
pass — it keys its sentinel to the branch in the session's working directory and can consume a stale
one. So the pass was run anyway. On a seven-line deletion there is little to over-engineer; what it
checked was that the deletion is bounded to the proof slot and its comment, that the remaining YAML
parses, and that the Monday cron and every job below are untouched. `git diff --stat` reports
`1 file changed, 7 deletions(-)`.

## Not done

The follow-up close of the tracking issue is manual, as always in this repo — the `Closes` keyword
does not fire here, because PRs land on `develop-v2` while the default branch is `develop`.
