### PR TITLE
build(tor): stop installing vim's xxd over the one busybox already ships (#1372)

### DIFF
--- a/build/tor/Dockerfile
+++ b/build/tor/Dockerfile
@@ -2,9 +2,10 @@
 # names the Alpine minor line (3.24) so Dependabot's patch-update policy has a real version to track.
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-# Install Tor plus the tools the bootstrap healthcheck needs: netcat (talk to the
-# control port) and xxd (hex-encode the auth cookie). --no-cache keeps the image small.
-RUN apk add --no-cache tor netcat-openbsd xxd
+# Install Tor plus netcat, which the bootstrap healthcheck needs to talk to the control port.
+# Deliberately NOT xxd: the healthcheck's `xxd -p -c 256` is served by busybox's own applet, so
+# `apk add xxd` bought nothing but vim's CVE stream (#1372). --no-cache keeps the image small.
+RUN apk add --no-cache tor netcat-openbsd
 
 # Copy the Tor config TEMPLATE + the entrypoint that renders it: the bridge subnet prefix is
 # substituted at container start (#180). The rendered torrc lands in /tmp (the unprivileged 'tor'

--- a/build/tor/healthcheck-selftest.sh
+++ b/build/tor/healthcheck-selftest.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Does build/tor/healthcheck.sh still run on nothing but the commands its own image ships?
+#
+# The #1098 guard (scripts/verify-healthcheck-scripts.sh) asks whether a healthcheck script EXISTS
+# where its Dockerfile promises. This asks the other half of the same contract: whether that script
+# can still RUN there. #1372 is the case that made the gap visible — build/tor/Dockerfile installed
+# `xxd` by name purely for healthcheck.sh's one call site, which bought vim's CVE stream for a
+# command Alpine's busybox already provides. Nothing in CI could see either the need or its removal.
+#
+# It is an ALLOWLIST, not a denylist: a dependency nobody declared fails here, rather than passing
+# because nobody thought to ban it. Widening HC_CMDS is the point at which someone has to check the
+# image really ships the new command.
+#
+# NAMED GAP, deliberately not approximated: this cannot prove the IMAGE's `xxd` behaves — the host's
+# is vim's, the very package #1372 removed. That the pinned digest's busybox provides an `xxd` applet
+# taking the same `-p -c 256` was proven inside the image on #1372, and is guarded by nothing but the
+# base-image pin. What IS proven here is the script's dependency set and its logic.
+#
+# It lives beside the script it tests, like entrypoint.sh and healthcheck.sh live beside the
+# Dockerfile, and is never COPY'd into the image — the Dockerfile copies named files only. It takes
+# `--self-test` with no other mode, matching every other entry in the harness registry that drives
+# it (tests/stack/test-harness-tooling.sh).
+#
+#   build/tor/healthcheck-selftest.sh --self-test
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HC="$HERE/healthcheck.sh"
+
+HC_CMDS=(xxd tr grep nc) # every external command build/tor/healthcheck.sh may use
+HC_HEX="000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+HC_DONE='250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY="Done"'
+HC_MID='250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=50 TAG=loading_descriptors'
+
+st_fail=0
+expect() { # <name> <got> <want>
+    if [ "$2" = "$3" ]; then
+        printf '  self-test ok: %s\n' "$1"
+    else
+        printf '  self-test FAIL: %s — expected [%s], got [%s]\n' "$1" "$3" "$2" >&2
+        st_fail=1
+    fi
+}
+
+hc_run() { # <cookie: none|empty|fixed> <control-port reply> <allowed cmd...> -> healthy|unhealthy
+    local cookie="$1" reply="$2" c i d oct="" rc=0
+    shift 2
+    d="$(mktemp -d "$HC_D/case.XXXXXX")"
+    mkdir -p "$d/bin"
+    # Truncate the capture every call: a stale one read as fresh is the vacuous version of the
+    # request assertion, and hc_run runs in a command substitution so it cannot hand back a path.
+    : >"$HC_D/sent"
+    for c in "$@"; do
+        if [ "$c" = "nc" ]; then
+            # Stub control port: record what the healthcheck sends, then answer as Tor would. A real
+            # `nc` would dial the fixed port 9051 on the host — untestable, and a collision between
+            # two concurrent suites. Shell builtins only: it runs under the same stripped PATH.
+            cat >"$d/bin/nc" <<'NCSTUB'
+#!/bin/sh
+while IFS= read -r l; do printf '%s\n' "$l"; done >"$HC_CAP"
+printf '250 OK\r\n%s\r\n250 closing connection\r\n' "$HC_REPLY"
+NCSTUB
+            chmod +x "$d/bin/nc"
+        else
+            ln -s "$(command -v "$c")" "$d/bin/$c"
+        fi
+    done
+    # A fixed cookie, and deliberately a nasty one: bytes 0x00-0x1f include a NUL and a 0x0a, which
+    # a non-binary-safe encode would truncate or mangle rather than spell as "00" and "0a".
+    case "$cookie" in
+    empty) : >"$d/cookie" ;;
+    fixed)
+        for i in $(seq 0 31); do oct="$oct$(printf '\\%03o' "$i")"; done
+        printf '%b' "$oct" >"$d/cookie"
+        ;;
+    esac
+    # /bin/sh by absolute path: with PATH stripped to the stub dir, `sh` itself is unresolvable.
+    PATH="$d/bin" HC_CAP="$HC_D/sent" HC_REPLY="$reply" TOR_COOKIE_FILE="$d/cookie" \
+        /bin/sh "$HC" >/dev/null 2>&1 || rc=$?
+    if [ "$rc" = 0 ]; then printf 'healthy\n'; else printf 'unhealthy\n'; fi
+}
+
+if [ "${1:-}" != "--self-test" ]; then
+    printf 'usage: %s --self-test\n' "$0" >&2
+    exit 2
+fi
+
+[ -r "$HC" ] || {
+    printf '  self-test FAIL: %s is missing — the check has nothing to drive\n' "$HC" >&2
+    exit 1
+}
+
+HC_D="$(mktemp -d)"
+trap 'rm -rf "$HC_D"' EXIT
+
+expect "healthy on a bootstrapped control port, image commands only" \
+    "$(hc_run fixed "$HC_DONE" "${HC_CMDS[@]}")" "healthy"
+# The WHOLE request, not just its AUTHENTICATE line: this is the only check that pins the exact
+# bytes the healthcheck speaks at the control port. (It does NOT discriminate the `tr -d` strip —
+# command substitution already eats a trailing newline, so dropping `tr` leaves the hex identical.
+# What catches that mutation is the drop-loop below, because `tr` stops being needed at all.)
+expect "sends AUTHENTICATE <64 lowercase hex> / GETINFO / QUIT, nothing else" \
+    "$(tr -d '\r' <"$HC_D/sent")" "AUTHENTICATE $HC_HEX
+GETINFO status/bootstrap-phase
+QUIT"
+expect "unhealthy mid-bootstrap — TAG=done is the gate, not a live port" \
+    "$(hc_run fixed "$HC_MID" "${HC_CMDS[@]}")" "unhealthy"
+expect "unhealthy with no cookie file (control port not up yet)" \
+    "$(hc_run none "$HC_DONE" "${HC_CMDS[@]}")" "unhealthy"
+expect "unhealthy on an empty cookie file (written but not filled)" \
+    "$(hc_run empty "$HC_DONE" "${HC_CMDS[@]}")" "unhealthy"
+
+# The controls, and they are what makes everything above evidence rather than decoration: if PATH
+# leaked to the host, every case would pass on the host's own commands and prove nothing. Each
+# declared command is dropped in turn, which also refuses an over-declared allowlist — a name in
+# HC_CMDS the script does not really need would keep passing here and go unnoticed.
+#
+# Read per-command, they are not all the same strength. `grep` and `nc` fail because the script
+# genuinely cannot proceed without them. `xxd` fails only because `[ -n "$COOKIE_HEX" ]` rejects the
+# empty result — `xxd -p -c 256 "$f" | tr -d '\n'` reports TR's status, so a missing xxd is not an
+# error the shell sees. Drop that guard and this control flips green, which is how it was found.
+for hc_drop in "${HC_CMDS[@]}"; do
+    hc_subset=()
+    for hc_c in "${HC_CMDS[@]}"; do [ "$hc_c" = "$hc_drop" ] || hc_subset+=("$hc_c"); done
+    expect "FAILS with $hc_drop missing — the PATH isolation is real" \
+        "$(hc_run fixed "$HC_DONE" "${hc_subset[@]}")" "unhealthy"
+done
+# ...and the over-tightening control: an extra command present must not change the verdict, or the
+# checks above are really counting the allowlist rather than exercising the script.
+expect "an unused extra command on PATH changes nothing" \
+    "$(hc_run fixed "$HC_DONE" "${HC_CMDS[@]}" sed)" "healthy"
+
+# The seam is only honest while the shipped default is untouched — same guard, and same reason, as
+# the tor entrypoint's TORRC_OUT default in tests/stack/test-tor-network.sh.
+expect "keeps /var/lib/tor/control_auth_cookie as its container default" \
+    "$(grep -c '^COOKIE_FILE=${TOR_COOKIE_FILE:-/var/lib/tor/control_auth_cookie}$' "$HC")" "1"
+expect "reads NO other cookie path outside that default" \
+    "$(grep -vE '^\s*#' "$HC" | grep -cF '/var/lib/tor/control_auth_cookie')" "1"
+
+exit "$st_fail"

--- a/build/tor/healthcheck.sh
+++ b/build/tor/healthcheck.sh
@@ -11,7 +11,11 @@
 
 set -eu
 
-COOKIE_FILE=/var/lib/tor/control_auth_cookie
+# The cookie path is fixed in the container. TOR_COOKIE_FILE is the test seam (#1372) — the same
+# shape as entrypoint.sh's TORRC_OUT, and for the same reason: the shell suite has to drive this
+# script for real, and it cannot write /var/lib/tor. Nothing sets it in production, so what ships
+# is the default; the suite asserts that default is still spelled exactly this way.
+COOKIE_FILE=${TOR_COOKIE_FILE:-/var/lib/tor/control_auth_cookie}
 CONTROL_HOST=127.0.0.1
 CONTROL_PORT=9051
 

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -71,3 +71,14 @@ echo "== unit: #1059 watch-report discrimination =="
 # that proves it and it needs no KVM.
 bash "$ROOT/tests/os/failure-evidence.sh" --self-test >/dev/null 2>&1
 assert_rc "#1059 watch-report self-test passes" "$?" "0"
+
+echo "== unit: tor healthcheck command-dependency self-test (#1372) =="
+# The #1098 pair above asks whether a healthcheck script EXISTS where its Dockerfile promises. This
+# asks the other half of the same contract: whether build/tor/healthcheck.sh can still RUN on
+# nothing but the commands that image ships. #1372 is the case that made the gap visible — the
+# Dockerfile installed `xxd` by name for one call site that busybox already served, and nothing in
+# CI could see either the need or its removal. Its --self-test drives the script for real with PATH
+# stripped to an allowlist of the image's commands, and drops each declared command in turn, because
+# a leaking PATH would pass every case on the host's own commands and prove nothing.
+bash "$ROOT/build/tor/healthcheck-selftest.sh" --self-test >/dev/null 2>&1
+assert_rc "tor healthcheck runs on the commands its own image ships (#1372)" "$?" "0"


### PR DESCRIPTION
Removes `xxd` from the tor image's `apk add`. One line of behaviour change; `healthcheck.sh` is
untouched.

## Why

The weekly shipped-image sweep found four fixable HIGH CVEs in the published v1.20.0 `pithead-tor`
digest on its first live run, all in the vim source package that provides `xxd`.

**That package was never needed.** `build/tor/healthcheck.sh:22` hex-encodes Tor's control auth cookie
with `xxd -p -c 256`, and Alpine's busybox already ships an `xxd` applet that handles exactly those
flags. `apk add xxd` installed vim's build of the same tool on top of one already on `PATH`.

**Deleting rather than bumping is the point.** All four CVEs are in vim's source package, so a version
bump buys a quiet week and the same package produces the next four.

## What was verified

All inside the pinned digest `alpine:3.24@sha256:28bd5fe8…`, not on the host — busybox `od` and GNU
`od` are different programs, so a host-only check would have proven the wrong thing.

| check | result |
| --- | --- |
| both applets exist | `busybox --list` reports one `xxd`, one `od` |
| identical output | busybox `xxd -p -c 256` ≡ `od -An -tx1 -v` byte for byte, random 32-byte input |
| package gone | `apk info` reports no vim and no xxd package |
| still working | `/usr/bin/xxd` → `/bin/busybox` (owned by `busybox-1.37.0-r31`); the healthcheck's own command still returns 64 lowercase hex chars |
| script unchanged | `tor-healthcheck.sh` still exits 1 with no cookie — same early-exit path |
| trivy on the rebuild | 0 fixable HIGH/CRITICAL |

**The last row is the weakest and is not the proof.** A rebuild resolves apk at build time, and
`apk add xxd` against this same digest installs the **fixed** `9.2.0854-r0` today — so a rebuild that
still installed xxd would also scan clean. The discriminating evidence is that the package is absent.
That asymmetry is exactly what the shipped-image sweep exists to expose, and it is why these CVEs were
visible at all.

## The negative control earned its keep

This change is one line instead of two files because the control caught me. After removing `xxd` from
`apk add` I checked it was gone, and got a contradiction:

```
$ command -v xxd     -> /usr/bin/xxd      (still there)
$ apk info -e xxd    -> (not installed)   (but the package is not)
```

Had the check only asserted the package was uninstalled, that reads as success and I would have shipped
a claim that the tool was gone when it was not. Resolving the contradiction found the busybox applet
and made the `healthcheck.sh` rewrite I had drafted unnecessary. I had already posted the `od` rewrite
as a recommendation; it is corrected on the issue rather than quietly dropped.

## Reachability, since "four HIGHs" is not by itself a severity

`xxd` runs on the healthcheck interval — `docker-compose.yml` wires `tor-healthcheck.sh` at
`interval: 30s`, so roughly every 30 seconds for the life of the container. Not "never executed".
But what it parses is Tor's own 32-byte control auth cookie: not network input, not operator input.
Influencing it means already having code execution in the container as the `tor` user. So: constantly
executed, on trusted local input of fixed size. Worth fixing, and it did not read as forcing a patch
cut — that call sits with the release owner.

## Owed, and disclosed rather than skipped

**A regression test is not in this PR, and this PR should not merge without it.** The tests lane owns
`tests/stack/` and has granted an additive append to `tests/stack/test-tor-network.sh` — the tor domain
file, already split out and already sourced. Naming the path here so the ownership is visible.

**What that test can and cannot honestly prove — this changed after review, and the first shape was
wrong.** I initially asked for an assertion that the encoding works *without the vim `xxd` package*.
That is not provable in the stack suite: it runs on the host, the host is Ubuntu, and on Ubuntu `xxd`
**is** vim's xxd. A host-side test would return 64 hex characters whether or not the image ships the
package, because it never consults the image — a false green of exactly the kind this change exists to
remove.

What the suite *can* guard is the direction that actually regresses: **`healthcheck.sh` growing a
dependency the image does not ship.** Run the script with `PATH` set to a stub directory holding only
the commands the tor image provides, and assert the exit status and the literal 64-character lowercase
hex output for a fixed cookie. The control is the point — remove `xxd` from the stub set and the test
must FAIL; if it still passes, `PATH` is leaking to the host and the assertion is decorative. That
reddens the day someone adds a `base64` or a `sed -E` the image lacks, which is the realistic
regression during a healthcheck edit.

**NAMED GAP, not approximated.** The image-level fact — that this pinned digest's busybox provides an
`xxd` applet accepting `-p -c 256` — is a property of the base image, and the pin is what protects it.
It is proven in the table above, inside the digest, cross-checked against `od`. It is **not**
mechanically guarded anywhere, and it does not belong in the shell suite at any tier; the place for it
would be wherever the base-image pin is bumped. No such check exists today. Stating that as a gap
rather than letting a host-side test stand in for it.

Also not done: no live Tor bootstrap was exercised. The healthcheck's `nc` leg is unchanged by this PR
and was not re-proven.

## Scope

`build/` only — this lane's exclusive path. Nothing shared, no override used.


---

## The test half (added 2026-08-24)

The one-line fix above was correct and unguarded. Nothing in CI could see either the need for `xxd`
or its removal, so merging on a green rollup would have landed the fix carrying the exact gap it
exists to close — **green there meant "no test noticed", not "checked"**.

`build/tor/healthcheck-selftest.sh --self-test` drives `build/tor/healthcheck.sh` for real with
`PATH` stripped to a stub dir holding **only** the commands the tor image provides, plus a stub
control port that records what the script sends. It is an **allowlist**: a dependency nobody declared
fails here, rather than passing because nobody thought to ban it. Twelve checks, all passing.

### What makes it evidence rather than decoration

Each declared command is dropped in turn and the run must FAIL. Without that control a leaking `PATH`
would let every case pass on the host's own commands and prove nothing about the image. The
over-tightening control is the mirror: an unused extra command on `PATH` must change nothing, or the
checks are really counting the allowlist.

### Mutation results — five run, four caught

| mutation of the shipped script | caught by |
| --- | --- |
| drop the `tr -d '\n'` strip | the `tr`-missing control (it stops being needed) |
| drop the `[ -n "$COOKIE_HEX" ]` guard | empty-cookie check, and the `xxd`-missing control |
| accept any bootstrap phase, not only `TAG=done` | mid-bootstrap check |
| repoint the container default cookie path | both seam checks |
| **drop `[ -r "$COOKIE_FILE" ] \|\| exit 1`** | **NOTHING — survives, see below** |

Deleting the self-test script outright reddens the suite rather than reading as a pass; that was
checked specifically, because a missing leg scoring as a pass is the failure mode this whole thread
is about.

### Two gaps, named rather than papered over

**The surviving mutation is real and is shipped documented.** Removing the unreadable-cookie guard
changes nothing observable, because `xxd -p -c 256 "$f" | tr -d '\n'` reports *tr's* exit status — a
failed read is not an error the shell ever sees — and the empty-hex guard below enforces the same
outcome. Two guards, one output. No discriminating assertion was found that is not flaky across `xxd`
implementations, so it is written into the code as a known gap.

**This does not prove the image's `xxd` behaves.** The host's is vim's — the very package removed
here. That the pinned digest's busybox provides an applet taking the same `-p -c 256` was proven
inside the image (table above) and is guarded by nothing but the base-image pin. What is proven here
is the script's dependency set and its logic. Proving the image-level fact belongs wherever the base
pin is bumped, and no such check exists today.

### Shared files, disclosed

- `tests/stack/test-harness-tooling.sh` — the append-only harness registry in `_shared.paths`. It
  gets the two-line registration its grant describes, matching the six entries already there. The
  logic lives in `build/`, which this lane owns outright, beside the script it tests and never
  `COPY`'d into the image.
- `build/tor/healthcheck.sh` grows one seam, `TOR_COOKIE_FILE`, in the same shape as
  `entrypoint.sh`'s `TORRC_OUT` and for the same reason: the suite cannot write `/var/lib/tor`. It is
  line-neutral, and the shipped default is asserted unchanged by two of the twelve checks.

The tests lane's original ruling placed this in `tests/stack/test-tor-network.sh`. That file is 780
lines against a recorded ceiling of exactly 780 and cannot take a line; the registry is where the
controller's 2026-08-24 `_shared.paths` ruling puts an additive harness self-test, and on merit it is
the sibling of the `#1098` entry directly above it — that one asks whether a healthcheck script
*exists* where its Dockerfile promises, this one asks whether it can still *run* there.

### Gates run

`make lint` rc=0 (full target list, not a filtered tail). `tests/stack/run.sh`: **2906 passed, 0
failed**, rc=0, rebased onto the current base. An over-engineering pass was run on this diff
regardless of whether the PR gate prompted for one; it is what moved the logic out of the shared file.
