### PR TITLE
fix(cli): a failed setup keeps the machine's configuration (#1059 Defect B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint-sh: ## shellcheck + shfmt over the CLI, build/* + dashboard/ container scri
 		os/overlay/pithead-data-reset os/overlay/pithead-mount-generator os/overlay/pithead-ssh-host-keys \
 		os/overlay/pithead-machine-id os/overlay/pithead-media-config os/overlay/pithead-hugepages \
 		os/overlay/pithead-journal-persist \
-		tests/os/run.sh tests/os/verify-image.sh tests/os/hugepages-boot-verdict.sh
+		tests/os/*.sh
 # run.sh by itself, keeping company only with the one file outside tests/stack that it sources:
 # os/overlay/pithead-boot, whose gate_ready and os_update_rollback_verdict read three globals
 # run.sh sets for them. Drop pithead-boot from this line and those three report as SC2034 — it

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -213,11 +213,22 @@ the boot gate do the committing, and it found this the first time it ran to comp
 directory is now one rule, `control_unit_dir`, read by the writer and both readers.
 
 **Fixed — a provisioning failure now surfaces its own reason on the reopened wizard.**
-Setup failures move the config aside as `config.json.failed` and re-mint a token; the
+Setup failures keep the config, copy it to `config.json.failed` and re-mint a token; the
 reopened page used to make an operator dig the reason out of the console. It no longer
 does: `pithead` writes the last `[ERROR]` line to `error.txt` and the failed config to
 `last-attempt.json` before reopening, and `wizard.py`/`wizard.mjs` surface both — the
 reason as the page's error text, the config as the retry prefill.
+
+**Fixed — a failed setup no longer costs the machine its configuration (#1059).** It used
+to move `config.json` aside, and delete it outright when that move failed. A non-zero
+`setup` does not mean the submitted configuration is at fault: the capture that found this
+was a concurrent `backup` stopping the stack under an in-flight `compose up`, on a config
+that had already rendered `.env`, provisioned Tor and started containers. Moving it aside
+existed to re-arm the setup wizard, and it could not — `pithead-firstboot.service` needs
+both `config.json` and `machine-role` absent, and `record_machine_role` has already run by
+then. So the machine keeps its configuration, takes an owner-only copy beside it, and
+removes the original only where doing so genuinely re-arms the wizard: a `machine-role`
+that never landed.
 
 **Fixed — the hugepages reservation now fits the machine's RAM (#977).** The baked 6 GiB
 sysctl imposed a silent ≥ 16 GiB floor the harness's 16 GiB VM could never notice.

--- a/pithead
+++ b/pithead
@@ -1585,6 +1585,39 @@ record_machine_role() { # <pithead|both|rig>
     printf '%s\n' "$1" >"$PWD/machine-role" 2>/dev/null || true
 }
 
+# The wizard's response to a failed (setup), as one step so it can be driven directly (#1059).
+#
+# It KEEPS the machine's configuration. A non-zero (setup) says something went wrong, never that
+# the submitted config is what went wrong — the capture that found this was a concurrent `backup`
+# calling stack_down out from under setup's in-flight `compose up`, on a config valid enough to
+# have rendered .env, provisioned Tor and started containers.
+#
+# This used to MOVE the file, to re-arm the setup wizard. It cannot, on any path that reaches it:
+# pithead-firstboot.service ANDs !config.json with !machine-role, and record_machine_role above
+# has already run, so the second condition holds the window shut whatever this does with the
+# first. Keeping the file also keeps the next boot working — pithead-boot.service's conditions
+# are ORed so it runs regardless, and os/overlay/pithead-boot's `./pithead render` reads exactly
+# the file the move used to take away.
+#
+# The removal therefore happens only where it can still buy something: a machine-role that never
+# landed (record_machine_role is best-effort). It lives INSIDE the success branch on purpose —
+# the defect this replaced was `mv ... 2>/dev/null || rm -f config.json`, which deleted the
+# operator's configuration outright whenever the mv failed, for a reason it had already
+# discarded. Structurally, nothing here can remove the file without a copy already on disk.
+#
+# install -m 600, not cp: config.json holds the dashboard password and the wallet address, and
+# the copy must not widen its mode.
+#
+# rc 0 = a copy was kept, 1 = it could not be.
+wizard_keep_failed_config() {
+    if install -m 600 "$PWD/config.json" "$PWD/config.json.failed" 2>/dev/null; then
+        [ -f "$PWD/machine-role" ] || rm -f "$PWD/config.json"
+        return 0
+    fi
+    warn "Could not keep a copy of the failed configuration as config.json.failed."
+    return 1
+}
+
 # The marker, read back. Anything unrecognised (or absent) is a coordinator: every machine
 # provisioned before this contract existed had no marker and was one.
 machine_role() { # echoes pithead|both|rig
@@ -2747,9 +2780,13 @@ firstboot_wizard() {
                     rm -f "$setup_log"
                     return
                 fi
-                warn "Provisioning failed. The submitted configuration is kept aside as config.json.failed;"
+                warn "Provisioning failed. A copy of the submitted configuration is kept as config.json.failed;"
                 warn "reopening the setup window so it can be corrected."
-                mv -f "$PWD/config.json" "$PWD/config.json.failed" 2>/dev/null || rm -f "$PWD/config.json"
+                # The machine KEEPS its configuration (#1059) — this used to move it aside, which
+                # on this path can only cost. The reasoning, and why the removal that remains is
+                # conditional, is at wizard_keep_failed_config's definition.
+                local kept_copy=0
+                if wizard_keep_failed_config; then kept_copy=1; fi
                 mkdir -p "$spool"
                 chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
                 # The reopened page gets BOTH halves of a usable retry: the reason it failed, and
@@ -2757,7 +2794,14 @@ firstboot_wizard() {
                 # machine still holds. The accept path wiped the spool, so both are restored here.
                 grep -a "\[ERROR\]" "$setup_log" | tail -n 1 | tr -d '[:cntrl:]' | tail -c 300 >"$spool/error.txt"
                 [ -s "$spool/error.txt" ] || printf 'Provisioning failed — see the machine console for detail.' >"$spool/error.txt"
-                [ -f "$PWD/config.json.failed" ] && jq -c . "$PWD/config.json.failed" >"$spool/last-attempt.json" 2>/dev/null
+                # Prefill from what THIS run failed on. The copy when it was made, the live file
+                # otherwise — never a config.json.failed left by an earlier attempt, which would
+                # hand the operator back answers they had already moved past.
+                if [ "$kept_copy" -eq 1 ]; then
+                    jq -c . "$PWD/config.json.failed" >"$spool/last-attempt.json" 2>/dev/null || true
+                elif [ -f "$PWD/config.json" ]; then
+                    jq -c . "$PWD/config.json" >"$spool/last-attempt.json" 2>/dev/null || true
+                fi
                 chown 1000:1000 "$spool/error.txt" "$spool/last-attempt.json" 2>/dev/null || true
                 rm -f "$setup_log"
                 break # outer loop re-mints a token and restarts the wizard container

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -40,15 +40,15 @@ osupdate_failure_evidence() {
 # The tree is the discriminator. Every path that removes config.json without touching .env
 # lives in the firstboot wizard loop, and on an INSTALLED machine that has already accepted a
 # config and brought its stack up, one of them is reachable: the setup-failure branch, which
-# does `mv -f config.json config.json.failed` and re-mints a token. (The rest are pre-setup
-# validator rejections, or installer-STICK paths keyed on an install-request and /boot/efi.)
-# `config.json.failed` on disk names that branch outright, and the spool it writes beside it
-# (error.txt, last-attempt.json) carries the reason setup failed. Its ABSENCE proves nothing,
-# though, and that asymmetry is the whole reason this dump exists: the branch is
-# `mv -f config.json config.json.failed 2>/dev/null || rm -f config.json`, so a failed mv
-# discards its own stderr and DELETES the file outright, leaving no artifact at all. Read a
-# missing config.json.failed as "no evidence either way", never as an alibi. A
-# `config.json.tmp` would instead name the credential write-back's atomic sibling.
+# re-mints a token. (The rest are pre-setup validator rejections, or installer-STICK paths keyed
+# on an install-request and /boot/efi.) `config.json.failed` on disk names that branch outright,
+# and the spool beside it (error.txt, last-attempt.json) carries the reason setup failed.
+# #1059's fix changed what that branch DOES, so read the dump accordingly. It was
+# `mv -f config.json config.json.failed 2>/dev/null || rm -f config.json` — itself a mechanism
+# for the vanish, and a failed mv deleted the file outright leaving no artifact. It is now an
+# `install -m 600` COPY that removes the original only when `machine-role` is absent, so it no
+# longer vanishes a coordinator's config.json — which makes a reported vanish a STRONGER signal.
+# A `config.json.tmp` would instead name the credential write-back's atomic sibling.
 backup_failure_evidence() {
     printf '     --- guest evidence (#1059) ---\n'
     _ssh "echo '-- backup log --'; cat /tmp/restore-backup.log 2>/dev/null

--- a/tests/stack/test-wizard-setup.sh
+++ b/tests/stack/test-wizard-setup.sh
@@ -322,7 +322,12 @@ wkf_reset() { # <present|absent>  — the machine-role marker
     # A fixed literal, not a fixture constant: wizard_keep_failed_config never parses the file,
     # so borrowing $WALLET would only buy an ordering dependency on another domain file.
     printf '{"submitted":"the operator answers"}\n' >"$WKF/config.json"
-    chmod 600 "$WKF/config.json"
+    # 644, NOT 600, and that is the whole point of the fixture. A copy tool derives the new
+    # file's mode from the source, so a 600 source makes "the copy is 600" true of `cp` as much
+    # as of `install -m 600` — the assertion would then be proven by the fixture instead of by
+    # the guard. 644 is also the real shape: config.json written under systemd's default umask
+    # 022 lands at 644, so this is what the tightening actually has to act on.
+    chmod 644 "$WKF/config.json"
     if [ "$1" = "present" ]; then printf 'pithead\n' >"$WKF/machine-role"; fi
     return 0
 }
@@ -380,5 +385,33 @@ else
         bad "and no half-written config.json.failed is left behind to look like a copy" "a copy exists after a failed install"
     assert_contains "the reason is reported instead of discarded" "$wkf_out" "Could not keep a copy of the failed configuration"
 fi
+
+# The same four assertions at ANY uid. The staging above cannot be built as root (mode 000 does
+# not deny root), and these are exactly the assertions that guard the reported defect, so the
+# branch must not be uncovered on a root runner. Shadowing install(1) forces the failure directly.
+# BESIDE the real-install case above, never instead of it: a stub proves the guard's shape, only a
+# real install failure proves that a real one reaches it. The shadow is therefore coupled to the
+# implementation still using install(1) — if that changes, this case reddens loudly (the success
+# path runs and deletes config.json) rather than passing vacuously. Retarget the shadow then;
+# do not delete the case.
+wkf_reset absent
+wkf_out=$(
+    cd "$WKF" || exit
+    # shellcheck disable=SC1090
+    source "$STACK"
+    set +e
+    install() { return 1; }
+    wizard_keep_failed_config 2>&1
+)
+wkf_rc=$?
+assert_rc "a stubbed-failing copy reports failure too (any uid)" "$wkf_rc" "1"
+[ -f "$WKF/config.json" ] &&
+    ok "a failed copy NEVER deletes the configuration, at any uid (#1059)" ||
+    bad "a failed copy NEVER deletes the configuration, at any uid (#1059)" "config.json was deleted"
+[ ! -e "$WKF/config.json.failed" ] &&
+    ok "and leaves no half-written copy behind, at any uid" ||
+    bad "and leaves no half-written copy behind, at any uid" "a copy exists after a failed install"
+assert_contains "the reason is reported at any uid" "$wkf_out" "Could not keep a copy of the failed configuration"
+
 unset WKF wkf_out wkf_rc
 unset -f wkf_reset

--- a/tests/stack/test-wizard-setup.sh
+++ b/tests/stack/test-wizard-setup.sh
@@ -301,3 +301,84 @@ assert_contains "setup announces the fingerprint for rig pinning" "$sut_out" "St
 unset SUT sut_out
 
 unset run_wizard w1_cfg w2_cfg pointer_out core_reads shape_reads
+
+echo "== unit: a failed setup keeps the machine's configuration (#1059) =="
+# The wizard's response to a non-zero `(setup)`. It used to be
+# `mv -f config.json config.json.failed 2>/dev/null || rm -f config.json`, and it discarded a
+# configuration that was valid enough to have rendered .env, provisioned Tor and started
+# containers — the live capture that found this was a concurrent `backup` calling stack_down out
+# from under setup's in-flight `compose up`, not a bad config. When the mv failed, for a reason
+# it had already thrown away down 2>/dev/null, the fallback DELETED the file outright.
+#
+# Moving it aside was there to re-arm the setup wizard, and that needs BOTH of
+# pithead-firstboot.service's ANDed conditions (asserted in run.sh's appliance-unit section).
+# record_machine_role runs unconditionally on the accept path, so on every reachable failure the
+# marker already holds the window shut and the move buys nothing.
+WKF="$SANDBOX/wizard-keep-failed"
+wkf_reset() { # <present|absent>  — the machine-role marker
+    rm -rf "$WKF"
+    mkdir -p "$WKF"
+    cp "$STACK" "$WKF/pithead"
+    # A fixed literal, not a fixture constant: wizard_keep_failed_config never parses the file,
+    # so borrowing $WALLET would only buy an ordering dependency on another domain file.
+    printf '{"submitted":"the operator answers"}\n' >"$WKF/config.json"
+    chmod 600 "$WKF/config.json"
+    if [ "$1" = "present" ]; then printf 'pithead\n' >"$WKF/machine-role"; fi
+    return 0
+}
+
+# The reported case, and the only one an installed coordinator can reach.
+wkf_reset present
+wkf_out=$(run_sourced "$WKF" wizard_keep_failed_config 2>&1)
+wkf_rc=$?
+assert_rc "keeping the failed config reports success" "$wkf_rc" "0"
+[ -f "$WKF/config.json" ] &&
+    ok "a failed setup KEEPS config.json when machine-role exists (#1059)" ||
+    bad "a failed setup KEEPS config.json when machine-role exists (#1059)" "config.json was removed"
+[ -f "$WKF/config.json.failed" ] &&
+    ok "a copy is kept as config.json.failed for the reopened page's prefill" ||
+    bad "a copy is kept as config.json.failed for the reopened page's prefill" "no copy on disk"
+assert_eq "the copy is byte-identical to what was submitted" \
+    "$(cat "$WKF/config.json.failed" 2>/dev/null)" "$(cat "$WKF/config.json" 2>/dev/null)"
+assert_eq "the copy stays owner-only — it holds the dashboard password and the wallet address" \
+    "$(file_mode "$WKF/config.json.failed")" "600"
+
+# The one case where removing it still buys something: record_machine_role is best-effort, so a
+# marker that never landed leaves the wizard genuinely able to re-arm. The removal must survive.
+wkf_reset absent
+wkf_out=$(run_sourced "$WKF" wizard_keep_failed_config 2>&1)
+wkf_rc=$?
+assert_rc "the re-arming case reports success too" "$wkf_rc" "0"
+[ ! -f "$WKF/config.json" ] &&
+    ok "config.json IS still removed when machine-role is absent — the only case that re-arms the wizard" ||
+    bad "config.json IS still removed when machine-role is absent — the only case that re-arms the wizard" "config.json survived"
+[ -f "$WKF/config.json.failed" ] &&
+    ok "the re-arming case keeps the copy before it removes anything" ||
+    bad "the re-arming case keeps the copy before it removes anything" "removed with no copy on disk"
+
+# The `|| rm -f` regression itself: make the copy impossible and check the configuration lives.
+# machine-role is ABSENT on purpose — this is the branch the removal is reachable from, so a
+# re-added fallback would actually delete here. The source is made unreadable rather than the
+# destination unwritable, deliberately: an unwritable parent would also defeat the `rm`, and the
+# case would then pass for a reason that has nothing to do with the guard.
+# Verified against install(1) rather than assumed — a destination that is a directory, and one
+# that is an existing 0400 file, BOTH succeed.
+if [ "$(id -u)" = "0" ]; then
+    echo "SKIP: running as root — mode 000 does not deny root, so an unreadable source cannot be staged"
+else
+    wkf_reset absent
+    chmod 000 "$WKF/config.json"
+    wkf_out=$(run_sourced "$WKF" wizard_keep_failed_config 2>&1)
+    wkf_rc=$?
+    chmod 600 "$WKF/config.json" 2>/dev/null || true
+    assert_rc "a copy that cannot be made reports failure" "$wkf_rc" "1"
+    [ -f "$WKF/config.json" ] &&
+        ok "a copy that fails NEVER deletes the configuration (#1059)" ||
+        bad "a copy that fails NEVER deletes the configuration (#1059)" "config.json was deleted with no copy on disk"
+    [ ! -e "$WKF/config.json.failed" ] &&
+        ok "and no half-written config.json.failed is left behind to look like a copy" ||
+        bad "and no half-written config.json.failed is left behind to look like a copy" "a copy exists after a failed install"
+    assert_contains "the reason is reported instead of discarded" "$wkf_out" "Could not keep a copy of the failed configuration"
+fi
+unset WKF wkf_out wkf_rc
+unset -f wkf_reset


### PR DESCRIPTION
Defect B of #1059 — the product half. The root cause (a concurrent `backup` calling
`stack_down` under setup's in-flight `compose up`) was established on the bench and is
recorded on the issue; the structural gap that allows it is #1342 and lands separately.

## What was wrong

```
pithead:2752   mv -f "$PWD/config.json" "$PWD/config.json.failed" 2>/dev/null || rm -f "$PWD/config.json"
```

**The `|| rm -f` destroys the operator's configuration.** The `mv`'s stderr is discarded, so
whatever made it fail is unknown, and the response to an unknown failure is to delete the file
outright. It also destroys the evidence: a missing `config.json.failed` can never be read as
"this branch did not fire", because this is the branch that leaves no trace.

**The `mv` itself buys nothing, on every path that reaches it.** Moving the file aside exists to
re-arm the setup wizard, and that needs BOTH of `pithead-firstboot.service`'s ANDed conditions:

```
os/overlay/pithead-firstboot.service:9    ConditionPathExists=!/data/pithead/config.json
os/overlay/pithead-firstboot.service:10   ConditionPathExists=!/data/pithead/machine-role
```

`record_machine_role` runs unconditionally at `pithead:2734`, eighteen lines above. So the second
condition already holds the window shut and the branch pays its whole cost — discarding a config
valid enough to have rendered `.env`, provisioned Tor and started containers — for none of its
benefit. Keeping the file also keeps the next boot working: `pithead-boot.service`'s conditions
are ORed so it runs regardless, and `os/overlay/pithead-boot:225`'s `./pithead render` reads
exactly the file the move used to take away.

A non-zero `(setup)` is not evidence that the submitted config is at fault, and this change stops
treating it as though it were.

## What it is now

`wizard_keep_failed_config` — an `install -m 600` copy (the file holds the dashboard password and
the wallet address), with the original removed **only** where removal can still re-arm the
wizard: a `machine-role` that never landed, `record_machine_role` being best-effort. The removal
lives INSIDE the copy's success branch, so nothing here can delete the file without a copy
already on disk — the guarantee is structural rather than a paired condition someone can later
separate.

Two smaller things fixed in the same branch, both consequences of the first:

- `last-attempt.json` now prefills from what THIS run failed on, never from a
  `config.json.failed` left by an earlier attempt on the same boot.
- `[ -f x ] && jq ...` as a bare list is fatal under `set -Eeuo pipefail` when the test fails.
  It was previously masked by a `mv` that essentially always succeeded.

## What was RUN

- **12 tier-1 assertions**, `tests/stack/test-wizard-setup.sh`. All pass.
- **Every guard mutation-checked.** Restoring the original line, dropping the `machine-role`
  guard, inverting it, re-adding `|| rm -f` outside the success branch, widening the copy's mode,
  deleting the warning, and reporting success on a failed copy — each kills its own case and
  nothing else. Restoring the original line kills six.
- **The failure fixture was chosen against `install(1)` empirically, not reasoned about.** My
  first two ideas were both wrong: a destination that is a directory and a destination that is an
  existing `0400` file BOTH succeed. An unwritable parent does fail — but it would also defeat the
  `rm`, so the case would have passed for a reason unrelated to the guard. An unreadable source is
  the one that discriminates, and it is skipped with a stated reason under `uid 0`, where mode
  `000` does not deny root.
- `install -m 600`'s availability on the appliance is not an assumption: `pithead:2319` already
  uses it on the firstboot path itself.
- **Full tier-1 suite: 2917 passed, 0 failed, rc 0** on the branch tip. All 12 new assertions
  confirmed present in that run BY NAME, not inferred from the total.
- `shellcheck --severity=warning` rc 0 on all three changed shell files under the CI-pinned
  0.11.0 (`command -v` checked first — it resolves to `~/.local/bin` here, not the stale 0.9.0).
  `shfmt -i 4 -d` rc 0. Cheap lint targets each rc 0, captured individually rather than off a
  pipe: `lint-file-budget`, `lint-topology`, `lint-operator-strings`, `lint-docs-voice`,
  `lint-md`, `lint-yaml`, `lint-toml`.

## Shared files, disclosed

- **`pithead`** — the fix itself. Override pre-granted by the controller.
- **`tests/stack/test-wizard-setup.sh`** — additive append, granted by the `tests` lane for this
  specific change. Placement is deliberate: `run.sh` cannot take an addition (ceiling equals its
  line count), and this file has headroom at 303 of 800. It ends at 384, under the 400 target, so
  it still takes no budget row.
- **`Makefile`** — `lint-sh` enumerated three of the six files in `tests/os/`, so THREE were
  never shellchecked by any gate: `failure-evidence.sh` (shipped in #1358),
  `reinstall-prefill-verdict.sh` and `restore-live-state-verdict.sh`. `shfmt` did cover all of
  them (it walks `git ls-files '*.sh'`), which is what made the hole invisible. An enumerated
  list silently drops whatever is added beside it, so the three paths are replaced with
  `tests/os/*.sh` rather than adding back the one file I happened to find — adding only mine
  would have left two holes behind a line that now reads as audited. Same shape and same fix the
  e2e lane applied to `ci.yml`. All three are clean at `--severity=warning`, so this adds a check
  rather than a fix. Verified by EXPANDING the glob (six files, zero duplicates,
  `tests/stack/run.sh` still isolated), not by reading the line.
- `os/KNOWN-ISSUES.md` and `tests/os/failure-evidence.sh` are this lane's own.

## NOT proven — do not let the greens imply otherwise

- **No bench run. This is not hardware evidence.** The behaviour is exercised at tier 1 against
  the real function in a sandbox; that a provisioned appliance reaches this branch and keeps its
  config across a reboot is unmeasured.
- **That today's behaviour lands the next boot in `fail_boot` is an INFERENCE**, from the four
  file:line facts above, not an observation. The fix does not depend on it — it is the reason the
  trade is worth making, not the reason the branch is wrong.
- **A genuinely unprovisionable config is now retried on the next boot** instead of being
  discarded. That is a deliberate trade: a repeated loud failure with the operator's configuration
  intact beats a single failure with it gone. `pithead-boot` bounds its health-gate reboots on
  `/data` (#1065, PR #1135), so it is not an unbounded loop — but it is a behaviour change and it
  should be seen rather than discovered.
- **One likely side effect I have reasoned about but not measured:** pre-fix, a resubmitted config
  was `cp`'d onto a path that no longer existed, so it was created under the process umask (`644`
  under systemd's default). Post-fix it lands on an existing `600` file, and `cp` preserves an
  existing destination's mode. If that is right the change tightens the mode rather than loosening
  it, which is the safe direction — but I have not run it, and it is not what this PR is for.
- `make lint-sh` WAS run, under the lint lock, after the glob change: **rc 0, zero findings** —
  both halves of the target, including the isolated `tests/stack/run.sh` invocation. The rc was
  captured from make itself, not read off a filtered tail.
## Over-engineering pass

Run by hand on this diff. `/ponytail-review` is not available as a command in this environment,
so this is the pass itself rather than a claim that a tool produced it. Two findings, both
resolved as KEEP with the reasoning stated so a reviewer can overrule me:

1. **Extracting `wizard_keep_failed_config` for a single call site.** Justified by testability
   and nothing else: `run_sourced` needs a named function, and without the extraction the only
   way to reach this behaviour is to drive the whole wizard loop, which is tier 3 at best. The
   standing bar asks for the lowest tier that proves it honestly, and this is what makes tier 1
   possible.
2. **The conditional removal, rather than deleting the removal outright.** Deleting it would be
   simpler and would cost one code path and two test cases. I kept it because dropping it would
   change behaviour in the one case where the existing code is CORRECT — a `machine-role` that
   never landed, `record_machine_role` being best-effort — and I have no evidence that case
   cannot happen. It is one line. If a reviewer judges the case unreachable, this is the right
   thing to cut.

Also considered and found minimal: the `kept_copy` flag (its value is consumed later, so the rc
cannot just be tested inline), the two-branch prefill (the re-arming path has no `config.json`
left, so both branches are reachable), and the comment-to-code ratio on the new function (it
matches the block it replaces and the surrounding file, and it records why the simpler
delete-the-branch option was not taken).
