### PR TITLE
fix(tests): read the compose haystack with a here-string, not a pipe (#1370)

### DIFF
--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -274,6 +274,12 @@ Every scenario, at every tier, holds to the same rules.
 - Reproducible. The live run records a manifest (stack `VERSION`, git rev, image digests).
 - Test code is real code. The same lint (shellcheck) and coverage gate apply to the tests
   themselves, and the inventory generator fails CI if it stops enumerating a suite.
+- An assertion reads its haystack directly, never through a pipe. `grep -q` exits at its first
+  match, so under `pipefail` the writer's broken pipe becomes the pipeline's exit status and the
+  match is thrown away: a directive that was present read as missing, and — in the direction
+  nobody watches — a forbidden pattern that was present read as absent, which is a hardening
+  regression wearing a green tick. Use a here-string. And a reader that could not run at all is a
+  failure in its own right, never folded into either verdict.
 
 ### Flake policy
 

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -73,25 +73,38 @@ fi
 echo "Checking hardening directives (#90) ..."
 RENDERED="$(docker compose --env-file "$ENV_FILE" -f "$ROOT/docker-compose.yml" config)"
 fails=0
-expect_min() { # <label> <pattern> <min-count>
+# An empty render would let every expect_absent pass for the reassuring reason, so refuse it here.
+[ -n "$RENDERED" ] || { echo "  ✗ compose rendered nothing to assert against" && exit 1; }
+# The helpers read their haystack with a here-string, NEVER a pipe: `grep -q` exits at its first
+# match, so under the pipefail this file sets, the writer's EPIPE became the pipeline's status and
+# the match was discarded (#1370) — a present directive read as missing and, in the direction
+# nobody sees, a forbidden pattern that IS present read as absent, i.e. a hardening regression
+# wearing a green tick. grep exiting >= 2 is "could not check", counted as a failure, never a verdict.
+expect_min() { # <label> <pattern> <min-count> [haystack, default $RENDERED]
     local n
-    n=$(printf '%s\n' "$RENDERED" | grep -c -- "$2")
+    n=$(grep -c -- "$2" <<<"${4-$RENDERED}" || true)
     if [ "$n" -ge "$3" ]; then echo "  ✓ $1 ($n)"; else
         echo "  ✗ $1: expected >= $3, got $n"
         fails=$((fails + 1))
     fi
 }
 expect_present() { # <label> <pattern>
-    if printf '%s\n' "$RENDERED" | grep -q -- "$2"; then echo "  ✓ $1"; else
-        echo "  ✗ $1: missing [$2]"
-        fails=$((fails + 1))
-    fi
+    local rc=0
+    grep -q -- "$2" <<<"$RENDERED" || rc=$?
+    case $rc in
+    0) echo "  ✓ $1" ;;
+    1) echo "  ✗ $1: missing [$2]" && fails=$((fails + 1)) ;;
+    *) echo "  ✗ $1: could not check [$2] (grep exited $rc)" && fails=$((fails + 1)) ;;
+    esac
 }
 expect_absent() { # <label> <pattern>
-    if printf '%s\n' "$RENDERED" | grep -q -- "$2"; then
-        echo "  ✗ $1: found [$2]"
-        fails=$((fails + 1))
-    else echo "  ✓ $1"; fi
+    local rc=0
+    grep -q -- "$2" <<<"$RENDERED" || rc=$?
+    case $rc in
+    0) echo "  ✗ $1: found [$2]" && fails=$((fails + 1)) ;;
+    1) echo "  ✓ $1" ;;
+    *) echo "  ✗ $1: could not check [$2] (grep exited $rc)" && fails=$((fails + 1)) ;;
+    esac
 }
 
 # no-new-privileges on all 5 leaf services.
@@ -100,7 +113,7 @@ expect_min "no-new-privileges on leaf services" "no-new-privileges:true" 5
 # dashboard. The dashboard now runs non-root and owns its volume (#255), so it no longer needs
 # CAP_DAC_OVERRIDE to write its history DB and joins the others; pin the count so dropping cap_drop
 # from any leaf fails CI.
-caps=$(printf '%s\n' "$RENDERED" | grep -c -- "- ALL")
+caps=$(grep -c -- "- ALL" <<<"$RENDERED" || true)
 if [ "$caps" -eq 5 ]; then echo "  ✓ cap_drop: [ALL] on all 5 leaves incl. dashboard ($caps)"; else
     echo "  ✗ cap_drop: [ALL]: expected 5 (incl. dashboard, #255), got $caps"
     fails=$((fails + 1))
@@ -144,8 +157,8 @@ expect_present "tari node pinned by digest" "minotari_node:v5.3.1-mainnet@sha256
 # Per-service precision checks via the JSON render (cleaner than grepping the flat YAML): the
 # Docker socket proxies must stay least-privilege, and the Tari probe must self-match safely.
 JSON="$(docker compose --env-file "$ENV_FILE" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
-jq_assert() { # <label> <filter>
-    if printf '%s' "$JSON" | jq -e "$2" >/dev/null 2>&1; then echo "  ✓ $1"; else
+jq_assert() { # <label> <filter> [json, default $JSON]
+    if jq -e "$2" <<<"${3-$JSON}" >/dev/null 2>&1; then echo "  ✓ $1"; else
         echo "  ✗ $1: failed [$2]"
         fails=$((fails + 1))
     fi
@@ -237,7 +250,7 @@ grep -vE '^PROXY_STRATUM_PASSWORD=|^PROXY_DONATE_LEVEL=' "$ENV_FILE" >"$OFF_ENV"
 echo 'PROXY_STRATUM_PASSWORD=' >>"$OFF_ENV"
 OFF_JSON="$(docker compose --env-file "$OFF_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
 rm -f "$OFF_ENV"
-if printf '%s' "$OFF_JSON" | jq -e '.services["xmrig-proxy"] | (.environment["PROXY_STRATUM_PASSWORD"] == "") and (.command | any(. == "--donate-level=0"))' >/dev/null 2>&1; then
+if jq -e '.services["xmrig-proxy"] | (.environment["PROXY_STRATUM_PASSWORD"] == "") and (.command | any(. == "--donate-level=0"))' <<<"$OFF_JSON" >/dev/null 2>&1; then
     echo "  ✓ default-off: empty stratum password + --donate-level=0 (#152/#173)"
 else
     echo "  ✗ default-off must leave PROXY_STRATUM_PASSWORD empty and render --donate-level=0"
@@ -384,7 +397,7 @@ else
 fi
 REMOTE_TARI_JSON="$(docker compose --env-file "$REMOTE_TARI_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
 rm -f "$REMOTE_TARI_ENV"
-if printf '%s' "$REMOTE_TARI_JSON" | jq -e '.services | has("tari") | not' >/dev/null 2>&1; then
+if jq -e '.services | has("tari") | not' <<<"$REMOTE_TARI_JSON" >/dev/null 2>&1; then
     echo "  ✓ tari service absent when local_tari is omitted (remote tari, #103)"
 else
     echo "  ✗ tari service still present with local_tari omitted (remote tari, #103)"
@@ -392,7 +405,7 @@ else
 fi
 # The same profile list must reach the tor container, which gates each node's inbound hidden service
 # on it (#103) — without this wiring tor would keep publishing an onion for a node that never starts.
-if printf '%s' "$REMOTE_TARI_JSON" | jq -e '.services.tor.environment.COMPOSE_PROFILES == "local_node"' >/dev/null 2>&1; then
+if jq -e '.services.tor.environment.COMPOSE_PROFILES == "local_node"' <<<"$REMOTE_TARI_JSON" >/dev/null 2>&1; then
     echo "  ✓ tor receives the active profile list, so its onion gate matches the running nodes (#103)"
 else
     echo "  ✗ tor did not receive the active profile list (#103)"
@@ -408,20 +421,12 @@ CUSTOM_ENV="$(mktemp)"
 } >"$CUSTOM_ENV"
 CUSTOM="$(docker compose --env-file "$CUSTOM_ENV" -f "$ROOT/docker-compose.yml" config 2>/dev/null)"
 rm -f "$CUSTOM_ENV"
-sub_check() { # <label> <pattern> <min-count>
-    local n
-    n=$(printf '%s\n' "$CUSTOM" | grep -c -- "$2")
-    if [ "$n" -ge "$3" ]; then echo "  ✓ $1 ($n)"; else
-        echo "  ✗ $1: expected >= $3, got $n"
-        fails=$((fails + 1))
-    fi
-}
-sub_check "custom subnet rebases the bridge network (#180)" "subnet: 10.84.0.0/24" 1
+expect_min "custom subnet rebases the bridge network (#180)" "subnet: 10.84.0.0/24" 1 "$CUSTOM"
 # Five static mining-bridge IPs (tor .25, monerod .26, tari .27, p2pool .28, dashboard-reach .29);
 # the two socket proxies moved off mining_net to loopback-published proxy_net (#345), so no longer 7.
-sub_check "custom subnet rebases all static service IPs (#180)" "ipv4_address: 10.84.0." 5
-sub_check "custom subnet rebases the dashboard SSRF CIDR (#180)" "MINING_NET_CIDR: 10.84.0.0/24" 1
-sub_check "custom subnet rebases the dashboard Tor SOCKS endpoint (#180)" "TOR_SOCKS_PROXY: socks5h://10.84.0.25:9050" 1
+expect_min "custom subnet rebases all static service IPs (#180)" "ipv4_address: 10.84.0." 5 "$CUSTOM"
+expect_min "custom subnet rebases the dashboard SSRF CIDR (#180)" "MINING_NET_CIDR: 10.84.0.0/24" 1 "$CUSTOM"
+expect_min "custom subnet rebases the dashboard Tor SOCKS endpoint (#180)" "TOR_SOCKS_PROXY: socks5h://10.84.0.25:9050" 1 "$CUSTOM"
 
 # Configurable stratum port (#172). Default env (no STRATUM_PORT — a pre-#172 .env) must keep
 # publishing/binding :3333; a custom port must move the publish, the container port, the -b bind
@@ -438,22 +443,16 @@ PORT_ENV="$(mktemp)"
 } >"$PORT_ENV"
 PORT_JSON="$(docker compose --env-file "$PORT_ENV" -f "$ROOT/docker-compose.yml" config --format json 2>/dev/null)"
 rm -f "$PORT_ENV"
-port_assert() { # <label> <filter>
-    if printf '%s' "$PORT_JSON" | jq -e "$2" >/dev/null 2>&1; then echo "  ✓ $1"; else
-        echo "  ✗ $1: failed [$2]"
-        fails=$((fails + 1))
-    fi
-}
-port_assert "custom stratum port moves the publish and container port (#172)" \
-    '.services["xmrig-proxy"].ports | any((.published == "4444") and (.target == 4444))'
-port_assert "custom stratum port moves the -b bind (#172)" \
-    '.services["xmrig-proxy"].command | any(. == "0.0.0.0:4444")'
-port_assert "custom stratum port reaches the dashboard hint env (#172)" \
-    '.services.dashboard.environment["STRATUM_PORT"] == "4444"'
-port_assert "internal p2pool stratum stays :3333 under a custom port (#172)" \
-    '.services["p2pool"].command | any(. == "0.0.0.0:3333")'
-port_assert "proxy upstream (P2POOL_URL) stays the internal :3333 (#172)" \
-    '.services["xmrig-proxy"].command | any(. == "172.28.0.28:3333")'
+jq_assert "custom stratum port moves the publish and container port (#172)" \
+    '.services["xmrig-proxy"].ports | any((.published == "4444") and (.target == 4444))' "$PORT_JSON"
+jq_assert "custom stratum port moves the -b bind (#172)" \
+    '.services["xmrig-proxy"].command | any(. == "0.0.0.0:4444")' "$PORT_JSON"
+jq_assert "custom stratum port reaches the dashboard hint env (#172)" \
+    '.services.dashboard.environment["STRATUM_PORT"] == "4444"' "$PORT_JSON"
+jq_assert "internal p2pool stratum stays :3333 under a custom port (#172)" \
+    '.services["p2pool"].command | any(. == "0.0.0.0:3333")' "$PORT_JSON"
+jq_assert "proxy upstream (P2POOL_URL) stays the internal :3333 (#172)" \
+    '.services["xmrig-proxy"].command | any(. == "172.28.0.28:3333")' "$PORT_JSON"
 
 if [ "$fails" -ne 0 ]; then
     echo "  ✗ $fails hardening check(s) failed"

--- a/tests/stack/test_compose.sh
+++ b/tests/stack/test_compose.sh
@@ -81,11 +81,12 @@ fails=0
 # nobody sees, a forbidden pattern that IS present read as absent, i.e. a hardening regression
 # wearing a green tick. grep exiting >= 2 is "could not check", counted as a failure, never a verdict.
 expect_min() { # <label> <pattern> <min-count> [haystack, default $RENDERED]
-    local n
-    n=$(grep -c -- "$2" <<<"${4-$RENDERED}" || true)
-    if [ "$n" -ge "$3" ]; then echo "  ✓ $1 ($n)"; else
-        echo "  ✗ $1: expected >= $3, got $n"
-        fails=$((fails + 1))
+    local n rc=0
+    n=$(grep -c -- "$2" <<<"${4-$RENDERED}") || rc=$?
+    if [ "$rc" -gt 1 ]; then
+        echo "  ✗ $1: could not check [$2] (grep exited $rc)" && fails=$((fails + 1))
+    elif [ "$n" -ge "$3" ]; then echo "  ✓ $1 ($n)"; else
+        echo "  ✗ $1: expected >= $3, got $n" && fails=$((fails + 1))
     fi
 }
 expect_present() { # <label> <pattern>


### PR DESCRIPTION
Fixes the compose hardening checks reported in #1370, both directions.

## The mechanism is not the one the issue describes, and that matters

The issue reads the CI log as a "transient write error". It is not transient and it is not a write
error in the sense of a fault. `grep -q` exits at its **first match**, and this file sets
`pipefail`, so the writer's SIGPIPE/EPIPE becomes the pipeline's exit status and the successful
match is discarded. The check's verdict therefore depends on the WRITER's fate, which has nothing
to do with whether the pattern was there.

Measured rather than reasoned:

- bash's `printf` writes the rendered config with **143 separate `write()` calls**, roughly one per
  line (`strace -e trace=write` on the real payload). So once the reader leaves early there is a
  long tail of writes still to fail.
- With SIGPIPE at its default disposition the writer dies at rc 141; where SIGPIPE is **ignored**
  and inherited, `printf` gets EPIPE instead, returns 1, and prints
  `printf: write error: Broken pipe` — which is the exact line in the CI log, so that is the
  disposition CI had. Both give a non-zero pipeline under `pipefail`; only the visibility differs,
  which means a local run fails the same way with no warning line at all.

## What I could not reproduce, stated plainly

The race did **not** fire on this box: 300 iterations of the real check against the real render,
0 false verdicts. The render is 17,189 bytes and the pipe buffer is 64 KiB, so the writer never
blocks and finishes before the reader can exit. Firing it needs the writer still writing when the
reader leaves — a constrained pipe or a descheduled writer, which is the CI condition and which I
did not reproduce here. The mechanism is proven; the specific trigger on that runner is inferred.
It does not change the fix: the defect is that the verdict is coupled to the writer at all.

## The fix

Every helper reads its haystack with a here-string. A here-string has no writer, so there is no
status the match did not earn. Beyond that:

- `grep` exiting **>= 2** is reported as `could not check` and counted as a failure. It must never
  share an output with "checked and clean" — which is the distinction the issue asks for.
- An **empty render** is refused outright. Previously it let every absent-check pass for the
  reassuring reason.

## Mutation table

Extracted from the real files, never retyped: the helpers are cut out of `origin/develop-v2` and
out of this branch and driven under `set -uo pipefail`. The **base column is the point** — if the
base did not get M1-M3 wrong, these cases would prove nothing.

| | what it proves | base (develop-v2) | this branch |
|---|---|---|---|
| **M1** | absent-check, forbidden pattern present early | `✓` — **silent false green** | `✗ found` |
| **M2** | present-check, required pattern present early | `✗ missing` — false red | `✓` |
| **M3** | `grep` errors (invalid BRE) | `✓` — **reads as clean** | `✗ could not check (grep exited 2)` |
| C1 | absent-check, pattern genuinely absent | `✓` | `✓` |
| C2 | present-check, pattern genuinely absent | `✗ missing` | `✗ missing` |
| C3 | absent-check, forbidden present, small payload | `✗ found` | `✗ found` |
| C4 | present-check, required present, small payload | `✓` | `✓` |

C1-C4 are the controls that matter in the other direction: they agree across both versions, so the
fix did not simply invert every verdict.

M1 is the half nobody had observed. It is the one that turns a real hardening regression into a
green tick, and it is silent by construction.

**The empty-render guard is tested end to end, separately**, because the helper-level case cannot
see it: with `docker` stubbed so `config -q` validates but `config` renders nothing, the base
prints `✓ no get_info (creds) in compose healthcheck` — an absent-check reporting clean against
nothing — while this branch prints `✗ compose rendered nothing to assert against` and stops. Said
honestly: the base run was already rc 1 from 84 other loud failures, so this was not a false green
at the suite level. The individual verdict was still a lie, and would be the only verdict if the
absent-check were the one that mattered.

I also control-tested the two things this PR newly introduces, since both could mask a failure:
`expect_min`'s `|| true` still reddens on a zero count and on a count below the minimum, and the
new optional haystack argument reddens when the pattern is absent from the haystack passed in.

## Over-engineering pass

Run on my own diff regardless of whether the gate prompted, and it found something. `sub_check` was
a verbatim copy of `expect_min` against `$CUSTOM`, and `port_assert` a verbatim copy of `jq_assert`
against `$PORT_JSON` — both carrying the same pipe defect. Both are gone; the originals take an
optional haystack. That is also what pays for the change: the file sits **exactly on its budget
ceiling**, so nothing could be added until something was removed.

**The budget row is deliberately left at 462 while the file is 461.** Re-ratcheting it to the exact
count is the habit that leaves every budgeted file with zero headroom and blocks the next one-line
fix outright. The gate passes either way; one line of slack costs nothing and touches no shared
file during a week when the tsv is contended.

## What was RUN

- `bash tests/stack/test_compose.sh` before and after: rc 0 both, **87 ticks / 0 crosses**, verdict
  output byte-identical once docker's own timestamped warnings are stripped.
- `shfmt -i 4 -d` clean. `shellcheck` **0.11.0** (not `/usr/bin`'s 0.9.0) at full severity: one
  pre-existing `SC2016` info on an untouched jq filter, nothing new.
- `scripts/lint-file-budget.sh` rc 0 · `lint-docs-voice` rc 0 · `lint-operator-strings` rc 0 ·
  topology detector clean on both changed files.
- The mutation table and the stubbed-docker guard test above.

## What was NOT run, and what I left

- `make lint` / `make test` / `make lint-sh` were not run locally — the lint lock was with another
  lane and `lint-sh` is the OOM path on this box. CI runs those on the merge commit.
- The `jq -e` helpers are converted to here-strings for consistency but were **not** the defect and
  are not claimed as fixed: `jq` must read its whole input to parse it, so it cannot exit early.
- Left deliberately out of scope, and worth someone filing: `tests/stack/run.sh` has the same
  `printf | grep -q` shape under `pipefail` in three places. The payloads are single command
  outputs rather than a full render, so the tail of writes is short, but the shape is identical.
  `run.sh` has zero budget headroom, and folding a behaviour change into the #1105 split would
  break that work's "no behaviour change" contract.
