### PR TITLE
test(integration): run the dashboard-to-rig write phase in the mandated gate (#1364)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -228,11 +228,14 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
 
 `--mode`: `targeted` (default, lean) validates the dashboard and the sync logic against the
 already-synced node: `check` + `--lifecycle` (one controlled restart exercises the sync gate /
-node-down failover) + `--auth-fail-closed`. No full config sweep, and never a re-sync. Container
-restarts reload the existing chain and re-confirm the tip in seconds. `check` is pure reads only.
-`matrix` is the opt-in full destructive config sweep (lifecycle + fault-injection + auth-fail-closed +
-hardening + `--subnet`, plus `--rigforge-control` when a rig is borrowed, all under `--safety-backup`
-auto-rollback) for a pre-release tier-4 gate. `--keep` leaves it deployed for
+node-down failover) + `--auth-fail-closed`, plus `--rigforge` and `--rigforge-control` when a rig is
+borrowed. No full config sweep, and never a re-sync. Container restarts reload the existing chain and
+re-confirm the tip in seconds. `check` is pure reads only. `matrix` is the opt-in full destructive
+config sweep (lifecycle + fault-injection + auth-fail-closed + hardening + `--subnet`, plus the same
+two rig phases, all under `--safety-backup` auto-rollback) for a pre-release tier-4 gate.
+The rig phases are gated on a borrowed miner rather than on the mode: the release runbook mandates
+`targeted`, so keeping the write paths matrix-only left them out of the gate that decides whether a
+release ships ([#1364](https://github.com/p2pool-starter-stack/pithead/issues/1364)). `--keep` leaves it deployed for
 inspection (skips the restore). Requires SSH access to the test bench and the miner; see the
 [testbench README](../../tests/integration/testbench-README.md).
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -187,10 +187,24 @@ Two runs of the matrix are required, and the automated one is the smaller of the
    This deploys the candidate to the bench's dedicated e2e checkout, repoints the rig at it
    (under the [rig lock](release-server.md#bench-allocation-and-the-rig-lock), with automatic
    restore of both), and proves what `--readiness` cannot: a real miner mining through the
-   stack, the lifecycle phase (restart, apply secret-preservation, node-down failover), and
-   fail-closed auth. If the release's diff touches the worker or control-descriptor path, add
-   the `--rigforge-control` legs (needs a rig with its control API enabled). The readiness
-   gate alone does not satisfy this requirement; abort the release on any failure.
+   stack, the lifecycle phase (restart, apply secret-preservation, node-down failover),
+   fail-closed auth, and the dashboard-to-rig write paths. Those write paths used to be
+   reachable only under `--mode matrix`, so this mandated run never asked for them and the whole
+   surface shipped unproven; the targeted run now requests them whenever a rig is borrowed. They
+   need a rig with its control API enabled, and each leg says so and skips when it is missing —
+   read the run's output rather than its exit code alone. The readiness gate does not satisfy
+   this requirement; abort the release on any failure.
+
+   A run that does not finish leaves the rig's writable config where it stopped. The `EXIT`
+   trap restores the rig's xmrig pool config and the baseline stack; it does not restore the
+   RigForge writable keys, and `run.sh` — which writes them — has no trap at all
+   ([#1379](https://github.com/p2pool-starter-stack/pithead/issues/1379)). So a `Ctrl-C`, an
+   SSH drop, or a cancelled job mid-leg can leave `max_temp_c` a degree above where it started,
+   or whichever key the run died inside. Every probe is a near neighbour of the value it read
+   off the rig, so nothing is damaged — but the rig is not where you left it, and the restore
+   summary will not mention it. Read the rig's current values in Worker Inspect against what
+   you expect, and put a stray one back the same way. This is the same shape as `--keep`: the
+   run tells you it did not restore, and the rest is yours.
 
 After deploying the published release to the bench, run the non-destructive live sweep as the
 closing check: `tests/integration/run.sh --local --dir <stack-dir> --check`. On a bench with no

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -88,7 +88,7 @@ OPTIONS:
                       targeted — LEAN (default): validate the dashboard + the sync logic against
                                  the EXISTING synced node — no full config sweep, no node re-sync.
                                  = check + lifecycle (one controlled restart exercises the sync
-                                 gate / node-down failover) + --auth-fail-closed.
+                                 gate / node-down failover), auth-fail-closed, RigForge read+control.
                       check    — non-destructive: readiness + current live state only (pure reads).
                       matrix   — the full destructive config matrix + lifecycle + fault-injection
                                  + auth-fail-closed, with --safety-backup auto-rollback. Opt-in —
@@ -106,7 +106,7 @@ OPTIONS:
 ENV OVERRIDES: BENCH_HOST, MINER_HOST, CANONICAL_DIR, E2E_DIR, MINER_XMRIG_CONFIG, GIT_REMOTE_URL
 
 EXAMPLES:
-  tests/integration/e2e.sh claude/my-feature                 # full matrix, borrow the configured miner
+  tests/integration/e2e.sh claude/my-feature                 # targeted (the default), borrow the miner
   tests/integration/e2e.sh claude/my-feature --mode check    # safe, non-destructive first run
   tests/integration/e2e.sh main --mode targeted --keep       # quick, leave it deployed to inspect
 EOF
@@ -688,10 +688,10 @@ run_harness() {
     # RigForge integration (#185/#235/#260) is only meaningful with a REAL rig mining through the stack.
     # The phase self-skips if no rigforge rig is connected, so this gate is just to avoid the noise.
     [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ] && phases="$phases --rigforge"
-    # RigForge control WRITE paths (#513/#514/#516/#517) need the rig pinned in dashboard.workers[] and
-    # its control API opted in. matrix only (it mutates config + dials the rig); each leg self-skips
-    # loudly when its prerequisite is missing, so this stays safe on a bench without the descriptor.
-    [ "$BORROW_MINER" = "1" ] && [ "$MODE" = "matrix" ] && phases="$phases --rigforge-control"
+    # The dashboard-to-rig WRITE paths (#513/#514/#516/#517/#1002b/#1236) — same gate as the read phase
+    # since #1364: matrix-only meant the mandated pre-cut run (--mode targeted) never asked for them, so
+    # the write surface shipped unproven. DESTRUCTIVE-then-restored; every leg self-skips loudly.
+    [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ] && phases="$phases --rigforge-control"
     # #905: no borrowed miner means no worker will ever appear — tell the harness to SKIP its two
     # mining assertions (workers online, stratum hashes) instead of failing a healthy stack.
     local no_mining=""

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Self-test for e2e.sh's phase composition (#1364): which run.sh phases each --mode actually
+# launches with. The defect this locks down was invisible because it was an ABSENCE — the
+# rigforge-control phase was gated on `--mode matrix` while docs/dev/releasing.md mandates
+# `--mode targeted` before every cut, so the whole dashboard-to-rig write surface
+# (#513/#514/#516/#517/#1002b/#1236) was never even REQUESTED by the gate that decides whether a
+# release ships. Nothing in the output mentioned it; there was no skip line to notice.
+#
+# It runs the REAL run_harness out of e2e.sh (extracted, then evaluated against stubbed ssh) and
+# reads the phase list off the command that would have been launched — not off a re-implementation
+# of the gate, which would pass happily while the shipped file said something else.
+#
+# Standalone (not sourced by selftest.sh) so it never touches selftest.sh's own file-budget
+# ceiling — same reasoning as selftest-rigforge-apply-settle.sh. Run directly, or via
+# `make test-integration-selftest`. No server, no bench, no rig.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+E2E_SRC="$HERE/e2e.sh"
+RUN_SRC="$HERE/run.sh"
+
+# --- Extract run_harness from the shipped e2e.sh --------------------------------------------
+# Fail CLOSED: if a refactor moves or renames the function this must go red, never silently stop
+# testing. A self-test whose subject quietly evaporates is the exact shape of gate this file exists
+# to catch, so the extraction is asserted before anything is evaluated.
+HARNESS_SRC="$(sed -n '/^run_harness() {$/,/^}$/p' "$E2E_SRC")"
+# An empty extraction fails this too — "" does not open and close — so no separate non-empty guard.
+assert_eq "the extraction is the whole function (opens and closes)" \
+    "$(printf '%s\n' "$HARNESS_SRC" | sed -n '1p;$p' | tr '\n' ' ')" "run_harness() { } "
+assert_contains "the extracted function still composes the rigforge phases" \
+    "$HARNESS_SRC" '--rigforge-control'
+
+# --- Drive it with ssh stubbed out ----------------------------------------------------------
+# Every on_bench call is recorded; the harness is told its run finished immediately with rc 0, so
+# the poll loop never sleeps. The one call we read back is the `nohup ./.e2e-run.sh` launch, which
+# carries the phase list verbatim — the same string the bench would have executed.
+compose_phases() { # <mode> <borrow_miner> -> the phase list e2e.sh would launch run.sh with
+    local launch
+    # SC2034/SC2329: the config vars and the log/step/warn/ok/die/on_bench stubs below are all read
+    # and called by the eval'd run_harness, which shellcheck cannot follow into.
+    # shellcheck disable=SC2034,SC2329
+    launch="$(
+        MODE="$1" BORROW_MINER="$2" WORKERS=1 BENCH_HOST=bench E2E_DIR=/srv/code/pithead-e2e
+        LAUNCH_LINE=""
+        log() { :; }
+        step() { :; }
+        warn() { :; }
+        ok() { :; }
+        die() {
+            echo "DIE: $*" >&2
+            exit 1
+        }
+        on_bench() {
+            case "$1" in
+            # The launch command names the done-marker too (it rm -f's it first), so match the
+            # launch FIRST — reversing these two makes every phase assertion pass vacuously.
+            *nohup*) LAUNCH_LINE="$1" ;;
+            *e2e-harness.done*)
+                # `test -f <done>` (the poll) and `cat <done>` (the exit code) share this substring;
+                # answering 0 to both ends the loop on its first pass with a clean harness result.
+                echo 0
+                return 0
+                ;;
+            esac
+            return 0
+        }
+        eval "$HARNESS_SRC"
+        run_harness >/dev/null 2>&1
+        # The one line worth keeping. A run that never reaches the launch yields an empty capture,
+        # which fails the exact-set assertions loudly rather than reporting a stale answer.
+        printf '%s\n' "$LAUNCH_LINE"
+    )"
+    # Everything between the runner's positional args and the trailing redirect is the phase list.
+    sed -n 's/.*\.e2e-run\.sh[^ ]* [^ ]* [^ ]* \(.*\) >\/dev\/null.*/\1/p' <<<"$launch"
+}
+
+has_phase() { # <phase-list> <flag> -> "yes" | "no"
+    case " $1 " in *" $2 "*) echo yes ;; *) echo no ;; esac
+}
+
+# The EXACT set a mode launches, order- and whitespace-independent. This is the fail-closed half:
+# per-flag has_phase checks are a denylist — they can only catch the absences someone thought of,
+# and a mutation that ADDS a destructive phase to --mode check walked straight through them.
+phase_set() { # <phase-list> -> the flags, sorted, space-joined
+    # shellcheck disable=SC2086  # deliberate word-splitting: the phase list is a flag string
+    printf '%s\n' $1 | LC_ALL=C sort | tr '\n' ' '
+}
+
+echo "== the mandated pre-cut gate (--mode targeted) reaches the write surface (#1364) =="
+TARGETED="$(compose_phases targeted 1)"
+assert_eq "targeted requests the rigforge-control WRITE phase (#1364)" \
+    "$(has_phase "$TARGETED" --rigforge-control)" "yes"
+assert_eq "targeted launches EXACTLY its documented phases, and nothing else" \
+    "$(phase_set "$TARGETED")" "--auth-fail-closed --lifecycle --rigforge --rigforge-control "
+
+echo "== --mode matrix keeps everything it had =="
+MATRIX="$(compose_phases matrix 1)"
+assert_eq "matrix still requests the rigforge-control WRITE phase" \
+    "$(has_phase "$MATRIX" --rigforge-control)" "yes"
+assert_eq "matrix launches EXACTLY its documented phases, and nothing else" \
+    "$(phase_set "$MATRIX")" \
+    "--auth-fail-closed --fault-injection --hardening --lifecycle --rigforge --rigforge-control --safety-backup --subnet "
+
+echo "== --mode check stays non-destructive (pure reads) =="
+CHECK="$(compose_phases check 1)"
+assert_eq "check does NOT request the write phase" \
+    "$(has_phase "$CHECK" --rigforge-control)" "no"
+assert_eq "check launches EXACTLY --check — no destructive phase may ever join it" \
+    "$(phase_set "$CHECK")" "--check "
+
+echo "== --no-miner: no rig means no rig phases, and the mining asserts are skipped (#905) =="
+NOMINER="$(compose_phases targeted 0)"
+assert_eq "no borrowed miner => no write phase (there is no rig to write to)" \
+    "$(has_phase "$NOMINER" --rigforge-control)" "no"
+assert_eq "no borrowed miner => EXACTLY the rig-free phases, plus --no-mining-asserts (#905)" \
+    "$(phase_set "$NOMINER")" "--auth-fail-closed --lifecycle --no-mining-asserts "
+
+echo "== the flag e2e.sh emits is one run.sh actually parses =="
+# run.sh's parser ends in `-*) die "Unknown option"`, so a phase e2e.sh invents is not a no-op —
+# it kills the whole harness run. Assert the handshake rather than trusting the two files agree.
+for flag in $(printf '%s %s %s %s' "$TARGETED" "$MATRIX" "$CHECK" "$NOMINER" | tr ' ' '\n' | grep . | LC_ALL=C sort -u); do
+    assert_eq "run.sh's arg parser accepts '$flag'" \
+        "$(grep -cE "^[[:space:]]*(\-\-[a-z-]+ \| )*${flag}\)" "$RUN_SRC" | awk '{print ($1>0)?"yes":"no"}')" "yes"
+done
+
+echo ""
+echo "selftest-e2e-phases: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What this is

The release runbook mandates `tests/integration/e2e.sh <ref> --mode targeted` before every cut. The RigForge control phase — the whole dashboard-to-rig **write** surface — was gated on `--mode matrix`. So the mandated gate never requested it, and the write paths for #513/#514/#516/#517/#1002b/#1236 shipped with no coverage in the gate that decides whether a release ships.

This is not a self-skip. The phase was never asked for, so nothing in the run's output mentioned it at all. There was no skip line to notice.

The runbook's escape hatch was not executable either: `docs/dev/releasing.md` told the operator to "add the `--rigforge-control` legs", and `e2e.sh` has no such flag — its parser dies on unknown options.

## The fix, and why it is not a flag

Gate the phase on **a borrowed miner** instead of on the mode — exactly the gate the read-only `--rigforge` phase one line above already uses:

```diff
-    [ "$BORROW_MINER" = "1" ] && [ "$MODE" = "matrix" ]  && phases="$phases --rigforge-control"
+    [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ] && phases="$phases --rigforge-control"
```

A `--rigforge-control` passthrough flag was the obvious first solution and it is the weaker fix. It would have left coverage conditional on the operator judging, per cut, whether "the release's diff touches the worker or control-descriptor path" — the runbook's own wording. That is a judgment a human has to get right every single release. "A rig was borrowed" is one the harness evaluates itself. The runbook's promised flag stops being a lie by becoming unnecessary rather than by being implemented.

It is also line-neutral, which matters here: `tests/integration/e2e.sh` sits at its recorded budget ceiling of 766 with **zero slack**, and no cut of that file is in flight. Per the standing ruling, the first question was whether a line-neutral form of the change existed rather than which vehicle could carry the growth. One did, and it turned out to be the better change on the merits — the ratchet is not the argument for it.

`--mode check` is untouched and stays pure reads.

Also in scope, both zero-line: the `--help` EXAMPLES line that called the default "full matrix" when it is `targeted`, and the `targeted` mode description. **`:87`'s mode line is deliberately left alone — it is correct**, as the controller established when narrowing this issue's claims.

## The exposure this creates, stated in the runbook

`e2e.sh` installs `trap restore_all EXIT INT TERM`, which reads as full abort safety. It is not, for this surface. `restore_all` restores the miner's xmrig **pool** config and the baseline stack. It does not restore the RigForge **writable** keys — and `run.sh`, which writes them, has no trap of any kind (`grep -n 'trap ' tests/integration/run.sh` returns nothing at the tip; `lib.sh`'s only trap removes the rig-lock holder).

That has been harmless for two reasons, neither of which is a control: the probes are near neighbours of the values they read off the rig, and almost nobody ran the phase. **This PR removes the second reason on purpose.** So `docs/dev/releasing.md` now states what an unfinished run can leave behind, that the restore summary will not mention it, and how to put it back — in the same voice as the existing `--keep` arm. Filed as a real defect in **#1379**; the paragraph is a note, not a fix.

## What was RUN

- `make lint` — **rc=0 end to end**, exit code read from `make` itself, not from surviving output.
- `make test-integration-selftest` — **rc=0**.
- `shellcheck` confirmed **0.11.0** (`~/.local/bin`, the version CI pins) before believing any local result; `/usr/bin`'s 0.9.0 produces findings CI never shows.
- **17 mutations, all 17 killed.** Twelve of the gate and its neighbours (revert to matrix-only; phase deleted; phase leaks into `check`; phase no longer needs a miner; read phase deleted; `targeted` drops `--lifecycle` / `--auth-fail-closed`; `targeted` silently gains the destructive matrix phases; `matrix` drops `--safety-backup`; `check` gains a destructive phase; `--no-mining-asserts` dropped; a flag `run.sh` cannot parse). Five of the **test's own scaffolding**, because a self-test that can go vacuous is worth less than none: `run_harness` renamed, the launch command stripped of its phase list, the stub dispatch order reversed, `phase_set` stopped normalising, and the parser handshake pointed at a file with no parser.
- The budget gate re-checked after rebasing onto the current `develop-v2`, with `git rev-list --count HEAD..origin/develop-v2` = 0 at the time it ran. `tests/integration/*` rows are unchanged by tonight's merges; `e2e.sh` is 766 against a ceiling of 766.

## The new test, and why it is shaped this way

`tests/integration/selftest-e2e-phases.sh` extracts the **real `run_harness` out of the shipped `e2e.sh`**, evaluates it against a stubbed `ssh`, and reads the phase list off the command that would have been launched. It does not re-implement the gate — a re-implementation passes happily while the shipped file says something else, which is the failure this issue is about. The extraction is asserted before anything is evaluated, so a refactor that moves or renames the function reds instead of silently testing nothing.

Assertions are **exact-set, not per-flag**. The first version checked "does `check` contain `--rigforge-control`? no — good", and a mutation that *added* `--fault-injection` to `--mode check` walked straight through it. A denylist only catches the absences someone thought of. Each mode now asserts the complete set it launches.

It also asserts the handshake across the file boundary: every flag `e2e.sh` emits must be one `run.sh`'s parser accepts. `run.sh` ends its parser in `die "Unknown option"`, so an invented phase is not a no-op — it kills the whole harness run.

Standalone, so it does not touch `selftest.sh`'s own budget ceiling; picked up by the existing `selftest*.sh` glob in the Makefile and CI, so no shared-file change.

## What was NOT run — the honest gap

**No rig was borrowed. Nothing here has executed against hardware.** Every claim about how a real rig or a real run behaves is re-derived from source at file:line. This PR proves the mandated gate *requests* the phase; it does not prove the phase *covers* anything on a bench.

That distinction is the point of the second finding, filed separately:

- **#1378** — `e2e.sh` never passes `--rig-host` and never sets `IT_RIG_TOKEN` (neither string appears in the file). So even on today's only route to the phase, the entire phase self-skips when the bench baseline carries no rig descriptor (`run.sh:2135-2139`), the #516 enriched-feed reflection leg **can never run at all** (`:2294-2296`), and #517 loses its rig-poll settle fallback so a correct rollback on a slow rig asserts red (`:2373`). Not folded in: the token half is a real design question — `run.sh:2129` says the token is local-only "so it never leaves the bench" — and it would give this PR two contracts.

**So #1364 should not be closed on this merge.** Making a phase reachable is not the same as making it cover. That is said in the issue's own thread as well as here, so it survives a session being cycled.

## Reviewed

The over-engineering pass was run on this diff twice — once by hand before the PR gate fired, because a gate whose silence is indistinguishable from a pass earns nothing, and once as four independent cleanup agents (reuse, simplification, efficiency, altitude) when it did. **All four returned findings; none came back empty, so nothing here is a check that silently did not run.**

Applied:

- **Reuse.** The extraction guard hand-rolled a `case` where `lib.sh:65` already has `assert_contains`. Now calls it.
- **Simplification + efficiency, the same mechanism found from two angles.** The launch line was captured through a shared `mktemp` file with an `export` and an `EXIT` trap. It now returns through plain command substitution — `mktemp`, the `export` and the trap are gone, and the staleness risk the efficiency pass flagged (a future early-return in `run_harness` leaving a call reading the *previous* call's launch line and reporting it as a pass) is removed by construction rather than by a guard.
- **Two redundant assertions dropped.** A non-empty check on `targeted` alone that no other mode had, and a non-empty check on the extraction. Both were already covered with clearer messages by the exact-set and open/close assertions — confirmed by mutation, not by reading.
- Earlier by hand: the cross-file parser handshake deduped from 16 greps with 6 duplicates to the 10 distinct flags.

Skipped, with the reason: the altitude pass noted the two rig-phase gate lines now share an identical condition and could collapse into one block. Left alone deliberately — each line carries its own load-bearing comment (why the read phase is safe by self-skip, versus why the write phase mattered for #1364), and merging them would blur two different explanations to save a line.

**The full mutation set was re-run after every one of these edits, because they changed the test itself. Final state: 19 mutations, 19 killed, 0 survived** — including four of the test's own scaffolding (`run_harness` renamed, the extraction returning empty, the stub dispatch order reversed, the launch capture dropped, `phase_set` no longer normalising). The unmutated control was confirmed green first; a kill list means nothing without it.

Base: `develop-v2` at `f48b115`, `git rev-list --count HEAD..origin/develop-v2` = 0 at the final gate run. Shares no files with any open PR at the time of writing.
