### PR TITLE
fix(dashboard): bounded reads for the clients #660 treated as internal (#1360)

### DIFF
--- a/dashboard/mining_dashboard/client/docker/docker_control.py
+++ b/dashboard/mining_dashboard/client/docker/docker_control.py
@@ -3,6 +3,7 @@ import logging
 import aiohttp
 
 from mining_dashboard.config.config import DOCKER_CONTROL_URL, DOCKER_TIMEOUT
+from mining_dashboard.helper.http import bounded_read
 
 logger = logging.getLogger("DockerControl")
 
@@ -73,7 +74,11 @@ class DockerControl:
                         log = logger.debug if quiet else logger.info
                         log(f"Container {container} {action}: ok (HTTP {resp.status})")
                         return True
-                    body = await resp.text()
+                    # Bounded (#1360). The 200-char slice below only ever trimmed the LOG LINE —
+                    # the whole body was buffered first, so an error response was the one path
+                    # here that read without a limit.
+                    raw = await bounded_read(resp.content, what=f"{container} {action} error")
+                    body = raw.decode("utf-8", errors="replace")
                     logger.error(
                         f"Container {container} {action} failed: HTTP {resp.status} {body[:200]}"
                     )

--- a/dashboard/mining_dashboard/client/monero/monero_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_client.py
@@ -8,6 +8,7 @@ from mining_dashboard.config.config import (
     MONERO_NODE_USERNAME,
     MONERO_RPC_URL,
 )
+from mining_dashboard.helper.http import bounded_get
 
 logger = logging.getLogger("MoneroClient")
 
@@ -42,7 +43,7 @@ class MoneroClient:
     def get_info(self):
         """Return monerod's `get_info` payload as a dict, or None if unreachable/errored."""
         try:
-            resp = requests.get(self.url, auth=self._auth, timeout=self.timeout)
+            resp = bounded_get(self.url, auth=self._auth, timeout=self.timeout)
         except requests.RequestException as e:
             logger.warning(f"monerod get_info unreachable at {self.url}: {e}")
             return None

--- a/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
@@ -8,6 +8,7 @@ from mining_dashboard.config.config import (
     WALLET_RPC_PASSWORD,
     WALLET_RPC_USERNAME,
 )
+from mining_dashboard.helper.http import bounded_request
 from mining_dashboard.service.earnings import ATOMIC_PER_XMR
 
 logger = logging.getLogger("MoneroWalletClient")
@@ -45,7 +46,9 @@ class MoneroWalletClient:
         """POST one JSON-RPC call; return the ``result`` dict, or None on any error."""
         payload = {"jsonrpc": "2.0", "id": "0", "method": method, "params": params or {}}
         try:
-            resp = requests.post(self.url, json=payload, auth=self._auth, timeout=self.timeout)
+            resp = bounded_request(
+                "POST", self.url, json=payload, auth=self._auth, timeout=self.timeout
+            )
         except requests.RequestException as e:
             logger.warning(f"wallet-rpc {method} unreachable at {self.url}: {e}")
             return None

--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -17,6 +17,7 @@ from mining_dashboard.config.config import (
 # rather than restated: a second literal would be a third copy of the same list, and the existing
 # drift guard only compares the dashboard's copy against pithead's. control_service imports only
 # `config`, so this does not close an import cycle.
+from mining_dashboard.helper.http import ResponseTooLarge, bounded_read
 from mining_dashboard.service.control_service import WORKER_WRITABLE_KEYS
 
 # Per-worker endpoint descriptors (#172): the validated dashboard.workers[] list from config.json.
@@ -360,23 +361,23 @@ class XMRigWorkerClient:
         try:
             async with self.session.get(url, headers=headers, timeout=API_TIMEOUT) as response:
                 if response.status == 200:
-                    # Read one byte past the ceiling and refuse on overflow. Deliberately NOT a
-                    # Content-Length check: that header is set by the far end, may be absent under
-                    # chunked encoding, and is exactly what a rig lying about its size would lie
-                    # about. Reading with a bound never trusts it in the first place.
-                    # Accumulate: StreamReader.read(n) is a SHORT read — it returns whatever is
-                    # buffered the moment anything is, NOT n bytes. One call would truncate any
-                    # body that arrives split across TCP reads, which is ordinary for a rig on
-                    # WiFi or any link with latency, and the rig would then read as unreachable
-                    # for a reason with nothing to do with its size. Stop at EOF, or one byte past
-                    # the ceiling — never buffering more than that however the body is framed.
-                    body = b""
-                    while len(body) <= _MAX_SUMMARY_BYTES:
-                        chunk = await response.content.read(_MAX_SUMMARY_BYTES + 1 - len(body))
-                        if not chunk:
-                            break
-                        body += chunk
-                    if len(body) > _MAX_SUMMARY_BYTES:
+                    # This loop is where the bounded async read was worked out (#1347); #1360
+                    # lifted it into ``bounded_read`` and this is the call site coming back to it.
+                    # Keeping a second copy meant two implementations of one contract, and they had
+                    # already diverged: the helper's accumulator was fixed to a ``bytearray``
+                    # because immutable ``bytes +=`` is O(n^2) in the NUMBER of reads, and the read
+                    # is SHORT, so the far end picks that number. This is the least trustworthy
+                    # endpoint we read — a rig's own API — so it is the last place to keep the
+                    # slow copy. Overflow is a refusal for THIS rig only, never an exception that
+                    # takes the poll down for every other worker, so it is caught here rather than
+                    # left to the blanket handler below, which would log it differently.
+                    try:
+                        body = await bounded_read(
+                            response.content,
+                            max_bytes=_MAX_SUMMARY_BYTES,
+                            what=f"{name} summary",
+                        )
+                    except ResponseTooLarge:
                         self._warn(host, name, url, f"body over {_MAX_SUMMARY_BYTES} bytes")
                         return {"api_ok": False}
                     payload = json.loads(body)

--- a/dashboard/mining_dashboard/client/xmrig_proxy_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_proxy_client.py
@@ -4,6 +4,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from mining_dashboard.helper.http import bounded_request
+
 
 class XMRigProxyClient:
     def __init__(self, host="127.0.0.1", port=8080, access_token=None):
@@ -70,7 +72,10 @@ class XMRigProxyClient:
         }
         """
         url = f"{self.base_url}/1/summary"
-        response = self.session.get(url, timeout=5)
+        # Bounded (#1360). Highest trust class of that set: xmrig-proxy is our own container, but
+        # this body is built from what MINERS advertise to it — the same boundary as #1347, one hop
+        # back. ``session=`` keeps the retry adapter configured above.
+        response = bounded_request("GET", url, timeout=5, session=self.session)
         response.raise_for_status()
         return response.json()
 
@@ -105,7 +110,10 @@ class XMRigProxyClient:
         }
         """
         url = f"{self.base_url}/1/workers"
-        response = self.session.get(url, timeout=5)
+        # Bounded (#1360). Highest trust class of that set: xmrig-proxy is our own container, but
+        # this body is built from what MINERS advertise to it — the same boundary as #1347, one hop
+        # back. ``session=`` keeps the retry adapter configured above.
+        response = bounded_request("GET", url, timeout=5, session=self.session)
         response.raise_for_status()
         return response.json()
 
@@ -140,7 +148,10 @@ class XMRigProxyClient:
         }
         """
         url = f"{self.base_url}/1/config"
-        response = self.session.get(url, timeout=5)
+        # Bounded (#1360). Highest trust class of that set: xmrig-proxy is our own container, but
+        # this body is built from what MINERS advertise to it — the same boundary as #1347, one hop
+        # back. ``session=`` keeps the retry adapter configured above.
+        response = bounded_request("GET", url, timeout=5, session=self.session)
         response.raise_for_status()
         return response.json()
 
@@ -165,7 +176,7 @@ class XMRigProxyClient:
         }
         """
         url = f"{self.base_url}/1/config"
-        response = self.session.put(url, json=config_data, timeout=5)
+        response = bounded_request("PUT", url, json=config_data, timeout=5, session=self.session)
         response.raise_for_status()
         # Handle 204 No Content or empty responses which cause JSON decode errors
         if response.status_code == 204 or not response.content:

--- a/dashboard/mining_dashboard/collector/containers.py
+++ b/dashboard/mining_dashboard/collector/containers.py
@@ -1,8 +1,10 @@
+import json
 import logging
 
 import aiohttp
 
 from mining_dashboard.config.config import DOCKER_PROXY_URL, DOCKER_TIMEOUT
+from mining_dashboard.helper.http import bounded_read
 
 logger = logging.getLogger("ContainerCollector")
 
@@ -49,7 +51,12 @@ async def get_container_health():
                     ) as response:
                         if response.status != 200:
                             continue
-                        payload = await response.json()
+                        # Bounded (#1360). Lowest trust class of that set — the payload shape is
+                        # dictated by our own compose file — but a proxy that misbehaves should
+                        # skip one container, not buffer an unbounded body into the data loop.
+                        payload = json.loads(
+                            await bounded_read(response.content, what=f"{name} inspect")
+                        )
                 except Exception as e:
                     logger.debug("Container inspect failed for %s: %s", name, e)
                     continue

--- a/dashboard/mining_dashboard/collector/logs.py
+++ b/dashboard/mining_dashboard/collector/logs.py
@@ -16,8 +16,20 @@ from mining_dashboard.config.config import (
     MONERO_NODE_HOST,
     NETWORK_STATS_PATH,
 )
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES, bounded_read
 
 logger = logging.getLogger("LogCollector")
+
+# The log read is the one bounded site (#1360) where a legitimately large body exists, so the cap
+# is derived from what the operator asked for rather than fixed. ``tail`` bounds LINES, never bytes,
+# so a container emitting very long lines is unbounded — and container logs carry miner-supplied
+# strings (worker names, pool messages), which is why "our own daemon serves it" is not the question.
+#
+# 16 KiB is where Docker's json-file driver splits a log line, so ``tail * 16 KiB`` is the ceiling a
+# well-behaved daemon can legitimately produce for the requested number of lines. The 1 MiB floor
+# keeps the default (100 lines) generous. A cap set too tight is worse than the exhaustion it
+# prevents, because it presents to the operator as the far end being broken rather than as a refusal.
+_LOG_BYTES_PER_LINE = 16 * 1024
 
 # Stateless client reused across cycles; reads monerod's get_info RPC (Issue #29).
 _monero_client = MoneroClient()
@@ -44,7 +56,11 @@ async def fetch_docker_logs(container_name, tail=None):
         async with aiohttp.ClientSession() as session:
             async with session.get(url, params=params, timeout=DOCKER_TIMEOUT) as response:
                 if response.status == 200:
-                    raw_data = await response.read()
+                    raw_data = await bounded_read(
+                        response.content,
+                        max_bytes=max(MAX_RESPONSE_BYTES, int(tail) * _LOG_BYTES_PER_LINE),
+                        what=f"{container_name} logs",
+                    )
                     return _parse_docker_stream(raw_data)
                 else:
                     logger.error(

--- a/dashboard/mining_dashboard/helper/http.py
+++ b/dashboard/mining_dashboard/helper/http.py
@@ -7,6 +7,14 @@ endpoint could hand any of them a multi-GB body and the process would buffer it 
 parsing. ``bounded_get`` streams the body and cuts it at a cap far above any legitimate payload;
 over-cap raises a ``requests.RequestException`` subclass, so every caller's existing failure
 contract (return ``None`` / keep the last good result) applies unchanged.
+
+#660 exempted the clients it judged *internal* — the on-box or same-LAN endpoints. That exemption
+did not survive contact: the rig poll was in the untreated set and needed bounding anyway (#1347),
+because "our own container" describes who serves the body, not who wrote it. xmrig-proxy's summary
+is built from what miners advertise; container logs carry miner-supplied worker names and pool
+messages; and a *remote* monerod is someone else's server on someone else's network. #1360 brings
+the rest of that set behind the same two helpers — ``bounded_get`` for the ``requests`` sites,
+``bounded_read`` for the ``aiohttp`` ones.
 """
 
 import json
@@ -45,14 +53,20 @@ class BoundedResponse:
             raise requests.HTTPError(f"HTTP {self.status_code}")
 
 
-def bounded_get(url, max_bytes=MAX_RESPONSE_BYTES, timeout=20, **kwargs):
-    """``requests.get`` with a hard response-size cap.
+def bounded_request(method, url, max_bytes=MAX_RESPONSE_BYTES, timeout=20, session=None, **kwargs):
+    """``requests`` with a hard response-size cap, for any method.
+
+    ``session`` takes a caller's own ``requests.Session`` so bounding a read never costs it the
+    connection pooling or the retry adapter it configured (#1360 — the xmrig-proxy client polls
+    twice a cycle and mounts a deliberate ``Retry``). Defaults to the module, i.e. plain
+    ``requests.<method>``.
 
     Streams the body and raises ``ResponseTooLarge`` once it exceeds ``max_bytes``, instead of
-    buffering an unbounded payload. Passes ``proxies`` / ``params`` / ``headers`` through
-    unchanged; raises exactly what ``requests.get`` raises otherwise.
+    buffering an unbounded payload. Passes ``proxies`` / ``params`` / ``headers`` / ``json``
+    through unchanged; raises exactly what ``requests`` raises otherwise.
     """
-    with requests.get(url, stream=True, timeout=timeout, **kwargs) as resp:
+    caller = getattr(session if session is not None else requests, method.lower())
+    with caller(url, stream=True, timeout=timeout, **kwargs) as resp:
         chunks, size = [], 0
         for chunk in resp.iter_content(chunk_size=65536):
             size += len(chunk)
@@ -60,3 +74,38 @@ def bounded_get(url, max_bytes=MAX_RESPONSE_BYTES, timeout=20, **kwargs):
                 raise ResponseTooLarge(f"response body exceeded {max_bytes} bytes: {url}")
             chunks.append(chunk)
         return BoundedResponse(resp.status_code, b"".join(chunks), resp.encoding)
+
+
+def bounded_get(url, max_bytes=MAX_RESPONSE_BYTES, timeout=20, **kwargs):
+    """``requests.get`` with a hard response-size cap — the #660 entry point, unchanged."""
+    return bounded_request("GET", url, max_bytes=max_bytes, timeout=timeout, **kwargs)
+
+
+async def bounded_read(content, max_bytes=MAX_RESPONSE_BYTES, what="response"):
+    """The async twin of :func:`bounded_get`: read an ``aiohttp`` body whole, or refuse it (#1360).
+
+    Takes the response's ``content`` stream rather than making the request, because the async call
+    sites differ in everything except this one step — session, params, timeout, and whether they
+    want bytes, text or JSON. Bounding the read is the only part they share.
+
+    **This is deliberately not a single ``read(max_bytes)``.** ``aiohttp``'s ``StreamReader.read(n)``
+    is a SHORT read: it returns what is currently buffered, never necessarily ``n`` bytes. A body
+    split across TCP reads — any link with latency — would come back truncated, and the far end
+    would then read as broken for a reason with nothing to do with its size. Measured against a real
+    aiohttp server while fixing #1347: one ``read(1000)`` of a 994-byte body returned 100 bytes.
+
+    So it accumulates until EOF or one byte PAST the cap, which is what makes the boundary exact —
+    a body of exactly ``max_bytes`` is returned, ``max_bytes + 1`` refuses. ``Content-Length`` is
+    deliberately never consulted: the far end picks it, so trusting it would let a hostile endpoint
+    declare 10 bytes and send 10 GB.
+
+    Raises :class:`ResponseTooLarge`, the same type the sync twin raises, so a caller's existing
+    ``except Exception`` fail-silent path applies unchanged.
+    """
+    body = b""
+    while len(body) <= max_bytes:
+        chunk = await content.read(max_bytes + 1 - len(body))
+        if not chunk:
+            return body
+        body += chunk
+    raise ResponseTooLarge(f"{what} body exceeded {max_bytes} bytes")

--- a/dashboard/mining_dashboard/helper/http.py
+++ b/dashboard/mining_dashboard/helper/http.py
@@ -102,10 +102,17 @@ async def bounded_read(content, max_bytes=MAX_RESPONSE_BYTES, what="response"):
     Raises :class:`ResponseTooLarge`, the same type the sync twin raises, so a caller's existing
     ``except Exception`` fail-silent path applies unchanged.
     """
-    body = b""
+    # A ``bytearray``, not ``bytes``, and that is not a style choice. ``bytes`` is immutable, so
+    # ``body += chunk`` reallocates and re-copies everything accumulated so far — O(n^2) in the
+    # number of reads. Because the read above is SHORT, the far end chooses that number: a sender
+    # writing one byte per segment turns a 1 MiB body into ~1M copies of a growing buffer. Measured
+    # through this function: 64 KiB took 0.13s, 128 KiB 0.82s, 256 KiB 3.68s. This is asyncio, so
+    # that time is the WHOLE event loop — every other collector and the state loop stall behind one
+    # hostile response. A cap that converts memory exhaustion into CPU exhaustion is not a fix.
+    body = bytearray()
     while len(body) <= max_bytes:
         chunk = await content.read(max_bytes + 1 - len(body))
         if not chunk:
-            return body
-        body += chunk
+            return bytes(body)
+        body.extend(chunk)
     raise ResponseTooLarge(f"{what} body exceeded {max_bytes} bytes")

--- a/dashboard/tests/client/test_docker_control.py
+++ b/dashboard/tests/client/test_docker_control.py
@@ -1,7 +1,9 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import mining_dashboard.client.docker.docker_control as dc_mod
 from mining_dashboard.client.docker.docker_control import DockerControl
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
 
 
 class _AsyncCM:
@@ -15,12 +17,32 @@ class _AsyncCM:
         return False
 
 
+class _Stream:
+    """An aiohttp ``StreamReader``. ``read(n)`` is a SHORT read — it hands back what is buffered,
+    never necessarily ``n`` bytes — and modelling that is the whole point: a bounded read written as
+    a single ``read(cap)`` passes a fake that returns everything at once, then truncates any real
+    body that arrives split across TCP reads. Same idiom as tests/client/test_summary_size_cap.py."""
+
+    def __init__(self, raw, chunk=1024):
+        self._raw, self._pos, self._chunk = raw, 0, chunk
+        self.bytes_read = 0
+
+    async def read(self, n=-1):
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, self._chunk))
+        chunk, self._pos = self._raw[self._pos : end], end
+        self.bytes_read += len(chunk)
+        return chunk
+
+
 class _FakeResp:
-    def __init__(self, status, text=""):
+    def __init__(self, status, text="", chunk=1024):
         self.status = status
         self._text = text
+        self.content = _Stream(text.encode(), chunk)
 
     async def text(self):
+        """Kept, though ``_post`` no longer calls it (#1360): it is what the unbounded read used,
+        so the oversized test below goes red if the bounding is removed."""
         return self._text
 
 
@@ -61,11 +83,28 @@ class TestStopStart:
             assert await c.start("xmrig-proxy") is True
         assert session.post.call_args.args[0] == "http://h:2375/containers/xmrig-proxy/start"
 
-    async def test_error_status_returns_false(self):
+    async def test_error_status_returns_false(self, caplog):
         session = _session_returning(_FakeResp(403, "forbidden"))
         c = DockerControl(proxy_url="tcp://h:2375")
-        with patch.object(dc_mod.aiohttp, "ClientSession", return_value=_AsyncCM(session)):
-            assert await c.stop("xmrig-proxy") is False
+        with caplog.at_level(logging.ERROR):
+            with patch.object(dc_mod.aiohttp, "ClientSession", return_value=_AsyncCM(session)):
+                assert await c.stop("xmrig-proxy") is False
+        # The bounded read still delivers a real error body — the point of #1360 is a ceiling on
+        # it, not the loss of the one thing that says WHY the container refused to stop.
+        assert "forbidden" in caplog.text
+
+    async def test_an_oversized_error_body_is_refused(self, caplog):
+        """The 200-char slice in the log line only ever trimmed what was PRINTED — the whole body
+        was buffered first, so an error response was the one unbounded read here (#1360). Both
+        versions return False, so the distinguishing evidence is the log: unbounded, the body
+        reaches it; bounded, a size refusal does."""
+        session = _session_returning(_FakeResp(403, "z" * (MAX_RESPONSE_BYTES + 1), chunk=65536))
+        c = DockerControl(proxy_url="tcp://h:2375")
+        with caplog.at_level(logging.ERROR):
+            with patch.object(dc_mod.aiohttp, "ClientSession", return_value=_AsyncCM(session)):
+                assert await c.stop("xmrig-proxy") is False
+        assert "exceeded" in caplog.text
+        assert "zzz" not in caplog.text
 
     async def test_connection_error_returns_false(self):
         c = DockerControl(proxy_url="tcp://h:2375")

--- a/dashboard/tests/client/test_monero_client.py
+++ b/dashboard/tests/client/test_monero_client.py
@@ -1,18 +1,41 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import requests
 
 import mining_dashboard.client.monero.monero_client as monero_mod
 from mining_dashboard.client.monero.monero_client import MoneroClient
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
 
 
-def _resp(status_code=200, json_data=None, raise_json=False):
-    resp = MagicMock(status_code=status_code)
+def _resp(status_code=200, json_data=None, raise_json=False, body=None):
+    """A streaming ``requests`` response — what ``bounded_get`` consumes since #1360.
+
+    The payload is served as real BYTES over ``iter_content``, because the client now receives a
+    ``BoundedResponse`` parsed from the stream rather than this mock. ``json()`` is still set on the
+    mock so the same fake also drives the unbounded ``requests.get`` this replaced; that is what
+    makes the oversized test below fail if the bounding is taken out.
+    """
+    raw = body if body is not None else json.dumps(json_data or {}).encode()
     if raise_json:
-        resp.json.side_effect = ValueError("no json")
-    else:
+        raw = b"not json"
+    resp = MagicMock(status_code=status_code, encoding="utf-8")
+    resp.iter_content.return_value = iter([raw[i : i + 65536] for i in range(0, len(raw), 65536)])
+    resp.json.side_effect = ValueError("no json") if raise_json else None
+    if not raise_json:
         resp.json.return_value = json_data or {}
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
     return resp
+
+
+def _oversized(json_data):
+    """A valid payload one byte past the cap: the refusal is on byte count, not on content."""
+    empty = json.dumps({**json_data, "pad": ""}).encode()
+    pad = "x" * (MAX_RESPONSE_BYTES + 1 - len(empty))
+    raw = json.dumps({**json_data, "pad": pad}).encode()
+    assert len(raw) == MAX_RESPONSE_BYTES + 1, len(raw)
+    return _resp(json_data=json_data, body=raw)
 
 
 class TestGetInfo:
@@ -50,6 +73,17 @@ class TestGetInfo:
     def test_non_json_returns_none(self):
         client = MoneroClient(username="u", password="p")
         with patch.object(monero_mod.requests, "get", return_value=_resp(raise_json=True)):
+            assert client.get_info() is None
+
+    def test_an_oversized_body_is_refused_and_never_parsed(self):
+        """A *remote* monerod (#183) is someone else's server on someone else's network, so the
+        #660 "internal" exemption never fitted it. The fake's ``json()`` returns a perfectly good
+        payload — unbounded, ``get_info`` hands that straight back; bounded, the body is refused on
+        its size before anything parses it, and the caller's existing None contract applies."""
+        client = MoneroClient(username="u", password="p")
+        with patch.object(
+            monero_mod.requests, "get", return_value=_oversized({"status": "OK", "height": 5})
+        ):
             assert client.get_info() is None
 
     def test_busy_status_returns_none(self):

--- a/dashboard/tests/client/test_monero_wallet_client.py
+++ b/dashboard/tests/client/test_monero_wallet_client.py
@@ -1,18 +1,43 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import requests
 
 import mining_dashboard.client.monero.monero_wallet_client as wallet_mod
 from mining_dashboard.client.monero.monero_wallet_client import MoneroWalletClient
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
 
 
-def _resp(status_code=200, json_data=None, raise_json=False):
-    resp = MagicMock(status_code=status_code)
-    if raise_json:
-        resp.json.side_effect = ValueError("no json")
-    else:
+def _resp(status_code=200, json_data=None, raise_json=False, body=None):
+    """A streaming ``requests`` response — what ``bounded_request`` consumes since #1360.
+
+    The payload is served as real BYTES over ``iter_content``: the client now receives a
+    ``BoundedResponse`` parsed from the stream, not this mock. ``json()`` is set on the mock too, so
+    the same fake drives the unbounded ``requests.post`` this replaced — which is what makes the
+    oversized test below fail if the bounding is taken out.
+    """
+    raw = (
+        b"not json"
+        if raise_json
+        else (body if body is not None else json.dumps(json_data or {}).encode())
+    )
+    resp = MagicMock(status_code=status_code, encoding="utf-8")
+    resp.iter_content.return_value = iter([raw[i : i + 65536] for i in range(0, len(raw), 65536)])
+    resp.json.side_effect = ValueError("no json") if raise_json else None
+    if not raise_json:
         resp.json.return_value = json_data or {}
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
     return resp
+
+
+def _oversized(json_data):
+    """A valid ``result`` payload one byte past the cap: refused on byte count, not on content."""
+    empty = json.dumps({**json_data, "pad": ""}).encode()
+    pad = "x" * (MAX_RESPONSE_BYTES + 1 - len(empty))
+    raw = json.dumps({**json_data, "pad": pad}).encode()
+    assert len(raw) == MAX_RESPONSE_BYTES + 1, len(raw)
+    return _resp(json_data=json_data, body=raw)
 
 
 def _transfers(rows):
@@ -107,6 +132,15 @@ class TestGetConfirmedPayouts:
 
     def test_non_json_returns_empty(self):
         with patch.object(wallet_mod.requests, "post", return_value=_resp(raise_json=True)):
+            assert self._client().get_confirmed_payouts() == []
+
+    def test_an_oversized_body_is_refused_and_never_parsed(self):
+        """``get_transfers`` is the one call here whose size the wallet, not us, decides: a wallet
+        with a long history answers with every incoming transfer it has. Unbounded, the fake's
+        ``json()`` payload comes straight back as two payouts; bounded, the read is refused on its
+        size and the caller's existing empty-list contract applies."""
+        rows = [{"txid": "aa", "amount": 1, "height": 1, "timestamp": 1}]
+        with patch.object(wallet_mod.requests, "post", return_value=_oversized(_transfers(rows))):
             assert self._client().get_confirmed_payouts() == []
 
     def test_rpc_error_object_returns_empty(self):

--- a/dashboard/tests/client/test_xmrig_proxy_client.py
+++ b/dashboard/tests/client/test_xmrig_proxy_client.py
@@ -1,8 +1,11 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from mining_dashboard.client.xmrig_proxy_client import XMRigProxyClient
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES, ResponseTooLarge
 
 
 @pytest.fixture
@@ -12,13 +15,36 @@ def client():
     return c
 
 
-def _resp(json_data=None, status_code=200, content=b"x"):
-    r = MagicMock()
+def _resp(json_data=None, status_code=200, body=None, chunk=None):
+    """A streaming ``requests`` response, i.e. what ``bounded_request`` actually consumes (#1360).
+
+    ``json_data`` is served as real BYTES over ``iter_content`` — the client now gets a
+    ``BoundedResponse`` built from the stream, so a mocked ``.json()`` would never be consulted.
+    It is ALSO set on the mock, so the same fake drives the unbounded ``self.session.get(...)``
+    this replaced: that is what lets the oversized tests below go red if the bounding is removed.
+    """
+    raw = body if body is not None else json.dumps(json_data or {}).encode()
+    size = chunk or max(len(raw), 1)
+    r = MagicMock(status_code=status_code, encoding="utf-8")
+    r.iter_content.return_value = iter([raw[i : i + size] for i in range(0, len(raw), size)])
     r.json.return_value = json_data or {}
-    r.status_code = status_code
-    r.content = content
+    r.content = raw
     r.raise_for_status.return_value = None
+    r.__enter__.return_value = r
+    r.__exit__.return_value = False
     return r
+
+
+def _oversized(json_data):
+    """A body of exactly ``cap + 1`` bytes that is otherwise a perfectly good payload.
+
+    Exactly one byte past is deliberate: it pins the boundary rather than clearing it by a mile,
+    so a cap applied with the wrong comparison shows up here."""
+    empty = json.dumps({**json_data, "pad": ""}).encode()
+    pad = "x" * (MAX_RESPONSE_BYTES + 1 - len(empty))
+    raw = json.dumps({**json_data, "pad": pad}).encode()
+    assert len(raw) == MAX_RESPONSE_BYTES + 1, len(raw)
+    return _resp(json_data=json_data, body=raw, chunk=65536)
 
 
 def test_auth_header_set():
@@ -49,16 +75,44 @@ def test_update_config_returns_json(client):
 
 
 def test_update_config_204_returns_empty(client):
-    client.session.put.return_value = _resp(status_code=204, content=b"")
+    client.session.put.return_value = _resp(status_code=204, body=b"")
     assert client.update_config({"x": 1}) == {}
 
 
 def test_get_summary_raises_on_http_error(client):
-    resp = _resp()
-    resp.raise_for_status.side_effect = RuntimeError("500")
-    client.session.get.return_value = resp
-    with pytest.raises(RuntimeError):
+    # The cap is applied to the BODY; the status contract is unchanged, and a 5xx still surfaces as
+    # a RequestException so the caller's existing handling applies.
+    client.session.get.return_value = _resp(status_code=500)
+    with pytest.raises(requests.RequestException):
         client.get_summary()
+
+
+def test_reads_go_through_the_client_s_own_session(client):
+    """The retry adapter is mounted on ``self.session`` (see the test below), so bounding the read
+    must not quietly fall back to module-level ``requests`` — that would drop the adapter and the
+    connection pool on the two calls made every state-loop cycle."""
+    client.session.get.return_value = _resp({"version": "6.x"})
+    client.get_summary()
+    assert client.session.get.called
+    # Streamed, so the body is never buffered whole by requests before we can refuse it.
+    assert client.session.get.call_args.kwargs["stream"] is True
+
+
+@pytest.mark.parametrize("call", ["get_summary", "get_workers", "get_config"])
+def test_an_oversized_read_is_refused(client, call):
+    """xmrig-proxy is our own container, but ``/1/summary`` and ``/1/workers`` are assembled from
+    what MINERS advertise to it — the #1347 boundary, one hop back. The payload here is valid JSON
+    the unbounded read would have returned happily; the refusal is on the byte count alone."""
+    client.session.get.return_value = _oversized({"version": "6.x"})
+    with pytest.raises(ResponseTooLarge):
+        getattr(client, call)()
+
+
+def test_an_oversized_config_write_response_is_refused(client):
+    # The PUT response is the same surface: xmrig-proxy echoes the accepted config back.
+    client.session.put.return_value = _oversized({"ok": True})
+    with pytest.raises(ResponseTooLarge):
+        client.update_config({"donate-level": 1})
 
 
 def test_connect_failures_are_never_retried():

--- a/dashboard/tests/collector/test_containers.py
+++ b/dashboard/tests/collector/test_containers.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import mining_dashboard.collector.containers as containers
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
 
 
 class _AsyncCM:
@@ -14,12 +16,33 @@ class _AsyncCM:
         return False
 
 
+class _Stream:
+    """An aiohttp ``StreamReader``. ``read(n)`` is a SHORT read — it hands back what is buffered,
+    never necessarily ``n`` bytes — and modelling that is the whole point: a bounded read written as
+    a single ``read(cap)`` passes a fake that returns everything at once, then truncates any real
+    body that arrives split across TCP reads. Same idiom as tests/client/test_summary_size_cap.py."""
+
+    def __init__(self, raw, chunk=1024):
+        self._raw, self._pos, self._chunk = raw, 0, chunk
+        self.bytes_read = 0
+
+    async def read(self, n=-1):
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, self._chunk))
+        chunk, self._pos = self._raw[self._pos : end], end
+        self.bytes_read += len(chunk)
+        return chunk
+
+
 class _FakeResp:
-    def __init__(self, status, payload=None):
+    def __init__(self, status, payload=None, chunk=1024):
         self.status = status
         self._payload = payload or {}
+        self.content = _Stream(json.dumps(self._payload).encode(), chunk)
 
     async def json(self):
+        """Kept, though the collector no longer calls it (#1360): it is what the unbounded
+        ``await response.json()`` used, so the oversized test below goes red if bounding is
+        removed rather than quietly passing on a fake that models only the new shape."""
         return self._payload
 
 
@@ -93,3 +116,18 @@ class TestGetContainerHealth:
         # Proxy unreachable entirely → {} and no raise (the data loop must keep running).
         with patch.object(containers.aiohttp, "ClientSession", side_effect=OSError("refused")):
             assert await containers.get_container_health() == {}
+
+    async def test_an_oversized_inspect_skips_only_that_container(self):
+        """Lowest trust class of the #1360 set — the payload shape comes from our own compose file
+        — but a proxy answering with an unbounded body must cost one container, not buffer the
+        whole thing into the state loop. Unbounded, ``json()`` hands back a valid payload and `tor`
+        appears; bounded, the read is refused and the per-container ``continue`` skips it."""
+        pad = "x" * MAX_RESPONSE_BYTES
+        responses = [_FakeResp(200, {**_inspect(health="healthy"), "pad": pad}, chunk=65536)] + [
+            _FakeResp(404)
+        ] * (len(containers.MONITORED_CONTAINERS) - 1)
+        with patch.object(
+            containers.aiohttp, "ClientSession", return_value=_AsyncCM(_session(responses))
+        ):
+            out = await containers.get_container_health()
+        assert out == {}

--- a/dashboard/tests/collector/test_logs.py
+++ b/dashboard/tests/collector/test_logs.py
@@ -2,6 +2,20 @@ import struct
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import mining_dashboard.collector.logs as logs
+from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
+
+
+def _cap_for(tail):
+    """The cap the collector derives for a given ``tail`` — read from the module, never restated,
+    so this cannot drift into asserting a number the code no longer uses."""
+    return max(MAX_RESPONSE_BYTES, tail * logs._LOG_BYTES_PER_LINE)
+
+
+async def _fetch(resp, tail=None):
+    session = MagicMock()
+    session.get.return_value = _AsyncCM(resp)
+    with patch.object(logs.aiohttp, "ClientSession", return_value=_AsyncCM(session)):
+        return await logs.fetch_docker_logs("monerod", tail=tail)
 
 
 def _frame(text, stream=1):
@@ -21,12 +35,33 @@ class _AsyncCM:
         return False
 
 
+class _Stream:
+    """An aiohttp ``StreamReader``. ``read(n)`` is a SHORT read — it hands back what is buffered,
+    never necessarily ``n`` bytes — and modelling that is the whole point: a bounded read written as
+    a single ``read(cap)`` passes a fake that returns everything at once, then truncates any real
+    body that arrives split across TCP reads. Same idiom as tests/client/test_summary_size_cap.py."""
+
+    def __init__(self, raw, chunk=1024):
+        self._raw, self._pos, self._chunk = raw, 0, chunk
+        self.bytes_read = 0
+
+    async def read(self, n=-1):
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, self._chunk))
+        chunk, self._pos = self._raw[self._pos : end], end
+        self.bytes_read += len(chunk)
+        return chunk
+
+
 class _FakeResp:
-    def __init__(self, status, data=b""):
+    def __init__(self, status, data=b"", chunk=1024):
         self.status = status
         self._data = data
+        self.content = _Stream(data, chunk)
 
     async def read(self):
+        """Kept, though the collector no longer calls it (#1360): it is what the unbounded read
+        used, so the oversized tests below go red if the bounding is removed rather than passing
+        against a fake that only models the new shape."""
         return self._data
 
 
@@ -62,6 +97,32 @@ class TestFetchDockerLogs:
         with patch.object(logs.aiohttp, "ClientSession", side_effect=OSError("refused")):
             out = await logs.fetch_docker_logs("monerod")
         assert "Connection to Docker Proxy failed" in out[0]
+
+    async def test_an_oversized_log_body_is_refused(self):
+        """Container logs carry miner-supplied strings — worker names, pool messages — so "our own
+        daemon serves it" is not the question (#1360). Unbounded, the whole frame is read and
+        parsed; bounded, the read is refused and the existing failure string is returned."""
+        cap = _cap_for(logs.LOG_TAIL_LINES)
+        out = await _fetch(_FakeResp(200, _frame("x" * (cap + 1)), chunk=65536))
+        assert out == ["Error: Connection to Docker Proxy failed."]
+
+    async def test_the_cap_scales_with_the_operator_s_tail_setting(self):
+        """``tail`` bounds LINES, never bytes, and it is operator-configurable. A FLAT cap would
+        refuse a legitimate large-tail config — the worse of the two failure modes, because it
+        presents as the daemon being broken rather than as a refusal."""
+        body = "y" * (2 * 1024 * 1024)
+        assert len(body) > _cap_for(1)  # refused at tail=1 ...
+        assert len(body) < _cap_for(1000)  # ... and accepted at tail=1000
+        assert await _fetch(_FakeResp(200, _frame(body), chunk=65536), tail=1000) == [body]
+        assert await _fetch(_FakeResp(200, _frame(body), chunk=65536), tail=1) == [
+            "Error: Connection to Docker Proxy failed."
+        ]
+
+    async def test_a_body_split_across_many_reads_is_still_read_whole(self):
+        """The regression a single ``read(cap)`` would cause: aiohttp's read is SHORT, so a body
+        arriving in pieces would come back truncated and a healthy daemon would look broken."""
+        out = await _fetch(_FakeResp(200, _frame("hello there"), chunk=3))
+        assert out == ["hello there"]
 
 
 class TestRemoteSyncStatus:

--- a/dashboard/tests/helper/test_http.py
+++ b/dashboard/tests/helper/test_http.py
@@ -7,7 +7,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from mining_dashboard.helper.http import BoundedResponse, ResponseTooLarge, bounded_get
+from mining_dashboard.helper.http import (
+    MAX_RESPONSE_BYTES,
+    BoundedResponse,
+    ResponseTooLarge,
+    bounded_get,
+    bounded_read,
+    bounded_request,
+)
 
 
 def _streaming_resp(chunks, status_code=200, encoding="utf-8"):
@@ -93,6 +100,112 @@ class TestBoundedGet:
             BoundedResponse(502, b"", "utf-8").raise_for_status()
 
 
+class _Stream:
+    """An aiohttp ``StreamReader``: ``read(n)`` is a SHORT read, returning what is buffered rather
+    than ``n`` bytes. Measured against a real aiohttp server while fixing #1347 — one ``read(1000)``
+    of a 994-byte body came back with 100 bytes."""
+
+    def __init__(self, raw, chunk=1024):
+        self._raw, self._pos, self._chunk = raw, 0, chunk
+        self.bytes_read = 0
+
+    async def read(self, n=-1):
+        end = len(self._raw) if n < 0 else min(len(self._raw), self._pos + min(n, self._chunk))
+        chunk, self._pos = self._raw[self._pos : end], end
+        self.bytes_read += len(chunk)
+        return chunk
+
+
+class TestBoundedRead:
+    """The async twin (#1360). The aiohttp call sites differ in everything — session, params,
+    timeout, whether they want bytes/text/JSON — except this one step, so the helper takes the
+    stream rather than making the request."""
+
+    async def test_a_body_up_to_the_cap_is_returned_whole(self):
+        # The accept side matters most: a cap that refuses a legitimate body presents to the
+        # operator as the far end being broken, which is worse than the exhaustion it prevents.
+        assert await bounded_read(_Stream(b"x" * 2048), max_bytes=2048) == b"x" * 2048
+
+    async def test_one_byte_past_the_cap_is_refused(self):
+        with pytest.raises(ResponseTooLarge):
+            await bounded_read(_Stream(b"x" * 2049), max_bytes=2048)
+
+    async def test_it_raises_the_same_type_as_the_sync_twin(self):
+        # Callers here fail silently on requests.RequestException; sharing the type means their
+        # existing handling covers a refusal with no change.
+        with pytest.raises(requests.RequestException):
+            await bounded_read(_Stream(b"x" * 4), max_bytes=2)
+
+    async def test_a_body_split_across_many_reads_is_still_read_whole(self):
+        # The regression a single read(max_bytes) would cause, and the reason the fake above models
+        # a short read at all: any link with latency delivers a body in pieces.
+        stream = _Stream(b"y" * 8192, chunk=97)  # a deliberately unaligned chunk
+        assert await bounded_read(stream, max_bytes=MAX_RESPONSE_BYTES) == b"y" * 8192
+
+    async def test_an_oversized_body_delivered_in_pieces_is_still_refused(self):
+        with pytest.raises(ResponseTooLarge):
+            await bounded_read(_Stream(b"y" * 8192, chunk=97), max_bytes=4096)
+
+    async def test_it_stops_reading_at_the_cap(self):
+        # Refusing after buffering the whole body would prevent nothing at all.
+        stream = _Stream(b"z" * (10 * 1024 * 1024), chunk=65536)
+        with pytest.raises(ResponseTooLarge):
+            await bounded_read(stream, max_bytes=4096)
+        assert stream.bytes_read <= 4097
+
+    async def test_an_empty_body_is_not_an_error(self):
+        assert await bounded_read(_Stream(b"")) == b""
+
+    async def test_the_refusal_names_what_was_being_read(self):
+        # These log at the caller; a message saying only "too large" would not say which container
+        # or which endpoint, on a box polling several every cycle.
+        with pytest.raises(ResponseTooLarge, match="monerod logs"):
+            await bounded_read(_Stream(b"x" * 4), max_bytes=2, what="monerod logs")
+
+
+class TestBoundedRequest:
+    def test_it_uses_a_caller_s_own_session(self):
+        """The xmrig-proxy client mounts a deliberate ``Retry`` adapter and polls twice a cycle;
+        bounding its reads must not silently drop that by falling back to module-level requests."""
+        session = MagicMock()
+        session.get.return_value = _streaming_resp([b"{}"])
+        resp = bounded_request("GET", "http://x/1/summary", session=session)
+        assert resp.json() == {}
+        assert session.get.called
+        assert session.get.call_args.kwargs["stream"] is True
+
+    def test_it_dispatches_on_the_method(self):
+        session = MagicMock()
+        session.put.return_value = _streaming_resp([b'{"ok": true}'])
+        assert bounded_request(
+            "PUT", "http://x/1/config", session=session, json={"a": 1}
+        ).json() == {"ok": True}
+        assert session.put.call_args.kwargs["json"] == {"a": 1}
+        assert not session.get.called
+
+    def test_no_session_falls_back_to_module_level_requests(self):
+        with patch(
+            "mining_dashboard.helper.http.requests.post", return_value=_streaming_resp([b"{}"])
+        ) as post:
+            bounded_request("POST", "http://x/json_rpc", json={"m": "x"})
+        assert post.call_args.kwargs["json"] == {"m": "x"}
+
+    def test_the_cap_applies_to_any_method(self):
+        session = MagicMock()
+        session.put.return_value = _streaming_resp([b"x" * 1024] * 3)
+        with pytest.raises(ResponseTooLarge):
+            bounded_request("PUT", "http://x/1/config", max_bytes=2048, session=session)
+
+    def test_bounded_get_still_delegates_with_its_660_signature(self):
+        with patch(
+            "mining_dashboard.helper.http.requests.get", return_value=_streaming_resp([b"{}"])
+        ) as g:
+            bounded_get("https://example.test/x", timeout=7, params={"a": "b"})
+        assert g.call_args.kwargs["timeout"] == 7
+        assert g.call_args.kwargs["params"] == {"a": "b"}
+        assert g.call_args.kwargs["stream"] is True
+
+
 class TestWiringDriftGuard:
     def test_external_clients_route_through_bounded_get(self):
         """Every external fetch module goes via bounded_get — any direct requests.<verb>( is drift."""
@@ -122,3 +235,39 @@ class TestWiringDriftGuard:
         hit = re.search(r"requests\.(get|head|request)\(", src)
         assert hit is None, f"telegram_commands.py: unbounded {hit.group() if hit else ''}"
         assert "bounded_get(" in src
+
+    def test_the_1360_internal_clients_route_through_the_bounded_helpers(self):
+        """#660 exempted the clients it judged *internal*; that exemption did not survive contact
+        (#1347), and #1360 brought the rest of the set behind the same helpers. This is a text
+        check and proves only the text — the behavioural half is one refusal test per site, in each
+        site's own test module."""
+        pkg = Path(__file__).resolve().parents[2] / "mining_dashboard"
+        sync_sites = {
+            pkg / "client" / "monero" / "monero_client.py": r"requests\.(get|post|put|request)\(",
+            pkg
+            / "client"
+            / "monero"
+            / "monero_wallet_client.py": r"requests\.(get|post|put|request)\(",
+            # This one calls through its own Session, so the drift to watch for is self.session.<verb>(
+            pkg / "client" / "xmrig_proxy_client.py": r"self\.session\.(get|post|put)\(",
+        }
+        for mod, pattern in sync_sites.items():
+            src = mod.read_text()
+            hit = re.search(pattern, src)
+            assert hit is None, (
+                f"{mod.name}: unbounded {hit.group() if hit else ''} slipped back in"
+            )
+            assert "bounded_get(" in src or "bounded_request(" in src, f"{mod.name}: not bounded"
+
+        async_sites = {
+            pkg / "collector" / "logs.py": r"await response\.(read|text|json)\(",
+            pkg / "collector" / "containers.py": r"await response\.(read|text|json)\(",
+            pkg / "client" / "docker" / "docker_control.py": r"await resp\.(read|text|json)\(",
+        }
+        for mod, pattern in async_sites.items():
+            src = mod.read_text()
+            hit = re.search(pattern, src)
+            assert hit is None, (
+                f"{mod.name}: unbounded {hit.group() if hit else ''} slipped back in"
+            )
+            assert "bounded_read(" in src, f"{mod.name}: no bounded_read call found"

--- a/dashboard/tests/helper/test_http.py
+++ b/dashboard/tests/helper/test_http.py
@@ -300,6 +300,10 @@ class TestWiringDriftGuard:
             pkg / "collector" / "logs.py": r"await response\.(read|text|json)\(",
             pkg / "collector" / "containers.py": r"await response\.(read|text|json)\(",
             pkg / "client" / "docker" / "docker_control.py": r"await resp\.(read|text|json)\(",
+            # #1347's own site. It is where this algorithm was worked out, and it kept a second
+            # copy until #1360 folded it back in -- the two had already diverged (only the helper
+            # got the bytearray fix). The pattern below is the hand-rolled loop coming back.
+            pkg / "client" / "xmrig_client.py": r"await response\.content\.read\(",
         }
         for mod, pattern in async_sites.items():
             src = mod.read_text()

--- a/dashboard/tests/helper/test_http.py
+++ b/dashboard/tests/helper/test_http.py
@@ -1,6 +1,7 @@
 """Tier 1 — bounded_get (#660): the shared response-size cap for external HTTP fetches."""
 
 import re
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -152,6 +153,42 @@ class TestBoundedRead:
         with pytest.raises(ResponseTooLarge):
             await bounded_read(stream, max_bytes=4096)
         assert stream.bytes_read <= 4097
+
+    async def test_a_trickled_body_does_not_cost_quadratic_time(self):
+        """A cap that turns memory exhaustion into CPU exhaustion is not a fix.
+
+        The read is SHORT, so the far end chooses how many reads a body takes: one byte per TCP
+        segment makes ~n of them. Accumulating into immutable ``bytes`` re-copies the whole buffer
+        each time, and this is asyncio — that time is the WHOLE event loop, not one coroutine.
+
+        This is a timing assertion, which is the honest way to catch a complexity regression and is
+        worth naming as such. The bound is sized off measurement rather than guessed: 512 KiB takes
+        ~0.31s accumulating linearly and ~15s quadratically (extrapolated from 3.68s at 256 KiB,
+        measured on this box under load). 4s therefore sits ~10x above the linear cost and ~4x below
+        the quadratic one, so it takes a very badly loaded box to false-red and no plausible one to
+        false-green."""
+
+        class Trickle:
+            """One byte per read — what aiohttp hands back when the sender writes one byte per
+            segment, and the worst case the short read allows."""
+
+            def __init__(self, n):
+                self.left = n
+
+            async def read(self, n=-1):
+                if self.left <= 0:
+                    return b""
+                self.left -= 1
+                return b"x"
+
+        size = 512 * 1024
+        started = time.perf_counter()
+        body = await bounded_read(Trickle(size), max_bytes=4 * 1024 * 1024)
+        elapsed = time.perf_counter() - started
+        assert len(body) == size  # the trickle is read whole, not just quickly
+        assert elapsed < 4.0, (
+            f"{elapsed:.1f}s for {size} one-byte reads — accumulation went quadratic"
+        )
 
     async def test_an_empty_body_is_not_an_error(self):
         assert await bounded_read(_Stream(b"")) == b""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,20 @@ map and the remaining lock-down steps.
   loopback, so the host-networked dashboard reaches them but no mining container can — a compromised
   `monerod`/`tari`/`p2pool`/`xmrig-proxy` cannot read other containers' env (inspect) or start/stop
   the stack through them.
+- **Every response the dashboard reads has a ceiling** (#660, #1347, #1360). The dashboard pulls
+  from a dozen places: GitHub's release feed, the price feed, the XvB API, its own `xmrig-proxy`,
+  `monerod` and the two view-only wallets, each rig's API, and container logs and inspect data
+  through the read-only Docker proxy. Every one of those reads stops at a size cap and gives up
+  rather than buffer whatever arrives, so a broken or hostile endpoint cannot exhaust the
+  dashboard's memory by answering a small request with a huge body. A refusal is treated like any
+  other unreachable endpoint — the panel keeps its last good value, and one oversized answer never
+  takes down the poll for everything else. The caps sit orders of magnitude above any real payload,
+  and the container-log cap scales with the number of lines you asked for (`LOG_TAIL_LINES`),
+  because a ceiling set too low is the worse failure: it presents as a broken daemon rather than as
+  a refusal. The reads on the box are bounded for the same reason the ones leaving it are — "our own
+  container" describes who *serves* a body, not who *wrote* it. `xmrig-proxy`'s summary is assembled
+  from what miners advertise to it, container logs carry miner-supplied worker names and pool
+  messages, and a remote `monerod` is someone else's server on someone else's network.
 - **Locked-down config.** `config.json` is created `chmod 600` (owner-only), and the internal RPC
   proxy token is generated once and preserved across re-runs.
 


### PR DESCRIPTION
Closes the rest of the set #660 exempted as "internal". #1347 / PR #1355 already did the rig poll; this does the other six sites, behind two shared helpers rather than six ad-hoc limits.

## What changed

`helper/http.py` gains the async twin the issue asked to decide first, plus a generalisation of the sync one:

- **`bounded_read(content, max_bytes, what)`** — takes the aiohttp response's stream, not the request, because the three async call sites differ in everything (session, params, timeout, whether they want bytes/text/JSON) except this one step. It accumulates until EOF or one byte past the cap. **Not a single `read(cap)`**: aiohttp's `StreamReader.read(n)` is a short read, so one read truncates any body split across TCP reads and the far end then looks broken for a reason unrelated to its size.
- **`bounded_request(method, url, ..., session=)`** — any verb, and it takes a caller's own `Session` so bounding a read never costs the xmrig-proxy client the `Retry` adapter it deliberately mounts and polls through twice a cycle. `bounded_get` keeps its #660 signature and delegates.

Six sites converted, top-down by the issue's trust ranking: `xmrig_proxy_client` (3 GETs + the PUT), `collector/logs`, `monero_client`, `monero_wallet_client`, `collector/containers`, `docker/docker_control`.

**The log cap is derived, not fixed:** `max(1 MiB, tail * 16 KiB)`. `LOG_TAIL_LINES` is operator-configurable and `tail` bounds lines, never bytes, so a flat cap would refuse a legitimate large-tail config — the worse of the two failure modes, since it presents as a broken daemon rather than as a refusal. 16 KiB is where Docker's json-file driver splits a line.

## Evidence — what was RUN

**Nine mutations, each reverting one behaviour and each seen to RED the module that names it**, with pytest's exit code read directly rather than through a pipe:

| mutation | result |
|---|---|
| xmrig-proxy GET `/1/summary` back to `self.session.get` | RED |
| xmrig-proxy PUT `/1/config` back to `self.session.put` | RED |
| `monerod get_info` back to `requests.get` | RED |
| wallet-rpc back to `requests.post` | RED |
| container inspect back to `await response.json()` | RED |
| docker logs back to `await response.read()` | RED |
| docker-control error body back to `await resp.text()` | RED |
| log cap flattened so it stops scaling with `tail` | RED |
| `bounded_read` accumulator back to immutable `bytes` | RED |

Full lane gate, each exit code checked separately: `pytest` 0 · `lint-py` 0 · `node --test` 0 (475 pass) · `lint-js` 0 · `lint-topology` 0 · `lint-md` 0 · `lint-docs-voice` 0 · `lint-operator-strings` 0 · `lint-file-budget` 0. Not run: `make lint-sh` / `make lint` / `make test` — shellcheck OOM-kills sessions on this box and nothing here is shell.

## The security-reviewer pass found a real defect, in this branch's own first version

`body += chunk` on immutable `bytes` reallocates and re-copies the whole buffer each time, so the cost is **O(n²) in the number of reads — and the read is deliberately short, so the far end chooses that number.** Under asyncio the cost is not one coroutine's: it stalls the entire event loop, so one hostile response blocks every other collector and the state loop.

Measured through the real function (a second route; the reviewer measured bare concatenation):

```
before   64 KiB 0.129s   128 KiB 0.824s   256 KiB 3.679s     ~4.5-6.4x per doubling
after    64 KiB 0.058s   128 KiB 0.104s   256 KiB 0.131s
```

Extrapolated, the first version spends ~60s of blocked event loop on a trickled body at the 1 MiB cap, and ~16 minutes at the 4 MiB cap `collector/logs.py` derives for its 250-line read. Fixed with a `bytearray`; the sync twin was never affected (it appends to a list and joins once). The guard is a timing assertion — the honest way to catch a complexity regression, labelled as such, with its bound sized off measurement rather than guessed.

**Two further reviewer notes, judged and deliberately NOT changed:** `docker_control` decodes with `errors="replace"` instead of `resp.text()`, losing aiohttp's header charset detection — worst case is mojibake in a 200-char server-side log line. `containers.py` does `json.loads(bytes)` instead of `response.json()`, dropping that method's Content-Type check — not a regression, since the old `ContentTypeError` and the new `JSONDecodeError` are caught by the same `except Exception: continue`.

**Verified clean by that pass, against library source rather than my comments:** connection release on early abort in both stacks (a cap that converted memory exhaustion into socket exhaustion was the main worry — urllib3 closes and discards rather than pooling; aiohttp force-closes because the payload is not at EOF); the boundary arithmetic; that no converted site's failure contract changed; that no credential reaches the interpolated URL in the refusal message (the xmrig-proxy token is a session header, the monero clients use `auth=`); and that `tail` is not reachable from any web or control route today.

## The over-engineering pass found the thing the issue actually asked for

The issue's ask was "an async twin of `bounded_get` ... **with the accumulate loop from `xmrig_client.get_stats` lifted into it**". The twin got written; the loop got *copied*, so `xmrig_client` kept its own.

That is not only tidiness. **The two copies had already diverged inside the session that created them.** The security finding above landed on the helper only — `xmrig_client` kept the quadratic accumulator, on the least trustworthy endpoint the dashboard reads: a rig's own API, which is the entire reason #1347 exists. Folding it back fixes that defect where it matters most and deletes the second implementation that let it hide. Behaviour unchanged: overflow is caught explicitly so the refusal stays a per-rig `{"api_ok": False}` rather than reaching the blanket handler, and one oversized rig still cannot take the poll down for every other worker. The drift guard gains the site; a tenth mutation restoring the old loop reds `TestWiringDriftGuard::test_the_1360_internal_clients_route_through_the_bounded_helpers`.

**Corrected after review — this row previously named `test_summary_size_cap.py`, and that was wrong.** The reviewer lane restored the old loop with its behaviour intact and that file came back 7 passed, rc 0. It is right that it did: `test_summary_size_cap.py` tests the *refusal contract*, and the old loop honoured it too — it was quadratic, not wrong — so nothing behavioural at that site can tell the two implementations apart. The original row therefore read as "a behavioural test holds the lift", which is stronger than what exists.

What actually holds it is a two-part guarantee, and it is worth stating plainly because the halves are unequal: the **timing test** proves `bounded_read` is not quadratic, and the **text drift guard** proves `xmrig_client` routes through it. So at the rig's own API — the least trustworthy endpoint here and the whole reason #1347 exists — the quadratic fix is held by a text assertion plus a timing test on a *different* function. The drift guard's regex is the load-bearing piece at that site. Its docstring already says it is a text check and proves only the text; this row now says so too.

Three further findings from that pass were judged and **not** taken — stated so they are not silently dropped. `bounded_request` could use `requests`' own `.request(method, url)` instead of `getattr` dispatch, but that moves every observable call from `session.get`/`put` to `session.request`, so the tests proving the retry adapter is used would have to assert something weaker. The `_Stream` fake is duplicated across four test files and `conftest.py` could host it, but this repo's precedent is local fakes and each site's fake also carries the specific legacy method (`json()`, `read()`, `text()`) that makes its oversized test fail against the unbounded version — a shared fake would have to carry all three. `int(tail)` converts nothing today, but it costs nothing and the cap is where a future caller threading a query-string value through would do real damage.

## A near-miss worth reading, because the gate that caught it was luck

One commit here shipped a comment describing the quadratic fix, and the test guarding it, **without the fix** — `git add -A` ran while a background mutation loop had the file in its mutated state, and captured that. It was pushed.

Two things about how it was caught. The commit summary said **44 insertions, 0 deletions** for a change that replaces lines; that contradiction was on screen and went unread. And the only reason it could not have shipped silently is that the same commit added a timing test, which would have failed in CI at 17.1s against its 4.0s bound. Had the fix been comment-only with no guard, a comment claiming a fix would have sat over unfixed code indefinitely.

Both commits are now verified by reading the committed blob (`git show HEAD:<path>`), not by trusting an exit code.

## Tests

Per site, a test that **fails against the unbounded version** — not one asserting the helper was called. The load-bearing detail: every fake keeps the method the unbounded code used (`json()`, `read()`, `text()`, a mocked `.json()`) alongside the new streaming shape, so it drives *either* version. A fake modelling only the new shape would pass against both and prove nothing. Every async fake does a SHORT read, per the issue's third acceptance bullet.

`docker_control` needed a different distinguishing signal, since both versions return `False`: the evidence is the log — a size refusal reaches it, the body does not.

Also adds `TestBoundedRead` / `TestBoundedRequest` at tier 1 (boundary exact at cap and cap+1, short-read reassembly, stops reading at the cap, session dispatch, method dispatch), and extends `TestWiringDriftGuard` to the six sites — text only, and labelled as such in its docstring, because the behaviour is proved per site.

## One defect this loop caught in my own work

Three of the new log tests had been appended into a *helper* class rather than the test class. **pytest never collected them.** The file's test count went up, the suite was green, and they were not running — nothing in the output distinguished that from a pass. The mutation loop found it indirectly, as two survivors I could not explain. Promoted to fleet COMMON: appending a test to a file is not the same as adding a test, and the check is a mutation, never a count and never a green run.

## Not done — the issue asks for this and it is unmet, not skipped

**No cap here has been measured against real traffic.** The issue's own "Not verified" section asks for it and singles out `collector/logs.py`. The caps are reasoned (16 KiB is Docker's line split; 1 MiB is orders of magnitude above the largest real payload) but not sampled. Sampling real container-log sizes against a live stack is the honest follow-up; it needs bench time, so it is not in this PR.

Also unmet: no live rig, remote node or bench exercised by this lane in any cycle. All RigForge and Docker API semantics come from reading source.

