### PR TITLE
fix(cli): serialise pithead's mutating windows behind a lock (#1342)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ config.json.bak-control
 Caddyfile
 # One-time first-run epilogue marker (#384), dropped beside .env at runtime.
 .pithead-first-run-done
+# Mutual-exclusion lock for pithead's mutating windows (#1342), dropped beside .env at runtime.
+# It holds only the current holder's pid/verb/timestamp, and the lock itself lives on the open
+# descriptor rather than on the file's existence — so a leftover file is inert, never a stale lock.
+.pithead.lock
 # pithead backup archives bundle .env, config.json, the Caddyfile, and the Tor onion private keys
 # into one tarball; secret scanners can't see inside a gzipped tar, so keep the whole dir out (#369).
 /backups/

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -308,6 +308,13 @@ the fault is not in the system copy — something on the data partition is wrong
 machine stays powered on with its reason in the logs rather than looping. In that state
 the dashboard is down; see [If something goes wrong](#if-something-goes-wrong).
 
+One case does not count as a failed start at all: the stack was already being changed by
+something else — the first-run install finishing, or a command you started — and this boot
+waited for it and ran out of time. Going back to the previous version would meet the same
+wait, so the machine does not spend its one restart on it. It stays powered on, says in the
+logs that it was waiting rather than failing, and keeps the return to the previous version
+available. Start it again once the other operation has finished.
+
 Updates are applied from the dashboard: an **OS updates** control in the header checks
 for a new release, downloads its signed image to the data partition (over Tor, resumable
 — mining keeps running), verifies the file on the machine before anything is written to

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	854
+tests/stack/test-lifecycle.sh	891
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	1007
+tests/stack/test-lifecycle.sh	1026
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	823
+tests/stack/test-lifecycle.sh	854
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,6 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
+tests/stack/test-lifecycle.sh	823
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	891
+tests/stack/test-lifecycle.sh	957
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	1026
+tests/stack/test-lifecycle.sh	1032
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -48,7 +48,7 @@ dashboard/tests/web/test_views.py	861
 dashboard/tests/web/test_wizard.py	974
 dashboard/tests/web/test_xvb_views.py	1342
 .github/workflows/ci.yml	513
-lib/pithead/99-remainder.sh	11470
+lib/pithead/99-remainder.sh	11556
 os/rootfs/Dockerfile	406
 scripts/build-pithead.sh	437
 scripts/release.sh	851
@@ -77,7 +77,7 @@ tests/stack/test-control-upgrade.sh	795
 tests/stack/test-dashboard-onion.sh	422
 tests/stack/test-dashboard.sh	592
 tests/stack/test-doctor.sh	507
-tests/stack/test-lifecycle.sh	957
+tests/stack/test-lifecycle.sh	1007
 tests/stack/test-monero-tari.sh	582
 tests/stack/test-release.sh	504
 tests/stack/test-release-signing.sh	454

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -107,9 +107,18 @@ takes it after its prompts, so a passphrase you have not typed yet holds nothing
 first-boot wizard holds it only while it deploys. Read-only commands — `status`, `doctor` and
 `logs` among them — never take it and never wait.
 
-The lock lives on `.pithead.lock` beside `.env`, and belongs to the running process rather than
-to the file: if a command is killed, the lock is released with it. A leftover `.pithead.lock`
-after a crash is an ordinary file, not a stale lock, and there is nothing to clean up by hand.
+The lock covers one stack, not one directory. A bundle install keeps each release in its own
+`pithead-vX.Y.Z` directory beside the one before it (see [The deploy-box
+layout](#the-deploy-box-layout)), and every one of those directories drives the same containers
+and the same data — including the fresh directory a one-click upgrade creates and runs from. They
+share a single `.pithead.lock` in the directory that holds them all. A plain `pithead/` checkout
+has no siblings and keeps its lock in the checkout. `PITHEAD_LOCK_FILE` overrides the path.
+
+The lock belongs to the running process rather than to the file: if a command is killed, the lock
+is released with it. A leftover `.pithead.lock` after a crash is an ordinary file, not a stale
+lock, and there is nothing to clean up by hand. Where the file cannot be opened at all — a
+directory only root can write, a read-only mount — pithead says so and runs anyway rather than
+refusing every command that changes the stack.
 
 ### Tab completion
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,6 +86,31 @@ failed and what did and didn't run, and the failing step's exit code becomes the
 Flags don't chain — `apply -y upgrade` is a single `apply` invocation (and `apply` rejects the
 stray argument), so run flagged commands separately.
 
+### Two commands at once
+
+Commands that change the stack take a lock, so a second one waits instead of running alongside
+the first. Without it a `backup` — which stops the stack to take a consistent archive — could
+remove a container out from under a `setup` or an `apply` that was still using it.
+
+The waiting command says what it is waiting for:
+
+```
+[WARNING] Another pithead operation is in progress (pid=4821 verb=backup since=2026-08-24T14:42:32Z) — waiting up to 300s for it to finish.
+```
+
+It then runs as soon as the first command finishes. If the wait runs out it stops without
+changing anything, and you can re-run it once the other command is done. Set
+`PITHEAD_LOCK_TIMEOUT` (seconds) to wait longer or give up sooner.
+
+The lock covers the parts of a command that change things, not the whole command. A `backup`
+takes it after its prompts, so a passphrase you have not typed yet holds nothing up, and the
+first-boot wizard holds it only while it deploys. Read-only commands — `status`, `doctor` and
+`logs` among them — never take it and never wait.
+
+The lock lives on `.pithead.lock` beside `.env`, and belongs to the running process rather than
+to the file: if a command is killed, the lock is released with it. A leftover `.pithead.lock`
+after a crash is an ordinary file, not a stale lock, and there is nothing to clean up by hand.
+
 ### Tab completion
 
 `pithead-completion.bash` (in the repo root and the release bundle) completes subcommands for

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -102,6 +102,11 @@ It then runs as soon as the first command finishes. If the wait runs out it stop
 changing anything, and you can re-run it once the other command is done. Set
 `PITHEAD_LOCK_TIMEOUT` (seconds) to wait longer or give up sooner.
 
+It only names a command it can show is still running. Where it cannot — the line was left behind
+by a command that was killed, or the lock is held by something that is not pithead at all — it
+says `holder unrecorded` in place of the name rather than reporting one that may have gone. The
+wait is the same either way: it is the lock that decides it, never the line.
+
 The lock covers the parts of a command that change things, not the whole command. A `backup`
 takes it after its prompts, so a passphrase you have not typed yet holds nothing up, and the
 first-boot wizard holds it only while it deploys. Read-only commands — `status`, `doctor` and
@@ -116,7 +121,8 @@ has no siblings and keeps its lock in the checkout. `PITHEAD_LOCK_FILE` override
 
 The lock belongs to the running process rather than to the file: if a command is killed, the lock
 is released with it. A leftover `.pithead.lock` after a crash is an ordinary file, not a stale
-lock, and there is nothing to clean up by hand. Where the file cannot be opened at all — a
+lock, and there is nothing to clean up by hand. The line inside it can outlive the command that
+wrote it, which is why the next command checks it before quoting it back to you. Where the file cannot be opened at all — a
 directory only root can write, a read-only mount — pithead says so and runs anyway rather than
 refusing every command that changes the stack.
 

--- a/lib/pithead/00-prelude.sh
+++ b/lib/pithead/00-prelude.sh
@@ -115,3 +115,155 @@ if [ "$_STACK_SOURCED" = "0" ]; then
     trap on_err ERR
     trap 'rm -f "${ENV_FILE}.new" "${ENV_FILE}.dryrun" 2>/dev/null || true' EXIT
 fi
+
+# --- Mutation lock (#1342) ---
+#
+# pithead had no mutual exclusion of any kind, so the writers on a box — the firstboot wizard
+# loop, the host-side runner draining the dashboard's spooled intents, and an operator verb from a
+# shell or a harness — could interleave with one another. The observed harm: a concurrent `backup`
+# runs stack_down inside a still-running `setup`, setup fails for a reason that has nothing to do
+# with the configuration, and the wizard treats that as a bad configuration (#1059).
+#
+# The lock goes around mutating WINDOWS, never around a whole verb. `backup` prompts for a
+# passphrase and then for permission to stop the stack, `restore` asks before overwriting, and
+# firstboot-wizard waits on a web form under TimeoutStartSec=infinity
+# (os/overlay/pithead-firstboot.service:35). A verb-scoped lock would sit inside those waits and
+# convert a race into a hang — the harder failure to read out of a journal, because a hang has no
+# message.
+#
+# Re-entrancy needs TWO mechanisms, because pithead DOES re-invoke itself for mutating verbs
+# (run_chain, control_lifecycle, control_backup):
+#   - within one process (backup -> down -> up): a depth counter.
+#   - across a re-invocation: an EXPORTED marker. The child inherits the descriptor across exec,
+#     so the lock is already held on its behalf — but without the marker it runs its own `exec 9>`,
+#     which opens a SECOND open file description on the same file and blocks on its own parent.
+#     Both halves were confirmed against the tools rather than reasoned: a child's `flock -n` on
+#     the inherited fd succeeds, and on a freshly opened one it blocks.
+#
+# fd 9 is a literal on purpose. Descriptors bash allocates itself (`exec {fd}>`) and any fd >= 10
+# are close-on-exec, so a child would not inherit the hold; fds 0-9 named explicitly are not.
+# Nothing else in this script uses fd 9. The lock lives on the descriptor, so the kernel releases
+# it if the holder dies — which matters here because error() is an exit and several of these paths
+# reach it.
+_PITHEAD_LOCK_DEPTH=0
+_PITHEAD_LOCK_OWNED=0
+_PITHEAD_LOCK_PATH=""
+_PITHEAD_LOCK_WARNED=0
+# Long enough that a routine `compose down` (seconds) never turns a backup into a refusal, short
+# enough that a wedged holder is reported instead of waited on forever.
+PITHEAD_LOCK_TIMEOUT="${PITHEAD_LOCK_TIMEOUT:-300}"
+# A timeout exits with THIS, not error()'s 1, because one caller has to tell the two apart:
+# os/overlay/pithead-boot reboots on its first failed boot so the bootloader falls back to the
+# other A/B slot, and declares "the fault is not the slot" on its second. A boot that merely
+# collided with the firstboot wizard's `setup` would spend that fallback on a slot that is fine
+# and then misdiagnose itself. 75 is sysexits.h's EX_TEMPFAIL — retry, nothing is wrong here.
+PITHEAD_EX_LOCK_TIMEOUT=75
+
+# WHERE the lock lives, and it is deliberately not the install directory.
+#
+# `$PWD/.pithead.lock` keys the lock on the directory pithead was run from — but the documented
+# bundle layout (docs/operations.md, "A recommended layout") gives ONE stack SEVERAL of those:
+# `current -> pithead-v1.5.0` sits beside `pithead-v1.4.0`, and the dashboard's one-click upgrade
+# creates a third sibling and runs `./pithead upgrade` INSIDE it (control_upgrade). Every one of
+# them drives the same Compose project (`pithead`, pinned in docker-compose.yml) against the same
+# data dirs, so a directory-keyed lock leaves that upgrade and a concurrent `backup` mutually
+# invisible — a lock that cannot be contended is #1059 again, wearing a green tick.
+#
+# So key it on the DEPLOY ROOT: the one thing every version dir of a stack shares. A plain
+# `pithead/` checkout has no siblings, keeps the directory-local path, and is unaffected.
+# PITHEAD_LOCK_FILE still overrides both, which is what the suite drives.
+is_versioned_install_dir() { # <dir> — the `pithead-vX.Y.Z` shape control_upgrade's #629 deploy creates
+    [[ "$(basename "$1")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+mutation_lock_path() {
+    if [ -n "${PITHEAD_LOCK_FILE:-}" ]; then
+        printf '%s' "$PITHEAD_LOCK_FILE"
+    elif is_versioned_install_dir "$PWD"; then
+        printf '%s' "$(dirname "$PWD")/.pithead.lock"
+    else
+        printf '%s' "$PWD/.pithead.lock"
+    fi
+}
+
+mutation_lock_acquire() { # <verb label>
+    local label="${1:-pithead}"
+
+    # Already inside a window this process holds (backup -> down/up): count and return.
+    if [ "$_PITHEAD_LOCK_DEPTH" -gt 0 ]; then
+        _PITHEAD_LOCK_DEPTH=$((_PITHEAD_LOCK_DEPTH + 1))
+        return 0
+    fi
+
+    # Held by an ancestor pithead that re-invoked us — we inherited its descriptor, so the lock is
+    # already held on our behalf. Opening our own here is the deadlock described above.
+    if [ -n "${PITHEAD_LOCK_HELD:-}" ]; then
+        _PITHEAD_LOCK_DEPTH=1
+        return 0
+    fi
+
+    if ! command -v flock >/dev/null 2>&1; then
+        # Refusing to run `up` on a box without util-linux would be a worse regression than the
+        # race this closes, so degrade — but loudly and once, never silently.
+        if [ "$_PITHEAD_LOCK_WARNED" -eq 0 ]; then
+            warn "flock is not installed, so pithead cannot serialise itself — another pithead running now can interleave with this one."
+            _PITHEAD_LOCK_WARNED=1
+        fi
+        return 0
+    fi
+
+    _PITHEAD_LOCK_PATH="$(mutation_lock_path)"
+    # Append, never truncate: `9>` empties the file at OPEN time — before the flock is taken — so
+    # it would wipe the holder record the waiter below is about to read.
+    #
+    # Fail OPEN here, matching the missing-flock branch above and for the same reason: a lock file
+    # this user cannot open is an environment fault (a deploy root only root can write, a
+    # read-only mount), and refusing every mutating verb on such a box is a worse regression than
+    # the race this closes. The two environmental failures are now handled the same direction on
+    # purpose — the asymmetry that used to sit here was not deliberate.
+    if ! exec 9>>"$_PITHEAD_LOCK_PATH"; then
+        if [ "$_PITHEAD_LOCK_WARNED" -eq 0 ]; then
+            warn "Cannot open the pithead lock file ($_PITHEAD_LOCK_PATH), so pithead cannot serialise itself — another pithead running now can interleave with this one."
+            _PITHEAD_LOCK_WARNED=1
+        fi
+        _PITHEAD_LOCK_PATH=""
+        return 0
+    fi
+    if ! flock -n 9; then
+        local holder
+        holder=$(head -n 1 "$_PITHEAD_LOCK_PATH" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
+        [ -n "$holder" ] || holder="holder unrecorded"
+        warn "Another pithead operation is in progress ($holder) — waiting up to ${PITHEAD_LOCK_TIMEOUT}s for it to finish."
+        if ! flock -w "$PITHEAD_LOCK_TIMEOUT" 9; then
+            exec 9>&-
+            # error()'s message, error()'s exit — except the status, for the reason at
+            # PITHEAD_EX_LOCK_TIMEOUT above. Anything reading only the message is unaffected.
+            echo -e "${C_RED}[ERROR]${C_RESET} Timed out after ${PITHEAD_LOCK_TIMEOUT}s waiting for another pithead operation ($holder) — nothing was changed. Re-run '$0 $label' once it has finished." >&2
+            exit "$PITHEAD_EX_LOCK_TIMEOUT"
+        fi
+    fi
+    _PITHEAD_LOCK_OWNED=1
+    _PITHEAD_LOCK_DEPTH=1
+    # Exported, not merely set: the marker has to survive into a re-invoked child.
+    export PITHEAD_LOCK_HELD="$$"
+    # Record the holder now that we are one. A truncating write through a second descriptor is
+    # safe while we hold the lock, and it is what lets the next waiter name who it is waiting for.
+    printf 'pid=%s verb=%s since=%s\n' "$$" "$label" \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)" >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
+    return 0
+}
+
+mutation_lock_release() {
+    [ "$_PITHEAD_LOCK_DEPTH" -gt 0 ] || return 0
+    _PITHEAD_LOCK_DEPTH=$((_PITHEAD_LOCK_DEPTH - 1))
+    [ "$_PITHEAD_LOCK_DEPTH" -eq 0 ] || return 0
+    # An inherited hold belongs to the ancestor: never close its descriptor and never clear its
+    # record. Only the process that took the lock gives it back.
+    [ "$_PITHEAD_LOCK_OWNED" -eq 1 ] || return 0
+    # Clear the record while we still hold the lock, so a stale line can never name a holder that
+    # has already gone.
+    : >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
+    _PITHEAD_LOCK_OWNED=0
+    unset PITHEAD_LOCK_HELD
+    exec 9>&-
+    return 0
+}

--- a/lib/pithead/00-prelude.sh
+++ b/lib/pithead/00-prelude.sh
@@ -282,7 +282,15 @@ mutation_lock_acquire() { # <verb label>
     export PITHEAD_LOCK_HELD="$$"
     # Record the holder now that we are one. A truncating write through a second descriptor is
     # safe while we hold the lock, and it is what lets the next waiter name who it is waiting for.
-    printf 'pid=%s verb=%s since=%s\n' "$$" "$label" \
+    #
+    # `$BASHPID`, not `$$`, and the difference is load-bearing rather than pedantic: the pid we
+    # write is the one a waiter checks for life, so it has to be the process that actually holds
+    # fd 9. In a subshell `$$` is the PARENT's pid — the firstboot wizard runs `setup` inside
+    # `(setup)` precisely so that the subshell's exit closes fd 9 and releases the window, and a
+    # record naming the parent would stay "alive" after the process holding the lock had gone.
+    # The `PITHEAD_LOCK_HELD` marker above is a different question — it marks the invocation whose
+    # descriptor a child inherits — and correctly stays `$$`.
+    printf 'pid=%s verb=%s since=%s\n' "$BASHPID" "$label" \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)" >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
     return 0
 }

--- a/lib/pithead/00-prelude.sh
+++ b/lib/pithead/00-prelude.sh
@@ -185,6 +185,42 @@ mutation_lock_path() {
     fi
 }
 
+# Describe the holder of a window we could not take — and never name one we cannot show is still
+# there.
+#
+# The record is written by whoever takes the lock and cleared by its release, but only an ORDERLY
+# release clears it. A verb that is Ctrl-C'd, or that hits `error()` inside its window, leaves its
+# line on disk: the kernel drops the flock with the descriptor, so the lock goes free while the
+# record does not. A later waiter reading that line would be told to wait for a pid that exited —
+# the exact misdiagnosis this message exists to prevent. The gap is narrow but ordinary: the next
+# acquire truncates the record only AFTER it has taken the lock, so a third invocation that loses
+# `flock -n` in between reads the dead line, and a holder that is not pithead at all (an
+# operator's own `flock .pithead.lock`) never writes one and so never clears the dead line either.
+#
+# So the record is trusted only while the pid it names is alive. `/proc` is asked first because it
+# answers regardless of who owns the process: `kill -0` returns non-zero on EPERM, and a root
+# `pithead` holding the window against an unprivileged waiter is an ordinary case here, not an
+# exotic one. `kill -0` is the fallback where /proc is not mounted. Anything that does not parse
+# as our own `pid=<n>` record is reported as unrecorded rather than echoed back, because a line we
+# cannot check is a line we cannot stand behind.
+#
+# What this does NOT cover, stated rather than implied: pid REUSE. A recycled pid reads as live
+# and we would name the wrong holder — the same wrong name the code has without this check, in a
+# far rarer case, and it costs a misleading message rather than a wrong action. The wait itself is
+# correct either way, because it is the flock that decides it, never the record.
+mutation_lock_holder() { # <lock file> — a holder description safe to show an operator
+    local line pid
+    line=$(head -n 1 "$1" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
+    pid="${line#pid=}"
+    pid="${pid%% *}"
+    if [ -n "$line" ] && [[ "$pid" =~ ^[0-9]+$ ]] &&
+        { [ -d "/proc/$pid" ] || kill -0 "$pid" 2>/dev/null; }; then
+        printf '%s' "$line"
+        return 0
+    fi
+    printf '%s' "holder unrecorded"
+}
+
 mutation_lock_acquire() { # <verb label>
     local label="${1:-pithead}"
 
@@ -230,8 +266,7 @@ mutation_lock_acquire() { # <verb label>
     fi
     if ! flock -n 9; then
         local holder
-        holder=$(head -n 1 "$_PITHEAD_LOCK_PATH" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
-        [ -n "$holder" ] || holder="holder unrecorded"
+        holder="$(mutation_lock_holder "$_PITHEAD_LOCK_PATH")"
         warn "Another pithead operation is in progress ($holder) — waiting up to ${PITHEAD_LOCK_TIMEOUT}s for it to finish."
         if ! flock -w "$PITHEAD_LOCK_TIMEOUT" 9; then
             exec 9>&-

--- a/lib/pithead/01-lifecycle.sh
+++ b/lib/pithead/01-lifecycle.sh
@@ -110,6 +110,7 @@ compose_up_checked() {
 }
 
 stack_up() {
+    mutation_lock_acquire up
     log "Starting stack..."
     warn_missing_data_dirs
     migrate_compose_project
@@ -152,6 +153,7 @@ stack_up() {
     print_clearnet_banner
     announce_dashboard_url
     print_first_run_epilogue
+    mutation_lock_release
 }
 
 # One-time onboarding after the stack first comes up (#384): explain that mining doesn't start until
@@ -168,13 +170,23 @@ print_first_run_epilogue() {
 }
 
 stack_down() {
+    mutation_lock_acquire down
     log "Stopping stack..."
     remove_tor_egress_firewall
     docker compose down
     log "Stack stopped."
+    mutation_lock_release
 }
 
 stack_restart() { # [tor|monerod]
+    # Reject a bad argument BEFORE taking the lock (#1342). Validating inside the window makes a
+    # typo wait out someone else's backup — up to PITHEAD_LOCK_TIMEOUT — only to be told it was a
+    # typo all along. Nothing here mutates, so there is nothing to serialise yet.
+    case "${1:-}" in
+    "" | tor | monerod) ;;
+    *) error "restart takes no argument, 'tor' (fresh Tor guards when clearnet egress is stuck), or 'monerod' (re-dial peers after a Tor restart left the node out of sync). Got: '$1'." ;;
+    esac
+    mutation_lock_acquire restart
     case "${1:-}" in
     "")
         log "Restarting stack..."
@@ -205,6 +217,9 @@ stack_restart() { # [tor|monerod]
         docker compose restart monerod
         log "monerod restarted. It should report synchronized again within a few minutes — verify: './pithead doctor' (Monero sync check)."
         ;;
-    *) error "restart takes no argument, 'tor' (fresh Tor guards when clearnet egress is stuck), or 'monerod' (re-dial peers after a Tor restart left the node out of sync). Got: '$1'." ;;
+    # Unreachable: the validation above admits only the three cases. Kept so that adding a value
+    # there and forgetting to handle it here fails loudly instead of restarting nothing.
+    *) error "Internal error: restart accepted '$1' but does not handle it." ;;
     esac
+    mutation_lock_release
 }

--- a/lib/pithead/99-remainder.sh
+++ b/lib/pithead/99-remainder.sh
@@ -118,6 +118,7 @@ stack_upgrade() {
     if is_appliance; then
         error "This is a Pithead OS appliance: the program tree is delivered by OS images and resynced from the system slot at every boot, so a tarball upgrade here would silently revert at the next reboot. Updates arrive as signed OS images — see the appliance guide."
     fi
+    mutation_lock_acquire upgrade
     log "Upgrading stack (rebuilding containers)..."
     # A release (git pull) may change config templates, add/rename .env vars, or restructure the
     # Caddyfile / Tari config — all GENERATED files mounted into containers. Re-render them before
@@ -199,6 +200,7 @@ stack_upgrade() {
     # the escape the ownership guard would refuse and leave the units on the previous install.
     provision_control_runner steal
     log "Stack upgraded."
+    mutation_lock_release
 }
 
 # Per-chain "is this node EXPOSED on clearnet right now?" (#183/#234): the flag is on AND the
@@ -1098,6 +1100,37 @@ wizard_keep_failed_config() {
     fi
     warn "Could not keep a copy of the failed configuration as config.json.failed."
     return 1
+}
+
+# CONTENTION IS NOT A BAD CONFIG — the wizard's half of #1342's routing, and it was missing.
+#
+# os/overlay/pithead-boot has the boot leg's half (fail_boot_contended): a lock timeout there is
+# contention, not a bad A/B slot, so the fallback is not spent. `setup` runs inside a mutating
+# window too, and can lose exactly the same race — but every non-zero (setup) was routed as a
+# provisioning failure, which tells the operator their configuration is wrong and asks them to
+# correct it. On a first boot there is no shell to contradict it with.
+#
+# Worse than misleading. That path calls wizard_keep_failed_config, which removes config.json
+# whenever the machine-role marker never landed — and record_machine_role is best-effort
+# (`printf ... || true`). So contention could take a VALID configuration away from the operator
+# and then blame them for it: #1059's own shape, on the one leg #1059's fix did not route.
+#
+# Kept as a function rather than inline at the call site, for the reason boot_up_failed gives on
+# the other leg: the two halves of one decision drift apart when they are written twice.
+#
+# rc 0 = a config.json.failed copy was kept (so the reopened page prefills from it), 1 = not.
+# Contention deliberately returns 1 WITHOUT calling wizard_keep_failed_config: nothing is copied,
+# nothing is removed, and the live config.json the operator submitted is what prefills the retry.
+wizard_setup_failed() { # <exit status of setup>
+    if [ "$1" = "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        warn "Another pithead operation still held the machine, and provisioning timed out waiting for it."
+        warn "That is contention, NOT a problem with the configuration you submitted — it is kept exactly as it is."
+        warn "Reopening the setup window so it can be resubmitted once the other operation has finished."
+        return 1
+    fi
+    warn "Provisioning failed. A copy of the submitted configuration is kept as config.json.failed;"
+    warn "reopening the setup window so it can be corrected."
+    wizard_keep_failed_config
 }
 
 # The marker, read back. Anything unrecognised (or absent) is a coordinator: every machine
@@ -2256,19 +2289,25 @@ firstboot_wizard() {
                 # teed: the console keeps its live narration, and the tail becomes the reopened
                 # page's error — a refusal that lives only in console scrollback cost a bench
                 # session an hour of believing the machine had crashed.
-                local setup_log
+                local setup_log setup_rc=0
                 setup_log=$(mktemp)
-                if (setup) 2>&1 | tee "$setup_log"; then
+                # The STATUS is captured, not just its truthiness: `if (setup) | tee` collapses
+                # every failure to one, and a lock timeout (PITHEAD_EX_LOCK_TIMEOUT) has to be
+                # told apart from a bad configuration — see wizard_setup_failed. PIPESTATUS is not
+                # needed here because `pipefail` is set, so the pipeline carries setup's own
+                # non-zero status; `|| setup_rc=$?` is what keeps `set -e` from taking the branch
+                # away before it can be read.
+                { (setup) 2>&1 | tee "$setup_log"; } || setup_rc=$?
+                if [ "$setup_rc" -eq 0 ]; then
                     rm -f "$setup_log"
                     return
                 fi
-                warn "Provisioning failed. A copy of the submitted configuration is kept as config.json.failed;"
-                warn "reopening the setup window so it can be corrected."
                 # The machine KEEPS its configuration (#1059) — this used to move it aside, which
                 # on this path can only cost. The reasoning, and why the removal that remains is
-                # conditional, is at wizard_keep_failed_config's definition.
+                # conditional, is at wizard_keep_failed_config's definition. Which of the two
+                # failures this was, and whether a copy is taken at all, is wizard_setup_failed's.
                 local kept_copy=0
-                if wizard_keep_failed_config; then kept_copy=1; fi
+                if wizard_setup_failed "$setup_rc"; then kept_copy=1; fi
                 mkdir -p "$spool"
                 chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
                 # The reopened page gets BOTH halves of a usable retry: the reason it failed, and
@@ -3110,8 +3149,12 @@ stack_backup() {
     # the way every path join should: only prefix $PWD onto a RELATIVE candidate.
     local _cfg_path="$CONFIG_FILE"
     case "$_cfg_path" in /*) ;; *) _cfg_path="$PWD/$_cfg_path" ;; esac
-    local items=("$_cfg_path" "$PWD/$ENV_FILE")
-    backup_require_items "${items[@]}"
+    # Kept as its own array so the check can be REPEATED under the lock below. This one runs
+    # before the passphrase and stop-the-stack prompts, and #1342's point is exactly that a
+    # precondition checked outside mutual exclusion can be false again by the time it is used.
+    local required=("$_cfg_path" "$PWD/$ENV_FILE")
+    local items=("${required[@]}")
+    backup_require_items "${required[@]}"
     [ -f "Caddyfile" ] && items+=("$PWD/Caddyfile")
 
     if [ -d "$TOR_DATA_DIR" ]; then
@@ -3187,8 +3230,21 @@ stack_backup() {
                 return
             fi
         fi
+        # AFTER both prompts (passphrase, and permission to stop the stack): the hold must not
+        # span an unbounded human wait. It runs from here across stack_down -> tar -> stack_up,
+        # so nothing can mutate config.json inside that span. Nested acquisition is a no-op, so
+        # the stack_down/stack_up below take no second lock.
+        mutation_lock_acquire backup
+        # Re-checked under the lock and BEFORE anything is stopped, so a file that vanished while
+        # the operator was at a prompt refuses here rather than failing tar with the stack already
+        # down — the same blast-radius rule as #1244/#1248.
+        backup_require_items "${required[@]}"
         was_running=1
         stack_down
+    else
+        # Stack already stopped: the same hold and the same re-check, still before tar.
+        mutation_lock_acquire backup
+        backup_require_items "${required[@]}"
     fi
 
     log "Creating backup archive..."
@@ -3248,6 +3304,7 @@ stack_backup() {
         stack_up
         log "Stack restarted after the backup."
     fi
+    mutation_lock_release
 }
 
 stack_restore() {
@@ -3326,6 +3383,9 @@ stack_restore() {
             error "Archive fails integrity verification (tampered or truncated) — nothing was restored."
     fi
 
+    # After the confirm and the passphrase prompt, and after the integrity verify (read-only):
+    # the extraction below is the mutating window.
+    mutation_lock_acquire restore
     log "Restoring from $archive ..."
     # The archive stores paths relative to / (leading slash stripped), so extracting at / puts
     # every file back exactly where it came from. sudo so we can write into the 100:101-owned
@@ -3352,6 +3412,7 @@ stack_restore() {
     ensure_owner "$DASHBOARD_DIR" "$APP_UID" "$APP_GID"
 
     log "Restore complete. Start the stack with '$0 up'."
+    mutation_lock_release
 }
 
 show_help() {
@@ -8303,6 +8364,11 @@ setup() {
         fi
     fi
 
+    # After the re-run prompt above, so the hold never spans a human wait. The firstboot
+    # wizard runs `(setup)` in a subshell (#1059), so this IS the wizard's hold and it is not one
+    # line wider than the provisioning itself — the loop's wait for a submitted form is outside it.
+    mutation_lock_acquire setup
+
     check_prerequisites
     ensure_config_exists
     ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one
@@ -8324,6 +8390,9 @@ setup() {
     update_current_symlink    # #455: versioned deploy dir -> maintain the `current ->` pointer
 
     log "Deployment preparation complete!"
+    # Provisioning is done. Everything below is either a message or an interactive "start now?",
+    # so the hold ends here; the stack_up it may call takes its own.
+    mutation_lock_release
     if [ "$REBOOT_REQUIRED" = true ]; then
         echo -e "\n${C_YELLOW}[!] ATTENTION: System optimization requires a reboot.${C_RESET}"
         echo "Please run: 'sudo reboot' now."
@@ -8846,6 +8915,11 @@ render_derived() {
 }
 
 apply() {
+    # apply reaches its mutating window down two different paths (a normal change, and the retry
+    # after a previous apply committed the config but did not finish recreating containers), so it
+    # tracks its own hold rather than acquiring twice — the depth counter would then never reach
+    # zero and the lock would outlive the verb inside a single process.
+    local lock_held=0
     local assume_yes=0 dry_run=0 porcelain=0 arg
     for arg in "$@"; do
         case "$arg" in
@@ -8949,6 +9023,10 @@ apply() {
             fi
         fi
 
+        # After every confirm above (the typed wallet redirect, the disruptive-change y/N):
+        # committing the rendered .env is where apply starts mutating.
+        mutation_lock_acquire apply
+        lock_held=1
         mv "$newenv" "$ENV_FILE"
         provision_node_onions # #103: a node that just went local needs its onion before it starts
         inject_service_configs
@@ -8978,13 +9056,20 @@ apply() {
             # files, not config.json — so returning here first made `apply` the one thing that
             # could not repair it, while doctor was telling the operator to run exactly that.
             # Idempotent and sudo-free when the units already match.
+            mutation_lock_acquire apply
             provision_control_runner
             log "No configuration changes detected. Nothing to apply."
+            mutation_lock_release
             return 0
         fi
         warn "A previous apply updated the config but did not finish recreating containers — retrying."
     fi
 
+    # The retry branch reaches here without a hold; the changed branch already has one.
+    if [ "$lock_held" -eq 0 ]; then
+        mutation_lock_acquire apply
+        lock_held=1
+    fi
     # Client-auth keys must be written before tor is recreated below, so an onion just turned on (or a
     # client-auth toggle) takes effect on this apply rather than the next (#343).
     provision_onion_client_auth
@@ -9039,6 +9124,7 @@ apply() {
     provision_local_miner || true
     log "Configuration applied."
     announce_dashboard_url
+    mutation_lock_release
 }
 
 # --- Subcommand chaining (#94) ---
@@ -9897,7 +9983,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # its default paths under the NEW dir and the stack would come up beside its own data.
     local new_dir="" cwd
     cwd=$(pwd -P) # physical path: the guard below compares canonicalized values on BOTH sides
-    if [[ "$(basename "$cwd")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if is_versioned_install_dir "$cwd"; then
         new_dir="$(dirname "$cwd")/pithead-$tag"
         local dvar dval
         for dvar in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR TOR_DATA_DIR DASHBOARD_DATA_DIR; do

--- a/os/overlay/pithead-boot
+++ b/os/overlay/pithead-boot
@@ -67,6 +67,30 @@ fail_boot() { # <what went wrong>
     exit 1
 }
 
+# CONTENTION IS NOT A BAD SLOT, and on this leg the difference is the box's only recovery (#1342).
+#
+# pithead serialises its mutating windows behind a lock, and there is no systemd ordering between
+# pithead-firstboot and this unit — so `./pithead up` below can collide with the wizard's `setup`,
+# whose window covers prerequisites, onion generation and the symlink update. If that wait times
+# out, `up` fails. Routed through fail_boot that reads as "this slot cannot start the stack": the
+# first reading REBOOTS to fall back to the other slot, and the second declares the fault is not
+# the slot. Both are wrong here. The other slot would meet the same contention, so the fallback
+# buys nothing — and it is spent, and the box then misdiagnoses itself out loud.
+#
+# So a lock timeout gets its own exit: the slot is left uncommitted (the fallback stays armed and
+# UNSPENT), the boot-failure counter is not touched, and nothing reboots.
+PITHEAD_EX_LOCK_TIMEOUT=75
+fail_boot_contended() { # <what could not be started>
+    echo "pithead-boot: $1 — another pithead operation still held the stack when this boot timed out waiting for it. That is contention, NOT a bad slot: the A/B fallback stays armed and is not spent, this boot is not counted against the failure budget, and the machine stays up. Re-run 'systemctl start pithead-boot' once the other operation has finished (journalctl -u pithead-boot)." >&2
+    exit 1
+}
+# The one place that decides which of the two a failed `up` was. Kept as a function rather than
+# repeated at both call sites below, so the hold-chain and the ordinary boot cannot drift apart.
+boot_up_failed() { # <exit status of ./pithead up>
+    [ "$1" = "$PITHEAD_EX_LOCK_TIMEOUT" ] && fail_boot_contended "the stack could not be brought up"
+    fail_boot "the stack could not be brought up"
+}
+
 # The dashboard's own site address, read from the .env this boot has just rendered (#1140).
 #
 # This probe used to dial https://localhost/, and said in a comment that localhost is a listed site
@@ -240,9 +264,9 @@ if [ -f .os-migration-pending ] &&
 fi
 
 if [ "$hold_chain" = 1 ]; then
-    PITHEAD_HOLD_CHAIN=1 ./pithead up || fail_boot "the stack could not be brought up"
+    PITHEAD_HOLD_CHAIN=1 ./pithead up || boot_up_failed $?
 else
-    ./pithead up || fail_boot "the stack could not be brought up"
+    ./pithead up || boot_up_failed $?
 fi
 
 IFS='|' read -r gate_scheme gate_host gate_port <<<"$(gate_url)"

--- a/pithead
+++ b/pithead
@@ -1787,6 +1787,37 @@ wizard_keep_failed_config() {
     return 1
 }
 
+# CONTENTION IS NOT A BAD CONFIG — the wizard's half of #1342's routing, and it was missing.
+#
+# os/overlay/pithead-boot has the boot leg's half (fail_boot_contended): a lock timeout there is
+# contention, not a bad A/B slot, so the fallback is not spent. `setup` runs inside a mutating
+# window too, and can lose exactly the same race — but every non-zero (setup) was routed as a
+# provisioning failure, which tells the operator their configuration is wrong and asks them to
+# correct it. On a first boot there is no shell to contradict it with.
+#
+# Worse than misleading. That path calls wizard_keep_failed_config, which removes config.json
+# whenever the machine-role marker never landed — and record_machine_role is best-effort
+# (`printf ... || true`). So contention could take a VALID configuration away from the operator
+# and then blame them for it: #1059's own shape, on the one leg #1059's fix did not route.
+#
+# Kept as a function rather than inline at the call site, for the reason boot_up_failed gives on
+# the other leg: the two halves of one decision drift apart when they are written twice.
+#
+# rc 0 = a config.json.failed copy was kept (so the reopened page prefills from it), 1 = not.
+# Contention deliberately returns 1 WITHOUT calling wizard_keep_failed_config: nothing is copied,
+# nothing is removed, and the live config.json the operator submitted is what prefills the retry.
+wizard_setup_failed() { # <exit status of setup>
+    if [ "$1" = "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        warn "Another pithead operation still held the machine, and provisioning timed out waiting for it."
+        warn "That is contention, NOT a problem with the configuration you submitted — it is kept exactly as it is."
+        warn "Reopening the setup window so it can be resubmitted once the other operation has finished."
+        return 1
+    fi
+    warn "Provisioning failed. A copy of the submitted configuration is kept as config.json.failed;"
+    warn "reopening the setup window so it can be corrected."
+    wizard_keep_failed_config
+}
+
 # The marker, read back. Anything unrecognised (or absent) is a coordinator: every machine
 # provisioned before this contract existed had no marker and was one.
 machine_role() { # echoes pithead|both|rig
@@ -2943,19 +2974,25 @@ firstboot_wizard() {
                 # teed: the console keeps its live narration, and the tail becomes the reopened
                 # page's error — a refusal that lives only in console scrollback cost a bench
                 # session an hour of believing the machine had crashed.
-                local setup_log
+                local setup_log setup_rc=0
                 setup_log=$(mktemp)
-                if (setup) 2>&1 | tee "$setup_log"; then
+                # The STATUS is captured, not just its truthiness: `if (setup) | tee` collapses
+                # every failure to one, and a lock timeout (PITHEAD_EX_LOCK_TIMEOUT) has to be
+                # told apart from a bad configuration — see wizard_setup_failed. PIPESTATUS is not
+                # needed here because `pipefail` is set, so the pipeline carries setup's own
+                # non-zero status; `|| setup_rc=$?` is what keeps `set -e` from taking the branch
+                # away before it can be read.
+                { (setup) 2>&1 | tee "$setup_log"; } || setup_rc=$?
+                if [ "$setup_rc" -eq 0 ]; then
                     rm -f "$setup_log"
                     return
                 fi
-                warn "Provisioning failed. A copy of the submitted configuration is kept as config.json.failed;"
-                warn "reopening the setup window so it can be corrected."
                 # The machine KEEPS its configuration (#1059) — this used to move it aside, which
                 # on this path can only cost. The reasoning, and why the removal that remains is
-                # conditional, is at wizard_keep_failed_config's definition.
+                # conditional, is at wizard_keep_failed_config's definition. Which of the two
+                # failures this was, and whether a copy is taken at all, is wizard_setup_failed's.
                 local kept_copy=0
-                if wizard_keep_failed_config; then kept_copy=1; fi
+                if wizard_setup_failed "$setup_rc"; then kept_copy=1; fi
                 mkdir -p "$spool"
                 chown 1000:1000 "$spool" 2>/dev/null || chmod 777 "$spool"
                 # The reopened page gets BOTH halves of a usable retry: the reason it failed, and

--- a/pithead
+++ b/pithead
@@ -116,6 +116,110 @@ if [ "$_STACK_SOURCED" = "0" ]; then
     trap 'rm -f "${ENV_FILE}.new" "${ENV_FILE}.dryrun" 2>/dev/null || true' EXIT
 fi
 
+# --- Mutation lock (#1342) ---
+#
+# pithead had no mutual exclusion of any kind, so the writers on a box — the firstboot wizard
+# loop, the host-side runner draining the dashboard's spooled intents, and an operator verb from a
+# shell or a harness — could interleave with one another. The observed harm: a concurrent `backup`
+# runs stack_down inside a still-running `setup`, setup fails for a reason that has nothing to do
+# with the configuration, and the wizard treats that as a bad configuration (#1059).
+#
+# The lock goes around mutating WINDOWS, never around a whole verb. `backup` prompts for a
+# passphrase and then for permission to stop the stack, `restore` asks before overwriting, and
+# firstboot-wizard waits on a web form under TimeoutStartSec=infinity
+# (os/overlay/pithead-firstboot.service:35). A verb-scoped lock would sit inside those waits and
+# convert a race into a hang — the harder failure to read out of a journal, because a hang has no
+# message.
+#
+# Re-entrancy needs TWO mechanisms, because pithead DOES re-invoke itself for mutating verbs
+# (run_chain, control_lifecycle, control_backup):
+#   - within one process (backup -> down -> up): a depth counter.
+#   - across a re-invocation: an EXPORTED marker. The child inherits the descriptor across exec,
+#     so the lock is already held on its behalf — but without the marker it runs its own `exec 9>`,
+#     which opens a SECOND open file description on the same file and blocks on its own parent.
+#     Both halves were confirmed against the tools rather than reasoned: a child's `flock -n` on
+#     the inherited fd succeeds, and on a freshly opened one it blocks.
+#
+# fd 9 is a literal on purpose. Descriptors bash allocates itself (`exec {fd}>`) and any fd >= 10
+# are close-on-exec, so a child would not inherit the hold; fds 0-9 named explicitly are not.
+# Nothing else in this script uses fd 9. The lock lives on the descriptor, so the kernel releases
+# it if the holder dies — which matters here because error() is an exit and several of these paths
+# reach it.
+_PITHEAD_LOCK_DEPTH=0
+_PITHEAD_LOCK_OWNED=0
+_PITHEAD_LOCK_PATH=""
+_PITHEAD_LOCK_WARNED=0
+# Long enough that a routine `compose down` (seconds) never turns a backup into a refusal, short
+# enough that a wedged holder is reported instead of waited on forever.
+PITHEAD_LOCK_TIMEOUT="${PITHEAD_LOCK_TIMEOUT:-300}"
+
+mutation_lock_acquire() { # <verb label>
+    local label="${1:-pithead}"
+
+    # Already inside a window this process holds (backup -> down/up): count and return.
+    if [ "$_PITHEAD_LOCK_DEPTH" -gt 0 ]; then
+        _PITHEAD_LOCK_DEPTH=$((_PITHEAD_LOCK_DEPTH + 1))
+        return 0
+    fi
+
+    # Held by an ancestor pithead that re-invoked us — we inherited its descriptor, so the lock is
+    # already held on our behalf. Opening our own here is the deadlock described above.
+    if [ -n "${PITHEAD_LOCK_HELD:-}" ]; then
+        _PITHEAD_LOCK_DEPTH=1
+        return 0
+    fi
+
+    if ! command -v flock >/dev/null 2>&1; then
+        # Refusing to run `up` on a box without util-linux would be a worse regression than the
+        # race this closes, so degrade — but loudly and once, never silently.
+        if [ "$_PITHEAD_LOCK_WARNED" -eq 0 ]; then
+            warn "flock is not installed, so pithead cannot serialise itself — another pithead running now can interleave with this one."
+            _PITHEAD_LOCK_WARNED=1
+        fi
+        return 0
+    fi
+
+    _PITHEAD_LOCK_PATH="${PITHEAD_LOCK_FILE:-$PWD/.pithead.lock}"
+    # Append, never truncate: `9>` empties the file at OPEN time — before the flock is taken — so
+    # it would wipe the holder record the waiter below is about to read.
+    exec 9>>"$_PITHEAD_LOCK_PATH" || error "Cannot open the pithead lock file: $_PITHEAD_LOCK_PATH"
+    if ! flock -n 9; then
+        local holder
+        holder=$(head -n 1 "$_PITHEAD_LOCK_PATH" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
+        [ -n "$holder" ] || holder="holder unrecorded"
+        warn "Another pithead operation is in progress ($holder) — waiting up to ${PITHEAD_LOCK_TIMEOUT}s for it to finish."
+        if ! flock -w "$PITHEAD_LOCK_TIMEOUT" 9; then
+            exec 9>&-
+            error "Timed out after ${PITHEAD_LOCK_TIMEOUT}s waiting for another pithead operation ($holder) — nothing was changed. Re-run '$0 $label' once it has finished."
+        fi
+    fi
+    _PITHEAD_LOCK_OWNED=1
+    _PITHEAD_LOCK_DEPTH=1
+    # Exported, not merely set: the marker has to survive into a re-invoked child.
+    export PITHEAD_LOCK_HELD="$$"
+    # Record the holder now that we are one. A truncating write through a second descriptor is
+    # safe while we hold the lock, and it is what lets the next waiter name who it is waiting for.
+    printf 'pid=%s verb=%s since=%s\n' "$$" "$label" \
+        "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)" >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
+    return 0
+}
+
+mutation_lock_release() {
+    [ "$_PITHEAD_LOCK_DEPTH" -gt 0 ] || return 0
+    _PITHEAD_LOCK_DEPTH=$((_PITHEAD_LOCK_DEPTH - 1))
+    [ "$_PITHEAD_LOCK_DEPTH" -eq 0 ] || return 0
+    # An inherited hold belongs to the ancestor: never close its descriptor and never clear its
+    # record. Only the process that took the lock gives it back.
+    [ "$_PITHEAD_LOCK_OWNED" -eq 1 ] || return 0
+    # Clear the record while we still hold the lock, so a stale line can never name a holder that
+    # has already gone.
+    : >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
+    _PITHEAD_LOCK_OWNED=0
+    unset PITHEAD_LOCK_HELD
+    exec 9>&-
+    return 0
+}
+
 # --- Lifecycle Helpers ---
 
 # The Compose project name is pinned to "pithead" (docker-compose.yml `name:`). A stack first
@@ -228,6 +332,7 @@ compose_up_checked() {
 }
 
 stack_up() {
+    mutation_lock_acquire up
     log "Starting stack..."
     warn_missing_data_dirs
     migrate_compose_project
@@ -270,6 +375,7 @@ stack_up() {
     print_clearnet_banner
     announce_dashboard_url
     print_first_run_epilogue
+    mutation_lock_release
 }
 
 # One-time onboarding after the stack first comes up (#384): explain that mining doesn't start until
@@ -286,13 +392,23 @@ print_first_run_epilogue() {
 }
 
 stack_down() {
+    mutation_lock_acquire down
     log "Stopping stack..."
     remove_tor_egress_firewall
     docker compose down
     log "Stack stopped."
+    mutation_lock_release
 }
 
 stack_restart() { # [tor|monerod]
+    # Reject a bad argument BEFORE taking the lock (#1342). Validating inside the window makes a
+    # typo wait out someone else's backup — up to PITHEAD_LOCK_TIMEOUT — only to be told it was a
+    # typo all along. Nothing here mutates, so there is nothing to serialise yet.
+    case "${1:-}" in
+    "" | tor | monerod) ;;
+    *) error "restart takes no argument, 'tor' (fresh Tor guards when clearnet egress is stuck), or 'monerod' (re-dial peers after a Tor restart left the node out of sync). Got: '$1'." ;;
+    esac
+    mutation_lock_acquire restart
     case "${1:-}" in
     "")
         log "Restarting stack..."
@@ -323,8 +439,11 @@ stack_restart() { # [tor|monerod]
         docker compose restart monerod
         log "monerod restarted. It should report synchronized again within a few minutes — verify: './pithead doctor' (Monero sync check)."
         ;;
-    *) error "restart takes no argument, 'tor' (fresh Tor guards when clearnet egress is stuck), or 'monerod' (re-dial peers after a Tor restart left the node out of sync). Got: '$1'." ;;
+    # Unreachable: the validation above admits only the three cases. Kept so that adding a value
+    # there and forgetting to handle it here fails loudly instead of restarting nothing.
+    *) error "Internal error: restart accepted '$1' but does not handle it." ;;
     esac
+    mutation_lock_release
 }
 
 # --- Tor-only egress enforcement (#270) ---------------------------------------------------------
@@ -636,6 +755,7 @@ stack_upgrade() {
     if is_appliance; then
         error "This is a Pithead OS appliance: the program tree is delivered by OS images and resynced from the system slot at every boot, so a tarball upgrade here would silently revert at the next reboot. Updates arrive as signed OS images — see the appliance guide."
     fi
+    mutation_lock_acquire upgrade
     log "Upgrading stack (rebuilding containers)..."
     # A release (git pull) may change config templates, add/rename .env vars, or restructure the
     # Caddyfile / Tari config — all GENERATED files mounted into containers. Re-render them before
@@ -717,6 +837,7 @@ stack_upgrade() {
     # the escape the ownership guard would refuse and leave the units on the previous install.
     provision_control_runner steal
     log "Stack upgraded."
+    mutation_lock_release
 }
 
 # Per-chain "is this node EXPOSED on clearnet right now?" (#183/#234): the flag is on AND the
@@ -3628,8 +3749,12 @@ stack_backup() {
     # the way every path join should: only prefix $PWD onto a RELATIVE candidate.
     local _cfg_path="$CONFIG_FILE"
     case "$_cfg_path" in /*) ;; *) _cfg_path="$PWD/$_cfg_path" ;; esac
-    local items=("$_cfg_path" "$PWD/$ENV_FILE")
-    backup_require_items "${items[@]}"
+    # Kept as its own array so the check can be REPEATED under the lock below. This one runs
+    # before the passphrase and stop-the-stack prompts, and #1342's point is exactly that a
+    # precondition checked outside mutual exclusion can be false again by the time it is used.
+    local required=("$_cfg_path" "$PWD/$ENV_FILE")
+    local items=("${required[@]}")
+    backup_require_items "${required[@]}"
     [ -f "Caddyfile" ] && items+=("$PWD/Caddyfile")
 
     if [ -d "$TOR_DATA_DIR" ]; then
@@ -3705,8 +3830,21 @@ stack_backup() {
                 return
             fi
         fi
+        # AFTER both prompts (passphrase, and permission to stop the stack): the hold must not
+        # span an unbounded human wait. It runs from here across stack_down -> tar -> stack_up,
+        # so nothing can mutate config.json inside that span. Nested acquisition is a no-op, so
+        # the stack_down/stack_up below take no second lock.
+        mutation_lock_acquire backup
+        # Re-checked under the lock and BEFORE anything is stopped, so a file that vanished while
+        # the operator was at a prompt refuses here rather than failing tar with the stack already
+        # down — the same blast-radius rule as #1244/#1248.
+        backup_require_items "${required[@]}"
         was_running=1
         stack_down
+    else
+        # Stack already stopped: the same hold and the same re-check, still before tar.
+        mutation_lock_acquire backup
+        backup_require_items "${required[@]}"
     fi
 
     log "Creating backup archive..."
@@ -3766,6 +3904,7 @@ stack_backup() {
         stack_up
         log "Stack restarted after the backup."
     fi
+    mutation_lock_release
 }
 
 stack_restore() {
@@ -3844,6 +3983,9 @@ stack_restore() {
             error "Archive fails integrity verification (tampered or truncated) — nothing was restored."
     fi
 
+    # After the confirm and the passphrase prompt, and after the integrity verify (read-only):
+    # the extraction below is the mutating window.
+    mutation_lock_acquire restore
     log "Restoring from $archive ..."
     # The archive stores paths relative to / (leading slash stripped), so extracting at / puts
     # every file back exactly where it came from. sudo so we can write into the 100:101-owned
@@ -3870,6 +4012,7 @@ stack_restore() {
     ensure_owner "$DASHBOARD_DIR" "$APP_UID" "$APP_GID"
 
     log "Restore complete. Start the stack with '$0 up'."
+    mutation_lock_release
 }
 
 show_help() {
@@ -8821,6 +8964,11 @@ setup() {
         fi
     fi
 
+    # After the re-run prompt above, so the hold never spans a human wait. The firstboot
+    # wizard runs `(setup)` in a subshell (#1059), so this IS the wizard's hold and it is not one
+    # line wider than the provisioning itself — the loop's wait for a submitted form is outside it.
+    mutation_lock_acquire setup
+
     check_prerequisites
     ensure_config_exists
     ensure_onion_password # #343: auto-generate a dashboard password if the onion is on without one
@@ -8842,6 +8990,9 @@ setup() {
     update_current_symlink    # #455: versioned deploy dir -> maintain the `current ->` pointer
 
     log "Deployment preparation complete!"
+    # Provisioning is done. Everything below is either a message or an interactive "start now?",
+    # so the hold ends here; the stack_up it may call takes its own.
+    mutation_lock_release
     if [ "$REBOOT_REQUIRED" = true ]; then
         echo -e "\n${C_YELLOW}[!] ATTENTION: System optimization requires a reboot.${C_RESET}"
         echo "Please run: 'sudo reboot' now."
@@ -9364,6 +9515,11 @@ render_derived() {
 }
 
 apply() {
+    # apply reaches its mutating window down two different paths (a normal change, and the retry
+    # after a previous apply committed the config but did not finish recreating containers), so it
+    # tracks its own hold rather than acquiring twice — the depth counter would then never reach
+    # zero and the lock would outlive the verb inside a single process.
+    local lock_held=0
     local assume_yes=0 dry_run=0 porcelain=0 arg
     for arg in "$@"; do
         case "$arg" in
@@ -9467,6 +9623,10 @@ apply() {
             fi
         fi
 
+        # After every confirm above (the typed wallet redirect, the disruptive-change y/N):
+        # committing the rendered .env is where apply starts mutating.
+        mutation_lock_acquire apply
+        lock_held=1
         mv "$newenv" "$ENV_FILE"
         provision_node_onions # #103: a node that just went local needs its onion before it starts
         inject_service_configs
@@ -9496,13 +9656,20 @@ apply() {
             # files, not config.json — so returning here first made `apply` the one thing that
             # could not repair it, while doctor was telling the operator to run exactly that.
             # Idempotent and sudo-free when the units already match.
+            mutation_lock_acquire apply
             provision_control_runner
             log "No configuration changes detected. Nothing to apply."
+            mutation_lock_release
             return 0
         fi
         warn "A previous apply updated the config but did not finish recreating containers — retrying."
     fi
 
+    # The retry branch reaches here without a hold; the changed branch already has one.
+    if [ "$lock_held" -eq 0 ]; then
+        mutation_lock_acquire apply
+        lock_held=1
+    fi
     # Client-auth keys must be written before tor is recreated below, so an onion just turned on (or a
     # client-auth toggle) takes effect on this apply rather than the next (#343).
     provision_onion_client_auth
@@ -9557,6 +9724,7 @@ apply() {
     provision_local_miner || true
     log "Configuration applied."
     announce_dashboard_url
+    mutation_lock_release
 }
 
 # --- Subcommand chaining (#94) ---

--- a/pithead
+++ b/pithead
@@ -152,6 +152,38 @@ _PITHEAD_LOCK_WARNED=0
 # Long enough that a routine `compose down` (seconds) never turns a backup into a refusal, short
 # enough that a wedged holder is reported instead of waited on forever.
 PITHEAD_LOCK_TIMEOUT="${PITHEAD_LOCK_TIMEOUT:-300}"
+# A timeout exits with THIS, not error()'s 1, because one caller has to tell the two apart:
+# os/overlay/pithead-boot reboots on its first failed boot so the bootloader falls back to the
+# other A/B slot, and declares "the fault is not the slot" on its second. A boot that merely
+# collided with the firstboot wizard's `setup` would spend that fallback on a slot that is fine
+# and then misdiagnose itself. 75 is sysexits.h's EX_TEMPFAIL — retry, nothing is wrong here.
+PITHEAD_EX_LOCK_TIMEOUT=75
+
+# WHERE the lock lives, and it is deliberately not the install directory.
+#
+# `$PWD/.pithead.lock` keys the lock on the directory pithead was run from — but the documented
+# bundle layout (docs/operations.md, "A recommended layout") gives ONE stack SEVERAL of those:
+# `current -> pithead-v1.5.0` sits beside `pithead-v1.4.0`, and the dashboard's one-click upgrade
+# creates a third sibling and runs `./pithead upgrade` INSIDE it (control_upgrade). Every one of
+# them drives the same Compose project (`pithead`, pinned in docker-compose.yml) against the same
+# data dirs, so a directory-keyed lock leaves that upgrade and a concurrent `backup` mutually
+# invisible — a lock that cannot be contended is #1059 again, wearing a green tick.
+#
+# So key it on the DEPLOY ROOT: the one thing every version dir of a stack shares. A plain
+# `pithead/` checkout has no siblings, keeps the directory-local path, and is unaffected.
+# PITHEAD_LOCK_FILE still overrides both, which is what the suite drives.
+is_versioned_install_dir() { # <dir> — the `pithead-vX.Y.Z` shape control_upgrade's #629 deploy creates
+    [[ "$(basename "$1")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+mutation_lock_path() {
+    if [ -n "${PITHEAD_LOCK_FILE:-}" ]; then
+        printf '%s' "$PITHEAD_LOCK_FILE"
+    elif is_versioned_install_dir "$PWD"; then
+        printf '%s' "$(dirname "$PWD")/.pithead.lock"
+    else
+        printf '%s' "$PWD/.pithead.lock"
+    fi
+}
 
 mutation_lock_acquire() { # <verb label>
     local label="${1:-pithead}"
@@ -179,10 +211,23 @@ mutation_lock_acquire() { # <verb label>
         return 0
     fi
 
-    _PITHEAD_LOCK_PATH="${PITHEAD_LOCK_FILE:-$PWD/.pithead.lock}"
+    _PITHEAD_LOCK_PATH="$(mutation_lock_path)"
     # Append, never truncate: `9>` empties the file at OPEN time — before the flock is taken — so
     # it would wipe the holder record the waiter below is about to read.
-    exec 9>>"$_PITHEAD_LOCK_PATH" || error "Cannot open the pithead lock file: $_PITHEAD_LOCK_PATH"
+    #
+    # Fail OPEN here, matching the missing-flock branch above and for the same reason: a lock file
+    # this user cannot open is an environment fault (a deploy root only root can write, a
+    # read-only mount), and refusing every mutating verb on such a box is a worse regression than
+    # the race this closes. The two environmental failures are now handled the same direction on
+    # purpose — the asymmetry that used to sit here was not deliberate.
+    if ! exec 9>>"$_PITHEAD_LOCK_PATH"; then
+        if [ "$_PITHEAD_LOCK_WARNED" -eq 0 ]; then
+            warn "Cannot open the pithead lock file ($_PITHEAD_LOCK_PATH), so pithead cannot serialise itself — another pithead running now can interleave with this one."
+            _PITHEAD_LOCK_WARNED=1
+        fi
+        _PITHEAD_LOCK_PATH=""
+        return 0
+    fi
     if ! flock -n 9; then
         local holder
         holder=$(head -n 1 "$_PITHEAD_LOCK_PATH" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
@@ -190,7 +235,10 @@ mutation_lock_acquire() { # <verb label>
         warn "Another pithead operation is in progress ($holder) — waiting up to ${PITHEAD_LOCK_TIMEOUT}s for it to finish."
         if ! flock -w "$PITHEAD_LOCK_TIMEOUT" 9; then
             exec 9>&-
-            error "Timed out after ${PITHEAD_LOCK_TIMEOUT}s waiting for another pithead operation ($holder) — nothing was changed. Re-run '$0 $label' once it has finished."
+            # error()'s message, error()'s exit — except the status, for the reason at
+            # PITHEAD_EX_LOCK_TIMEOUT above. Anything reading only the message is unaffected.
+            echo -e "${C_RED}[ERROR]${C_RESET} Timed out after ${PITHEAD_LOCK_TIMEOUT}s waiting for another pithead operation ($holder) — nothing was changed. Re-run '$0 $label' once it has finished." >&2
+            exit "$PITHEAD_EX_LOCK_TIMEOUT"
         fi
     fi
     _PITHEAD_LOCK_OWNED=1
@@ -10583,7 +10631,7 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
     # its default paths under the NEW dir and the stack would come up beside its own data.
     local new_dir="" cwd
     cwd=$(pwd -P) # physical path: the guard below compares canonicalized values on BOTH sides
-    if [[ "$(basename "$cwd")" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    if is_versioned_install_dir "$cwd"; then
         new_dir="$(dirname "$cwd")/pithead-$tag"
         local dvar dval
         for dvar in MONERO_DATA_DIR TARI_DATA_DIR P2POOL_DATA_DIR TOR_DATA_DIR DASHBOARD_DATA_DIR; do

--- a/pithead
+++ b/pithead
@@ -282,7 +282,15 @@ mutation_lock_acquire() { # <verb label>
     export PITHEAD_LOCK_HELD="$$"
     # Record the holder now that we are one. A truncating write through a second descriptor is
     # safe while we hold the lock, and it is what lets the next waiter name who it is waiting for.
-    printf 'pid=%s verb=%s since=%s\n' "$$" "$label" \
+    #
+    # `$BASHPID`, not `$$`, and the difference is load-bearing rather than pedantic: the pid we
+    # write is the one a waiter checks for life, so it has to be the process that actually holds
+    # fd 9. In a subshell `$$` is the PARENT's pid — the firstboot wizard runs `setup` inside
+    # `(setup)` precisely so that the subshell's exit closes fd 9 and releases the window, and a
+    # record naming the parent would stay "alive" after the process holding the lock had gone.
+    # The `PITHEAD_LOCK_HELD` marker above is a different question — it marks the invocation whose
+    # descriptor a child inherits — and correctly stays `$$`.
+    printf 'pid=%s verb=%s since=%s\n' "$BASHPID" "$label" \
         "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo unknown)" >"$_PITHEAD_LOCK_PATH" 2>/dev/null || true
     return 0
 }

--- a/pithead
+++ b/pithead
@@ -185,6 +185,42 @@ mutation_lock_path() {
     fi
 }
 
+# Describe the holder of a window we could not take — and never name one we cannot show is still
+# there.
+#
+# The record is written by whoever takes the lock and cleared by its release, but only an ORDERLY
+# release clears it. A verb that is Ctrl-C'd, or that hits `error()` inside its window, leaves its
+# line on disk: the kernel drops the flock with the descriptor, so the lock goes free while the
+# record does not. A later waiter reading that line would be told to wait for a pid that exited —
+# the exact misdiagnosis this message exists to prevent. The gap is narrow but ordinary: the next
+# acquire truncates the record only AFTER it has taken the lock, so a third invocation that loses
+# `flock -n` in between reads the dead line, and a holder that is not pithead at all (an
+# operator's own `flock .pithead.lock`) never writes one and so never clears the dead line either.
+#
+# So the record is trusted only while the pid it names is alive. `/proc` is asked first because it
+# answers regardless of who owns the process: `kill -0` returns non-zero on EPERM, and a root
+# `pithead` holding the window against an unprivileged waiter is an ordinary case here, not an
+# exotic one. `kill -0` is the fallback where /proc is not mounted. Anything that does not parse
+# as our own `pid=<n>` record is reported as unrecorded rather than echoed back, because a line we
+# cannot check is a line we cannot stand behind.
+#
+# What this does NOT cover, stated rather than implied: pid REUSE. A recycled pid reads as live
+# and we would name the wrong holder — the same wrong name the code has without this check, in a
+# far rarer case, and it costs a misleading message rather than a wrong action. The wait itself is
+# correct either way, because it is the flock that decides it, never the record.
+mutation_lock_holder() { # <lock file> — a holder description safe to show an operator
+    local line pid
+    line=$(head -n 1 "$1" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
+    pid="${line#pid=}"
+    pid="${pid%% *}"
+    if [ -n "$line" ] && [[ "$pid" =~ ^[0-9]+$ ]] &&
+        { [ -d "/proc/$pid" ] || kill -0 "$pid" 2>/dev/null; }; then
+        printf '%s' "$line"
+        return 0
+    fi
+    printf '%s' "holder unrecorded"
+}
+
 mutation_lock_acquire() { # <verb label>
     local label="${1:-pithead}"
 
@@ -230,8 +266,7 @@ mutation_lock_acquire() { # <verb label>
     fi
     if ! flock -n 9; then
         local holder
-        holder=$(head -n 1 "$_PITHEAD_LOCK_PATH" 2>/dev/null | tr -d '[:cntrl:]' | head -c 120)
-        [ -n "$holder" ] || holder="holder unrecorded"
+        holder="$(mutation_lock_holder "$_PITHEAD_LOCK_PATH")"
         warn "Another pithead operation is in progress ($holder) — waiting up to ${PITHEAD_LOCK_TIMEOUT}s for it to finish."
         if ! flock -w "$PITHEAD_LOCK_TIMEOUT" 9; then
             exec 9>&-

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -414,7 +414,7 @@ assert_rc "the holder records itself so a waiter can name it" "$(lock_await_reco
 : >"$LKLOG"
 out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
 rc=$?
-assert_rc "a mutating verb refuses rather than interleaving with a held window" "$rc" "1"
+assert_rc "a mutating verb refuses rather than interleaving with a held window" "$rc" "75"
 # `verb=backup` is the discriminator for opening the lock file with `9>>` and not `9>`: `9>`
 # truncates at OPEN time, before the flock, which would wipe the record this waiter just read.
 assert_contains "the refusal names the verb holding the window" "$out" "verb=backup"
@@ -458,7 +458,7 @@ while [ "$i" -lt 200 ]; do
 done
 out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
 rc=$?
-assert_rc "an unrecorded holder still blocks the window" "$rc" "1"
+assert_rc "an unrecorded holder still blocks the window" "$rc" "75"
 assert_contains "an unrecorded holder is reported as unrecorded" "$out" "holder unrecorded"
 assert_not_contains "and is never reported under the previous holder's name" "$out" "verb=backup"
 kill "$LKEXT" 2>/dev/null
@@ -544,7 +544,7 @@ lock_reinvoke_probe() { # <1=keep the inherited marker|0=strip it> -> "<child rc
 assert_eq "a re-invoked pithead inside a held window proceeds on the inherited marker" \
     "$(lock_reinvoke_probe 1)" "0|called|held|intact"
 assert_eq "without the marker that same child blocks on its own parent and changes nothing" \
-    "$(lock_reinvoke_probe 0)" "1|untouched|held|intact"
+    "$(lock_reinvoke_probe 0)" "75|untouched|held|intact"
 assert_eq "a re-invoked child can open a second window without deadlocking on its parent" \
     "$(lock_reinvoke_probe 2)" "0|untouched|held|intact"
 
@@ -595,4 +595,227 @@ rm -f "$LKDIR/.pithead.lock"
 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down >/dev/null 2>&1
 assert_eq "the lock defaults to .pithead.lock in the stack directory" \
     "$([ -f "$LKDIR/.pithead.lock" ] && echo present || echo absent)" "present"
+
+# An unopenable lock file degrades OPEN, exactly like a missing flock and for the same reason: a
+# deploy root only root can write, or a read-only mount, is an environment fault, and refusing
+# every mutating verb on such a box is a worse regression than the race. The path here has a
+# REGULAR FILE as its parent, so the open fails with ENOTDIR for any uid — a chmod-based fixture
+# would silently stop being a fixture under a root-run suite and the case would pass vacuously.
+printf 'not a directory\n' >"$LKDIR/notadir"
+: >"$LKLOG"
+out="$(PITHEAD_LOCK_FILE="$LKDIR/notadir/nope.lock" DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
+rc=$?
+assert_rc "an unopenable lock file degrades instead of refusing every mutating verb" "$rc" "0"
+assert_contains "and says out loud that it is no longer serialising anything" "$out" "cannot serialise itself"
+assert_contains "the mutation it could not serialise still runs" "$(cat "$LKLOG")" "compose down"
+
+# The lock is keyed on the DEPLOY ROOT, not on the directory pithead was run from. One stack is
+# several sibling pithead-vX.Y.Z dirs (`current ->`, the rollback copy, and the fresh dir the
+# dashboard's one-click upgrade creates and runs `./pithead upgrade` inside), all driving the same
+# Compose project against the same data. Keyed on the directory, that upgrade and a concurrent
+# `backup` took different lock files and could not see each other — uncontended by construction,
+# which is #1059 wearing a green tick.
+LKROOT="$SANDBOX/deploy"
+mkdir -p "$LKROOT/pithead-v1.0.0" "$LKROOT/pithead-v2.0.0" "$LKROOT/plain-a" "$LKROOT/plain-b"
+# Hold a window in one dir; drive a mutating verb from its sibling. `env -u PITHEAD_LOCK_HELD`
+# because the concurrent actor is a SEPARATE process tree — inheriting the marker would make the
+# child skip the lock entirely and the case would pass without ever contending.
+lock_sibling_probe() { # <holder dir> <other dir> -> "<rc>|<mutated?>"
+    local clog="$LKROOT/sib.log"
+    : >"$clog"
+    (
+        cd "$1" || exit 9
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e # sourcing pithead turns errexit on here (pithead:14)
+        mutation_lock_acquire backup
+        PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$clog" PATH="$LKBIN:$PATH" \
+            env -u PITHEAD_LOCK_HELD bash -c 'cd "$2" || exit 9; source "$1"; set +e; stack_down' _ "$STACK" "$2" >/dev/null 2>&1
+        local rc=$? mutated=untouched
+        grep -q 'compose down' "$clog" 2>/dev/null && mutated=mutated
+        printf '%s|%s\n' "$rc" "$mutated"
+    ) 2>/dev/null
+}
+assert_eq "a window held in one version dir blocks its sibling, which is where the one-click upgrade runs" \
+    "$(lock_sibling_probe "$LKROOT/pithead-v1.0.0" "$LKROOT/pithead-v2.0.0")" "75|untouched"
+# The control that makes the case above mean something: two dirs that are NOT a versioned deploy
+# keep their own locks, so the block is the deploy root talking and not merely "two directories".
+assert_eq "two unrelated stacks still lock independently" \
+    "$(lock_sibling_probe "$LKROOT/plain-a" "$LKROOT/plain-b")" "0|mutated"
+rm -f "$LKROOT/.pithead.lock" "$LKROOT/pithead-v1.0.0/.pithead.lock"
+DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKROOT/pithead-v1.0.0" stack_down >/dev/null 2>&1
+assert_eq "a versioned install keys its lock on the deploy root its siblings share" \
+    "$([ -f "$LKROOT/.pithead.lock" ] && echo present || echo absent)" "present"
+assert_eq "and leaves no second, uncontendable lock inside the version dir" \
+    "$([ -f "$LKROOT/pithead-v1.0.0/.pithead.lock" ] && echo present || echo absent)" "absent"
+
+# WIRING, verb by verb. Everything above proves the lock PRIMITIVE; these prove each verb is
+# actually attached to it. Every runtime case above drives stack_down, so six of the eight locked
+# verbs could stop acquiring — or stop releasing — with nothing going red.
+LKW="$SANDBOX/lockwiring"
+mkdir -p "$LKW/bin"
+make_stubs "$LKW/bin"
+cat >"$LKW/bin/sudo" <<'SUDOEOF'
+#!/usr/bin/env bash
+# restore's chown to the container uid cannot work unprivileged; everything else runs as the
+# test user, so the verb reaches its own window instead of aborting before it.
+[ "$1" = "chown" ] && exit 0
+exec "$@"
+SUDOEOF
+chmod +x "$LKW/bin/sudo"
+# A provisioned install, rebuildable — every verb driven below WRITES to it, and a used fixture
+# stops being a fixture. The hand-written .env is deliberately not what a render produces, so
+# `apply` sees a change and takes its committing branch rather than returning early.
+lock_wiring_fixture() { # <dir>
+    mkdir -p "$1/data/tor" "$1/data/dashboard"
+    cat >"$1/.env" <<'ENVEOF'
+MONERO_ONION_ADDRESS=mona.onion
+TARI_ONION_ADDRESS=taria.onion
+P2POOL_ONION_ADDRESS=p2pa.onion
+PROXY_AUTH_TOKEN=LKWTOKEN
+HOST_IP=box.lan
+DEPLOYMENT_COMPLETED=true
+COMPOSE_PROFILES=local_node
+ENVEOF
+    printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"%s"}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" "$VALID_TARI" >"$1/config.json"
+    printf 'CADDY-ORIG\n' >"$1/Caddyfile"
+    printf 'ONIONKEY-ORIG\n' >"$1/data/tor/hs_ed25519_secret_key"
+    printf 'DBDATA-ORIG\n' >"$1/data/dashboard/dashboard.db"
+}
+lock_wiring_fixture "$LKW"
+tar -czf "$LKW/wiring-archive.tar.gz" -C "$LKW" config.json
+LKWHELD="$LKW/held.lock"
+LKWFREE="$LKW/free.lock"
+# Which directory a pair runs in. `setup` needs an UNPROVISIONED one: the fixture above carries a
+# rendered .env, and setup refuses a non-interactive re-run before it reaches its window — so
+# driven there it would report "did not wait" for a reason that has nothing to do with the lock.
+LKWDIR="$LKW"
+LKWFRESH="$LKW/fresh"
+LKWBAL="$LKW/balance"
+mkdir -p "$LKWFRESH"
+
+lock_wiring_probe() { # <lock file> <fn> [args...] -> "<timedout|ran>+<mutated|untouched>"
+    local lk="$1" log="$LKW/wiring-docker.log" out t=ran m=untouched
+    shift
+    : >"$log"
+    out=$(cd "$LKWDIR" && PITHEAD_LOCK_FILE="$lk" PITHEAD_LOCK_TIMEOUT=1 PITHEAD_APPLIANCE=0 \
+        DOCKER_LOG="$log" PATH="$LKW/bin:$PATH" \
+        env -u PITHEAD_LOCK_HELD bash -c 'source "$1"; set +e; shift; "$@"' _ "$STACK" "$@" 2>&1)
+    case "$out" in *"waiting up to"*) t=timedout ;; esac
+    # Only the MUTATING compose calls: `backup` runs `compose ps` to decide whether the stack is
+    # up before it takes the window, and a read-only query is not a mutation.
+    grep -Eq 'compose (up|down|stop|create|restart)' "$log" 2>/dev/null && m=mutated
+    printf '%s+%s' "$t" "$m"
+}
+# The pair, per verb, in one assertion: refuses against a held window and touches nothing, and
+# gets PAST the lock when nothing holds it. The second half is the control — without it
+# "timed out" would also be true of a verb that cannot run in this fixture at all.
+lock_wiring_pair() { # <fn> [args...] -> "<held>|<free timed out?>"
+    local held free
+    held=$(lock_wiring_probe "$LKWHELD" "$@")
+    rm -f "$LKWFREE"
+    free=$(lock_wiring_probe "$LKWFREE" "$@")
+    rm -f "$LKWFREE"
+    printf '%s|%s' "$held" "${free%%+*}"
+}
+# One holder for all six pairs below. `flock -w`, not `flock -n`: the readiness poll under it
+# takes the lock itself to test for it, and a non-blocking holder that loses that race exits —
+# leaving every case below to pass against a lock nobody held. Bounded, so a genuinely stuck
+# fixture is reported by the guard below instead of hanging the suite.
+: >"$LKWHELD"
+(
+    exec 9>>"$LKWHELD"
+    flock -w 20 9 || exit 1
+    exec sleep 120
+) &
+LKWHOLDER=$!
+i=0
+while [ "$i" -lt 200 ]; do
+    flock -n "$LKWHELD" true 2>/dev/null || break
+    sleep 0.05
+    i=$((i + 1))
+done
+# The wiring cases are only evidence while this holds — say so rather than reporting six passes
+# earned by an absent holder.
+if flock -n "$LKWHELD" true 2>/dev/null; then
+    bad "the holder for the verb-wiring cases takes the window" "the lock is free, so the six cases below prove nothing"
+fi
+assert_eq "up waits on a held window and changes nothing" "$(lock_wiring_pair stack_up)" "timedout+untouched|ran"
+assert_eq "upgrade waits on a held window and changes nothing" "$(lock_wiring_pair stack_upgrade)" "timedout+untouched|ran"
+LKWDIR="$LKWFRESH"
+assert_eq "setup waits on a held window and changes nothing" "$(lock_wiring_pair setup)" "timedout+untouched|ran"
+LKWDIR="$LKW"
+assert_eq "restore waits on a held window and changes nothing" \
+    "$(lock_wiring_pair stack_restore -y "$LKW/wiring-archive.tar.gz")" "timedout+untouched|ran"
+assert_eq "backup waits on a held window and changes nothing" \
+    "$(lock_wiring_pair stack_backup -y --no-encrypt)" "timedout+untouched|ran"
+assert_eq "apply waits on a held window and changes nothing" "$(lock_wiring_pair apply -y)" "timedout+untouched|ran"
+kill "$LKWHOLDER" 2>/dev/null
+wait "$LKWHOLDER" 2>/dev/null
+
+# The other half of the wiring: a verb that finishes must hand the lock back exactly once. A
+# missing release leaves the window open for the rest of the process, and a DOUBLE acquire leaves
+# the depth counter at 1 with nothing left to decrement it — the failure the `apply` retry-branch
+# guard exists to prevent. Neither is visible from outside the process, because the kernel drops
+# the hold when it exits; both are visible from inside it.
+lock_wiring_balance() { # <fn> [args...] -> "depth=<n> state=<free|held>"
+    # On a FRESH fixture every time, and that is load-bearing rather than tidiness: a completed
+    # `apply` re-renders .env, so a second apply against the same dir finds nothing to change and
+    # returns before the retry-branch guard this case exists to protect. Re-using the dir left
+    # that guard unfalsifiable — the case passed either way, which reads exactly like coverage.
+    rm -rf "$LKWBAL"
+    lock_wiring_fixture "$LKWBAL"
+    rm -f "$LKWFREE"
+    (cd "$LKWBAL" && PITHEAD_LOCK_FILE="$LKWFREE" PITHEAD_APPLIANCE=0 DOCKER_LOG=/dev/null \
+        PATH="$LKW/bin:$PATH" env -u PITHEAD_LOCK_HELD \
+        bash -c 'source "$1"; set +e; shift; "$@" >/dev/null 2>&1
+                 st=free; flock -n "$PITHEAD_LOCK_FILE" true 2>/dev/null || st=held
+                 printf "depth=%s state=%s" "$_PITHEAD_LOCK_DEPTH" "$st"' _ "$STACK" "$@") 2>/dev/null
+}
+assert_eq "up gives its window back when it finishes" "$(lock_wiring_balance stack_up)" "depth=0 state=free"
+assert_eq "upgrade gives its window back when it finishes" "$(lock_wiring_balance stack_upgrade)" "depth=0 state=free"
+assert_eq "backup gives its window back when it finishes" \
+    "$(lock_wiring_balance stack_backup -y --no-encrypt)" "depth=0 state=free"
+assert_eq "restore gives its window back when it finishes" \
+    "$(lock_wiring_balance stack_restore -y "$LKW/wiring-archive.tar.gz")" "depth=0 state=free"
+assert_eq "apply takes its window once and gives it back, however it reached the recreate" \
+    "$(lock_wiring_balance apply -y)" "depth=0 state=free"
 unset -f lock_hold_bg lock_await_record lock_state lock_reinvoke_probe lock_nest_probe
+unset -f lock_sibling_probe lock_wiring_fixture lock_wiring_probe lock_wiring_pair lock_wiring_balance
+
+echo "== unit: the appliance boot leg tells lock contention from a bad slot (#1342) =="
+# pithead-boot's fail_boot reboots on the first failed boot so the bootloader falls back to the
+# other A/B slot, and on the second declares that the fault is not the slot. There is no systemd
+# ordering between pithead-firstboot and pithead-boot, so `./pithead up` here can collide with the
+# wizard's `setup` window — and a collision routed through fail_boot spends the one fallback the
+# box has on a slot that is fine, then misdiagnoses itself. Sourcing the boot script defines its
+# functions and runs none of it (its BASH_SOURCE guard), so this drives the real routing.
+BOOTC="$SANDBOX/bootcontend"
+mkdir -p "$BOOTC"
+boot_up_probe() { # <exit status from `pithead up`> -> "<counter>|<rebooted?>|<which message>"
+    local out verdict=other
+    rm -f "$BOOTC/.boot-gate-failures" "$BOOTC/rebooted"
+    # Both branches report on STDERR, so the redirect belongs to the subshell and INSIDE the
+    # capture: `$(...) 2>&1` sends it to the caller's stderr instead and leaves $out empty.
+    out=$( (
+        cd "$BOOTC" || exit 9
+        # shellcheck disable=SC1090
+        source "$ROOT/os/overlay/pithead-boot"
+        BOOT_FAIL_COUNT="$BOOTC/.boot-gate-failures"
+        PITHEAD_REBOOT_CMD="touch $BOOTC/rebooted"
+        boot_up_failed "$1"
+    ) 2>&1 )
+    # Each branch is read on the one sentence ONLY it writes, and the other's absence is asserted
+    # by the verdict being a single value: both messages mention the A/B fallback, so keying on
+    # that shared phrase would let either branch stand in for the other.
+    case "$out" in *"contention, NOT a bad slot"*) verdict=contended ;; esac
+    case "$out" in *"slot left uncommitted so"*) verdict="$verdict+slotfailure" ;; esac
+    printf '%s|%s|%s' \
+        "$(cat "$BOOTC/.boot-gate-failures" 2>/dev/null || echo none)" \
+        "$([ -f "$BOOTC/rebooted" ] && echo rebooted || echo no-reboot)" "$verdict"
+}
+assert_eq "a lock timeout spends no A/B fallback, is not counted, and says it is contention" \
+    "$(boot_up_probe 75)" "none|no-reboot|contended"
+assert_eq "any other failed up still reads as a bad slot and falls back" \
+    "$(boot_up_probe 1)" "1|rebooted|other+slotfailure"
+unset -f boot_up_probe

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -456,6 +456,13 @@ while [ "$i" -lt 200 ]; do
     sleep 0.05
     i=$((i + 1))
 done
+# A poll that gives up must say so. If this one exhausts, the external holder never took the
+# window: the two rc/message cases below would be reporting on an uncontended run, and the third
+# passes for the worst reason available — nothing was reported under ANY name, so "never under
+# the previous holder's name" is true of an empty string.
+if [ "$(lock_state)" != "held" ]; then
+    bad "the unrecorded holder takes the window" "the lock is free, so the three cases below prove nothing"
+fi
 out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
 rc=$?
 assert_rc "an unrecorded holder still blocks the window" "$rc" "75"
@@ -485,6 +492,11 @@ while [ "$i" -lt 200 ]; do
     sleep 0.05
     i=$((i + 1))
 done
+# Same shape. If the waiter never announced, the kill below frees the window before anything was
+# blocked on it, and the three cases become a report on a verb that never contended at all.
+if ! grep -q "waiting up to" "$LKWOUT" 2>/dev/null; then
+    bad "the waiter reaches the held window before the holder is killed" "no announcement, so the three cases below prove nothing"
+fi
 kill "$LKHOLDER" 2>/dev/null
 wait "$LKHOLDER" 2>/dev/null
 wait "$LKWAITER" 2>/dev/null
@@ -665,7 +677,11 @@ SUDOEOF
 chmod +x "$LKW/bin/sudo"
 # A provisioned install, rebuildable — every verb driven below WRITES to it, and a used fixture
 # stops being a fixture. The hand-written .env is deliberately not what a render produces, so
-# `apply` sees a change and takes its committing branch rather than returning early.
+# `apply` sees a change and takes its committing branch rather than returning early — but that
+# holds only on a directory no verb has run in yet. The free half of each pair below re-renders
+# this .env, so by the time `apply` is probed on the shared fixture there is nothing left to
+# change. That is why the committing branch is driven on its own fixture, here and in
+# lock_wiring_balance.
 lock_wiring_fixture() { # <dir>
     mkdir -p "$1/data/tor" "$1/data/dashboard"
     cat >"$1/.env" <<'ENVEOF'
@@ -691,6 +707,7 @@ LKWFREE="$LKW/free.lock"
 # driven there it would report "did not wait" for a reason that has nothing to do with the lock.
 LKWDIR="$LKW"
 LKWFRESH="$LKW/fresh"
+LKWAPPLY="$LKW/applying"
 LKWBAL="$LKW/balance"
 mkdir -p "$LKWFRESH"
 
@@ -749,7 +766,21 @@ assert_eq "restore waits on a held window and changes nothing" \
     "$(lock_wiring_pair stack_restore -y "$LKW/wiring-archive.tar.gz")" "timedout+untouched|ran"
 assert_eq "backup waits on a held window and changes nothing" \
     "$(lock_wiring_pair stack_backup -y --no-encrypt)" "timedout+untouched|ran"
-assert_eq "apply waits on a held window and changes nothing" "$(lock_wiring_pair apply -y)" "timedout+untouched|ran"
+# apply takes the window in THREE places and the shared fixture reaches exactly one of them:
+# five free-runs have re-rendered its .env by now, so apply finds nothing to change and returns
+# on the no-change branch. Drive all three, each on the fixture it needs. Until this split,
+# DELETING either of the other two acquires outright left this whole file green.
+assert_eq "apply waits on a held window when it has nothing to change" "$(lock_wiring_pair apply -y)" "timedout+untouched|ran"
+lock_wiring_fixture "$LKWAPPLY"
+LKWDIR="$LKWAPPLY"
+assert_eq "apply waits on a held window before it commits a change" "$(lock_wiring_pair apply -y)" "timedout+untouched|ran"
+# The third window is the retry branch — a previous apply committed the config and then failed to
+# recreate. That state is what this fixture is in now (the free run above re-rendered its .env),
+# so arming the marker is the whole setup. Nothing else in this file reaches that acquire:
+# deleting it leaves every other case green, which is how it stayed unguarded until now.
+: >"$LKWAPPLY/.env.apply-incomplete"
+assert_eq "apply waits on a held window while it retries a failed recreate" "$(lock_wiring_pair apply -y)" "timedout+untouched|ran"
+LKWDIR="$LKW"
 kill "$LKWHOLDER" 2>/dev/null
 wait "$LKWHOLDER" 2>/dev/null
 

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -709,6 +709,7 @@ LKWDIR="$LKW"
 LKWFRESH="$LKW/fresh"
 LKWAPPLY="$LKW/applying"
 LKWBAL="$LKW/balance"
+LKWSETUP="$LKW/setupprompt"
 mkdir -p "$LKWFRESH"
 
 lock_wiring_probe() { # <lock file> <fn> [args...] -> "<timedout|ran>+<mutated|untouched>"
@@ -811,6 +812,55 @@ assert_eq "restore gives its window back when it finishes" \
     "$(lock_wiring_balance stack_restore -y "$LKW/wiring-archive.tar.gz")" "depth=0 state=free"
 assert_eq "apply takes its window once and gives it back, however it reached the recreate" \
     "$(lock_wiring_balance apply -y)" "depth=0 state=free"
+# restart is the sixth verb with a window and the only one the block above did not name. Nothing
+# else in this file reaches its release either: the four restart cases at the top of the file
+# assert what it restarted, not what it did with the lock, so deleting stack_restart's
+# `mutation_lock_release` left every case in this file green.
+assert_eq "restart gives its window back when it finishes" \
+    "$(lock_wiring_balance stack_restart)" "depth=0 state=free"
+
+# SETUP'S RELEASE — its own probe, because a balance case cannot reach it.
+#
+# setup's release is not at the end of the verb. It sits BEFORE the interactive "start now?",
+# and setup's own comment says why: everything below it is a message or a human wait, and the
+# firstboot wizard runs `(setup)` in a subshell, so a hold spanning the prompt would park the
+# window on an absent operator while pithead-boot's `up` timed out against it. The property is
+# therefore an ORDERING — released BEFORE the wait — which an end-state balance cannot see.
+#
+# Nor can a balance case be driven here at all: setup refuses a non-interactive re-run against a
+# provisioned dir before it ever reaches its window (which is why the pair case above needs the
+# fresh dir), and against a fresh one it would run the entire wizard. So the probe stubs the
+# provisioning body — every step between the acquire and the release — and leaves the LOCK
+# WIRING real, which is the only thing under test. prompt_start_stack becomes the probe itself,
+# reporting whether the window was free at the instant setup reached the human wait.
+#
+# REACHING the probe is the anti-vacuity control: if the stubs ever stop letting setup through,
+# nothing prints and the assertion fails on an empty string instead of passing on a run that
+# never got there. The end-state half is read too, so a release that moved rather than vanished
+# still shows up.
+lock_wiring_setup_prompt() { # -> "at-prompt=<free|held> depth=<n> state=<free|held>"
+    rm -rf "$LKWSETUP"
+    mkdir -p "$LKWSETUP"
+    rm -f "$LKWFREE"
+    (cd "$LKWSETUP" && PITHEAD_LOCK_FILE="$LKWFREE" PITHEAD_APPLIANCE=0 DOCKER_LOG=/dev/null \
+        PATH="$LKW/bin:$PATH" env -u PITHEAD_LOCK_HELD \
+        bash -c 'source "$1"; set +e
+            for f in check_prerequisites ensure_config_exists ensure_onion_password \
+                parse_and_validate_config preflight_resources check_stratum_exposure \
+                load_preserved_state resolve_dashboard_host prepare_directories render_env \
+                provision_tor inject_service_configs optimize_kernel generate_caddyfile \
+                provision_control_runner render_local_miner_config update_current_symlink \
+                provision_local_miner; do eval "$f() { :; }"; done
+            prompt_start_stack() {
+                st=free; flock -n "$PITHEAD_LOCK_FILE" true 2>/dev/null || st=held
+                printf "at-prompt=%s " "$st" >&3
+            }
+            setup >/dev/null 2>&1
+            st=free; flock -n "$PITHEAD_LOCK_FILE" true 2>/dev/null || st=held
+            printf "depth=%s state=%s" "$_PITHEAD_LOCK_DEPTH" "$st" >&3' _ "$STACK" 3>&1) 2>/dev/null
+}
+assert_eq "setup hands its window back BEFORE the interactive start prompt" \
+    "$(lock_wiring_setup_prompt)" "at-prompt=free depth=0 state=free"
 
 # THE RUNNING-STACK BACKUP BRANCH — unreachable by every case above, and that is the point.
 #

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -852,3 +852,40 @@ assert_eq "a lock timeout spends no A/B fallback, is not counted, and says it is
 assert_eq "any other failed up still reads as a bad slot and falls back" \
     "$(boot_up_probe 1)" "1|rebooted|other+slotfailure"
 unset -f boot_up_probe
+
+# THE WIZARD'S HALF OF THE SAME ROUTING — the leg #1342 left unrouted, recreating #1059's shape.
+#
+# The block above proves the BOOT leg tells contention from a bad slot. `setup` runs inside a
+# mutating window too and can lose the same race, but every non-zero (setup) was routed as a
+# provisioning failure: the operator is told their configuration is wrong and asked to correct it,
+# on a first boot where there is no shell to contradict it. Worse, that path calls
+# wizard_keep_failed_config, which REMOVES config.json when the machine-role marker never landed —
+# and record_machine_role is best-effort (`printf ... || true`).
+#
+# THE FIXTURE IS CHOSEN TO MAKE THE REMOVAL REACHABLE: config.json present, machine-role ABSENT.
+# With the marker present nothing is removed on either branch, both rows would read "kept", and
+# this pair could not fail for any change to the routing.
+WIZC="$SANDBOX/wizcontend"
+wizard_fail_probe() { # <exit status of setup> -> "<config>|<copy>|<verdict>|<rc>"
+    local out rc=0 verdict=other
+    rm -rf "$WIZC"
+    mkdir -p "$WIZC"
+    printf '{"monero":{}}\n' >"$WIZC/config.json"
+    out=$(run_sourced "$WIZC" wizard_setup_failed "$1" 2>&1) || rc=$?
+    # Keyed on a sentence ONLY one branch writes, for the reason the boot probe above gives: both
+    # branches mention reopening the setup window, so that shared phrase would let either stand in
+    # for the other.
+    case "$out" in *"contention, NOT a problem with the configuration"*) verdict=contended ;; esac
+    case "$out" in *"so it can be corrected"*) verdict="$verdict+badconfig" ;; esac
+    printf '%s|%s|%s|%s' \
+        "$([ -f "$WIZC/config.json" ] && echo kept || echo DELETED)" \
+        "$([ -f "$WIZC/config.json.failed" ] && echo copied || echo no-copy)" \
+        "$verdict" "$rc"
+}
+# rc is the prefill signal: 0 means a config.json.failed copy was kept and the reopened page fills
+# from it, 1 means the live config.json is what the operator gets back.
+assert_eq "a lock-timeout setup keeps the operator's configuration and names it as contention" \
+    "$(wizard_fail_probe 75)" "kept|no-copy|contended|1"
+assert_eq "any other failed setup still copies the config aside and asks for a correction" \
+    "$(wizard_fail_probe 1)" "DELETED|copied|other+badconfig|0"
+unset -f wizard_fail_probe

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -811,6 +811,72 @@ assert_eq "restore gives its window back when it finishes" \
     "$(lock_wiring_balance stack_restore -y "$LKW/wiring-archive.tar.gz")" "depth=0 state=free"
 assert_eq "apply takes its window once and gives it back, however it reached the recreate" \
     "$(lock_wiring_balance apply -y)" "depth=0 state=free"
+
+# THE RUNNING-STACK BACKUP BRANCH — unreachable by every case above, and that is the point.
+#
+# stack_backup takes the window in TWO places, chosen on `docker compose ps --status running -q`.
+# make_stubs' docker (tests/stack/lib.sh) has NO case arm for that query and falls through to
+# `exit 0` with empty stdout, so `running` is always empty and BOTH backup cases above take the
+# stack-already-stopped branch. Deleting the running branch's acquire outright left this whole
+# file green — the same shape as apply's two unreached windows, and it hides more: without it the
+# archive is taken in a THIRD window rather than one, with `tar` running UNLOCKED between
+# stack_down's release and stack_up's re-acquire. A concurrent setup or apply can then bring
+# containers up mid-archive, which is a torn backup — #970's retry failure mode arriving for a
+# reason the retry cannot fix.
+#
+# A balance case CANNOT see this: with or without that acquire the verb ends depth=0 and free. The
+# property that discriminates is WHEN the window is held, so the probe asks the only question that
+# separates them — was it held at the moment the archive was taken?
+LKWRUN="$LKW/runningstack"
+LKWRUNLK="$LKW/running.lock"
+lock_backup_running_probe() { # -> "<which branch>|<window while the archive is taken>"
+    local log="$LKWRUN/docker.log" branch=stopped
+    rm -rf "$LKWRUN"
+    lock_wiring_fixture "$LKWRUN"
+    mkdir -p "$LKWRUN/bin"
+    : >"$log"
+    rm -f "$LKWRUNLK" "$LKWRUN/window"
+    # A docker that reports a RUNNING stack — the one answer the shared stub cannot give.
+    cat >"$LKWRUN/bin/docker" <<'DOCKEREOF'
+#!/usr/bin/env bash
+echo "[docker] $*" >>"${DOCKER_LOG:-/dev/null}"
+case "$*" in
+"compose ps --status running -q") echo "c0ffeec0ffee" ;;
+esac
+exit 0
+DOCKEREOF
+    # A sudo that runs nothing and records whether the mutation window is held at the instant the
+    # archive is taken. `flock -n` from this child opens its OWN descriptor, so the parent's fd 9
+    # hold denies it — the same mechanism the balance cases use to read the lock's state.
+    cat >"$LKWRUN/bin/sudo" <<'SUDOEOF'
+#!/usr/bin/env bash
+case "$1" in
+tar)
+    if flock -n "$PITHEAD_LOCK_FILE" true 2>/dev/null; then
+        printf 'free' >"$WINDOW_OUT"
+    else
+        printf 'held' >"$WINDOW_OUT"
+    fi
+    ;;
+esac
+exit 0
+SUDOEOF
+    chmod +x "$LKWRUN/bin/docker" "$LKWRUN/bin/sudo"
+    (cd "$LKWRUN" && PITHEAD_LOCK_FILE="$LKWRUNLK" PITHEAD_APPLIANCE=0 DOCKER_LOG="$log" \
+        WINDOW_OUT="$LKWRUN/window" PATH="$LKWRUN/bin:$PATH" env -u PITHEAD_LOCK_HELD \
+        bash -c 'source "$1"; set +e; shift; "$@"' _ "$STACK" \
+        stack_backup -y --no-encrypt) >/dev/null 2>&1
+    # Which branch actually ran, read from the stack having been STOPPED for the backup. Without
+    # this half the row is vacuous in exactly the way it exists to fix: if the stub ever stops
+    # answering the query, the stopped branch takes its own window, the archive is still taken
+    # under it, and a "held" verdict would read as coverage of a branch that never ran.
+    grep -Eq 'compose .*\bdown\b' "$log" 2>/dev/null && branch=running
+    printf '%s|%s' "$branch" "$(cat "$LKWRUN/window" 2>/dev/null || printf 'never-archived')"
+}
+assert_eq "a backup that stops a running stack holds one window across the archive" \
+    "$(lock_backup_running_probe)" "running|held"
+unset -f lock_backup_running_probe
+
 unset -f lock_hold_bg lock_await_record lock_state lock_reinvoke_probe lock_nest_probe
 unset -f lock_sibling_probe lock_wiring_fixture lock_wiring_probe lock_wiring_pair lock_wiring_balance
 

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -439,8 +439,27 @@ rc=$?
 assert_rc "a window that completed is available to the next verb" "$rc" "0"
 assert_eq "release clears the record, so nothing can name a holder that has gone" "$(cat "$LKFILE")" ""
 
-# A holder that is not pithead (an operator's own flock, a future caller) writes no record. The
-# waiter must say so rather than print a stale name it happens to find.
+# Arm the STALE-RECORD fixture the three cases below need, and note why they need it: with the
+# lock file empty, `verb=backup` exists nowhere on disk and "never reported under the previous
+# holder's name" is true of an empty string — an assertion that cannot fail for any change to
+# pithead. So leave the record a real holder leaves when it is killed inside its window: the
+# kernel drops the flock with the descriptor, and nothing clears the line. That is what an
+# operator's Ctrl-C, and `error()` inside a window, both leave behind.
+#
+# The pair that discriminates is this stanza against the LIVE-holder case above: there the same
+# record must be named in full (`verb=backup`), here the same bytes must not be, because the pid
+# they name has gone. Suppressing every name would fail the first; echoing the file back would
+# fail the second.
+lock_hold_bg
+lock_await_record || bad "the killed holder for the stale-record cases records itself" "no record"
+kill "$LKHOLDER" 2>/dev/null
+wait "$LKHOLDER" 2>/dev/null
+assert_contains "a holder killed inside its window leaves its record on disk" "$(cat "$LKFILE")" "verb=backup"
+assert_eq "while the kernel has already given the window itself back" "$(lock_state)" "free"
+
+# A holder that is not pithead (an operator's own flock, a future caller) writes no record, and
+# the record it finds on disk is the dead one armed above. The waiter must say so rather than
+# print a stale name it happens to find.
 # `flock -n FILE sleep 60 &` would NOT do: flock forks, so killing $! orphans a sleep that still
 # holds the inherited descriptor for the full 60s and blocks every case after this one. Open the
 # descriptor here and `exec` the sleep onto it instead, so the holder is one killable process.

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -801,10 +801,12 @@ boot_up_probe() { # <exit status from `pithead up`> -> "<counter>|<rebooted?>|<w
         cd "$BOOTC" || exit 9
         # shellcheck disable=SC1090
         source "$ROOT/os/overlay/pithead-boot"
+        # shellcheck disable=SC2034  # both are read by the sourced boot script, not by this shell
         BOOT_FAIL_COUNT="$BOOTC/.boot-gate-failures"
+        # shellcheck disable=SC2034
         PITHEAD_REBOOT_CMD="touch $BOOTC/rebooted"
         boot_up_failed "$1"
-    ) 2>&1 )
+    ) 2>&1)
     # Each branch is read on the one sentence ONLY it writes, and the other's absence is asserted
     # by the verdict being a single value: both messages mention the A/B fallback, so keying on
     # that shared phrase would let either branch stand in for the other.

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -383,6 +383,12 @@ LKLOG="$LKDIR/docker.log"
 # Take the window in a background process and sit in it. `exec sleep` so the holder is ONE
 # process: a forked sleep would inherit fd 9 and keep the lock alive past the kill below.
 lock_hold_bg() { # -> sets LKHOLDER
+    # Clear the record BEFORE starting, so `lock_await_record` below can only be satisfied by the
+    # holder this call starts. Without it a record left by an earlier holder — a stale one is a
+    # fixture in this file, and abnormal exits leave them in the field — satisfies the poll
+    # instantly, the caller proceeds believing the window is held, and every case that needs
+    # contention silently reports on an uncontended run instead.
+    : >"$LKFILE"
     (
         cd "$LKDIR" || exit 9
         export PITHEAD_LOCK_FILE="$LKFILE"

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -365,3 +365,234 @@ apply_noop_steps() {
 assert_eq "a no-change apply still converges the control units, and recreates nothing" \
     "$(apply_noop_steps)" "provision,"
 unset apply_noop_steps
+
+echo "== unit: the mutation lock serialises mutating windows (#1342) =="
+# #1342: nothing in pithead excluded two mutating runs from each other, so a concurrent `backup`
+# — which stops the stack — could delete a container out from under a still-running `setup`. The
+# lock is scoped to mutating WINDOWS rather than whole verbs, because a wizard waiting on an
+# operator (TimeoutStartSec=infinity) holding a whole-verb lock would block the boot unit forever.
+# These cases prove the window refuses, names WHO holds it, gives it back, survives a
+# re-invocation of pithead inside a hold, and counts nesting correctly.
+LKDIR="$SANDBOX/lock"
+mkdir -p "$LKDIR"
+LKBIN="$SANDBOX/lockbin"
+make_stubs "$LKBIN"
+LKFILE="$LKDIR/explicit.lock"
+LKLOG="$LKDIR/docker.log"
+
+# Take the window in a background process and sit in it. `exec sleep` so the holder is ONE
+# process: a forked sleep would inherit fd 9 and keep the lock alive past the kill below.
+lock_hold_bg() { # -> sets LKHOLDER
+    (
+        cd "$LKDIR" || exit 9
+        export PITHEAD_LOCK_FILE="$LKFILE"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        mutation_lock_acquire backup
+        exec sleep 60
+    ) >/dev/null 2>&1 &
+    LKHOLDER=$!
+}
+# Poll for the holder record rather than sleeping a guessed interval — a sleep long enough to be
+# reliable is long enough to slow the suite, and a short one is a flake waiting to happen.
+lock_await_record() {
+    local i=0
+    while [ "$i" -lt 200 ]; do
+        [ -s "$LKFILE" ] && return 0
+        sleep 0.05
+        i=$((i + 1))
+    done
+    return 1
+}
+# An external probe run as a CHILD opens its own descriptor, so it conflicts with a hold taken in
+# any process — including this one. That is what makes it usable as a same-process probe.
+lock_state() { if flock -n "$LKFILE" true 2>/dev/null; then echo free; else echo held; fi; }
+
+lock_hold_bg
+assert_rc "the holder records itself so a waiter can name it" "$(lock_await_record && echo 0 || echo 1)" "0"
+
+: >"$LKLOG"
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
+rc=$?
+assert_rc "a mutating verb refuses rather than interleaving with a held window" "$rc" "1"
+# `verb=backup` is the discriminator for opening the lock file with `9>>` and not `9>`: `9>`
+# truncates at OPEN time, before the flock, which would wipe the record this waiter just read.
+assert_contains "the refusal names the verb holding the window" "$out" "verb=backup"
+# Only that the wait is ANNOUNCED — this message is printed before the blocking flock, so it
+# cannot show that any waiting happened. The release-during-wait case below proves that part.
+assert_contains "the waiter announces the wait before blocking" "$out" "waiting up to 1s"
+assert_contains "the refusal states that nothing was changed" "$out" "nothing was changed"
+assert_eq "a refused window touches no container" "$(cat "$LKLOG")" ""
+
+# The lock lives on the descriptor, so the kernel releases it when the holder dies — no stale
+# lock file to clean up by hand, which is why `error()` (an exit) is safe inside a window.
+kill "$LKHOLDER" 2>/dev/null
+wait "$LKHOLDER" 2>/dev/null
+: >"$LKLOG"
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
+rc=$?
+assert_rc "the kernel gives the window back when the holder dies" "$rc" "0"
+assert_contains "the freed window actually runs the mutation it was holding back" "$(cat "$LKLOG")" "compose down"
+: >"$LKLOG"
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
+rc=$?
+assert_rc "a window that completed is available to the next verb" "$rc" "0"
+assert_eq "release clears the record, so nothing can name a holder that has gone" "$(cat "$LKFILE")" ""
+
+# A holder that is not pithead (an operator's own flock, a future caller) writes no record. The
+# waiter must say so rather than print a stale name it happens to find.
+# `flock -n FILE sleep 60 &` would NOT do: flock forks, so killing $! orphans a sleep that still
+# holds the inherited descriptor for the full 60s and blocks every case after this one. Open the
+# descriptor here and `exec` the sleep onto it instead, so the holder is one killable process.
+(
+    exec 9>>"$LKFILE"
+    flock -n 9 || exit 1
+    exec sleep 60
+) &
+LKEXT=$!
+i=0
+while [ "$i" -lt 200 ]; do
+    [ "$(lock_state)" = "held" ] && break
+    sleep 0.05
+    i=$((i + 1))
+done
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down 2>&1)"
+rc=$?
+assert_rc "an unrecorded holder still blocks the window" "$rc" "1"
+assert_contains "an unrecorded holder is reported as unrecorded" "$out" "holder unrecorded"
+assert_not_contains "and is never reported under the previous holder's name" "$out" "verb=backup"
+kill "$LKEXT" 2>/dev/null
+wait "$LKEXT" 2>/dev/null
+
+# A blocked waiter must actually WAIT and then proceed — not print that it is waiting and refuse.
+# Driven by releasing the lock underneath a waiter that is already blocked, rather than by timing:
+# start the waiter, poll until it has announced the wait, then kill the holder and read its result.
+# The pair is what discriminates. "Announced the wait" alone would also be true of a build that
+# refuses on contact; rc=0 alone would also be true of a lock that was never taken.
+: >"$LKLOG"
+LKWOUT="$LKDIR/waiter.out"
+: >"$LKWOUT"
+lock_hold_bg
+lock_await_record || bad "the holder for the release-during-wait case records itself" "no record"
+(
+    PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=30 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down >"$LKWOUT" 2>&1
+    echo "rc=$?" >>"$LKWOUT"
+) &
+LKWAITER=$!
+i=0
+while [ "$i" -lt 200 ]; do
+    grep -q "waiting up to" "$LKWOUT" 2>/dev/null && break
+    sleep 0.05
+    i=$((i + 1))
+done
+kill "$LKHOLDER" 2>/dev/null
+wait "$LKHOLDER" 2>/dev/null
+wait "$LKWAITER" 2>/dev/null
+assert_contains "a contending verb blocks rather than refusing on contact" "$(cat "$LKWOUT")" "waiting up to"
+assert_contains "and proceeds once the holder leaves, instead of timing out" "$(cat "$LKWOUT")" "rc=0"
+assert_contains "the mutation it was waiting to make then actually runs" "$(cat "$LKLOG")" "compose down"
+
+# The re-invocation pair, and it is the load-bearing case. pithead re-invokes ITSELF for mutating
+# verbs (run_chain, control_lifecycle's `"$self" restart`, control_backup's `"$self" backup -y`),
+# so a lock that only knew about descriptors would deadlock a parent against its own child. fd 9
+# is inherited across exec, but a child that opens its OWN descriptor on the same file blocks —
+# which is why the marker is EXPORTED rather than merely set. Stripping the marker is therefore
+# the mutation that proves the marker is what carries the hold across the re-invocation.
+lock_reinvoke_probe() { # <1=keep the inherited marker|0=strip it> -> "<child rc>|<docker>|<parent>"
+    local keep="$1" clog="$LKDIR/child.log"
+    : >"$clog"
+    (
+        cd "$LKDIR" || exit 9
+        export PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1
+        export PATH="$LKBIN:$PATH" DOCKER_LOG="$clog"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        # pithead:14 is `set -Eeuo pipefail`, and sourcing it turns errexit on HERE — which would
+        # kill this subshell at the deliberately-failing child below. run_sourced does the same.
+        set +e
+        mutation_lock_acquire backup
+        local crc st=free called=untouched
+        # Take the child's exit status from the child itself, not from an `echo "$?"` inside it:
+        # the refusal path is error(), which exits, so any trailing echo never runs and would
+        # report an empty status for the very case this asserts.
+        case "$keep" in
+        1) bash -c 'source "$1"; stack_down' _ "$STACK" >/dev/null 2>&1 ;;
+        0) env -u PITHEAD_LOCK_HELD bash -c 'source "$1"; stack_down' _ "$STACK" >/dev/null 2>&1 ;;
+        # Two sequential windows in one re-invoked child. This is what the not-owner guard in
+        # mutation_lock_release is for: without it the FIRST release closes the inherited
+        # descriptor and drops the marker, so the child's SECOND window opens a descriptor of its
+        # own and deadlocks against the parent that invoked it.
+        2) bash -c 'source "$1"; set +e
+               mutation_lock_acquire down && mutation_lock_release
+               mutation_lock_acquire down && mutation_lock_release' _ "$STACK" >/dev/null 2>&1 ;;
+        esac
+        crc=$?
+        flock -n "$LKFILE" true 2>/dev/null || st=held
+        [ -s "$clog" ] && called=called
+        # An inherited hold belongs to the ancestor, so the child's release must leave the record
+        # alone. Clearing it would leave the parent holding a window that the next waiter can only
+        # describe as "unrecorded" — the lock still correct, the diagnosis silently lost.
+        local rec recstate=other
+        rec=$(head -n 1 "$LKFILE" 2>/dev/null)
+        case "$rec" in
+        *verb=backup*) recstate=intact ;;
+        "") recstate=cleared ;;
+        esac
+        printf '%s|%s|%s|%s\n' "$crc" "$called" "$st" "$recstate"
+    ) 2>/dev/null
+}
+assert_eq "a re-invoked pithead inside a held window proceeds on the inherited marker" \
+    "$(lock_reinvoke_probe 1)" "0|called|held|intact"
+assert_eq "without the marker that same child blocks on its own parent and changes nothing" \
+    "$(lock_reinvoke_probe 0)" "1|untouched|held|intact"
+assert_eq "a re-invoked child can open a second window without deadlocking on its parent" \
+    "$(lock_reinvoke_probe 2)" "0|untouched|held|intact"
+
+# Nesting: an inner window (backup -> down) must not hand the lock back when IT finishes, only
+# when the outermost one does. This is what the depth counter is for; without it the first
+# release inside a backup would free the stack mid-archive.
+lock_nest_probe() { # <releases> -> free|held
+    (
+        cd "$LKDIR" || exit 9
+        export PITHEAD_LOCK_FILE="$LKFILE"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e # sourcing pithead turns errexit on here (pithead:14)
+        mutation_lock_acquire backup
+        mutation_lock_acquire down
+        local i=0
+        while [ "$i" -lt "$1" ]; do
+            mutation_lock_release
+            i=$((i + 1))
+        done
+        if flock -n "$LKFILE" true 2>/dev/null; then echo free; else echo held; fi
+    ) 2>/dev/null
+}
+assert_eq "an inner window closing does not release the outer one" "$(lock_nest_probe 1)" "held"
+assert_eq "the outermost release is the one that gives the lock back" "$(lock_nest_probe 2)" "free"
+
+# A bad argument must be rejected AT ONCE, not after waiting out someone else's window. Validating
+# inside the hold made `restart typo` sit for PITHEAD_LOCK_TIMEOUT seconds only to report a typo.
+lock_hold_bg
+assert_rc "the holder for the restart cases records itself" "$(lock_await_record && echo 0 || echo 1)" "0"
+: >"$LKLOG"
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_restart bogus 2>&1)"
+rc=$?
+assert_rc "a bad restart argument is still rejected while the lock is held" "$rc" "1"
+assert_contains "the rejection names the contract" "$out" "takes no argument, 'tor'"
+assert_not_contains "a bad argument never waits out another operation's window" "$out" "waiting up to"
+assert_eq "and it touches no container" "$(cat "$LKLOG")" ""
+# Control for the assertion above: without this, "no waiting message" would also be true of a lock
+# that was never held, and the case would pass for a reason unrelated to the guard.
+out="$(PITHEAD_LOCK_FILE="$LKFILE" PITHEAD_LOCK_TIMEOUT=1 DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_restart 2>&1)"
+assert_contains "while a VALID restart against the same held window does wait" "$out" "waiting up to"
+kill "$LKHOLDER" 2>/dev/null
+wait "$LKHOLDER" 2>/dev/null
+
+# The shipped default: no PITHEAD_LOCK_FILE, so the lock is .pithead.lock in the stack directory
+# (pithead cd's to its own directory when executed, so that path is stable across invocations).
+rm -f "$LKDIR/.pithead.lock"
+DOCKER_LOG="$LKLOG" PATH="$LKBIN:$PATH" run_sourced "$LKDIR" stack_down >/dev/null 2>&1
+assert_eq "the lock defaults to .pithead.lock in the stack directory" \
+    "$([ -f "$LKDIR/.pithead.lock" ] && echo present || echo absent)" "present"
+unset -f lock_hold_bg lock_await_record lock_state lock_reinvoke_probe lock_nest_probe


### PR DESCRIPTION
Closes the mutual-exclusion gap in #1342: nothing in `pithead` excluded two mutating runs from
each other. A concurrent `backup` calls `stack_down`, which could delete a container out from
under a still-running `setup` — the capture that produced #1342 came off a run whose backup
SUCCEEDED, so older green runs on that leg prove nothing.

## What this does

`mutation_lock_acquire <verb>` / `mutation_lock_release`: `flock` on fd 9 at
`${PITHEAD_LOCK_FILE:-$PWD/.pithead.lock}`, `PITHEAD_LOCK_TIMEOUT` default 300s. Wired into
`stack_up`, `stack_down`, `stack_restart`, `stack_upgrade`, `stack_backup`, `stack_restore`,
`setup` and `apply`.

Scoped to mutating WINDOWS, not whole verbs. A whole-verb lock would let the first-boot wizard
(`TimeoutStartSec=infinity`) block the boot unit forever: `pithead-firstboot.service` and
`pithead-boot.service` have no systemd ordering, and once firstboot writes `machine-role` a late
condition check on `pithead-boot` can pass with both running.

## Design decisions a reviewer would otherwise have to ask about

1. **`setup` takes the lock itself**, so the wizard's `(setup)` subshell holds it with no change
   to `firstboot_wizard`. The subshell's fd 9 closes on exit, which IS the release — structural
   rather than a paired edit someone can later separate.
2. **`setup` releases at "Deployment preparation complete!"**, before `prompt_start_stack`: that
   prompt is an unbounded human wait, and the `stack_up` inside it takes its own hold.
3. **`stack_restart` is locked**, which was not in the design posted on the issue. Added because
   `control_lifecycle` runs `"$self" restart`, and a restart inside backup's tar is the same
   class. Disclosed as an addition — veto it if you disagree.
4. **`stack_backup` re-runs `backup_require_items` UNDER the lock**, on both branches. The
   original check runs before the passphrase and stop-the-stack prompts, and #1342's whole point
   is that a precondition checked outside mutual exclusion can be false by the time it is used.
   Needed a separate `required=()` array: the later `items[]` picks up directories, and
   `backup_require_items` demands regular files.
5. **`stack_restart` now validates its argument BEFORE taking the lock.** This is a regression my
   own first pass introduced and I caught reviewing it: validating inside the window made
   `pithead restart <typo>` wait out someone else's backup — up to 300s — only to report a typo.
   Measured at 37ms after the fix, against a held lock.

## Re-entrancy needs two mechanisms

`pithead` DOES re-invoke itself for mutating verbs — `run_chain`, `control_lifecycle`'s
`"$self" restart`, `control_backup`'s `"$self" backup -y` — so a dispatch-level lock would
self-deadlock. Handled with a shell depth counter within one process AND an EXPORTED
`PITHEAD_LOCK_HELD` marker across a re-invocation: fd 9 is inherited across `exec`, but a child
that opens its OWN descriptor on the same file blocks on its parent.

**No CURRENT call path puts a re-invocation inside a hold** — verified by censusing every
`mutation_lock_acquire` call site; none of the re-invoking functions is itself inside a window.
The marker is defensive, and the tests prove the mechanism rather than a live path.

## Behaviour change to the boot path — stated rather than left to be found

`pithead-boot.service` carries `TimeoutStartSec=infinity` and `os/overlay/pithead-boot` calls
`./pithead up` at `:243`/`:245`. A boot that races a provisioning run now waits and then
`fail_boot`s, rather than bringing a second stack up underneath it. That is correct, and it is a
change to the boot path.

## Tests — 28 tier-1 assertions in `tests/stack/test-lifecycle.sh`

Placement agreed with the `tests` lane. **Superseded below:** the file now carries a tsv row and
ends at 957 lines after F1 — see "Rebased, and a file-budget note" and its closes-the-file warning. Run with
`bash tests/stack/run.sh`.

Covered: refusal under contention naming the holding verb; the announced wait; "nothing was
changed"; a refused window touching no container; kernel release on holder death; reuse after a
completed window; the record cleared on release; an unrecorded holder reported as unrecorded and
never under a stale name; the re-invocation pair both ways; a re-invoked child opening a second
window without deadlocking; nesting depth; the argument-validation ordering; and the default
lock path.

**Every guard was mutated and each mutant dies.** 11 single-site mutations of `pithead`, 11
killed, 0 survivors:

| Mutation | Killed by |
|---|---|
| `stack_down` never acquires | 11 assertions |
| `9>` instead of `9>>` (truncate at open) | the refusal names the holding verb |
| no "unrecorded" fallback | an unrecorded holder is reported as unrecorded |
| marker set but not exported | the inherited-marker case |
| acquire ignores the inherited marker | the inherited-marker case |
| depth never counts past one | an inner window closing does not release the outer |
| release does not clear the record | record-cleared + unrecorded-holder |
| release ignores the not-owner guard | the second-window deadlock case |
| refusal drops "nothing was changed" | that assertion |
| restart validates inside the lock again | the ordering pair |
| refuse on contact instead of waiting | the release-during-wait pair |

**Two mutants survived the first pass and both were untested behaviour, not redundant
assertions** — recorded because the distinction is the one this project keeps getting wrong:

- The not-owner guard in `mutation_lock_release`: its record-clearing branch is unreachable
  (`_PITHEAD_LOCK_PATH` is never set on the inherited path), so what it actually prevents is a
  re-invoked child DEADLOCKING on its own parent's second window. Added that case.
- "it waits for the holder": my assertion matched a message printed BEFORE the blocking `flock`,
  so it would pass on a build that refused on contact. Replaced with a release-during-wait case
  driven by killing the holder under an already-blocked waiter, and the announcement assertion
  renamed to say only what it checks.

## Gates run

`bash -n`, `shellcheck --severity=warning` (0.11.0), `shfmt -i 4 -d` — rc 0 on both changed
shell files. `lint-file-budget`, `lint-topology`, `lint-operator-strings`, `lint-docs-voice` —
rc 0 each, exit codes captured directly rather than off a pipe.

## Shared files, disclosed

- `pithead` — the change itself. Lane hatch used, pre-granted by the controller.
- `tests/stack/test-lifecycle.sh` — the `tests` lane's path; placement agreed with that lane.
- `.gitignore` — `.pithead.lock` is a runtime file beside `.env`.
- `docs/operations.md` — in `_shared.paths`; no hatch needed.

## Over-engineering pass

Run by hand on my own diff. One finding, acted on: `stack_restart`'s second `case` no longer
duplicates the long contract message — the unreachable arm carries a short internal-error string
instead, kept rather than deleted so that adding a valid value and forgetting to handle it fails
loudly instead of restarting nothing.

## NOT proven — do not let the greens imply otherwise

- **No bench run.** This is not hardware evidence. The boot-path consequence above is reasoned
  from the unit files and `pithead-boot`, not measured on a guest.
- **`make lint-sh` not run** — it needs the fleet lint lock and shellcheck's peak on
  `tests/stack/run.sh` does not fit alongside other work. Both changed shell files were
  shellchecked directly with the pinned 0.11.0 instead.
- **`factory_reset`, `config_reset`, `rotate_secrets`, `reset_dashboard`, `os_update`, and the
  installer-path mutations inside `firstboot_wizard` outside `(setup)` take NO lock.** That is a
  deliberate scope boundary, not an oversight, and it is untested either way.
- **"Read-only verbs take nothing" is structurally true but is not proven behaviourally** by any
  test here.


## Rebased, and a file-budget note for whoever takes the next #1105 phase

Rebased onto `develop-v2` after `tests/stack/run.sh`'s ceiling dropped 4178 -> 3841 (the #1390
cut). No content of this PR changed. Verified by content rather than by the rebase's exit code:
the row reads 3841, the tsv is byte-identical to the base's (so the silent row-drop an auto-merge
can cause did not happen here), and `bash -n`, `shellcheck --severity=warning` (0.11.0) and
`shfmt -i 4 -d` were re-run on both changed shell files afterwards, because a clean auto-merge is
not evidence the result still lints.

**This PR takes `tests/stack/test-lifecycle.sh` from 367 to 957 lines — +590, past the 400
target.** (An earlier revision of this section said 598; that was measured before the finding-fix
commits and is corrected here rather than left to be read as current.) Three consequences worth
stating rather than leaving to be discovered:

- The file carries its own tsv row, at 957 (891 before F1 added the running-stack case). Checked at source rather than taken on trust:
  `check_monotonic` only walks rows present in the BASE (`scripts/lint-file-budget.sh:207`), so a
  row that does not exist there cannot be read as a raise — and `origin/develop-v2` has no
  `test-lifecycle.sh` row, so the row is genuinely new here and settable. `run_gate` fails only on
  `lines -gt ceiling` (`:157`), which passes at 957 of 957.
- **⚠ MERGING THIS CLOSES THE FILE, and the next lane to append to it will meet a red gate with no
  explanation.** The `tests` lane asked that this be stated in the record rather than learned from
  a failure. Re-derived at source, both halves: after merge the row sits on the base, so `run_gate`
  refuses any append (958 > 957) **and** `check_monotonic` refuses any raise — "Ceilings only go
  down." The only way back in is a commit that **shrinks** the file and lowers the row with it. Ask
  the `tests` lane for that commit; do not try to raise the ceiling, because nothing in the gate
  will let you.
- **That makes it the largest test file this lane owns, and under #1105's own program it is a split
  candidate rather than a budget candidate.** Splitting it inside a mutation-lock PR would be the
  wrong vehicle — a move PR's contract is "no behaviour change" and this one is all behaviour — so
  it is flagged here for the next #1105 phase instead of acted on.

### Correction: the suite figure above was measured BEFORE the rebase and does not carry

Stating this rather than letting the number stand and be read as current. The `2933 passed / 0
failed` figure was measured at the pre-rebase base. The range this branch rebased across
(`d14d9d6..9eb8861`) **does touch `tests/stack/`**: #1390 moved 341 lines out of
`tests/stack/run.sh` into a new `tests/stack/test-appliance-install.sh` (+386). That is a move
rather than new coverage, so the count plausibly lands in the same place — **but "plausibly" is an
argument, not a measurement, and this lane has been caught by exactly this before.**

So: treat the suite total as **unmeasured at the new base**. What is unaffected and still stands
is everything measured on the diff itself — the 28 tier-1 assertions and the 11-of-11 mutation
kills are properties of this branch's own code, and the four lint gates plus `bash -n` /
`shellcheck` / `shfmt` were all re-run after the rebase. CI's Shell tests job is the arbiter for
the suite total; read it rather than the number above.


---

# UPDATE — the reviewer's three blocking findings are fixed. This section supersedes anything above it that disagrees.

**All three were real. I checked each at source before acting on it, and none of the three is about the lock primitive — they are all about reach.** Commits `43d5605`, `65ef7a3`, `48f0f9a`.

## 1 (blocking) — the default one-click upgrade escaped the lock. Fixed by changing the KEY.

Confirmed at source: `control_upgrade` runs `(cd "$new_dir" && ./pithead upgrade)` in a **sibling** directory, and the child resolved `${PITHEAD_LOCK_FILE:-$PWD/.pithead.lock}` to a file in a directory nothing else ever runs from — uncontended by construction, while driving compose against the same project-pinned containers a concurrent `backup` had stopped.

**I deliberately did not take the minimal patch.** Exporting `PITHEAD_LOCK_FILE` across that one boundary would have made that invocation safe and left every other cross-directory invocation unprotected while reading as fixed — including the operator route this PR's own failure message prints (`cd <dir> && ./pithead upgrade`). The key now identifies the **stack**: a versioned install (`pithead-vX.Y.Z`) locks on the **deploy root** its siblings share, which is the one thing every version dir of a stack has in common. A plain `pithead/` checkout has no siblings and is unchanged. `control_upgrade` and the lock now share one rule for what a versioned dir is, rather than two copies of the regex.

## 2 (blocking) — six verbs had unmutated wiring. Cases added; all six mutants now die.

Two instruments, because the two failure directions are not visible the same way:

- **A refusal pair per verb** — with a window held, the verb waits and touches no container; with nothing held, the same verb gets past the lock. The second half is the control: without it, "timed out" would also be true of a verb that cannot run in the fixture at all.
- **A balance case per verb that completes** — after the verb returns, in-process, the depth counter is 0 and the lock is free. This is the only thing that can see a missing release or a double acquire, because the kernel drops the hold when the process exits.

## 3 (blocking, promoted by the controller) — a boot-leg lock timeout no longer reads as a bad slot.

A timeout now exits **75** (`EX_TEMPFAIL`) rather than `error()`'s 1, and `os/overlay/pithead-boot` routes that to a distinct path: it spends no A/B fallback, does not touch the boot-failure counter, does not reboot, and says it was waiting. `fail_boot`'s behaviour for every other failure is unchanged. The two messages share the phrase "A/B fallback", so each case is asserted on the one sentence only its branch writes and the verdict is a single value — either branch standing in for the other would fail.

## 4 (non-blocking) — the asymmetry is now deliberate, in the fail-OPEN direction.

An unopenable lock file degrades with a warning, matching the missing-`flock` branch and its stated rationale. A deploy directory the invoking user cannot write no longer refuses every mutating verb.

## PROVEN, by running it, at the rebased head

- **`tests/stack/test-lifecycle.sh`: 96 assertions, 96 passed, 0 failed.**
- **12 single-site mutations, 12 killed, 0 survivors — every kill captured by NAME, and each names the case it was aimed at.** Baseline and post-restore both 96/0; both mutated files restored byte-identical (`cmp`). Positive control (`stack_down` never acquires) kills 14 named cases, which is what makes the rest readable.
  `stack_restart` / `stack_up` / `setup` / `stack_restore` / `stack_upgrade` never acquires · `stack_backup` never releases · `apply` double-acquires · the lock ignores the deploy root · an unopenable lock file fails closed again · a timeout exits 1 · the boot leg stops telling contention apart.
- `bash -n`, `shellcheck --severity=warning` (0.11.0, the CI-pinned binary — `/usr/bin` here is 0.9.0) and `shfmt -i 4 -d` clean on `pithead`, `os/overlay/pithead-boot` and the test file, each exit code captured directly rather than off a pipe.
- `lint-file-budget`, `lint-topology`, `lint-operator-strings`, `lint-docs-voice` rc 0 each.

**Two instrument defects found and fixed on the way, because a mutation table is only as good as the harness that reads it.** First, the readiness poll for the wiring holder took the lock to test for it and killed a non-blocking holder that lost the race — six cases would have passed against a lock nobody held; the holder now blocks with a bound, and a guard fails the run outright if the lock is free when those cases start. Second, and sharper: **`apply`'s balance case ran on a fixture an earlier case had already applied to**, so `apply` returned on its no-change branch and never reached the guard the mutation targets. It read as coverage and was unfalsifiable — the mutant survived, and the fix was one line in the *fixture*, not in the assertion. Each balance case now builds its own.

## NOT proven — and the greens above do not imply otherwise

- **No suite figure is claimed.** The pre-rebase `2933/0` did not survive a rebase that touches `tests/stack/`, and I have not re-measured the full suite. **CI's Shell tests job is the arbiter.**
- **`make lint-sh` was not run** — the lint lock was not taken. The targeted `shellcheck` above is the Makefile's engine but not the Makefile's invocation.
- **No bench run. This is not hardware evidence.** Finding 3's boot-leg behaviour is proven at tier 1 against the real `pithead-boot` functions, sourced; that the routing behaves the same on an appliance guest mid-first-boot is reasoned, not measured.
- `factory_reset`, `config_reset`, `rotate_secrets`, `reset_dashboard`, `os_update` and the installer-path mutations inside `firstboot_wizard` outside `(setup)` still take no lock, deliberately, and are untested either way.
- **The in-place upgrade fallback overwrites the install dir before it re-invokes `pithead`, and that overwrite is outside any window.** Pre-existing, not raised in review, and not fixed here — named rather than left for someone to find.

## Shared files, and the budget row

`pithead` (the lock) and `os/overlay/pithead-boot` (the boot leg) are shared and both are load-bearing for this fix; `tests/stack/test-lifecycle.sh` is the tests lane's path. All committed through the one-shot lane hatch.

`docs/dev/file-budget.tsv` carries one added row: this PR's coverage takes `tests/stack/test-lifecycle.sh` past the target, and #1396 (`da00253`) now makes an over-target file with no row a failure. Only the added line was taken from `--generate` — the `ci.yml` and `tests/integration/run.sh` lowerings it also wants are the two the controller ruled must be preserved. Both owed post-rebase checks were run: the row reads back from `HEAD`'s blob, and `--generate` diffs to exactly those two preserved rows and nothing else.


---

# UPDATE 2 — second review round: F3 fixed and proven. Commit `4628551`.

A second non-author adversarial pass at `d36212c` returned four findings. **This section covers F3
only.** F1 (blocking) and F2/F4 (should-fix) are open and are NOT addressed here.

## F3 (blocking) — contention was routed as a bad configuration on the wizard leg, and it could delete the operator's config

Finding 3 above routed the **boot** leg: a lock timeout there is contention, not a bad A/B slot.
The symmetric statement was never made on the **firstboot wizard** leg, and `setup` runs inside a
mutating window that can lose the same race.

`pithead:2948` was `if (setup) 2>&1 | tee "$setup_log"; then`. Under `pipefail` a lock timeout
inside `(setup)` exits 75 and the pipeline is false, so every non-zero collapsed to one verdict:
the wizard warned *"Provisioning failed … reopening the setup window so it can be corrected"* and
called `wizard_keep_failed_config`, which runs `[ -f "$PWD/machine-role" ] || rm -f
"$PWD/config.json"`. `record_machine_role` is best-effort (`printf … || true`, and the file's own
comment says so). **So on a box where the marker write failed, contention took a valid
configuration away and then told the operator their configuration was wrong — on a first boot with
no shell to contradict it. That is #1059's own shape, on the one leg #1059's fix did not route.**

**The fix** adds `wizard_setup_failed`, which makes the decision once as a function — the reason
`boot_up_failed` gives on the other leg: two halves of one decision drift apart when written twice.
The call site now captures `setup`'s **status** rather than its truthiness. Contention returns 1
*without* calling `wizard_keep_failed_config`: nothing copied, nothing removed, and the live
`config.json` the operator submitted is what prefills the retry.

## PROVEN — clean and mutant suites, run as a pair, read from the rc FILES

| | rc | result |
|---|---|---|
| clean (`4628551`) | **0** | 2974 passed, 0 failed |
| mutant (fix applied, `PITHEAD_EX_LOCK_TIMEOUT` comparison neutered to `if false`) | **1** | 2973 passed, **1 failed** |

The mutant was asserted APPLIED and `bash -n` runnable before the run, because a syntax-error
control reds a suite for the wrong reason. **It red on exactly the one row that can discriminate,
naming it:**

```
✗ a lock-timeout setup keeps the operator's configuration and names it as contention
    expected [kept|no-copy|contended|1], got [DELETED|copied|other+badconfig|0]
```

That `got` value is the defect itself: the config **DELETED** and the operator blamed.

**Only one of the two new rows can discriminate, and that is deliberate.** The `wizard_fail_probe 1`
row is a **control** — it is unaffected by the mutation and stayed green, which is what separates
"the fix is load-bearing" from "the mutant broke the file". The two boot-leg twin rows above it
also stayed green, and nothing else moved in 2974 assertions.

**The fixture is chosen to make the removal reachable** — `config.json` present, `machine-role`
ABSENT. With the marker present nothing is removed on either branch, both rows would read "kept",
and the pair could not fail for any change to the routing.

## Labelled, because the reviewer labelled it

That an appliance first-boot `up` actually exceeds the 300s default is **reasoned from what that
path does, not measured.** If it never exceeds 300s the finding is latent rather than live. **The
routing asymmetry stands either way, and that is what is fixed here.** One partial mitigation that
already existed and is not claimed as this fix's work: `pithead:2963` does tail the honest timeout
text into `error.txt`, so the give-up was named — the wrapper around it said the wrong thing.

## NOT proven for F3

- **No bench run.** That this routing behaves the same on an appliance guest mid-first-boot is
  reasoned at tier 1 against the real functions, sourced — not measured on hardware.
- The 300s claim above, as labelled.
- F1, F2 and F4 from this review round are untouched.

---

# UPDATE 3 — F1 fixed and proven; and this PR is now BLOCKED on #1464, which it discovered

Head `a3ed6ee`, rebased onto `develop-v2` at `39ee46a`.

## F1 (blocking) — the running-stack backup window was unreachable by any assertion

`stack_backup` takes the window in two places, chosen on `docker compose ps --status running -q`.
`make_stubs`' docker stub (`tests/stack/lib.sh`) has **no case arm** for that query and falls
through to `exit 0` with empty stdout, so `running` was always empty and **both** existing backup
cases took the stack-already-stopped branch. Deleting the running branch's acquire left the whole
file green.

What that hid is worse than one unasserted line: without it the archive is taken in a **third**
window rather than one, with `tar` running **unlocked** between `stack_down`'s release and
`stack_up`'s re-acquire. A concurrent `setup` or `apply` can then bring containers up mid-archive —
a torn backup, which is #970's retry failure mode arriving for a reason the retry cannot fix.

**The fix is a test, not a code change.** The acquire already exists and is correct; nothing could
reach it.

**A balance case cannot see this defect** — with or without the acquire the verb ends `depth=0
state=free`. The discriminating property is *when* the window is held, so the probe asks the only
question that separates them: was it held at the instant the archive was taken? A `sudo` stub reads
the lock with `flock -n` from its own descriptor, which the parent's fd 9 hold denies — the same
mechanism the balance cases already use.

**The verdict carries the branch as well as the window, and that half is not decoration.** If the
docker stub ever stops answering the query, the stopped branch takes its own window, the archive is
still taken under it, and a bare `held` would read as coverage of a branch that never ran.

### PROVEN — clean and mutant as a pair, read from the rc FILES

| | rc | result |
|---|---|---|
| clean (`79e6aaf`) | **0** | 2975 passed, 0 failed |
| mutant (the running-branch acquire deleted) | **1** | 2974 passed, **1 failed** |

The mutant was asserted APPLIED (two acquires → one) and `bash -n` runnable before the run. It red
on exactly the new row, naming it:

```
✗ a backup that stops a running stack holds one window across the archive
    expected [running|held], got [running|free]
```

**The `running` half held on BOTH sides**, which is the part that makes this readable: the fixture
genuinely drove the running branch, and only the window half flipped. A broken stub would have read
`stopped|held` and failed for the opposite reason.

## BLOCKED — #1464, which this branch is what surfaced

`pithead` is exempt from the file budget; since #1456 its content lives in
`lib/pithead/99-remainder.sh`, whose row **ratchets and can never rise**. The exemption therefore
became a hard freeze on the CLI's size. Measured both halves, and there is no third option:

- row left at 11870 → `run_gate`: `99-remainder.sh is 12123 lines, over its recorded ceiling of 11870`
- row raised to 12123 → `check_monotonic`: `raises ... from 11870 to 12123. Ceilings only go down.`

The narrow `check_monotonic` exemption ruled on in **#1464** lands first; this PR merges behind it.
The row is set to the honest 12123 here so the gate reports the real state rather than a stale one.

**Also now mandatory for every `pithead` PR, and discovered here:** a changed `pithead` leaves
`99-remainder.sh` stale, and `git merge-tree` merges that **textually clean** — the trial merge had
4 `wizard_setup_failed` references in `pithead` and 0 in the remainder. Re-cut with
`awk 'NR>=119' pithead > lib/pithead/99-remainder.sh`; `--check` then reports `pithead parity OK`.

## Still open on this PR

**F2 and F4 (should-fix) are UNTOUCHED.** F2: `setup`'s release and `stack_restart`'s have no
assertion aimed at them. F4: `test-lifecycle.sh:470` cannot fail for any change to `pithead`.



---

# UPDATE 4 — F2 and F4 discharged, so all four findings are closed; and the #1464 block is gone. Head `3ac1b19`.

UPDATE 3 left F2 and F4 open and this PR blocked. Both statements are now stale. **This section
supersedes them.** Commits `d0bea80` (F2), `58d4fe0` + `204eb4e` (F4), `3ac1b19` (a correction the
F4 run exposed).

## The #1464 block has lifted

PR #1467 merged: the `lib/pithead/99-remainder.sh` row now tracks the un-split remainder **both
ways**, so a `pithead` change that grows it is no longer a dead end. **Run rather than reasoned
about** — this lane nearly declared itself blocked a second time by arguing from the general
"ceilings only go down" rule instead of invoking the gate:

```
file-budget: NOTE — lib/pithead/99-remainder.sh's ceiling rises from 11470 to 11556, matching
the file. That row records the un-split remainder of the generated pithead artifact, so it
tracks it both ways (#1464). Every Phase 2 cut lowers it.
file budget OK — ... rc=0
```

## F2 (should-fix) — `setup`'s and `stack_restart`'s releases had nothing aimed at them

The `lock_wiring_balance` block covers `stack_up`, `stack_upgrade`, `stack_backup`, `stack_restore`
and `apply`, and its own comment says it is the only instrument in this file that can see a missing
release. `setup` and `stack_restart` were outside it, so **deleting either verb's
`mutation_lock_release` left all 96 assertions green** while shipped behaviour regressed.

`restart` takes a balance case — it is the sixth verb with a window and the only one the block did
not name. **`setup` gets its own probe instead**, because a balance case cannot reach the property
that matters: `setup` releases *before* the interactive "start now?" prompt, so the property is an
**ordering**, and an end-state balance is blind to it. That ordering is load-bearing on the
appliance — the firstboot wizard runs `(setup)` in a subshell, so a hold spanning the prompt parks
the window on an absent operator while `pithead-boot`'s `up` times out against it. `setup` also
cannot be driven to completion in this harness at all: it refuses a non-interactive re-run against
a provisioned dir before reaching its window.

So the probe stubs the provisioning body **between** the acquire and the release, leaves the lock
wiring real, and replaces `prompt_start_stack` with a probe reporting whether the window was free
at that instant. **Reaching the probe is the anti-vacuity control**: if the stubs stop letting
`setup` through, nothing prints and the assertion fails on an empty string rather than passing on a
run that never got there. The end-state half is read too, so a release that *moved* rather than
vanished still shows up.

### PROVEN — clean and two mutants, each read from the rc FILES

| run | mutation | result |
|---|---|---|
| clean | none | **2977 passed / 0 failed** |
| mutant A | `stack_restart`'s release deleted | 2976 / **1** — `restart gives its window back when it finishes` (`depth=1 state=held`) |
| mutant B | `setup`'s release deleted | 2976 / **1** — `setup hands its window back BEFORE the interactive start prompt` (`at-prompt=held depth=1 state=held`) |

**Each mutant leaves the OTHER row green.** That is what makes these two instruments rather than
one message printed twice, and it is the property the F4 evidence below deliberately does *not*
claim.

## F4 (should-fix) — the unrecorded-holder case could not fail for any change to `pithead`

`test-lifecycle.sh:470` asserted that an unrecorded holder is never reported under the previous
holder's name **while the lock file was empty** — so `verb=backup` existed nowhere on disk and the
assertion was true of an empty string.

Fixing the fixture exposed a real defect behind it. The waiter's message took the holder's name from
whatever the first line of the lock file said, with **nothing checking the recorded holder was the
actual one**. An orderly release clears that line; a Ctrl-C or an `error()` inside a window does not
— the kernel drops the flock with the descriptor, so the lock goes free while the record stays. A
later waiter that lost `flock -n` could then be told to wait for a pid that had exited: precisely
the misdiagnosis the message exists to prevent.

`mutation_lock_holder` now trusts the record only while the pid it names is alive — `/proc` first,
because it answers regardless of who owns the process (`kill -0` returns non-zero on EPERM, and a
root `pithead` holding the window against an unprivileged waiter is ordinary here), `kill -0` as the
fallback where `/proc` is not mounted. Anything that does not parse as our own `pid=<n>` record is
reported as **unrecorded** rather than echoed back. **Pid reuse stays undetectable and is named in
the comment**: it costs a misleading name in a rare case, never a wrong action, because the flock
decides the wait and the record never does.

`204eb4e` carries the docs half — `docs/operations.md` showed the named message and left the reader
to assume it is always available. It is not, and now says so.

## `$$` in a subshell is a SHIPPED defect, not a test artifact

**Stated here at the `tests` lane's explicit request**, because the commit that fixes it lands
mostly in test-adjacent evidence and could be read as a fixture repair. It is not.

`mutation_lock_acquire` wrote `pid=$$` into the lock record. **In a subshell `$$` is the PARENT's
pid.** The firstboot wizard runs `setup` inside `(setup)` *precisely* because the subshell's exit
closes fd 9 and IS the release — so the shipped record named a process that **outlives the window it
describes**. A waiter checking that pid for life would find it alive after the holder had gone. That
is on the appliance's first-boot path, not in a fixture.

`$BASHPID` names the process the lock actually lives on, which is the pid a waiter has to test. The
exported `PITHEAD_LOCK_HELD` marker answers a different question — which invocation's descriptor a
child inherits — and **correctly stays `$$`** (`pithead:282`).

**How it was found is the transferable half.** The clean run failed and the mutant failed the *same
two assertions*. Identical failures on both sides is the signature of a fixture that never armed,
not of a working control — the message had to be read rather than the run repeated.

A second correction came out of the same run: `lock_await_record` polled only for a **non-empty**
file, so a record an earlier case had left satisfied the poll instantly and the contention cases
reported on an uncontended run. Two of them failed clean and *passed* under the mutant — that
asymmetry is a race, not a defect. `lock_hold_bg` now clears the record before it starts, which
closes the class rather than the instance: an abnormal exit leaves such records in the field too.

### PROVEN — three runs, all cut from `3ac1b19`, all read from the rc FILES

| run | mutation | rc | result | rows killed |
|---|---|---|---|---|
| clean | none | **0** | **2979 passed / 0 failed** | — |
| mutant A | the liveness conjunct (`pithead:217`) → `{ true; }` | 1 | 2977 / **2** | `an unrecorded holder is reported as unrecorded` + `and is never reported under the previous holder's name` |
| mutant B | the record's `$BASHPID` → `$$` (`pithead:293`) | 1 | 2977 / **2** | the **same two** |

Both mutants were **proven applied** before launch: `git diff --numstat` = 1 added / 1 removed, on
`pithead` only, the fixture byte-identical to the clean tree, `bash -n` clean. No bystander failures
in either.

**The control is what makes the reds mean anything, and it held.** `a holder killed inside its
window leaves its record on disk` stayed **green** in all three runs. It reads the FILE rather than
the message, so a green there says the fixture armed — the two reds are the code path failing, not
the fixture failing to produce a stale record.

**A and B kill the same two rows, and that is one message read twice, not two instruments.** What it
does prove is that **each changed line is individually load-bearing**: revert either and the suite
reds. Worded that way deliberately and no further — contrast F2 above, where each mutant leaves the
other row green.

## The `$$` sweep the tests lane asked for — done by a non-author, and its central claim re-derived here

The `tests` lane asked that this PR name **any other `tests/stack/` fixture** that kills a subshell
holder and asserts on what it left behind, since those could rest on the same confusion. The lane
that wrote the fix had not swept; a non-author reviewer ran the sweep at the `develop-v2` tip.

**Result: no other fixture rests on it.** The lock-holder machinery does not exist on `develop-v2` at
all, and that absence is the finding — the confusion is confined to code this PR introduces, not
inherited from anything merged.

| file:line | pid source | verdict |
|---|---|---|
| `tests/stack/run.sh:1577` | `$!` immediately after `... &` | **clean** — `wait "$bg_pid"` at `:1586`; assertions read file content, no pid is written to disk |
| `test-lifecycle.sh:400` (`lock_hold_bg`) | `$!` | **clean** — 5 call sites, every `kill`/`wait` pair reads back the value this line set |
| `test-lifecycle.sh:774` (`LKWHOLDER=$!` after `( ... ) &`) | `$!` | **clean** — `$!` after `(...) &` names the subshell itself, which is correct; it writes no pid anywhere |
| `pithead:282` (`PITHEAD_LOCK_HELD="$$"`) | `$$` | **correctly `$$`** — marks the invocation whose descriptor a child inherits, a different question from the on-disk record |
| `pithead:2488`, `:11663`, `:11770` | `$!` | unrelated backgrounded-job captures, all correct |

**I re-derived the central claim by a different route rather than relaying it**, because the sweep's
greps ran through this box's `grep`, where a mid-pattern `$` can match nothing. Re-run with `git
grep -F` against both `origin/develop-v2` and this head:

- **`git grep -F '$$' -- tests/stack/` returns two sites the sweep did not name**:
  `tests/stack/test-appliance-boot.sh:566` and `:600`, both `PITHEAD_REBOOT_CMD="touch
  $BG/rebooted.$$"`. **They are benign, and I checked rather than assumed**: `:566` sits inside a
  `( ... )` subshell so its `$$` *is* the parent's pid — but the value is only a filename-uniqueness
  suffix, and **every reader globs `rebooted.*`** (`:571`, `:578`, `:602`) rather than
  reconstructing the name or reading it back as a pid. Nothing tests that number for life.
- `git grep -nE '[^&>|]&[[:space:]]*$'` finds exactly one backgrounded job on `develop-v2`
  (`run.sh:1577`) and four more on this head, all in `test-lifecycle.sh` — matching the sweep.

**What the sweep did NOT check**, carried forward rather than dropped: nothing outside
`tests/stack/`; no suite was run, so it is a static read; other open PRs' branches were not swept;
and the pre-existing `.tmp.$$` scratch-filename suffixes in `lib/pithead/99-remainder.sh` were
judged benign by the same reasoning as above without every reader being traced.

## The `tests/stack/test-lifecycle.sh` grant, and what merging this costs that file

**The `tests` lane (`pithead-b3`) granted both appends directly**, and is named here as granting at
its own request. The grant covers (1) F2's restart and setup release probes and (2) F4's
record-truncation and stale-record fixture; it **expires when this PR merges**. Its durable source
predates the ask (`roles/tests.md`, first committed 2026-08-23). It is a **record, not an ownership
line** — lane-guard still refuses the file, and every commit to it went through the one-shot
`.lane-override`, touched immediately before each.

**⚠ Merging this closes the file at 1032/1032**, and `b3` named that as a consequence it accepted
rather than a condition. `develop-v2` has this file at 367 lines with **no row**; the branch lands it
at 1032 with a 1032 ceiling. The next append by any lane — the tests lane included — is refused, and
the only way back in is a commit that **shrinks** the file and lowers the row with it. Do not try to
raise the ceiling; `check_monotonic` will not allow it.

## Gates run at this head, by me, in this session

- **`build-pithead.sh --check`: `pithead parity OK — the committed artifact is exactly what 4
  slice(s) build.`** This matters on every `pithead` PR: a changed `pithead` leaves
  `99-remainder.sh` stale and `git merge-tree` merges that **textually clean**.
- `bash -n` clean on `pithead`, `tests/stack/test-lifecycle.sh` and `os/overlay/pithead-boot`.
- `shfmt -i 4 -d` clean on `pithead`, the test file and all of `lib/pithead/*.sh`.
- **`lint-file-budget` rc 0**, with `origin/develop-v2` probed **before and after** the run and
  unmoved at `7d59eec` — every worktree on this box shares one `.git`, so another lane's fetch can
  move the gate's base mid-run and a sha-pinned worktree does not control for it.

### The base moved to `7d59eec`; no rebase is needed, and the tsv merges without a silent row drop

Re-derived rather than assumed, because a dropped budget row is the silent-failure class here.
`git diff --name-only <merge-base>..origin/develop-v2` shows the 7 intervening commits touch
dashboard tests, `docs/`, and `tests/integration/` — **neither `pithead`, nor `lib/pithead/`, nor
`tests/stack/`**. So the suite figures above are unaffected by the move.

`git merge-tree --write-tree` then accounts for **every** row: base 85, this head 87, merged **86**.
The difference is fully explained — `develop-v2` dropped one row
(`dashboard/tests/service/test_storage_service.py`) since this branch's base, and this branch adds
exactly one (`tests/stack/test-lifecycle.sh`). Both of my rows survive the merge intact
(`99-remainder.sh 11556`, `test-lifecycle.sh 1032`).

## NOT proven — and nothing above should be read past these

- **⚠ There has been NO non-author review since `d36212c6`.** The last adversarial pass produced
  F1–F4; **everything since — the F1, F2, F3 and F4 fixes and the `$BASHPID` correction — is
  author-verified only.** A non-author pass at this exact head is running now, and **this PR should
  not merge on the author's evidence alone.** Stated as the first item deliberately: the greens above
  are numerous and none of them is a second pair of eyes.
- **`make lint` / `make lint-sh` were not run.** The fleet lint lock was never taken; `shellcheck`
  is the OOM path that has killed whole sessions on this box. The individual gates above were run by
  hand instead, and **CI's Shell tests job is the arbiter.**
- **F1's and F3's coverage was not re-run at this head.** It was proven in the sessions that fixed
  them (UPDATE 2 and UPDATE 3) and is inherited here, not re-measured.
- **No bench run. This is not hardware evidence.** The boot-path and firstboot-wizard consequences
  are proven at tier 1 against the real functions, sourced; that they behave the same on an
  appliance guest mid-first-boot is reasoned.
- **Commit `7ac4dc7`'s subject says "after the P0 split"; it re-cuts `99-remainder.sh` after
  **P1**.** The body is correct. Flagged here rather than rewritten, because rewriting a pushed
  commit to fix a subject costs more than the note.
- `factory_reset`, `config_reset`, `rotate_secrets`, `reset_dashboard`, `os_update` and the
  installer-path mutations inside `firstboot_wizard` outside `(setup)` still take no lock,
  deliberately, and remain untested either way.
- **The in-place upgrade fallback overwrites the install dir before it re-invokes `pithead`, and that
  overwrite is outside any window.** Pre-existing, not raised in review, not fixed here — carried
  forward rather than quietly dropped.
