### PR TITLE
fix(tests): count harness self-test sections from every file, not one filename (#1388)

### DIFF
--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -39,12 +39,12 @@ bullets() { sed 's/^/- /'; }
 
 # --- gather ---------------------------------------------------------------
 PY_DASH_FILES=$(find dashboard/tests -name 'test_*.py' | sort)
-PY_FAKE_FILE="tests/integration/fakes/test_contract.py"
 NODE_FILES=$(find dashboard/tests/frontend -name '*.test.mjs' 2>/dev/null | sort)
 
 n_py_dash=0
 for f in $PY_DASH_FILES; do n_py_dash=$((n_py_dash + $(py_tests "$f" | count))); done
-n_py_fake=$(py_tests "$PY_FAKE_FILE" | count)
+n_py_fake=0
+for f in tests/integration/fakes/test_*.py; do n_py_fake=$((n_py_fake + $(py_tests "$f" | count))); done
 n_node=0
 for f in $NODE_FILES; do n_node=$((n_node + $(node_tests "$f" | count))); done
 # Every tests/stack suite, not just run.sh — #1105 moves sections out of run.sh into per-domain
@@ -54,7 +54,14 @@ for f in $NODE_FILES; do n_node=$((n_node + $(node_tests "$f" | count))); done
 # instead of splitting into two nonexistent ones and reporting phantom drift.
 n_stack=0
 for f in tests/stack/*.sh; do n_stack=$((n_stack + $(sh_sections "$f" | count))); done
-n_selftest=$(sh_sections tests/integration/selftest.sh | count)
+# Every tests/integration/selftest*.sh, not just selftest.sh. Makefile and ci.yml both glob these,
+# so all of them are run and linted, while counting the one filename published a third of the
+# sections and hid the rest (#1388). The self-tests grew from one file to five and the singular
+# name never followed. Same enumerate-vs-glob shape the stack aggregate above was fixed for; the
+# tell is a gate line naming paths one by one beside a sibling line that globs. The glob is
+# iterated directly rather than through a word-split string, for the reason given above it.
+n_selftest=0
+for f in tests/integration/selftest*.sh; do n_selftest=$((n_selftest + $(sh_sections "$f" | count))); done
 n_scen=$(awk -F'\t' 'NF>1{print $1}' <(sed -n '/scenario_matrix() {/,/^EOF/p' tests/integration/scenarios.sh | grep -E '\t') | count)
 n_axes=$(grep -cE '=' <(sed -n '/axis_coverage() {/,/^EOF/p' tests/integration/scenarios.sh | grep -E '^[a-z].*='))
 n_mini=$(grep -cE 'log "scenario [0-9]' tests/integration/mini-stack/run-mini-stack.sh)
@@ -96,6 +103,20 @@ for f in tests/stack/*.sh; do
     if [ "$(sh_sections "$f" | count)" -eq 0 ]; then
         echo "inventory drift: $f has no '== section ==' header — it moved, was renamed, or" \
             "changed shape; fix the file, or add it to SECTIONLESS with a reason" >&2
+        exit 1
+    fi
+done
+
+# The same per-FILE check for the harness self-tests, and it is the half the aggregate above cannot
+# do. Now that n_selftest globs, one self-test dropping to zero sections hides inside a comfortably
+# non-zero sum exactly as a stack suite did — the aggregate can see a whole tier go dark and never a
+# single file. Every self-test carries headers today, so there is no SECTIONLESS counterpart here;
+# if one ever legitimately has none, give it one rather than adding an exception, since these files
+# exist to be enumerated.
+for f in tests/integration/selftest*.sh; do
+    if [ "$(sh_sections "$f" | count)" -eq 0 ]; then
+        echo "inventory drift: $f has no '== section ==' header — it moved, was renamed, or" \
+            "changed shape; fix the file, or fold it into a sibling self-test" >&2
         exit 1
     fi
 done
@@ -225,9 +246,9 @@ cat <<EOF
 
 ## Tier 2 — Contract (real clients vs controllable fakes)
 
-### tests/integration/fakes/test_contract.py — ${n_py_fake} tests
+### tests/integration/fakes/test_*.py — ${n_py_fake} tests
 EOF
-py_tests "$PY_FAKE_FILE" | bullets
+for f in tests/integration/fakes/test_*.py; do py_tests "$f"; done | bullets
 
 cat <<EOF
 
@@ -263,9 +284,9 @@ grep -hoE '(assert_[a-z_]+|it_pass) "[^"]+"' tests/integration/run.sh |
 
 cat <<EOF
 
-### Harness self-test (tests/integration/selftest.sh) — ${n_selftest} sections
+### Harness self-test (tests/integration/selftest*.sh) — ${n_selftest} sections
 EOF
-sh_sections tests/integration/selftest.sh | bullets
+for f in tests/integration/selftest*.sh; do sh_sections "$f"; done | bullets
 
 cat <<EOF
 


### PR DESCRIPTION

> **Figures corrected before merge, and the correction is the PR's own point.** This body first
> said 61 sections / grand total 2763 and *"they agree exactly: 1 / 5 / 5 / 17 / 33"*. Rebasing
> onto the current tip moved it to **67 / 2769**, because `selftest-e2e-phases.sh` grew 5 → 11
> underneath. Nothing about the fix changes — a wider gap only makes the case harder — but
> "agree exactly" had become the one false sentence in the body. **The count went up between
> writing and merging, silently, which is exactly the drift this change exists to keep visible.**
> (Caught by the reviewer lane; re-derived here rather than taken.)


Addresses issue #1388. No closing keyword is used here deliberately: `develop-v2` is not this repo's default branch, so keywords never fire, and the negated form is ignored by GitHub rather than respected. The issue gets shut by hand on merge, with a comment naming this PR.

The inventory published **"33 harness self-test sections" while CI ran 67**. Thirty-four were invisible — 51% of that tier — because `n_selftest` read one hard-coded filename while the line directly above it globs, and while `Makefile` and `ci.yml` both glob these files to run and lint them.

**This is live drift, not a historical curiosity.** The fifth self-test file, `selftest-e2e-phases.sh`, landed on develop-v2 **today** in #1384 — the count was 56 at the base I started from, 61 by the time I branched, and 67 at the head this merged from. Every self-test that lands widens the gap silently.

I re-derived the numbers rather than taking the issue's, and they agree exactly: 1 / 11 / 5 / 17 / 33 across the five files.

## Counting is not the whole fix

The aggregate zero-check can only see a counter reach **zero**, so a *partial* enumeration is invisible to it by construction — 33 is comfortably non-zero. The stack suites were given a per-FILE zero check for precisely this reason, after counting only `run.sh` had hidden 162 sections. The self-tests were never brought under the same reasoning. They are now.

## Mutation table

The numbers alone prove nothing here: **a loop that counts every file and a loop that counts none both emit a number.** Every case run in a scratch tree built with `git archive`, never in a live worktree.

| | case | result |
|---|---|---|
| C1 | base, unmutated | 33 sections, grand total 2735 |
| C2 | this fix, unmutated | 67 sections, grand total 2769, rc 0 |
| M1 | headers stripped from ONE self-test (`selftest-rigforge-writable-keys.sh`, 17 sections) | **this fix → rc 1 naming that exact file; base → rc 0, SILENT** |
| M2 | glob made to match nothing | rc 1, aggregate drift gate fires on `n_selftest` |
| M3 | the one contract test removed | rc 1, drift gate fires on `n_py_fake` |
| C3 | tree restored | rc 0, 67 again |

**M1 is the pair that matters** — a 17-section self-test going completely dark is invisible on the base and loud here. **M2 is what separates a real loop from a decorative one**, showing `n_selftest` genuinely derives from the glob. **C3** shows the mutations caused the reds rather than the tree being broken throughout.

## The sibling counters — the issue's owed item, discharged

The issue flagged `n_scen`, `n_axes`, `n_mini`, `n_py_fake` and `n_node` as unchecked, on the grounds that both previous instances of this shape had neighbours nobody had noticed. Checked:

- **`n_py_fake` shares the shape** — one hard-coded `fakes/test_contract.py` where a glob belongs. Converted. **This changes no number today**: it is the only `test_*.py` in that directory, so the count is 67/2769 either way. Converted because the shape is the defect, not the current count. Do not read it as a second miscount.
- `n_node`'s find matches the Makefile's `node --test dashboard/tests/frontend/*.test.mjs` glob exactly.
- `n_py_dash`'s find covers `test_*.py`; there are no `*_test.py` files for pytest to collect that it would miss.
- `n_scen`, `n_axes`, `n_mini` name files that genuinely are single files today.

**None of them is currently miscounting.** Three still name single paths and would drift the same way if a sibling ever appeared; I left them, because converting a glob that matches one file reads as a fix and is not one.

## Over-engineering pass (by hand)

The gate keys its sentinel to the pane's branch and clears on a second invocation, so it is not evidence either way; this was run on merit.

**One item considered and rejected, with the reasoning exposed so it can be overruled:** the new per-file zero check is near-identical to the stack suites' loop directly above it, and could be factored into a helper taking a glob and an exception list. I kept them separate — the stack loop carries `SECTIONLESS` handling the self-tests do not need, a helper would have to take that exception list as a parameter for one caller's benefit, and the file's established idiom throughout is explicit inline loops. Keeping the new loop visually parallel to the one it is modelled on is what makes the symmetry legible. A reviewer who disagrees should say so.

## What was run

The table above; `shfmt -i 4 -d` and `shellcheck --severity=warning` (0.11.0), both clean; `scripts/lint-file-budget.sh` OK. `tests/inventory.sh` carries no budget row and is well under target, so growth here is free.

Not run: `make lint` / `make test` — CI runs those on the merge commit.

