### PR TITLE
docs(appliance): the A/B rollback is a root-shell action, not a dashboard button (#1394)

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -395,8 +395,8 @@ the thing you will want at 3am:
   machine stays up with the reason in the journal instead of looping. Publish a fixed
   version; the fleet takes it on the next update.
 - **It boots, passes its checks, and is still wrong** — this one is on us, not the
-  updater. Publish `v+1` with the fix. Operators who already committed roll back with
-  `rauc status mark-bad booted && reboot`, which the dashboard exposes as a button.
+  updater. Publish `v+1` with the fix. An operator who already committed rolls back from
+  a root shell with `rauc status mark-bad booted && reboot`; the dashboard has no button.
 
 What bounds the damage in every case: `/data` is never touched by an update. Wallets,
 config and the synced chain survive a rollback, a bad release, and a factory reset of the


### PR DESCRIPTION
Fixes the false claim in the bad-release runbook reported in #1394. Two lines, line-neutral.

## The defect

`docs/dev/appliance-release.md:399` told the reader:

> Operators who already committed roll back with `rauc status mark-bad booted && reboot`, which the dashboard exposes as a button.

There is no such button, and no path by which one could work today. Four independent routes agree:

- The dashboard's server side enforces `OS_UPDATE_ACTIONS = frozenset({"check", "download", "verify", "install", "reboot"})` (`dashboard/mining_dashboard/web/server.py:224`, rejected at `:239-241`). A rollback intent cannot be posted at all.
- The control-verb dispatch has thirteen verbs and no rollback (`pithead:11713-11727`); anything else is answered "unknown action".
- The dashboard's OS module sequences exactly those five steps. Its `rolled_back` string renders a **verdict** of the automatic fallback — "failed its health checks and was rolled back automatically" — not an action.
- Outside docs, the only `mark-bad` in the tree is `tests/os/run.sh:314`, where the battery runs it as root over SSH.

The command itself was right. Only the claim about where an operator finds it was wrong.

## Why it earned a fix rather than a shrug

The sentence propagated into a blocker assessment. The Tari v5.6.0 rollback-trap analysis cites this exact line to argue the one-way JMT migration is reachable from an operator-initiated button, which made that exposure read as two paths when it is one. An overstated blocker costs as much as an understated one; the correction is on #1129.

## What was run

- `lint-docs-voice`, `lint-topology`, `lint-operator-strings`, `lint-file-budget` — **rc 0 each, every exit code captured directly rather than read off a pipe.**
- The file stays at **403 lines**, deliberately: the replacement is the same two lines, so the budget ratchet never enters into it. `appliance-release.md` carries no tsv row.

**Not run, and not implied:** `make lint-sh` and the suite. This diff touches one Markdown file — no shell, no test, no rendered config. The lint lock was not taken and did not need to be.

**No bench run, and none is owed.** Nothing here changes behaviour. The claims about what the dashboard can and cannot send are read from source at the tip, not exercised on hardware — but they are read from four independent places that agree, including a server-side allowlist that is dispositive on its own.

## Lane note

`docs/` is shared ground, so no lane hatch was used or needed; `.lane-override` is absent. The over-engineering pass was run by hand rather than through the repo's gate, whose silence is not evidence a review happened: this is a two-line replacement that adds no structure, no helper and no indirection to review.
