### PR TITLE
fix(budget): fail when an over-target file carries no ceiling entry (#1375)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -42,6 +42,7 @@ dashboard/tests/web/test_views.py	3576
 dashboard/tests/web/test_wizard.py	974
 .github/workflows/ci.yml	513
 os/rootfs/Dockerfile	406
+scripts/lint-file-budget.sh	407
 scripts/release.sh	851
 scripts/shipped-image-sweep-report.sh	429
 scripts/trivyignore-watch.sh	599
@@ -69,3 +70,4 @@ tests/stack/test-release-signing.sh	454
 tests/stack/test-rig-worker.sh	617
 tests/stack/test-secrets.sh	401
 tests/stack/test-tor-network.sh	780
+tests/stack/test-wizard-setup.sh	417

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -2,8 +2,8 @@
 # The file-budget ratchet gate (#1105 Phase 0): stop the biggest files in the repo from getting
 # any bigger, without demanding anyone rewrite them today. Two rules:
 #
-#   1. A brand-new tracked file has a hard ceiling of 800 lines (target: 400 — see the
-#      docs/dev/file-budget.tsv header for the target/ceiling rationale). Over 800 fails outright.
+#   1. A tracked file over the 400-line target must record a ceiling in
+#      docs/dev/file-budget.tsv; over 800 the refusal names the hard ceiling instead.
 #   2. An existing offender (already over 400 when this gate landed, or added to the budget
 #      since) gets its CURRENT line count recorded in docs/dev/file-budget.tsv as a personal
 #      ceiling. A PR may not grow that file past its recorded ceiling. Ceilings only ever go
@@ -166,6 +166,12 @@ run_gate() {
             echo "file-budget: FAIL — $path is $lines lines, over the hard ceiling of $HARD_CEILING for a" \
                 "new/unbudgeted file (target: $TARGET_LINES)."
             fail=1
+        elif [ "$lines" -gt "$TARGET_LINES" ]; then
+            # The other half of the same rule: an entry IFF over target. --generate has always
+            # emitted exactly this set (`awk '$2 > t'`); the gate now refuses what it would write.
+            echo "file-budget: FAIL — $path is $lines lines (> $TARGET_LINES target) but has no" \
+                "$BUDGET_FILE entry. Add one: scripts/lint-file-budget.sh --generate."
+            fail=1
         fi
     done <<<"$candidates"
 
@@ -186,7 +192,7 @@ run_gate() {
         echo "See CONTRIBUTING.md — file budget gate."
         return 1
     fi
-    echo "file budget OK — no file grew past its ceiling, no new file crossed $HARD_CEILING lines, $BUDGET_FILE is monotonic."
+    echo "file budget OK — every over-target file has a ceiling, none grew past it, $BUDGET_FILE is monotonic."
     return 0
 }
 
@@ -278,7 +284,18 @@ self_test() {
     git -C "$tmp" add new.sh
     rc=0
     (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "a new 800-line file passes (at the hard ceiling)" 0 "$rc"
+    expect "an over-target file with NO entry FAILS (800, inside the hard ceiling)" 1 "$rc"
+    if grep -q "new.sh is 800 lines (> 400 target) but has no" "$out"; then
+        echo "  self-test ok: names the missing entry, not the hard ceiling"
+    else
+        echo "  self-test FAIL: did not name the missing entry"
+        st_fail=1
+    fi
+    printf '# test budget\nbudgeted.sh\t500\nnew.sh\t800\n' >"$tmp/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "recording the entry is the fix — the same file then passes" 0 "$rc"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
     seq 1 801 >"$tmp/new.sh"
     rc=0
     (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?


### PR DESCRIPTION
Completes the file-budget gate's own rule in the direction it never enforced: a file **over** the 400-line target with **no** ceiling entry now fails. Refs #1375.

## What the gate did before

`run_gate` enforced one direction. At or under target **with** an entry → FAIL ("Remove the entry"). Over target with **no** entry → armed nothing, because the only branch an unrowed file could reach was the 800-line hard ceiling. A file that crossed the target after creation sat at that ceiling with hundreds of lines of silent headroom while the gate printed `file budget OK`.

## The finding that reframes it — verified, not read

**This is symmetry-completion, and the base gate itself proves it.** The base ALREADY keys the converse direction to `TARGET_LINES`: a 300-line file that still carries a row fails on the base with *"is 300 lines (<= 400 target) but still has a ... entry. Remove the entry."* (`scripts/lint-file-budget.sh:160`). So the invariant was always **a row IFF over 400** — the implemented half says so in its own message — and the other half was simply absent. This change adds the missing half. Nothing is overridden and no implementation detail is appealed to.

**Separately, and it is why the header changes too: a recorded row already escapes the hard ceiling.** A 900-line file with a row at 900 passes the *base* gate at rc 0. So "over 800 fails outright", in the script's own header, was never true — 800 was not a size limit but a *"record a row"* trigger, and this change moves that trigger down to where the other half already sat. Correcting a header that is demonstrably false is CLAUDE.md's standing bar, not a rewrite of anyone's design.

> *An earlier version of this body argued the 800 → 400 move **from** the header being false. That does not follow — they are two separate claims. The symmetry argument above is the reviewer lane's, adopted because it is strictly stronger, and verified at source before adopting.*

## Truth table — base vs branch, each case its own throwaway git repo

Message captured, not just an rc.

| fixture | base | branch | |
|---|---|---|---|
| 900 lines + row at 900 | rc 0 | rc 0 | a row governs; unchanged |
| 900 lines, no row | rc 1 | rc 1 | hard-ceiling message; unchanged |
| **500 lines, no row** | **rc 0** | **rc 1** | the hole, now refused |
| 300 lines, no row | rc 0 | rc 0 | under target: removal stays sanctioned |

The 900-no-row row is the **negative control** — it refuses on both sides, which is what makes the 500-line pass on the base evidence rather than a broken harness. The last row is #1375's second required direction: a dropped row for a file that genuinely shrank under target must stay green.

## One existing self-test case changed meaning

It was encoding the hole at its own boundary. `a new 800-line file passes (at the hard ceiling)` now reads `an over-target file with NO entry FAILS (800, inside the hard ceiling)`, and asserts the refusal names the *missing entry* rather than the hard ceiling. Added: recording the entry is the fix, and the same file then passes. The 801-line hard-ceiling case is kept and still passes.

## Mutation table — kills captured by NAME

| mutation | named kills |
|---|---|
| **M1** remove the new check | `an over-target file with NO entry FAILS`, `names the missing entry, not the hard ceiling` |
| **M2** fire even when an entry exists | `recording the entry is the fix`, plus the ceiling-calibration and lane-detection cases |

**Said plainly rather than glossed: `recording the entry is the fix` SURVIVES M1** — the base passes that case too. It is load-bearing against M2 (a check that fires despite a recorded row would make the gate unfixable), and M2 is the mutation that matters for it. Baseline green before and after both mutations.

## Violators enumerated before landing, as ruled

Exactly **one** over-target file lacked a row — `tests/stack/test-wizard-setup.sh` at 417 — and its row lands in **this commit**, not a follow-on PR. The tsv's path set and `--generate`'s are now identical, **70 = 70**.

## This script crossed the target itself

399 → 407, so it records its own ceiling here. That is the gate applying its rule to the file that defines it rather than exempting it. **Named cost:** further self-test cases now need a line-neutral form, on the file most likely to grow when a new failure mode is found. Flagging it rather than hiding it — if a reviewer would rather exempt this file, that is a reasonable counter-position.

## Deliberately NOT taken from `--generate`

It also wanted to lower `.github/workflows/ci.yml` 513 → 512 and `tests/integration/run.sh` 2551 → 2527. Lowering a ceiling reds every un-rebased branch in every lane with a message naming a file their diff never touched; those are reclaimed inside a cut when lanes are rebasing anyway, never as a standalone tidy. **Both preserved.**

## Shared file, under a one-shot lane override

`scripts/lint-file-budget.sh` is outside this lane's paths and was touched under `.lane-override`, consumed on use. It was ruled this lane's to change for this work, with both conditions honoured: violators enumerated first, and the required row in the same commit.

## Rebase, and the check that a rebase exit code does not give you

Rebased onto the current `develop-v2` after `tests/stack/run.sh`'s ceiling went **down** 4178 → 3841. Verified the **row**, not the operation: `git show HEAD:docs/dev/file-budget.tsv` reads 3841, and HEAD contains the tip. Separately, against the failure mode #1375 itself names: `--generate` re-run after the rebase is byte-identical to the merged tsv, and **no row was dropped** against the base's row set.

## Over-engineering pass (run on merit, not because a gate asked)

It found one real question: **the hard-ceiling branch is now subsumed** — both it and the new branch produce a FAIL, so 800 no longer gates anything and only selects wording. I kept it deliberately, because at >800 "this file is too big" is better advice than "add a row", and deleting a guard's message inside a behaviour-change PR is scope creep. Stated so a reviewer can overrule me; if the call goes the other way, removing `HARD_CEILING` outright is a clean follow-up.

## Run here / not run

**Run:** the gate (rc 0), its self-test (17/17 ok), the truth table above, the mutation table above, `shfmt -i 4 -d` clean, `shellcheck` **0.11.0** (CI-pinned) at **full severity** clean on this script.

**NOT run:** `make lint`, `make test`, `make lint-sh` — shellcheck on `tests/stack/run.sh` is this box's OOM path. CI is the check for those.

**Adversarial review: done** — see below.

`Closes` never fires in this repo (PRs land on `develop-v2`, the default branch is `develop`), so **#1375 will be closed by hand** naming this PR.

## Review and merge order

**Reviewer lane verdict: MERGE, no blocking findings.** They rebuilt the four-fixture truth table independently in throwaway repos and reproduced all four rows including the negative control, confirmed the gate at rc 0 on the real tree with the path sets diffed (not counted) at 70 = 70, and re-derived `--self-test` rc 0. The one finding worth acting on was the justification above, and it is adopted.

**This PR was stacked on #1392 while that was open.** #1392 has since merged (`f0fc9e31`) and this branch is rebased onto it, so it now carries exactly one commit and its diff is only the gate change plus the two budget rows. The stacking is recorded because merge order was briefly load-bearing — merging this one first would have landed #1388's fix under this number.
