### PR TITLE
fix(dashboard): reach the calm provenance verdict only through an allowlist (#1371)

### DIFF
--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -38,13 +38,25 @@ import re
 # would let a compromised one write its own provenance.
 CONFIG_SOURCES = ("control", "local", "restore")
 
-# A control change whose id we matched, but which this dashboard's own history records as not having
-# held. RigForge's rollback re-apply stamps the SAME change id it just reverted, so the rig goes on
-# naming a change that is no longer what it is running — and "Last changed from this dashboard" over
-# one of those is the one confidently wrong answer this line can give, in exactly the case an
-# operator most needs it right. ``rejected`` cannot reach us today (a rejected change returns before
-# config.json is touched, so it is never stamped at all); it is listed anyway so that the check
-# fails closed rather than open if RigForge's apply path ever changes.
+# The one status that positively records a control change as having taken effect. This is an
+# ALLOWLIST and that is the whole point (#1371): "Last changed from this dashboard" is the one
+# confidently wrong answer this line can give, so it is reached only by a status that says the
+# change held, never by the absence of a status that says it did not. The first shape of this check
+# was the inverse — everything outside ``REVERTED_STATUSES`` read as ``here`` — which handed the
+# reassuring answer to ``accepted`` (the rig took the request; it has not said it kept it) and to
+# every status a future RigForge or a future dashboard might write. A denylist cannot be made
+# fail-closed by lengthening it; only inverting it does that.
+HELD_STATUSES = ("applied",)
+
+# Among the statuses that are NOT in ``HELD_STATUSES``, the ones we can name precisely: the change
+# reached the rig and the rig threw it away. RigForge's rollback re-apply stamps the SAME change id
+# it just reverted, so the rig goes on naming a change that is no longer what it is running.
+# ``rejected`` cannot reach us today (a rejected change returns before config.json is touched, so it
+# is never stamped at all); it is listed for the wording, not for safety.
+#
+# This one stays a denylist on purpose, and it is safe to be one because it no longer decides
+# anything the operator can be misled by: it picks the SPECIFIC wording among rows we have already
+# refused to call ``here``. A status missing from it falls to ``unconfirmed``, which under-claims.
 REVERTED_STATUSES = ("rolled_back", "failed", "rejected")
 
 # Long enough for the ids RigForge actually mints (a 16-hex change id, a 16-hex revision) with room
@@ -108,6 +120,13 @@ def config_origin(meta, change_id_known, change_status=None):
                       the id it just reverted, so the rig keeps naming it while running whatever
                       preceded it. Saying ``here`` over this would print a calm "changed from this
                       dashboard" directly above a history row reading "Rolled back" in red.
+    - ``unconfirmed``— applied over the control channel with an id we know, and our own row for it
+                      records neither that it held nor that it was reverted (#1371). ``accepted``
+                      is the one that actually happens: the rig acknowledged the request and our
+                      reconciler has not yet caught the row up to a terminal outcome, so a rollback
+                      that lost the race to the poll sits here indefinitely. Distinct from both
+                      neighbours because it is the honest answer — we do not know — and folding it
+                      into either would state something we cannot support.
     - ``elsewhere`` — applied over a control channel, with an id we have never seen. Another host,
                       or our record of it is gone. Either way it is not something to present as ours.
     - ``rig``       — applied on the rig itself.
@@ -127,7 +146,11 @@ def config_origin(meta, change_id_known, change_status=None):
     if source == "control":
         if not change_id_known:
             return "elsewhere"
-        return "reverted" if change_status in REVERTED_STATUSES else "here"
+        if change_status in HELD_STATUSES:
+            return "here"
+        if change_status in REVERTED_STATUSES:
+            return "reverted"
+        return "unconfirmed"
     if source == "local":
         return "rig"
     if source == "restore":

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -149,6 +149,14 @@ export function buildChartMarkers(markers) {
 // rollback after a change fails to hold, so the text has to leave room for the rig having healed
 // itself rather than someone having edited it. `unrecorded` claims nothing for the same reason — a
 // never-changed rig and a config edited underneath RigForge look identical from here.
+//
+// `unconfirmed` is the one that says "we do not know", and it must keep saying only that: it can
+// neither promise the change held nor accuse the rig of dropping it. It is reached by an
+// `accepted` row, which the host runner writes only after polling the rig's /status for a terminal
+// outcome for 20s and getting none ("queued on the rig; outcome not yet observed", pithead's own
+// note). Phrased "is unconfirmed" rather than "was never confirmed" on purpose — the reconciler
+// can still settle that row on a later read poll, so claiming finality would be a second wrong
+// answer in place of the first one this verdict exists to remove.
 const CONFIG_ORIGIN_TEXT = {
   here: { cls: "text-muted", label: "Last changed from this dashboard" },
   reverted: {
@@ -156,6 +164,12 @@ const CONFIG_ORIGIN_TEXT = {
     label: "Last change from this dashboard was rolled back",
     detail:
       "the rig re-stamps the change id it reverted, so it is running whatever config came before",
+  },
+  unconfirmed: {
+    cls: "status-warn",
+    label: "Last change from this dashboard is unconfirmed",
+    detail:
+      "the rig acknowledged it but has not reported an outcome — it may be running, or it may have been rolled back",
   },
   elsewhere: {
     cls: "status-warn",

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -10,7 +10,12 @@ reaches us wearing the same ``source`` and the same change id as the one that he
 
 import pytest
 
-from mining_dashboard.client.rig_config_meta import config_origin, parse_config_meta
+from mining_dashboard.client.rig_config_meta import (
+    HELD_STATUSES,
+    REVERTED_STATUSES,
+    config_origin,
+    parse_config_meta,
+)
 from mining_dashboard.client.xmrig_client import parse_rigforge
 
 GOOD = {
@@ -73,8 +78,8 @@ def test_a_timestamp_the_rig_did_not_stamp_is_not_shown():
         assert parse_config_meta({**GOOD, "changed_at": junk})["changed_at"] is None
 
 
-def test_a_control_change_we_have_a_record_of_is_ours():
-    assert config_origin(GOOD, change_id_known=True) == "here"
+def test_a_control_change_we_have_a_record_of_and_that_held_is_ours():
+    assert config_origin(GOOD, change_id_known=True, change_status="applied") == "here"
 
 
 @pytest.mark.parametrize("status", ["rolled_back", "failed", "rejected"])
@@ -84,11 +89,61 @@ def test_a_control_change_our_history_says_did_not_hold_is_not_claimed_as_runnin
     assert config_origin(GOOD, change_id_known=True, change_status=status) == "reverted"
 
 
-@pytest.mark.parametrize("status", ["applied", "noop", "throttled", None])
-def test_a_change_that_was_not_reverted_still_reads_as_ours(status):
-    # The negative control for the guard above: it must catch reverted rows WITHOUT swallowing the
-    # ordinary ones. ``None`` covers a history row from before the status column carried a value.
-    assert config_origin(GOOD, change_id_known=True, change_status=status) == "here"
+@pytest.mark.parametrize(
+    "status",
+    [
+        # REACHABLE, and the reason this issue exists. ``accepted`` is what
+        # ``add_worker_config_version`` writes when the rig returns a 202, and
+        # ``reconcile_worker_config_status`` is the only thing that ever moves it off. A rollback
+        # slower than the host runner's status-poll deadline leaves the row here forever, so the
+        # rig names a change it has already thrown away while our row still says "accepted".
+        "accepted",
+        # Written only by the control-UPGRADE path (rigforge server.py's ``_record_worker_result``
+        # with ``change_type="upgrade"``; its own comment reads "noop/throttled are upgrade-only").
+        # Those rows DO land in ``worker_config`` and this scan DOES walk them — but an upgrade's
+        # change id can never become a rig's ``last_change_id``, because ``_control_upgrade_do``
+        # ends by exec'ing ``rigforge.sh upgrade`` as a CHILD PROCESS and
+        # ``RIGFORGE_CONFIG_SOURCE`` / ``RIGFORGE_CONFIG_CHANGE_ID`` are declared ``local`` and
+        # never exported, so the child stamps ``source=local`` with an empty id. One ``export`` on
+        # that line would silently break that, and nothing at this call site would show it — which
+        # is exactly why the cautious answer is asserted here rather than assumed.
+        "noop",
+        "throttled",
+        # NOT reachable through today's writer: ``_record_worker_result`` filters on
+        # ``_RECORDABLE_WORKER_STATUSES`` and ``reconcile_worker_config_status`` on
+        # ``_RECONCILE_TERMINAL``, and no member of either is missing above. They are asserted
+        # anyway, because that is the entire property an allowlist buys: a status nobody here
+        # anticipated — a future RigForge outcome, a row from an older schema, a NULL column — is
+        # refused BY CONSTRUCTION rather than by someone remembering to add it to a denylist.
+        "pending",
+        "unknown",
+        "timeout",
+        "error",
+        None,
+        "",
+    ],
+)
+def test_a_change_our_history_cannot_confirm_held_is_never_claimed_as_running(status):
+    assert config_origin(GOOD, change_id_known=True, change_status=status) == "unconfirmed"
+
+
+def test_the_reassuring_verdict_is_reached_only_through_the_allowlist():
+    # The property, stated as a test rather than as a comment: ``here`` is not the fall-through.
+    # The first shape of this check returned ``here`` for everything outside REVERTED_STATUSES,
+    # which is why every status above used to read as "Last changed from this dashboard".
+    #
+    # The emptiness guard below is load-bearing, not a formality. Without it every assertion in
+    # this test is vacuous the moment ``HELD_STATUSES`` is empty: the loop does not run and
+    # ``all()`` over nothing is True, so a test named for the allowlist passes with no allowlist
+    # at all. Caught by mutation — emptying the tuple redded four other tests and left this one
+    # green, which is the one result a test asserting this property must never give.
+    assert HELD_STATUSES, "an empty allowlist makes every assertion below vacuous"
+    for status in HELD_STATUSES:
+        assert config_origin(GOOD, change_id_known=True, change_status=status) == "here"
+    assert all(s not in REVERTED_STATUSES for s in HELD_STATUSES)
+    # Omitting the argument entirely must not be the calm answer either — a caller that cannot say
+    # what our row records has told us nothing, not that the change held.
+    assert config_origin(GOOD, change_id_known=True) == "unconfirmed"
 
 
 def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -8,7 +8,9 @@
 // so the assertions are about what it may and may not CLAIM, not about markup:
 //   - silence when the rig cannot answer (never the word "unknown");
 //   - "restored" never phrased as someone having edited the rig;
-//   - "unrecorded" never phrased as a change having happened.
+//   - "unrecorded" never phrased as a change having happened;
+//   - "unconfirmed" phrased as neither of its neighbours — it may not read as the change having
+//     held, and it may not state the rollback it has no record of either.
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
@@ -87,6 +89,19 @@ test("a rolled-back change of ours is never dressed up as the running config", (
   const note = configOriginNote("reverted", META);
   assert.notEqual(note.label, here.label);
   assert.match(note.title, /came before/i);
+});
+
+test("an unconfirmed change of ours neither claims it held nor accuses the rig", () => {
+  const out = renderToString(ConfigProvenance({ origin: "unconfirmed", meta: META }));
+  const note = configOriginNote("unconfirmed", META);
+  // This verdict exists to say "we do not know", so it has to fail BOTH ways. It must not read as
+  // the calm `here` line over a change the rig may have rolled back...
+  assert.doesNotMatch(out, /Last changed from this dashboard/);
+  assert.match(out, /status-warn/);
+  // ...and it must not state the rolled-back outcome either, which we have no record of.
+  assert.notEqual(note.label, configOriginNote("reverted", META).label);
+  assert.doesNotMatch(note.label, /rolled back/i);
+  assert.match(note.title, /has not reported an outcome/i);
 });
 
 test("unrecorded claims no change happened and no change did not", () => {

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -94,6 +94,38 @@ class TestConfigOrigin:
         )
         assert d["config_origin"] == "here"
 
+    def test_a_change_the_rig_only_acknowledged_is_not_claimed_as_the_running_config(
+        self, monkeypatch
+    ):
+        # The reachable half of the allowlist inversion, driven through the real StateManager
+        # rather than through config_origin alone. ``accepted`` is what we write on the rig's 202
+        # and it is NOT an outcome: ``reconcile_worker_config_status`` is the only thing that ever
+        # moves the row off it, and a rollback slower than the host runner's status-poll deadline
+        # never gets reconciled. The rig goes on naming the change it reverted (RigForge re-stamps
+        # the same id), our row still reads "accepted", and the old denylist printed the calm
+        # "Last changed from this dashboard" over a config the rig had already thrown away.
+        d = _detail(
+            monkeypatch, {"config_meta": _META}, spooled=_META["last_change_id"], status="accepted"
+        )
+        assert d["config_origin"] == "unconfirmed"
+
+    def test_a_status_this_dashboard_has_never_written_still_fails_closed(self, monkeypatch):
+        # The property the inversion buys, asserted end to end: a status no code path here
+        # produces today must not reach the reassuring verdict. Under the previous denylist both of
+        # these read as "here" purely by not being enumerated. Two samples and not a longer list:
+        # through the real StateManager a status is a TEXT column value, so an unanticipated
+        # non-empty string and the empty string are the only two paths there are to travel. The
+        # full vocabulary is enumerated against ``config_origin`` itself in
+        # tests/client/test_rig_config_meta.py, which is the tier that owns it.
+        for status in ("pending", ""):
+            d = _detail(
+                monkeypatch,
+                {"config_meta": _META},
+                spooled=_META["last_change_id"],
+                status=status,
+            )
+            assert d["config_origin"] == "unconfirmed", status
+
     def test_control_change_we_never_spooled_is_elsewhere(self, monkeypatch):
         # Same source, same shape — only the id differs. Another host drove this rig, or our
         # record of it is gone. Either way it is not ours to present as ours.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -430,12 +430,18 @@ what applied it and a change id, and the dashboard looks for that id among this 
 rows — the table directly below — so the verdict is one you can check by eye:
 
 - **Last changed from this dashboard** — the id matches a change in the history below, and that
-  change held.
+  change is recorded as having been applied. Only that outcome earns this line: every other one,
+  including an outcome that was never recorded at all, gets one of the lines below instead.
 - **Last change from this dashboard was rolled back** — the id matches a change the history below
   records as rolled back or failed. When a control change does not come back live, RigForge
   restores the previous config and stamps that restore with the *same* change id it just reverted,
   so the rig goes on naming a change it is no longer running. The rig is on whatever config came
   before it.
+- **Last change from this dashboard is unconfirmed** — the id matches a change in the history
+  below, and no outcome was ever recorded for it. The dashboard waits on the rig for the result of
+  a change it sends; when the rig has not said what it did within that wait, the change is recorded
+  as acknowledged but unsettled. It may be running, or the rig may have rolled it back. This line
+  says only that the record cannot tell you which, and it can still resolve on a later reading.
 - **Last changed from another dashboard** — applied over a control channel, but with an id this
   dashboard has never issued. Another host drove this rig, or its record here is gone.
 - **Last changed on the rig itself** — applied on the rig, not over a control channel at all.


### PR DESCRIPTION
## What this changes

`config_origin` decided "this change held" by asking whether the history row's status was **not** in
a denylist, so every status nobody had enumerated returned the calm `here` — "Last changed from this
dashboard". This inverts it: `here` is reached only through `HELD_STATUSES`, and everything that is
neither held nor known-reverted gets a third verdict, `unconfirmed`.

```python
# before                                         # after
return ("reverted" if change_status              if change_status in HELD_STATUSES:
        in REVERTED_STATUSES else "here")            return "here"
                                                 if change_status in REVERTED_STATUSES:
                                                     return "reverted"
                                                 return "unconfirmed"
```

The issue asked for an allowlist and this is that, in the form the issue described: a status that
positively records the change as having held, the known-reverted set keeping its more specific
wording, and everything else reading as *we cannot confirm this*.

## The case that actually reaches an operator

`accepted`. It is not hypothetical and it is not a transient — traced to the host runner rather than
to our own comment about it. `control_worker_apply` polls the rig's `/status` for a terminal outcome
for 20 seconds and records `applied` / `rejected` / `rolled_back` / `failed` when it gets one. Only
when that deadline burns does it write `accepted`, with its own note attached (`pithead:10846`):

> `queued on the rig; outcome not yet observed`

So an `accepted` row means the rig took the request and had not said what it did with it. Combine
that with the mechanism #1345 exists for — RigForge's rollback re-apply re-stamps the change id it
just reverted, so the rig goes on naming a change it threw away — and the old denylist printed
"Last changed from this dashboard" over a config the rig had already rolled back. That is the exact
answer #1345 was written to prevent, reached down the path where reconciliation did not win.

**The dashboard already knew this, in a comment nine lines from the writer.** `server.py:295-299`,
above `_RECORDABLE_WORKER_STATUSES`, reads: *"`accepted` is genuinely non-terminal (still running on
the rig past the wait budget) but IS the runner's final write for that request id"*. That comment and
`config_origin`'s verdict contradicted each other, and the verdict is the one an operator reads.

## Why the remaining denylist is not the same defect

`REVERTED_STATUSES` stays a denylist deliberately. It no longer decides anything an operator can be
misled by: it picks the *specific wording* among rows the allowlist has already refused to call
`here`. A status missing from it falls through to `unconfirmed`, which under-claims. The safety
property moved to the allowlist; this one is now about phrasing. That is stated in the source so the
next reader does not have to re-derive whether it is a leftover.

## `unconfirmed` says only what it knows

It has to fail in both directions, so the test asserts both: it must not read as the calm `here`
line over a change the rig may have discarded, and it must not state the rolled-back outcome we have
no record of either. The wording is "is unconfirmed", not "was never confirmed" — the reconciler
(`reconcile_worker_config_status`, on the regular read poll) can still settle an `accepted` row
later, so claiming finality would be a second wrong answer in place of the first.

## Where noop / throttled land, and the claim I deliberately did NOT assert

`noop` and `throttled` are written only by the control-**upgrade** path, and upgrade rows do land in
`worker_config` — `_record_worker_result` with `change_type="upgrade"` is the only writer, and the
comment above `_RECORDABLE_WORKER_STATUSES` says "noop/throttled are upgrade-only". The history scan
in `worker_detail` does walk them.

What stops one being *matched* is separate: `_control_upgrade_do` ends by exec'ing `rigforge.sh
upgrade` as a **child process**, and `RIGFORGE_CONFIG_SOURCE` / `RIGFORGE_CONFIG_CHANGE_ID` are
declared `local` and never exported, so the child stamps `source=local` with an empty change id. An
upgrade's change id therefore cannot become a rig's `last_change_id`.

I did not turn that into an assertion, because it is a claim about another repo's shell scoping that
a dashboard unit test cannot observe — asserting it here would encode a belief rather than test a
behaviour. What the tests assert instead is the direction that is safe whether or not it holds:
`noop` and `throttled` never read as `here`. The trace is recorded in the test comment, including
the detail that a single `export` on that line would silently break it.

**This is the load-bearing property of the inversion:** under an `applied`-only allowlist, every
status nobody anticipated lands on the cautious branch regardless of who is right about that
scoping. The fix does not depend on the trace being correct.

## The two passes this lane mandates

**Security review — run, clean.** A `security-reviewer` subagent read the diff plus `worker_detail.py`,
`server.py`, `storage_service.py` and `confighistory.mjs`. No defects. What it confirmed, each stated
as checked rather than assumed: `here` is reachable only by exact-string membership in
`HELD_STATUSES` (no case-folding, no strip, no truthiness coercion, so `"Applied"`, `" applied"`,
`None`, `""` all fall to `unconfirmed`); the `unconfirmed` label and detail are static strings with no
rig-controlled interpolation, rendered through the preact/htm tagged template rather than `innerHTML`;
and no error path lands on `here`.

I re-derived its highest-cost claim by my own route rather than taking it: `get_worker_config_history`
is worker-scoped in SQL (`WHERE worker = ?`), so a change id spooled for a *different* rig cannot be
selected, and a `sqlite3.Error` returns `[]` → no match → `elsewhere`. Both fail in the under-claiming
direction. This is the inverted polarity of `worker_config_change_known`, which the source comment in
`worker_detail.py` already warns about: that lookup is unscoped (any rig's change id counts) and
returns `True` on a `sqlite3.Error`, both correct for the #530 rig-edit audit, where a false "known"
merely declines to accuse a rig. Here `True` would mean "yes, it is ours", so the same two properties
would print "Last changed from this dashboard" off a transient DB error. The scan this code uses
instead is worker-scoped by construction and fails closed. Anyone reusing that helper for #1369
needs its own error path returning "not ours".

**Over-engineering pass — run by hand, one change made.** Two candidates, one kept and one trimmed:

- *Kept:* `HELD_STATUSES = ("applied",)` as a one-element tuple rather than an inline
  `== "applied"`. It matches the module's existing idiom (`CONFIG_SOURCES`, `REVERTED_STATUSES` are
  both module-level tuples), the property test iterates it to state "here is reached only through the
  allowlist" generically and asserts it is disjoint from `REVERTED_STATUSES`, and inlining it would
  make the allowlist/denylist symmetry invisible at the one line where it decides something.
- *Trimmed:* `test_a_status_this_dashboard_has_never_written_still_fails_closed` looped four statuses
  through the real `StateManager`. Through that path a status is a `TEXT` column value, so
  `pending` / `unknown` / `timeout` are three samples of one equivalence class and `""` is the only
  member of the other — the extra two re-proved that sqlite round-trips a string. Now two samples,
  one per class, with the reasoning in the comment. The full vocabulary stays enumerated against
  `config_origin` in `test_rig_config_meta.py`, which is the tier that owns it.

- *Fixed:* the pass turned up a hole my first reading missed. `test_the_reassuring_verdict_is_reached_only_through_the_allowlist`
  **passed vacuously when the allowlist was emptied** — the loop had no iterations and `all()` over
  an empty sequence is `True`, so a test named for the allowlist was green with no allowlist at all.
  The mutation table is what exposed it: M3 redded four other tests and left this one alone. Added a
  one-line `assert HELD_STATUSES` guard and re-ran M3 to confirm the test now dies where it
  previously survived. Same family as the rest of this diff — a check that could not fail.

Recorded because the gate's silence is not a pass: the ponytail hook keys its sentinel to the pane's
branch, not the PR's, so it is not evidence about this or any PR. This pass was run regardless.

## Evidence

**Seven mutations, each seen to RED with a NAMED failing test.** Baseline `pytest=0 node=0` before,
`pytest=0 node=0` after restore. The loop captures pytest `FAILED` node ids and node's TAP `not ok`
lines and refuses to count a mutation that reds without a named kill — an exit code alone cannot be
checked against the guard you predicted would catch it.

| # | mutation | named kills |
|---|---|---|
| M1 | denylist fall-through restored (the defect itself) | 12, incl. `test_a_status_this_dashboard_has_never_written_still_fails_closed` |
| M2 | allowlist widened to admit `accepted` | 2 — unit `...cannot_confirm_held...[accepted]`, web `test_a_change_the_rig_only_acknowledged_is_not_claimed_as_the_running_config` |
| M3 | allowlist emptied — nothing may read as ours | 4, all of them the ordinary `applied` cases |
| M4 | the unknown branch accuses rollback instead of leaving it unknown | 12 |
| M5 | upgrade-only statuses re-admitted to the allowlist | 2 — unit `[noop]`, `[throttled]` |
| M6 | `unconfirmed` has no operator text, so the line renders silent | 1 (frontend) |
| M7 | `unconfirmed` text overstates: claims the rollback it cannot know | 1 (frontend) |

Two of those are worth reading as a pair. **M2 and M5 kill disjoint sets** — widening the allowlist
to `accepted` and widening it to `noop`/`throttled` are separate defects and the suite tells them
apart, which is the difference between a table that discriminates and one that only reds. **M3 is
the negative control**: emptying the allowlist reds only the ordinary held-change tests, which is
what proves the inversion did not simply make everything cautious.

**M1 still names the test the over-engineering pass trimmed**, run after the trim rather than before
— so the simplification did not cost a kill. That check is the reason the trim is safe rather than
merely smaller.



**Lane gate, run from the repo root after the rebase, each exit code captured separately rather than
read out of a filtered stream** — `pytest` 0 · `node --test` 0 (**476 pass / 0 fail**) · `lint-py` 0 ·
`lint-js` 0 · `lint-topology` 0 · `lint-md` 0 · `lint-docs-voice` 0 · `lint-operator-strings` 0 ·
`lint-file-budget` 0. Run with `PATH=$HOME/.local/bin:$PATH`, and the resolved binaries checked
first — `shellcheck` 0.11.0 and `uv` both come from `~/.local/bin`, which is not on PATH in these
shells, so a bare run gives a stale engine or a 127 that reads as a lint failure.

**`scripts/lint-file-budget.sh --generate` diffed against the merged tsv** (a clean auto-merge of that
file can drop rows silently at rc 0). Three differences, none from this branch: `ci.yml` and
`tests/integration/run.sh` each sit *below* a recorded ceiling, which the gate never fails on, and
`tests/stack/test-wizard-setup.sh` is 417 lines with no row — the known gap where crossing
`TARGET_LINES` arms nothing, not a row this rebase dropped.

**Rebased onto `develop-v2` before opening** (the branch was 19 commits behind). No overlap: none of
the six touched files were modified by those commits, and `docs/dev/file-budget.tsv` was not changed
on the base. None of the six carries a budget row at all, so the ratchet does not apply here —
checked against `git show origin/develop-v2:docs/dev/file-budget.tsv`, not carried from a note.

**Not run, and stated rather than implied:** `make lint-sh`, `make lint` and `make test` were not
run — shellcheck OOM-kills sessions on this box, and this lane runs the targets individually instead.
No live rig, bench, or browser exercised this change; the provenance line has been checked by
render-probe tests only, never looked at in a browser. The RigForge scoping trace above is read from
source, not executed.
