### PR TITLE
test(integration): abort-safe unwind for the RigForge writable-key legs (#1379)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -356,6 +356,37 @@ loudly without its prerequisite:
 - Auto-rollback ([#517](https://github.com/p2pool-starter-stack/pithead/issues/517), rigforge#236):
   a change the rig rolls back is recorded as `rolled_back` in the worker-apply result and history.
 
+### The abort-safe unwind
+
+Every leg above restores what it changed when it finishes. That covers a leg that *fails*; it does
+not cover a run that never reaches its own restore. Ctrl-C, a `set -u` abort, an SSH drop or a
+cancelled CI job used to leave a borrowed production miner on a probe value, while `e2e.sh`'s
+`restore_all` reported a clean restore of the *pool* config and said nothing about the writable keys
+([#1379](https://github.com/p2pool-starter-stack/pithead/issues/1379)).
+
+`rig-key-ledger.sh` closes that window. A key goes on a ledger when its write is sent — before, not
+after, so the apply itself is covered — and comes off only when its revert is **confirmed applied**.
+An `EXIT` trap restores whatever is still on the ledger, by the same route that changed it: the
+dashboard's `/api/control/worker-apply` for the #513, #1236 and #1002b legs, a direct dial at the
+rig's control API for #516's rig-side edit. Each restore names its key, value and rig on stderr.
+
+Three properties are worth knowing rather than rediscovering:
+
+- **It is a no-op by construction, not by a guard.** A run that writes no writable key never marks
+  anything, so no trap is ever installed. `--mode targeted` runs that borrow no rig are unaffected.
+- **The trap is composed, not stacked.** `trap … EXIT` replaces rather than stacks, and `rig_lock`
+  already installs one to clear the shared-bench holder breadcrumb. The ledger's handler folds that
+  removal into its own body — which is what `lib.sh` prescribed for whatever trap came second — so
+  arming it cannot silently strand the breadcrumb or silently skip the restore.
+- **`#517` is deliberately outside the ledger.** Its leg induces a change the *rig* rolls back on
+  its own. Unwinding it from here would race that rollback and could re-apply a value the rig had
+  already reverted, so the rig stays the authority for it.
+
+What it cannot do: the restore dials the dashboard or the rig while the run is already dying, so it
+is best-effort, and it cannot run at all if the shell never exits — `kill -9`, an OOM kill, or the
+box losing power. After an end like that, read the rig's values in Worker Inspect and put a stray
+one back by hand.
+
 Prerequisites: a real RigForge rig connected (self-skips otherwise); `--rig-host` + `IT_RIG_TOKEN`
 to inject a descriptor when the baseline lacks one, and to dial the rig directly for the #516 feed
 leg; `IT_RIG_POOLS_PROBE` (a JSON `pools` value safe to apply to the borrowed rig) for the pools

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -195,16 +195,22 @@ Two runs of the matrix are required, and the automated one is the smaller of the
    read the run's output rather than its exit code alone. The readiness gate does not satisfy
    this requirement; abort the release on any failure.
 
-   A run that does not finish leaves the rig's writable config where it stopped. The `EXIT`
-   trap restores the rig's xmrig pool config and the baseline stack; it does not restore the
-   RigForge writable keys, and `run.sh` — which writes them — has no trap at all
-   ([#1379](https://github.com/p2pool-starter-stack/pithead/issues/1379)). So a `Ctrl-C`, an
-   SSH drop, or a cancelled job mid-leg can leave `max_temp_c` a degree above where it started,
-   or whichever key the run died inside. Every probe is a near neighbour of the value it read
-   off the rig, so nothing is damaged — but the rig is not where you left it, and the restore
-   summary will not mention it. Read the rig's current values in Worker Inspect against what
-   you expect, and put a stray one back the same way. This is the same shape as `--keep`: the
-   run tells you it did not restore, and the rest is yours.
+   A run that does not finish now unwinds its own writable-key changes
+   ([#1379](https://github.com/p2pool-starter-stack/pithead/issues/1379)). Each key is recorded
+   when its write goes out and retired only when its revert is confirmed, and an `EXIT` trap
+   restores whatever is still outstanding — so a `Ctrl-C`, a `kill`, an SSH drop or a cancelled
+   job mid-leg puts `max_temp_c`, `DONATION`, `watchdog_interval_min` or `pools` back the way the
+   run found it, by the same route that changed it. The unwind names every key it restores on
+   stderr; a run that ends cleanly has nothing outstanding and says nothing.
+
+   Two limits are worth knowing before you rely on it. The restore is **best-effort**: it dials
+   the dashboard or the rig while the run is already dying, and if that dial fails there is
+   nothing further it can do. And it cannot run at all if the shell never gets to exit — a
+   `kill -9`, an OOM kill, or the box losing power. In either case the rig is left on a probe
+   value, which is always a near neighbour of what it read off the rig, so nothing is damaged.
+   If a run ended in one of those ways, read the rig's current values in Worker Inspect against
+   what you expect and put a stray one back the same way. This is the same shape as `--keep`:
+   what the run could not restore, it tells you about, and the rest is yours.
 
 After deploying the published release to the bench, run the non-destructive live sweep as the
 closing check: `tests/integration/run.sh --local --dir <stack-dir> --check`. On a bench with no

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -381,9 +381,9 @@ monero_caught_up() {
 # same lock path on every box IS the protocol; do not fork the two copies. FD 9 is inherited
 # by children, which is what keeps the lock held for the whole run — never close it.
 # RIG_LOCK_FILE/RIG_LOCK_HOLDER are env-overridable so the tier-1 self-test can sandbox the
-# paths (rigforge#183 note 6). run.sh sets no other EXIT trap; if one is ever added there,
-# fold this rm -f into its body instead of trapping twice — a later `trap … EXIT` replaces,
-# it doesn't stack (rigforge#183 note 3). The lock is opened READ-only (9<, rigforge#242/#252) so a
+# paths (rigforge#183 note 6). run.sh NOW installs an EXIT trap — rig_key_atexit (rig-key-ledger.sh,
+# #1379) — folding this rm -f into its body per note 3, since a later `trap … EXIT` replaces rather
+# than stacks. That is its ONLY other copy; keep the pair in step. Opened READ-only (9<, #242/#252) so a
 # root run can reserve a box whose lock file a prior non-root reserve created — fs.protected_regular
 # blocks even root's write-open (9>) of a foreign-owned lock, silently dropping the flock (#249).
 rig_lock() { # rig_lock <project> <suite> [shared]

--- a/tests/integration/rig-key-ledger.sh
+++ b/tests/integration/rig-key-ledger.sh
@@ -1,0 +1,141 @@
+# shellcheck shell=bash
+#
+# Abort-safe unwind for the RigForge writable-key legs (#1379).
+#
+# `e2e.sh` installs `trap restore_all EXIT INT TERM`, which reads as full abort safety for the
+# borrowed rig. It is not: `restore_all` puts back the miner's xmrig POOL config and the baseline
+# stack, and never touches the rig's RigForge writable config — DONATION, max_temp_c, autotune,
+# watchdog, watchdog_interval_min, pools. Those writes are made from run.sh and this directory's
+# other modules, in a process that had no trap of any kind. Every writable-key leg was a bare
+# apply/revert pair with no unwind path, so a run that died between the two — Ctrl-C, a `set -u`
+# abort, a cancelled CI job, an SSH drop — left a borrowed production miner on a probe value while
+# the trap that DID exist reported a clean restore of the pool config.
+#
+# It had not bitten yet for two reasons, neither of them a control: the probes are chosen benign
+# (max_temp_c +1; the #1236 legs read each original off the rig and write a near neighbour), and
+# almost nobody ran the phase. #1364 removes the second one on purpose by putting the write phase
+# into the mandated `--mode targeted` pre-cut run.
+#
+# THE LEDGER, and why it is a ledger rather than a saved snapshot. A key is recorded when its write
+# goes out and cleared only when its revert is CONFIRMED applied — so at the end of a healthy run
+# the ledger is empty and the trap restores nothing. That makes the issue's "must be a no-op when
+# no writable key was touched" requirement structurally true rather than a guarded special case:
+# when nothing was written, no mark ever happened, so no trap was ever installed. It also keeps a
+# leg whose revert came back non-applied on the books, so the trap retries it at exit instead of
+# trusting an assertion that already red.
+#
+# THE TRAP IS COMPOSED, NOT STACKED, AND THAT IS THE WHOLE HAZARD IN THIS FILE. `trap … EXIT`
+# REPLACES; it does not stack. run.sh calls `rig_lock` (lib.sh), which installs an EXIT trap of its
+# own to remove the display-only lock-holder breadcrumb. A naive second `trap … EXIT` here would
+# silently produce one of two failures with no output difference either way:
+#
+#   installed BEFORE rig_lock runs  -> the holder trap replaces ours and NO key is ever restored,
+#                                      i.e. this fix reads as shipped and does nothing;
+#   installed AFTER                 -> ours replaces the holder cleanup and every run strands the
+#                                      breadcrumb, the display side of the shared-bench protocol.
+#
+# lib.sh predicted exactly this and prescribed the fix in its own words — fold the holder `rm -f`
+# into the body of whatever trap is added, rather than trapping twice. `rig_key_atexit` below is
+# that fold, and it is the ONLY copy of that removal outside lib.sh's own. Its ordering is asserted
+# at tier 1 by driving the real `rig_lock` against sandboxed paths, so if lib.sh's holder-path logic
+# ever changes, this copy reds rather than drifting quietly.
+#
+# WHY `EXIT` ALONE AND NOT `EXIT INT TERM`. Measured on this box rather than assumed: a bare EXIT
+# trap DOES run when the shell dies of SIGINT or SIGTERM, and `trap … EXIT INT TERM` runs the
+# handler TWICE for one signal — once for the signal, once for the exit that follows. `EXIT` covers
+# Ctrl-C, a `kill`, and a cancelled CI job with exactly one firing. The unwind is written to be
+# idempotent anyway, because a trap that assumes it runs once is a trap nobody can safely change.
+#
+# ROUTES. Two, because the write surface is not all one path: `dash` is the dashboard's
+# /api/control/worker-apply (the #513, #1236 and #1002b legs) and `rig` is a direct dial at the
+# rig's own control API (#516's feed leg). A restore has to go back the way its write came, so the
+# route travels in the ledger with the key.
+#
+# Sourced by run.sh, which supplies `_worker_apply`, `_rig_control_apply`, `it_warn` and `jq`.
+# Every function here is drivable standalone against stubs — that is the tier the mutation proofs
+# live at (selftest-rig-key-ledger.sh), not a bench.
+
+# One outstanding write per line: <route>\t<rig>\t<key>\t<original-value-as-json>. A newline-
+# delimited string, deliberately not an associative array: there are none anywhere in this
+# directory and lib.sh:438 shows the bash 3.2 awareness this harness is written to.
+# This variable is deliberately not named after the writable keys it holds. gitleaks'
+# generic-api-key rule reads an identifier containing that word, together with whatever the
+# next line starts with, as one credential, and reds the secret scan on this file. The finding
+# is anchored in the commit that introduces it, so renaming back cannot be undone at the tip.
+_RIG_LEDGER=""
+_RIG_KEY_TRAP_ARMED=0
+
+# The EXIT handler: restore everything still outstanding, THEN do lib.sh's holder cleanup. Ordering
+# matters — the rig restore is the thing worth doing, so it goes first and the breadcrumb removal
+# cannot be skipped by it (no `set -e` here, and every step is best-effort).
+rig_key_atexit() {
+    rig_key_unwind
+    # The fold lib.sh:rig_lock's comment prescribes. Re-derived from the durable env/default rather
+    # than a local, exactly as the trap it replaces did, and best-effort in the same two steps: a
+    # holder marker we cannot remove must never be fatal. (#244/#249)
+    local h="${RIG_LOCK_HOLDER:-${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}.holder}"
+    rm -f "$h" 2>/dev/null || sudo -n rm -f "$h" 2>/dev/null || true
+}
+
+# Install the composed trap, once, at the FIRST mark. Lazy on purpose: see the no-op reasoning above.
+_rig_key_arm() {
+    [ "$_RIG_KEY_TRAP_ARMED" = "1" ] && return 0
+    _RIG_KEY_TRAP_ARMED=1
+    trap rig_key_atexit EXIT
+    return 0
+}
+
+# Record an outstanding write. Call this BEFORE the apply goes out, not after — the window this
+# exists to cover includes the apply itself.
+rig_key_mark() { # <route: dash|rig> <rig> <key> <original-value-as-json>
+    _rig_key_arm
+    _RIG_LEDGER="${_RIG_LEDGER}$1	$2	$3	$4
+"
+    return 0
+}
+
+# Retire an outstanding write. Call this only once the revert is CONFIRMED applied; a revert that
+# came back anything else stays on the books so the trap retries it.
+rig_key_clear() { # <route> <rig> <key>
+    local out="" r w k v
+    # `<<<` and not a pipe: a pipeline runs its right-hand side in a SUBSHELL, and the assignment
+    # to _RIG_LEDGER would be discarded with it — leaving every entry permanently outstanding
+    # and the trap re-applying originals over a healthy rig at the end of a clean run.
+    while IFS=$'\t' read -r r w k v; do
+        [ -n "$r" ] || continue
+        { [ "$r" = "$1" ] && [ "$w" = "$2" ] && [ "$k" = "$3" ]; } && continue
+        out="$out$r	$w	$k	$v
+"
+    done <<<"$_RIG_LEDGER"
+    _RIG_LEDGER="$out"
+    return 0
+}
+
+# How many writes are outstanding. The self-test's handle on the no-op requirement, and a cheap way
+# for a caller to say something true in the run output.
+rig_key_outstanding() { printf '%s' "$_RIG_LEDGER" | grep -c .; }
+
+# Restore every outstanding write, by the route that made it. Best-effort and idempotent: this runs
+# at EXIT, frequently while the run is already dying, so nothing here may abort and nothing may
+# depend on the dashboard or the rig still answering. The ledger is emptied whatever happened —
+# a second firing must not re-POST originals over a rig that already took them.
+rig_key_unwind() {
+    local r w k v payload
+    [ -n "$_RIG_LEDGER" ] || return 0
+    while IFS=$'\t' read -r r w k v; do
+        [ -n "$r" ] || continue
+        # it_warn, not it_step: this is a run that did not end the way it meant to, and the operator
+        # reading the log needs to know the rig was left mid-change and what we did about it. (It is
+        # invisible in the summary counters — #1365 — which is why it says the whole story here.)
+        it_warn "aborted mid-change: restoring $k=$v on rig '$w' via the $r route (#1379)"
+        payload="$(jq -nc --arg k "$k" --argjson v "$v" '{($k): $v}' 2>/dev/null)" || continue
+        [ -n "$payload" ] || continue
+        case "$r" in
+        dash) _worker_apply "$w" "$payload" >/dev/null 2>&1 || true ;;
+        rig) _rig_control_apply "$payload" >/dev/null 2>&1 || true ;;
+        *) it_warn "unknown restore route '$r' for $k on rig '$w' — NOT restored (#1379)" ;;
+        esac
+    done <<<"$_RIG_LEDGER"
+    _RIG_LEDGER=""
+    return 0
+}

--- a/tests/integration/rigforge-writable-keys.sh
+++ b/tests/integration/rigforge-writable-keys.sh
@@ -71,6 +71,8 @@ _settle_worker_apply_key() { # <rig> <key> <want-json> <dial-result-json> -> "<s
 _writable_key_round_trip() { # <rig> <key> <orig-json> <probe-json>
     local rig="$1" key="$2" orig="$3" probe="$4" res status ckeys change_id
     it_step "Worker Inspect edit: $key $orig -> $probe via /api/control/worker-apply…"
+    # On the books BEFORE the write goes out — the window #1379 covers includes the apply itself.
+    rig_key_mark dash "$rig" "$key" "$orig"
     res="$(_worker_apply "$rig" "$(jq -nc --arg k "$key" --argjson v "$probe" '{($k): $v}')")"
     IFS='|' read -r status ckeys change_id <<<"$(_settle_worker_apply_key "$rig" "$key" "$probe" "$res")"
     assert_eq "$key edit applied on the rig (#1236)" "$status" "applied"
@@ -83,6 +85,11 @@ _writable_key_round_trip() { # <rig> <key> <orig-json> <probe-json>
     res="$(_worker_apply "$rig" "$(jq -nc --arg k "$key" --argjson v "$orig" '{($k): $v}')")"
     IFS='|' read -r status _ _ <<<"$(_settle_worker_apply_key "$rig" "$key" "$orig" "$res")"
     assert_eq "$key edit reverted on the rig (#1236)" "$status" "applied"
+    # Retired only on a CONFIRMED revert. A revert that came back anything else stays on the books
+    # so the EXIT trap retries it — the assertion above has already red, and trusting it to have
+    # restored the rig would be trusting the thing that just told us it did not. (#1379)
+    [ "$status" = "applied" ] && rig_key_clear dash "$rig" "$key"
+    return 0
 }
 
 # #1236, and the refusals. Three of the six writable keys are deliberately NOT driven here, and the
@@ -172,6 +179,9 @@ run_rigforge_pools() { # <rig>
         return 0
     fi
     it_step "Worker Inspect edit: pools -> the operator-supplied probe via /api/control/worker-apply…"
+    # The restore target is last_applied, which still carries `pass` — the same un-stripped value
+    # the revert below uses, and the only one safe to write back (#113). (#1379)
+    rig_key_mark dash "$rig" pools "$orig_pools"
     res="$(_worker_apply "$rig" "{\"pools\":$IT_RIG_POOLS_PROBE}")"
     status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
     ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
@@ -179,6 +189,8 @@ run_rigforge_pools() { # <rig>
     assert_contains "the rig's /status confirms pools changed (#1002b)" "$ckeys" "pools"
     it_step "reverting pools to the dashboard's last-applied value…"
     res="$(_worker_apply "$rig" "{\"pools\":$orig_pools}")"
-    assert_eq "pools edit reverted on the rig (#1002b)" \
-        "$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)" "applied"
+    status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
+    assert_eq "pools edit reverted on the rig (#1002b)" "$status" "applied"
+    [ "$status" = "applied" ] && rig_key_clear dash "$rig" pools
+    return 0
 }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -25,6 +25,8 @@ source "$HERE/lib.sh"
 # shellcheck source=tests/integration/scenarios.sh
 source "$HERE/scenarios.sh"
 source "$HERE/rigforge-apply-settle.sh"
+# shellcheck source=tests/integration/rig-key-ledger.sh
+source "$HERE/rig-key-ledger.sh" # must precede any module that marks a write (#1379)
 # shellcheck source=tests/integration/rigforge-writable-keys.sh
 source "$HERE/rigforge-writable-keys.sh"
 
@@ -2206,6 +2208,7 @@ run_rigforge_control() {
     else
         new_maxt=$((orig_maxt + 1))
         it_step "Worker Inspect edit: max_temp_c $orig_maxt -> $new_maxt via /api/control/worker-apply…"
+        rig_key_mark dash "$rig" max_temp_c "$orig_maxt" # abort-safe unwind (#1379)
         res="$(_worker_apply "$rig" "{\"max_temp_c\":$new_maxt}")"
         IFS='|' read -r status ckeys change_id <<<"$(_settle_worker_apply_maxt "$rig" "$new_maxt" "$res")"
         assert_eq "Worker Inspect edit applied on the rig (#513)" "$status" "applied"
@@ -2217,6 +2220,7 @@ run_rigforge_control() {
         res="$(_worker_apply "$rig" "{\"max_temp_c\":$orig_maxt}")"
         IFS='|' read -r status _ _ <<<"$(_settle_worker_apply_maxt "$rig" "$orig_maxt" "$res")"
         assert_eq "reversible edit reverted on the rig (#513)" "$status" "applied"
+        [ "$status" = "applied" ] && rig_key_clear dash "$rig" max_temp_c # (#1379)
     fi
 
     # ---- #1236/#1002b: the other writable keys, and the ones we deliberately refuse ----
@@ -2301,6 +2305,7 @@ run_rigforge_reverse() { # <rig-name> <orig-max_temp_c-or-empty>
     fi
     local reflect=$((orig_maxt + 2)) change_id
     it_step "rig-side edit (direct control API): max_temp_c -> $reflect on $RIG_HOST:$RIG_CONTROL_PORT…"
+    rig_key_mark rig "$rig" max_temp_c "$orig_maxt" # abort-safe unwind, rig route (#1379)
     change_id="$(_rig_control_apply "{\"max_temp_c\":$reflect}")"
     if [ -z "$change_id" ]; then
         it_fail "direct rig control apply accepted (#516)" "the rig's /apply did not return a change_id"
@@ -2313,7 +2318,8 @@ run_rigforge_reverse() { # <rig-name> <orig-max_temp_c-or-empty>
         fi
         # Revert the rig to its original ceiling.
         change_id="$(_rig_control_apply "{\"max_temp_c\":$orig_maxt}")"
-        [ -n "$change_id" ] && _rig_control_await "$change_id" applied || true
+        { [ -n "$change_id" ] && _rig_control_await "$change_id" applied &&
+            rig_key_clear rig "$rig" max_temp_c; } || true # retire only on a confirmed revert (#1379)
     fi
 }
 

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -160,11 +160,13 @@ echo "== dying DURING the apply is covered — which is what mark-before-write b
 # The window the ordering exists for, and the only thing that makes it falsifiable at this tier: a
 # stub that never returns, because the process dies inside the apply itself. Move the mark below
 # the write in any leg and this is the assertion that reds — with an instantaneous stub, every
-# other assertion here passes either way.
+# other assertion here passes either way. The stub's sleep only has to outlast the command
+# substitution the parent is blocked in — the SIGINT is already pending by then — so 0.2s does the
+# job 2s did and gives the file back ~1.8s. Checked at both values against the mutation above.
 scenario 'source "$INT_DIR/rigforge-apply-settle.sh"' \
     'source "$INT_DIR/rigforge-writable-keys.sh"' \
     '_worker_detail() { printf "%s" "{\"rig_config\":{\"DONATION\":7}}"; }' \
-    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; kill -INT $$; sleep 2; }' \
+    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; kill -INT $$; sleep 0.2; }' \
     'run_rigforge_writable_keys rig1 >/dev/null 2>&1' \
     'sleep 5' >/dev/null
 assert_eq "a death inside the apply still restores the original (#1379)" \

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -161,9 +161,9 @@ echo "== dying DURING the apply is covered — which is what mark-before-write b
 scenario 'source "$INT_DIR/rigforge-apply-settle.sh"' \
     'source "$INT_DIR/rigforge-writable-keys.sh"' \
     '_worker_detail() { printf "%s" "{\"rig_config\":{\"DONATION\":7}}"; }' \
-    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; kill -INT $$; sleep 30; }' \
+    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; kill -INT $$; sleep 2; }' \
     'run_rigforge_writable_keys rig1 >/dev/null 2>&1' \
-    'sleep 30' >/dev/null
+    'sleep 5' >/dev/null
 assert_eq "a death inside the apply still restores the original (#1379)" \
     "$(restores | tail -1)" 'dash|{"DONATION":7}'
 assert_eq "the probe went out and the original came back — two POSTs, in that order" \

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -29,6 +29,10 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 APPLY_LOG="$WORK/applies.log"
 SCEN_OUT="$WORK/out.txt"
+# Exported, not passed as prefix assignments: a prefix assignment is visible only to the forked
+# process, so `$WORK` in the same command line would still expand to the caller's value (SC2097).
+export INT_DIR="$HERE"
+export APPLY_LOG WORK
 
 # --- The scenario harness ---------------------------------------------------
 # Each scenario is a fresh bash CHILD. That is the point: an EXIT trap can only be honestly
@@ -57,8 +61,7 @@ scenario() {
         cat "$WORK/prelude.sh"
         printf '%s\n' "$@"
     } >"$WORK/scen.sh"
-    INT_DIR="$HERE" APPLY_LOG="$APPLY_LOG" WORK="$WORK" \
-        bash "$WORK/scen.sh" >"$SCEN_OUT" 2>&1
+    bash "$WORK/scen.sh" >"$SCEN_OUT" 2>&1
     printf '%s' "$?"
 }
 

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# Self-test for the abort-safe writable-key unwind (rig-key-ledger.sh, #1379) — no rig, no server,
+# no docker.
+#
+# This file IS the lane's bar for #1379, and the bar is higher than usual because the thing under
+# test is an INSTRUMENT: a trap that silently does nothing is indistinguishable from a trap that
+# works, in a run whose whole point is that it did not reach its own cleanup. So every assertion
+# below is written to die if the behaviour it covers is removed, and the two that matter most are
+# driven in a REAL child process that REALLY dies — one by a non-zero exit, one by SIGINT — because
+# a trap asserted by calling its handler by hand proves only that the handler is a function.
+#
+# The composition assertion (`rig_lock` + our trap) drives lib.sh's ACTUAL rig_lock against
+# sandboxed RIG_LOCK_FILE/RIG_LOCK_HOLDER paths (rigforge#183 note 6), not a copy of it. That is
+# deliberate: `rig_key_atexit` carries the only other copy of the holder-breadcrumb removal, and a
+# test against a re-implementation would keep passing while the two copies drifted apart.
+#
+# Standalone (not sourced by selftest.sh) so it never touches selftest.sh's file-budget ceiling —
+# same reasoning as selftest-rigforge-writable-keys.sh and selftest-rigforge-apply-settle.sh.
+# Run directly, or via `make test-integration-selftest`.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+APPLY_LOG="$WORK/applies.log"
+SCEN_OUT="$WORK/out.txt"
+
+# --- The scenario harness ---------------------------------------------------
+# Each scenario is a fresh bash CHILD. That is the point: an EXIT trap can only be honestly
+# observed from outside the process it fires in, and the failure this issue is about is a process
+# that dies before its cleanup. The stubs record every restore attempt as "<route>|<payload>" so a
+# scenario's effect is a fact about a FILE, not about a shell variable — a stub recording into a
+# variable would lose every write made inside a `$( … )` and read exactly like "nothing was
+# restored", which is the passing-for-the-wrong-reason shape this directory has already been bitten
+# by once.
+cat >"$WORK/prelude.sh" <<'PRELUDE'
+set -uo pipefail
+# shellcheck source=/dev/null
+source "$INT_DIR/lib.sh"
+# shellcheck source=/dev/null
+source "$INT_DIR/rig-key-ledger.sh"
+_worker_apply() { printf 'dash|%s\n' "$2" >>"$APPLY_LOG"; }
+_rig_control_apply() { printf 'rig|%s\n' "$1" >>"$APPLY_LOG"; }
+PRELUDE
+
+# scenario <body...> — run it in a fresh child; echo the child's rc. Stdout+stderr land in SCEN_OUT,
+# restore attempts in APPLY_LOG, both reset per scenario.
+scenario() {
+    : >"$APPLY_LOG"
+    : >"$SCEN_OUT"
+    {
+        cat "$WORK/prelude.sh"
+        printf '%s\n' "$@"
+    } >"$WORK/scen.sh"
+    INT_DIR="$HERE" APPLY_LOG="$APPLY_LOG" WORK="$WORK" \
+        bash "$WORK/scen.sh" >"$SCEN_OUT" 2>&1
+    printf '%s' "$?"
+}
+
+restores() { cat "$APPLY_LOG"; }
+n_restores() { grep -c . "$APPLY_LOG"; }
+
+echo "== no write, no trap, no restore: the no-op is structural, not a guarded special case =="
+rc="$(scenario 'echo "TRAP=[$(trap -p EXIT)]"' 'exit 0')"
+assert_eq "a run that marks nothing exits cleanly" "$rc" "0"
+# The load-bearing half of the issue's no-op requirement. Not "the trap ran and did nothing" —
+# NO TRAP EXISTS. Mutating _rig_key_arm to install eagerly at source time kills this.
+assert_eq "no EXIT trap is installed when no writable key was touched (#1379)" \
+    "$(grep -c 'TRAP=\[\]' "$SCEN_OUT")" "1"
+assert_eq "and nothing is POSTed at the rig" "$(n_restores)" "0"
+
+echo "== a run that dies mid-change restores the outstanding key =="
+rc="$(scenario 'rig_key_mark dash rig1 DONATION 5' 'exit 9')"
+assert_eq "the child really died non-zero" "$rc" "9"
+assert_eq "the outstanding key is restored to its original, via the dash route (#1379)" \
+    "$(restores)" 'dash|{"DONATION":5}'
+
+echo "== Ctrl-C — the failure mode the issue leads with =="
+# Measured, not assumed: a bare EXIT trap DOES run when bash dies of SIGINT, and `EXIT INT TERM`
+# would run the handler TWICE for one signal. This asserts both halves at once — the restore
+# happened, and it happened exactly once.
+scenario 'rig_key_mark dash rig1 max_temp_c 100' 'kill -INT $$' 'sleep 30' >/dev/null
+assert_eq "SIGINT mid-change restores the key (#1379)" \
+    "$(restores)" 'dash|{"max_temp_c":100}'
+assert_eq "and fires exactly once, not twice" "$(n_restores)" "1"
+
+echo "== SIGTERM — a cancelled CI job or a reaped run =="
+scenario 'rig_key_mark dash rig1 DONATION 0' 'kill -TERM $$' 'sleep 30' >/dev/null
+assert_eq "SIGTERM mid-change restores the key (#1379)" "$(restores)" 'dash|{"DONATION":0}'
+
+echo "== a CONFIRMED revert retires the entry; the trap then has nothing to do =="
+rc="$(scenario 'rig_key_mark dash rig1 DONATION 5' 'rig_key_clear dash rig1 DONATION' 'exit 0')"
+assert_eq "a cleared ledger leaves the rig alone at exit" "$(n_restores)" "0"
+assert_eq "and the run still exits clean" "$rc" "0"
+
+echo "== clear is exact: route, rig and key must ALL match =="
+# Three separate near-miss clears. Each one alone catches a different sloppy predicate — a clear
+# keyed on the key alone, on the rig alone, or ignoring the route — and none of them may retire it.
+scenario 'rig_key_mark dash rig1 DONATION 5' \
+    'rig_key_clear rig rig1 DONATION' \
+    'rig_key_clear dash rig2 DONATION' \
+    'rig_key_clear dash rig1 max_temp_c' \
+    'exit 1' >/dev/null
+assert_eq "a near-miss clear does NOT retire the entry (#1379)" \
+    "$(restores)" 'dash|{"DONATION":5}'
+
+echo "== the rig route restores by direct dial, never through the dashboard =="
+scenario 'rig_key_mark rig rig1 max_temp_c 100' 'exit 1' >/dev/null
+assert_eq "#516's rig-side write is restored the way it was made (#1379)" \
+    "$(restores)" 'rig|{"max_temp_c":100}'
+assert_eq "and the dashboard route is not used for it" "$(restores | grep -c '^dash|')" "0"
+
+echo "== several outstanding keys: every one restored, and only the outstanding ones =="
+scenario 'rig_key_mark dash rig1 DONATION 5' \
+    'rig_key_mark dash rig1 watchdog_interval_min 5' \
+    'rig_key_mark rig rig2 max_temp_c 90' \
+    'rig_key_clear dash rig1 watchdog_interval_min' \
+    'exit 1' >/dev/null
+assert_eq "two outstanding, one retired" "$(n_restores)" "2"
+assert_eq "the retired key is not re-POSTed" "$(restores | grep -c watchdog_interval_min)" "0"
+assert_eq "the DONATION entry survives" "$(restores | grep -c 'dash|{"DONATION":5}')" "1"
+assert_eq "the other rig's entry survives, on its own route" \
+    "$(restores | grep -c 'rig|{"max_temp_c":90}')" "1"
+
+echo "== the unwind is idempotent — a second firing must not re-POST over a healthy rig =="
+scenario 'rig_key_mark dash rig1 DONATION 5' 'rig_key_unwind' 'rig_key_unwind' 'exit 0' >/dev/null
+assert_eq "restored once despite two explicit unwinds and the EXIT trap (#1379)" "$(n_restores)" "1"
+
+echo "== a non-scalar original round-trips as JSON, not as a mangled string =="
+scenario 'rig_key_mark dash rig1 pools '"'"'[{"url":"real:1","pass":"secret"}]'"'"'' 'exit 1' >/dev/null
+assert_eq "a pools original is restored intact, credential and all (#1002b/#1379)" \
+    "$(restores)" 'dash|{"pools":[{"url":"real:1","pass":"secret"}]}'
+
+echo "== COMPOSITION: our trap replaces rig_lock's, so it must do rig_lock's job too =="
+# Drives lib.sh's REAL rig_lock against sandboxed paths. This is the assertion that catches the
+# hazard the whole design is shaped around: `trap … EXIT` replaces rather than stacks, so arming
+# ours after rig_lock's would strand the shared-bench holder breadcrumb on every run.
+scenario 'export RIG_LOCK_FILE="$WORK/rig.lock" RIG_LOCK_HOLDER="$WORK/rig.holder"' \
+    'rig_lock selftest "rig-key-ledger #1379"' \
+    '[ -s "$RIG_LOCK_HOLDER" ] && echo HOLDER-WRITTEN' \
+    'rig_key_mark dash rig1 DONATION 5' \
+    'exit 0' >/dev/null
+assert_eq "rig_lock really wrote its holder breadcrumb (the control for the next assertion)" \
+    "$(grep -c HOLDER-WRITTEN "$SCEN_OUT")" "1"
+assert_eq "arming the ledger trap AFTER rig_lock still removes the holder breadcrumb (#1379)" \
+    "$([ -e "$WORK/rig.holder" ] && echo STRANDED || echo gone)" "gone"
+assert_eq "and the writable key is restored in the same firing" \
+    "$(restores)" 'dash|{"DONATION":5}'
+rm -f "$WORK/rig.lock" "$WORK/rig.holder"
+
+echo "== dying DURING the apply is covered — which is what mark-before-write buys =="
+# The window the ordering exists for, and the only thing that makes it falsifiable at this tier: a
+# stub that never returns, because the process dies inside the apply itself. Move the mark below
+# the write in any leg and this is the assertion that reds — with an instantaneous stub, every
+# other assertion here passes either way.
+scenario 'source "$INT_DIR/rigforge-apply-settle.sh"' \
+    'source "$INT_DIR/rigforge-writable-keys.sh"' \
+    '_worker_detail() { printf "%s" "{\"rig_config\":{\"DONATION\":7}}"; }' \
+    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; kill -INT $$; sleep 30; }' \
+    'run_rigforge_writable_keys rig1 >/dev/null 2>&1' \
+    'sleep 30' >/dev/null
+assert_eq "a death inside the apply still restores the original (#1379)" \
+    "$(restores | tail -1)" 'dash|{"DONATION":7}'
+assert_eq "the probe went out and the original came back — two POSTs, in that order" \
+    "$(restores | head -1)" 'dash|{"DONATION":0}'
+
+echo "== the operator is TOLD, on stderr, that the rig was left mid-change =="
+# A silent restore is nearly as bad as none: the run's summary counters cannot see it (#1365), so
+# the sentence is the only signal that a borrowed production miner was touched and put back.
+scenario 'rig_key_mark dash rig1 DONATION 5' 'exit 1' >/dev/null
+assert_eq "the unwind names the key, the value and the rig (#1379)" \
+    "$(grep -c "aborted mid-change: restoring DONATION=5 on rig 'rig1'" "$SCEN_OUT")" "1"
+
+echo "== an unknown route is refused loudly rather than POSTed somewhere arbitrary =="
+scenario 'rig_key_mark bogus rig1 DONATION 5' 'exit 1' >/dev/null
+assert_eq "an unknown route POSTs nothing at all" "$(n_restores)" "0"
+assert_eq "and says so" "$(grep -c "unknown restore route 'bogus'" "$SCEN_OUT")" "1"
+
+echo "== integration with the #1236 legs: a confirmed round trip leaves nothing outstanding =="
+# The legs' own stubs, driven end to end, so the mark/clear pairing is asserted where it is USED
+# rather than only where it is defined.
+scenario 'source "$INT_DIR/rigforge-apply-settle.sh"' \
+    'source "$INT_DIR/rigforge-writable-keys.sh"' \
+    '_worker_detail() { printf "%s" "{\"rig_config\":{\"DONATION\":7},\"history\":[{\"change_id\":\"c1\",\"status\":\"applied\"}]}"; }' \
+    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; printf "{\"status\":\"applied\",\"change_id\":\"c1\",\"changed_keys\":[\"DONATION\"]}"; }' \
+    'wait_for() { return 0; }' \
+    'run_rigforge_writable_keys rig1 >/dev/null 2>&1' \
+    'echo "OUTSTANDING=$(rig_key_outstanding)"' \
+    'exit 0' >/dev/null
+assert_eq "a healthy DONATION round trip retires its own ledger entry (#1236/#1379)" \
+    "$(grep -c 'OUTSTANDING=0' "$SCEN_OUT")" "1"
+assert_eq "so the EXIT trap POSTs no restore of its own" \
+    "$(restores | grep -c '{"DONATION":7}')" "1"
+
+echo "== and a round trip whose REVERT never lands stays on the books for the trap =="
+# The case an assertion cannot rescue: the leg's own "reverted" assert has already red, so trusting
+# it to have restored the rig would be trusting the thing that just said it did not.
+scenario 'source "$INT_DIR/rigforge-apply-settle.sh"' \
+    'source "$INT_DIR/rigforge-writable-keys.sh"' \
+    '_worker_detail() { printf "%s" "{\"rig_config\":{\"DONATION\":7},\"history\":[{\"change_id\":\"c1\",\"status\":\"applied\"}]}"; }' \
+    '_worker_apply() { printf "dash|%s\n" "$2" >>"$APPLY_LOG"; printf "{\"status\":\"failed\",\"change_id\":\"c1\"}"; }' \
+    'wait_for() { return 1; }' \
+    'run_rigforge_writable_keys rig1 >/dev/null 2>&1' \
+    'echo "OUTSTANDING=$(rig_key_outstanding)"' \
+    'exit 1' >/dev/null
+assert_eq "a revert that never confirmed leaves the key outstanding (#1379)" \
+    "$(grep -c 'OUTSTANDING=1' "$SCEN_OUT")" "1"
+assert_eq "and the trap retries it at exit" \
+    "$(restores | tail -1)" 'dash|{"DONATION":7}'
+
+echo ""
+echo "selftest-rig-key-ledger: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Addresses #1379. No closing keyword is used anywhere in this body or in the commit messages: in pithead the keyword never fires (PRs land on `develop-v2` while the default branch is `develop`), and negating one does not work either — GitHub ignores the negation. #1379 gets a by-hand close, with a comment naming this PR, once it merges.

## What was broken

`e2e.sh:282` installs `trap restore_all EXIT INT TERM`, which reads as full abort safety for a borrowed rig. It is not. `restore_all` puts back the miner's **xmrig pool config** and the baseline stack; it never touches the rig's **RigForge writable config** — `DONATION`, `max_temp_c`, `autotune`, `watchdog`, `watchdog_interval_min`, `pools`. Those writes are made from `run.sh`, which had **no trap of any kind**, so every writable-key leg was a bare apply/revert pair with no unwind. A run that died between the two — `Ctrl-C`, a `set -u` abort, a cancelled CI job, an SSH drop — left a borrowed production miner on a probe value, while the trap that *did* exist reported a clean restore of the pool config and said nothing about the key that was left changed.

It had not bitten yet for two reasons, neither of them a control: the probes are chosen benign, and almost nobody ran the phase. #1364 is removing the second one on purpose by putting the write phase into the mandated `--mode targeted` pre-cut run.

## The shape

`tests/integration/rig-key-ledger.sh` (new, 137 lines, unbudgeted). A key goes on a ledger when its write is **sent** — before, not after, so the apply itself is inside the covered window — and comes off only when its revert is **confirmed applied**. An `EXIT` trap restores whatever is still on the ledger, by the same route that made the write.

Three consequences worth naming, because each was a design decision rather than a detail:

- **The no-op requirement is structural, not a guarded special case.** The issue asks that the trap do nothing when no writable key was touched. Here, when nothing was written no mark ever happened, so **no trap was ever installed**. The test asserts the absence of a trap, not a trap that ran and did nothing.
- **A revert that came back anything but `applied` stays on the books.** The leg's own "reverted" assertion has already gone red at that point; retiring the entry on it would be trusting the thing that just said it failed. The trap retries at exit instead.
- **Two routes, because the write surface is not one path.** `dash` is the dashboard's `/api/control/worker-apply` (#513, #1236, #1002b); `rig` is a direct dial at the rig's control API (#516's feed leg). A restore has to go back the way its write came, so the route travels in the ledger with the key.

## The hazard this is shaped around, which the codebase had already predicted

`trap … EXIT` **replaces**; it does not stack. `run.sh:2465` calls `rig_lock`, which installs an EXIT trap at `lib.sh:430` to clear the shared-bench holder breadcrumb. A naive second `trap … EXIT` produces one of two silent failures with no output difference either way:

- installed **before** `rig_lock` runs → the holder trap replaces ours and **no key is ever restored**: the fix reads as shipped and does nothing;
- installed **after** → ours replaces the holder cleanup and every run **strands the breadcrumb**.

`lib.sh:384-385` anticipated exactly this and prescribed the fix in its own words: fold the `rm -f` into the body of whatever trap is added, rather than trapping twice. `rig_key_atexit` is that fold. **That comment was a claim about behaviour that this change makes false, so it is rewritten in place** — line-neutral, and pointing at the one other copy of the removal so the pair cannot drift unnoticed.

The self-test drives lib.sh's **actual** `rig_lock` against sandboxed `RIG_LOCK_FILE`/`RIG_LOCK_HOLDER` paths, not a re-implementation of it, precisely so that a future change to the holder-path logic reds here instead of drifting quietly.

## Measured rather than assumed

Two bash semantics decide whether this design works at all, so both were run on this box rather than reasoned about:

| trap spec | signal | handler firings |
|---|---|---|
| `EXIT` | `SIGINT` | **1** |
| `EXIT` | `SIGTERM` | **1** |
| `EXIT INT TERM` | `SIGINT` | **2** |
| `EXIT INT TERM` | `SIGTERM` | **2** |

A bare `EXIT` trap **does** fire when bash dies of `SIGINT`/`SIGTERM` — so it covers the `Ctrl-C` case the issue leads with — and the `EXIT INT TERM` spelling runs the handler **twice** for one signal. Hence bare `EXIT` here. The same matrix shows `e2e.sh:282` double-firing `restore_all` on any signalled abort; that is a separate, older instance and is **filed as #1401**, not fixed here — `e2e.sh` is at 766/766 with zero slack.

Also verified rather than assumed: an EXIT trap set in the parent does **not** re-fire when a `$( … )` command substitution exits, which is what keeps the unwind from running on every apply.

## Verification — what was RUN

- **`selftest-rig-key-ledger.sh` (new): 31 passed, 0 failed, rc=0.** Picked up by the existing `selftest*.sh` glob in both the `Makefile` and `ci.yml` — confirmed by expanding the glob and by finding its 16 sections in `tests/inventory.sh`'s output, not by assuming directory membership.
- **`make test-integration-selftest`: rc=0** — all six selftests, 354 assertions, 0 failed.
- **Mutation: 12 mutations, 12 killed, 0 survived, 0 unapplied, 0 wrong-kill**, each dying on the assertion that names it; post-restore baseline rc=0. Every mutation is a faithful regression of a plausible naive implementation, not a string injection.
- **`make lint`: rc=0**, with all 12 targets confirmed to have executed by reading the commands in the log rather than the surviving text. shellcheck 0.11.0 (checked with `--version`), `PATH=$HOME/.local/bin:$PATH` so `lint-py`/`lint-yaml` did not false-red on `Error 127`.
- **File budget**: `lib.sh` **692/692, line-neutral**. `run.sh` 2533/2551 — six of its recorded slack lines, cleared with the controller against the standing ruling, which turns out to be about not *lowering* a ceiling rather than reserving those lines. `rig-key-ledger.sh` (137) and `rigforge-writable-keys.sh` (196) are both under the 400 target and correctly unrowed.
- Rebased onto `f0fc9e3` and re-verified there. That base range does not touch `docs/dev/file-budget.tsv`, so the clean-auto-merge row-drop hazard does not apply; the budget gate was re-run at the tip regardless.

## What I did NOT do

- **No rig was borrowed and no abort was staged on hardware.** Every claim about behaviour is tier-1, against stubs. The two assertions that matter most drive a **real child process that really dies** — one by a non-zero exit, one by `SIGINT` — but the dashboard and rig on the other end are stubs. This does not prove a real rig accepts the restore payload.
- **`#517` is deliberately outside the ledger, and this is a judgement call I would rather have argued with than assumed.** Its leg induces a change the *rig* rolls back on its own; unwinding it from here would race that rollback and could re-apply a value the rig had already reverted. It is stated in the source and the docs. If a reviewer thinks the race is the lesser risk, say so and I will wire it.
- **`_RIG_KEY_TRAP_ARMED` IS falsifiable — this bullet used to claim it was not, and that was wrong.** The reviewer lane found the case the suite was missing: a *foreign* `EXIT` trap installed between two marks. As shipped that records **0 restores** (both keys lost); with the guard removed, **2** (both restored, which is the positive control proving the harness records restores at all). So the flag is not the conservative option — it converts a recoverable trap-stomp into a permanent one. It is latent, not live: every `trap … EXIT` in the harness today is either `rig_lock`'s (before any mark) or ours. Behaviour is unchanged here and the tradeoff is filed as **#1404** rather than decided under review.
- **The over-engineering pass is PARTIAL and I am not scoring it as complete.** `/ponytail-review` is installed and enabled on this box but is **not invocable from a session** — `Skill("ponytail:ponytail-review")` and `Skill("ponytail-review")` both return *Unknown skill* (COMMON asserts the opposite; the controller has the correction). So I ran a hand pass — the `_RIG_KEY_TRAP_ARMED` finding above is its output — and then `/simplify`, which fans out four cleanup agents (reuse / simplification / efficiency / altitude).
  **Only the REUSE agent had reported when this PR was opened: no findings, having checked `lib.sh`'s helpers, the existing payload-building pattern and the other selftests' stub machinery at source.** The simplification, efficiency and altitude agents were still in flight. **All four have now reported and none is owed.** Simplification and altitude reported and are posted as a comment here. The **efficiency** agent outlived the session that spawned it and delivered into the next one — read, then re-verified at this HEAD rather than taken on trust. Its finding was real and is applied: see the update section below.
- The ponytail gate's state is not evidence about any particular PR — it keys its sentinel to the pane's current branch and clears on a second invocation whether or not a review happened — so its silence was not treated as a pass here.

## A latent-coupling note a future reader cannot reconstruct from the diff

The first `make lint` came back rc=2 on **this PR's own new file**: SC2097/SC2098, from passing `INT_DIR=… APPLY_LOG=… WORK=…` as prefix assignments to `bash "$WORK/scen.sh"`. A prefix assignment is visible only to the forked process, so the `$WORK` on that same command line still expanded the *caller's* value. It was harmless **only because both values happened to be identical** — which is precisely the shape that stops being harmless after one edit. Fixed by exporting once.

Worth noting for anyone reading a lint result: `lint-sh` is the **first** target in the `lint:` chain, so that abort left eleven targets unrun. Reading the tail rather than make's exit code would have shown eleven phantom greens.



---

## Update — force-pushed, history rewritten (`acc672c` -> `e29f11c`)

Two changes since the first push. The branch was rewritten rather than extended, for a reason worth
reading before anyone reuses the recipe.

### 1. `Secret scan (gitleaks)` was RED, and a fix at the tip does not clear it

A **false positive on this PR's own new file**, found independently by the reviewer and tests lanes
and by me within the same few minutes. Rule `generic-api-key`: the identifier `_RIG_KEY_LEDGER`
contains the word the rule keys on, and its regex runs past the newline to take the *next* line as
the secret. Nothing sensitive was on either line — no credential, nothing to rotate.

It was **not** only this PR's problem: CI checks out full history with every branch, so gitleaks in
`git` mode scans every pushed ref, and this single finding reddened the gate on **every open PR** in
the repo.

**The part that decides the fix, measured on the digest CI pins, in `git` mode over a real clone,
`--log-opts=f0fc9e3..HEAD`:**

| candidate | gitleaks |
|---|---|
| control, as-is | rc=1, 1 finding |
| comment line between the two assignments | rc=1 — no |
| swap the two declaration lines, **tip only** | rc=1 — no |
| rename `_RIG_KEY_LEDGER` -> `_RIG_LEDGER` across **all** commits | **rc=0, 0 findings** |

The finding is anchored in the commit that introduces the line, so a fix applied as a follow-up
commit leaves the gate red. Both peer lanes had verified their candidates in `dir` mode over the
tip, where the two middle rows come back green — the scan mode is the whole difference, and each
lane has been told.

Fix: the rename (9 sites, one file, line-neutral), applied across every commit via
`git rebase --exec`, plus a comment recording why the identifier avoids that word so a later edit
cannot silently re-arm it. **No `.gitleaks.toml` allowlist** — the reviewer lane's objection was
right: the entries there are for cases where redaction is impossible by design, and this was a name
I could simply change. Muting it would have weakened a secret gate on a file that will grow.

Verified after the rewrite, in a `git clone` and not a worktree (a worktree makes the container
report `0 commits scanned` and exit **0** — a green that scanned nothing): **1126 commits scanned,
no leaks found, rc=0.**

### 2. The efficiency agent's finding, re-verified before taking it

The death-inside-apply stub slept 2s, which was **86% of the whole self-test's wall clock**. It only
has to outlast the command substitution the parent is blocked in — the `SIGINT` is already pending
by then — so the value is margin, not a race. Now `sleep 0.2`: **2.40s -> 0.56s**.

Taken only because the assertion survived it: **31 passed / 0 failed at sleep 2, 0.2 and 0.05, three
runs each**, and the mutation this leg exists for — the mark moved below the write — **still dies on
the assertion that names it at both 2s and 0.2s**. A faster test that no longer fails would have been
the worse outcome.

### Re-verified at `e29f11c`, each read off the command's own exit code

- `make test-integration-selftest`: **rc=0 — six selftest files, 354 assertions, 0 failed.** The
  count matches the pre-change run exactly, so nothing was silently dropped.
- `selftest-rig-key-ledger.sh` standalone: **rc=0, 31 passed, 0 failed.**
- shellcheck **0.11.0** (`--version` checked) on both changed files: **rc=0**. `shfmt -i 4 -d`: rc=0.
- `lint-file-budget`, `lint-topology`, `lint-operator-strings`: **rc=0 each**, read individually
  rather than from a tail. `rig-key-ledger.sh` 141 and `selftest-rig-key-ledger.sh` 223 — both under
  the 400 target, so still correctly unrowed under the new both-directions budget gate.
- **Not re-run locally: the full `make lint` chain.** The delta since the rc=0 run recorded above is
  a variable rename, two comments and one constant, and the targeted shellcheck/shfmt above cover
  the changed files with the pinned engine. CI's Shell tests job is the verdict on the rest — I am
  naming that rather than implying a local green I did not take.
