### PR TITLE
fix(tests): make the wizard-setup domain sourceable standalone (#1387)

### DIFF
--- a/tests/stack/test-wizard-setup.sh
+++ b/tests/stack/test-wizard-setup.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
 #
-# Wizard + setup domain (#1105 Phase 1): the interactive wizard flows, the setup e2e paths, and
-# the setup-time kernel/GRUB tuning (optimize_kernel runs inside cmd_setup). Sourced by
-# tests/stack/run.sh after lib.sh.
+# Wizard + setup domain (#1105 Phase 1): the interactive wizard flows, the setup e2e paths, and the
+# setup-time kernel/GRUB tuning (optimize_kernel runs inside cmd_setup). Sourceable standalone (#1387).
+WALLET="${WALLET:-$VALID_PRIMARY}" # exactly build_val_sandbox's own default; a no-op under run.sh
 echo "== unit: randomx_boot_params (#176) =="
 # The kernel boot params pithead writes into GRUB_CMDLINE_LINUX_DEFAULT for RandomX. Guards the
 # regression where the THP-disable param was PLURAL (transparent_hugepages=never) — an unrecognized


### PR DESCRIPTION
`tests/stack/test-wizard-setup.sh` read `$WALLET` without ever assigning it. That name is not a
`lib.sh` top-level — it exists only as a side effect of `build_val_sandbox()` having been **called**,
which happens in a *sibling* domain file (`test-config.sh:209`). The file therefore worked only
because of where `run.sh` happens to source it, and sourcing it on its own aborted.

This is issue option (1): default the name at the top of the file, in exactly the form the builder
itself uses (`lib.sh:175`, `:189`), so the file declares its own dependency rather than inheriting one.

## No-op under `run.sh` — verified at source, not assumed

`run.sh` sources `test-config.sh` at `:122` and `test-wizard-setup.sh` at `:1743`, and
`test-config.sh:209` calls the builder at top level. So `$WALLET` is already set by the time this
file loads and the `:-` branch is never taken.

The issue's one stated caveat — that a local default might not match what the other domains used —
does not apply: the value is character-for-character what `build_val_sandbox` would have produced.

## Exactly line-neutral, 417 -> 417

3 insertions, 3 deletions. Deliberate: this file sits at its recorded ceiling with zero headroom, so
a purely additive form could not land at all.

## Proof, with the base as a negative control

Two trees built with `git archive`, byte-identical except these three lines, each running the issue's
own repro from the tree root:

```
bash -c 'set -uo pipefail; HERE=tests/stack; source "$HERE/lib.sh"; source "$HERE/test-wizard-setup.sh"'
```

| tree | rc | output lines | unbound-variable messages |
|---|---|---|---|
| base (control) | **127** | 24 — dies partway | 2, naming the defect |
| fixed | **0** | 98 — runs to the last section | 0 |

The control's failure is a *named* one, not an exit code alone:
`test-wizard-setup.sh: line 80: WALLET: unbound variable`.

`rc 127` is bash's own unbound-variable status, probed directly rather than inferred. The line-73
occurrence prints but does **not** abort, because that expansion sits in a pipeline element — the
subshell dies and the parent survives; line 80 is a top-level argument and takes the shell down.
That is why the control fails for the reason named rather than as a bystander.

## Gates

Run locally: `shfmt` clean; `shellcheck` **0.11.0** (the CI-pinned binary, not `/usr/bin`'s 0.9.0)
at `--severity=warning`, clean on this file only; `scripts/lint-file-budget.sh` OK.

**Not run locally:** the full `make lint-sh` — `shellcheck` on `run.sh` is this box's OOM path, so CI
is that check. The full stack suite likewise runs in CI.

## Over-engineering pass

Run by hand on merit rather than because a gate asked. The issue lists four options. Options (3) and
(4) all add lines and would need a shrinking carrier for no behavioural benefit. Option (2) moves the
dependency rather than removing it. Option (1) — this one — is the only line-neutral form and is the
one the issue itself says "actually makes the file a unit".

## What this does NOT do

It fixes the one file. The sourceable-standalone **contract** is still not written down and no gate
enforces it. The 24-file coupling sweep that unblocks that gate is complete and posted on this issue:
`test-wizard-setup.sh` was the only Class A (undeclared) file, so this closes the whole class that the
sweep found — but the gate itself is separate work.
