### PR TITLE
fix(dashboard): the log cap must count frame headers, not just payload (#1360)

### DIFF
--- a/dashboard/mining_dashboard/collector/logs.py
+++ b/dashboard/mining_dashboard/collector/logs.py
@@ -29,7 +29,30 @@ logger = logging.getLogger("LogCollector")
 # well-behaved daemon can legitimately produce for the requested number of lines. The 1 MiB floor
 # keeps the default (100 lines) generous. A cap set too tight is worse than the exhaustion it
 # prevents, because it presents to the operator as the far end being broken rather than as a refusal.
+#
+# Both halves of that were measured against a live stack (#1360), because they are claims about an
+# external system rather than about our code. The driver does split at exactly 16384 payload bytes: a
+# single 40,960-byte line came back as frames of 16384 / 16384 / 8193. And the half the derivation
+# silently depends on — ``tail=N`` counts FRAMES, not logical lines — holds too: ``tail=1`` against
+# that three-frame line returns only its last 8193-byte fragment. Were ``tail`` counting logical
+# lines, no per-line constant could bound the response at all.
 _LOG_BYTES_PER_LINE = 16 * 1024
+
+# ...but the payload is not the whole frame. Docker prefixes each one with an 8-byte header (stream
+# type, three pad bytes, then a big-endian uint32 payload size — see ``_parse_docker_stream``), and
+# ``bounded_read`` counts RAW STREAM bytes, headers included. A cap of ``tail * 16 KiB`` is therefore
+# short by ``tail * 8`` against what a completely full window legitimately weighs, so the maximally
+# packed case — the exact case the ceiling exists to admit — was refused. Measured: three frames
+# whose payloads sum to 40,961 arrive as 40,985 raw bytes.
+_LOG_FRAME_HEADER = 8
+
+
+def _log_cap(tail):
+    """The byte cap for a ``tail``-line log read: the 1 MiB floor, or what ``tail`` completely full
+    frames actually weigh on the wire, whichever is larger. Exposed rather than inlined so a test
+    cannot restate the arithmetic and quietly drift from it."""
+    return max(MAX_RESPONSE_BYTES, int(tail) * (_LOG_BYTES_PER_LINE + _LOG_FRAME_HEADER))
+
 
 # Stateless client reused across cycles; reads monerod's get_info RPC (Issue #29).
 _monero_client = MoneroClient()
@@ -58,7 +81,7 @@ async def fetch_docker_logs(container_name, tail=None):
                 if response.status == 200:
                     raw_data = await bounded_read(
                         response.content,
-                        max_bytes=max(MAX_RESPONSE_BYTES, int(tail) * _LOG_BYTES_PER_LINE),
+                        max_bytes=_log_cap(tail),
                         what=f"{container_name} logs",
                     )
                     return _parse_docker_stream(raw_data)

--- a/dashboard/tests/collector/test_logs.py
+++ b/dashboard/tests/collector/test_logs.py
@@ -8,7 +8,7 @@ from mining_dashboard.helper.http import MAX_RESPONSE_BYTES
 def _cap_for(tail):
     """The cap the collector derives for a given ``tail`` — read from the module, never restated,
     so this cannot drift into asserting a number the code no longer uses."""
-    return max(MAX_RESPONSE_BYTES, tail * logs._LOG_BYTES_PER_LINE)
+    return logs._log_cap(tail)
 
 
 async def _fetch(resp, tail=None):
@@ -117,6 +117,26 @@ class TestFetchDockerLogs:
         assert await _fetch(_FakeResp(200, _frame(body), chunk=65536), tail=1) == [
             "Error: Connection to Docker Proxy failed."
         ]
+
+    async def test_a_completely_full_tail_window_is_accepted_headers_and_all(self):
+        """The maximally packed legitimate case — ``tail`` frames each carrying a full 16 KiB
+        payload — is the exact case the derived ceiling exists to admit, and it was refused (#1360).
+
+        ``bounded_read`` counts RAW stream bytes, so the real weight of a full window is
+        ``tail * (16384 + 8)``: Docker prefixes every frame with an 8-byte header. A cap of
+        ``tail * 16384`` is short by ``tail * 8`` and cuts the window off just before its end.
+
+        ``tail=64`` is the smallest value that demonstrates it, because below it the 1 MiB floor
+        dominates and hides the shortfall: at 64, ``64 * 16384`` is exactly the floor, so the header
+        bytes are the whole of the difference. Against the pre-fix cap this body is one frame's
+        header too large and the collector returns the connection-failure string instead of logs."""
+        tail = 64
+        raw = b"".join(_frame("z" * logs._LOG_BYTES_PER_LINE) for _ in range(tail))
+        assert len(raw) == tail * (logs._LOG_BYTES_PER_LINE + logs._LOG_FRAME_HEADER)
+        assert len(raw) > max(MAX_RESPONSE_BYTES, tail * logs._LOG_BYTES_PER_LINE)  # pre-fix: over
+        assert len(raw) <= _cap_for(tail)  # post-fix: admitted, and only just
+        out = await _fetch(_FakeResp(200, raw, chunk=65536), tail=tail)
+        assert out == ["z" * logs._LOG_BYTES_PER_LINE] * tail
 
     async def test_a_body_split_across_many_reads_is_still_read_whole(self):
         """The regression a single ``read(cap)`` would cause: aiohttp's read is SHORT, so a body


### PR DESCRIPTION
## What this fixes

`bounded_read` counts **raw stream bytes**. The log cap counted only **payload**. So the cap was short
by `tail * 8` — 2,000 bytes at the production `tail=250` — and the one case the derived ceiling exists
to admit, a completely full window, was refused.

| | bytes |
|---|---|
| cap at `tail=250` | 4,096,000 |
| true structural maximum | 4,098,000 |
| shortfall | 2,000 |

The bug is small; the claim it broke is not. The whole argument for a derived cap rather than a flat
one is that it **cannot** be too tight, because a cap that is too tight presents to the operator as
the far end being broken rather than as a refusal. That claim was false at the boundary.

## This came from measuring, not from reading

#1360's outstanding acceptance was that the caps ship *reasoned but unsampled*. Measured against a
live 10-container stack; full numbers posted on the issue. Two results matter here.

**The derivation's stated half is true.** A single 40,960-byte log line came back as frames of exactly
`16384 / 16384 / 8193`, so the json-file driver does split at 16 KiB.

**Its unstated half is true too, and everything depends on it.** `tail=N` counts **frames**, not
logical lines — `tail=1` against that three-frame line returned only the last 8,193-byte fragment.
Had `tail` counted logical lines, no per-line constant could bound the response at all and the cap
would be unfixable rather than off by a header. That was never written down; it is now, in the module.

**The defect fell out of the same arithmetic.** Three frames whose payloads sum to 40,961 arrive as
40,985 raw bytes — 24 bytes, three headers, 8 bytes each.

For scale: real traffic peaks at **1.47% of the cap** at `tail=250`, so nothing is failing in the
field today. This fixes a correctness gap at a boundary, not an outage.

## The test fails against the pre-fix code

Per this issue's acceptance — a test that fails against the unfixed version, not one that asserts a
helper was called.

`test_a_completely_full_tail_window_is_accepted_headers_and_all` builds `tail` frames each carrying a
full 16 KiB payload. Reverting `_log_cap` to `tail * _LOG_BYTES_PER_LINE` reds it **by name and alone**:

```
FAILED tests/collector/test_logs.py::TestFetchDockerLogs::test_a_completely_full_tail_window_is_accepted_headers_and_all
```

One named kill, no bystanders; restored and green afterwards. `tail=64` is deliberate and the docstring
says why: below it the 1 MiB floor dominates and hides the shortfall entirely, so a smaller tail would
give a test that passes either way.

`_cap_for` in the test now delegates to `logs._log_cap` instead of restating the formula. That helper's
own docstring already warned it "cannot drift into asserting a number the code no longer uses" — it
could, and it would have, since it duplicated the arithmetic this PR changes.

## Over-engineering pass — run by hand, in the gate's own format

The gate fired and its tool is not invocable here, so this was done by hand against the method's own
tag vocabulary rather than cleared silently. A cleared gate is not a review.

    logs.py:L33-38: shrink: 6 comment lines recording the live-stack measurement.
                    Two lines carry it: the split point and that tail counts frames.
    logs.py:L41-47: shrink: 7 lines (comment + named constant) to express "+ 8".
                    Fold the why into _log_cap's docstring, inline the 8.
    logs.py:L50-54: KEPT (not yagni) — two callers, and the second is the point.
    test_logs.py:L128: KEPT — restates the pre-fix formula deliberately, to pin
                    "this body exceeds the old cap". Intentional, not drift.

**net: -6 lines possible**, and I have not taken them. Both findings are real and both are prose.

**My resolution, stated so a reviewer can overrule it rather than discover it.** I kept both. The
measured facts are the entire reason this issue exists — the caps shipped *reasoned but unsampled*,
and the next person to touch this constant needs to know the derivation rests on `tail` counting
frames, which is nowhere else in the codebase. `_LOG_FRAME_HEADER` sits beside the existing
`_LOG_BYTES_PER_LINE`, matching module idiom, and the test reads it rather than hardcoding 8.

**That said, my first pass on this diff scored it `net: -0` and that was wrong** — I was grading my
own prose generously. Applying the method's actual tags found six lines I had waved through. If a
reviewer takes them, nothing breaks and no test changes.

## What was run

`pytest` (full dashboard suite) 0 · `lint-py` 0 · `lint-file-budget` 0 · `lint-topology` 0 ·
`lint-operator-strings` 0 · `lint-docs-voice` 0. Each exit code captured separately, not through a
filtered `make` tail. `make lint-sh` / `make lint` / `make test` NOT run — shellcheck OOM-kills
sessions on this box; no shell files are touched by this diff.

Both files are unrowed and under the 400-line target (`logs.py` 243, `test_logs.py` 268), so this is
not budget-blocked — unlike the neighbouring #1369/#1367 work.

## What was NOT done

- **#1360 stays open, and should.** It carries `do-not-close`. This fixes one defect the measurement
  turned up; it is not the issue's acceptance.
- **The top-ranked site is still the worst sampled.** xmrig-proxy's `/1/workers` measured 116 bytes
  with **zero miners connected**, and that endpoint is ranked first precisely because it carries
  miner-supplied strings. That number is a floor, not a sample of the threat.
- No adversarial input anywhere; stack up ~2h; site 3 measured against a *local* monerod while the
  argument for its ranking is about *remote*-node mode.
- The 16 KiB frame probe used a stock alpine container — correct for a driver-level property, and not
  a claim about our images.
