### PR TITLE
test(stack): five grep -q checks reported a pass while the forbidden pattern was present (#1385)

### DIFF
--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -2510,7 +2510,7 @@ export FAKE_LOAD_SECS=0
 hstart=$(date +%s)
 hout=$(hbl)
 hlen=$(($(date +%s) - hstart))
-printf '%s' "$hout" | grep -q "still loading" &&
+grep -q "still loading" <<<"$hout" &&
     bad "a fast load stays quiet" "heartbeat fired anyway" ||
     ok "a fast load stays quiet — no heartbeat for work already done"
 [ "$hlen" -lt 3 ] &&
@@ -2560,15 +2560,15 @@ fi
 # shell reports itself — `2>/dev/null` on the inner command cannot reach it. Harmless to control
 # flow, but it would print "No such file or directory" into the journal of every coordinator
 # boot. Existence has to be tested before the read.
-sed -n "${rig_line:-1}p" "$BOOTSCRIPT" | grep -q '\[ -f machine-role \]' &&
+grep -q '\[ -f machine-role \]' <(sed -n "${rig_line:-1}p" "$BOOTSCRIPT") &&
     ok "the marker is tested for existence before it is read (no error on every coordinator boot)" ||
     bad "the marker is tested for existence before it is read (no error on every coordinator boot)" \
         "$(sed -n "${rig_line:-1}p" "$BOOTSCRIPT")"
 rig_branch=$(sed -n "${rig_line:-1},/^fi\$/p" "$BOOTSCRIPT")
-printf '%s' "$rig_branch" | grep -qE '\./pithead (up|render|load-images)' &&
+grep -qE '\./pithead (up|render|load-images)' <<<"$rig_branch" &&
     bad "the rig branch starts nothing container-shaped" "it calls the stack's own commands" ||
     ok "the rig branch starts nothing container-shaped"
-printf '%s' "$rig_branch" | grep -q 'mark-good' &&
+grep -q 'mark-good' <<<"$rig_branch" &&
     ok "a rig commits its A/B slot exactly like a coordinator" ||
     bad "a rig commits its A/B slot exactly like a coordinator" "no mark-good in the rig branch"
 # The units are the other half of the fork: without the triggering condition a rig never runs
@@ -2585,7 +2585,7 @@ grep -q '^ConditionPathExists=!/data/pithead/machine-role' "$FBUNIT" &&
     bad "the wizard window is closed by the role marker too (no wizard on a provisioned rig)" "missing"
 # The marker, not rig.json: a fleet stick writes a rig's ANSWERS in flight while installing one
 # onto a disk, and must stay an installer through it — only an ACCEPTED role writes the marker.
-grep -h '^ConditionPathExists=' "$BOOTUNIT" "$FBUNIT" | grep -q 'rig\.json' &&
+grep -q 'rig\.json' <(grep -h '^ConditionPathExists=' "$BOOTUNIT" "$FBUNIT") &&
     bad "neither unit keys on the in-flight rig.json (a stick would stop being an installer)" "it does" ||
     ok "neither unit keys on the in-flight rig.json (a stick stays an installer)"
 unset BOOTSCRIPT BOOTUNIT FBUNIT mg_line lm_line rig_line li_line rig_branch

--- a/tests/stack/test-appliance-os-update.sh
+++ b/tests/stack/test-appliance-os-update.sh
@@ -251,7 +251,7 @@ assert_contains "plain build declares no migration" "$plain_manifest" "data_migr
 mig_manifest="$(cd "$ROOT" && . os/rauc/populate-slot.sh && render_bundle_manifest 1.18.0 release true 1.18.0)"
 assert_contains "a migrating build names its floor" "$mig_manifest" "minimum_os_version=1.18.0"
 # No key may ever render with an empty value — that is the exact shape rauc rejects.
-if printf '%s\n' "$plain_manifest" "$mig_manifest" | grep -qE '^[a-z_]+=$'; then
+if grep -qE '^[a-z_]+=$' <(printf '%s\n' "$plain_manifest" "$mig_manifest"); then
     bad "no manifest key renders with an empty value" "found one"
 else
     ok "no manifest key renders with an empty value"

--- a/tests/stack/test-release.sh
+++ b/tests/stack/test-release.sh
@@ -496,7 +496,7 @@ echo hi >"$RELTMP/pithead/f"
 xattr -w com.test val "$RELTMP/pithead/f" 2>/dev/null ||
     setfattr -n user.test -v val "$RELTMP/pithead/f" 2>/dev/null || true
 tar --no-xattrs -czf "$RELTMP/b.tar.gz" -C "$RELTMP" pithead 2>/dev/null
-if gzip -dc "$RELTMP/b.tar.gz" 2>/dev/null | grep -qa -e 'LIBARCHIVE.xattr' -e 'SCHILY.xattr'; then
+if grep -qa -e 'LIBARCHIVE.xattr' -e 'SCHILY.xattr' <(gzip -dc "$RELTMP/b.tar.gz" 2>/dev/null); then
     bad "tar --no-xattrs yields an xattr-free bundle" "xattr pax headers present despite --no-xattrs"
 else
     ok "tar --no-xattrs yields an xattr-free bundle"


### PR DESCRIPTION
test(stack): five grep -q checks reported a pass while the forbidden pattern was present (#1385)

`grep -q` exits at its FIRST match. The producer is then still writing, takes SIGPIPE/EPIPE, and
under `set -o pipefail` (run.sh:7, inherited by every domain file) the PRODUCER's status becomes
the pipeline's. So `producer | grep -q PAT` reports failure precisely when the pattern was FOUND.
With the suite's `… && bad … || ok …` idiom, `&& bad` is skipped and `|| ok` runs — a forbidden
pattern that IS present prints a tick.

Seven sites, all in tests/stack/. Five fail toward GREEN, which is why this is not cosmetic.

The fix takes the producer out of the pipeline, by a uniform rule:

    producer is a shell VARIABLE  ->  here-string          grep -q PAT <<<"$var"
    producer is a COMMAND        ->  process substitution  grep -q PAT <(cmd)

Neither form has a pipeline, so `pipefail` has no producer status to promote. Process substitution
is the right half for the command cases rather than `<<<"$(cmd)"`: `test-release.sh` decompresses a
tar archive, and materialising binary in a shell variable strips NULs and trailing newlines.

Every replacement is one line for one line — 7 insertions, 7 deletions, no file's line count moves.
That is not tidiness: all three files sit at a ceiling exactly equal to their size (run.sh 3841,
test-release.sh 504, test-appliance-os-update.sh 457), so an additive form could not land at all.

SITE LINE NUMBERS RE-DERIVED, NOT TAKEN FROM THE ISSUE. #1390 cut run.sh 4178 -> 3841 after #1385
was filed, so its run.sh line numbers were stale by ~340. Located by shape instead; the count still
comes to seven, and `grep -rn '| grep -q' tests/stack/*.sh` now returns nothing.

MUTATION TABLE. Each stanza was cut out of the real file with `sed`, from the base tree and from
this branch, and never retyped — the edits are line-neutral, so the same line ranges address both.
Driven under `set -uo pipefail` with `ok`/`bad` stubs.

  site                 file                          direction   big-present   absent   small-present
  s1 heartbeat         run.sh                        fail-green  GREEN -> RED  GREEN=GREEN  RED=RED
  s2 marker            run.sh                        fail-red    GREEN -> GREEN (NOT REPRODUCED)
  s3 rig branch up     run.sh                        fail-green  GREEN -> RED  GREEN=GREEN  RED=RED
  s4 mark-good         run.sh                        fail-red    RED -> GREEN  RED=RED      GREEN=GREEN
  s5 rig.json unit     run.sh                        fail-green  GREEN -> RED  GREEN=GREEN  RED=RED
  s6 manifest key      test-appliance-os-update.sh   fail-green  GREEN -> RED  GREEN=GREEN  RED=RED
  s7 xattr headers     test-release.sh               fail-green  GREEN -> RED  GREEN=GREEN  RED=RED

"big-present" plants the pattern EARLY in a payload far larger than the 64 KiB pipe buffer, so a
reader that leaves early strands a long tail of writes. Six of seven reproduce the defect on base
and are correct on this branch.

TWO CONTROLS, because a table of reds proves nothing on its own:
  "absent"        — the pattern genuinely is not there. Base and branch AGREE on every row, so the
                    change is not simply inverting every verdict.
  "small-present" — pattern present, tiny payload: the size the suite actually runs at, where the
                    producer finishes before the reader can exit. BOTH versions are correct on every
                    row, so nothing changes for the passing case.

s2 DID NOT REPRODUCE, and it is stated rather than rounded up. Its producer is `sed -n "${rig_line}p"`,
which emits exactly ONE line — `grep` must read to the newline before it can match, so it cannot
exit early and there is no EPIPE window. Even a 900 KB single line left the base correct. That site
is changed for uniformity of shape, with no demonstrated exposure. s4 is the other fail-red site and
it DID reproduce.

THE SMALL-PAYLOAD CONTROL CAUGHT A DEFECT IN MY OWN INSTRUMENT, which is the reason it is worth
running. s5's fixture wrote 20000 filler lines unconditionally, so its "small" case was never small
and the row silently measured the big case twice. Fixed, then re-run; the table above is the
corrected one.

GATES. shfmt clean on all three files; `bash -n` parses all three; shellcheck 0.11.0 (the CI-pinned
binary) clean on the two small files at `--severity=warning`, 1.09s / 63 MB peak. run.sh was
deliberately NOT shellchecked locally — that is this box's OOM path and it has taken whole sessions
off it. Instead the five changed run.sh stanzas were linted in isolation at FULL severity, with a
negative control confirming that fixture can fail: only SC2015 (info) on the pre-existing
`A && B || C` idiom, which this diff does not touch and which `--severity=warning` filters. CI runs
the real invocation. `scripts/lint-file-budget.sh` OK.

NOT FIXED, and pre-existing rather than introduced: none of these checks notices a producer that
fails for a real reason. If `gzip -dc` cannot read the archive, base and branch both fall to the
`ok` branch and report an xattr-free bundle. That is a separate defect from the one #1385 names.

No doc change: this is test-internal, and the house docs describe tiers rather than shell idioms.
