### PR TITLE
fix(dashboard): a full history window cannot settle who changed the config (#1369)

### DIFF
--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -105,7 +105,7 @@ def parse_config_meta(meta):
     return out if any(out.values()) else None
 
 
-def config_origin(meta, change_id_known, change_status=None):
+def config_origin(meta, change_id_known, change_status=None, history_truncated=False):
     """Where the rig's current config came from, as far as we can honestly tell.
 
     ``change_id_known`` is whether this dashboard has a ``worker_config`` row for the rig's
@@ -129,6 +129,16 @@ def config_origin(meta, change_id_known, change_status=None):
                       into either would state something we cannot support.
     - ``elsewhere`` — applied over a control channel, with an id we have never seen. Another host,
                       or our record of it is gone. Either way it is not something to present as ours.
+    - ``untraced``  — applied over a control channel, with an id we did not find, *and* the history
+                      we searched was full to its limit (#1369). The id may sit one row past the
+                      window, so "we have never seen it" is a claim the read cannot support and
+                      ``elsewhere`` would print an accusation over a change that may well be ours.
+                      ``history_truncated`` is what separates the two, and it is deliberately the
+                      only thing this argument may do: when it is False every verdict is exactly
+                      what it was before, so a caller that cannot tell loses nothing. That matters
+                      most on the error path — ``get_worker_config_history`` returns ``[]`` on a
+                      ``sqlite3.Error``, and an empty list is NOT a full window, so a DB hiccup
+                      keeps today's ``elsewhere`` instead of being upgraded into a confident one.
     - ``rig``       — applied on the rig itself.
     - ``restored``  — restored from a saved config by the operator-run ``restore`` command.
                       Deliberately not folded into ``rig``: a restore is not someone editing the rig.
@@ -145,7 +155,7 @@ def config_origin(meta, change_id_known, change_status=None):
     source = meta.get("source")
     if source == "control":
         if not change_id_known:
-            return "elsewhere"
+            return "untraced" if history_truncated else "elsewhere"
         if change_status in HELD_STATUSES:
             return "here"
         if change_status in REVERTED_STATUSES:

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -176,6 +176,18 @@ const CONFIG_ORIGIN_TEXT = {
     label: "Last changed from another dashboard",
     detail: "applied over a control channel, with a change id this dashboard has no record of",
   },
+  // `untraced` is `elsewhere` with the accusation taken back out. The server reaches it when the id
+  // was not found AND the history it searched was full, so the id may simply sit past the end of
+  // the window. `text-muted` rather than `status-warn` on purpose: the two muted verdicts are the
+  // ones that claim nothing, and a warning colour over "we could not tell" is the same overclaim in
+  // a different medium. The cost is stated where it belongs — a genuinely foreign change on a
+  // long-history rig lands here too, so a true alarm is traded for a statement that is always true.
+  untraced: {
+    cls: "text-muted",
+    label: "Last changed over a control channel",
+    detail:
+      "too many changes since to tell whether it was this dashboard — the id is older than the history read",
+  },
   rig: { cls: "status-warn", label: "Last changed on the rig itself" },
   restored: {
     cls: "status-warn",

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -41,6 +41,12 @@ from mining_dashboard.web.views import (
     rigforge_update_for,
 )
 
+# How far back the provenance match may look. Named rather than left to the storage layer's default
+# because the verdict depends on it TWICE: once to find the id, and once to know whether not finding
+# it meant anything (#1369). A bare call would leave the second use comparing against a number
+# written down somewhere else, which is how the two drift apart.
+_HISTORY_LIMIT = 50
+
 
 def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
     """Per-worker hashrate-over-time chart (#1013): ``worker_history.h15`` for one rig, same
@@ -85,7 +91,7 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     workers = data.get("workers", []) if data else []
     worker = next((w for w in workers if w.get("name") == name), None)
     descriptor = next((e for e in config.DASHBOARD_WORKERS if e["name"] == name), None)
-    history = state_mgr.get_worker_config_history(name)
+    history = state_mgr.get_worker_config_history(name, limit=_HISTORY_LIMIT)
     for row in history:
         ts = row.get("ts")
         row["applied_at"] = format_time_abs(ts) if ts else ""
@@ -112,7 +118,14 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # It also makes the verdict checkable: "here" now means precisely "the id is one of the rows
     # rendered directly below this line, and that row records the change as having held", so an
     # operator can confirm it by eye rather than trust it.
-    # An id older than that window reads as "elsewhere" — wrong in the direction that under-claims.
+    #
+    # But a bounded window can only settle a MISS when it saw the whole history. Reading exactly
+    # ``_HISTORY_LIMIT`` rows means there may be more we did not read, so a miss could be an id one
+    # row past the end rather than an id nobody here spooled — and "elsewhere" reads as "Last
+    # changed from another dashboard", an accusation the read cannot support (#1369). Passing the
+    # fullness of the window lets that case say "we do not know" instead. Only that case changes:
+    # a short read is still conclusive, which is what keeps the ``sqlite3.Error`` path (a ``[]``
+    # return, and 0 is not full) answering exactly as it does today rather than more confidently.
     #
     # The matched ROW, not merely whether one exists: RigForge's rollback re-apply re-stamps the id
     # it just reverted, so a rolled-back change still matches by id. The row's status is the only
@@ -141,7 +154,10 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         # for a rig that cannot answer — the client renders that as silence, not as "unknown".
         "rig_config_meta": rig_meta,
         "config_origin": config_origin(
-            rig_meta, matched is not None, (matched or {}).get("status")
+            rig_meta,
+            matched is not None,
+            (matched or {}).get("status"),
+            history_truncated=len(history) >= _HISTORY_LIMIT,
         ),
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -150,7 +150,40 @@ def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():
     # The case worth having: an id minted by a rig's control server that never reached this
     # dashboard's history. Another host applied it, or our record of it is gone. Reporting it as
     # "applied from here" would be the exact lie this issue exists to stop.
+    #
+    # This is also the case that keeps a FAILED read where it is (#1369). A short window still
+    # settles the miss, and `get_worker_config_history` returns [] on a sqlite3.Error — an empty
+    # list is not a full window, so a DB hiccup keeps exactly this verdict rather than being handed
+    # a stronger claim. That is why the rule is written as ">= limit -> soften" and not as a
+    # separate "we read the whole history" assurance. Caller-side twin:
+    # `test_a_history_read_that_fails_never_manufactures_trust`.
     assert config_origin(GOOD, change_id_known=False) == "elsewhere"
+
+
+def test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard():
+    # #1369: "we did not find it" only means "it is not there" if we could see the whole history.
+    # A full window means the id may sit one row past the end, so `elsewhere` — which renders as
+    # "Last changed from another dashboard" — is an accusation the read cannot support.
+    assert config_origin(GOOD, change_id_known=False, history_truncated=True) == "untraced"
+
+
+def test_the_new_argument_can_only_ever_soften_the_miss():
+    # The whole safety property of this fix in one assertion: `history_truncated` may change the
+    # verdict for a MISS and nothing else. Every case where we found the id keeps the answer it
+    # had, so a caller that starts passing the flag cannot silently move a verdict it was right
+    # about. Mutating the flag's use into any of these branches reds this test.
+    for status, expected in (
+        ("applied", "here"),
+        ("rolled_back", "reverted"),
+        ("accepted", "unconfirmed"),
+    ):
+        for truncated in (False, True):
+            assert (
+                config_origin(
+                    GOOD, change_id_known=True, change_status=status, history_truncated=truncated
+                )
+                == expected
+            )
 
 
 def test_a_change_made_on_the_rig_says_so():

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -104,6 +104,29 @@ test("an unconfirmed change of ours neither claims it held nor accuses the rig",
   assert.match(note.title, /has not reported an outcome/i);
 });
 
+test("untraced withdraws the accusation elsewhere makes, without making the opposite one", () => {
+  const out = renderToString(ConfigProvenance({ origin: "untraced", meta: META }));
+  const note = configOriginNote("untraced", META);
+  // The server reaches this when the id was not found in a history window that was FULL, so the
+  // one thing it must not do is repeat `elsewhere`'s claim that another dashboard did it.
+  assert.doesNotMatch(out, /from another dashboard/);
+  assert.notEqual(note.label, configOriginNote("elsewhere", META).label);
+  // Nor may it swing the other way and claim the change as ours.
+  assert.doesNotMatch(out, /Last changed from this dashboard/);
+  // Muted, not warned: the two verdicts that claim nothing are the two that are not coloured as a
+  // problem, and a warning over "we could not tell" is the same overclaim in a different medium.
+  assert.doesNotMatch(out, /status-warn/);
+  assert.match(note.title, /older than the history read/i);
+});
+
+test("an unknown verdict token renders nothing rather than a blank warning", () => {
+  // configOriginNote returns null for a token it does not know, which is why a server-side verdict
+  // added without its label here would vanish silently instead of failing loudly. This pins that
+  // behaviour so the silence stays a deliberate choice for absent verdicts only.
+  assert.equal(configOriginNote("a-token-no-client-knows", META), null);
+  assert.notEqual(configOriginNote("untraced", META), null);
+});
+
 test("unrecorded claims no change happened and no change did not", () => {
   const note = configOriginNote("unrecorded", { revision: META.revision });
   assert.match(note.label, /No recorded config change/);

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -209,6 +209,77 @@ class TestConfigOrigin:
             sm.close()
         assert d["config_origin"] == "elsewhere"
 
+    @pytest.mark.parametrize(
+        "filler,expected",
+        [(48, "here"), (49, "here"), (50, "untraced")],
+    )
+    def test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses(
+        self, monkeypatch, filler, expected
+    ):
+        """#1369, at the boundary. The provenance match reads a bounded window of this rig's
+        history. Once enough later changes exist, our own `applied` row falls off the end and the
+        id stops being found — and before this fix that printed "Last changed from another
+        dashboard" over a change this dashboard *did* make.
+
+        The filler rows are `rejected` on purpose. A rejected change returns before the rig's
+        config is touched, so nothing is re-stamped and `last_change_id` stays pinned to the good
+        change throughout — which is the situation being modelled. `rolled_back` fillers would be
+        the opposite: RigForge's rollback re-apply re-stamps the id it just reverted, so those
+        would mostly exercise the `reverted` path and this test could pass for a reason that has
+        nothing to do with windowing.
+
+        49 filler rows leaves the good row as the 50th and last readable one; 50 pushes it out.
+        The cliff is exact, which is what makes the off-by-one worth pinning.
+        """
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.add_worker_config_version(
+                "rig1", _META["last_change_id"], "applied", {"DONATION": 5}, None, ts=1000.0
+            )
+            for i in range(filler):
+                sm.add_worker_config_version(
+                    "rig1", f"later{i:04d}", "rejected", {"DONATION": 6}, None, ts=2000.0 + i
+                )
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert d["config_origin"] == expected
+        # The window really is the mechanism, not an accident of row count.
+        assert len(d["history"]) == min(filler + 1, 50)
+
+    def test_a_rolled_back_change_still_reads_as_reverted_on_a_long_history(self, monkeypatch):
+        # The truncation verdict must not swallow the case where we DID find the row. The rig
+        # re-stamps the id it reverted, so the id is still matched even on a rig with a full
+        # window — and the answer stays `reverted`, not the new "we do not know".
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            for i in range(60):
+                sm.add_worker_config_version(
+                    "rig1", f"older{i:04d}", "rejected", {"DONATION": 6}, None, ts=1000.0 + i
+                )
+            sm.add_worker_config_version(
+                "rig1", _META["last_change_id"], "rolled_back", {"DONATION": 5}, None, ts=9000.0
+            )
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert len(d["history"]) == 50  # the window IS full, so the softening was available...
+        assert d["config_origin"] == "reverted"  # ...and correctly not taken
+
     def test_a_history_read_that_fails_never_manufactures_trust(self, monkeypatch):
         # A DB the dashboard cannot read must not print "you did this". The #530 audit path fails
         # OPEN on a read error (a false "known" there only declines to accuse a rig); the same


### PR DESCRIPTION
## What

`config_origin` reported `elsewhere` — rendered to the operator as **"Last changed from another
dashboard"** — whenever the rig's `last_change_id` was not found in the history window. The window
is bounded at 50 rows, so on a rig with more than 50 changes since our own, a change *this*
dashboard made falls off the end and gets reported as somebody else's. That is an accusation the
read cannot support.

This makes the miss honest. When the window came back **full**, the verdict is now `untraced` —
"Last changed over a control channel", with the reason in the tooltip — instead of naming another
dashboard.

The boundary is exact and was reproduced before the fix was written: with the good `applied` row
plus N `rejected` rows, 49 fillers leaves it the 50th and last readable row (`here`), 50 pushes it
out. Both edges are pinned by test.

## The pass that shaped this, and one correction to how it was described

The scope ruling asked for the **strictly additive** form, on the grounds that the naive rule
(`len(history) < limit` → conclusive → `elsewhere`) would turn a DB hiccup into a *confident* false
accusation, since `get_worker_config_history` returns `[]` on a `sqlite3.Error`.

**Building it, I found that reasoning is half right and worth correcting rather than repeating.**
`len < limit` and `not (len >= limit)` are the same predicate, so the naive form and the additive
form emit the *same token* on the error path — both say `elsewhere`, which is what the code does
today. The hazard is real but it is not a difference in output: it is that treating a short read as
positive evidence invites a later change that *surfaces* that confidence — a "we checked the whole
history" assurance the error path would earn falsely.

So the rule is written as `>= limit → soften` rather than as a conclusiveness flag, and nothing in
the payload claims the history was read in full. The error path keeps exactly the behaviour it has
now: `test_a_history_read_that_fails_never_manufactures_trust` still asserts `elsewhere` and still
passes, unchanged.

## The accepted cost — please weigh this rather than discover it

On a rig with more than 50 recorded changes, a **genuinely foreign** change now also reads
"we do not know" instead of "Last changed from another dashboard". That is a real loss of a true
alarm. It is traded for a statement that is always true, in place of one that was only sometimes
right — and the same window that hides the foreign change was already hiding ours.

The verdict is styled `text-muted`, not `status-warn`, matching the other verdict that claims
nothing (`unrecorded`). Colouring "we could not tell" as a problem would be the same overclaim in a
different medium. **A reviewer who thinks the alarm is worth keeping should say so — that is a
defensible call and this is the line to argue about.**

Restoring the correct `here` verdict for these rigs needs the scoped exact-id lookup, which needs a
carrier this PR does not have. #1369 stays open with `do-not-close` for it.

## Scope

No at-ceiling file is touched. Every file here is unrowed in `docs/dev/file-budget.tsv`:
`web/worker_detail.py` (150), `client/rig_config_meta.py` (158), `web/static/workerlogic.mjs` (203)
and three test files. The five pinned rows (`storage_service.py`, `data_service.py`,
`workerview.mjs`, `workerview.test.mjs`, `test_storage_service.py`) are untouched.

`_HISTORY_LIMIT = 50` is named at the caller rather than left to the storage layer's default,
because the verdict now depends on it twice — to find the id, and to know whether not finding it
meant anything.

The client half is not optional: `configOriginNote` returns `null` for a token it does not know, so
a server-side verdict shipped without its label would render as **silence**, not as a failure. A
test pins that too.
