### PR TITLE
chore(os): bump the baked RigForge pin to v1.16.0

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -186,14 +186,14 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image
 # build because nothing can be installed later — apt cannot run on the read-only root, and even
 # a rw-remount install leaves its /etc state (alternatives, ld.so.cache) on the volatile overlay
-# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.15.1 release
+# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.16.0 release
 # (by commit, not tag name, so a moved tag cannot change the bake); bump it release by release.
-# v1.15.1 and not v1.15.0: it carries the API-reader fix that stopped a dead worker API aborting
-# tune and autotune sweeps outright, and it is what every rig in the field runs — baking the older
-# tree would ship an appliance whose built-in miner is behind the workers beside it. (When this was
-# first written, GitHub's releases/latest pointer still named v1.15.0, so RigForge's own
-# `upgrade --check` called the newer patch a development build; that was rigforge#371 and the
-# release now carries the Latest label, so the two agree.)
+# v1.16.0 is the floor for the HugePages pool ceiling: hugepages_pool_ceiling_mb (rigforge#398,
+# filed from #1103) is absent from v1.15.1's tree entirely, and declaring it into one fails OPEN —
+# parse_config never reads the key, so the rendered config would look capped and behave as today.
+# When bumping: re-check that the span's control /status vocabulary is still covered by the closed
+# allowlists both poll loops in the root pithead script match on (rigforge#344 added pending and
+# age_seconds). A status neither arm names must stay non-terminal — it must never read as applied.
 # pithead-sync copies the tree to /data/rigforge every boot; `pithead local-miner` runs
 # its setup with RIGFORGE_APPLIANCE=1 when local_miner.enabled.
 #
@@ -204,7 +204,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=60aa883901fc74ea39ed2f21962b8ba7f96d73ba
+ARG RIGFORGE_REF=4ce29b3daf063fd1b45e050649e93aa9592618e1
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \


### PR DESCRIPTION
Bumps the baked RigForge pin from v1.15.1 to v1.16.0. Refs #1407; #1103's critical path.

## Why the pin has to move before #1103 can mean anything

`hugepages_pool_ceiling_mb` (rigforge#398, filed from #1103) does not exist in
v1.15.1's tree — zero occurrences, and it is absent from `_warn_unknown_config_keys`'
known-key list. Declaring it into a v1.15.1 rig therefore **fails OPEN**: `parse_config`
never reads the key, the unknown-key handler warns and continues, and the rendered
config would *look* capped while behaving exactly as it does today. That is the worst
available outcome for a safety key, and it is why the bump lands on its own, before any
ceiling declaration.

## Verified at source across the span, not taken from the changelog

- The pinned tarball resolves; its file set is identical to tag v1.16.0 and
  `rigforge.sh`'s sha256 matches the tag blob byte-for-byte.
- **The XMRig bake is untouched.** `XMRIG_VERSION`/`XMRIG_COMMIT` are unchanged
  (v6.26.0) and still match the Dockerfile's `sed` anchors; `xmrig_already_built()` is
  byte-identical across the span. A Tor-only box still accepts the prebuilt tree
  instead of attempting a clone it cannot make.
- **No new dependency.** `install_dependencies()` and `_missing_appliance_tools()` are
  byte-identical across the span, and appliance mode takes the latter.
- **Zero hunks in the span touch a `RIGFORGE_APPLIANCE`-guarded path.**
- The span widens the control `/status` vocabulary with `pending` and `age_seconds`
  (rigforge#344). Both poll loops in the root `pithead` script match a **closed
  allowlist** of terminal states with **no catch-all arm**, so an unrecognised status
  falls through, keeps polling, and is recorded `accepted` at the deadline — it can
  never be read as applied. The dashboard side is the same shape
  (`status not in _CONTROL_TERMINAL`), and an unknown status is already a negative
  control in its tests. Nothing reads `age_seconds`.

## What was RUN

Built the rootfs and a bootable image from this commit on the bench, then ran the
harness's `rig` phase — the phase that exercises the built-in miner, which is the only
surface this change touches.

- `os/build-image.sh` rc=0, `os/rauc/mkimage.sh --dev` rc=0. The stale-tarball override
  was deliberately **not** set, so `mkimage`'s commit-stamp check ran for real and passed.
- Against the built rootfs: `RIGFORGE_REF` records `version=1.16.0` at the new commit;
  the prebuilt xmrig is present and mode 755; the commit marker equals the baked tree's
  own `XMRIG_COMMIT`; the sha record equals the binary's actual sha256; and
  `hugepages_pool_ceiling_mb` is present in the baked tree (5 occurrences).
- Lifted `xmrig_already_built()` **out of the baked tree itself** and ran it against the
  baked layout: **accepts, rc=0** (no clone). Two negative controls both reject as they
  must — a wrong commit pin, and a tampered binary whose sha no longer matches. The
  controls are what make the positive evidence rather than a check that cannot fail.
- `tests/os/run.sh --phase rig` on a KVM guest: **21 passed, 0 failed, rc=0**, including
  the decisive one — *"the rig mines the BAKED binary byte for byte — no compile, no
  clone, no clearnet"* — plus a full A/B update, self-commit and reboot-persistence cycle
  on the updated slot.
- `lint-file-budget`, `lint-topology`, `lint-operator-strings`: rc=0 each, captured
  directly rather than off a pipe. The comment rewrite is **line-neutral** (8 lines for
  8), so the file stays at its recorded 406 ceiling.

## What was NOT run, and one gap worth filing separately

- **Not run:** `make lint-sh` (no shell file changed, and it is the OOM risk on this
  box), `make test`, and the `boot`/`update`/`install`/`provision`/`media`/`fault`/`reset`
  phases. I ran the one phase that covers the changed surface, not the full battery.
- **Not measured:** the restart-free control fast path (rigforge#381) and the `pending`
  wire state were reasoned about at source and exercised only insofar as the `rig` phase
  touches them. No live control-apply against a v1.16.0 rig was driven.
- **Pre-existing gap, not introduced here:** rigforge v1.15.2 added cross-repo wire
  contract fixtures under `tests/contract/v1/` and **pithead consumes them nowhere** — it
  has no guard at all against RigForge wire-shape drift. This bump was safe by the
  allowlist shape of our pollers, not by any check. Worth its own issue.
- The base is an older develop-v2 commit rather than the current tip: branching from the
  cached ref avoided a `fetch`, which would move `origin/*` under every worktree on this
  box and spray spurious file-budget REDs across the other lanes.

## Over-engineering pass

Run by hand on my own diff (four angles: reuse, simplification, efficiency, altitude).
Two findings, both real:

- **Altitude — FIXED in this PR.** My first draft of the comment asserted a *conclusion*
  about `pithead`'s poll loops ("they match a closed allowlist, so a new status can never
  read as applied") from inside a build file. That is an unverified claim wearing
  documentation's clothes: nothing checks it, and it goes stale silently the moment
  either poll loop changes. Rewritten as an *instruction* to the next person bumping the
  pin — re-check that the span's `/status` vocabulary is still covered — which cannot go
  stale the same way. Kept line-neutral.
- **Reuse — NOT fixed here, routed instead.** `RIGFORGE_REF` is tracked by nothing:
  zero references in `scripts/` and `.github/workflows/`. The weekly upstream-currency
  watch (#1128) reads its pins from `scripts/release.sh`'s `pin()`, and the baked
  RigForge pin is not among them — so nothing tells us when RigForge ships a release,
  and this bump happened only because #1103 needed it. The fix belongs in
  `scripts/pin-watch.sh`, which is not this lane's path; raising it with that lane rather
  than reaching in.

Nothing found under efficiency (the diff adds no work) or simplification beyond the
altitude item.

## A note on the evidence sha

The bench evidence above was taken at `51920f9`; the head is `6a7d0bf` after the altitude
fix. The two differ **only in Dockerfile comment text** — verified by diffing both
revisions with all comment lines stripped, which comes back identical, so every `ARG`,
`RUN` and `COPY` directive that produces the image is unchanged. Comments create no
layer. Say the word if you would rather the battery were re-run at the head anyway.
