### PR TITLE
fix(pin-watch): watch the baked RigForge pin, resolving its tag to a commit (#1410)

### DIFF
--- a/docs/dev/dual-distribution-plan.md
+++ b/docs/dev/dual-distribution-plan.md
@@ -428,9 +428,10 @@ the #54 matrix per cut, same mandate as the targeted e2e.
   os-image release ships it. The watchers: Dependabot tracks every base digest
   (`build/*`, `dashboard/`, `docker-compose.yml`, `os/rootfs`), the weekly CI sweeps rebuild and
   Trivy-scan the stack images (ci.yml) and the rootfs (os-rootfs.yml), and
-  pin-watch.yml files an issue when a hand-pinned binary (docker-compose, cosign)
-  falls behind upstream. A security-relevant bump landing on the integration branch
-  is a release trigger, not just a green check.
+  pin-watch.yml files an issue when one of the hand-pinned upstreams (docker-compose,
+  cosign, and the baked RigForge tree) falls behind its latest release. A
+  security-relevant bump landing on the integration branch is a release trigger,
+  not just a green check.
 
 ## Repo outline (target state)
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -51,6 +51,11 @@ reports and never bumps: a Tari or `monerod` minor can carry a one-time data mig
 work to schedule rather than a pull request to merge. Dependabot covers the base images it can see
 and is set to ignore minor and major bumps on the component pins for the same reason.
 
+One pin is not spelled as a version. The appliance pins RigForge by commit, so that a moved tag
+cannot change what is baked; that row resolves the latest release tag to the commit it names and
+compares the two commits. Comparing the commit against the tag directly would read stale for ever,
+including straight after a correct bump.
+
 A lookup that could not be made is reported as unchecked, never as current, and the run fails. The
 report carries the date of the last fully successful check, so a watcher that has stopped looks
 different from one with nothing to say.

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -94,7 +94,11 @@ latest_release() { # <owner/repo> -> tag on stdout, rc 1 on any failure
 # prints in its _COMMIT warning below, and the comparison is sha against sha.
 #
 # The resolution is a SECOND network call, and it gets the first one's treatment: a failure returns
-# rc 1 so the caller renders an unchecked row. It must never fall through to `current`.
+# rc 1 so the caller renders an unchecked row. MEASURED with both refusals removed, so this names the
+# real failure rather than the one it is tempting to assume: the fall-through is not a wrong verdict
+# but a CONFIDENT one — the row reads `stale`, `failed` stays 0, the run exits 0 and stamps itself
+# fully successful. A watcher that has stopped working then looks exactly like one with nothing to
+# report, which is the defect this script's own header says it exists to prevent.
 
 comparable() { # <component> <owner/repo> <tag> -> the tag in that pin's spelling, rc 1 on failure
     local sha
@@ -151,8 +155,8 @@ if [ "${1:-}" = "--self-test" ]; then
             gh() { printf '%s' 4ce29b3daf063fd1b45e050649e93aa9592618e1; }
             comparable rigforge foo/bar v1.16.0
         )" "4ce29b3daf063fd1b45e050649e93aa9592618e1"
-    # The issue's own requirement: a resolution that cannot run reaches the unchecked row, never
-    # `current`. It is not uniquely load-bearing — see the overlap note on the next case but one.
+    # The issue's own requirement: a resolution that cannot run reaches the unchecked row rather than
+    # any verdict at all. It is not uniquely load-bearing — see the overlap note on the next case but one.
     st "a commit resolution that cannot run fails" \
         "$(
             gh() { return 1; }

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -50,6 +50,7 @@ upstream_for() {
     socket-proxy) echo Tecnativa/docker-socket-proxy ;;
     compose) echo docker/compose ;;
     cosign) echo sigstore/cosign ;;
+    rigforge) echo p2pool-starter-stack/rigforge ;;
     esac
 }
 
@@ -83,6 +84,30 @@ latest_release() { # <owner/repo> -> tag on stdout, rc 1 on any failure
     # an issue body, or otherwise trusted.
     printf '%s' "$tag" | grep -qE '^v?[0-9]' || return 1
     printf '%s' "$tag"
+}
+
+# Every pin above spells a VERSION, so the release tag is directly comparable to it. RIGFORGE_REF
+# does not: os/rootfs/Dockerfile pins rigforge by COMMIT so that a moved tag cannot change the bake,
+# and comparing a sha against `v1.16.0` reads **stale** every week for ever — including the hour
+# after a correct bump. That is a different lie from the silence this row was added to end, not a
+# fix for it. So the tag is resolved to the commit it names, with the same idiom this script already
+# prints in its _COMMIT warning below, and the comparison is sha against sha.
+#
+# The resolution is a SECOND network call, and it gets the first one's treatment: a failure returns
+# rc 1 so the caller renders an unchecked row. It must never fall through to `current`.
+
+comparable() { # <component> <owner/repo> <tag> -> the tag in that pin's spelling, rc 1 on failure
+    local sha
+    case "$1" in
+    rigforge)
+        sha=$(gh api "repos/$2/commits/$3" --jq .sha 2>/dev/null) || return 1
+        # Third-party input, under the same rule as the tag itself: a value that is not shaped like
+        # a commit must not be compared, and must not be printed into an issue body.
+        printf '%s' "$sha" | grep -qE '^[0-9a-f]{40}$' || return 1
+        printf '%s' "$sha"
+        ;;
+    *) printf '%s' "$3" ;;
+    esac
 }
 
 # --- self-test -----------------------------------------------------------------------------------
@@ -119,6 +144,43 @@ if [ "${1:-}" = "--self-test" ]; then
             gh() { printf 'nightly'; }
             latest_release foo/bar >/dev/null 2>&1 && echo ok || echo failed
         )" "failed"
+    # A COMMIT pin cannot be compared against a TAG. What follows covers the resolution that
+    # makes the rigforge row honest, and the property the sha comparison rests on.
+    st "an upstream tag resolves to the commit it names" \
+        "$(
+            gh() { printf '%s' 4ce29b3daf063fd1b45e050649e93aa9592618e1; }
+            comparable rigforge foo/bar v1.16.0
+        )" "4ce29b3daf063fd1b45e050649e93aa9592618e1"
+    # The issue's own requirement: a resolution that cannot run reaches the unchecked row, never
+    # `current`. It is not uniquely load-bearing — see the overlap note on the next case but one.
+    st "a commit resolution that cannot run fails" \
+        "$(
+            gh() { return 1; }
+            comparable rigforge foo/bar v1.16.0 >/dev/null 2>&1 && echo ok || echo failed
+        )" "failed"
+    # The two refusals below overlap on every realistic input, and a mutation round proved it: with
+    # the `|| return 1` removed, this next case still failed — because an empty `sha` fails the shape
+    # check too, so the shape guard silently covered for the exit-code guard's deletion. Each is now
+    # pinned on the one input only IT refuses. This one is the exit code being trusted over stdout.
+    st "a resolution that exits non-zero is refused even when it printed a commit" \
+        "$(
+            gh() {
+                printf '%s' 4ce29b3daf063fd1b45e050649e93aa9592618e1
+                return 1
+            }
+            comparable rigforge foo/bar v1.16.0 >/dev/null 2>&1 && echo ok || echo failed
+        )" "failed"
+    st "an answer that is not shaped like a commit is refused, not compared" \
+        "$(
+            gh() { printf 'Not Found'; }
+            comparable rigforge foo/bar v1.16.0 >/dev/null 2>&1 && echo ok || echo failed
+        )" "failed"
+    # And every version-spelled pin is still compared against the tag itself, unresolved.
+    st "a version pin is compared against the tag, with no lookup at all" \
+        "$(comparable caddy caddyserver/caddy v2.11.4)" "v2.11.4"
+    # Both sides of that comparison go through norm(), so norm must leave a commit sha untouched.
+    st "normalisation leaves a commit sha alone" \
+        "$(norm 60aa883901fc74ea39ed2f21962b8ba7f96d73ba)" "60aa883901fc74ea39ed2f21962b8ba7f96d73ba"
     [ "$st_fail" = 0 ] && echo "pin-watch self-test OK"
     exit "$st_fail"
 fi
@@ -131,9 +193,10 @@ set -- # release.sh's arg parser must not see ours
 # shellcheck disable=SC1091
 source "$ROOT/scripts/release.sh"
 
-# The appliance rootfs COMPILES two more binaries from source, and dependabot has no ecosystem for
-# an ARG consumed by wget — so nothing else can see them. They exist on the appliance lane only,
-# hence the guard: on `develop` this loop is simply shorter, not wrong.
+# The appliance rootfs builds three more things from an `ARG` — two binaries compiled from source
+# and the RigForge tree fetched as a source tarball — and dependabot has no ecosystem for an ARG
+# consumed by a download, so nothing else can see any of them. They exist on the appliance lane
+# only, hence the guard: on `develop` this loop is simply shorter, not wrong.
 #
 # BOUNDARY, stated because a silent one is what this whole issue is about: GitHub runs `schedule:`
 # from the DEFAULT branch, so a single-job workflow only ever reads `develop` and these two rows
@@ -145,16 +208,17 @@ lane="the product stack"
 # A real `if`, for the same reason the publish step in pin-watch.yml uses one: `[ -f X ] && var=…`
 # evaluates to 1 on the develop lane, which is only safe while nothing depends on the exit status.
 if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
-    components="$components compose cosign"
+    components="$components compose cosign rigforge"
     lane="the product stack and the appliance rootfs"
 fi
 
-# release.sh's pin() is the one place pins are read from the tree; the two rootfs binaries have no
+# release.sh's pin() is the one place pins are read from the tree; the three rootfs `ARG`s have no
 # case there because a release does not bundle them.
 tree_pin() {
     case "$1" in
     compose) sed -n 's/^ARG COMPOSE_VERSION=//p' "$ROOT/os/rootfs/Dockerfile" ;;
     cosign) sed -n 's/^ARG COSIGN_VERSION=//p' "$ROOT/os/rootfs/Dockerfile" ;;
+    rigforge) sed -n 's/^ARG RIGFORGE_REF=//p' "$ROOT/os/rootfs/Dockerfile" ;;
     *) pin "$1" ;;
     esac
 }
@@ -178,7 +242,15 @@ for component in $components; do
         failed=$((failed + 1))
         continue
     fi
-    if [ "$(norm "$raw")" = "$(norm "$latest")" ]; then
+    # A resolution failure is its own row, with its own sentence. Sharing the string above would
+    # let either guard silently cover for the other's deletion, which this repo has already shipped
+    # once. The tag IS known here, so it is still reported — only the verdict is withheld.
+    if ! cmp_to=$(comparable "$component" "$repo" "$latest"); then
+        row "$component" "\`$(norm "$raw")\`" "\`$(norm "$latest")\`" "**upstream tag could not be resolved to a commit — NOT checked**"
+        failed=$((failed + 1))
+        continue
+    fi
+    if [ "$(norm "$raw")" = "$(norm "$cmp_to")" ]; then
         verdict="current"
     else
         verdict="**stale** → \`$latest\`"
@@ -201,8 +273,12 @@ if [ -f "$ROOT/os/rootfs/Dockerfile" ]; then
     # #1137 describes for image digests. (This warning came from the appliance-lane watcher this
     # script replaced; the fact outlived the file.)
     printf '%s\n' "\`compose\` and \`cosign\` are compiled from source in \`os/rootfs/Dockerfile\`, so each bump is TWO ARGs — the version AND its paired \`_COMMIT\`. Resolve the commit with \`gh api repos/<owner>/<repo>/commits/<tag> --jq .sha\`; bumping the version alone still builds the old code."
+    # RIGFORGE_REF is the opposite spelling and needs the same idiom pointed the other way: the
+    # table resolves the tag to a commit to reach its verdict, and whoever acts on a stale row has
+    # to write that commit into the ARG. Saying which commit here saves them repeating the lookup.
+    printf '%s\n' "\`RIGFORGE_REF\` pins a COMMIT, not a tag, so a moved tag cannot change the bake. The row above compares it against the commit its latest release points at; to bump it, write that commit — \`gh api repos/p2pool-starter-stack/rigforge/commits/<tag> --jq .sha\` — into \`ARG RIGFORGE_REF\`, release by release."
 else
-    printf '%s\n' "The appliance rootfs's own pins (its docker-compose and cosign, compiled from \`ARG\` values that no dependabot ecosystem can read) are NOT in this table. They are in the appliance report, which the same workflow run produces from an explicit \`develop-v2\` checkout (#1146)."
+    printf '%s\n' "The appliance rootfs's own pins (its docker-compose, cosign and baked RigForge tree, all built from \`ARG\` values that no dependabot ecosystem can read) are NOT in this table. They are in the appliance report, which the same workflow run produces from an explicit \`develop-v2\` checkout (#1146)."
 fi
 printf '%s\n' "Also NOT checked: whether each image pin's digest still corresponds to its tag. The digest is what actually runs, so a half-done bump is invisible to the table above."
 if [ "$failed" -gt 0 ]; then

--- a/scripts/pin-watch.sh
+++ b/scripts/pin-watch.sh
@@ -104,6 +104,10 @@ comparable() { # <component> <owner/repo> <tag> -> the tag in that pin's spellin
     local sha
     case "$1" in
     rigforge)
+        # `commits/<tag>`, never `git/refs/tags/<tag>`: every rigforge release tag is annotated, so
+        # the refs endpoint answers with the TAG object's sha, which is also 40 hex and so passes
+        # the shape check below. It can never equal a commit pin, and the row would read stale for
+        # ever — including right after a correct bump, which is the failure this row exists to catch.
         sha=$(gh api "repos/$2/commits/$3" --jq .sha 2>/dev/null) || return 1
         # Third-party input, under the same rule as the tag itself: a value that is not shaped like
         # a commit must not be compared, and must not be printed into an issue body.


### PR DESCRIPTION
Watches `ARG RIGFORGE_REF` in the appliance report, which was absent from it end to end — not
flagged unchecked, just absent. Addresses #1410.

## What was wrong

`tree_pin()` already opened `os/rootfs/Dockerfile` and parsed `COMPOSE_VERSION` and
`COSIGN_VERSION` out of it. `ARG RIGFORGE_REF` sits at `:207` of that same file with no case, and
`upstream_for()` had no `rigforge` entry, so the component never reached the table at all. Nothing
else covers it: dependabot's docker ecosystem reads `FROM` lines, and `tests/os/verify-image.sh:189`
asserts only that a ref was *recorded*, never that it is current — our own "a version that is only
PRINTED is not CHECKED" shape.

## Why it is not a one-line case

Every other pin spells a VERSION, so the release tag is directly comparable. `RIGFORGE_REF` spells a
COMMIT, deliberately, so that a moved tag cannot change what is baked. A naive row would print a sha
against `v1.16.0` and read **stale** unconditionally — *including the hour after a correct bump*,
which trains the reader to ignore the row. That is a different lie from the current silence, not a
fix for it.

So `comparable()` resolves the release tag to the commit it names and the comparison is sha against
sha, using the idiom this script already prints in its `_COMMIT` warning. The tag stays in the
`upstream latest` column and the pin keeps its own spelling in `pinned`, so the row reads the way
every other row does.

## Evidence — both sides of the verdict, measured on real trees

The central risk was a row that says the same thing whatever the pin is. It does not. #1411 bumped
the baked pin to v1.16.0 while this branch was in flight, which gave a real before/after rather than
a simulated one:

```
at 191cc59, pre-bump:   | rigforge | 60aa8839… | 1.16.0 | **stale** -> v1.16.0 |   stale=2 failed=0, rc 0
at 97ea377, post-bump:  | rigforge | 4ce29b3d… | 1.16.0 | current              |   stale=1 failed=0, rc 0
```

**The pre-bump row is not reproducible from the current tree, and that is worth saying plainly.** It
was measured at `191cc59`, before the bump landed; run the script at the tip today and you get the
`current` row, because the pin it reads has changed underneath. So that half of the table is a
record of a measurement, not an instruction you can replay.

I had also proved the `current` side before #1411 landed, by editing the pin in a throwaway clone and
flipping it back — same result in both directions, so the live agreement is a check on that rather
than my only sample.

Separately re-derived at source rather than read from the comment: `60aa8839…` **is** rigforge
v1.15.1, so the pre-bump report's "two releases behind" was accurate.

## The failure path, which is the assertion that matters

A resolution that cannot run must reach the unchecked row, never `current`. Driven through the real
script with a `gh` shim on PATH, restoring between runs, with a **positive control** so the passes
are evidence rather than a dead harness:

```
resolution exits non-zero .............. rc=1, row reads "**upstream tag could not be resolved to a
                                         commit — NOT checked**", failed=1
resolution answers "Not Found" ......... rc=1, same refusal
resolution answers a valid commit ...... rc=0, row reads "current", failed=0   <- control
```

The refusal gets its **own sentence** rather than sharing the existing `upstream lookup failed`
string. Two guards sharing one output string let either silently cover for the other's deletion —
this repo has shipped that once already.

## Mutation table — every new assertion, with a NAMED kill

Run in a throwaway `git clone`, not the working checkout. Baseline green, post-restore green, file
restored byte-identical.

| # | mutation | killed (by name) | aimed at |
|---|---|---|---|
| M1 | `\|\| return 1` on the `gh` call → `\|\| true` | *a resolution that exits non-zero is refused even when it printed a commit* | same |
| M2 | delete the commit-shape check | *an answer that is not shaped like a commit is refused, not compared* | same |
| M3 | `rigforge)` arm → `*)` (resolve every component) | *a version pin is compared against the tag, with no lookup at all* | same |
| M4 | return the tag instead of the resolved sha | *an upstream tag resolves to the commit it names* | same |
| M5 | delete the `tree_pin` case | *(report-level, no self-test aims at it)* — row becomes **could not read the pin from the tree**, rc 1 | — |

**M1 survived the first time round, and that is the useful part of this PR.** With `|| return 1`
removed, the "cannot run" case still failed — because an empty `sha` fails the shape check too, so
the shape guard silently covered for the exit-code guard's deletion. That is the same defect I was
deliberately avoiding in the report rows, reproduced in my own test suite. Fixed the way it should
be: each guard is now pinned on the one input **only it** refuses — a stub that prints a valid
commit *and* exits non-zero isolates the exit-code guard. Both now die independently, each killing
only its own assertion.

M5 is disclosed as report-level rather than dressed up: no self-test aims at it, and I verified by
hand that deleting the case fails loudly rather than dropping the row silently.

## Design pass, done by hand

The PR gate keys its sentinel to the pane's branch and clears on a second invocation regardless, so
its state is not evidence about this diff. Findings, resolved either way with the reasoning exposed:

- **`comparable()` as a function rather than an inline `if` in the loop.** Kept. Inlining is shorter
  but puts both refusal paths out of reach of the self-test tier the issue asked for coverage at.
- **The two unchecked-row blocks are near-duplicates.** Deliberately not factored. They differ in the
  middle column and must differ in their sentence; a shared helper would re-create the shared-string
  defect this change exists to avoid. Two lines saved is not worth that.
- **Case-insensitive sha comparison — declined.** `gh` and git both emit lowercase and the Dockerfile
  carries lowercase. A hand-typed uppercase sha would read stale, which is loud, not silent.
- **Abbreviated-sha (prefix) tolerance — declined.** The pin is full-length and the Dockerfile
  comment says it pins by commit on purpose. A directional prefix match on a shared comparison, to
  handle a spelling nobody uses, is speculative. Both of these are named so a reviewer can overrule
  me rather than having to notice the absence.
- **`norm()` on the sha.** Left applied uniformly rather than special-cased; it is identity on hex,
  and there is now an assertion pinning that, so a future strip rule that ate hex would go red.

## Shared files

Two docs, both in `_shared.paths`, staged with the change rather than deferred:

- `docs/dev/dual-distribution-plan.md` enumerated the watched pins as "(docker-compose, cosign)" and
  was incomplete the moment this row landed.
- `docs/dev/releasing.md` describes the watcher generically, which stayed true but hid the one pin
  compared by commit rather than by version.

No workflow file is touched. `scripts/pin-watch.sh` is exclusively owned by this lane.

## What I did NOT do

- **Not bumped anything.** The bump was #1407/#1411 and it has already landed independently.
- **No fix for `tests/os/verify-image.sh:189`**, which asserts a `ref=` line exists and never that it
  is current — it would stay green at v1.15.1 for ever. That file is outside this lane's paths;
  recorded here so it is not lost.
- **No registry/digest work**, which the script's header already excludes by design.
- No bench, no hardware, no CI watched yet.

## Gates

`make lint` — **MAKE_RC=0**, read from make's own exit code rather than a filtered tail. Run with
`shellcheck` 0.11.0 and `uv`/`uvx` resolvable, since the defaults here are a stale shellcheck and a
missing `uv` that reports as a false RED. Self-test 13/13. `lint-file-budget` rc 0; after rebasing I
ran both owed checks — verified the row itself, and `--generate` + diff, whose only drift is the two
long-documented headroom rows.

`scripts/pin-watch.sh` is 291 lines against a target of 400 and correctly carries no budget row.
