### PR TITLE
fix(e2e): a leftover borrow is detected by its backup, not by its tag (#1178)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -207,9 +207,16 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    repoint finds the bench already named, so it only reorders the pool list and tags nothing — the
    contamination leaves no marker, and a tag-based check cannot see it. Two other outcomes are worth
    knowing: when the rig does not look borrowed, leftover backups are cleared as stale, because
-   RigForge regenerates the xmrig config from its own source on every apply; and when the config
-   cannot be read at all, nothing is cleared and nothing is restored, since a config half-written by a
-   run that died mid-restore looks exactly like that and must not cost the only copy of the original.
+   RigForge regenerates the xmrig config from its own source on every apply (`rigforge.sh:3979` at the
+   baked pin — though a fast-path control-apply of `watchdog_interval_min` or `max_temp_c` deliberately
+   skips that path, `rigforge.sh:4203` and `:4228`); and when the config cannot be read at all, nothing
+   is cleared and nothing is restored, since a config half-written by a run that died mid-restore looks
+   exactly like that and must not cost the only copy of the original.
+
+   One outcome cannot be resolved from the rig alone. When it looks borrowed and no backup survives,
+   the pre-borrow state is gone: a surviving untagged bench pool is then either the rig's own permanent
+   one or an un-undoable reorder, and nothing on the rig separates them. The run says so and asks for a
+   hand repair, rather than reporting the reassuring reading of the two.
 5. Deploys the branch (`pithead upgrade` — re-renders the generated configs and rebuilds the
    first-party images from `build/`, so a Dockerfile or entrypoint change is actually under test;
    `apply` never builds and would reuse whatever images were last built on the box,

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -194,6 +194,22 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    With `--no-miner` nothing is borrowed, and the harness runs with `--no-mining-asserts`: the
    workers-online and stratum-hashes assertions skip with a logged notice while every other
    assertion stays binding ([#905](https://github.com/p2pool-starter-stack/pithead/issues/905)).
+
+   Before it takes that backup, the borrow undoes a previous run that died without restoring —
+   SIGKILL, an OOM kill, `--keep`, a failed teardown. Such a run leaves the rig pointed at the bench
+   and leaves its `.e2e-orig.*` backup on disk, because the restore prunes that backup only once it
+   has compared the bytes back into place. So a surviving backup means an un-restored borrow, and the
+   oldest one holds the true pre-borrow config. Restoring from it first is what stops this run's
+   backup from recording the borrowed state as "the original" and every later restore returning to it
+   ([#1178](https://github.com/p2pool-starter-stack/pithead/issues/1178)).
+
+   A rig that keeps a permanent bench pool of its own is the case that makes this necessary. There the
+   repoint finds the bench already named, so it only reorders the pool list and tags nothing — the
+   contamination leaves no marker, and a tag-based check cannot see it. Two other outcomes are worth
+   knowing: when the rig does not look borrowed, leftover backups are cleared as stale, because
+   RigForge regenerates the xmrig config from its own source on every apply; and when the config
+   cannot be read at all, nothing is cleared and nothing is restored, since a config half-written by a
+   run that died mid-restore looks exactly like that and must not cost the only copy of the original.
 5. Deploys the branch (`pithead upgrade` — re-renders the generated configs and rebuilds the
    first-party images from `build/`, so a Dockerfile or entrypoint change is actually under test;
    `apply` never builds and would reuse whatever images were last built on the box,

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -599,16 +599,17 @@ borrow_miner() {
     # so a surviving .e2e-orig.* is an un-restored borrow and the OLDEST is the true original.
     # Without one the pre-borrow state is gone — strip the tag, and say plainly that a pure reorder
     # cannot be undone. Not borrowed but leftovers present means RigForge regenerated the file since
-    # (it does, on every apply): clear them, which is what keeps "oldest" meaning the original.
+    # (rigforge.sh:3979, on every apply — but NOT on a fast-path control-apply of watchdog_interval_min or max_temp_c, which skips _apply_runtime outright, rigforge.sh:4203/:4228): clear them, which keeps "oldest" meaning the original.
     # Unreadable clears and restores NOTHING — a config half-written by a run that died mid-restore
     # looks exactly like this, and must not cost the only copy of the original.
-    local leftover borrowed
+    local leftover borrowed verdict="the recovery above found no un-restored borrow to undo. Read as the rig's own permanent bench pool: the backup taken next records it and the restore returns to it."
     leftover="$(on_miner "ls -1 '$MINER_XMRIG_CONFIG'.e2e-orig.* 2>/dev/null | sort | head -n1" || true)"
     borrowed="$(on_miner "jq -r --arg b '$BENCH_HOST' 'if (((.pools[0].url // \"\") | ascii_downcase | contains(\$b | ascii_downcase)) or any(.pools[]?; .[\"rig-id\"]? == \"pithead-e2e\")) then \"yes\" else \"no\" end' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
     if [ "$borrowed" = "yes" ] && [ -n "$leftover" ]; then
         warn "$MINER_HOST is still borrowed by an earlier e2e run that never restored it; $leftover holds its pre-borrow config. Restoring from it now, BEFORE this run's backup is minted (#1178)."
         on_miner "cp -a '$leftover' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && rm -f '$MINER_XMRIG_CONFIG'.e2e-orig.*" || die "Failed to restore $MINER_HOST from $leftover."
     elif [ "$borrowed" = "yes" ]; then
+        verdict="the recovery above could NOT undo the borrow it found — no .e2e-orig.* survived, so this is EITHER the rig's own permanent bench pool OR that un-undoable REORDER, and nothing on the rig tells them apart. HAND-REPAIR before trusting this run's restore."
         warn "$MINER_HOST looks borrowed but NO .e2e-orig.* backup survives, so the pre-borrow state is unrecoverable. Stripping any tagged pool; a pure REORDER cannot be undone and this run's backup will record it."
         on_miner "jq '.pools |= [.[] | select(.[\"rig-id\"]? != \"pithead-e2e\")]' '$MINER_XMRIG_CONFIG' > '$MINER_XMRIG_CONFIG.e2e.tmp' && mv '$MINER_XMRIG_CONFIG.e2e.tmp' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG'" || die "Failed to strip leftover tagged pool(s) from $MINER_HOST config."
     elif [ "$borrowed" = "no" ] && [ -n "$leftover" ]; then
@@ -618,9 +619,9 @@ borrow_miner() {
         warn "could not read $MINER_HOST's pool list, so it cannot be judged borrowed or clean — leaving the config AND any backup(s) untouched. A half-written config looks exactly like this."
     fi
 
-    # Report an untagged bench-naming pool that SURVIVED the recovery above — the recovery found no
-    # un-restored borrow, so this is the rig's own permanent bench pool: the backup records it and
-    # the restore returns to it, which is right. Said BEFORE the backup, because the backup is what
+    # Report an untagged bench-naming pool that SURVIVED the recovery above. Its MEANING depends on
+    # which arm ran, so the arms set $verdict: normally the rig's own permanent bench pool, but
+    # ambiguous if the unrecoverable arm fired. Said BEFORE the backup, because the backup is what
     # "restore" means afterwards. `.url // ""` and a lowercased needle because one sibling entry
     # with no .url makes jq exit non-zero for the WHOLE expression; and the answer is a three-way,
     # not a boolean — a probe that goes quiet exactly when the fault is present must not read clean.
@@ -633,8 +634,8 @@ borrow_miner() {
         ;;
     0) ;;
     *)
-        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools untagged pool(s), and the recovery above found no un-restored borrow to undo."
-        warn "  Read as the rig's own permanent bench pool: the backup taken next records it and the restore returns to it. Verify by hand if that surprises you: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools untagged pool(s), and $verdict"
+        warn "  Verify by hand if that surprises you: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
         ;;
     esac
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -606,6 +606,7 @@ borrow_miner() {
     leftover="$(on_miner "ls -1 '$MINER_XMRIG_CONFIG'.e2e-orig.* 2>/dev/null | sort | head -n1" || true)"
     borrowed="$(on_miner "jq -r --arg b '$BENCH_HOST' 'if (((.pools[0].url // \"\") | ascii_downcase | contains(\$b | ascii_downcase)) or any(.pools[]?; .[\"rig-id\"]? == \"pithead-e2e\")) then \"yes\" else \"no\" end' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
     if [ "$borrowed" = "yes" ] && [ -n "$leftover" ]; then
+        verdict="it survived the recovery above, which restored this rig from its OLDEST backup — so this pool predates the borrow: the rig's own permanent bench pool."
         warn "$MINER_HOST is still borrowed by an earlier e2e run that never restored it; $leftover holds its pre-borrow config. Restoring from it now, BEFORE this run's backup is minted (#1178)."
         on_miner "cp -a '$leftover' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && rm -f '$MINER_XMRIG_CONFIG'.e2e-orig.*" || die "Failed to restore $MINER_HOST from $leftover."
     elif [ "$borrowed" = "yes" ]; then

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -374,14 +374,11 @@ PROBE
 
     # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
     #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
-    #
-    #    Note what this check can and cannot see. It runs AFTER restore_all's `apply -y`, and that
-    #    apply converges the units (v1.19.2+), so on the ordinary #1085 path the strand is already
-    #    repaired by the time we look — this arm is a proof that the box was LEFT working, not a
-    #    detector of the strand itself. The strand is caught upstream, by CONTROL_VERDICT_BEFORE
-    #    recorded in restore_all before that apply, and by run.sh's ExecStart assertion. What this
-    #    arm does catch on its own: a pithead too old to converge (no-check), a disabled channel
-    #    where apply leaves stray units alone, and strands this run did not cause.
+    #    It runs AFTER restore_all's `apply -y`, which converges the units (v1.19.2+), so on the
+    #    ordinary #1085 path the strand is already repaired: this arm proves the box was LEFT
+    #    working, it does not detect the strand (CONTROL_VERDICT_BEFORE and run.sh's ExecStart
+    #    assertion do). Alone it catches a pithead too old to converge (no-check), a disabled
+    #    channel where apply leaves stray units, and strands this run did not cause.
     local doc verdict_line
     doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
     verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
@@ -526,10 +523,10 @@ provision() {
         git -C '$E2E_DIR' fetch --quiet origin '$BRANCH'
         # The e2e checkout is DEDICATED and disposable, so force a pristine tree instead of assuming
         # one (#454): drop stray untracked files (e.g. a leftover bench script) that would otherwise
-        # abort 'checkout' with \"would be overwritten\". -x clears ignored build cruft too; the
-        # -e excludes keep data/backups and the harness's own results/, so the shared chains and
-        # rollback anchors are never touched. config.json/.env ARE wiped (gitignored, no -e) but the
-        # next step re-seeds them from CANONICAL_DIR — don't drop that seed thinking clean spares them.
+        # abort 'checkout' with \"would be overwritten\". -x clears ignored build cruft too; the -e
+        # excludes keep data/backups and results/, so chains and rollback anchors are never touched.
+        # config.json/.env ARE wiped (gitignored, no -e) — the next step re-seeds them, so don't drop
+        # that seed thinking clean spares them.
         git -C '$E2E_DIR' checkout -q -f -B '$BRANCH' FETCH_HEAD
         git -C '$E2E_DIR' reset -q --hard FETCH_HEAD
         git -C '$E2E_DIR' clean -qfdx -e /results -e /backups -e /data
@@ -592,38 +589,41 @@ borrow_miner() {
     }
     log "Borrowing $MINER_HOST → pointing it at $BENCH_HOST"
 
-    # Strip our OWN leftovers first, before anything else touches the config (#1178). The repoint
-    # below tags the pool it injects with "rig-id": "pithead-e2e" — a documented per-pool xmrig key,
-    # ignored for pool selection — so a pool already carrying that tag is unambiguous: no run but this
-    # harness writes it, and finding one before THIS run has injected anything means a previous run
-    # repointed the rig and never restored it (crash, SIGKILL, --keep, or a failed teardown). Strip it
-    # before the backup below is minted, or the backup enshrines the borrowed state as "original" and
-    # every later restore returns to it — the self-perpetuating contamination measured live on a
-    # loaner: 32 backups, 3 distinct contents, the two most recent already carrying a bench pool.
-    local tagged_pools
-    tagged_pools="$(on_miner "jq -r '[.pools[]? | select(.[\"rig-id\"]? == \"pithead-e2e\")] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
-    case "$tagged_pools" in "" | *[!0-9]*) tagged_pools=0 ;; esac
-    if [ "$tagged_pools" -gt 0 ]; then
-        warn "$MINER_HOST's xmrig config already carries $tagged_pools pool(s) tagged rig-id=pithead-e2e — a previous e2e run repointed this rig and never restored it."
-        warn "  Stripping the leftover tagged pool(s) now, before this run's backup, so the backup records the true original."
-        on_miner "jq '.pools |= [.[] | select(.[\"rig-id\"]? != \"pithead-e2e\")]' '$MINER_XMRIG_CONFIG' > '$MINER_XMRIG_CONFIG.e2e.tmp' && mv '$MINER_XMRIG_CONFIG.e2e.tmp' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG'" ||
-            die "Failed to strip leftover tagged pool(s) from $MINER_HOST config."
+    # Undo a run that died borrowed, before this run's backup is minted (#1178) — or the backup
+    # enshrines the borrowed state as "the original" and every later restore returns to it.
+    # ONE detector, three remedies. "Still borrowed" is: the primary pool names the bench, OR any
+    # pool carries our tag. Needing EITHER is the point — the repoint below has two mutation paths
+    # and the tag marks only one of them, because a rig that ALREADY names the bench takes the
+    # `then .` arm and is merely REORDERED, tagging nothing. A tag-only detector is blind to that.
+    # The remedy is the backup: restore_all prunes it only once the bytes are proven back (#1067),
+    # so a surviving .e2e-orig.* is an un-restored borrow and the OLDEST is the true original.
+    # Without one the pre-borrow state is gone — strip the tag, and say plainly that a pure reorder
+    # cannot be undone. Not borrowed but leftovers present means RigForge regenerated the file since
+    # (it does, on every apply): clear them, which is what keeps "oldest" meaning the original.
+    # Unreadable clears and restores NOTHING — a config half-written by a run that died mid-restore
+    # looks exactly like this, and must not cost the only copy of the original.
+    local leftover borrowed
+    leftover="$(on_miner "ls -1 '$MINER_XMRIG_CONFIG'.e2e-orig.* 2>/dev/null | sort | head -n1" || true)"
+    borrowed="$(on_miner "jq -r --arg b '$BENCH_HOST' 'if (((.pools[0].url // \"\") | ascii_downcase | contains(\$b | ascii_downcase)) or any(.pools[]?; .[\"rig-id\"]? == \"pithead-e2e\")) then \"yes\" else \"no\" end' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
+    if [ "$borrowed" = "yes" ] && [ -n "$leftover" ]; then
+        warn "$MINER_HOST is still borrowed by an earlier e2e run that never restored it; $leftover holds its pre-borrow config. Restoring from it now, BEFORE this run's backup is minted (#1178)."
+        on_miner "cp -a '$leftover' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && rm -f '$MINER_XMRIG_CONFIG'.e2e-orig.*" || die "Failed to restore $MINER_HOST from $leftover."
+    elif [ "$borrowed" = "yes" ]; then
+        warn "$MINER_HOST looks borrowed but NO .e2e-orig.* backup survives, so the pre-borrow state is unrecoverable. Stripping any tagged pool; a pure REORDER cannot be undone and this run's backup will record it."
+        on_miner "jq '.pools |= [.[] | select(.[\"rig-id\"]? != \"pithead-e2e\")]' '$MINER_XMRIG_CONFIG' > '$MINER_XMRIG_CONFIG.e2e.tmp' && mv '$MINER_XMRIG_CONFIG.e2e.tmp' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG'" || die "Failed to strip leftover tagged pool(s) from $MINER_HOST config."
+    elif [ "$borrowed" = "no" ] && [ -n "$leftover" ]; then
+        warn "$MINER_HOST carries leftover e2e backup(s) but does not look borrowed — RigForge regenerates this file on every apply. Clearing them as stale, so 'oldest' keeps meaning the original."
+        on_miner "rm -f '$MINER_XMRIG_CONFIG'.e2e-orig.*" || die "Failed to clear stale e2e backups on $MINER_HOST."
+    elif [ "$borrowed" != "no" ]; then
+        warn "could not read $MINER_HOST's pool list, so it cannot be judged borrowed or clean — leaving the config AND any backup(s) untouched. A half-written config looks exactly like this."
     fi
 
-    # Say so BEFORE the backup is taken, because the backup is what "restore" means afterwards. The
-    # repoint below has an `if any(.pools[]?; .url | contains($b)) then .` arm — written for a rig
-    # that legitimately keeps a bench pool — and that arm still absorbs an UNTAGGED bench-naming pool
-    # with no complaint. Tagged leftovers are handled above; this is the remaining, genuinely
-    # ambiguous case: an untagged pool naming the bench could be the operator's own, or contamination
-    # from before the tag existed (#1178 — the tag cannot repair what it predates).
-    # `.url // ""` and a lowercased needle, because a pool entry with no .url makes `.url |
-    # ascii_downcase` raise and jq exits non-zero for the WHOLE expression — one malformed sibling
-    # entry and the probe reports nothing. And the answer is a three-way, not a boolean: "could not
-    # tell" must not read as "clean". The old spelling ended `2>/dev/null || echo 0`, which failed
-    # open on every error path — a truncated config, a dropped ssh — and those are correlated with
-    # the very fault this probe exists to find: a config left half-written by a run that died before
-    # restoring. A probe that goes quiet exactly when the thing it looks for is present is the
-    # defect class this whole PR is about, one function away from the comment that says so.
+    # Report an untagged bench-naming pool that SURVIVED the recovery above — the recovery found no
+    # un-restored borrow, so this is the rig's own permanent bench pool: the backup records it and
+    # the restore returns to it, which is right. Said BEFORE the backup, because the backup is what
+    # "restore" means afterwards. `.url // ""` and a lowercased needle because one sibling entry
+    # with no .url makes jq exit non-zero for the WHOLE expression; and the answer is a three-way,
+    # not a boolean — a probe that goes quiet exactly when the fault is present must not read clean.
     local bench_pools
     bench_pools="$(on_miner "jq -r --arg b '$BENCH_HOST' '[.pools[]? | select((.url // \"\") | ascii_downcase | contains(\$b | ascii_downcase))] | length' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
     case "$bench_pools" in
@@ -633,10 +633,8 @@ borrow_miner() {
         ;;
     0) ;;
     *)
-        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools pool(s) before this run borrowed it, and none of them are tagged rig-id=pithead-e2e."
-        warn "  Either this rig legitimately keeps a permanent bench pool, or it's contamination from before the tag existed — left alone; the tag can't tell those apart retroactively."
-        warn "  The backup taken next records THAT state as the original, so a later restore returns to it."
-        warn "  Check by hand before trusting a restore: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
+        warn "$MINER_HOST's xmrig config ALREADY names $BENCH_HOST in $bench_pools untagged pool(s), and the recovery above found no un-restored borrow to undo."
+        warn "  Read as the rig's own permanent bench pool: the backup taken next records it and the restore returns to it. Verify by hand if that surprises you: jq '.pools[].url' $MINER_XMRIG_CONFIG on $MINER_HOST"
         ;;
     esac
     MINER_CFG_BACKUP="$MINER_XMRIG_CONFIG.e2e-orig.$(on_miner 'date +%Y%m%d-%H%M%S')"
@@ -646,9 +644,8 @@ borrow_miner() {
     # user/pass/keepalive carry over, override url→bench and force plain stratum), then reorder so the
     # bench pool is primary and the rest stay as failover. Non-destructive, fully reversible from the
     # backup above. ponytail: hardcodes :3333 (the seeded canonical stratum_port default, which the bench runs).
-    # Tagged "rig-id": "pithead-e2e" (#1178) — a documented per-pool xmrig key, ignored for pool
-    # selection — so a future run (or the restore path below) can tell this injected entry apart from
-    # anything an operator put there.
+    # The injected entry is tagged "rig-id": "pithead-e2e" (#1178) — a documented per-pool xmrig key,
+    # ignored for pool selection — which is what the restore path's belt-and-braces check keys on.
     on_miner "
         jq --arg b '$BENCH_HOST' '
             (if any(.pools[]?; .url | ascii_downcase | contains(\$b)) then .

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -606,7 +606,7 @@ borrow_miner() {
     leftover="$(on_miner "ls -1 '$MINER_XMRIG_CONFIG'.e2e-orig.* 2>/dev/null | sort | head -n1" || true)"
     borrowed="$(on_miner "jq -r --arg b '$BENCH_HOST' 'if (((.pools[0].url // \"\") | ascii_downcase | contains(\$b | ascii_downcase)) or any(.pools[]?; .[\"rig-id\"]? == \"pithead-e2e\")) then \"yes\" else \"no\" end' '$MINER_XMRIG_CONFIG' 2>/dev/null" || true)"
     if [ "$borrowed" = "yes" ] && [ -n "$leftover" ]; then
-        verdict="it survived the recovery above, which restored this rig from its OLDEST backup — so this pool predates the borrow: the rig's own permanent bench pool."
+        verdict="it survived the recovery above, which restored this rig from its OLDEST backup, so it predates THIS run's borrow. If an earlier run reported HAND-REPAIR, that ambiguity is still unresolved."
         warn "$MINER_HOST is still borrowed by an earlier e2e run that never restored it; $leftover holds its pre-borrow config. Restoring from it now, BEFORE this run's backup is minted (#1178)."
         on_miner "cp -a '$leftover' '$MINER_XMRIG_CONFIG' && chmod 600 '$MINER_XMRIG_CONFIG' && rm -f '$MINER_XMRIG_CONFIG'.e2e-orig.*" || die "Failed to restore $MINER_HOST from $leftover."
     elif [ "$borrowed" = "yes" ]; then

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -334,12 +334,10 @@ for flag in $(printf '%s %s %s %s' "$TARGETED" "$MATRIX" "$CHECK" "$NOMINER" | t
 done
 
 echo "== borrow_miner's recovery block, fired on known instances (#1178) =="
-# F2 of the #1415 review: nothing in the repo ever fired this detector, so its only evidence of
-# working was PR-body prose from a harness that was never committed. Driven like run_harness above —
-# the REAL block out of the shipped e2e.sh — except on_miner runs each command LOCALLY against a temp
-# config, so the actual jq/ls/cp/rm execute and ssh is the only thing substituted. That is the whole
-# of on_miner (e2e.sh:172). Extraction is asserted first: a refactor that moves this must go red
-# rather than silently stop testing.
+# F2 of the #1415 review: nothing in the repo ever fired this detector, so its only evidence was
+# PR-body prose from a harness never committed. Drives the REAL block out of the shipped e2e.sh with
+# on_miner running each command LOCALLY against a temp config — ssh is the only substitution, and it
+# is the whole of on_miner (e2e.sh:172). Extraction is asserted first, so a refactor reds.
 RECOVERY_SRC="$(sed -n '/^    local leftover borrowed/,/^    esac$/p' "$E2E_SRC")"
 assert_eq "the recovery-block extraction opens and closes" \
     "$(printf '%s\n' "$RECOVERY_SRC" | sed -n '1p;$p' | awk '{print $1}' | tr '\n' ' ')" "local esac "
@@ -386,11 +384,14 @@ drive_recovery '{"pools":[{"url":"pithead.example:3333"},{"url":"bench.example:3
 assert_eq "a leftover borrow is restored from the oldest backup" "$(jq -r '.pools[0].url' "$CFGDIR/config.json")" "orig1.example:3333"
 assert_eq "  and every backup is pruned once the bytes are back" "$(ls -1 "$CFGDIR" | wc -l)" "1"
 assert_eq "  and the report does NOT then deny the borrow it just undid (#1415 F1, arm 1)" "$(contains "$OUT" "found no un-restored borrow to undo")" "no"
+assert_eq "  positive control for the line above: the report DOES fire here" "$(contains "$OUT" "untagged pool(s)")" "yes"
 
 # Unreadable must cost nothing — a config half-written by a run that died mid-restore looks like this.
 drive_recovery 'not json at all' 1
 assert_eq "an unreadable config leaves the only surviving backup alone" "$(ls -1 "$CFGDIR" | wc -l)" "2"
 assert_eq "  and the silence is not reported as clean" "$(contains "$OUT" "leaving the config AND any backup(s) untouched")" "yes"
+assert_eq "  and the REPORT block says so in its own words, which is a SECOND guard" "$(contains "$OUT" "do NOT read the silence as clean")" "yes"
+assert_eq "  and the config bytes are untouched too — that message claims BOTH halves" "$(cat "$CFGDIR/config.json")" "not json at all"
 
 echo ""
 echo "selftest-e2e-phases: $IT_PASS passed, $IT_FAIL failed"

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -333,6 +333,64 @@ for flag in $(printf '%s %s %s %s' "$TARGETED" "$MATRIX" "$CHECK" "$NOMINER" | t
         "$(grep -cE "^[[:space:]]*(\-\-[a-z-]+ \| )*${flag}\)" "$RUN_SRC" | awk '{print ($1>0)?"yes":"no"}')" "yes"
 done
 
+echo "== borrow_miner's recovery block, fired on known instances (#1178) =="
+# F2 of the #1415 review: nothing in the repo ever fired this detector, so its only evidence of
+# working was PR-body prose from a harness that was never committed. Driven like run_harness above —
+# the REAL block out of the shipped e2e.sh — except on_miner runs each command LOCALLY against a temp
+# config, so the actual jq/ls/cp/rm execute and ssh is the only thing substituted. That is the whole
+# of on_miner (e2e.sh:172). Extraction is asserted first: a refactor that moves this must go red
+# rather than silently stop testing.
+RECOVERY_SRC="$(sed -n '/^    local leftover borrowed/,/^    esac$/p' "$E2E_SRC")"
+assert_eq "the recovery-block extraction opens and closes" \
+    "$(printf '%s\n' "$RECOVERY_SRC" | sed -n '1p;$p' | awk '{print $1}' | tr '\n' ' ')" "local esac "
+
+drive_recovery() { # <pools-json> <n-backups> -> $OUT (the warn lines), $CFGDIR (the resulting tree)
+    local i=1
+    CFGDIR="$(mktemp -d)"
+    printf '%s' "$1" >"$CFGDIR/config.json"
+    while [ "$i" -le "$2" ]; do
+        printf '{"pools":[{"url":"orig%s.example:3333"}]}' "$i" >"$CFGDIR/config.json.e2e-orig.$i"
+        i=$((i + 1))
+    done
+    OUT="$(
+        exec </dev/null
+        # SC2034/SC2329: the config vars and the stubs are read and called by the eval'd block,
+        # which shellcheck cannot follow into.
+        # shellcheck disable=SC2034,SC2329
+        MINER_HOST=rig1 BENCH_HOST=bench.example MINER_XMRIG_CONFIG="$CFGDIR/config.json"
+        on_miner() { eval "$1"; }
+        warn() { echo "WARN $*"; }
+        die() { echo "DIE $*" && exit 1; }
+        eval "recovery() { $RECOVERY_SRC; }"
+        recovery
+    )"
+}
+
+# The case the review named: a rig that merely KEEPS a permanent bench pool, at index 1, untagged.
+# `.pools[0]` positionality is the only reason that reads as clean, and nothing said so. Broaden that
+# jq to any(.pools[]?; ...) and arm 1 cp's a stale backup over the operator's live config, every gate
+# still green. Asserting the BYTES catches it; a message assert would not, because arm 1 warns too.
+BEFORE='{"pools":[{"url":"pithead.example:3333"},{"url":"bench.example:3333"}]}'
+drive_recovery "$BEFORE" 1
+assert_eq "a permanent bench pool at [1] is not treated as a leftover borrow" "$(cat "$CFGDIR/config.json")" "$BEFORE"
+assert_eq "  its stale backup is cleared, so 'oldest' keeps meaning the original" "$(ls -1 "$CFGDIR" | wc -l)" "1"
+assert_eq "  and it is reported as the rig's own permanent bench pool" "$(contains "$OUT" "permanent bench pool")" "yes"
+
+# F1: the unrecoverable arm must not be followed by the reassuring verdict that cancels it.
+drive_recovery '{"pools":[{"url":"bench.example:3333"}]}' 0
+assert_eq "an un-undoable reorder says so" "$(contains "$OUT" "HAND-REPAIR")" "yes"
+assert_eq "  and does NOT also report there was no un-restored borrow to undo (#1415 F1)" "$(contains "$OUT" "found no un-restored borrow to undo")" "no"
+
+# Arm 1: a borrow WITH surviving backups restores from the OLDEST, then prunes them all.
+drive_recovery '{"pools":[{"url":"bench.example:3333","rig-id":"pithead-e2e"}]}' 2
+assert_eq "a leftover borrow is restored from the oldest backup" "$(jq -r '.pools[0].url' "$CFGDIR/config.json")" "orig1.example:3333"
+assert_eq "  and every backup is pruned once the bytes are back" "$(ls -1 "$CFGDIR" | wc -l)" "1"
+
+# Unreadable must cost nothing — a config half-written by a run that died mid-restore looks like this.
+drive_recovery 'not json at all' 1
+assert_eq "an unreadable config leaves the only surviving backup alone" "$(ls -1 "$CFGDIR" | wc -l)" "2"
+assert_eq "  and the silence is not reported as clean" "$(contains "$OUT" "do NOT read the silence as clean")" "yes"
+
 echo ""
 echo "selftest-e2e-phases: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -349,7 +349,7 @@ drive_recovery() { # <pools-json> <n-backups> -> $OUT (the warn lines), $CFGDIR 
     CFGDIR="$(mktemp -d)"
     printf '%s' "$1" >"$CFGDIR/config.json"
     while [ "$i" -le "$2" ]; do
-        printf '{"pools":[{"url":"orig%s.example:3333"}]}' "$i" >"$CFGDIR/config.json.e2e-orig.$i"
+        printf '{"pools":[{"url":"orig%s.example:3333"},{"url":"bench.example:3333"}]}' "$i" >"$CFGDIR/config.json.e2e-orig.$i"
         i=$((i + 1))
     done
     OUT="$(
@@ -382,14 +382,15 @@ assert_eq "an un-undoable reorder says so" "$(contains "$OUT" "HAND-REPAIR")" "y
 assert_eq "  and does NOT also report there was no un-restored borrow to undo (#1415 F1)" "$(contains "$OUT" "found no un-restored borrow to undo")" "no"
 
 # Arm 1: a borrow WITH surviving backups restores from the OLDEST, then prunes them all.
-drive_recovery '{"pools":[{"url":"bench.example:3333","rig-id":"pithead-e2e"}]}' 2
+drive_recovery '{"pools":[{"url":"pithead.example:3333"},{"url":"bench.example:3333","rig-id":"pithead-e2e"}]}' 2
 assert_eq "a leftover borrow is restored from the oldest backup" "$(jq -r '.pools[0].url' "$CFGDIR/config.json")" "orig1.example:3333"
 assert_eq "  and every backup is pruned once the bytes are back" "$(ls -1 "$CFGDIR" | wc -l)" "1"
+assert_eq "  and the report does NOT then deny the borrow it just undid (#1415 F1, arm 1)" "$(contains "$OUT" "found no un-restored borrow to undo")" "no"
 
 # Unreadable must cost nothing — a config half-written by a run that died mid-restore looks like this.
 drive_recovery 'not json at all' 1
 assert_eq "an unreadable config leaves the only surviving backup alone" "$(ls -1 "$CFGDIR" | wc -l)" "2"
-assert_eq "  and the silence is not reported as clean" "$(contains "$OUT" "do NOT read the silence as clean")" "yes"
+assert_eq "  and the silence is not reported as clean" "$(contains "$OUT" "leaving the config AND any backup(s) untouched")" "yes"
 
 echo ""
 echo "selftest-e2e-phases: $IT_PASS passed, $IT_FAIL failed"


### PR DESCRIPTION
## What this fixes

`borrow_miner` has **two** mutation paths and the `"rig-id": "pithead-e2e"` tag marks only one of
them:

- **inject-and-tag** — the rig does not name the bench, so a bench pool is cloned in and tagged.
- **reorder-only** — the rig *already* names the bench, so the repoint takes its `if any(...) then .`
  arm, injects nothing, tags nothing, and the following `.pools |=` step still promotes the bench
  pool to primary.

A run that dies without restoring (SIGKILL, OOM, `--keep`, a failed teardown) therefore leaves **no
marker at all** on the second path. The next run's leftover check finds nothing, mints a backup of
the *reordered* config and calls it "the original", and every later restore returns the rig to the
borrowed order. Self-perpetuating, and silent.

This is the case #1184 was verified against and could not cover — its own live verification measured
**19 passed / 0 failed** on a rig that does not name the bench and **14 passed / 5 failed** on one
that does, with backup #2 byte-identical to the borrowed config.

## The change

The sound marker is **the backup, not the tag**. `restore_all` prunes `.e2e-orig.*` only once `cmp`
has proven the bytes back in place (#1067), so a surviving one *is* an un-restored borrow — and
because it records the whole config rather than one injected entry, it covers both mutation paths.
The oldest holds the true pre-borrow state.

The leftover-tag strip and this recovery are two remedies for one condition, so they are collapsed
into **one detector with three remedies**. "Still borrowed" is *a bench primary **or** our tag*:

| state | remedy |
|---|---|
| borrowed, backup survives | restore from the oldest, clear the rest |
| borrowed, no backup | strip the tag, and say plainly that a pure reorder is unrecoverable |
| not borrowed, backup survives | clear as stale — the rig regenerates this file on every apply |
| unreadable | touch **nothing**: that is what a half-written config looks like |

Needing *either* signal is the point: a tag-only detector is blind to the reorder path, and a
primary-only detector is blind to a config edited since. Merging also removed an ordering dependency
between the two old blocks, and is **11 lines shorter** than keeping them separate.

## Over-engineering pass

Run by hand and recorded here, because the repo's gate for this cannot be satisfied from a session
and its silence is not evidence either way. The pass is what produced the merge above: the first
working version of this change added a second detector beside the existing one, which was 21 lines
over the file's budget ceiling and carried a silent "recovery must run before the strip" ordering
rule. One detector with three remedies is smaller, has no ordering rule, and states the
unrecoverable case out loud instead of leaving it implied.

## What was run

**Local battery** (`borrow_miner` and the miner half of `restore_all` driven with `on_miner`
redirected to a local shell — real bytes, no ssh), deterministic across three runs each:

```
clean    39 passed /  0 failed   x3
mutated  30 passed /  8 failed   x3   (identical failing-name sets)
```

The mutation blinds leftover discovery, which disables this fix while leaving the tag-strip intact —
i.e. exactly the previous behaviour. Every kill is reported **by name**. Two things that matter more
than the totals:

- **The scenario-1 (tag path) `#1178` assertion still PASSES under the mutation.** The fix is not
  covering for the path that already worked; it adds the reorder path.
- Scenario 4 (unreadable config) passes both ways — that guard is independent of the mutation, which
  is correct, and saying so is cheaper than letting the table imply otherwise.

**Live, on a real loaner rig over real ssh** — the one claim the local harness cannot make, since it
cannot prove the new `jq` filter survives remote-shell quoting:

```
scenario 1 (bench the rig does NOT name)          19 passed / 0 failed
scenario 2 (bench the rig ALREADY names, untagged) 19 passed / 0 failed   <- was 14 / 5
```

The rig was left **byte-exact**: final config sha equals the pre-borrow baseline sha, original pool
order, zero `.e2e-orig.*` and zero `.e2e.tmp` on disk — read back directly afterwards rather than
taken from the driver's own verdict.

Worth noting, since a previous measurement recorded the opposite: on the crash-recovery path the
restore is now **byte-exact, not merely content-exact**. The old path rewrote the config through
`jq` (2-space) over a 4-space generated file; restoring from a `cp -a` backup preserves the bytes.

**Gates:** `shellcheck` 0.11.0 (the CI-pinned version, not `/usr/bin`'s 0.9.0) over
`tests/integration/*.sh` rc=0, peak RSS 350 MB; `shfmt -i 4 -d` rc=0; `bash -n` clean;
`lint-file-budget`, `lint-topology`, `lint-operator-strings`, `lint-docs-voice` each rc=0, read
individually rather than through a filtered `make` chain. **`make lint-sh` and `make test` were NOT
run** — the lint lock and the shellcheck OOM path are shared, and the targeted run above covers every
file this branch touches.

`tests/integration/e2e.sh` lands at **763 against its 766 ceiling**, reached by compressing the prose
this change invalidates — not by riding a cut. The ceiling was verified at the branch base, not
assumed.

## What this does NOT do, and known edges

- **Nothing here is evidence about the bench half of `restore_all`** — stack restore, credential
  re-bake, the control channel. It was stubbed in both harnesses, deliberately and throughout.
- `miner_reload` was stubbed in the live run so the rig's real hashrate was never redirected at a
  deployed stack for the borrow window. It is load-bearing for no assertion in this area.
- **A rig whose own primary pool is the bench reads as "borrowed" on every run.** With no backup
  present that costs a warning per run and a no-op strip; it cannot corrupt anything, but it is a
  false positive and it is stated rather than hidden.
- **The backup filename has 1-second resolution** (`.e2e-orig.<YYYYmmdd-HHMMSS>`), so two borrows
  inside one second reuse the filename and the second `cp -a` overwrites the first. The rig lock
  serialises real runs, so this is observed and not fixed here — but it made one local assertion
  wall-clock dependent before the harness was changed to mirror real spacing.
- **`--keep` is deliberately undone by the next run**, which now starts from the true original and
  says so.
- Scenario 2 was measured against one rig with one pool layout. The gap is structural, not sampled,
  but the measurement is a single rig.

## Issue

Evidence for #1178. Deliberately **not** using a closing keyword: this repo's PRs land on a
non-default branch so keywords never fire, and #1178 carries `do-not-close`. Closing it is a separate
decision for whoever removes that label.


---

## Second commit — the three review findings, all fixed in-PR

Rebased onto `develop-v2` after #1421 merged. Every number below was re-derived at the pushed head, not carried from the earlier round.

### F1 (HIGH) — the report cancelled the warning it followed

Fixed. The `*)` arm stated two things unconditionally and both are false when the unrecoverable arm fired. The arms now set `$verdict`; the ambiguous case says the borrow could not be undone, that nothing on the rig separates a permanent bench pool from an un-undoable reorder, and to hand-repair. Benign arms keep the previous wording verbatim.

Chose a `$verdict` string over testing `$borrowed` at the `*)` arm, because after arm 1 restores from a backup `$borrowed` still reads `yes` — it is the pre-recovery reading — and that case is benign. The ambiguous case is exactly `borrowed=yes AND leftover empty`, which only arm 2 knows.

Cost **+1 line**, so `e2e.sh` is 764 against its 766 ceiling.

### F3 (LOW-MED) — the uncited cross-repo claim

Fixed, and the claim is **narrower than the comment said**. Read at the baked pin via the contents API, no local rigforge worktree touched:

- `apply` does regenerate — `_apply_runtime()` runs `(cd "$build" && generate_xmrig_config)` at `rigforge.sh:3979`.
- **The control fast path deliberately does not.** `CONTROL_FAST_PATH_KEYS="watchdog_interval_min max_temp_c"` (`:4203`), and the fast path "DELIBERATELY skips apply()/_apply_runtime entirely: no generate_xmrig_config" (`:4228`).

So the original parenthetical was true of `apply` and false of a fast-path control-apply. Both the code comment and `docs/dev/integration-testing.md` now cite the line and name the exception. **Line-neutral** — which is why F1 and F3 together cost 1 line rather than the 3 the review costed.

### F2 (MEDIUM) — the positive control, built rather than deferred

The controller had waived this to a follow-up and then withdrew the waiver; it is built here.

It lands in **`tests/integration/selftest-e2e-phases.sh`**, not `selftest.sh` (686/686, zero headroom). That file already extracts a function out of the shipped `e2e.sh` and evaluates it against stubs, and **already defines `on_miner()` as a stub** — so the `[ "${BASH_SOURCE[0]}" = "$0" ]` guard the review costed is not needed at all, and costs zero lines in `e2e.sh`. `Makefile:28` globs `selftest*.sh`, so the cases are already run by CI with no gate wiring and no enumerated-list hole. 338 → 396 lines, under the 400 target, still no budget row.

Ten cases drive the **real** block extracted from the shipped `e2e.sh`, with `on_miner` running each command locally against a temp config so the actual jq/ls/cp/rm execute — ssh is the only substitution, and it is the whole of `on_miner` (`e2e.sh:172`). The extraction is asserted first, so a refactor that moves the block reds rather than silently stopping the test.

**The case the review named** is the one worth reading: a rig that merely keeps a permanent bench pool at index 1, untagged. `.pools[0]` positionality is the sole reason that reads as clean, and nothing in the tree said so. The assertion is on the config **bytes**, deliberately — a message assert would miss it, because the arm that would wrongly fire also warns.

### Mutation — four aimed kills, re-run at the pushed head

Each mutation `cmp`-proven to have applied, failing assertion NAMES captured, run aborts if an anchor is missing. Kill sets are 1–2 assertions, not a module-wide blast.

    baseline control                              rc=0  59 passed
    M1  broaden the borrowed jq off .pools[0]     rc=1  kills "a permanent bench pool at [1] is not treated as a leftover borrow"
    M2  drop F1's ambiguous verdict               rc=1  kills "does NOT also report there was no un-restored borrow to undo"
    M3  restore from the newest backup            rc=1  kills "a leftover borrow is restored from the oldest backup"
    M4  stale-backup arm stops clearing them      rc=1  kills "its stale backup is cleared"
    post-restore control                          rc=0  59 passed, e2e.sh byte-identical

**M1 is the row that earns the change** — it is the review's failure scenario, and before this commit nothing in the repo would have noticed it.

## What was RUN

At the pushed head, with `PATH=$HOME/.local/bin:$PATH` (`uv` and the CI-pinned shellcheck 0.11.0 are not otherwise on PATH):

    lint-file-budget                      rc=0
    lint-docs-voice                       rc=0
    lint-operator-strings                 rc=0
    shellcheck 0.11.0, the CI glob        rc=0
    shfmt -i 4 -d                         rc=0
    make test-integration-selftest        rc=0   214 passed, 0 failed (59 in this file)

Post-rebase I ran both budget checks, which guard different failures: verified the rows read the expected values at HEAD, and separately regenerated the tsv and diffed it, since a clean auto-merge can drop rows at rc 0. All four deltas are headroom, none are dropped rows; this branch does not touch the tsv at all.

**Not run:** no bench, no rig, no `make lint-sh` in full, no `tests/stack` suite. Nothing here is `tests/stack` shell, and the recovery block is now exercised without hardware — which is the point of F2.

## What I did NOT do

The unreadable arm (`borrowed` neither `yes` nor `no`) combined with the `*)` arm keeps the benign default. I could not construct a reachable instance: both jq expressions read the same file, and every malformed shape I traced makes the `bench_pools` jq fail too, landing in the other case arm. **That is a traced argument, not a test.** If you can construct a counter-example it costs one of the two remaining lines.

#1178 keeps `do-not-close` until this lands — its acceptance bar is the reorder-only path, and F1 is that path's report contradicting its own remedy.


---

## Third commit — the re-review's two findings, plus one I found in my own work

The non-author re-review at `9ada56f` **discharged F1, F2 and F3** and returned two LOW findings. A
pass I ran against my own head while that review was in flight found a third. All three are the same
shape, and it is the shape this block exists to fix: **a guard that is present and correct, and that
nothing would notice the loss of.**

### R2 (review, LOW-MED) — half the detector was deletable, every gate green

The headline of this PR is *"needing either signal is the point"*. It was not tested. The case-3
fixture put the tagged pool at `.pools[0]` **with a bench URL**, so the positional limb alone
satisfied the detector and the `or` limb never did any work. **Delete the tag limb outright and the
suite stayed 59/0** — and that fixture was the only one in the tree carrying the tag at all.

Widening it to two pools with the tag on the second costs **zero lines** and makes the deletion red
by name.

### The unreadable arm — found here, same shape, two mechanisms at once

Its assertion matched `do NOT read the silence as clean`. That sentence is emitted by the **report
block's own `""` case** as well — *two guards sharing one output string, either covering for the
other's deletion.* Its sibling asserted the backup count was unchanged, which holds just as well when
**no arm runs at all** — *correctness arriving by absence.* Together: **delete that arm entirely and
the suite stayed 59/0.**

The assertion now keys on the one sentence only that arm writes. Line-neutral.

This also retires the "What I did NOT do" note above: the unreadable arm is now covered by a
mutation that kills it, rather than by a traced argument.

### R1 (review, LOW) — and the only shipped-code line in this commit

Arm 1 left `$verdict` at its default, so after it restored a rig whose own config names the bench,
the report two lines later read *"the recovery above found no un-restored borrow to undo"* —
**denying the borrow arm 1 had just announced and undone.** That is the defect the previous commit is
named for, surviving at the arm it was not fixed at. Found independently by the review and by me.

Reachable on the live loaner shape (a permanent untagged bench failover plus a run that died
borrowed), which the old fixtures could not express: `drive_recovery`'s generated backups never named
the bench, so arm 1 could never be followed by a firing report arm. They do now, and an assertion
holds the sentence out. **+1 line** in `e2e.sh`, +1 in the selftest.

### Mutation — six aimed kills at the pushed head

Each `cmp`-proven applied, anchor-count checked first, scored **only** by the failing assertion's own
message text, with a blast-radius refusal:

    baseline control                            rc=0  60 passed / 0 failed
    M1  broaden the borrowed jq off .pools[0]   kills "a permanent bench pool at [1] is not treated as ..."
    M9  drop the rig-id tag limb                kills "a leftover borrow is restored from the oldest backup"
    M3  restore from the newest backup          kills "a leftover borrow is restored from the oldest backup"
    M4  stale-backup arm stops clearing         kills "its stale backup is cleared ..."
    M5  delete the unreadable arm outright      kills "and the silence is not reported as clean"
    M7  arm 1 stops setting its own verdict     kills "and the report does NOT then deny the borrow it just undid"
    post-restore control                        rc=0  60 passed, both files byte-identical

**M5 and M9 both survived at 59/0 before this commit. That is what it is for.**

Two corrections to the table in the section above, both from the review and both upheld:

- **M1 and M2 each killed *two* assertions at `9ada56f`, not one.** The aimed one was among the dead
  both times, so the conclusion stood, but the named-kill column was incomplete. At this head the
  fixture change narrows M1 to exactly its aimed assertion.
- **My first spelling of M1 in this round broke jq's parentheses rather than its meaning**, and
  blast-radiused six assertions. The battery's own size guard refused to score it; it was reformulated
  as a semantic change. A mutation that reds for the wrong reason is not a kill.

### What was RUN, at `6665ca8`

    shellcheck 0.11.0, the Makefile line verbatim   rc=0
    shfmt -i 4 -d, the Makefile line verbatim       rc=0
    make test-integration-selftest                  rc=0   214 passed / 0 failed (60 in this file)
    lint-file-budget                                rc=0
    lint-operator-strings                           rc=0
    lint-topology                                   rc=0

`e2e.sh` **764 → 765** against its 766 ceiling. `selftest-e2e-phases.sh` **396 → 397**, still under
the 400 target and still unrowed. The branch does not touch `docs/dev/file-budget.tsv`.

**Not run: any rig.** The remote-shell quoting evidence is still only the earlier live loaner run,
and `restore_all`'s bench half remains stubbed in both harnesses. The `tests/stack/run.sh` shellcheck
line was not run either — nothing here is `tests/stack` shell, and CI runs it.

### Acceptance, and the label

**#1178 keeps `do-not-close`, and merging this does not discharge it.** This PR delivers detection,
correct reporting, and a committed positive control that is deterministic and needs no hardware —
stronger than a live run for the detector *logic*. It does **not** exercise the real ssh/rig path at
this head, and the review states the same limit independently. Removing the label wants either that
live run at the merged head, or an explicit ruling that the committed control supersedes it. Neither
has happened.
