### PR TITLE
fix(dashboard): a hop to a node you cannot classify must not borrow a reassuring colour (#1350)

### DIFF
--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -1,5 +1,5 @@
 """Egress posture (#170) — for each stack component, its outbound connections and their network
-route (Tor / clearnet / local / inactive), plus a privacy roll-up.
+route (Tor / clearnet / LAN / local / unknown / inactive), plus a privacy roll-up.
 
 Routes are *derived from the live config*, never hardcoded, so the panel can't drift from reality or
 lie after a regression — the #160 audit's lesson (``--onion-address`` *looked* like Tor but wasn't).
@@ -17,8 +17,8 @@ Two backstops matter for whether a clearnet route is actually an IP leak:
 The alert sinks (#380) have one more wrinkle: ``notifications.tor: false`` is a LAN carve-out for
 self-hosted endpoints Tor exits can't reach. A POST to a private/loopback IP never leaves your
 network, so it routes as *local*, not a clearnet leak. Only IP literals can prove that without a
-DNS lookup — a hostname endpoint with Tor off counts as clearnet, honestly, since we can't know
-where it resolves.
+DNS lookup. A hop to a relocatable node takes the same rule via ``topology_graph.node_route``
+(#1350), but keeps *LAN* and *unknown* apart instead of collapsing both into clearnet.
 
 So a connection is a *leak* only when its route is clearnet AND it isn't neutralised by a backstop.
 """
@@ -28,14 +28,14 @@ from urllib.parse import urlsplit
 
 from mining_dashboard.config import config
 from mining_dashboard.service.topology_graph import (  # noqa: F401  (re-exported)
+    CLEARNET,
+    INACTIVE,
+    LOCAL,
     TOPOLOGY_NODES,
+    TOR,
+    node_route,
     topology_nodes,
 )
-
-TOR = "tor"
-CLEARNET = "clearnet"
-LOCAL = "local"
-INACTIVE = "inactive"
 
 
 def _xvb_route(xvb_enabled, xvb_tor):
@@ -100,7 +100,7 @@ def compute_egress_posture(
     xvb_tor,
     monero_clearnet_sync,
     tari_clearnet_sync,
-    remote_monero,
+    monero_route,
     healthchecks_enabled,
     telegram_enabled,
     price_feed_enabled=False,
@@ -134,7 +134,7 @@ def compute_egress_posture(
             "firewalled": True,
             "conns": [
                 {"to": "sidechain P2P peers", "route": CLEARNET if p2pool_clearnet else TOR},
-                {"to": "monerod RPC/ZMQ", "route": CLEARNET if remote_monero else LOCAL},
+                {"to": "monerod RPC/ZMQ", "route": monero_route},
             ],
         },
         {
@@ -235,7 +235,7 @@ def egress_posture_from_config():
         xvb_tor=config.XVB_TOR_ENABLED,
         monero_clearnet_sync=config.MONERO_CLEARNET_SYNC,
         tari_clearnet_sync=config.TARI_CLEARNET_SYNC,
-        remote_monero=config.MONERO_NODE_HOST != config.LOCAL_MONERO_HOST,
+        monero_route=node_route(config.MONERO_NODE_HOST, is_local=config.monero_is_local()),
         healthchecks_enabled=bool(config.HEALTHCHECKS_PING_URL),
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],
@@ -278,12 +278,12 @@ def compute_topology(
     xvb_tor,
     monero_clearnet_sync,
     tari_clearnet_sync,
-    remote_monero,
-    # Defaulted, unlike remote_monero: the egress posture does not model a remote Tari
-    # node's gRPC route yet (#1350), so the two functions no longer take identical knobs
-    # and the shared sweep fixtures splat into both. topology_from_config passes it, and
-    # test_topology_graph asserts that it does rather than trusting the signature to.
-    remote_tari=False,
+    monero_route,
+    # Defaulted, unlike monero_route: the egress posture has no Tari RPC conn to route, so the
+    # two functions do not take identical knobs and the shared sweep fixtures splat into both.
+    # topology_from_config passes it, and test_topology_graph asserts that it does rather than
+    # trusting the signature to.
+    tari_route=LOCAL,
     healthchecks_enabled,
     telegram_enabled,
     price_feed_enabled=False,
@@ -305,7 +305,7 @@ def compute_topology(
         xvb_tor=xvb_tor,
         monero_clearnet_sync=monero_clearnet_sync,
         tari_clearnet_sync=tari_clearnet_sync,
-        remote_monero=remote_monero,
+        monero_route=monero_route,
         healthchecks_enabled=healthchecks_enabled,
         telegram_enabled=telegram_enabled,
         price_feed_enabled=price_feed_enabled,
@@ -318,7 +318,6 @@ def compute_topology(
     sinks = _notify_route(notify_sinks_enabled, notify_tor, notify_sinks_private)
     standby = _xvb_standby_route(xvb_standby_source)
     sidechain = CLEARNET if p2pool_clearnet else TOR
-    rpc = CLEARNET if remote_monero else LOCAL
 
     edges = [
         # Ingress from your LAN — the only listeners actually exposed to the network.
@@ -377,12 +376,12 @@ def compute_topology(
         _edge("tor", "internet", TOR, "SOCKS + onion circuits", "p2p"),
         # Internal mesh (hidden until expanded).
         _edge("xmrig-proxy", "p2pool", LOCAL, "upstream pool", "internal"),
-        _edge("p2pool", "monerod", rpc, "RPC / ZMQ", "internal"),
-        _edge("p2pool", "tari", LOCAL, "gRPC merge-mine", "internal"),
+        _edge("p2pool", "monerod", monero_route, "RPC / ZMQ", "internal"),
+        _edge("p2pool", "tari", tari_route, "gRPC merge-mine", "internal"),
         _edge("caddy", "dashboard", LOCAL, "reverse-proxy :8000", "internal"),
-        _edge("dashboard", "monerod", LOCAL, "get_info RPC", "internal"),
+        _edge("dashboard", "monerod", monero_route, "get_info RPC", "internal"),
         _edge("dashboard", "xmrig-proxy", LOCAL, "proxy API", "internal"),
-        _edge("dashboard", "tari", LOCAL, "gRPC", "internal"),
+        _edge("dashboard", "tari", tari_route, "gRPC", "internal"),
         _edge("dashboard", "docker", LOCAL, "container API", "internal"),
     ]
     # Optional clearnet initial-sync paths (#183) bypass the Tor hub straight to the internet.
@@ -401,7 +400,7 @@ def compute_topology(
         else:
             edge["leak"] = True
 
-    nodes = topology_nodes(remote_monero=remote_monero, remote_tari=remote_tari)
+    nodes = topology_nodes(monero_route=monero_route, tari_route=tari_route)
     return {"nodes": nodes, "edges": edges, "summary": posture["summary"]}
 
 
@@ -414,8 +413,8 @@ def topology_from_config():
         xvb_tor=config.XVB_TOR_ENABLED,
         monero_clearnet_sync=config.MONERO_CLEARNET_SYNC,
         tari_clearnet_sync=config.TARI_CLEARNET_SYNC,
-        remote_monero=not config.monero_is_local(),
-        remote_tari=not config.tari_is_local(),
+        monero_route=node_route(config.MONERO_NODE_HOST, is_local=config.monero_is_local()),
+        tari_route=node_route(config.TARI_GRPC_ADDRESS, is_local=config.tari_is_local()),
         healthchecks_enabled=bool(config.HEALTHCHECKS_PING_URL),
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],

--- a/dashboard/mining_dashboard/service/topology_graph.py
+++ b/dashboard/mining_dashboard/service/topology_graph.py
@@ -1,16 +1,37 @@
-"""The stack's topology graph: the zones each component sits in, the fixed node list, and the
-per-request marking of which nodes are this machine's own (#1040).
+"""The stack's topology graph: the zones each component sits in, the fixed node list, the route
+vocabulary every hop is coloured by, and the per-request marking of which nodes are this
+machine's own (#1040).
 
 Split out of ``egress.py`` because that module sits at its file-budget ceiling and this is the
 part of it that is data rather than logic. ``egress`` imports back from here; the dependency runs
 one way, and re-exporting ``TOPOLOGY_NODES`` keeps every existing importer working unchanged.
+The route constants live here for the same reason ``ZONE_LAN`` does — ``node_route`` needs them
+and ``egress`` has no room — and ``egress`` re-exports them, so every existing importer of
+``egress.LOCAL`` and friends keeps working unchanged.
 """
+
+import ipaddress
 
 # Zones, left-to-right by trust: your LAN, the host's container bridge, the Tor hub, the Internet.
 ZONE_LAN = "lan"
 ZONE_HOST = "host"
 ZONE_TOR = "tor"
 ZONE_NET = "internet"
+
+# Routes a hop can take. LOCAL is this machine (loopback or the container bridge); LAN is a hop
+# that leaves the host but provably stays on the operator's own network; CLEARNET leaves it for
+# the internet; UNKNOWN is an address we cannot classify without resolving it, and we never do.
+TOR = "tor"
+CLEARNET = "clearnet"
+LOCAL = "local"
+LAN = "lan"
+UNKNOWN = "unknown"
+INACTIVE = "inactive"
+
+# Exactly the routes ``node_route`` can return, in increasing order of exposure. Named so the
+# sweep in test_egress and the frontend's palette contract both pin against one list instead of
+# each restating it — a new route added here fails both until it is coloured and labelled.
+NODE_ROUTES = (LOCAL, LAN, CLEARNET, UNKNOWN)
 
 # Nodes bracket the host components with the external actors they actually talk to. ``internal``
 # nodes (the socket proxies) only appear when the operator expands the internal mesh.
@@ -29,18 +50,51 @@ TOPOLOGY_NODES = [
 ]
 
 
-def topology_nodes(*, remote_monero, remote_tari):
+def node_route(address, *, is_local):
+    """Route of a hop to a relocatable node, from its configured address SHAPE alone (#1350).
+
+    ``address`` is a bare host or a ``host:port`` pair — the two forms the node knobs come in
+    (``MONERO_NODE_HOST`` and ``TARI_GRPC_ADDRESS`` respectively), so the caller never has to
+    split one and the two call sites cannot drift in how they do it.
+
+    Same #160 reasoning as ``egress._xvb_standby_route`` and ``egress._sinks_all_private``, and
+    deliberately the same shape: only an IP literal can be *proven* to stay on the operator's
+    network. A private/loopback/link-local literal is a LAN hop; any other literal is clearnet.
+
+    **A hostname is never resolved.** A DNS lookup at diagram-build time would itself be an
+    egress, so in a Tor-routed stack the diagram would cause the exact exposure it exists to warn
+    about, on every render. An address we cannot classify is therefore ``UNKNOWN`` — its own
+    visible state, never quietly borrowing LAN's or CLEARNET's colour. Allowlist-shaped, so an
+    address nobody anticipated fails to the state that admits we do not know.
+    """
+    if is_local:
+        return LOCAL
+    host = (address or "").strip()
+    if host.count(":") == 1:  # host:port — a bare IPv6 literal has more, so it keeps its colons
+        host = host.rsplit(":", 1)[0]
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:  # not an IP literal (a hostname) — unprovable, and we will not resolve it
+        return UNKNOWN
+    return LAN if (ip.is_private or ip.is_loopback or ip.is_link_local) else CLEARNET
+
+
+def topology_nodes(*, monero_route, tari_route):
     """``TOPOLOGY_NODES`` with the two relocatable nodes marked local or remote (#1040).
 
     monerod and tari are the only nodes an operator can run somewhere else; every other node in
     the graph is always this machine's own, so it carries no ``remote`` key at all rather than a
     redundant ``False`` the diagram would then have to decide not to draw.
 
+    Takes the hop's ROUTE rather than a bool (#1350): "remote" is now every route that is not
+    ``LOCAL``, so a LAN or unclassifiable node still reads as remote in the caption while the
+    edge carries the finer distinction.
+
     Returns a COPY. The graph is built per request and the node list is a module-level constant —
     marking it in place would leak one call's topology into the next.
     """
-    relocatable = {"monerod": remote_monero, "tari": remote_tari}
+    relocatable = {"monerod": monero_route, "tari": tari_route}
     return [
-        {**n, "remote": bool(relocatable[n["id"]])} if n["id"] in relocatable else n
+        {**n, "remote": relocatable[n["id"]] != LOCAL} if n["id"] in relocatable else n
         for n in TOPOLOGY_NODES
     ]

--- a/dashboard/mining_dashboard/web/static/topology.mjs
+++ b/dashboard/mining_dashboard/web/static/topology.mjs
@@ -1,7 +1,9 @@
 // Stack topology (#170, trust-boundary view). A data-driven SVG of the whole stack: every component
 // is a node, every connection an edge coloured by the route the server derived from live config
 // (service/egress.py · compute_topology). Tor = green; clearnet = red and lands on the `internet`
-// node so a leak visibly BYPASSES the Tor hub; local/LAN = grey. The P2P daemons get a double arrow
+// node so a leak visibly BYPASSES the Tor hub; LAN = blue; unverified = amber; local = grey. LAN
+// and unverified exist because a node reached at a private address is not a leak and a node named
+// by hostname cannot be judged without a DNS lookup we refuse to make (#1350). The P2P daemons get a double arrow
 // (egress + onion ingress). The internal host-only mesh is hidden until expanded, so the default
 // view stays focused on what crosses the trust boundary. Geometry is pure (boxAnchor, logic.mjs);
 // this file is presentation only — it carries no routing logic of its own (the #61 principle).
@@ -25,19 +27,30 @@ export const POS = {
   internet: { x: 392, y: 220, w: 96, h: 36 },
 };
 
+// Every route the server can put on an edge needs an entry in ALL THREE of these: a colour, a
+// label, and a place in ROUTES (which generates the arrowhead markers). A route missing from
+// ROUTE_COLOR silently borrows local's grey, and one missing from ROUTES points marker-end at an
+// id that was never defined, so its arrowhead just vanishes — both look like a working diagram.
+// The server half of this contract is NODE_ROUTES in service/topology_graph.py.
 export const ROUTE_COLOR = {
   tor: "var(--ok)",
   clearnet: "var(--bad)",
+  lan: "var(--accent)",
+  unknown: "var(--warn)",
   local: "var(--text-muted)",
   inactive: "var(--text-muted)",
 };
 export const ROUTE_NAME = {
   tor: "Tor",
   clearnet: "Clearnet",
-  local: "Local/LAN",
+  // "Local" is this machine; "LAN" is a hop that leaves it but stays on your network. Before
+  // #1350 the two were one state and this label said "Local/LAN" — it now has to tell them apart.
+  lan: "LAN",
+  unknown: "Unverified",
+  local: "Local",
   inactive: "Inactive",
 };
-const ROUTES = ["tor", "clearnet", "local", "inactive"];
+export const ROUTES = ["tor", "clearnet", "lan", "unknown", "local", "inactive"];
 
 const center = (n) => ({ x: n.x + n.w / 2, y: n.y + n.h / 2 });
 const nodeCls = (zone) =>
@@ -83,7 +96,11 @@ export class StackTopology extends Component {
         <div class="topo-controls">
           <span class="topo-legend"><i class="topo-sw" style="background:var(--ok)"></i>Tor</span>
           <span class="topo-legend"><i class="topo-sw" style="background:var(--bad)"></i>Clearnet</span>
-          <span class="topo-legend"><i class="topo-sw" style="background:var(--text-muted)"></i>Local / LAN</span>
+          <span class="topo-legend" title="Leaves this machine but stays on your own network"><i
+            class="topo-sw" style="background:var(--accent)"></i>LAN</span>
+          <span class="topo-legend" title="Configured as a name, so where it goes cannot be checked without a DNS lookup"><i
+            class="topo-sw" style="background:var(--warn)"></i>Unverified</span>
+          <span class="topo-legend"><i class="topo-sw" style="background:var(--text-muted)"></i>Local</span>
           <button class="topo-toggle" aria-pressed=${internal}
             title="Container-to-container links inside the stack"
             onClick=${() => {
@@ -94,7 +111,7 @@ export class StackTopology extends Component {
           </button>
         </div>
         <svg viewBox="0 0 500 322" class="topo-svg" role="img"
-             aria-label="Stack network topology: each component and its connections, coloured green for Tor and red for clearnet.">
+             aria-label="Stack network topology: each component and its connections, coloured green for Tor, red for clearnet, blue for your own LAN, and amber where the route could not be verified.">
           <defs>
             ${ROUTES.map(
               (r) => html`
@@ -139,9 +156,10 @@ export class StackTopology extends Component {
     const key = e.leak ? "clearnet" : e.route;
     const color = ROUTE_COLOR[key] || ROUTE_COLOR.local;
     const dash = e.kind === "internal" ? "3 3" : e.blocked_by_firewall ? "2 3" : null;
-    // Marching ants (dashboard.css .topo-edge-ants) mark a live route — Tor or clearnet — so it
-    // reads as "active traffic" against the static grey local/inactive edges. Skipped whenever a
-    // dash pattern is already spoken for (internal mesh, firewall-blocked) so it can't collide.
+    // Marching ants (dashboard.css .topo-edge-ants) mark a route that leaves this machine — Tor,
+    // clearnet, LAN or unverified — so it reads as "active traffic" against the static grey
+    // local/inactive edges. Skipped whenever a dash pattern is already spoken for (internal mesh,
+    // firewall-blocked) so it can't collide.
     const ants = !dash && key !== "local" && key !== "inactive";
     const note = e.leak ? " — LEAK" : e.blocked_by_firewall ? " — firewall-blocked" : "";
     const from = byId[e.from]?.label || e.from;

--- a/dashboard/tests/frontend/topology.test.mjs
+++ b/dashboard/tests/frontend/topology.test.mjs
@@ -12,7 +12,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-    POS, ROUTE_COLOR, ROUTE_NAME, edgePath,
+    POS, ROUTE_COLOR, ROUTE_NAME, ROUTES, edgePath,
 } from '../../mining_dashboard/web/static/topology.mjs';
 
 // Canonical node ids — MUST equal service/egress.py TOPOLOGY_NODES ids. The backend half of this
@@ -63,10 +63,39 @@ test('edgePath: column-crossing edges route orthogonally through a clear lane', 
     );
 });
 
+// Every route token egress.py can put on an edge. MUST stay in lockstep with NODE_ROUTES in
+// service/topology_graph.py plus the two routes only non-node hops take. The backend half of this
+// contract is tests/service/test_egress.py::test_every_edge_is_well_formed_for_all_configs.
+const SERVER_ROUTES = ['tor', 'clearnet', 'lan', 'unknown', 'local', 'inactive'];
+
 test('route palette + names cover every route the server can emit', () => {
-    // egress.py emits exactly these four route tokens; the diagram must colour & label them all.
-    for (const r of ['tor', 'clearnet', 'local', 'inactive']) {
+    // A route with no colour falls through `ROUTE_COLOR[key] || ROUTE_COLOR.local` and renders as
+    // an ordinary grey local hop — no error, no blank edge, just a quiet lie about the network.
+    for (const r of SERVER_ROUTES) {
         assert.ok(ROUTE_COLOR[r], `no colour for route "${r}"`);
         assert.ok(ROUTE_NAME[r], `no label for route "${r}"`);
     }
+});
+
+test('every route gets an arrowhead marker generated for it', () => {
+    // ROUTES drives the <defs> marker ids that `marker-end=url(#topo-a-<route>)` points at. A
+    // route missing here still draws its line, in the right colour, with NO arrowhead — which
+    // reads as a rendering quirk rather than as the missing state it actually is.
+    for (const r of SERVER_ROUTES) {
+        assert.ok(ROUTES.includes(r), `route "${r}" has no arrowhead marker`);
+    }
+});
+
+test('lan and unknown are visually distinct from local and from clearnet', () => {
+    // #1350's whole point. `unknown` is the state with no natural failure mode: nothing in the
+    // stack breaks if it renders wrong, so this assertion is the only thing standing between a
+    // correct backend and a diagram that quietly shows an unverified hop as a proven-local one.
+    // `lan` must not take clearnet's colour either — that was option (a), rejected because
+    // `leaks` counts "clearnet egress that actually exposes the host IP" and a LAN hop does not.
+    for (const r of ['lan', 'unknown']) {
+        assert.notEqual(ROUTE_COLOR[r], ROUTE_COLOR.local, `"${r}" is indistinguishable from local`);
+        assert.notEqual(ROUTE_COLOR[r], ROUTE_COLOR.clearnet, `"${r}" is coloured as a leak`);
+        assert.notEqual(ROUTE_NAME[r], ROUTE_NAME.local, `"${r}" is labelled as local`);
+    }
+    assert.notEqual(ROUTE_COLOR.lan, ROUTE_COLOR.unknown, 'lan and unknown share a colour');
 });

--- a/dashboard/tests/service/test_egress.py
+++ b/dashboard/tests/service/test_egress.py
@@ -12,6 +12,7 @@ from mining_dashboard.service.egress import (
     compute_egress_posture,
     compute_topology,
 )
+from mining_dashboard.service.topology_graph import NODE_ROUTES
 
 # The privacy-safe resting config: firewall on, p2pool over Tor, XvB over Tor, local node, no sync,
 # healthchecks off (no ping URL configured), no alert sinks configured.
@@ -22,7 +23,7 @@ SAFE = {
     "xvb_tor": True,
     "monero_clearnet_sync": False,
     "tari_clearnet_sync": False,
-    "remote_monero": False,
+    "monero_route": LOCAL,
     "healthchecks_enabled": False,
     "telegram_enabled": False,
     "notify_sinks_enabled": False,
@@ -197,9 +198,9 @@ def test_xvb_standby_topology_edge_tracks_route():
     assert standby_edges(_topo(xvb_standby_source="http://192.168.1.5/x")) == []  # LAN, no node
 
 
-def test_remote_monerod_rpc_is_clearnet():
-    assert _conn(_posture(remote_monero=False), "p2pool", "monerod RPC")["route"] != CLEARNET
-    assert _conn(_posture(remote_monero=True), "p2pool", "monerod RPC")["route"] == CLEARNET
+def test_the_monerod_rpc_conn_carries_the_route_it_was_given():
+    assert _conn(_posture(monero_route=LOCAL), "p2pool", "monerod RPC")["route"] == LOCAL
+    assert _conn(_posture(monero_route=CLEARNET), "p2pool", "monerod RPC")["route"] == CLEARNET
 
 
 def test_clearnet_initial_sync_surfaces_only_when_enabled():
@@ -351,7 +352,6 @@ _KNOBS = (
     "xvb_tor",
     "monero_clearnet_sync",
     "tari_clearnet_sync",
-    "remote_monero",
     "healthchecks_enabled",
     "telegram_enabled",
     "notify_sinks_enabled",
@@ -361,9 +361,9 @@ _KNOBS = (
 
 
 def _all_configs():
-    """Every one of the 2**len(_KNOBS) combinations of the boolean knobs."""
-    for combo in itertools.product((False, True), repeat=len(_KNOBS)):
-        yield dict(zip(_KNOBS, combo, strict=True))
+    """Every boolean-knob combination, run once per route the monerod hop can take (#1350)."""
+    for r, *c in itertools.product(NODE_ROUTES, *[(False, True)] * len(_KNOBS)):
+        yield {"monero_route": r, **dict(zip(_KNOBS, c, strict=True))}
 
 
 # Canonical node ids — MUST stay in lockstep with the frontend's POS map in
@@ -401,7 +401,7 @@ def test_every_edge_endpoint_is_a_placeable_node_for_all_configs():
 
 
 def test_every_edge_is_well_formed_for_all_configs():
-    routes = {TOR, CLEARNET, LOCAL, INACTIVE}
+    routes = {TOR, INACTIVE, *NODE_ROUTES}
     kinds = {"ingress", "egress", "p2p", "internal"}
     for cfg in _all_configs():
         for e in compute_topology(**cfg)["edges"]:
@@ -431,7 +431,7 @@ def test_firewall_off_counts_every_clearnet_path_as_a_leak():
         xvb_tor=False,
         monero_clearnet_sync=True,
         tari_clearnet_sync=True,
-        remote_monero=True,
+        monero_route=CLEARNET,
     )
     clearnet = sum(1 for comp in p["components"] for c in comp["conns"] if c["route"] == CLEARNET)
     assert clearnet >= 5  # sidechain, RPC, monero IBD, tari IBD, XvB donation
@@ -451,7 +451,7 @@ def test_firewall_on_blocks_every_clearnet_path():
         xvb_tor=False,
         monero_clearnet_sync=True,
         tari_clearnet_sync=True,
-        remote_monero=True,
+        monero_route=CLEARNET,
     )
     assert p["summary"]["leaks"] == 0
     assert _conn(p, "dashboard", "XvB stats")["route"] == TOR

--- a/dashboard/tests/service/test_node_route.py
+++ b/dashboard/tests/service/test_node_route.py
@@ -1,0 +1,237 @@
+"""How a hop to a relocatable node is routed, and what that route does to the leak count (#1350).
+
+New file: egress.py's own test module sits at its file-budget ceiling, and this covers the piece
+#1350 adds — the address-shape classifier and the two route states it introduces.
+
+The four edges this is really about (`p2pool`->`monerod`, `p2pool`->`tari`, `dashboard`->`monerod`,
+`dashboard`->`tari`) all claimed `local` before this, three of them hardcoded. One render could
+already contradict itself: with a remote monerod the node was marked `remote` and p2pool's hop to
+it said `clearnet`, while the dashboard's hop to the SAME daemon still said `local`.
+"""
+
+import pytest
+
+from mining_dashboard.service.egress import (
+    CLEARNET,
+    LOCAL,
+    compute_egress_posture,
+    compute_topology,
+)
+from mining_dashboard.service.topology_graph import LAN, NODE_ROUTES, UNKNOWN, node_route
+
+# The resting config, mirroring test_egress.SAFE: everything private-by-default, so any leak the
+# assertions below see was caused by the route under test and not by an unrelated knob.
+SAFE = {
+    "firewall": True,
+    "p2pool_clearnet": False,
+    "xvb_enabled": True,
+    "xvb_tor": True,
+    "monero_clearnet_sync": False,
+    "tari_clearnet_sync": False,
+    "monero_route": LOCAL,
+    "healthchecks_enabled": False,
+    "telegram_enabled": False,
+}
+
+
+def _posture(**overrides):
+    return compute_egress_posture(**{**SAFE, **overrides})
+
+
+def _topo(**overrides):
+    return compute_topology(**{**SAFE, **overrides})
+
+
+def _edge(topo, src, dst):
+    return next(e for e in topo["edges"] if e["from"] == src and e["to"] == dst)
+
+
+# --- The classifier ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "192.168.1.10",  # RFC1918
+        "10.0.0.9",
+        "172.16.4.4",
+        "127.0.0.1",  # loopback
+        "169.254.7.7",  # link-local
+        "fc00::1",  # RFC4193 unique-local
+        "::1",  # IPv6 loopback, and it keeps its colons through the port split
+        "10.0.0.9:18081",  # host:port, the TARI_GRPC_ADDRESS shape
+    ],
+)
+def test_a_private_address_literal_is_a_lan_hop(address):
+    assert node_route(address, is_local=False) == LAN
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "8.8.8.8",
+        "1.1.1.1:18081",
+        "2001:4860:4860::8888",
+        # CGNAT — routable beyond your LAN, so not provably yours. Version-dependent: CPython
+        # treats 100.64.0.0/10 as public through 3.12 and private from 3.13, so this row moves on
+        # an interpreter bump. test_egress's `_sinks_all_private` pins the same address the same
+        # way, so both move together and neither can drift alone.
+        "100.64.0.1",
+        "::ffff:8.8.8.8",  # IPv4-mapped: the mapped address is public, and that is what counts
+    ],
+)
+def test_a_public_address_literal_is_clearnet(address):
+    assert node_route(address, is_local=False) == CLEARNET
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "monerod.example.com",
+        "nas.local",
+        "localhost",  # a NAME for the loopback, and we do not resolve names — so still unknown
+        "node.example.com:18081",
+        "",
+        "   ",
+        None,
+        "not an address at all",
+        "[::1]:18081",  # bracketed IPv6 is not a shape these knobs produce; unproven, so unknown
+    ],
+)
+def test_anything_that_is_not_an_address_literal_is_unknown(address):
+    # Allowlist-shaped and fail-closed: an address nobody anticipated lands on the state that
+    # admits we do not know, never on LAN's or clearnet's. The reassuring answer has to be earned.
+    assert node_route(address, is_local=False) == UNKNOWN
+
+
+def test_a_local_node_is_local_whatever_its_address_looks_like():
+    # `is_local` is the operator's own configuration answer and it outranks the address shape:
+    # a local node reached over the container bridge is not a LAN hop, it is this machine.
+    for address in ("172.28.0.26", "8.8.8.8", "monerod.example.com", ""):
+        assert node_route(address, is_local=True) == LOCAL
+
+
+class _DnsAttempted(BaseException):
+    """Raised if the classifier reaches for a resolver.
+
+    Deliberately a BaseException, and that is the whole point of it. A mutation that DOES resolve
+    the hostname will realistically wrap the lookup in `except Exception` and fall back to UNKNOWN
+    on failure — which produces the correct RESULT and leaves an assertion on the return value
+    green. This sentinel is not catchable by that handler, so the attempt itself fails the test
+    rather than the answer it happened to arrive at. (Found by mutating this test's own guard: an
+    AssertionError sentinel was swallowed exactly that way and the mutant survived.)
+    """
+
+
+def test_the_classifier_never_resolves_a_hostname(monkeypatch):
+    # The decisive constraint, and the one with no other way to check it. A DNS lookup at
+    # diagram-build time is ITSELF an egress, so in a Tor-routed stack the diagram would cause the
+    # exact exposure it exists to warn about, on every render. Poison every resolver path: if the
+    # classifier reaches for one, this raises instead of quietly succeeding on the test host.
+    import socket
+
+    def _boom(*a, **kw):
+        raise _DnsAttempted("node_route performed a DNS lookup")
+
+    for name in ("getaddrinfo", "gethostbyname", "gethostbyname_ex", "getnameinfo"):
+        monkeypatch.setattr(socket, name, _boom)
+    assert node_route("monerod.example.com", is_local=False) == UNKNOWN
+    assert node_route("localhost", is_local=False) == UNKNOWN
+    assert node_route("192.168.1.10", is_local=False) == LAN
+
+
+def test_the_classifier_returns_only_declared_routes():
+    # NODE_ROUTES is what the frontend's palette contract pins against; a route the classifier can
+    # return but that list does not name would reach the diagram with no colour and no arrowhead.
+    seen = {
+        node_route(a, is_local=loc)
+        for loc in (True, False)
+        for a in ("192.168.1.10", "8.8.8.8", "example.com", "", "fc00::1", "10.0.0.9:1")
+    }
+    assert seen <= set(NODE_ROUTES)
+    assert seen == {LOCAL, LAN, CLEARNET, UNKNOWN}  # and all four are actually reachable
+
+
+# --- What a route does to the security summary -------------------------------------------
+
+
+@pytest.mark.parametrize("firewall", [True, False])
+@pytest.mark.parametrize("route", [LAN, UNKNOWN])
+def test_a_lan_or_unknown_node_hop_moves_neither_security_counter(route, firewall):
+    # `leaks` is defined at its own declaration as "clearnet egress that actually exposes the host
+    # IP". A node on your own LAN does not expose it, so counting one would be inventing a leak —
+    # and inventing a leak is as wrong as hiding one. `unknown` must not be counted either: we do
+    # not know that it leaks, and the diagram carries that doubt where the count cannot.
+    #
+    # Asserted with the firewall BOTH ways on purpose. `blocked_by_firewall` is the other half of
+    # the same branch, so a route that wrongly counted as clearnet would show up in exactly one of
+    # these two rows depending on the firewall — one row alone would miss half the mistake.
+    summary = _posture(monero_route=route, firewall=firewall)["summary"]
+    assert summary["leaks"] == 0
+    assert summary["blocked_by_firewall"] == 0
+    assert summary["all_tor"] is True
+    assert summary["level"] == "ok"
+
+
+@pytest.mark.parametrize("firewall", [True, False])
+def test_a_clearnet_node_hop_still_moves_a_counter(firewall):
+    # The control for the test above. Without this, "the counters did not move" would be equally
+    # consistent with the monerod hop having stopped reaching the counter at all — which is what
+    # a careless edit to the conn at egress.py's p2pool component would actually do.
+    summary = _posture(monero_route=CLEARNET, firewall=firewall)["summary"]
+    assert summary["leaks"] == (0 if firewall else 1)
+    assert summary["blocked_by_firewall"] == (1 if firewall else 0)
+
+
+def test_a_lan_node_visibly_changes_the_count_that_used_to_be_charged(monkeypatch):
+    # The behaviour change this PR ships, stated as a test rather than left for an operator to
+    # notice. A remote monerod on a private address was charged to the security summary before
+    # this (blocked with the firewall on, a LEAK with it off); it now moves neither counter.
+    assert _posture(monero_route=CLEARNET, firewall=False)["summary"]["leaks"] == 1
+    assert _posture(monero_route=LAN, firewall=False)["summary"]["leaks"] == 0
+
+
+# --- What a route does to the diagram ----------------------------------------------------
+
+
+@pytest.mark.parametrize("route", NODE_ROUTES)
+def test_every_hop_to_a_relocatable_node_carries_that_node_s_route(route):
+    # All four edges, including the three that were hardcoded `local`. Parametrised over every
+    # route so a fix that special-cases one state and drops the others cannot pass.
+    topo = _topo(monero_route=route, tari_route=route)
+    assert _edge(topo, "p2pool", "monerod")["route"] == route
+    assert _edge(topo, "dashboard", "monerod")["route"] == route
+    assert _edge(topo, "p2pool", "tari")["route"] == route
+    assert _edge(topo, "dashboard", "tari")["route"] == route
+
+
+def test_the_two_hops_to_one_daemon_can_never_disagree():
+    # The self-contradiction #1350 is really about: before this, `p2pool`->`monerod` followed the
+    # remote knob while `dashboard`->`monerod` was hardcoded local, so one render described the
+    # SAME daemon as two different things. They are now derived from one value and cannot drift.
+    for route in NODE_ROUTES:
+        topo = _topo(monero_route=route)
+        hops = {e["from"]: e["route"] for e in topo["edges"] if e["to"] == "monerod"}
+        assert hops == {"p2pool": route, "dashboard": route}, route
+
+
+def test_a_lan_or_unknown_edge_is_never_tagged_as_a_leak():
+    # `leak` / `blocked_by_firewall` are the diagram's own red-flag tags, set by a separate loop
+    # from the summary counters — so they need their own assertion, not an inference from the
+    # count. Only clearnet may carry either.
+    for route in (LAN, UNKNOWN):
+        for firewall in (True, False):
+            topo = _topo(monero_route=route, tari_route=route, firewall=firewall)
+            for src, dst in (("p2pool", "monerod"), ("dashboard", "tari")):
+                edge = _edge(topo, src, dst)
+                assert edge.get("leak") is None, (route, firewall, src)
+                assert edge.get("blocked_by_firewall") is None, (route, firewall, src)
+
+
+def test_a_lan_node_still_reads_as_remote_in_the_diagram():
+    # The node caption and the edge colour answer different questions and must not be conflated:
+    # "is it on this machine" (no) and "does reaching it expose me" (no). An operator needs both.
+    nodes = {n["id"]: n for n in _topo(monero_route=LAN, tari_route=UNKNOWN)["nodes"]}
+    assert nodes["monerod"]["remote"] is True
+    assert nodes["tari"]["remote"] is True
+    assert _edge(_topo(monero_route=LAN), "p2pool", "monerod")["route"] == LAN

--- a/dashboard/tests/service/test_topology_graph.py
+++ b/dashboard/tests/service/test_topology_graph.py
@@ -6,9 +6,19 @@ machine's own.
 """
 
 from mining_dashboard.service import egress
-from mining_dashboard.service.topology_graph import TOPOLOGY_NODES, topology_nodes
+from mining_dashboard.service.topology_graph import (
+    CLEARNET,
+    LAN,
+    LOCAL,
+    TOPOLOGY_NODES,
+    UNKNOWN,
+    topology_nodes,
+)
 
-_COMBOS = ((False, False), (True, False), (False, True), (True, True))
+# Route pairs, not bools (#1350). Every row mixes the two nodes' answers, and the last row is the
+# one that matters most: both nodes are away from this machine but by DIFFERENT routes, so a
+# marking that collapses "not local" to a single shared answer still has to get both right.
+_COMBOS = ((LOCAL, LOCAL), (LAN, LOCAL), (LOCAL, CLEARNET), (UNKNOWN, LAN))
 
 
 def test_only_the_relocatable_nodes_carry_a_location():
@@ -19,29 +29,40 @@ def test_only_the_relocatable_nodes_carry_a_location():
     # The mixed rows are the point: the failure that matters is not a missing flag, it is one node
     # reported using the OTHER node's answer, which sends an operator to the wrong machine.
     for mono, tari in _COMBOS:
-        nodes = {n["id"]: n for n in topology_nodes(remote_monero=mono, remote_tari=tari)}
-        assert nodes["monerod"]["remote"] is mono, (mono, tari)
-        assert nodes["tari"]["remote"] is tari, (mono, tari)
+        nodes = {n["id"]: n for n in topology_nodes(monero_route=mono, tari_route=tari)}
+        assert nodes["monerod"]["remote"] is (mono != LOCAL), (mono, tari)
+        assert nodes["tari"]["remote"] is (tari != LOCAL), (mono, tari)
         assert sorted(i for i, n in nodes.items() if "remote" in n) == ["monerod", "tari"]
+
+
+def test_every_route_that_is_not_local_reads_as_remote():
+    # `remote` is the caption an operator uses to decide which machine to go look at. A LAN node
+    # and an unclassifiable one are both somewhere else, so both must caption as remote — the
+    # finer distinction is the edge's job, not the node's. Asserted per route rather than through
+    # _COMBOS so a route added to NODE_ROUTES without a decision here shows up as a gap.
+    for route in (LAN, CLEARNET, UNKNOWN):
+        nodes = {n["id"]: n for n in topology_nodes(monero_route=route, tari_route=route)}
+        assert nodes["monerod"]["remote"] is True, route
+        assert nodes["tari"]["remote"] is True, route
 
 
 def test_marking_never_mutates_the_shared_node_list():
     # The node list is a module-level constant and the graph is rebuilt per request: marking it in
     # place would leak one caller's topology into the next one's diagram.
     for mono, tari in _COMBOS:
-        topology_nodes(remote_monero=mono, remote_tari=tari)
+        topology_nodes(monero_route=mono, tari_route=tari)
     assert all("remote" not in n for n in TOPOLOGY_NODES)
 
 
 def test_the_served_graph_carries_each_node_s_real_location(monkeypatch):
-    # compute_topology defaults remote_tari, so a signature alone would not catch topology_from_config
+    # compute_topology defaults tari_route, so a signature alone would not catch topology_from_config
     # forgetting to pass it — the diagram would then call every Tari node local, forever and quietly.
-    # Both helpers are given different answers so a swapped wire-up fails too.
-    # Tari must come out REMOTE here. remote_tari defaults to False, so asserting a local Tari
+    # Tari must come out REMOTE here. tari_route defaults to LOCAL, so asserting a local Tari
     # would pass whether or not the value was ever passed — the assertion has to differ from the
     # default to mean anything. Monero is given the opposite answer so a swapped wiring fails too.
     monkeypatch.setattr(egress.config, "monero_is_local", lambda: True)
     monkeypatch.setattr(egress.config, "tari_is_local", lambda: False)
+    monkeypatch.setattr(egress.config, "TARI_GRPC_ADDRESS", "10.0.0.7:18142")
     nodes = {n["id"]: n for n in egress.topology_from_config()["nodes"]}
     assert nodes["monerod"]["remote"] is False
     assert nodes["tari"]["remote"] is True

--- a/dashboard/tests/web/test_views.py
+++ b/dashboard/tests/web/test_views.py
@@ -3058,16 +3058,16 @@ class TestEgressTopology:
         assert st["egress"]["summary"]["leaks"] >= 1
 
     def test_remote_monerod_is_reflected_in_the_payload(self, monkeypatch):
-        # A remote (non-local) monerod RPC host is a clearnet hop; with the firewall on it's blocked,
-        # not leaked, so the badge stays green but the blocked count rises — end to end.
-        _set_egress_config(monkeypatch, MONERO_NODE_HOST="10.0.0.9", LOCAL_MONERO_HOST="127.0.0.1")
-        st = build_state(_data(), _state_mgr(), "all")
-        assert st["egress"]["summary"]["all_tor"] is True
-        assert st["egress"]["summary"]["blocked_by_firewall"] >= 1
-        assert any(
-            e["from"] == "p2pool" and e["to"] == "monerod" and e["route"] == "clearnet"
-            for e in st["topology"]["edges"]
-        )
+        # #1350: a private-addressed remote monerod is a LAN hop and charges neither counter; a
+        # public one is clearnet, blocked not leaked. Both hops read — they used to disagree.
+        def _payload(host):
+            _set_egress_config(monkeypatch, MONERO_NODE_HOST=host, LOCAL_MONERO_HOST="127.0.0.1")
+            st = build_state(_data(), _state_mgr(), "all")
+            hops = {e["from"]: e["route"] for e in st["topology"]["edges"] if e["to"] == "monerod"}
+            return hops, st["egress"]["summary"]["blocked_by_firewall"]
+
+        assert _payload("10.0.0.9") == ({"p2pool": "lan", "dashboard": "lan"}, 0)
+        assert _payload("8.8.8.8") == ({"p2pool": "clearnet", "dashboard": "clearnet"}, 1)
 
     def test_payload_stays_json_serializable_with_a_leak(self, monkeypatch):
         _set_egress_config(monkeypatch, P2POOL_CLEARNET=True, TOR_EGRESS_FIREWALL=False)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -134,6 +134,19 @@ only when every configured endpoint is a private or loopback IP literal, since s
 leaves your network. A hostname can't be proven private without a DNS lookup, so a hostname
 endpoint with Tor off counts as **clearnet**, a real leak.
 
+The topology diagram applies that same rule to the hops that reach a remote monerod or Tari node,
+and keeps three answers apart instead of two. A node reached at a private, loopback or link-local
+IP literal draws as **LAN**: the hop leaves this machine but stays on your network, so it does not
+expose your IP and is not counted as a leak. Any other IP literal draws as **clearnet** and is
+counted. A node configured by **hostname** draws as **Unverified** — the diagram will not resolve
+a name to classify it, because that lookup would itself be an egress, and on a Tor-routed stack it
+would cause the exact exposure the panel exists to warn about, on every render. Unverified is not
+counted as a leak either; the panel says it cannot tell rather than guessing in either direction.
+
+**LAN is a statement about exposure, not about encryption.** A remote-node hop is a plaintext
+connection whichever way it draws, so the rows above still apply: anyone who can watch your local
+network can read it. LAN means only that the traffic does not reach the internet.
+
 ---
 
 ## Build / setup-time egress


### PR DESCRIPTION
Fixes the topology diagram's claim that every hop to a relocatable node is local, and gives an
unclassifiable address a state of its own instead of letting it borrow a reassuring colour.

## This is a defect, not an enhancement

The issue reads as an enhancement. It is not. A remote Tari node is already modelled — the
topology builder passes it and `topology_nodes` already marks the node `"remote": True` — so with
a remote monerod **one render already contradicted itself**: the node was captioned `remote`,
p2pool's hop to it said `clearnet`, and the dashboard's hop to the *same daemon* still said
`local`. Two edges, one daemon, two different answers, in the half of the UI an operator reads for
a security judgement.

Three of the four hops were hardcoded `local` regardless of configuration.

## What it does

`topology_graph.node_route(address, *, is_local)` derives a hop's route from the configured
address **shape** alone:

| configured as | route |
|---|---|
| a node on this machine | `local` |
| a private / loopback / link-local IP literal | `lan` |
| any other IP literal | `clearnet` |
| anything else, including every hostname | `unknown` |

**This extends a pattern that already existed in `egress.py`, twice.** `_xvb_standby_route` and
`_sinks_all_private` both classify by address shape and both already refuse to resolve a hostname
— one of them says so in its own docstring. The four edges in this issue are the outliers that
never adopted it, and `import ipaddress` was already at the top of the file.

**A hostname is never resolved, and that is not a performance argument.** A DNS lookup at
diagram-build time is *itself an egress*. On a Tor-routed stack the diagram would cause the exact
exposure it exists to warn about, on every render. So an address that cannot be classified gets
`unknown` — allowlist-shaped, fail-closed by construction, and rendered as its own visible state
rather than quietly taking LAN's or clearnet's colour.

`lan` rather than `clearnet` is a correctness call, not taste: the counter's own declaration reads
`leaks = 0  # clearnet egress that actually exposes the host IP`. A node on the operator's LAN
does not expose the host IP, so colouring that hop clearnet asserts something the counter's own
definition denies.

## THE CONTRACT CHANGE — please read this before reviewing the diff

`compute_egress_posture` and `compute_topology` are shared pure functions, and **two of their
keyword arguments change type**:

- `remote_monero: bool` → `monero_route: str` (a route token)
- `remote_tari: bool = False` → `tari_route: str = LOCAL`

`topology_nodes(*, remote_monero, remote_tari)` changes the same way, and now derives
`"remote"` as `route != LOCAL` instead of `bool(...)`.

The route constants (`TOR`/`CLEARNET`/`LOCAL`/`INACTIVE`, plus the new `LAN`/`UNKNOWN`) **moved**
from `egress.py` to `topology_graph.py`, because the classifier needs them and the dependency runs
one way. `egress.py` re-exports them, so `xvb_standby.py`'s `from ...egress import LOCAL` and
every other existing importer keeps working unchanged.

### Every caller, enumerated and walked

Re-derived at the branch tip with
`grep -rn "monero_route\|tari_route\|remote_monero\|remote_tari" dashboard/ --include=*.py --include=*.mjs | grep -v generated`
rather than inherited from an earlier note.

| site | what it does now |
|---|---|
| `egress.py:103` | `compute_egress_posture` knob, renamed |
| `egress.py:137` | the counted monerod RPC conn — `"route": monero_route` |
| `egress.py:238` | `egress_posture_from_config` calls the classifier |
| `egress.py:281,286` | `compute_topology` knobs, renamed and retyped |
| `egress.py:308` | pass-through into the posture |
| `egress.py:379,380,382,384` | the four edges this issue is about |
| `egress.py:403` | `topology_nodes(...)` |
| `egress.py:416,417` | `topology_from_config` calls the classifier |
| `topology_graph.py:82,96` | `topology_nodes` signature and marking |
| `test_egress.py:26,202,203,366,434,454` | substituted line-neutrally |
| `test_topology_graph.py:32,44,53` | route pairs instead of bool pairs |
| `test_views.py:3060` | **corrected — see below** |

`egress.py:321`'s `rpc = CLEARNET if remote_monero else LOCAL` is **deleted**; the four edges take
the route directly.

**Not callers, checked rather than assumed:** `collector/logs.py:130,241`
(`_get_remote_monero_sync_status`) is a name collision, along with its tests; and
`test_wizard.py:304` exercises `wizard.build_config`, not the egress knobs.

## The security summary visibly changes, and one existing test encoded the old belief

`egress.py:137` builds the monerod RPC conn, and that conn **already flowed into the leak
counter**. So for a monerod at a private address the counters move:

| | before | after |
|---|---|---|
| firewall on | counted `blocked_by_firewall` | **not counted** |
| firewall off | counted a **leak** | **not counted** |

That is correct by `leaks`' own definition, and it is a real change to a security roll-up rather
than a cosmetic one, so it is asserted explicitly rather than shipped as a side effect.

**`test_views.py::test_remote_monerod_is_reflected_in_the_payload` failed on this fix, and it was
right to.** It pinned a remote monerod at a private RFC1918 address and asserted the blocked count
rose. It encoded exactly the belief this issue says is wrong, so it fought the fix. It is
corrected to cover **both** address shapes (private → `lan`, neither counter; public → `clearnet`,
blocked), and it now reads both hops to the daemon, because those two used to be able to disagree.

## Guarding it — the mutation loop is the point of this change, not a formality

The two new states are **not alike**, and the difference is why the loop was mandated:

| new state | does anything fail if you get it wrong? |
|---|---|
| `lan` | **Yes.** A visible count moves. There is a natural signal. |
| `unknown` | **No.** Nothing anywhere changes unless the renderer is right. |

A fully green suite is compatible with `unknown` rendering as `local`, or not rendering at all —
and the half that *does* have a signal makes the whole change feel guarded. So the guard is an
explicit assertion on the **rendered value**, and the renderer was mutated to prove it dies.

The renderer had exactly that failure mode waiting: `ROUTE_COLOR[key] || ROUTE_COLOR.local` means
an unrecognised token silently takes local's grey, and `ROUTES` drives the arrowhead `<defs>`, so
a token missing there points `marker-end` at an id that was never defined and its arrowhead just
vanishes. Both look like a working diagram.

**13 mutations, 13 killed, every one naming the test it was aimed at.** Baseline green before,
green after, tree byte-identical to pre-run. The harness refuses to score a red with no failing
test name, a red whose names do not include the aimed test, or a kill set so wide the mutation
probably broke the module rather than the behaviour.

| # | mutation | named kill |
|---|---|---|
| M1 | an unclassifiable hostname returns `lan` instead of `unknown` | `test_anything_that_is_not_an_address_literal_is_unknown` (+10) |
| M2 | every non-local node is clearnet (the pre-#1350 behaviour) | `test_a_private_address_literal_is_a_lan_hop` (+11) |
| M3 | resolve the hostname after all | `test_the_classifier_never_resolves_a_hostname` (+5) |
| M4 | a LAN hop is charged to the security summary | `..._moves_neither_security_counter[lan-True/False]`, `test_a_lan_node_visibly_changes_the_count_that_used_to_be_charged`, and the end-to-end views test |
| M5 | an `unknown` hop is charged to the security summary | `..._moves_neither_security_counter[unknown-True/False]` |
| M6 | `dashboard`->`monerod` back to hardcoded `local` | `test_the_two_hops_to_one_daemon_can_never_disagree` (+4) |
| M7 | `p2pool`->`tari` back to hardcoded `local` | `test_every_hop_to_a_relocatable_node_carries_that_node_s_route[lan/clearnet/unknown]` |
| M8 | a LAN/unknown node stops reading as remote | `test_every_route_that_is_not_local_reads_as_remote` (+3) |
| **M9** | **`unknown` silently takes local's grey** | **`lan and unknown are visually distinct from local and from clearnet` — alone** |
| M10 | `unknown` has no colour at all | `route palette + names cover every route the server can emit` — alone |
| M11 | `unknown` has no arrowhead marker | `every route gets an arrowhead marker generated for it` — alone |
| M12 | `lan` takes clearnet's red (option (a)) | `lan and unknown are visually distinct...` — alone |
| M13 | `lan` is labelled exactly as local | `lan and unknown are visually distinct...` — alone |

**M9 is the row that matters.** It is the one failure with no natural signal anywhere in the
stack, and it dies by name, alone. **M4 and M5 kill disjoint sets** (`[lan-*]` vs `[unknown-*]`),
so the two states are independently guarded rather than one covering for the other — and the
negative control `test_a_clearnet_node_hop_still_moves_a_counter` survives both, which is what
rules out the mutation having simply made every route uncounted.

### Two defects in my own instrument, both worth more than the rows they fixed

Reported rather than quietly corrected, because both are shapes this project keeps filing.

**The never-resolve guard was defeatable by a broad `except`.** M3's first form made the classifier
resolve the hostname and fall back to `unknown` on failure. My sentinel was an `AssertionError`,
`except Exception` swallowed it, the *result* was still correct, and the assertion on the return
value stayed green — the mutation survived as a bystander kill. The sentinel is now a
`BaseException` subclass, which that handler cannot catch, so the DNS attempt itself fails the test
rather than the answer it happened to reach. When a guard says "this must never do X", asserting on
the result is not enough if a plausible X-doing implementation has a fallback.

**Two mutations were `NameError`s wearing a kill's clothes.** M4/M5 first injected the `LAN` name
into `egress.py`, which deliberately does not import it, so the module died at import and reddened
everything — the aimed test included, as a bystander. Capturing names and checking the aimed one
PASSED them. The tell was that they also killed their own negative control. Both now use literal
tokens, and the harness refuses to score a kill set wider than 25 tests.

## What was run

- Full dashboard pytest suite: **2120 passed, 0 failed** (baseline on the branch point: 2080).
- Frontend: `node --test tests/frontend/` — **480 pass / 0 fail** (baseline 478).
- Gate targets, each exit code captured separately rather than through a filter: `lint-py` 0,
  `lint-js` 0, `lint-md` 0, `lint-docs-voice` 0, `lint-operator-strings` 0, `lint-topology` 0,
  `lint-file-budget` 0.

## What was NOT run, and other honest gaps

- **`make lint-sh` / `make lint` / `make test` were not run** — shellcheck has OOM-killed sessions
  on this box. There are no shell files in this diff.
- **No live rig, browser, bench or remote node.** The new `LAN` and `Unverified` states have never
  been seen on screen; the frontend evidence is the render-contract tests only. Someone with a
  browser should look at the legend before this is trusted visually.
- **The colour choices are unreviewed by anyone but me** — `lan` is `var(--accent)` (blue) and
  `unknown` is `var(--warn)` (amber). The tests pin that they are *distinct* from local, from
  clearnet and from each other; they cannot pin that they are *legible*, including for colour
  vision deficiency. Worth an eye.
- **No `security-reviewer` subagent.** This adds no input path, no parse and no network call — it
  strictly *removes* the possibility of one, since the never-resolve rule is now enforced by a
  test. Say so if you disagree and I will run the pass before merge.
- `[::1]:18081` (bracketed IPv6 with a port) classifies as `unknown`, not `lan`. Neither knob
  produces that shape today; it is pinned as a test so the choice is visible rather than latent.

## File budget

`egress.py` **423/424** and `test_egress.py` **480/480** both had zero headroom, and
`test_views.py` **3576/3576** likewise. The change is line-neutral or negative in all three — the
classifier and the route vocabulary live in `topology_graph.py`, which is unrowed and is the
vocabulary's natural home. No carrier, no ratchet argument, lands standalone. Counts re-derived
from `git show origin/develop-v2:docs/dev/file-budget.tsv`.

## Over-engineering pass

Done by hand (the gate's own state is not evidence about any particular PR). Two things came out
of it and both are in the diff: the sweep in `test_egress.py` was going to keep a boolean
dimension and a translation step, and became a route dimension instead — same line count, and it
now runs every well-formedness assertion over `lan` and `unknown` edges rather than only the two
states that existed when it was written. And `NODE_ROUTES` replaced a tuple I had first duplicated
into the test module, so the sweep and the frontend palette contract pin against one list.

One thing I kept and a reviewer may overrule: `ROUTE_NAME.local` changes from `"Local/LAN"` to
`"Local"`. That label was accurate when the two were one state and is actively misleading now.
