### PR TITLE
fix(tests): inventory's emptiness guard failed open on a 24-of-25 breakage — make it a floor

### DIFF
--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -189,8 +189,20 @@ while read -r base; do
     MISSING="${MISSING}${base}"$'\n'
 done <<<"$EXPECTED"
 n_missing=$(printf '%s' "$MISSING" | count)
+n_expected=$(printf '%s' "$EXPECTED" | count)
+# Nothing to compare is itself drift, and it is the ONE case a set-difference floor cannot see. If
+# every domain file and every stanza disappear TOGETHER — a botched revert of the #1105 split, or a
+# merge that drops the directory — then SOURCED and EXPECTED collapse to empty at the same time,
+# MISSING is empty, and the floor above is vacuously satisfied. The emptiness test this floor
+# replaced DID catch that, so it is asserted explicitly rather than quietly lost with it. Its own
+# sentence, not a share of the floor's: two guards on one string means either can cover for the
+# other's deletion.
+if [ "$n_expected" -eq 0 ]; then
+    echo "inventory drift: tests/stack/ holds no sourced domain files at all — the split's shape" \
+        "changed, or the directory was emptied; there is nothing for the drift floor to compare" >&2
+    exit 1
+fi
 if [ "$n_missing" -gt 0 ]; then
-    n_expected=$(printf '%s' "$EXPECTED" | count)
     echo "inventory drift: $n_missing of $n_expected domain files on disk are not sourced by" \
         "run.sh — a 'source' line was deleted, or, the closer this count runs to $n_expected, the" \
         "pattern above stopped matching. Either way the suite would still pass, silently skipping" \

--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -181,7 +181,12 @@ done <<<"$SOURCED"
 # none. Exiting on the first offender was the other half: it named one file, alphabetically first,
 # for a 24-file regression, and the reader sizes the problem from that message.
 MISSING=""
-while read -r base; do
+# `IFS=` is load-bearing: `read -r` into a single variable strips leading and trailing IFS
+# whitespace, so a file on disk whose name STARTS with a space, sourced by nothing, would be
+# stripped to its bare name — which IS in SOURCED — and silently accepted. A mid-name space was
+# caught either way, which is what made this invisible. Direction 1's identical construct above
+# needs no such fix: SOURCED comes from a character class that cannot emit a space.
+while IFS= read -r base; do
     if [ -z "$base" ]; then continue; fi
     # Matched between newlines, not spaces: a filename containing a space would survive the glob
     # above (it is iterated directly) only to be split apart by a space-delimited lookup here.
@@ -190,16 +195,21 @@ while read -r base; do
 done <<<"$EXPECTED"
 n_missing=$(printf '%s' "$MISSING" | count)
 n_expected=$(printf '%s' "$EXPECTED" | count)
-# Nothing to compare is itself drift, and it is the ONE case a set-difference floor cannot see. If
-# every domain file and every stanza disappear TOGETHER — a botched revert of the #1105 split, or a
-# merge that drops the directory — then SOURCED and EXPECTED collapse to empty at the same time,
-# MISSING is empty, and the floor above is vacuously satisfied. The emptiness test this floor
-# replaced DID catch that, so it is asserted explicitly rather than quietly lost with it. Its own
-# sentence, not a share of the floor's: two guards on one string means either can cover for the
-# other's deletion.
+# Nothing to compare is itself drift, and it is the ONE case the set difference above cannot see. If
+# every expected domain file and every stanza disappear TOGETHER — a botched revert of the #1105
+# split — then SOURCED and EXPECTED empty at the same time, MISSING is empty, and the comparison is
+# vacuously satisfied. The emptiness test this replaced DID catch that, so it is asserted explicitly
+# rather than quietly lost with it. Its own sentence, not a share of the one below: two guards on
+# one string means either can silently cover for the other's deletion.
+# Scope, stated because a comment that names a case this guard never sees is worse than no comment:
+# dropping the WHOLE directory does not reach here — `n_stack` counts 0 and the aggregate gate above
+# exits first, with byte-identical output whether this guard is alive or dead. What is unique to
+# this check is the narrower case where run.sh and the sectioned UNSOURCED files survive, keeping
+# `n_stack` non-zero, while the expected domain files and their stanzas both go.
 if [ "$n_expected" -eq 0 ]; then
-    echo "inventory drift: tests/stack/ holds no sourced domain files at all — the split's shape" \
-        "changed, or the directory was emptied; there is nothing for the drift floor to compare" >&2
+    echo "inventory drift: no domain files are expected to be sourced — every tests/stack file is" \
+        "run.sh, UNSOURCED, or gone, so there is nothing to check run.sh's stanzas against;" \
+        "restore the domain files, or update the pattern in tests/inventory.sh" >&2
     exit 1
 fi
 if [ "$n_missing" -gt 0 ]; then

--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -127,8 +127,8 @@ done
 # aggregate nor the per-file gate can see it. The hyphen-named domain files have no standalone CI
 # invocation of their own — the underscore-named test_*.sh suites do, and fail their own step — so
 # for them these two checks are the whole safety net. Both read one SOURCED list, so the pattern
-# cannot drift between them, and a pattern that stops matching trips the emptiness guard rather
-# than quietly satisfying both loops at once.
+# cannot drift between them, and a pattern that stops matching cannot quietly satisfy both loops at
+# once: direction 2 compares the list against the files on disk and reports how many are missing.
 #
 # The pattern is anchored to the start of the line and admits no `#` ahead of the `source`, and
 # that is the load-bearing half: without it a commented-out `# source "$HERE/x.sh"` reads here as
@@ -141,15 +141,26 @@ done
 # control flow rather than grep, and is not claimed.
 SOURCED=$(grep -oE '^[^#]*source "\$HERE/[A-Za-z0-9_.-]+\.sh"' tests/stack/run.sh |
     sed -E 's|^.*source "\$HERE/||; s|"$||')
-if [ -z "$SOURCED" ]; then # the grep itself going quiet must not read as "all present"
-    echo "inventory drift: no 'source \"\$HERE/...\"' lines found in run.sh — the split's shape" \
-        "changed; update the pattern in tests/inventory.sh" >&2
-    exit 1
-fi
+# The domain files run.sh is expected to source: every tests/stack/*.sh but the sourcer itself and
+# the suites that carry their own CI step and fail there. Hoisted above both directions because the
+# floor below needs its size, and both loops need its membership.
+# Not sourced by run.sh, by design — each is invoked as its own CI step and fails there:
+UNSOURCED="test_appliance_hugepages.sh test_compose.sh test_data_reset.sh \
+    test_firstboot_journal.sh test_os_update_recovery.sh"
+EXPECTED=""
+for f in tests/stack/*.sh; do
+    base="${f#tests/stack/}"
+    if [ "$base" = "run.sh" ]; then continue; fi # the sourcer itself
+    case " $UNSOURCED " in *" $base "*) continue ;; esac
+    EXPECTED="${EXPECTED}${base}"$'\n'
+done
 
 # Direction 1 (#1336) — every file run.sh claims to source must exist. Catches a domain file
 # deleted or renamed out from under a live `source` line.
 while read -r want; do
+    # A here-string over an empty SOURCED yields ONE blank line, not zero, so without this the
+    # loop would test `tests/stack/` and report a garbled name for a pattern that matched nothing.
+    if [ -z "$want" ]; then continue; fi
     if [ ! -f "tests/stack/$want" ]; then
         echo "inventory drift: run.sh sources tests/stack/$want, which does not exist — the file" \
             "was moved or renamed and the suite would still pass, silently skipping it" >&2
@@ -161,21 +172,33 @@ done <<<"$SOURCED"
 # the `source` lines that are PRESENT, so a line deleted while its file stays on disk is never
 # looked at; the per-file section gate then finds the orphaned file with its headers intact and
 # passes it. Nothing else asks the question in this direction.
-# Not sourced by run.sh, by design — each is invoked as its own CI step and fails there:
-UNSOURCED="test_appliance_hugepages.sh test_compose.sh test_data_reset.sh \
-    test_firstboot_journal.sh test_os_update_recovery.sh"
-for f in tests/stack/*.sh; do
-    base="${f#tests/stack/}"
-    if [ "$base" = "run.sh" ]; then continue; fi # the sourcer itself
-    case " $UNSOURCED " in *" $base "*) continue ;; esac
+#
+# This is a FLOOR, not an emptiness test, and it collects rather than exiting on the first offender
+# (#1420). It used to be guarded by `[ -z "$SOURCED" ]`, on the reasoning that the pattern going
+# quiet must not read as "all present" — and that guard failed open on a real 24-of-25 breakage,
+# because lib.sh's stanza is bare by design and kept matching. A fallback condition of "the set is
+# empty" is defeated by a single survivor. Comparing the two sets makes one survivor as loud as
+# none. Exiting on the first offender was the other half: it named one file, alphabetically first,
+# for a 24-file regression, and the reader sizes the problem from that message.
+MISSING=""
+while read -r base; do
+    if [ -z "$base" ]; then continue; fi
     # Matched between newlines, not spaces: a filename containing a space would survive the glob
     # above (it is iterated directly) only to be split apart by a space-delimited lookup here.
     case $'\n'"$SOURCED"$'\n' in *$'\n'"$base"$'\n'*) continue ;; esac
-    echo "inventory drift: tests/stack/$base is on disk but nothing sources it — a 'source' line" \
-        "was deleted and the suite would still pass, silently skipping the file's sections;" \
-        "restore the line, or add the file to UNSOURCED with a reason" >&2
+    MISSING="${MISSING}${base}"$'\n'
+done <<<"$EXPECTED"
+n_missing=$(printf '%s' "$MISSING" | count)
+if [ "$n_missing" -gt 0 ]; then
+    n_expected=$(printf '%s' "$EXPECTED" | count)
+    echo "inventory drift: $n_missing of $n_expected domain files on disk are not sourced by" \
+        "run.sh — a 'source' line was deleted, or, the closer this count runs to $n_expected, the" \
+        "pattern above stopped matching. Either way the suite would still pass, silently skipping" \
+        "every section in these files. Restore the line, fix the pattern, or add the file to" \
+        "UNSOURCED with a reason:" >&2
+    printf '%s' "$MISSING" | sed 's/^/  /' >&2
     exit 1
-done
+fi
 
 # --- emit -----------------------------------------------------------------
 cat <<EOF


### PR DESCRIPTION
Addresses the two mechanical halves of #1420. One file, one region.

**#1420 stays open** — it carries `do-not-close` and the acceptance
assessment is its newest comment. The deferred third item is named at the bottom of this body.

## The defect

`tests/inventory.sh` guarded against its own `source` pattern going quiet with `[ -z "$SOURCED" ]`,
and the comment on that line stated exactly that purpose. It failed open on a real breakage: #1416
put a guard prefix on every domain stanza, the line-anchored pattern stopped matching **24 of the 25
stanzas**, and the guard stayed silent because `lib.sh`'s stanza is bare by design and kept matching.
`SOURCED` sat at one entry.

**A fallback condition of "the set is empty" is defeated by a single survivor.**

Direction 2 did catch it, several checks later, and sized it wrongly: it exits on its first offender,
so a 24-file regression was reported as one file — alphabetically first — and the reader sizes the
problem from that message.

## The change

- **The emptiness test becomes a floor.** The sourced set is compared against the domain files on
  disk, so one survivor is as loud as none.
- **Direction 2 collects.** Every offender is gathered and reported with the count and the list,
  instead of exiting on the first.
- The expected-files set is hoisted above both directions: the floor needs its size, both loops need
  its membership.
- Direction 1 gains a blank-line skip. A here-string over an empty `SOURCED` yields **one blank
  line, not zero**, and with the emptiness guard gone that case now reaches direction 1, where it
  would otherwise test `tests/stack/` and print a garbled name.

## What was run

Mutation battery — **9 scored rows in the harness, all passing**, plus F2 verified separately
with its own control (below) — in a scratch copy — never in a live worktree. Every row asserts three
things, not two: the mutation applied (`cmp`, and the run aborts with `exit 3` if it did not — M5
tripped exactly that and was fixed rather than scored), something died, and **what died is the guard
the mutation was aimed at**, matched on that guard's own distinct sentence.

    C  control, unmutated             rc=0                                    PASS
    M1 pattern re-anchored            rc=1  AIMED  24 of 25 domain files, 24 named
    M2 one stanza deleted             rc=1  AIMED   1 of 25 domain files,  1 named
    M3 two stanzas deleted            rc=1  AIMED   2 of 25 domain files,  2 named
    M4 domain file removed from disk  rc=1  AIMED  direction 1's own sentence, 0 listed
    M5 pattern matches nothing        rc=1  AIMED  25 of 25 domain files, 25 named
    M6 guard deleted + M1 re-applied  rc=0                                    PASS
    Z  post-restore control           rc=0                                    PASS

**M1 is the real regression** — the exact breakage the old guard failed open on — and **M6 is what
makes it evidence**: with the direction-2 block deleted, M1 goes green, so nothing else in the file
was catching it and M1 is not a bystander kill. **M3 is the collect-don't-exit half specifically**:
the old code would have named one of those two files. **M4 carries direction 1's own sentence and
lists no files**, which is the check that the two guards do not share an output string — either one
covering for the other's deletion is a defect shape this repo has already filed.

Gates, each read from its own exit code, never through a filter: `bash tests/inventory.sh` rc 0 ·
`shfmt -i 4 -d` rc 0 · `shellcheck` rc 0 at the gate's own `--severity=warning`, run with
`PATH=$HOME/.local/bin:$PATH` so it is **0.11.0**, the version CI pins, not `/usr/bin`'s 0.9.0 ·
`scripts/lint-file-budget.sh` rc 0. The file goes 300 → 345 lines, still under `TARGET_LINES=400`,
so it correctly stays unrowed and no ceiling moves.

At full severity `shellcheck` reports 2 × SC2016 (info) on the `SOURCED` grep. **Those are
pre-existing and not mine** — the base has 3 of them; my diff removes one by deleting the old
guard's message. I have not touched them.

The lane guard was verified with a negative control rather than assumed: `tests/inventory.sh` passes
(`tests.paths` owns it explicitly), and a staged `Makefile` is refused rc 1. No `.lane-override` was
used and nothing outside this lane's paths is touched.

## Over-engineering pass

Run by hand on merit, not because a gate prompted me — this repo's PR-opening gate keys its sentinel
to the pane's branch rather than the PR's, so its silence is not evidence that a review happened.
It found one thing: `n_expected` was computed unconditionally when it is only ever used inside the
failure branch, and I moved it inside the `if`. **That edit was later REVERSED** — the empty-expected
guard needs the value before the branch. The pass removed the exact computation a later guard
required, which is worth stating rather than quietly restoring. The battery was re-run afterwards and all rows still hold —
a mutation anchor invalidated by your own mid-session edit is a live hazard here, and the anchors
(the `SOURCED` pattern, two `run.sh` stanzas, the `MISSING=""` slice) were checked against it.

I also considered replacing the direction-2 loop with `comm` over two sorted lists. Declined: the
existing newline-delimited membership test is deliberately space-safe, and the file documents why.

## Not in this PR, deliberately

**The third item in #1420 — the aggregate counters at `:77`** (`n_py_dash n_py_fake n_node n_stack
n_selftest n_scen n_axes n_mini`, each tested against zero and so each able to fall from hundreds to
one and pass). The issue itself calls that a per-counter judgement rather than one ruling, and it is
a different question from the one this change answers. Leaving #1420 open for it; **treat those
counters as unchecked, not as clean** — nobody has verified them either way, and this PR is not
evidence about them.


---

## Amended after two adversarial passes — the head is now `28f5b6c`

The table above is the original 8 rows; M7 is the 9th and is in the harness. F2's check is not a
harness row — it was run standalone, with the mid-name-space control. Two more were added and every claim below was
measured, not argued:

- **M7 — both sets collapse to empty.** My original claim that this floor "strictly subsumes" the
  emptiness guard it replaces was **false**: a set difference sees disagreement and cannot see both
  sides empty together. `44b5146` went rc 0 where the base went rc 1. Fixed. The second reviewer
  reproduced it and ran the bystander control my table lacked (guard neutered → M7 rc 0, clean tree
  rc 0, ordinary drift still rc 1), which is what makes M7 a guard rather than a demonstration.
- **F2 — a leading-space filename was silently accepted as sourced.** `read -r` without `IFS=`
  stripped ` test-doctor.sh` to a name that IS in SOURCED. Before rc 0, after rc 1; mid-name space
  reds on both, so the fix is not the cause. Found unbriefed by the first reviewer.

**Corrections to this body's own claims, all of them mine:**

- **This PR changes no trigger.** Head and base agree on rc across every row. It **sizes and names
  what the base already caught badly** — which is what #1420 complained about. "M1 is the real
  regression" is true of its *message*, not its *rc*.
- **"Floor" is a misnomer** — there is no arithmetic; it is a set difference.
- **M6 proves something narrower** than claimed: under M1, direction 1 is blinded by construction,
  leaving direction 2 alone. Not "nothing else was catching it".

**This PR does NOT discharge #1420** and the issue carries `do-not-close`. It closes the
collect-offenders half; the single-survivor defect class it names survives at a different place
(#1429), and the `:77` counters are deferred and **unchecked, not clean**.

