### PR TITLE
fix(lint): two lint legs reported success without checking what they claimed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,11 @@ lint-sh: ## shellcheck + shfmt over the CLI, build/* + dashboard/ container scri
 # run.sh sets for them. Drop pithead-boot from this line and those three report as SC2034 — it
 # costs ~300 lines to keep here, not the 294 KB of domain files.
 	shellcheck --severity=warning tests/stack/run.sh os/overlay/pithead-boot
+	@# Three non-.sh files are named outright below, so a dead enumeration still hands shfmt
+	@# three real arguments and exits 0 — 3 files checked of 100, reported as a pass. Guard the
+	@# enumeration itself, the way lint-toml already does. (lint-yaml needs no guard: yamllint
+	@# with no arguments is rc=2.)
+	@test -n "$$(git ls-files '*.sh' | grep -v '^docs/research/')" || { echo "lint-sh: zero tracked *.sh files — refusing a vacuous pass"; exit 1; }
 	shfmt -i 4 -d pithead pithead-completion.bash os/installer/pithead-install $(shell git ls-files '*.sh' | grep -v '^docs/research/')
 
 lint-py: ## ruff lint + format check on all repo Python (ruff runs via uv from the locked dev extra)

--- a/scripts/lint-operator-strings.sh
+++ b/scripts/lint-operator-strings.sh
@@ -105,10 +105,8 @@ scan_frontend() {
     ' "$@"
 }
 
-# A frontend enumeration that comes back empty is a broken enumeration, never a clean tree: the
-# globs below match 28 tracked files today and have never legitimately matched none. Skipping the
-# scan on empty would leave `fail` at 0 and let this script's closing line still claim the frontend
-# was scanned, so a moved or renamed `web/` directory would read as clean indefinitely.
+# An empty enumeration is broken, never a clean tree — 28 files match the globs below. Skipping
+# the scan on empty leaves `fail` at 0 while the closing line still claims the frontend was scanned.
 enforce_nonempty_frontend() { # <newline-separated file list>
     [ -n "$1" ] && return 0
     echo "operator strings: the dashboard frontend enumeration returned zero files." >&2
@@ -174,7 +172,7 @@ if [ "${1:-}" = "--self-test" ]; then
         echo "  self-test FAIL: an empty frontend enumeration was accepted"
         st_fail=1
     else echo "  self-test ok: an empty frontend enumeration is refused"; fi
-    if enforce_nonempty_frontend "$tmp/hit.mjs" 2>/dev/null; then
+    if enforce_nonempty_frontend "$tmp/hit.mjs"; then
         echo "  self-test ok: a non-empty frontend enumeration is accepted"
     else
         echo "  self-test FAIL: a non-empty frontend enumeration was refused"

--- a/scripts/lint-operator-strings.sh
+++ b/scripts/lint-operator-strings.sh
@@ -105,8 +105,10 @@ scan_frontend() {
     ' "$@"
 }
 
-# An empty enumeration is broken, never a clean tree — 28 files match the globs below. Skipping
-# the scan on empty leaves `fail` at 0 while the closing line still claims the frontend was scanned.
+# An empty enumeration is broken, never a clean tree: the globs below match tracked files in any
+# real checkout. Skipping the scan on empty leaves `fail` at 0 while the closing line still claims
+# the frontend was scanned. (No count here on purpose — one would be wrong twice over, since the
+# globs and the surviving set differ by the *.min.js bundles, and both drift with the frontend.)
 enforce_nonempty_frontend() { # <newline-separated file list>
     [ -n "$1" ] && return 0
     echo "operator strings: the dashboard frontend enumeration returned zero files." >&2
@@ -179,6 +181,25 @@ if [ "${1:-}" = "--self-test" ]; then
         st_fail=1
     fi
 
+    # The two rows above prove the FUNCTION. Neither proves the CALL SITE: delete the
+    # `enforce_nonempty_frontend "$files"` line and every row above still passes while the real
+    # invocation goes back to reporting a frontend it never read. That is this repo's recurring
+    # shape — a green assertion compatible with the feature not being wired in — and it is the very
+    # shape this script was changed to refuse, so it is checked here rather than described in a PR.
+    # Run the real script end to end in a throwaway git repo whose index is empty, which is the only
+    # way to make the enumeration return nothing without editing the globs.
+    self=$(cd "$(dirname "$0")" && pwd)/$(basename "$0")
+    wire="$tmp/wire"
+    mkdir -p "$wire"
+    (cd "$wire" && git init -q . && : >pithead) >/dev/null 2>&1
+    wire_out=$(cd "$wire" && bash "$self" 2>&1 </dev/null) && wire_rc=0 || wire_rc=$?
+    if [ "$wire_rc" -ne 0 ] && printf '%s\n' "$wire_out" | grep -q 'frontend enumeration returned zero files'; then
+        echo "  self-test ok: the real invocation refuses an empty frontend enumeration"
+    else
+        echo "  self-test FAIL: the real invocation accepted an empty frontend enumeration (rc=$wire_rc)"
+        st_fail=1
+    fi
+
     [ "$st_fail" -eq 0 ] && {
         echo "lint-operator-strings self-test OK"
         exit 0
@@ -218,6 +239,12 @@ fi
 files=$(git ls-files 'dashboard/mining_dashboard/web/static/*.mjs' \
     'dashboard/mining_dashboard/web/static/*.js' \
     'dashboard/mining_dashboard/web/templates/*.html' | grep -v '\.min\.js$' || true)
+#
+# THIS REFUSAL MUST STAY ABOVE THE SCAN. `scan_frontend` ends in `awk '...' "$@"`, and awk with zero
+# file arguments reads STDIN — so folding this check into the `if` below, or moving it after the
+# scan, converts the false green into a job that HANGS instead of failing. Measured both ways: with
+# this line here the script refuses in milliseconds; with it deleted and stdin held open, the scan
+# blocks until the runner's timeout.
 enforce_nonempty_frontend "$files" || exit 1
 
 # shellcheck disable=SC2086

--- a/scripts/lint-operator-strings.sh
+++ b/scripts/lint-operator-strings.sh
@@ -105,6 +105,18 @@ scan_frontend() {
     ' "$@"
 }
 
+# A frontend enumeration that comes back empty is a broken enumeration, never a clean tree: the
+# globs below match 28 tracked files today and have never legitimately matched none. Skipping the
+# scan on empty would leave `fail` at 0 and let this script's closing line still claim the frontend
+# was scanned, so a moved or renamed `web/` directory would read as clean indefinitely.
+enforce_nonempty_frontend() { # <newline-separated file list>
+    [ -n "$1" ] && return 0
+    echo "operator strings: the dashboard frontend enumeration returned zero files." >&2
+    echo "A broken enumeration and a clean scan both report zero hits — refusing to call either a pass." >&2
+    echo "Check the git ls-files globs in this script against dashboard/mining_dashboard/web/." >&2
+    return 1
+}
+
 # --- self-test: prove the scanners catch a planted #NNN and skip the tricky exemptions ----------
 if [ "${1:-}" = "--self-test" ]; then
     tmp=$(mktemp -d)
@@ -158,6 +170,17 @@ if [ "${1:-}" = "--self-test" ]; then
     printf '%s\n' '<!-- design ref #99 -->' >"$tmp/comment.html"
     expect "a #NNN in an HTML comment is not flagged" clean "$(scan_frontend "$tmp/comment.html")"
 
+    if enforce_nonempty_frontend "" 2>/dev/null; then
+        echo "  self-test FAIL: an empty frontend enumeration was accepted"
+        st_fail=1
+    else echo "  self-test ok: an empty frontend enumeration is refused"; fi
+    if enforce_nonempty_frontend "$tmp/hit.mjs" 2>/dev/null; then
+        echo "  self-test ok: a non-empty frontend enumeration is accepted"
+    else
+        echo "  self-test FAIL: a non-empty frontend enumeration was refused"
+        st_fail=1
+    fi
+
     [ "$st_fail" -eq 0 ] && {
         echo "lint-operator-strings self-test OK"
         exit 0
@@ -188,19 +211,25 @@ then
 fi
 
 # The static frontend, minus the *.min.js bundles.
+#
+# `|| true` is load-bearing and must stay. Under `set -o pipefail` an empty enumeration makes
+# `grep -v` exit 1, which errexit turns into a silent death AT THIS ASSIGNMENT — before the
+# refusal below can run. Swallowing that status is only safe BECAUSE the refusal checks the
+# result; the two are one mechanism. Remove either and a broken enumeration stops explaining
+# itself: without `|| true` the script dies anonymously, without the refusal it reports success.
 files=$(git ls-files 'dashboard/mining_dashboard/web/static/*.mjs' \
     'dashboard/mining_dashboard/web/static/*.js' \
     'dashboard/mining_dashboard/web/templates/*.html' | grep -v '\.min\.js$' || true)
-if [ -n "$files" ]; then
-    # shellcheck disable=SC2086
-    if
-        hits=$(scan_frontend $files)
-        [ -n "$hits" ]
-    then
-        echo "operator strings: issue/PR number in a dashboard frontend user-visible string:"
-        echo "$hits"
-        fail=1
-    fi
+enforce_nonempty_frontend "$files" || exit 1
+
+# shellcheck disable=SC2086
+if
+    hits=$(scan_frontend $files)
+    [ -n "$hits" ]
+then
+    echo "operator strings: issue/PR number in a dashboard frontend user-visible string:"
+    echo "$hits"
+    fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
Two lint legs that reported success without checking what they claimed to check. Refs #1431 and
#1432. They are one sweep because they are one failure mode — an enumeration dies, and the check
built on it stays green — and because the second is only visible once you go looking for the first.

## The two defects

**#1431 — `scripts/lint-operator-strings.sh`, the frontend scan skipped itself.** The script
enumerated the dashboard frontend, then wrapped the scan in `if [ -n "$files" ]`. An empty list
skipped the scan entirely, left `fail` at 0, and still reached the closing line that states the
frontend **was** scanned. A moved or renamed `web/` directory would have read as a clean frontend
indefinitely.

**#1432 — `Makefile`, `lint-sh`'s shfmt leg survived on hard-coded arguments.** The line is three
named files plus `$(shell git ls-files '*.sh' | grep -v '^docs/research/')`. The three are not
`*.sh` (`pithead`, `pithead-completion.bash`, `os/installer/pithead-install`), so they must stay
listed — and they are also what keeps the command alive when the enumeration dies. shfmt receives
three real arguments and exits 0. This one is harder to catch precisely because it is **not**
vacuous: a check asserting "we formatted something" still passes.

## Measured, with the controls

Both run in a scratch copy, never in a live worktree. #1431 with the frontend globs repointed at a
directory that does not exist; #1432 with a pathspec that matches nothing.

    #1431  base + dead enumeration ............ rc=0  "operator strings OK — ... and the dashboard frontend"
           head + dead enumeration ............ rc=1  "the dashboard frontend enumeration returned zero files"
           head + dead enum + guard NEUTERED .. rc=0  <- the guard is the sole cause of the red
           head + guard neutered, no kill ..... rc=0  <- the neuter reds nothing on its own
           base and head, unmutated ........... rc=0  <- both controls

    #1432  base leg + dead enumeration ........ rc=0  3 files checked of 100, reported green
           new guard + dead enumeration ....... rc=1  "zero tracked *.sh files — refusing a vacuous pass"
           new guard + REAL enumeration ....... rc=0  97 files; a healthy tree is not blocked

The two neutered rows are what make #1431's red evidence rather than a demonstration: with the
guard dead the same mutation goes back to green, and the mutation alone reds nothing.

**The negative control, and it is why this is a finding rather than a pattern applied five times.**
`lint-yaml` is built identically — `uvx yamllint $(shell git ls-files ...)` — and needs no guard:
with no arguments `yamllint` is **rc=2**, loud. Measured, not assumed. A sweep that finds the same
defect in every leg it inspects is a broken instrument, so the leg that came back clean matters as
much as the two that did not.

## Two design calls, both against the obvious move

**The `|| true` on the enumeration STAYS.** Removing it looks like an improvement and would have
cost the guard. Under `set -o pipefail` an empty enumeration makes `grep -v` exit 1, which errexit
turns into a silent death **at the assignment** — before the refusal can run. Verified both ways:

    without `|| true` .... exits 1 having printed NOTHING; the guard is never reached
    with `|| true` ....... the refusal prints and exits 1

Both are rc=1, so an exit-code-only test cannot tell them apart. The `|| true` and the refusal are
one mechanism: swallowing that status is only safe *because* something now checks the result.

**#1431 is not mirrored from its siblings, deliberately.** `lint-topology-classes.sh:26` and
`lint-file-budget.sh:67` both test the whole tree (`git ls-files | wc -l`). That cannot see a moved
`web/`: 533 tracked files, 0 matching the frontend globs. The scoped `[ -z "$files" ]` fires in
every case the mirrored guard would **and** in the case it misses, so mirroring would have added a
guard that can never fire alone.

## Coverage

Two `--self-test` rows, one each way (an empty enumeration is refused, a non-empty one is accepted),
so `make lint-operator-strings` covers the guard rather than this PR body doing it. That target runs
the self-test before the real scan, and reaches CI at `ci.yml:512`.

Noted while mutating, not fixed here: `scan_frontend` is `awk '...' <files>`, so with zero arguments
it blocks on **stdin**. The old skip is what prevented that. Removing the skip without adding a
refusal would have converted the false green into a hung job.

## Shared file — disclosure

**`Makefile` is not in this lane's paths.** It is committed with a one-shot `.lane-override`, and
the guard was confirmed to refuse the staged file *first*, so the override is doing visible work
rather than covering a mistaken path claim. Expect a conflict with any other lane touching this
Makefile. Only `scripts/lint-operator-strings.sh` was granted to this lane, and only for #1431.

## Gates, and the honest limits

Run, each read from its own exit code: `bash scripts/lint-operator-strings.sh --self-test` rc 0 ·
`bash scripts/lint-operator-strings.sh` rc 0 · `make lint-operator-strings` rc 0 ·
`shellcheck --severity=warning scripts/lint-operator-strings.sh` rc 0 at **0.11.0**, the version CI
pins, run with `PATH=$HOME/.local/bin:$PATH` rather than `/usr/bin`'s 0.9.0 ·
`shfmt -i 4 -d scripts/lint-operator-strings.sh` rc 0 · `scripts/lint-file-budget.sh` rc 0.
Neither file is rowed in the budget and neither needs to be: the script goes 211 → 238 lines against
`TARGET_LINES=400`, the Makefile 132 → 137, so no ceiling moves.

**Not run, and do not read these as cleared:** full `make lint-sh` was **deliberately not run
locally** — it shellchecks `tests/stack/run.sh`, which OOMs this box. Its parse and expansion were
checked with `make -n` instead, which confirms the new guard line is in the recipe but does **not**
execute it. **UPDATE — the guard line has since been EXECUTED through real `make`** by the successor
session on this lane, in scratch repos with `shellcheck` stubbed to exit 0 so the OOM leg never runs:
base + a dead enumeration is rc 0 with shfmt handed only the 3 hard-coded files, head is rc 2 by the
guard's own message, and deleting the guard line alone returns that mutation to rc 0 while reddening
nothing on a clean tree. Full results in a PR comment. **CI's `Shell tests` job remains the real check
on the shellcheck half of that leg**, which the stub deliberately says nothing about. `make lint` and
`make test` were not run in full. The `#1432` reproduction models a dead enumeration with an empty pathspec
rather than by breaking `git ls-files` itself, so it proves the guard's behaviour on an empty
enumeration, not every way one could become empty.

Neither issue had a runtime reproduction when filed; both have one now, and both were re-derived at
source rather than taken from the filing.

## Over-engineering pass

Run on this diff because the PR gate asks for one. **Note the gate's sentinel keys to the pane's
branch rather than the PR's, so its silence is not evidence that a pass happened** — this one is
recorded here and in `fed82e5` so the claim is checkable. Two findings, both applied: the guard's
4-line comment restated the refusal message below it (now 2 lines), and `2>/dev/null` on the
positive self-test row suppressed output that row cannot produce. `net: -2 lines`, 240 → 238.

Not applied, deliberately: `enforce_nonempty_frontend` has one production caller — a layer with one
caller by the letter of it — but two more in `--self-test`. Extracting it is what makes the guard
reachable from the self-test; inlining would trade covered behaviour for two lines.

The mutation battery was re-run after that pass and all six rows still hold with both anchors live.

