### PR TITLE
fix(lint): refuse a missing pithead instead of reporting the CLI clean (#1434)

### DIFF
--- a/scripts/lint-operator-strings.sh
+++ b/scripts/lint-operator-strings.sh
@@ -117,6 +117,22 @@ enforce_nonempty_frontend() { # <newline-separated file list>
     return 1
 }
 
+# A missing scan target is broken, never a clean tree. Both pithead legs below name the CLI as a
+# literal path, and `scan_pithead`/`scan_pithead_docs` end in grep and awk over that path inside an
+# `if` condition, where errexit is exempt by design. With the file gone they fatal to stderr, the
+# substitution yields the empty string, `[ -n "$hits" ]` is false, `fail` stays 0 — and the closing
+# line still states that no issue/PR numbers were found in pithead output. Nothing downstream
+# consumes stderr: the make target, the CI step and a local run all decide on the exit code alone.
+# Same false green as the empty enumeration above, reached from a missing target rather than an
+# empty list (issue #1434).
+enforce_scan_target_present() { # <path>
+    [ -f "$1" ] && return 0
+    echo "operator strings: the file this linter scans is not here: $1" >&2
+    echo "A missing target and a clean scan both report zero hits — refusing to call either a pass." >&2
+    echo "Run this from the repo root; if the CLI moved, update the path in this script." >&2
+    return 1
+}
+
 # --- self-test: prove the scanners catch a planted #NNN and skip the tricky exemptions ----------
 if [ "${1:-}" = "--self-test" ]; then
     tmp=$(mktemp -d)
@@ -200,6 +216,34 @@ if [ "${1:-}" = "--self-test" ]; then
         st_fail=1
     fi
 
+    if enforce_scan_target_present "$tmp/absent" 2>/dev/null; then
+        echo "  self-test FAIL: a missing scan target was accepted"
+        st_fail=1
+    else echo "  self-test ok: a missing scan target is refused"; fi
+    if enforce_scan_target_present "$tmp/hit.sh"; then
+        echo "  self-test ok: a present scan target is accepted"
+    else
+        echo "  self-test FAIL: a present scan target was refused"
+        st_fail=1
+    fi
+
+    # Same reasoning as the wire test above, for the pithead legs: the two rows immediately above
+    # prove the FUNCTION, and only this one proves the CALL SITE. Scored on the printed refusal
+    # rather than on the exit code, because a script that dies anonymously also exits non-zero — an
+    # rc-only assertion here would pass a "fix" that never prints anything an operator can act on.
+    # Delete the `enforce_scan_target_present pithead` line and every row above still passes while
+    # the real invocation goes back to reporting a clean CLI it never opened.
+    bare="$tmp/bare"
+    mkdir -p "$bare"
+    (cd "$bare" && git init -q .) >/dev/null 2>&1
+    bare_out=$(cd "$bare" && bash "$self" 2>&1 </dev/null) && bare_rc=0 || bare_rc=$?
+    if [ "$bare_rc" -ne 0 ] && printf '%s\n' "$bare_out" | grep -q 'the file this linter scans is not here'; then
+        echo "  self-test ok: the real invocation refuses a missing pithead"
+    else
+        echo "  self-test FAIL: the real invocation accepted a missing pithead (rc=$bare_rc)"
+        st_fail=1
+    fi
+
     [ "$st_fail" -eq 0 ] && {
         echo "lint-operator-strings self-test OK"
         exit 0
@@ -209,6 +253,11 @@ if [ "${1:-}" = "--self-test" ]; then
 fi
 
 fail=0
+
+# THIS REFUSAL MUST STAY ABOVE BOTH pithead legs. Folding it into either `if` condition below puts
+# it back inside the very errexit exemption that caused the defect, and moving it after the scans
+# lets a missing CLI read as a clean one for the length of the run.
+enforce_scan_target_present pithead || exit 1
 
 if
     hits=$(scan_pithead pithead)

--- a/scripts/lint-operator-strings.sh
+++ b/scripts/lint-operator-strings.sh
@@ -126,8 +126,8 @@ enforce_nonempty_frontend() { # <newline-separated file list>
 # Same false green as the empty enumeration above, reached from a missing target rather than an
 # empty list (issue #1434).
 enforce_scan_target_present() { # <path>
-    [ -f "$1" ] && return 0
-    echo "operator strings: the file this linter scans is not here: $1" >&2
+    [ -r "$1" ] && return 0
+    echo "operator strings: the file this linter scans cannot be read: $1" >&2
     echo "A missing target and a clean scan both report zero hits — refusing to call either a pass." >&2
     echo "Run this from the repo root; if the CLI moved, update the path in this script." >&2
     return 1
@@ -226,6 +226,19 @@ if [ "${1:-}" = "--self-test" ]; then
         echo "  self-test FAIL: a present scan target was refused"
         st_fail=1
     fi
+    # A target that exists but cannot be read reproduces the same false green as a missing one, which
+    # is why the check is `-r` and not `-f`. The staging can fail on its own terms — a user that
+    # bypasses file permissions cannot make a file unreadable to itself — so the row says it skipped
+    # rather than reporting a pass it did not earn.
+    unread="$tmp/unreadable"
+    : >"$unread"
+    chmod 000 "$unread"
+    if [ -r "$unread" ]; then
+        echo "  self-test skipped: this user bypasses file permissions, so an unreadable target cannot be staged"
+    elif enforce_scan_target_present "$unread" 2>/dev/null; then
+        echo "  self-test FAIL: an unreadable scan target was accepted"
+        st_fail=1
+    else echo "  self-test ok: an unreadable scan target is refused"; fi
 
     # Same reasoning as the wire test above, for the pithead legs: the two rows immediately above
     # prove the FUNCTION, and only this one proves the CALL SITE. Scored on the printed refusal
@@ -233,11 +246,19 @@ if [ "${1:-}" = "--self-test" ]; then
     # rc-only assertion here would pass a "fix" that never prints anything an operator can act on.
     # Delete the `enforce_scan_target_present pithead` line and every row above still passes while
     # the real invocation goes back to reporting a clean CLI it never opened.
+    # The fixture needs a NON-EMPTY frontend, and that is the whole point of it. Without one, the
+    # row's two conjuncts come from unlinked mechanisms: the message from this function, and the
+    # non-zero rc from `enforce_nonempty_frontend`, which refuses a checkout that has no frontend
+    # either. Both then survive a call site mutated to `|| true` or folded into the `if` below — the
+    # original defect, fully restored, with every row here still printing ok. With a frontend
+    # present, the pithead guard is the only thing that can make this run non-zero. Do not "simplify"
+    # this fixture back to a bare `git init`.
     bare="$tmp/bare"
-    mkdir -p "$bare"
-    (cd "$bare" && git init -q .) >/dev/null 2>&1
+    mkdir -p "$bare/dashboard/mining_dashboard/web/static"
+    printf '%s\n' 'const t = "clean";' >"$bare/dashboard/mining_dashboard/web/static/app.mjs"
+    (cd "$bare" && git init -q . && git add -A) >/dev/null 2>&1
     bare_out=$(cd "$bare" && bash "$self" 2>&1 </dev/null) && bare_rc=0 || bare_rc=$?
-    if [ "$bare_rc" -ne 0 ] && printf '%s\n' "$bare_out" | grep -q 'the file this linter scans is not here'; then
+    if [ "$bare_rc" -ne 0 ] && printf '%s\n' "$bare_out" | grep -q 'the file this linter scans cannot be read'; then
         echo "  self-test ok: the real invocation refuses a missing pithead"
     else
         echo "  self-test FAIL: the real invocation accepted a missing pithead (rc=$bare_rc)"
@@ -254,9 +275,11 @@ fi
 
 fail=0
 
-# THIS REFUSAL MUST STAY ABOVE BOTH pithead legs. Folding it into either `if` condition below puts
-# it back inside the very errexit exemption that caused the defect, and moving it after the scans
-# lets a missing CLI read as a clean one for the length of the run.
+# THIS REFUSAL MUST STAY ABOVE BOTH pithead legs, and the self-test enforces it rather than merely
+# asking. Folding it into either `if` condition below puts it back inside the errexit exemption that
+# caused the defect, and returns rc 0 with the closing OK line — the original defect intact. Moving
+# it down is milder but still wrong: below the scans it still refuses, after two fail-open scans and
+# six stderr fatals nothing reads; below the closing echo it stops mattering at all.
 enforce_scan_target_present pithead || exit 1
 
 if


### PR DESCRIPTION
Closes #1434.

The third fail-open leg in `scripts/lint-operator-strings.sh`, and the last one: both `pithead` legs reported the CLI clean when the CLI was not there to scan.

## The shape

`scan_pithead` and `scan_pithead_docs` each end in grep and awk over a literal path, and each call sits in an `if` condition — where errexit is exempt by design. With the file gone they fatal to **stderr**, the substitution yields the empty string, `[ -n "$hits" ]` is false, `fail` stays 0, and the script reaches its closing line, which states that no issue/PR numbers were found in pithead output. Nothing downstream consumes stderr: the make target, the CI step and a local run all decide on the exit code alone.

## Measured at this head, control first

I re-derived the anchors and the runtime behaviour myself rather than taking the report's word for either. The `:214`/`:223` anchors are exactly where the issue put them.

| | rc | last line |
|---|---|---|
| intact tree | 0 | `operator strings OK — …` |
| `pithead` renamed away, **before** | 0 | `operator strings OK — …` |
| `pithead` renamed away, **after** | 1 | `operator strings: the file this linter scans is not here: pithead` |

The intact-tree row is the control: it is what makes the first two rows indistinguishable to anything downstream, rather than merely quiet. One correction to the report — the renamed run prints **six** stderr diagnostics, not five (four `grep:`, two `awk:`); two legs × one grep-pair-plus-awk each. Nothing reads them either way.

## The fix

`enforce_scan_target_present` mirrors `enforce_nonempty_frontend` rather than inventing a third pattern. Its call sits **above both legs**: folding it into either `if` condition puts it back inside the errexit exemption that caused the defect, and returns rc 0 with the closing OK line — the original defect intact.

The check is `[ -r ]`, not `[ -f ]`: a `pithead` that exists but cannot be read reproduces #1434 exactly (`chmod 000 pithead` gives rc 0 and the OK line, after six `Permission denied` diagnostics nothing consumes), so the refusal says "cannot be read", which is true of both cases.

## Why the self-test is scored on the message, not the exit code

Three rows. The two direct rows prove the *function*; only the wire row proves the script *calls* it. Both mutants were run:

- **Delete the call site, function intact** → the wire row FAILS. Note it still exits **1**, because a checkout with no `pithead` also has no frontend to enumerate, so the frontend refusal fires instead. **An rc-only assertion passes this mutant.**
- **Keep the call site, silence the three refusal echoes** → the wire row FAILS while the direct row still passes. An rc-only assertion passes this one too.

That is the standing lesson from the two sibling fixes: the correct fix and the broken one both exit non-zero, and only the printed text separates them.

## Scope

`pithead` is the only hard-coded scan target left in the script — the frontend enumeration is dynamic and already guarded — so the sweep the issue invites is complete within this file at two legs and one target. Nothing outside `scripts/lint-operator-strings.sh` is touched, so no `.lane-override` is needed and the lane guard passed on its own (controlled: staging an out-of-lane file is refused).

`shellcheck --severity=warning` (0.11.0, the CI-pinned engine) and `shfmt -i 4 -d` are both clean on the file. The script has no `docs/dev/file-budget.tsv` row, so the budget gate is untouched.

Note the base is `develop-v2`, which is not the default branch, so the closing keyword above will not fire on merge — the issue gets closed by hand.

## Over-engineering pass

Everything here is authored, so the whole diff was in scope.

**The one real question: a function, or the inline refusal the issue proposed?** The issue's fix shape was a single `[ -f pithead ] || { echo …; exit 1; }` — about five lines against this change's fourteen, and it would drop the two direct self-test rows as well. I took the function anyway, for two reasons I can defend: the script now has two guards of the same kind, and they should look alike, so a third has a shape to copy rather than a third pattern to invent; and a function is directly testable, where an inline refusal is only reachable through the whole-script wire test. If a reviewer weighs the symmetry cheaper than the eighteen lines, this is the place to say so.

**What I did trim to:** three refusal lines, matching `enforce_nonempty_frontend` exactly rather than picking a new length. No count of anything and no line number in any string, so nothing here goes stale on the next cut.

**The row I nearly cut and kept: "a present scan target is accepted."** It looks like a tautology next to the refusal row. It is not — it is the guard against a guard that refuses everything, which is a failure this repo has actually shipped before. It costs one line and it fails loudly if the `[ -f "$1" ] && return 0` short-circuit is ever inverted.

---

## Corrections after non-author review (`0a7f4b3`)

**A claim in an earlier version of this body was falsified and is withdrawn.** It said that moving the refusal below the scans "lets a missing CLI read as a clean one for the length of the run." It does not: moved below both legs the script still exits 1 with the full refusal, after two fail-open scans and six stderr fatals nothing reads. Untidy, not a false green. The genuinely harmful placements are inside an `if` condition and below the closing `echo`, and the comment above the call site now says that instead.

**The self-test had a hole, and it was in the row I argued hardest for.** Two mutants restored the defect in full — rc 0 *and* the closing OK line — while every row, wire row included, still printed ok:

- the call site changed to `|| true`
- the call folded into the first `if` — the exact mutation the comment above it forbids

The cause was the fixture, not the guard. In a bare `git init` the wire row's two conjuncts came from unlinked mechanisms: the message from the function, and the non-zero rc from `enforce_nonempty_frontend`, because a checkout with no `pithead` has no frontend either. So the comment was a correct rule with nothing enforcing it — in the script whose whole purpose is to refuse that shape.

The fixture now commits a frontend file, so the pithead guard is the only thing that can make that run non-zero. Full battery, each mutant in a fresh copy:

| mutant | restores the defect? | self-test |
|---|---|---|
| delete the call site | yes — rc 0 + OK line | KILLED |
| silence the refusal's echoes | no — rc 1, no message | KILLED |
| call site → `\|\| true` | **yes** — rc 0 + OK line | **KILLED** (was ESCAPED) |
| fold the call into the `if` | **yes** — rc 0 + OK line | **KILLED** (was ESCAPED) |
| move the call below both legs | no — rc 1, refuses | escapes, correctly |

The last row is deliberate: that mutant is untidy, not a false green, so the self-test is right not to fail on it.

**Scope, restated honestly.** The in-file claim holds — `pithead` is the only hard-coded scan target left here. The *cross-file* sweep does not, and the review said so: `scripts/lint-docs-voice.sh` codes the same false green as a deliberate `exit 0` when its enumeration is empty. That file is outside this lane's grant, so it is filed as #1441 with its own control rather than folded into this diff.
