### PR TITLE
test(e2e): count and name every skip, so the verdict can say what did not run (#1365)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -473,6 +473,34 @@ On a scenario failure, the harness captures (redacted) to `results/<scenario>/`:
 `api-state.json`, and `logs.txt` (last 200 lines per service). The end-of-run summary lists
 each failed assertion and points at these.
 
+### Reading the verdict — what did not run
+
+The summary counts three kinds of skip separately and names every one:
+
+```
+passed:  312
+skipped: 2 scenarios, 1 phases, 4 legs
+did NOT run:
+    - scenario prune-remote — no pruned chain supplied
+    - PHASE    rigforge-control — no worker exposes a RigForge enriched feed
+    - leg      pools write (#1002b) — no IT_RIG_POOLS_PROBE
+```
+
+A scenario skip drops one matrix row; a phase skip drops every leg under it with one line; a leg
+skip drops one assertion group. They stay in separate buckets because they are not the same size
+of hole, and a phase drop announces itself more loudly in the live output.
+
+Until [#1365](https://github.com/p2pool-starter-stack/pithead/issues/1365) only the scenario
+skips were counted. A run that dropped the whole rigforge-control phase and a run that exercised
+it produced summaries differing by nothing but the pass count, and the pass count moves for a
+dozen unrelated reasons. The output had no way to say a surface had not run, which leaves the
+reader unable to tell "checked and clean" from "never ran" — the distinction the gate exists to
+make.
+
+Every skip leaves through `it_skip_scenario`, `it_skip_phase` or `it_skip_leg`
+(`tests/integration/skip-accounting.sh`). Plain `it_warn` stays for warnings that are not a
+dropped check.
+
 ---
 
 ## The self-test (CI)
@@ -482,6 +510,11 @@ rendering and value typing, expectation derivation (profile gating), secret reda
 SSH/local exec wrapper, JSON parsing, and matrix axis coverage. It runs in CI on every PR (the
 `shell` job) and via `make test-integration-selftest`, so the harness itself is held to the
 same lint/test standard as the rest of the stack.
+
+Several self-tests sit beside it as standalone files, picked up by the same globbed target.
+`selftest-skip-accounting.sh` is the one that keeps the skip accounting honest: besides checking
+the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
+through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
 
 ---
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -44,11 +44,19 @@ redact() {
 }
 
 # --- Assertions -------------------------------------------------------------
-# Counters are global so the runner can total them across scenarios.
+# Counters are global so the runner can total them across scenarios. The skip buckets and the
+# three helpers that move them live next door; sourced here so anything that has lib.sh has them.
+# Fail CLOSED: sourced as a bare name this resolves to "lib.sh/skip-accounting.sh", and a
+# harness that merely warns would then miscount every skip in silence — the exact defect below.
+# shellcheck source=tests/integration/skip-accounting.sh
+source "${BASH_SOURCE[0]%/*}/skip-accounting.sh" ||
+    {
+        echo "lib.sh: skip-accounting.sh must sit beside it (source lib.sh by a path, not a bare name)" >&2
+        exit 1
+    }
 IT_PASS=0
 IT_FAIL=0
 IT_FAILED_NAMES=""
-
 it_pass() {
     IT_PASS=$((IT_PASS + 1))
     printf '    %b✓%b %s\n' "$IT_GREEN" "$IT_RESET" "$1"
@@ -600,21 +608,6 @@ wait_monero_synced() { wait_for "${1:-300}" 10 "Monero sync complete" _pred_mone
 wait_miner_running() { wait_for "${1:-180}" 5 "miner released" _pred_miner_running; }
 wait_tari_synced() { wait_for "${1:-300}" 10 "Tari sync complete" _pred_tari_synced; }
 wait_pool_ready() { wait_for "${1:-180}" 5 "pool type determinate (${2})" _pred_pool_ready "$2"; }
-
-# Mining-liveness verdict (#905/#1082), factored out of assert_running_state so selftest can
-# prove --no-mining-asserts is a CONDITIONAL skip, not a permanent one: the two assertions must
-# still run — and be able to go red — every time the flag is unset. Only the caller-set skip
-# flag suppresses them; there is no auto-detection here (a live worker-count of zero from a
-# genuinely fallen-off rig must stay indistinguishable from a parked bench unless the operator
-# says so explicitly — see #1082's fail-open discussion).
-assert_mining_state() { # <skip: 0|1> <workers> <hashes> <expected-workers>
-    if [ "$1" = "1" ]; then
-        it_warn "SKIPPED workers online + stratum total hashes: no miner attached to this box (--no-mining-asserts) — drop the flag (and attach a miner) to make these binding again (#905/#1082)"
-        return 0
-    fi
-    assert_num_ge "workers online (>= $4)" "${2:-0}" "$4"
-    assert_num_gt "stratum total hashes > 0" "${3:-0}" 0
-}
 
 # Ground truth for the sidechain axis (#746): the rendered P2POOL_FLAGS in the box's .env carry
 # --mini / --nano (main carries neither). The dashboard classifies the sidechain by counting

--- a/tests/integration/rigforge-writable-keys.sh
+++ b/tests/integration/rigforge-writable-keys.sh
@@ -123,7 +123,7 @@ run_rigforge_writable_keys() { # <rig>
     it_log "   #1236: autotune and watchdog are deliberately NOT driven (a real tuning run; and dropping thermal protection on a rig at its temperature ceiling), and pools is never derived from the rig's own read (credential-stripped, #113) — see docs/dev/integration-testing.md"
     detail="$(_worker_detail "$rig")"
     if ! printf '%s' "$detail" | jq -e '(.rig_config | type) == "object"' >/dev/null 2>&1; then
-        it_warn "rig '$rig' reports no writable config (.rig_config is null — 'could not read', or a RigForge older than v1.10.0/rigforge#253) — skipping the writable-key legs (#1236)"
+        it_skip_phase "rigforge writable-key legs (#1236)" "rig '$rig' reports no writable config (.rig_config is null — 'could not read', or a RigForge older than v1.10.0/rigforge#253)"
         return 0
     fi
 
@@ -132,7 +132,7 @@ run_rigforge_writable_keys() { # <rig>
     # is RigForge's own default. Bounds are 0-100 (rigforge.sh:406), so both directions are valid.
     orig="$(_rig_config_key "$detail" DONATION)"
     if [ -z "$orig" ]; then
-        it_warn "rig '$rig' reports no DONATION in its writable config — skipping that leg (can't read the original to restore it) (#1236)"
+        it_skip_leg "DONATION write (#1236)" "rig '$rig' reports no DONATION in its writable config — can't read the original to restore it"
     elif ! printf '%s' "$orig" | grep -qE '^[0-9]+$'; then
         it_fail "the rig's reported DONATION is a number (#1236)" "got [$orig]"
     else
@@ -146,7 +146,7 @@ run_rigforge_writable_keys() { # <rig>
     # (rigforge.sh:556); step away from whichever end we are on so the probe is always in range.
     orig="$(_rig_config_key "$detail" watchdog_interval_min)"
     if [ -z "$orig" ]; then
-        it_warn "rig '$rig' reports no watchdog_interval_min in its writable config — skipping that leg (can't read the original to restore it) (#1236)"
+        it_skip_leg "watchdog_interval_min write (#1236)" "rig '$rig' reports no watchdog_interval_min in its writable config — can't read the original to restore it"
     elif ! printf '%s' "$orig" | grep -qE '^[0-9]+$' || [ "$orig" -lt 1 ] || [ "$orig" -gt 1440 ]; then
         it_fail "the rig's reported watchdog_interval_min is in RigForge's 1-1440 range (#1236)" "got [$orig]"
     else
@@ -166,7 +166,7 @@ run_rigforge_writable_keys() { # <rig>
 run_rigforge_pools() { # <rig>
     local rig="$1" orig_pools res status ckeys
     if [ -z "${IT_RIG_POOLS_PROBE:-}" ]; then
-        it_warn "no IT_RIG_POOLS_PROBE (a JSON pools value safe to apply to rig '$rig') — skipping the pools write leg (#1002b)"
+        it_skip_leg "pools write (#1002b)" "no IT_RIG_POOLS_PROBE (a JSON pools value safe to apply to rig '$rig')"
         return 0
     fi
     if ! printf '%s' "${IT_RIG_POOLS_PROBE:-}" | jq -e . >/dev/null 2>&1; then
@@ -175,7 +175,7 @@ run_rigforge_pools() { # <rig>
     fi
     orig_pools="$(_worker_detail "$rig" | jq -c '.last_applied.pools // empty' 2>/dev/null)"
     if [ -z "$orig_pools" ]; then
-        it_warn "rig '$rig' has no dashboard-applied pools on record (.last_applied.pools) — skipping the pools write leg (can't read a restorable original; the rig's own .rig_config.pools is credential-stripped and must not be written back) (#1002b)"
+        it_skip_leg "pools write (#1002b)" "rig '$rig' has no dashboard-applied pools on record (.last_applied.pools) — can't read a restorable original; the rig's own .rig_config.pools is credential-stripped and must not be written back"
         return 0
     fi
     it_step "Worker Inspect edit: pools -> the operator-supplied probe via /api/control/worker-apply…"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -634,7 +634,7 @@ assert_running_state() {
     #    timeout.
     if [ "$SKIP_MINING_ASSERTS" = "1" ]; then
         # #905: no miner is connected on purpose (e2e --no-miner), so a live worker/hash count
-        # would fail a healthy stack. assert_mining_state (lib.sh) skips these two loudly; every
+        # would fail a healthy stack. assert_mining_state (skip-accounting.sh) skips these two loudly; every
         # other assertion in the scenario stays binding.
         assert_mining_state "1" "" "" "$EXPECTED_WORKERS"
     else

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -435,8 +435,7 @@ run_scenario() {
     it_log "── scenario: ${name} ───────────────────────────────"
 
     if ! resolve_overrides "$overrides"; then
-        it_warn "SKIPPED ${name}: ${SKIP_REASON}"
-        IT_SKIPPED=$((IT_SKIPPED + 1))
+        it_skip_scenario "$name" "$SKIP_REASON"
         return 0
     fi
 
@@ -892,7 +891,7 @@ assert_metrics_via_caddy() {
     local host secure scheme port curl_auth="" body
     host="$(env_on_box HOST_IP)"
     if [ -z "$host" ]; then
-        it_warn "skipping /metrics-via-Caddy (no HOST_IP in .env)"
+        it_skip_leg "/metrics via Caddy" "no HOST_IP in .env"
         return 0
     fi
     secure="$(env_on_box DASHBOARD_SECURE)"
@@ -908,7 +907,7 @@ assert_metrics_via_caddy() {
     fi
     if [ -n "$(env_on_box DASHBOARD_AUTH_HASH_B64)" ]; then
         if [ -z "${IT_DASHBOARD_PASSWORD:-}" ]; then
-            it_warn "skipping /metrics-via-Caddy (dashboard login is set — export IT_DASHBOARD_PASSWORD to test through it)"
+            it_skip_leg "/metrics via Caddy" "dashboard login is set — export IT_DASHBOARD_PASSWORD to test through it"
             return 0
         fi
         curl_auth="-u $(quote_arg "$(env_on_box DASHBOARD_AUTH_USER):$IT_DASHBOARD_PASSWORD")"
@@ -1164,7 +1163,7 @@ run_lifecycle() {
         pithead status >/dev/null 2>&1
         assert_rc "status OK after node recovery" "$?" "0"
     else
-        it_warn "skipping node-down failover (remote mode: no local monerod to stop)"
+        it_skip_leg "node-down failover" "remote mode: no local monerod to stop"
     fi
 
     # backup → restore round-trip (#102): a backup archives config/.env/onions/dashboard; a
@@ -1278,7 +1277,7 @@ fault_db_readonly() {
     local ddir
     ddir="$(env_on_box DASHBOARD_DATA_DIR)"
     if [ -z "$ddir" ]; then
-        it_warn "skipping db-readonly fault (no DASHBOARD_DATA_DIR in .env)"
+        it_skip_leg "db-readonly fault" "no DASHBOARD_DATA_DIR in .env"
         return 0
     fi
     it_step "fault: make the dashboard data dir read-only (#131/#202)…"
@@ -1308,7 +1307,7 @@ fault_db_readonly() {
 # run_fault_injection's belt-and-braces) reinstate it — hence opt-in, local-box only.
 fault_firewall_rollback() {
     if [ "$(env_on_box TOR_EGRESS_FIREWALL)" = "false" ]; then
-        it_warn "skipping firewall-rollback fault (network.tor_egress_firewall=false)"
+        it_skip_leg "firewall-rollback fault" "network.tor_egress_firewall=false"
         return 0
     fi
     it_step "fault: force an iptables -I failure during the firewall apply…"
@@ -1408,12 +1407,12 @@ fault_disk_enospc() {
     local ddir
     ddir="$(env_on_box DASHBOARD_DATA_DIR)"
     if [ -z "$ddir" ]; then
-        it_warn "skipping ENOSPC fault (no DASHBOARD_DATA_DIR in .env)"
+        it_skip_leg "ENOSPC fault" "no DASHBOARD_DATA_DIR in .env"
         return 0
     fi
     it_step "fault: mount a 1MiB tmpfs over the dashboard data dir and fill it (real ENOSPC, #383)…"
     if ! rx "sudo mount -t tmpfs -o size=1m,uid=1000,gid=1000 tmpfs $(quote_arg "$ddir")" >/dev/null 2>&1; then
-        it_warn "could not mount a tmpfs over the data dir (no root / tmpfs support?) — skipping the ENOSPC fault"
+        it_skip_leg "ENOSPC fault" "could not mount a tmpfs over the data dir (no root / tmpfs support?)"
         return 0
     fi
     rx "dd if=/dev/zero of=$(quote_arg "$ddir/.itest-fill") bs=1M count=4 >/dev/null 2>&1" >/dev/null 2>&1 || true
@@ -1435,7 +1434,7 @@ run_fault_injection() {
     echo ""
     it_log "── fault-injection phase ───────────────────────────"
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_warn "skipping fault injection (remote mode: no local monerod to break)"
+        it_skip_phase "fault-injection" "remote mode: no local monerod to break"
         return 0
     fi
 
@@ -1596,7 +1595,7 @@ run_hardening() {
     it_log "── v1.4 hardening phase (#377/#33/#424) ────────────"
 
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_warn "skipping hardening phase (remote mode: no local containers/systemd to exercise)"
+        it_skip_phase "hardening" "remote mode: no local containers/systemd to exercise"
         return 0
     fi
 
@@ -1629,14 +1628,14 @@ run_hardening() {
     #    stays with the doctor egress check, which is the stack self-checking its own egress.)
     local pre_onion=0
     if [ "$(env_on_box DASHBOARD_ONION_ADDRESS)" = "placeholder" ] || [ -z "$(env_on_box DASHBOARD_ONION_ADDRESS)" ]; then
-        it_warn "dashboard onion not provisioned on this box — skipping the external-reachability checks (#424/#343)"
+        it_skip_leg "dashboard onion external reachability (#424/#343)" "onion not provisioned on this box"
     else
         it_step "external Tor client: reach the dashboard onion before the restart (baseline)…"
         _onion_reachable_external && pre_onion=1
         if [ "$pre_onion" = "1" ]; then
             it_pass "dashboard onion reachable from an independent external Tor client (#343/#360)"
         else
-            it_warn "dashboard onion not reachable from outside before the restart (live Tor network) — can't prove recovery, skipping the post-restart check (#424)"
+            it_skip_leg "dashboard onion post-restart recovery (#424)" "onion not reachable from outside before the restart (live Tor network) — can't prove recovery"
         fi
         it_step "restart tor (the #424 heal action)…"
         pithead restart tor >/dev/null 2>&1
@@ -1681,7 +1680,7 @@ run_hardening() {
     local cdir
     cdir="$(env_on_box CONTROL_DIR)"
     if [ -z "$cdir" ]; then
-        it_warn "CONTROL_DIR not set on the box — skipping the spool round-trips"
+        it_skip_leg "control spool round-trips" "CONTROL_DIR not set on the box"
     else
         # 3a. A NON-sensitive change (an allowlisted alert toggle) committed via the spool must be
         #     applied BY THE PATH UNIT — not by us calling control-run-pending.
@@ -1761,7 +1760,7 @@ run_auth_fail_closed() {
     local orig
     orig="$(env_on_box PROXY_AUTH_TOKEN)"
     if [ -z "$orig" ]; then
-        it_warn "skipping: PROXY_AUTH_TOKEN already empty on the box (run 'pithead setup'/'apply' first)"
+        it_skip_leg "proxy auth fail-closed" "PROXY_AUTH_TOKEN already empty on the box (run 'pithead setup'/'apply' first)"
         return 0
     fi
 
@@ -1858,7 +1857,15 @@ summary() {
     echo ""
     it_log "════════════════ summary ════════════════"
     it_log "passed:  $IT_PASS"
-    it_log "skipped: $IT_SKIPPED"
+    it_log "skipped: $IT_SKIPPED scenarios, $IT_SKIPPED_PHASES phases, $IT_SKIPPED_LEGS legs"
+    # Name what did not run (#1365). The count says how big the hole is; only the names say
+    # where it is, and a summary that cannot distinguish "checked and clean" from "never ran"
+    # is not a verdict. Goes to stderr with the other warnings so a log split by stream keeps
+    # the omissions next to the reasons that caused them.
+    if [ -n "$IT_SKIPPED_NAMES" ]; then
+        it_warn "did NOT run:"
+        echo -e "$IT_SKIPPED_NAMES" >&2
+    fi
     if [ "$IT_FAIL" -gt 0 ]; then
         it_err "failed:  $IT_FAIL"
         echo -e "$IT_FAILED_NAMES" >&2
@@ -1888,14 +1895,14 @@ run_rigforge_integration() {
     local st rig
     st="$(api_state)"
     if [ -z "$st" ]; then
-        it_warn "rigforge-integration: /api/state unreachable — skipping"
+        it_skip_phase "rigforge-integration" "/api/state unreachable"
         return 0
     fi
     # A worker whose enriched rigforge block is present (version populated) = a real RigForge rig
     # whose sister API the dashboard reached and parse_rigforge parsed (#235).
     rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
     if [ -z "$rig" ]; then
-        it_warn "no worker exposes a RigForge enriched feed (a real rigforge rig with api:enabled on :8081?) — enriched-feed consumption not asserted here; the parse contract is covered by the tier-2 test"
+        it_skip_phase "rigforge-integration" "no worker exposes a RigForge enriched feed (a real rigforge rig with api:enabled on :8081?); the parse contract is covered by the tier-2 test"
         return 0
     fi
     it_pass "dashboard consumed a real RigForge rig's enriched feed: $rig (#235)"
@@ -1912,7 +1919,7 @@ run_rigforge_integration() {
     #    exists when dashboard.control is on. Off here → the enriched-feed leg above still proves
     #    #235/#260; the control path itself is covered by the hardening phase + the tier-2 test.
     if [ "$(printf '%s' "$st" | jq -r '.control_enabled // false' 2>/dev/null)" != "true" ]; then
-        it_warn "dashboard.control off — Worker Inspect (#185) read/write not exposed here (covered by the hardening phase + tier-2 contract); enriched-feed consumption validated"
+        it_skip_leg "Worker Inspect read/write (#185)" "dashboard.control off — not exposed here (covered by the hardening phase + tier-2 contract); enriched-feed consumption validated"
         return 0
     fi
 
@@ -2013,11 +2020,11 @@ run_subnet_scenario() {
     it_log "── moved-subnet phase (#201/#180) ──────────────────"
 
     if [ "$IT_MODE" != "local" ]; then
-        it_warn "skipping moved-subnet phase (needs local mode: it brings the stack down/up and inspects the live docker network)"
+        it_skip_phase "moved-subnet" "needs local mode: it brings the stack down/up and inspects the live docker network"
         return 0
     fi
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_warn "skipping moved-subnet phase (remote mode: monerod's moved-prefix proxy is one of the named checks)"
+        it_skip_phase "moved-subnet" "remote mode: monerod's moved-prefix proxy is one of the named checks"
         return 0
     fi
 
@@ -2108,11 +2115,11 @@ run_rigforge_control() {
     it_log "── RigForge control phase (#513/#514/#516/#517) ────"
 
     if [ "$IT_MODE" != "local" ]; then
-        it_warn "skipping rigforge-control (needs local mode: it edits config.json + dials the rig on the mining LAN)"
+        it_skip_phase "rigforge-control" "needs local mode: it edits config.json + dials the rig on the mining LAN"
         return 0
     fi
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_warn "skipping rigforge-control (remote mode: no local dashboard container to drive)"
+        it_skip_phase "rigforge-control" "remote mode: no local dashboard container to drive"
         return 0
     fi
 
@@ -2121,7 +2128,7 @@ run_rigforge_control() {
     st="$(api_state)"
     rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
     if [ -z "$rig" ]; then
-        it_warn "no worker exposes a RigForge enriched feed — the write paths need a real rig with its :8081 API on; skipping (#513/#514/#516/#517)"
+        it_skip_phase "rigforge-control" "no worker exposes a RigForge enriched feed — the write paths need a real rig with its :8081 API on (#513/#514/#516/#517)"
         return 0
     fi
 
@@ -2137,7 +2144,7 @@ run_rigforge_control() {
         if [ -n "$RIG_HOST" ] && [ -n "${IT_RIG_TOKEN:-}" ]; then
             inject=1
         else
-            it_warn "rig '$rig' has no workers.list[] (or legacy dashboard.workers[]) descriptor and no --rig-host + IT_RIG_TOKEN to inject one — skipping the write paths (#513/#514/#516/#517)"
+            it_skip_phase "rigforge-control" "rig '$rig' has no workers.list[] (or legacy dashboard.workers[]) descriptor and no --rig-host + IT_RIG_TOKEN to inject one (#513/#514/#516/#517)"
             return 0
         fi
     fi
@@ -2204,7 +2211,7 @@ run_rigforge_control() {
     local orig_maxt new_maxt res status ckeys change_id
     orig_maxt="$(printf '%s' "$st" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .rigforge.stats[]? | select(.label=="Temp / max") | .value) // empty' 2>/dev/null | sed -n 's#.*/ *\([0-9][0-9]*\).*#\1#p')"
     if [ -z "$orig_maxt" ]; then
-        it_warn "rig '$rig' watchdog isn't reporting a max_temp_c in the feed — skipping the reversible write leg (can't read the original to restore it) (#513)"
+        it_skip_leg "reversible write, max_temp_c (#513)" "rig '$rig' watchdog isn't reporting a max_temp_c in the feed — can't read the original to restore it"
     else
         new_maxt=$((orig_maxt + 1))
         it_step "Worker Inspect edit: max_temp_c $orig_maxt -> $new_maxt via /api/control/worker-apply…"
@@ -2289,18 +2296,18 @@ run_rigforge_reverse() { # <rig-name> <orig-max_temp_c-or-empty>
         assert_eq "config.json hand-edit shows up in the masked prefill (#516 render_masked_config claim)" \
             "$(rx "cat $(quote_arg "$cdir/masked/config.json") 2>/dev/null" | jq -r --arg n "$rig" 'first((.workers.list // .dashboard.workers // [])[] | select(.name==$n) | .watts) // empty' 2>/dev/null)" "$probe_watts"
     else
-        it_warn "CONTROL_DIR not set — skipping the masked-prefill leg of #516"
+        it_skip_leg "masked prefill (#516)" "CONTROL_DIR not set"
     fi
 
     # Feed leg (needs the raw token to dial the rig directly): change max_temp_c ON the rig via its
     # own control API, then assert the dashboard's enriched feed reflects it — the rig->dashboard
     # direction, independent of the dashboard write path.
     if [ -z "${IT_RIG_TOKEN:-}" ] || [ -z "$RIG_HOST" ]; then
-        it_warn "no IT_RIG_TOKEN + --rig-host to dial the rig directly — skipping the enriched-feed reflection leg of #516"
+        it_skip_leg "enriched-feed reflection (#516)" "no IT_RIG_TOKEN + --rig-host to dial the rig directly"
         return 0
     fi
     if [ -z "$orig_maxt" ]; then
-        it_warn "rig watchdog max_temp_c not visible in the feed — skipping the enriched-feed reflection leg of #516"
+        it_skip_leg "enriched-feed reflection (#516)" "rig watchdog max_temp_c not visible in the feed"
         return 0
     fi
     local reflect=$((orig_maxt + 2)) change_id
@@ -2361,7 +2368,7 @@ run_rigforge_rollback() { # <rig-name>
     local rig="$1" res status
     it_log "   #517: control-apply auto-rollback (rigforge#236)"
     if [ -z "${IT_RIG_ROLLBACK_CHANGES:-}" ]; then
-        it_warn "no IT_RIG_ROLLBACK_CHANGES (a writable-key change the rig's fault-injection rolls back) — skipping the auto-rollback leg (#517)"
+        it_skip_leg "control-apply auto-rollback (#517)" "no IT_RIG_ROLLBACK_CHANGES (a writable-key change the rig's fault-injection rolls back)"
         return 0
     fi
     if ! printf '%s' "$IT_RIG_ROLLBACK_CHANGES" | jq -e 'type == "object"' >/dev/null 2>&1; then
@@ -2423,7 +2430,7 @@ run_rigforge_upgrade() { # <rig-name>
     ver="$(printf '%s' "$(api_state)" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .rigforge.version) // empty' 2>/dev/null)"
     posted="v${ver#v}"
     if ! printf '%s' "$posted" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-        it_warn "rig '$rig' isn't reporting a clean vX.Y.Z version (got [$ver]) — skipping the upgrade leg (#1002a)"
+        it_skip_leg "rig upgrade (#1002a)" "rig '$rig' isn't reporting a clean vX.Y.Z version (got [$ver])"
         return 0
     fi
 
@@ -2449,7 +2456,6 @@ run_rigforge_upgrade() { # <rig-name>
 }
 
 # --- Main -------------------------------------------------------------------
-IT_SKIPPED=0
 
 main() {
     parse_args "$@"

--- a/tests/integration/selftest-skip-accounting.sh
+++ b/tests/integration/selftest-skip-accounting.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Self-test for the harness's skip accounting (#1365).
+#
+# The defect this locks down was an ABSENCE. The harness had exactly three counter increments —
+# IT_PASS, IT_FAIL, and the scenario skip — so every leg-level and phase-level drop incremented
+# nothing and appeared in no column. A run that dropped the entire rigforge-control phase and a
+# run that exercised it produced summaries differing only in the pass count, and the pass count
+# moves for a dozen unrelated reasons. Nothing in the output could say "this did not run", which
+# leaves a reader unable to tell "checked and clean" from "never ran" — the distinction a release
+# gate exists to make.
+#
+# Two halves, and the second is the one that keeps the fix alive:
+#   1. the counters and the named list behave (each helper moves its OWN bucket, records what and
+#      why), and the REAL summary() out of run.sh renders all three buckets and the names;
+#   2. a CENSUS of the shipped harness: no skip may go out through a bare `it_warn` again. That is
+#      the regression the fix was for — 34 sites had drifted in one at a time, each individually
+#      reasonable, and a test that only checked the helpers would stay green through every one of
+#      them coming back.
+#
+# Standalone (not sourced by selftest.sh) so it never touches selftest.sh's file-budget ceiling —
+# same reasoning as selftest-e2e-phases.sh. Run directly, or via `make test-integration-selftest`.
+# No server, no bench, no rig.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+RUN_SRC="$HERE/run.sh"
+
+# --- The helpers exist at all -----------------------------------------------------------------
+# Fail CLOSED. If a refactor renames or removes one, this file must go red rather than quietly
+# stop testing — a self-test whose subject evaporates is the same shape of lie it exists to catch.
+for fn in it_skip_scenario it_skip_phase it_skip_leg; do
+    assert_eq "lib.sh defines $fn" "$(type -t "$fn")" "function"
+done
+
+# --- Each helper moves its OWN bucket, and only its own ----------------------------------------
+# Run in a subshell with the warn output discarded: the subject here is the counters, not the text.
+counts() { # <helper> -> "<scenarios> <phases> <legs>"
+    (
+        "$1" "some-name" "some-reason" 2>/dev/null
+        printf '%s %s %s' "$IT_SKIPPED" "$IT_SKIPPED_PHASES" "$IT_SKIPPED_LEGS"
+    )
+}
+assert_eq "a scenario skip increments only the scenario bucket" "$(counts it_skip_scenario)" "1 0 0"
+assert_eq "a phase skip increments only the phase bucket" "$(counts it_skip_phase)" "0 1 0"
+assert_eq "a leg skip increments only the leg bucket" "$(counts it_skip_leg)" "0 0 1"
+
+# Mutation proof for the counting itself: a helper whose increment is removed must NOT still read
+# as counted. Without this the three assertions above would pass against a body that only warns.
+_mutated="$(
+    it_skip_leg() { _it_skip_record "leg     " "$1" "$2"; } # the increment, deliberately gone
+    it_skip_leg "some-name" "some-reason"
+    printf '%s' "$IT_SKIPPED_LEGS"
+)"
+assert_eq "an it_skip_leg with its increment removed counts 0 (mutation proof)" "$_mutated" "0"
+
+# --- Every skip is NAMED, with its reason ------------------------------------------------------
+# A bare count says how big the hole is and nothing about where. The names are the deliverable.
+_names="$(
+    it_skip_phase "rigforge-control" "no rig attached" 2>/dev/null
+    it_skip_leg "pools write (#1002b)" "no IT_RIG_POOLS_PROBE" 2>/dev/null
+    printf '%b' "$IT_SKIPPED_NAMES"
+)"
+assert_contains "the named list carries the phase name" "$_names" "rigforge-control"
+assert_contains "the named list carries the phase reason" "$_names" "no rig attached"
+assert_contains "the named list carries the leg name" "$_names" "pools write (#1002b)"
+assert_contains "the named list carries the leg reason" "$_names" "no IT_RIG_POOLS_PROBE"
+assert_contains "a phase drop is marked louder than a leg drop" "$_names" "PHASE"
+
+# The warn text a live run actually shows must say which kind of drop it was — the operator reads
+# the stream, not the summary, while the run is still going.
+_warned="$(
+    it_skip_phase "rigforge-control" "no rig attached" 2>&1
+    it_skip_leg "pools write (#1002b)" "no IT_RIG_POOLS_PROBE" 2>&1
+)"
+assert_contains "a phase drop announces itself as a whole phase" "$_warned" "SKIPPED WHOLE PHASE rigforge-control"
+assert_contains "a leg drop announces itself as one leg" "$_warned" "skipped leg pools write (#1002b)"
+
+# --- The REAL summary() out of run.sh renders all three buckets --------------------------------
+# Extracted rather than re-spelled: a re-implementation would pass happily while the shipped file
+# printed something else, which is precisely the class of green this lane exists to remove.
+SUMMARY_SRC="$(sed -n '/^summary() {$/,/^}$/p' "$RUN_SRC")"
+assert_eq "the extraction is the whole function (opens and closes)" \
+    "$(printf '%s\n' "$SUMMARY_SRC" | sed -n '1p;$p' | tr '\n' ' ')" "summary() { } "
+
+render_summary() { # -> summary output, both streams, with the given counters
+    (
+        eval "$SUMMARY_SRC"
+        # Read by the eval'd summary(), which shellcheck cannot see into.
+        # shellcheck disable=SC2034
+        OUT_DIR="/nonexistent"
+        # summary() reads the same globals this file's own assertions write, so a failure HERE
+        # would otherwise surface as a failure of the simulated run. Isolate the pass/fail state;
+        # the skip counters are what is under test and stay as the caller set them.
+        IT_FAIL=0
+        IT_FAILED_NAMES=""
+        summary 2>&1
+    )
+}
+
+_rendered="$(
+    {
+        it_skip_scenario "prune-remote" "no pruned chain supplied"
+        it_skip_phase "rigforge-control" "no rig attached"
+        it_skip_leg "pools write (#1002b)" "no IT_RIG_POOLS_PROBE"
+        it_skip_leg "rig upgrade (#1002a)" "rig reports no clean version"
+    } 2>/dev/null
+    IT_PASS=7
+    render_summary
+)"
+assert_contains "the summary reports all three buckets separately" "$_rendered" "skipped: 1 scenarios, 1 phases, 2 legs"
+assert_contains "the summary still reports the pass count" "$_rendered" "passed:  7"
+assert_contains "the summary lists what did NOT run" "$_rendered" "did NOT run:"
+assert_contains "the summary names the dropped phase" "$_rendered" "rigforge-control"
+assert_contains "the summary names a dropped leg" "$_rendered" "pools write (#1002b)"
+assert_contains "the summary names the second dropped leg" "$_rendered" "rig upgrade (#1002a)"
+
+# A clean run must not grow a hollow "did NOT run:" header with nothing under it.
+_clean="$(
+    IT_PASS=3
+    render_summary
+)"
+assert_contains "a clean run reports zeroes in every bucket" "$_clean" "skipped: 0 scenarios, 0 phases, 0 legs"
+case "$_clean" in
+*"did NOT run"*) it_fail "a run that skipped nothing prints no omissions block" "got [$_clean]" ;;
+*) it_pass "a run that skipped nothing prints no omissions block" ;;
+esac
+
+# --- CENSUS: no skip may leave through a bare it_warn again ------------------------------------
+# The counted helpers are the only sanctioned exit for a skip. This is the half that holds: the 34
+# converted sites drifted in one at a time over the harness's life, and each looked reasonable on
+# its own. `it_warn` stays for genuine warnings — a cleanup that did not fully land, a degraded
+# input — which is why the census matches on skip WORDING rather than banning the call.
+census_wording() { # <file> -> skip warnings that never reach a counter
+    grep -n 'it_warn' "$1" |
+        grep -Ei 'skipp(ed|ing)' |
+        grep -v 'it_warn "SKIPPED scenario' |
+        grep -v 'it_warn "▲ SKIPPED WHOLE PHASE' |
+        grep -v 'it_warn "skipped leg'
+}
+
+# The wording rule only catches a drop that SAYS "skipping". It missed one worded "not exposed
+# here" that returned 0 immediately after — so this second rule matches the SHAPE instead: a
+# warning followed straight away by `return 0` is a leg that did not run, whatever its prose.
+# Between them they cover both the drops that announce themselves and the ones that do not.
+#
+# One legitimate warn-then-return exists and is allowlisted by name rather than by a looser
+# regex: `--keep:` reports a deliberate cleanup that was skipped on purpose, not coverage lost.
+# Keeping the allowlist explicit means a NEW warn-then-return has to be looked at by a human
+# before it can be waved through, which is the whole point.
+census_shape() { # <file> -> warn-then-return-0 sites that are not counted skips
+    awk '
+        /it_warn/ { w = NR; t = $0; next }
+        w && NF {
+            if ($0 ~ /^[[:space:]]*return 0[[:space:]]*$/ && t !~ /--keep:/) print w ": " t
+            w = 0
+        }
+    ' "$1"
+}
+census() { # <file> -> every uncounted skip, by either rule
+    census_wording "$1"
+    census_shape "$1"
+}
+# Globbed, not enumerated, for the same reason the Makefile target is: an enumerated list
+# silently omits any harness file added later, and a check that never runs reads exactly like one
+# that passed. Self-tests are excluded — they stub and assert ON this wording.
+for f in "$HERE"/*.sh; do
+    case "$(basename "$f")" in selftest*) continue ;; esac
+    _stray="$(census "$f")"
+    assert_eq "no uncounted skip survives in $(basename "$f")" "${_stray:-none}" "none"
+done
+
+# And the census can actually FIRE — a guard nobody has seen go red is a guard nobody should
+# trust. Feed it a file holding exactly the shape it must catch.
+_tmp="$(mktemp)"
+printf '%s\n' 'it_warn "skipping the pools write leg (no probe)"' >"$_tmp"
+assert_ne "the wording rule fires on a bare-warn skip (positive control)" "$(census_wording "$_tmp")" ""
+printf '%s\n' '    it_warn "not exposed here"' '    return 0' >"$_tmp"
+assert_ne "the shape rule fires on a warn-then-return with no skip wording (positive control)" \
+    "$(census_shape "$_tmp")" ""
+assert_eq "the wording rule alone would MISS that one (this is why both rules exist)" \
+    "$(census_wording "$_tmp")" ""
+printf '%s\n' 'it_warn "restore apply reported a non-zero exit; check the box."' >"$_tmp"
+assert_eq "the wording rule leaves a genuine non-skip warning alone (negative control)" "$(census_wording "$_tmp")" ""
+printf '%s\n' '    it_warn "--keep: leaving the safety backup"' '    return 0' >"$_tmp"
+assert_eq "the shape rule leaves the allowlisted --keep cleanup alone (negative control)" \
+    "$(census_shape "$_tmp")" ""
+rm -f "$_tmp"
+
+echo "selftest-skip-accounting: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-skip-accounting.sh
+++ b/tests/integration/selftest-skip-accounting.sh
@@ -30,6 +30,7 @@ source "$HERE/lib.sh"
 
 RUN_SRC="$HERE/run.sh"
 
+echo "== the three counted-skip helpers exist at all (fail closed if one is renamed away) =="
 # --- The helpers exist at all -----------------------------------------------------------------
 # Fail CLOSED. If a refactor renames or removes one, this file must go red rather than quietly
 # stop testing — a self-test whose subject evaporates is the same shape of lie it exists to catch.
@@ -37,6 +38,7 @@ for fn in it_skip_scenario it_skip_phase it_skip_leg; do
     assert_eq "lib.sh defines $fn" "$(type -t "$fn")" "function"
 done
 
+echo "== each helper moves its OWN bucket, and a helper without its increment counts nothing =="
 # --- Each helper moves its OWN bucket, and only its own ----------------------------------------
 # Run in a subshell with the warn output discarded: the subject here is the counters, not the text.
 counts() { # <helper> -> "<scenarios> <phases> <legs>"
@@ -58,6 +60,7 @@ _mutated="$(
 )"
 assert_eq "an it_skip_leg with its increment removed counts 0 (mutation proof)" "$_mutated" "0"
 
+echo "== every skip is NAMED with its reason, and a phase drop is louder than a leg drop =="
 # --- Every skip is NAMED, with its reason ------------------------------------------------------
 # A bare count says how big the hole is and nothing about where. The names are the deliverable.
 _names="$(
@@ -80,6 +83,7 @@ _warned="$(
 assert_contains "a phase drop announces itself as a whole phase" "$_warned" "SKIPPED WHOLE PHASE rigforge-control"
 assert_contains "a leg drop announces itself as one leg" "$_warned" "skipped leg pools write (#1002b)"
 
+echo "== the REAL summary() out of run.sh reports all three buckets and names the omissions =="
 # --- The REAL summary() out of run.sh renders all three buckets --------------------------------
 # Extracted rather than re-spelled: a re-implementation would pass happily while the shipped file
 # printed something else, which is precisely the class of green this lane exists to remove.
@@ -130,6 +134,7 @@ case "$_clean" in
 *) it_pass "a run that skipped nothing prints no omissions block" ;;
 esac
 
+echo "== census: no skip may leave the harness through a bare it_warn, by wording OR by shape =="
 # --- CENSUS: no skip may leave through a bare it_warn again ------------------------------------
 # The counted helpers are the only sanctioned exit for a skip. This is the half that holds: the 34
 # converted sites drifted in one at a time over the harness's life, and each looked reasonable on

--- a/tests/integration/skip-accounting.sh
+++ b/tests/integration/skip-accounting.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+#
+# Skip accounting for the integration harness (#1365).
+#
+# This file is *sourced* by lib.sh, never executed. It exists as its own file rather than as a
+# block inside lib.sh because lib.sh sits on its file-budget ceiling (docs/dev/file-budget.tsv)
+# and that ratchet only moves down — the same split #1258 worked through.
+#
+# Skips are counted too, in three buckets, and every one is NAMED (#1365). Before this the
+# harness had exactly three counter increments — IT_PASS, IT_FAIL and the scenario skip — so a
+# run that dropped the whole rigforge-control phase and a run that exercised it produced
+# summaries differing only in the pass count, and the pass count moves for a dozen unrelated
+# reasons. The output had no way to say "this did not run", which leaves the reader unable to
+# tell "checked and clean" from "never ran" — the one distinction a gate exists to make.
+IT_SKIPPED=0
+IT_SKIPPED_PHASES=0
+IT_SKIPPED_LEGS=0
+IT_SKIPPED_NAMES=""
+
+# --- Counted skips ----------------------------------------------------------
+# Each takes WHAT did not run and WHY. Both halves are load-bearing: a bare count tells the
+# reader how much is missing but not what, and a run that ends "skipped legs: 6 (pools,
+# auto-rollback, upgrade, #516-reflection, #516-prefill, node-down-failover)" says what it did
+# not prove.
+#
+# A scenario skip drops one matrix row; a phase skip drops every leg under it with one line; a
+# leg skip drops one assertion group. They are separate buckets rather than one total because
+# they are not the same event and must not average out — losing the whole rigforge-control phase
+# is not the same size of hole as losing its pools leg.
+_it_skip_record() {
+    IT_SKIPPED_NAMES="${IT_SKIPPED_NAMES}\n    - ${1} ${2} — ${3}"
+}
+it_skip_scenario() {
+    IT_SKIPPED=$((IT_SKIPPED + 1))
+    _it_skip_record "scenario" "$1" "$2"
+    it_warn "SKIPPED scenario ${1}: ${2}"
+}
+it_skip_phase() {
+    IT_SKIPPED_PHASES=$((IT_SKIPPED_PHASES + 1))
+    _it_skip_record "PHASE   " "$1" "$2"
+    it_warn "▲ SKIPPED WHOLE PHASE ${1}: ${2}"
+}
+it_skip_leg() {
+    IT_SKIPPED_LEGS=$((IT_SKIPPED_LEGS + 1))
+    _it_skip_record "leg     " "$1" "$2"
+    it_warn "skipped leg ${1}: ${2}"
+}
+
+# --- The one assertion pair that is conditionally skipped ---------------------------------------
+# It lives here rather than in lib.sh because its whole contract is a skip: it is the only place
+# the harness suppresses assertions on the caller's say-so, and it is now the caller of
+# it_skip_leg. (lib.sh sitting on its file-budget ceiling is what forced the split; this is the
+# block that belonged on this side of it.)
+# Mining-liveness verdict (#905/#1082), factored out of assert_running_state so selftest can
+# prove --no-mining-asserts is a CONDITIONAL skip, not a permanent one: the two assertions must
+# still run — and be able to go red — every time the flag is unset. Only the caller-set skip
+# flag suppresses them; there is no auto-detection here (a live worker-count of zero from a
+# genuinely fallen-off rig must stay indistinguishable from a parked bench unless the operator
+# says so explicitly — see #1082's fail-open discussion).
+assert_mining_state() { # <skip: 0|1> <workers> <hashes> <expected-workers>
+    if [ "$1" = "1" ]; then
+        it_skip_leg "workers online + stratum total hashes (#905/#1082)" "no miner attached to this box (--no-mining-asserts) — drop the flag (and attach a miner) to make these binding again"
+        return 0
+    fi
+    assert_num_ge "workers online (>= $4)" "${2:-0}" "$4"
+    assert_num_gt "stratum total hashes > 0" "${3:-0}" 0
+}


### PR DESCRIPTION
Closes nothing by itself — see the checklist at the end.

## The defect

The harness had exactly three counter increments: `IT_PASS`, `IT_FAIL`, and the scenario skip. Every other skip left through a bare `it_warn`, which touches no counter, so it appeared in no column of the verdict.

A run that dropped the **entire** rigforge-control phase and a run that exercised it produced summaries differing by nothing but the pass count — and the pass count moves for a dozen unrelated reasons. Nothing in the output could say a surface had not run, which leaves the reader unable to tell "checked and clean" from "never ran". That is the distinction a release gate exists to make.

## What this does

Three counted helpers in a new `tests/integration/skip-accounting.sh`, each taking **what** did not run and **why**: `it_skip_scenario`, `it_skip_phase`, `it_skip_leg`. Separate buckets, because losing a whole phase is not the same size of hole as losing one leg — and a phase drop is louder in the live stream.

```
passed:  312
skipped: 2 scenarios, 1 phases, 4 legs
did NOT run:
    - scenario prune-remote — no pruned chain supplied
    - PHASE    rigforge-control — no worker exposes a RigForge enriched feed
    - leg      pools write (#1002b) — no IT_RIG_POOLS_PROBE
```

## The census, re-derived at this tip rather than taken from the issue

33 sites in `run.sh` and `rigforge-writable-keys.sh`, one more in `lib.sh`, and **a 35th the issue's own count missed**. Two corrections to the issue as filed:

- It said 28 and put the `pools` legs in `run.sh`. They have since moved to `rigforge-writable-keys.sh`, and its own body says 28 in one place and 29 in another.
- Its census was wording-based, so it missed `run.sh`'s Worker Inspect drop, which says "not exposed here" and never says "skipping". That site is a whole read/write leg.

## The guard, which is the half that has to hold

`selftest-skip-accounting.sh` checks the counters and the **real** `summary()` extracted from `run.sh` (extracted, not re-spelled — a re-implementation passes happily while the shipped file prints something else). Then it censuses every harness file by two rules:

1. skip **wording**;
2. the **shape** of a warning followed immediately by `return 0`.

Rule 2 is what found the 35th site, and the file asserts that rule 1 alone would have missed it. Both rules carry a positive **and** a negative control, and the one legitimate warn-then-return (`--keep:`, a deliberate cleanup) is allowlisted by name so a new one has to be looked at by a human.

## Proof it can fail

Six mutations of the shipped code, each demonstrated red:

| mutation | result |
|---|---|
| revert a converted site to a bare `it_warn "skipping …"` | census/wording reds |
| revert the #185 site to its wordless warn-then-return | census/shape reds |
| `summary()` stops reporting the leg bucket | 3 assertions red |
| `summary()` stops naming what did not run | reds |
| `it_skip_phase` loses its increment | 2 assertions red |
| a phase drop stops being louder than a leg drop | reds |

One mutation appeared to survive. It was re-run and confirmed to be an **ineffective** mutation — the `sed` targeted `run.sh` for a site that lives in `rigforge-writable-keys.sh`, so nothing changed. An ineffective mutation reads exactly like a surviving one; applied to the right file it reds.

Separately, sourcing `lib.sh` by a bare name would have resolved the new source to `lib.sh/skip-accounting.sh` and left the helpers undefined — a silent miscount. Every current call site uses a path, so this never fired, but it is now fail-closed and the guard was observed to fire.

## Shared and budgeted files

- `docs/` — the doc update ships with the change, per CLAUDE.md. `docs/` is in `_shared.paths`; no `.lane-override` used.
- **No `Makefile` change**: `test-integration-selftest` globs `selftest*.sh`, so the new self-test is picked up.
- **No `docs/dev/file-budget.tsv` change.** `lib.sh` sat on its ceiling (692) and that ratchet only moves down, so the addition moved out to its own file instead of growing it. `assert_mining_state` moved with it — its whole contract is a conditional skip and it is now a caller of `it_skip_leg`. `lib.sh` goes **692 → 685**; the recorded ceiling is deliberately left alone rather than ratcheted down, to avoid a conflict on a file that is regenerated per-lane.

## What was run

All green at `f664870`:

- all 7 integration self-tests — **408 assertions, 0 failed** (was 368)
- `shellcheck 0.11.0` (the version CI pins) over `tests/integration/*.sh`; repo-wide `shfmt -i 4 -d`
- `lint-file-budget`, `lint-docs-voice`, `lint-md`, `lint-operator-strings`, `lint-topology`, `lint-yaml`

## What was NOT run, and why

- **`make lint-sh` in full.** It is the serialized OOM path that has killed whole sessions on this box, and a peer review agent is resident. Every file this diff touches was linted with the same shellcheck binary and flags CI uses, so the marginal information is zero. CI will run it.
- **No live e2e run.** This changes what the harness *reports*, not what it *does*. Nothing parses the summary text — checked across `e2e.sh`, `scripts/`, `.github/workflows/` and `docs/dev/releasing.md`.
- **The new counts have never been seen on a real run**, only on simulated state. The first live gate run is where the numbers get their first real exercise.

## The over-engineering pass, and what it cut

Run on this diff before opening the PR. One finding in my own work, acted on: a "the shipped summary reads the leg counter at all" assertion that was a **grep over the source text**, not behaviour — the exact shape this project files bugs about. It is cut. The mutation it claimed to cover (`summary()` stops reporting the leg bucket) is still caught, by two behavioural assertions, re-verified after the cut.

Kept, with the reasoning stated so it can be argued with:

- **Three buckets, not one.** A single count re-creates the "`skipped: 5` reads as wallpaper" problem #1083 describes, and the issue asks for a phase drop to be louder than a leg drop.
- **The two-rule census.** The shape rule is not belt-and-braces — it found the 35th site, and the self-test asserts the wording rule alone would have missed it.
- **The fail-closed source guard**, three lines for a case that does not occur today. The failure it prevents is a silent miscount, which is the defect class this whole PR is about.

## Follow-ups, not done here

- The issue also suggests making a leg skip a **hard failure** when its prerequisite should be present (a rig is attached, so a missing probe is a harness bug, not an environment). That is #1236's ask for its two legs and is deliberately out of scope here — this PR makes the drops visible, it does not change any verdict.
- This sharpens #1083: `skipped: 5` was never the number of things that did not run, only the number that were counted.
