### PR TITLE
fix(security): pull the patched openssl past the digest-pinned bases (CVE-2026-14456, develop-v2 twin)

### DIFF
--- a/build/tor/Dockerfile
+++ b/build/tor/Dockerfile
@@ -5,7 +5,10 @@ FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec4
 # Install Tor plus netcat, which the bootstrap healthcheck needs to talk to the control port.
 # Deliberately NOT xxd: the healthcheck's `xxd -p -c 256` is served by busybox's own applet, so
 # `apk add xxd` bought nothing but vim's CVE stream (#1372). --no-cache keeps the image small.
-RUN apk add --no-cache tor netcat-openbsd
+# --upgrade names the base's own openssl libs so they follow the distro's security repo: the
+# digest-pinned base can lag a published fix until upstream rebuilds the image, and that lag
+# closed the CVE gate base-wide on 2026-08-28 (CVE-2026-14456, #1438).
+RUN apk add --no-cache --upgrade libcrypto3 libssl3 tor netcat-openbsd
 
 # Copy the Tor config TEMPLATE + the entrypoint that renders it: the bridge subnet prefix is
 # substituted at container start (#180). The rendered torrc lands in /tmp (the unprivileged 'tor'

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -15,10 +15,16 @@ ENV UV_PYTHON_DOWNLOADS=never \
     UV_LINK_MODE=copy \
     PATH="/app/.venv/bin:$PATH"
 
-# System dependencies.
+# System dependencies. The openssl trio is already in the base image — naming it here pulls the
+# distro's current security build past the digest-pinned base, which can lag a published fix until
+# upstream rebuilds the image; that lag closed the CVE gate base-wide on 2026-08-28
+# (CVE-2026-14456, #1438). apt-get upgrade is the blanket alternative and hadolint bans it (DL3005).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     iproute2 \
+    libssl3t64 \
+    openssl \
+    openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
develop-v2 twin of #1439, for #1438 — clears the `Build image (dashboard)` / `Build image (tor)` reds by installing the distro's patched openssl at build time instead of muting the finding (this PR originally carried a `.trivyignore` mute; see #1439 for the review that killed it and the full evidence). Applied to this lane's own Dockerfiles, not cherry-picked — this lane's tor image differs (no xxd since #1372). `.trivyignore` untouched.

Verified locally: this branch's tor image rebuilt and scanned with the gate's exact flags and unchanged ignore file, rc=0, libs at 3.5.8-r0. The dashboard leg is proven on the develop twin (identical base digest and apt block); this PR's own image checks are the independent proof.

**Lane disclosure:** filed from the controller — gate closure blocked every lane; diff confined to the two RUN lines plus comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdY4iq3UwCmJvy8FVe1drK
