### PR TITLE
Only one of a run's skips is a gap, and the summary could not say which (#1083)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -480,10 +480,12 @@ The summary counts three kinds of skip separately and names every one:
 ```
 passed:  312
 skipped: 2 scenarios, 1 phases, 4 legs
+  of which: 5 missing (an input would have run it), 1 by-design (this run's mode excludes it), 1 covered elsewhere
 did NOT run:
-    - scenario prune-remote — no pruned chain supplied
-    - PHASE    rigforge-control — no worker exposes a RigForge enriched feed
-    - leg      pools write (#1002b) — no IT_RIG_POOLS_PROBE
+    - [missing]   scenario prune-remote — no pruned chain supplied
+    - [by-design] PHASE    hardening — remote mode: no local containers/systemd to exercise
+    - [covered]   leg      Worker Inspect read/write (#185) — dashboard.control off (covered by the hardening phase + tier-2 contract)
+    - [missing]   leg      pools write (#1002b) — no IT_RIG_POOLS_PROBE
 ```
 
 A scenario skip drops one matrix row; a phase skip drops every leg under it with one line; a leg
@@ -500,6 +502,35 @@ make.
 Every skip leaves through `it_skip_scenario`, `it_skip_phase` or `it_skip_leg`
 (`tests/integration/skip-accounting.sh`). Plain `it_warn` stays for warnings that are not a
 dropped check.
+
+### Only one of the three classes is a gap
+
+Counting and naming the drops still left the reader unable to answer the question they actually
+have: is this hole one we accepted, or one we could have filled today? That is
+[#1083](https://github.com/p2pool-starter-stack/pithead/issues/1083) — five scenario skips read as
+"known and fine" for months precisely because the number never moved. So every skip carries a
+class, and the classes are not decoration:
+
+| class | means | is it a gap? |
+|---|---|---|
+| `missing` | An input would have run it — an env var, a flag, a data dir. | **Yes. This is the number worth reading.** |
+| `by-design` | Structurally inapplicable to this run's configuration. Remote mode has no local monerod to stop; no flag changes that. | No. Covering it means running a different scenario. |
+| `covered` | Exercised elsewhere, and the reason says where. | No. It is an absence of duplicate evidence. |
+
+The test applied at each call site: could a different invocation of this same harness against this
+same box have covered it? Yes means `missing`; no means `by-design`.
+
+The class is the optional third argument and it defaults to `missing`. The default is the
+pessimistic one on purpose — an unclassified skip is an unexplained absence, so it lands in the
+bucket that counts. Defaulting the other way would let a real hole disappear by omission, which is
+#1083's own failure mode one level up. An unrecognised class is reported loudly and still counted
+as `missing`, so the class totals always reconcile with the bucket totals; a summary whose own
+arithmetic does not add up misleads more than a wrong label does.
+
+`selftest-skip-accounting.sh` holds both halves: the helpers behave, and a static census refuses
+any call site that invents a class. The census is static because most of these legs fire only on a
+bench with a rig attached — a typo on a leg that skips once a quarter would otherwise sit in the
+tree unnoticed.
 
 ---
 

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -522,10 +522,10 @@ same box have covered it? Yes means `missing`; no means `by-design`.
 
 The class is the optional third argument and it defaults to `missing`. The default is the
 pessimistic one on purpose — an unclassified skip is an unexplained absence, so it lands in the
-bucket that counts. Defaulting the other way would let a real hole disappear by omission, which is
-#1083's own failure mode one level up. An unrecognised class is reported loudly and still counted
-as `missing`, so the class totals always reconcile with the bucket totals; a summary whose own
-arithmetic does not add up misleads more than a wrong label does.
+bucket that counts. Defaulting the other way would let a real hole disappear by omission,
+which is #1083's own failure mode one level up. An unrecognised class is reported loudly and
+still counted as `missing`, so the class totals always reconcile with the bucket totals; a
+summary whose own arithmetic does not add up misleads more than a wrong label does.
 
 `selftest-skip-accounting.sh` holds both halves: the helpers behave, and a static census refuses
 any call site that invents a class. The census is static because most of these legs fire only on a

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -135,6 +135,7 @@ resolve_overrides() {
     local overrides="$1" prune mode tari_mode subnet out="$1"
     RESOLVED=""
     SKIP_REASON=""
+    SKIP_CLASS="missing" # #1083: every prerequisite below names an input the caller could supply
 
     prune="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^monero\.prune=//p')"
     mode="$(printf '%s' "$overrides" | tr ' ' '\n' | sed -n 's/^monero\.mode=//p')"
@@ -147,6 +148,7 @@ resolve_overrides() {
     # a move it structurally can't do (loud SKIP, never a silent drop).
     if [ -n "$subnet" ]; then
         SKIP_REASON="network.subnet move needs a full down/up — run the --subnet phase (not a hot apply)"
+        SKIP_CLASS="covered" # the --subnet phase DOES exercise this; it is not an uncovered path (#1083)
         return 1
     fi
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -435,7 +435,7 @@ run_scenario() {
     it_log "── scenario: ${name} ───────────────────────────────"
 
     if ! resolve_overrides "$overrides"; then
-        it_skip_scenario "$name" "$SKIP_REASON"
+        it_skip_scenario "$name" "$SKIP_REASON" "$SKIP_CLASS"
         return 0
     fi
 
@@ -1163,7 +1163,7 @@ run_lifecycle() {
         pithead status >/dev/null 2>&1
         assert_rc "status OK after node recovery" "$?" "0"
     else
-        it_skip_leg "node-down failover" "remote mode: no local monerod to stop"
+        it_skip_leg "node-down failover" "remote mode: no local monerod to stop" "by-design"
     fi
 
     # backup → restore round-trip (#102): a backup archives config/.env/onions/dashboard; a
@@ -1434,7 +1434,7 @@ run_fault_injection() {
     echo ""
     it_log "── fault-injection phase ───────────────────────────"
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_skip_phase "fault-injection" "remote mode: no local monerod to break"
+        it_skip_phase "fault-injection" "remote mode: no local monerod to break" "by-design"
         return 0
     fi
 
@@ -1595,7 +1595,7 @@ run_hardening() {
     it_log "── v1.4 hardening phase (#377/#33/#424) ────────────"
 
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_skip_phase "hardening" "remote mode: no local containers/systemd to exercise"
+        it_skip_phase "hardening" "remote mode: no local containers/systemd to exercise" "by-design"
         return 0
     fi
 
@@ -1858,6 +1858,10 @@ summary() {
     it_log "════════════════ summary ════════════════"
     it_log "passed:  $IT_PASS"
     it_log "skipped: $IT_SKIPPED scenarios, $IT_SKIPPED_PHASES phases, $IT_SKIPPED_LEGS legs"
+    # #1083: the totals above say how much did not run; this line says how much of that is a GAP.
+    # Five stable skips read as "known and fine" for months precisely because one number could not
+    # tell an accepted absence from an uncovered path. Only "missing" is the second kind.
+    it_log "  of which: $IT_SKIPPED_MISSING missing (an input would have run it), $IT_SKIPPED_BY_DESIGN by-design (this run's mode excludes it), $IT_SKIPPED_COVERED covered elsewhere"
     # Name what did not run (#1365). The count says how big the hole is; only the names say
     # where it is, and a summary that cannot distinguish "checked and clean" from "never ran"
     # is not a verdict. Goes to stderr with the other warnings so a log split by stream keeps
@@ -1902,7 +1906,7 @@ run_rigforge_integration() {
     # whose sister API the dashboard reached and parse_rigforge parsed (#235).
     rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
     if [ -z "$rig" ]; then
-        it_skip_phase "rigforge-integration" "no worker exposes a RigForge enriched feed (a real rigforge rig with api:enabled on :8081?); the parse contract is covered by the tier-2 test"
+        it_skip_phase "rigforge-integration" "no worker exposes a RigForge enriched feed (a real rigforge rig with api:enabled on :8081?); the parse contract is covered by the tier-2 test" "covered"
         return 0
     fi
     it_pass "dashboard consumed a real RigForge rig's enriched feed: $rig (#235)"
@@ -1919,7 +1923,7 @@ run_rigforge_integration() {
     #    exists when dashboard.control is on. Off here → the enriched-feed leg above still proves
     #    #235/#260; the control path itself is covered by the hardening phase + the tier-2 test.
     if [ "$(printf '%s' "$st" | jq -r '.control_enabled // false' 2>/dev/null)" != "true" ]; then
-        it_skip_leg "Worker Inspect read/write (#185)" "dashboard.control off — not exposed here (covered by the hardening phase + tier-2 contract); enriched-feed consumption validated"
+        it_skip_leg "Worker Inspect read/write (#185)" "dashboard.control off — not exposed here (covered by the hardening phase + tier-2 contract); enriched-feed consumption validated" "covered"
         return 0
     fi
 
@@ -2020,11 +2024,11 @@ run_subnet_scenario() {
     it_log "── moved-subnet phase (#201/#180) ──────────────────"
 
     if [ "$IT_MODE" != "local" ]; then
-        it_skip_phase "moved-subnet" "needs local mode: it brings the stack down/up and inspects the live docker network"
+        it_skip_phase "moved-subnet" "needs local mode: it brings the stack down/up and inspects the live docker network" "by-design"
         return 0
     fi
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_skip_phase "moved-subnet" "remote mode: monerod's moved-prefix proxy is one of the named checks"
+        it_skip_phase "moved-subnet" "remote mode: monerod's moved-prefix proxy is one of the named checks" "by-design"
         return 0
     fi
 
@@ -2115,11 +2119,11 @@ run_rigforge_control() {
     it_log "── RigForge control phase (#513/#514/#516/#517) ────"
 
     if [ "$IT_MODE" != "local" ]; then
-        it_skip_phase "rigforge-control" "needs local mode: it edits config.json + dials the rig on the mining LAN"
+        it_skip_phase "rigforge-control" "needs local mode: it edits config.json + dials the rig on the mining LAN" "by-design"
         return 0
     fi
     if ! has_compose_profile "$(env_on_box COMPOSE_PROFILES)" local_node; then
-        it_skip_phase "rigforge-control" "remote mode: no local dashboard container to drive"
+        it_skip_phase "rigforge-control" "remote mode: no local dashboard container to drive" "by-design"
         return 0
     fi
 

--- a/tests/integration/selftest-skip-accounting.sh
+++ b/tests/integration/selftest-skip-accounting.sh
@@ -217,7 +217,10 @@ assert_eq "a scenario skip is classified too, not just legs" "$(classes it_skip_
 # skip in the harness silently stops counting as a hole — the #1083 failure mode, one level up.
 # Mutation proof, so the assertion above cannot pass against a body that defaults the other way.
 _mutdefault="$(
-    it_skip_leg() { IT_SKIPPED_LEGS=$((IT_SKIPPED_LEGS + 1)); _it_skip_record "leg     " "$1" "$2" "${3:-covered}"; }
+    it_skip_leg() {
+        IT_SKIPPED_LEGS=$((IT_SKIPPED_LEGS + 1))
+        _it_skip_record "leg     " "$1" "$2" "${3:-covered}"
+    }
     it_skip_leg "some-name" "some-reason" 2>/dev/null
     printf '%s %s' "$IT_SKIPPED_COVERED" "$IT_SKIPPED_MISSING"
 )"

--- a/tests/integration/selftest-skip-accounting.sh
+++ b/tests/integration/selftest-skip-accounting.sh
@@ -54,7 +54,7 @@ assert_eq "a leg skip increments only the leg bucket" "$(counts it_skip_leg)" "0
 # Mutation proof for the counting itself: a helper whose increment is removed must NOT still read
 # as counted. Without this the three assertions above would pass against a body that only warns.
 _mutated="$(
-    it_skip_leg() { _it_skip_record "leg     " "$1" "$2"; } # the increment, deliberately gone
+    it_skip_leg() { _it_skip_record "leg     " "$1" "$2" "missing"; } # the increment, deliberately gone
     it_skip_leg "some-name" "some-reason"
     printf '%s' "$IT_SKIPPED_LEGS"
 )"
@@ -195,6 +195,99 @@ printf '%s\n' '    it_warn "--keep: leaving the safety backup"' '    return 0' >
 assert_eq "the shape rule leaves the allowlisted --keep cleanup alone (negative control)" \
     "$(census_shape "$_tmp")" ""
 rm -f "$_tmp"
+
+echo "== every skip carries a CLASS, and only \"missing\" is a gap (#1083) =="
+# --- The class axis (#1083) --------------------------------------------------------------------
+# #1365 made the harness say WHAT did not run. It still could not say whether a hole was one we
+# had accepted or one we could have filled that day, which is exactly why five stable scenario
+# skips read as "known and fine" for months. The class is that missing axis, and its whole value
+# is that ONE of the three buckets is a gap and the other two are not.
+classes() { # <helper> <class...> -> "<by-design> <covered> <missing>"
+    (
+        "$1" "some-name" "some-reason" ${2+"$2"} 2>/dev/null
+        printf '%s %s %s' "$IT_SKIPPED_BY_DESIGN" "$IT_SKIPPED_COVERED" "$IT_SKIPPED_MISSING"
+    )
+}
+assert_eq "an unclassified skip defaults to missing, the pessimistic bucket" "$(classes it_skip_leg)" "0 0 1"
+assert_eq "an explicit by-design skip lands in by-design only" "$(classes it_skip_leg by-design)" "1 0 0"
+assert_eq "an explicit covered skip lands in covered only" "$(classes it_skip_phase covered)" "0 1 0"
+assert_eq "a scenario skip is classified too, not just legs" "$(classes it_skip_scenario by-design)" "1 0 0"
+
+# The default is the load-bearing half: if it ever flips to a non-gap bucket, every unannotated
+# skip in the harness silently stops counting as a hole — the #1083 failure mode, one level up.
+# Mutation proof, so the assertion above cannot pass against a body that defaults the other way.
+_mutdefault="$(
+    it_skip_leg() { IT_SKIPPED_LEGS=$((IT_SKIPPED_LEGS + 1)); _it_skip_record "leg     " "$1" "$2" "${3:-covered}"; }
+    it_skip_leg "some-name" "some-reason" 2>/dev/null
+    printf '%s %s' "$IT_SKIPPED_COVERED" "$IT_SKIPPED_MISSING"
+)"
+assert_eq "a default flipped to covered is visible (mutation proof)" "$_mutdefault" "1 0"
+
+# An unknown class must be LOUD and must still be counted. Counting it nowhere would break the
+# reconciliation below, and a summary whose own totals do not add up misleads more than a bad label.
+_unknown="$(
+    it_skip_leg "some-name" "some-reason" "bydesign" 2>&1
+    printf '|%s %s %s' "$IT_SKIPPED_BY_DESIGN" "$IT_SKIPPED_COVERED" "$IT_SKIPPED_MISSING"
+)"
+assert_contains "an unknown class is reported, not silently bucketed" "$_unknown" "unknown skip class 'bydesign'"
+assert_contains "an unknown class still lands in the pessimistic bucket" "$_unknown" "|0 0 1"
+
+# Reconciliation: the three class totals must always sum to the three bucket totals. This is what
+# makes the breakdown citable — without it the two lines could drift apart and both look fine.
+_recon="$(
+    {
+        it_skip_scenario "s" "r" by-design
+        it_skip_phase "p" "r" covered
+        it_skip_leg "l1" "r"
+        it_skip_leg "l2" "r" by-design
+    } 2>/dev/null
+    printf '%s %s' "$((IT_SKIPPED + IT_SKIPPED_PHASES + IT_SKIPPED_LEGS))" \
+        "$((IT_SKIPPED_BY_DESIGN + IT_SKIPPED_COVERED + IT_SKIPPED_MISSING))"
+)"
+assert_eq "class totals reconcile with bucket totals" "$_recon" "4 4"
+
+echo "== the REAL summary() renders the class breakdown, and the named list tags each drop =="
+_rendered_cls="$(
+    {
+        it_skip_scenario "prune-remote" "no pruned chain supplied"
+        it_skip_phase "hardening" "remote mode: no local containers" by-design
+        it_skip_leg "Worker Inspect read/write (#185)" "covered by the hardening phase" covered
+    } 2>/dev/null
+    IT_PASS=7
+    render_summary
+)"
+assert_contains "the summary breaks the skips down by class" "$_rendered_cls" \
+    "of which: 1 missing (an input would have run it), 1 by-design"
+assert_contains "the breakdown names the covered bucket too" "$_rendered_cls" "1 covered elsewhere"
+assert_contains "the named list tags a by-design drop" "$_rendered_cls" "[by-design]"
+assert_contains "the named list tags a covered drop" "$_rendered_cls" "[covered]"
+assert_contains "the named list tags an unannotated drop as missing" "$_rendered_cls" "[missing]"
+
+echo "== census: every class argument in the shipped harness is one of the three (#1083) =="
+# --- CENSUS: no call site may invent a class ---------------------------------------------------
+# The runtime guard above only fires on a path that actually RUNS, and most of these skip sites
+# fire only on a bench with a rig attached. A typo like "bydesign" on a leg that skips once a
+# quarter would sit in the tree unnoticed. This census is static, so it sees every site every run.
+census_class() { # <file> -> call sites whose trailing class argument is not one of the three
+    grep -nE 'it_skip_(scenario|phase|leg) .*"[a-z-]+"[[:space:]]*$' "$1" |
+        grep -vE '"(by-design|covered|missing)"[[:space:]]*$'
+}
+for f in "$HERE"/*.sh; do
+    case "$(basename "$f")" in selftest*) continue ;; esac
+    _badcls="$(census_class "$f")"
+    assert_eq "no invented skip class in $(basename "$f")" "${_badcls:-none}" "none"
+done
+
+# ...and it can fire. A near-miss is the case that matters: an obviously-wrong class would be
+# caught by eye, a missing hyphen would not.
+_tmp2="$(mktemp)"
+printf '%s\n' '    it_skip_leg "some leg" "some reason" "bydesign"' >"$_tmp2"
+assert_ne "the class census fires on a near-miss class (positive control)" "$(census_class "$_tmp2")" ""
+printf '%s\n' '    it_skip_leg "some leg" "some reason" "by-design"' >"$_tmp2"
+assert_eq "the class census leaves a valid class alone (negative control)" "$(census_class "$_tmp2")" ""
+printf '%s\n' '    it_skip_leg "some leg" "a reason ending in a word"' >"$_tmp2"
+assert_eq "the class census leaves a plain two-argument call alone (negative control)" "$(census_class "$_tmp2")" ""
+rm -f "$_tmp2"
 
 echo "selftest-skip-accounting: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/skip-accounting.sh
+++ b/tests/integration/skip-accounting.sh
@@ -58,8 +58,8 @@ IT_SKIPPED_MISSING=0
 # An unrecognised class is a hard error rather than a silently-created fourth bucket. A typo that
 # invents its own bucket would drop that skip out of every total while still printing a plausible
 # line, and a miscount that reads as a count is worse than a crash.
-_it_skip_class() {
-    case "$1" in
+_it_skip_record() {
+    case "$4" in
         by-design) IT_SKIPPED_BY_DESIGN=$((IT_SKIPPED_BY_DESIGN + 1)) ;;
         covered) IT_SKIPPED_COVERED=$((IT_SKIPPED_COVERED + 1)) ;;
         missing) IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1)) ;;
@@ -67,14 +67,10 @@ _it_skip_class() {
             # Loud AND still counted, in the pessimistic bucket. Erroring without counting would
             # make the three class totals stop summing to the bucket totals, and a summary whose
             # own arithmetic does not reconcile is a worse instrument than a wrong label.
-            it_err "skip-accounting: unknown skip class '${1}' (expected by-design|covered|missing) — counted as missing"
+            it_err "skip-accounting: unknown skip class '${4}' (expected by-design|covered|missing) — counted as missing"
             IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1))
-            return 1
             ;;
     esac
-}
-_it_skip_record() {
-    _it_skip_class "$4" || true # already reported and counted; still name it in the list
     IT_SKIPPED_NAMES="${IT_SKIPPED_NAMES}\n    - [${4}] ${1} ${2} — ${3}"
 }
 it_skip_scenario() {

--- a/tests/integration/skip-accounting.sh
+++ b/tests/integration/skip-accounting.sh
@@ -60,16 +60,16 @@ IT_SKIPPED_MISSING=0
 # line, and a miscount that reads as a count is worse than a crash.
 _it_skip_record() {
     case "$4" in
-        by-design) IT_SKIPPED_BY_DESIGN=$((IT_SKIPPED_BY_DESIGN + 1)) ;;
-        covered) IT_SKIPPED_COVERED=$((IT_SKIPPED_COVERED + 1)) ;;
-        missing) IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1)) ;;
-        *)
-            # Loud AND still counted, in the pessimistic bucket. Erroring without counting would
-            # make the three class totals stop summing to the bucket totals, and a summary whose
-            # own arithmetic does not reconcile is a worse instrument than a wrong label.
-            it_err "skip-accounting: unknown skip class '${4}' (expected by-design|covered|missing) — counted as missing"
-            IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1))
-            ;;
+    by-design) IT_SKIPPED_BY_DESIGN=$((IT_SKIPPED_BY_DESIGN + 1)) ;;
+    covered) IT_SKIPPED_COVERED=$((IT_SKIPPED_COVERED + 1)) ;;
+    missing) IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1)) ;;
+    *)
+        # Loud AND still counted, in the pessimistic bucket. Erroring without counting would
+        # make the three class totals stop summing to the bucket totals, and a summary whose
+        # own arithmetic does not reconcile is a worse instrument than a wrong label.
+        it_err "skip-accounting: unknown skip class '${4}' (expected by-design|covered|missing) — counted as missing"
+        IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1))
+        ;;
     esac
     IT_SKIPPED_NAMES="${IT_SKIPPED_NAMES}\n    - [${4}] ${1} ${2} — ${3}"
 }

--- a/tests/integration/skip-accounting.sh
+++ b/tests/integration/skip-accounting.sh
@@ -17,6 +17,28 @@ IT_SKIPPED_PHASES=0
 IT_SKIPPED_LEGS=0
 IT_SKIPPED_NAMES=""
 
+# --- Why it did not run, not just that it did not (#1083) ---------------------------------------
+# Counting and naming the drops (#1365) still left the summary unable to answer the question a
+# reader actually has: is this hole one we accepted, or one we could have filled today? #1083 is
+# that complaint — five stable scenario skips read as "known and fine" precisely because the
+# number never moves. So every skip now also carries a CLASS, and the classes are not decoration:
+# only one of them is a gap.
+#
+#   by-design  Structurally inapplicable to THIS run's configuration. No input, flag or env var
+#              would make it run — remote mode genuinely has no local monerod to stop. Covering
+#              it means running a different scenario, not fixing anything.
+#   covered    Exercised somewhere else, and the reason says where. Not an absence of evidence;
+#              an absence of DUPLICATE evidence. Counting it as a gap is what made the number
+#              wallpaper in the first place.
+#   missing    Would have run if a named input had been supplied. THIS IS THE ONLY ONE THAT IS A
+#              GAP, and it is the number worth reading.
+#
+# The distinguishing test, applied at each call site: could a different invocation of this same
+# harness against this same box have covered it? Yes -> missing. No -> by-design.
+IT_SKIPPED_BY_DESIGN=0
+IT_SKIPPED_COVERED=0
+IT_SKIPPED_MISSING=0
+
 # --- Counted skips ----------------------------------------------------------
 # Each takes WHAT did not run and WHY. Both halves are load-bearing: a bare count tells the
 # reader how much is missing but not what, and a run that ends "skipped legs: 6 (pools,
@@ -27,22 +49,47 @@ IT_SKIPPED_NAMES=""
 # leg skip drops one assertion group. They are separate buckets rather than one total because
 # they are not the same event and must not average out — losing the whole rigforge-control phase
 # is not the same size of hole as losing its pools leg.
+#
+# The class is the OPTIONAL third argument and it defaults to "missing". The default is deliberate
+# and it is the pessimistic one: an unclassified skip is an unexplained absence, so it lands in the
+# bucket that counts as a gap. Getting the default wrong in the other direction would let a real
+# hole disappear by omission — which is the #1083 failure mode itself, one level up.
+#
+# An unrecognised class is a hard error rather than a silently-created fourth bucket. A typo that
+# invents its own bucket would drop that skip out of every total while still printing a plausible
+# line, and a miscount that reads as a count is worse than a crash.
+_it_skip_class() {
+    case "$1" in
+        by-design) IT_SKIPPED_BY_DESIGN=$((IT_SKIPPED_BY_DESIGN + 1)) ;;
+        covered) IT_SKIPPED_COVERED=$((IT_SKIPPED_COVERED + 1)) ;;
+        missing) IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1)) ;;
+        *)
+            # Loud AND still counted, in the pessimistic bucket. Erroring without counting would
+            # make the three class totals stop summing to the bucket totals, and a summary whose
+            # own arithmetic does not reconcile is a worse instrument than a wrong label.
+            it_err "skip-accounting: unknown skip class '${1}' (expected by-design|covered|missing) — counted as missing"
+            IT_SKIPPED_MISSING=$((IT_SKIPPED_MISSING + 1))
+            return 1
+            ;;
+    esac
+}
 _it_skip_record() {
-    IT_SKIPPED_NAMES="${IT_SKIPPED_NAMES}\n    - ${1} ${2} — ${3}"
+    _it_skip_class "$4" || true # already reported and counted; still name it in the list
+    IT_SKIPPED_NAMES="${IT_SKIPPED_NAMES}\n    - [${4}] ${1} ${2} — ${3}"
 }
 it_skip_scenario() {
     IT_SKIPPED=$((IT_SKIPPED + 1))
-    _it_skip_record "scenario" "$1" "$2"
+    _it_skip_record "scenario" "$1" "$2" "${3:-missing}"
     it_warn "SKIPPED scenario ${1}: ${2}"
 }
 it_skip_phase() {
     IT_SKIPPED_PHASES=$((IT_SKIPPED_PHASES + 1))
-    _it_skip_record "PHASE   " "$1" "$2"
+    _it_skip_record "PHASE   " "$1" "$2" "${3:-missing}"
     it_warn "▲ SKIPPED WHOLE PHASE ${1}: ${2}"
 }
 it_skip_leg() {
     IT_SKIPPED_LEGS=$((IT_SKIPPED_LEGS + 1))
-    _it_skip_record "leg     " "$1" "$2"
+    _it_skip_record "leg     " "$1" "$2" "${3:-missing}"
     it_warn "skipped leg ${1}: ${2}"
 }
 


### PR DESCRIPTION
Closes nothing automatically — `Closes #N` does not fire here, because this merges to `develop-v2` while the default branch is `develop`. I will close #1083 by hand.

## The problem, in the issue's own words

> the summary should distinguish "cannot run here, by design" from "did not run this time", so the number stops being wallpaper.

#1365 made the harness say *what* did not run. It still could not say whether a hole was one we had accepted or one we could have filled that day — which is exactly why five stable scenario skips read as "known and fine" for months.

## What changed

Every skip now carries a class, and only one of the three is a gap:

| class | means | is it a gap? |
|---|---|---|
| `missing` | An input would have run it — an env var, a flag, a data dir. | **Yes. The number worth reading.** |
| `by-design` | Structurally inapplicable to this run's configuration. Remote mode has no local monerod to stop; no flag changes that. | No. |
| `covered` | Exercised elsewhere, and the reason says where. | No — an absence of *duplicate* evidence. |

The verdict gains one line:

```
skipped: 2 scenarios, 1 phases, 4 legs
  of which: 5 missing (an input would have run it), 1 by-design (this run's mode excludes it), 1 covered elsewhere
```

and each named omission is tagged `[missing]` / `[by-design]` / `[covered]`.

The test applied at each of the 34 call sites: **could a different invocation of this same harness against this same box have covered it?** Yes means `missing`; no means `by-design`. Nine sites are annotated (7 `by-design`, 2 `covered`); the other 25 keep the default.

## Two design decisions worth arguing with

**The default is `missing`, the pessimistic bucket.** An unclassified skip is an unexplained absence, so it counts as a gap. Defaulting the other way would let a real hole disappear by omission — which is #1083's own failure mode one level up. There is a mutation proof for exactly this: flipping the default to `covered` goes red.

**An unrecognised class is loud *and still counted*.** Erroring without counting would make the class totals stop summing to the bucket totals, and a summary whose own arithmetic does not reconcile is a worse instrument than a wrong label. There is an assertion that the two totals reconcile.

## What I re-derived rather than trusted

My own recon for this issue said the axis was binary — PERMANENT vs INCIDENTAL. Reading the code showed **three** classes, not two: `network.subnet` is neither "cannot run" nor "did not run", it is *run somewhere else* by the `--subnet` phase. A two-way axis would have forced it into the wrong bucket and the summary would still have misled, just differently. The issue's own suggestion 3 anticipates this ("or an explicit statement that it is covered elsewhere"); my recon did not.

Also re-derived: there is exactly **one** scenario-skip site (`run.sh:438`), fed by `resolve_overrides` as the single writer of `SKIP_REASON`. So the scenario axis needed two lines of plumbing, not five.

## Evidence

**Six mutations of the shipped code, each demonstrated red**, and the mutation was confirmed applied by grep before each verdict — two of the six initially reported as "did not apply" and were redone, which is the trap #1365 paid for (an ineffective mutation is indistinguishable from a surviving one):

| mutation | result |
|---|---|
| default flipped `missing` -> `covered` | RED (67/1) |
| class tag `[${4}]` dropped from the named list | RED (65/3) |
| unknown class silently accepted (`it_err` removed) | RED (67/1) |
| unknown class counted nowhere (reconciliation breaks) | RED (67/1) |
| breakdown line removed from `summary()` | RED (66/2) |
| a `by-design` annotation typo'd to `bydesign` | RED (67/1) |

**All 7 integration self-tests green** — `selftest-skip-accounting` 68 passed (up from 43), plus `selftest` 214, `selftest-e2e-phases` 63, `selftest-rigforge-writable-keys` 50, `selftest-rig-key-ledger` 31, `selftest-rigforge-apply-settle` 5, `selftest-compose-profiles` 5. `tests/inventory.sh` rc=0. `scripts/lint-file-budget.sh` rc=0 (`lib.sh` 687/692, `run.sh` 2543/2551; `skip-accounting.sh` is 114 lines, under the 400 target, so it correctly needs no budget entry). `make lint-docs-voice` passes.

## What was NOT run, and one honest caveat

- **`make lint-sh` was not run in full** — it is the OOM path on this box and is serialized fleet-wide. Substituted a targeted `shellcheck -x` over `tests/integration/*.sh` and **diffed the finding counts against the merge base**: the only new output is SC2030/SC2031 (both *info*), four sites, all inside the new self-test, all inherent to the subshell isolation the file already used. No new warning- or error-level finding. CI's shellcheck job is the binding one.
- **No live run.** This is a summary-rendering change proven by the real `summary()` extracted out of `run.sh` rather than re-spelled, but it has not been seen on a bench. The class assignments for the seven `by-design` sites are a reading of each site's reason text, not an observation of those legs skipping on hardware.
- **This does not close the coverage gaps #1083 also lists.** It makes them legible and separates the four that an input would fix from the one that is covered elsewhere. Remote-node mode still has no live coverage in the routine gate; that remains the issue's other half.

Diff is `tests/integration/*` plus `docs/dev/integration-testing.md` (shared `docs/`, disclosed here per lane policy).
