### PR TITLE
test(integration): the restore could hand back the branch under test and call it proven (#1448)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -46,7 +46,7 @@ scripts/lint-file-budget.sh	407
 scripts/release.sh	851
 scripts/shipped-image-sweep-report.sh	429
 scripts/trivyignore-watch.sh	599
-tests/integration/e2e.sh	766
+tests/integration/e2e.sh	691
 tests/integration/fakes/test_contract.py	451
 tests/integration/lib.sh	692
 tests/integration/run.sh	2551

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -229,6 +229,14 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    dir, not `CANONICAL_DIR`. That keeps the restore from handing the `pithead` project locally-built
    `:dev` images. If the label can't be read (stack down), it falls back to `CANONICAL_DIR`; override
    with `CANONICAL_DIR=<dir>`. The synced chains are never touched (asserted post-restore).
+   How the baseline comes back depends on what it is. A release bundle gets `pithead apply` then
+   `pithead up`: its images are versioned tags the branch never touched, so rebuilding them would be
+   waste. A **source checkout** gets `pithead upgrade` instead, and the difference is not an
+   optimisation. `pithead` exports `STACK_VERSION=dev` for any source checkout, so a source-checkout
+   baseline and the branch under test resolve to the same `:dev` tag — which deploying the branch has
+   already overwritten, with a pull policy of `never` to correct it. `apply` + `up` would bring the
+   branch back up under the baseline's name. The rebuild falls back to `apply` + `up` if it fails, so
+   a baseline that cannot rebuild is no worse off than before.
 7. Proves the restored stack matches the on-disk config
    ([#971](https://github.com/p2pool-starter-stack/pithead/issues/971)): the credential marker
    baked into the running dashboard container (`docker inspect`) must equal the on-disk `.env`
@@ -248,6 +256,19 @@ What it does, then reverses on exit (even on failure / Ctrl-C, via an `EXIT` tra
    all-clear on exactly the stranded box. That needs the live install on v1.19.2 or newer, the
    release whose `doctor` gained the check; an older one is reported as unproven rather than as a
    pass.
+   Last, the proof asks what code is actually running. The three checks above are all green on a
+   stack running the branch's images under the baseline's name: the credentials are read from the
+   on-disk `.env` at runtime, monerod answers with them, and the control units name the install
+   either way. So the run records each service's image **ID** before it touches anything and again
+   after the restore, and grades them per service — kept, rebuilt, still-the-branch's, or gone. Image
+   IDs, not tags: a tag that moved is the defect, so the tag cannot be the instrument. Per service,
+   not as one list: a branch that changes two Dockerfiles rebuilds two images, and the rest carry an
+   ID that legitimately matches both sides. A service still on the image the run built for the branch
+   fails the proof and names itself. A rebuilt image is reported as "not the branch's" and no more:
+   settling "built from the install directory" would need the image's own build provenance, and the
+   dashboard's `org.opencontainers.image.revision` ships empty
+   ([#1449](https://github.com/p2pool-starter-stack/pithead/issues/1449)) while the other four
+   images carry it.
 
 `--mode`: `targeted` (default, lean) validates the dashboard and the sync logic against the
 already-synced node: `check` + `--lifecycle` (one controlled restart exercises the sync gate /

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -250,25 +250,25 @@ restore_all() {
     stranded) step "control units before restore: STRANDED (expected — the branch deploy repoints them); the apply below must converge them" ;;
     *) step "control units before restore: $CONTROL_VERDICT_BEFORE" ;;
     esac
-    # #272, on the other end of the run. deploy_branch deliberately does NOT restore-shaped `apply`,
-    # because "apply runs `compose up --pull` (never --build), so it would test whatever images were
-    # last built on the box, not this branch" — and this restore used exactly that pairing. On a
-    # RELEASE-BUNDLE baseline it is right: STACK_VERSION is v<VERSION>, so the baseline's images are
-    # versioned tags the branch never touched, and a rebuild here would be waste. On a SOURCE-CHECKOUT
-    # baseline it is wrong, and silently: `pithead` exports STACK_VERSION=dev for any source checkout
-    # (export_build_provenance), so the baseline and the branch under test SHARE the `:dev` tag, and
-    # deploy_branch's build has already overwritten it. `apply && up` then brings the BRANCH back up
-    # under the baseline's name; the pull policy is `never` in a source checkout, so nothing corrects
-    # it, and checks 1-3 below are all green on it. Rebuild from the baseline's own tree instead.
-    # `is_source_checkout` is `[ -f dashboard/Dockerfile ]` (pithead:180) — mirrored, not re-invented.
-    # Falls back to the old pairing if the rebuild fails: a restore that half-ran is worse than one
-    # that ran the cheaper way, and check 4 reports either outcome honestly.
+    # #272, on the other end of the run. deploy_branch deliberately avoids a restore-shaped `apply`,
+    # because "apply runs `compose up --pull` (never --build), so it would test whatever images were last
+    # built on the box, not this branch" — and this restore used exactly that pairing. On a RELEASE-BUNDLE
+    # baseline that is right: STACK_VERSION is v<VERSION>, so the baseline's images are versioned tags the
+    # branch never touched. On a SOURCE-CHECKOUT baseline it is wrong, and silently: `pithead` exports
+    # STACK_VERSION=dev for any source checkout (export_build_provenance), so baseline and branch SHARE the
+    # `:dev` tag, which deploy_branch's build has already overwritten. `apply && up` then brings the BRANCH
+    # back up under the baseline's name; the pull policy is `never` here, so nothing corrects it, and checks
+    # 1-3 below are all green on it. Rebuild from the baseline's own tree instead, falling back to the old
+    # pairing if that fails; check 4 grades either outcome honestly. `is_source_checkout` is
+    # `[ -f dashboard/Dockerfile ]` (pithead:180) — mirrored, not reinvented. The `{ }` below is
+    # load-bearing: unbraced, a failed `cd` runs the FALLBACK in the ssh session's default directory and
+    # STILL returns 0 — a restore that never entered RESTORE_DIR, reported as run. Proven, not read off.
     local restore_cmd="./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"
     if on_bench "test -f '$RESTORE_DIR/dashboard/Dockerfile'"; then
         step "$RESTORE_DIR is a source checkout — restoring with 'pithead upgrade' so ITS images are rebuilt, not the branch's reused (#272)"
         restore_cmd="./pithead upgrade >/dev/null 2>&1 || { $restore_cmd; }"
     fi
-    if on_bench "cd '$RESTORE_DIR' && $restore_cmd"; then
+    if on_bench "cd '$RESTORE_DIR' && { $restore_cmd; }"; then
         wait_bench_healthy 300 && ok "baseline stack healthy again" || warn "baseline stack came up but isn't reporting healthy yet — check 'pithead status' on $BENCH_HOST"
         # Proof, even when the health wait timed out: a stack running the WRONG creds looks
         # exactly this healthy — that's the incident (#971). Never trust "up" alone.

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -38,6 +38,9 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/lib.sh"
 # shellcheck source=tests/integration/rig-supply.sh
 source "$HERE/rig-supply.sh"
+# restore-proof.sh: verify_restore_proof + the image-identity check the restore is graded on (#272).
+# shellcheck source=tests/integration/restore-proof.sh
+source "$HERE/restore-proof.sh"
 
 # --- Config (override via env or flags) -------------------------------------
 BENCH_HOST="${BENCH_HOST:-}"
@@ -247,7 +250,25 @@ restore_all() {
     stranded) step "control units before restore: STRANDED (expected — the branch deploy repoints them); the apply below must converge them" ;;
     *) step "control units before restore: $CONTROL_VERDICT_BEFORE" ;;
     esac
-    if on_bench "cd '$RESTORE_DIR' && ./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"; then
+    # #272, on the other end of the run. deploy_branch deliberately does NOT restore-shaped `apply`,
+    # because "apply runs `compose up --pull` (never --build), so it would test whatever images were
+    # last built on the box, not this branch" — and this restore used exactly that pairing. On a
+    # RELEASE-BUNDLE baseline it is right: STACK_VERSION is v<VERSION>, so the baseline's images are
+    # versioned tags the branch never touched, and a rebuild here would be waste. On a SOURCE-CHECKOUT
+    # baseline it is wrong, and silently: `pithead` exports STACK_VERSION=dev for any source checkout
+    # (export_build_provenance), so the baseline and the branch under test SHARE the `:dev` tag, and
+    # deploy_branch's build has already overwritten it. `apply && up` then brings the BRANCH back up
+    # under the baseline's name; the pull policy is `never` in a source checkout, so nothing corrects
+    # it, and checks 1-3 below are all green on it. Rebuild from the baseline's own tree instead.
+    # `is_source_checkout` is `[ -f dashboard/Dockerfile ]` (pithead:180) — mirrored, not re-invented.
+    # Falls back to the old pairing if the rebuild fails: a restore that half-ran is worse than one
+    # that ran the cheaper way, and check 4 reports either outcome honestly.
+    local restore_cmd="./pithead apply -y >/dev/null 2>&1 && ./pithead up >/dev/null 2>&1"
+    if on_bench "test -f '$RESTORE_DIR/dashboard/Dockerfile'"; then
+        step "$RESTORE_DIR is a source checkout — restoring with 'pithead upgrade' so ITS images are rebuilt, not the branch's reused (#272)"
+        restore_cmd="./pithead upgrade >/dev/null 2>&1 || { $restore_cmd; }"
+    fi
+    if on_bench "cd '$RESTORE_DIR' && $restore_cmd"; then
         wait_bench_healthy 300 && ok "baseline stack healthy again" || warn "baseline stack came up but isn't reporting healthy yet — check 'pithead status' on $BENCH_HOST"
         # Proof, even when the health wait timed out: a stack running the WRONG creds looks
         # exactly this healthy — that's the incident (#971). Never trust "up" alone.
@@ -311,119 +332,6 @@ wait_synced() { # <timeout_s>
     done
 }
 
-# Restore proof (#971): after the restore brings the baseline back up, prove the LIVE stack
-# actually runs RESTORE_DIR's on-disk config. A pre-#921 e2e run once left the containers on
-# harness-rendered creds while the on-disk .env kept the real ones — internally consistent, so it
-# mined and looked healthy for a day, while every host-side RPC probe 401ed. Two checks:
-#   1. The credential marker baked into the running dashboard container (docker inspect) is the
-#      same line as the on-disk .env's — env_bake_verdict (lib.sh) prints verdict words only,
-#      never values.
-#   2. monerod answers a host-side get_info with the on-disk creds — the exact probe the incident
-#      broke. Only .status is required (sync may still be re-confirming); polled briefly because
-#      the containers were just recreated. The probe script travels over ssh stdin (bash -s), so
-#      the creds stay on the box and the remote command string carries no shell parens.
-#   3. The box-global control units still name RESTORE_DIR (#1085). deploy_branch's `pithead
-#      upgrade` repoints them at E2E_DIR, and the hardening phase's teardown deletes them outright
-#      when it owns them — either way the live dashboard's config edits and one-click upgrades
-#      queue into a spool nothing watches, while every other signal here still reads healthy.
-#      The verdict comes from RESTORE_DIR's OWN doctor, run from RESTORE_DIR. That is not a
-#      preference: check_control_units compares the installed units' ExecStart against $PWD, and
-#      `pithead` cd's to the directory of the binary you invoke (SCRIPT_DIR, pithead:100) — so the
-#      BRANCH's copy would compare against E2E_DIR and print the OK verdict on exactly the
-#      stranded box this check exists to catch. It needs RESTORE_DIR on v1.19.2+, the release that
-#      added the check; anything older classifies as no-check and FAILS rather than passing quietly.
-# Returns 0 when all three hold.
-RESTORE_PROOF_VAR="MONERO_NODE_PASSWORD"
-verify_restore_proof() {
-    local prc=0 disk cid baked="" verdict
-    disk="$(on_bench "grep -E '^${RESTORE_PROOF_VAR}=' '$RESTORE_DIR/.env' 2>/dev/null | head -n1" || true)"
-    cid="$(on_bench "docker ps -q --filter label=com.docker.compose.project=pithead --filter label=com.docker.compose.service=dashboard 2>/dev/null | head -n1" || true)"
-    [ -n "$cid" ] && baked="$(on_bench "docker inspect --format '{{json .Config.Env}}' '$cid' 2>/dev/null | jq -r '.[]'" || true)"
-    verdict="$(env_bake_verdict "$RESTORE_PROOF_VAR" "$disk" "$baked")"
-    if [ "$verdict" = "match" ]; then
-        ok "restore proof: dashboard container env matches the on-disk .env ($RESTORE_PROOF_VAR)"
-    else
-        warn "restore proof: $RESTORE_PROOF_VAR baked into the live dashboard container vs $RESTORE_DIR/.env: $verdict"
-        prc=1
-    fi
-
-    local out deadline=$(($(date +%s) + 60))
-    while :; do
-        out="$(
-            on_bench "cd '$RESTORE_DIR' && bash -s" <<'PROBE'
-u=$(grep -E '^MONERO_NODE_USERNAME=' .env 2>/dev/null | cut -d= -f2-)
-p=$(grep -E '^MONERO_NODE_PASSWORD=' .env 2>/dev/null | cut -d= -f2-)
-url=$(grep -E '^MONERO_RPC_URL=' .env 2>/dev/null | cut -d= -f2-)
-[ -n "$url" ] || url="http://127.0.0.1:18081"
-if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null)
-else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi
-printf '%s' "$body" | jq -e '.status=="OK"' >/dev/null 2>&1 && echo rpc-ok || echo rpc-fail
-PROBE
-        )" || true
-        if [ "$out" = "rpc-ok" ]; then
-            ok "restore proof: host-side get_info answers with the on-disk creds"
-            break
-        fi
-        if [ "$(date +%s)" -ge "$deadline" ]; then
-            warn "restore proof: host-side get_info with the on-disk creds did NOT answer within 60s — the live monerod may be running different creds than $RESTORE_DIR/.env"
-            prc=1
-            break
-        fi
-        sleep 10
-    done
-
-    # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
-    #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
-    #    It runs AFTER restore_all's `apply -y`, which converges the units (v1.19.2+), so on the
-    #    ordinary #1085 path the strand is already repaired: this arm proves the box was LEFT
-    #    working, it does not detect the strand (CONTROL_VERDICT_BEFORE and run.sh's ExecStart
-    #    assertion do). Alone it catches a pithead too old to converge (no-check), a disabled
-    #    channel where apply leaves stray units, and strands this run did not cause.
-    local doc verdict_line
-    doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
-    verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
-    case "$(control_units_verdict "$doc")" in
-    on-target)
-        # The units name the right directory. That is text; `enabled` is behaviour, and
-        # provision_control_runner's `systemctl enable --now` is warn-only, so apply can return 0
-        # with correctly-named units that will never fire.
-        if on_bench "systemctl is-enabled pithead-control.path >/dev/null 2>&1"; then
-            ok "restore proof: the control runner units point at $RESTORE_DIR, and the path unit is enabled"
-        else
-            warn "restore proof: the control units name $RESTORE_DIR but pithead-control.path is NOT enabled — correctly addressed and never fired."
-            warn "  Repair on the box: sudo systemctl enable --now pithead-control.path"
-            CONTROL_PROOF_FAILED=1
-        fi
-        ;;
-    disabled)
-        # NOT a pass. `apply` leaves the units alone when control is disabled, so this is the one
-        # state in which a strand SURVIVES the restore. Look for the leftovers directly.
-        if on_bench "grep -qsF 'ExecStart=$E2E_DIR/pithead' /etc/systemd/system/pithead-control.service"; then
-            warn "restore proof: the control channel is disabled in $RESTORE_DIR's config, and the box-global units still name the e2e checkout ($E2E_DIR). A disabled apply does not clean them up."
-            warn "  Repair on the box: sudo rm -f /etc/systemd/system/pithead-control.{path,service} && sudo systemctl daemon-reload"
-            CONTROL_PROOF_FAILED=1
-        else
-            ok "restore proof: control channel disabled in $RESTORE_DIR, and no unit names the e2e checkout"
-        fi
-        ;;
-    not-live)
-        warn "restore proof: $RESTORE_DIR is not the live install by its own reckoning — doctor declined to grade its control channel. Units NOT proven."
-        warn "  doctor said: ${verdict_line:-<no verdict line>}"
-        ;;
-    no-check)
-        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. On a pre-v1.19.2 install the restore's own apply cannot converge the units either, so assume the box IS stranded."
-        warn "  Check by hand: systemctl cat pithead-control.service"
-        CONTROL_PROOF_FAILED=1
-        ;;
-    *)
-        warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
-        warn "  doctor said: ${verdict_line:-<no verdict line>}"
-        CONTROL_PROOF_FAILED=1
-        ;;
-    esac
-    return "$prc"
-}
-
 # Nudge the miner's xmrig to reload its (rewritten) config. xmrig watches its config file and
 # reloads on change; the systemctl/SIGHUP fallbacks cover builds that don't. Whichever works, we
 # verify by polling the test bench for the worker — so the exact mechanism doesn't matter.
@@ -475,6 +383,17 @@ preflight() {
             warn "live stack runs from $RESTORE_DIR (not CANONICAL_DIR=$CANONICAL_DIR) — restore will target it (#454)."
     else
         warn "couldn't resolve the live stack's working dir — restore will use CANONICAL_DIR=$CANONICAL_DIR."
+    fi
+    # The images the baseline is on, captured for the same reason and at the same moment as
+    # RESTORE_DIR: deploy_branch is about to rebuild the first-party images, and on a source-checkout
+    # box it rebuilds them under the very tag the baseline resolves to. Nothing downstream can tell
+    # the baseline's images from the branch's once that has happened, so the record has to be taken
+    # here or not at all. Read by verify_restore_proof's check 4.
+    BASELINE_IMAGES="$(stack_image_census)"
+    if [ -n "$BASELINE_IMAGES" ]; then
+        ok "baseline image census: $(printf '%s\n' "$BASELINE_IMAGES" | grep -c .) service(s) recorded"
+    else
+        warn "nothing running to census — the restore's image check will report NOT CHECKED rather than pass."
     fi
     # Chains at tip BEFORE anything is locked or borrowed (#914): a bench that starts hours
     # behind fails the required-sync assertions as environment noise — not a regression — and
@@ -675,6 +594,13 @@ deploy_branch() {
     # Record what was actually built, so "what did we test" is unambiguous in the run log (#272).
     on_bench "cd '$E2E_DIR' && docker compose images --format '{{.Service}} {{.Repository}}:{{.Tag}} {{.ID}}' 2>/dev/null | grep -E 'p2pool|dashboard|monero|tor|xmrig' || true" | while IFS= read -r l; do step "image: $l"; done
     wait_bench_healthy 300 || warn "stack applied but not yet healthy; the harness will wait on real readiness signals"
+    # What the branch's build produced, by service — read by verify_restore_proof's check 4, so that
+    # "the branch's image came back up as the baseline" is a distinguishable outcome and not an
+    # invisible one. Taken AFTER the health wait rather than straight after the upgrade: the census
+    # reads running containers, and one still being recreated would simply be absent. That direction
+    # only ever weakens the check (a service missing here can never be accused of being the branch's,
+    # so the failure mode is a missed catch, never a false accusation) — but a settled stack is free.
+    BRANCH_IMAGES="$(stack_image_census)"
     wait_synced 300 || true # let the recreated monerod/tari re-confirm their tip before the harness pre-check
     ok "branch deployed; stack reconciled"
 }

--- a/tests/integration/restore-proof.sh
+++ b/tests/integration/restore-proof.sh
@@ -202,6 +202,12 @@ PROBE
     #                                   "not the branch's" is a weaker claim than "built from
     #                                   RESTORE_DIR". Settling that would need the image's own build
     #                                   provenance, and the dashboard's ships empty (#1449).
+    # Where a false RED would come from, named rather than discovered later: 'gone' turns a service
+    # that is not running into a proof failure, and wait_bench_healthy above only WARNS on a timeout.
+    # So a stack that is genuinely still coming up after its 300s poll now fails the restore instead
+    # of passing with a warning. That is the intended reading — a service that ran before the run and
+    # does not run after it is a failed restore, whatever the reason — but it is a behaviour change on
+    # a slow box, and it is the first thing to look at if a restore starts failing here.
     local now_images verdicts line stale=0 rebuilt=0 kept=0 gone=0
     now_images="$(stack_image_census)"
     if [ -z "$BASELINE_IMAGES" ]; then

--- a/tests/integration/restore-proof.sh
+++ b/tests/integration/restore-proof.sh
@@ -1,0 +1,240 @@
+# shellcheck shell=bash
+#
+# The restore proof (#971, #1085) and the image-identity check that goes with it (#272, restore side).
+#
+# Sourced by e2e.sh, which supplies on_bench/ok/warn/step, RESTORE_DIR, E2E_DIR and
+# env_bake_verdict/control_units_verdict (lib.sh). Split out of e2e.sh rather than written there:
+# the classifier below has to be drivable with no ssh and no docker, because that is the tier its
+# mutation proof runs at (selftest-e2e-restore-proof.sh), and e2e.sh is at its file budget.
+#
+# The proof answers one question the rest of the harness cannot: after the EXIT trap has put the
+# box back, is the box actually back? A restore that half-worked looks exactly as healthy as one
+# that worked — that is the #971 incident, and the image check below is the same shape one layer
+# further in.
+
+# What the live stack was RUNNING, by service, before this run touched anything, and what
+# deploy_branch then built. Both are image IDs, not tags: the defect they exist to catch is a tag
+# that MOVED, so the tag cannot be the instrument. Empty means "not captured" — a skip, never a pass.
+BASELINE_IMAGES=""
+BRANCH_IMAGES=""
+
+# The image OBJECT each running service is on. `docker ps` scopes it to the one pinned Compose
+# project, so this reads the live stack whichever checkout last drove it. A re-tag does not move an
+# image ID; only a rebuild or a different image does.
+stack_image_census() { # -> sorted "<service>=<image-id>" lines; empty when no stack is running
+    on_bench "docker ps -q --filter label=com.docker.compose.project=pithead 2>/dev/null |
+        xargs -r docker inspect --format '{{index .Config.Labels \"com.docker.compose.service\"}}={{.Image}}' 2>/dev/null |
+        sort" 2>/dev/null || true
+}
+
+# One service's image ID out of a census. Empty when the census does not carry that service.
+census_get() { # <census> <service>
+    printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -n1
+}
+
+# Which services came back on what. Pure — three strings in, one verdict per baseline service out,
+# no ssh and no docker — so the mutation proof for it runs with no bench
+# (selftest-e2e-restore-proof.sh). Graded per service because a partial overlap is the realistic
+# case: a branch that changes two Dockerfiles rebuilds two images, and the other services
+# legitimately carry an image ID that matches the baseline AND the branch.
+#   kept     the same image object it ran before the run
+#   rebuilt  different from both censuses — built from RESTORE_DIR's own tree by the restore
+#   stale    the image THIS RUN built for the branch, now running under the baseline's name
+#   gone     ran before the run, not running now
+# `stale` is graded before `rebuilt` on purpose: an image that equals the branch's is never
+# evidence of a rebuild, however different it is from the baseline.
+# No `[ -n "$branch" ]` guard on the stale arm, deliberately: reaching it already requires a
+# non-empty $now, so an absent branch census (a --mode check run, where deploy_branch never ran)
+# fails the equality on its own. The guard was there in the first draft; it could not change any
+# outcome, and the mutation battery is what showed that — an unkillable mutant is a claim about the
+# code, not about the test.
+# It walks the BASELINE, so a service that only exists in the after-census is not graded: the
+# question here is whether what was running came back, not whether something new appeared. A new
+# service is a compose-file change, which the deploy phase already exercises.
+grade_image_census() { # <baseline> <now> <branch> -> "<verdict> <service>" lines
+    local svc now base branch
+    while IFS= read -r svc; do
+        [ -n "$svc" ] || continue
+        svc="${svc%%=*}"
+        base="$(census_get "$1" "$svc")"
+        now="$(census_get "$2" "$svc")"
+        branch="$(census_get "$3" "$svc")"
+        if [ -z "$now" ]; then
+            printf 'gone %s\n' "$svc"
+        elif [ "$now" = "$base" ]; then
+            printf 'kept %s\n' "$svc"
+        elif [ "$now" = "$branch" ]; then
+            printf 'stale %s\n' "$svc"
+        else
+            printf 'rebuilt %s\n' "$svc"
+        fi
+    done <<<"$1"
+}
+
+# Restore proof (#971): after the restore brings the baseline back up, prove the LIVE stack
+# actually runs RESTORE_DIR's on-disk config. A pre-#921 e2e run once left the containers on
+# harness-rendered creds while the on-disk .env kept the real ones — internally consistent, so it
+# mined and looked healthy for a day, while every host-side RPC probe 401ed. Four checks:
+#   1. The credential marker baked into the running dashboard container (docker inspect) is the
+#      same line as the on-disk .env's — env_bake_verdict (lib.sh) prints verdict words only,
+#      never values.
+#   2. monerod answers a host-side get_info with the on-disk creds — the exact probe the incident
+#      broke. Only .status is required (sync may still be re-confirming); polled briefly because
+#      the containers were just recreated. The probe script travels over ssh stdin (bash -s), so
+#      the creds stay on the box and the remote command string carries no shell parens.
+#   3. The box-global control units still name RESTORE_DIR (#1085). deploy_branch's `pithead
+#      upgrade` repoints them at E2E_DIR, and the hardening phase's teardown deletes them outright
+#      when it owns them — either way the live dashboard's config edits and one-click upgrades
+#      queue into a spool nothing watches, while every other signal here still reads healthy.
+#      The verdict comes from RESTORE_DIR's OWN doctor, run from RESTORE_DIR. That is not a
+#      preference: check_control_units compares the installed units' ExecStart against $PWD, and
+#      `pithead` cd's to the directory of the binary you invoke (SCRIPT_DIR, pithead:100) — so the
+#      BRANCH's copy would compare against E2E_DIR and print the OK verdict on exactly the
+#      stranded box this check exists to catch. It needs RESTORE_DIR on v1.19.2+, the release that
+#      added the check; anything older classifies as no-check and FAILS rather than passing quietly.
+#   4. The live containers are on the images the baseline ran, or on ones rebuilt from RESTORE_DIR
+#      — never on the ones this run built for the branch. Spelled out at the check itself.
+# Returns 0 when all four hold.
+RESTORE_PROOF_VAR="MONERO_NODE_PASSWORD"
+# shellcheck disable=SC2034  # CONTROL_PROOF_FAILED is declared and read by e2e.sh, which sources
+# this file; it is set here because this is where the control-channel verdict is graded.
+verify_restore_proof() {
+    local prc=0 disk cid baked="" verdict
+    disk="$(on_bench "grep -E '^${RESTORE_PROOF_VAR}=' '$RESTORE_DIR/.env' 2>/dev/null | head -n1" || true)"
+    cid="$(on_bench "docker ps -q --filter label=com.docker.compose.project=pithead --filter label=com.docker.compose.service=dashboard 2>/dev/null | head -n1" || true)"
+    [ -n "$cid" ] && baked="$(on_bench "docker inspect --format '{{json .Config.Env}}' '$cid' 2>/dev/null | jq -r '.[]'" || true)"
+    verdict="$(env_bake_verdict "$RESTORE_PROOF_VAR" "$disk" "$baked")"
+    if [ "$verdict" = "match" ]; then
+        ok "restore proof: dashboard container env matches the on-disk .env ($RESTORE_PROOF_VAR)"
+    else
+        warn "restore proof: $RESTORE_PROOF_VAR baked into the live dashboard container vs $RESTORE_DIR/.env: $verdict"
+        prc=1
+    fi
+
+    local out deadline=$(($(date +%s) + 60))
+    while :; do
+        out="$(
+            on_bench "cd '$RESTORE_DIR' && bash -s" <<'PROBE'
+u=$(grep -E '^MONERO_NODE_USERNAME=' .env 2>/dev/null | cut -d= -f2-)
+p=$(grep -E '^MONERO_NODE_PASSWORD=' .env 2>/dev/null | cut -d= -f2-)
+url=$(grep -E '^MONERO_RPC_URL=' .env 2>/dev/null | cut -d= -f2-)
+[ -n "$url" ] || url="http://127.0.0.1:18081"
+if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null)
+else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi
+printf '%s' "$body" | jq -e '.status=="OK"' >/dev/null 2>&1 && echo rpc-ok || echo rpc-fail
+PROBE
+        )" || true
+        if [ "$out" = "rpc-ok" ]; then
+            ok "restore proof: host-side get_info answers with the on-disk creds"
+            break
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            warn "restore proof: host-side get_info with the on-disk creds did NOT answer within 60s — the live monerod may be running different creds than $RESTORE_DIR/.env"
+            prc=1
+            break
+        fi
+        sleep 10
+    done
+
+    # 3. The control units must still name RESTORE_DIR (#1085). Grep the verdict, never doctor's
+    #    exit code — it is 1 on ANY dr_fail, so an unrelated failure elsewhere would swamp this.
+    #    It runs AFTER restore_all's `apply -y`, which converges the units (v1.19.2+), so on the
+    #    ordinary #1085 path the strand is already repaired: this arm proves the box was LEFT
+    #    working, it does not detect the strand (CONTROL_VERDICT_BEFORE and run.sh's ExecStart
+    #    assertion do). Alone it catches a pithead too old to converge (no-check), a disabled
+    #    channel where apply leaves stray units, and strands this run did not cause.
+    local doc verdict_line
+    doc="$(on_bench "cd '$RESTORE_DIR' && ./pithead doctor 2>/dev/null" || true)"
+    verdict_line="$(printf '%s\n' "$doc" | awk '/^Dashboard control channel:/{getline; print; exit}')"
+    case "$(control_units_verdict "$doc")" in
+    on-target)
+        # The units name the right directory. That is text; `enabled` is behaviour, and
+        # provision_control_runner's `systemctl enable --now` is warn-only, so apply can return 0
+        # with correctly-named units that will never fire.
+        if on_bench "systemctl is-enabled pithead-control.path >/dev/null 2>&1"; then
+            ok "restore proof: the control runner units point at $RESTORE_DIR, and the path unit is enabled"
+        else
+            warn "restore proof: the control units name $RESTORE_DIR but pithead-control.path is NOT enabled — correctly addressed and never fired."
+            warn "  Repair on the box: sudo systemctl enable --now pithead-control.path"
+            CONTROL_PROOF_FAILED=1
+        fi
+        ;;
+    disabled)
+        # NOT a pass. `apply` leaves the units alone when control is disabled, so this is the one
+        # state in which a strand SURVIVES the restore. Look for the leftovers directly.
+        if on_bench "grep -qsF 'ExecStart=$E2E_DIR/pithead' /etc/systemd/system/pithead-control.service"; then
+            warn "restore proof: the control channel is disabled in $RESTORE_DIR's config, and the box-global units still name the e2e checkout ($E2E_DIR). A disabled apply does not clean them up."
+            warn "  Repair on the box: sudo rm -f /etc/systemd/system/pithead-control.{path,service} && sudo systemctl daemon-reload"
+            CONTROL_PROOF_FAILED=1
+        else
+            ok "restore proof: control channel disabled in $RESTORE_DIR, and no unit names the e2e checkout"
+        fi
+        ;;
+    not-live)
+        warn "restore proof: $RESTORE_DIR is not the live install by its own reckoning — doctor declined to grade its control channel. Units NOT proven."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
+        ;;
+    no-check)
+        warn "restore proof: $RESTORE_DIR's doctor printed no control-channel verdict — that pithead predates the check (v1.19.2), or the box has no systemd. On a pre-v1.19.2 install the restore's own apply cannot converge the units either, so assume the box IS stranded."
+        warn "  Check by hand: systemctl cat pithead-control.service"
+        CONTROL_PROOF_FAILED=1
+        ;;
+    *)
+        warn "restore proof: the control runner units do NOT point at $RESTORE_DIR — the live dashboard's config changes and one-click upgrades queue into a spool nothing reads, with nothing reporting a fault."
+        warn "  doctor said: ${verdict_line:-<no verdict line>}"
+        CONTROL_PROOF_FAILED=1
+        ;;
+    esac
+
+    # 4. WHAT CODE IS ACTUALLY RUNNING. Checks 1-3 are all green on a stack running the BRANCH's
+    #    images under the baseline's name: the creds are read from the on-disk .env at runtime, so
+    #    the bake matches; monerod answers with them; and the control units name RESTORE_DIR either
+    #    way. Not one of them ever looked at the image. The restore comment at #454 already warned
+    #    that restoring from the wrong dir "hands the pithead project locally-built :dev images" —
+    #    this is the same hazard reached from the RIGHT dir, when that dir is a source checkout and
+    #    therefore shares `:dev` with the branch under test.
+    #    Graded per service against two censuses, because a partial overlap is the realistic case —
+    #    a branch that only changes two Dockerfiles rebuilds only two images, and the other three
+    #    legitimately match both sides:
+    #      same as baseline          -> restored (or never rebuilt). Fine.
+    #      differs, EQUALS the branch-> the branch's image is live under the baseline's name. RED.
+    #      differs from both         -> rebuilt from RESTORE_DIR's own tree. Reported, not asserted:
+    #                                   "not the branch's" is a weaker claim than "built from
+    #                                   RESTORE_DIR". Settling that would need the image's own build
+    #                                   provenance, and the dashboard's ships empty (#1449).
+    local now_images verdicts line stale=0 rebuilt=0 kept=0 gone=0
+    now_images="$(stack_image_census)"
+    if [ -z "$BASELINE_IMAGES" ]; then
+        warn "restore proof: image identity NOT CHECKED — no baseline census was taken (nothing was running at preflight)."
+    elif [ -z "$now_images" ]; then
+        warn "restore proof: image identity NOT CHECKED — no stack is running to census now."
+        prc=1
+    else
+        verdicts="$(grade_image_census "$BASELINE_IMAGES" "$now_images" "$BRANCH_IMAGES")"
+        while IFS= read -r line; do
+            case "$line" in
+            kept\ *) kept=$((kept + 1)) ;;
+            rebuilt\ *) rebuilt=$((rebuilt + 1)) ;;
+            stale\ *)
+                warn "restore proof: '${line#stale }' is still on the image THIS RUN BUILT for the branch — the baseline was renamed, not restored."
+                stale=$((stale + 1))
+                ;;
+            gone\ *)
+                warn "restore proof: service '${line#gone }' ran before this run and is NOT running now."
+                gone=$((gone + 1))
+                ;;
+            esac
+        done <<<"$verdicts"
+        if [ "$stale" -gt 0 ] || [ "$gone" -gt 0 ]; then prc=1; fi
+        if [ "$stale" -gt 0 ]; then
+            warn "  $stale service(s) are running the branch under test. Rebuild the baseline by hand: cd $RESTORE_DIR && ./pithead upgrade"
+        elif [ "$gone" -gt 0 ]; then
+            warn "  the restore did not bring the whole baseline back — check 'pithead status' in $RESTORE_DIR."
+        elif [ "$rebuilt" -gt 0 ]; then
+            ok "restore proof: $kept service(s) back on their pre-run images, $rebuilt rebuilt from $RESTORE_DIR (not the branch's)"
+        else
+            ok "restore proof: all $kept service(s) are back on the exact images they ran before this run"
+        fi
+    fi
+    return "$prc"
+}

--- a/tests/integration/selftest-e2e-restore-proof.sh
+++ b/tests/integration/selftest-e2e-restore-proof.sh
@@ -165,7 +165,7 @@ drive_restore() { # <is-source-checkout: yes|no> -> the `cd RESTORE_DIR && ...` 
             # restore command.
             "test -f "*dashboard/Dockerfile*) [ "$SRC_CHECKOUT" = yes ] && return 0 || return 1 ;;
             "cd '$RESTORE_DIR' && "*)
-                printf '%s' "${1#cd \'$RESTORE_DIR\' && }" >"$CMD_FILE"
+                printf '%s' "$1" >"$CMD_FILE"
                 return 0
                 ;;
             esac
@@ -179,8 +179,13 @@ drive_restore() { # <is-source-checkout: yes|no> -> the `cd RESTORE_DIR && ...` 
 }
 
 echo "== the restore command, by baseline kind =="
-SRC_CMD="$(drive_restore yes)"
-BUNDLE_CMD="$(drive_restore no)"
+# The capture is the WHOLE `cd ... && ...` string, because section 2b runs it; the leading cd is
+# stripped here only so the by-kind assertions below read as before.
+SRC_FULL="$(drive_restore yes)"
+BUNDLE_FULL="$(drive_restore no)"
+SRC_CMD="${SRC_FULL#*&& }"
+BUNDLE_CMD="${BUNDLE_FULL#*&& }"
+assert_contains "the capture is the full command, cd included" "$SRC_FULL" "cd '/srv/code/baseline' &&"
 
 # The fix. A source-checkout baseline shares `:dev` with the branch, so the restore must REBUILD
 # from the baseline's tree. Kills the mutation that reverts the restore to `apply && up`.
@@ -193,6 +198,45 @@ assert_contains "the source-checkout restore falls back to apply/up if the rebui
 assert_eq "a release-bundle baseline is NOT rebuilt" \
     "$(case "$BUNDLE_CMD" in *upgrade*) echo yes ;; *) echo no ;; esac)" "no"
 assert_contains "a release-bundle baseline still gets apply + up" "$BUNDLE_CMD" "./pithead apply -y"
+
+# --- 2b. The grouping, DRIVEN --------------------------------------------------------------------
+# `cd D && upgrade || { apply && up; }` does not mean what it looks like: the `||` binds to the whole
+# `cd D && upgrade`, so a FAILED cd runs the FALLBACK in the ssh session's default directory and the
+# whole command still returns 0 — a restore that never entered RESTORE_DIR, reported as having run.
+# The braces in e2e.sh are what prevent that. This runs the SHIPPED command string against a cd that
+# cannot succeed, rather than asserting on its text: a text assertion here would pass on any string
+# that happens to contain a brace.
+grouping_probe() { # <full-command> -> "<rc> ran|clean"
+    local sandbox cmd rc ran
+    sandbox="$(mktemp -d)"
+    # A `pithead` in the DEFAULT directory is the whole hazard: if the fallback runs after a failed
+    # cd, this is what it would find and execute.
+    printf '#!/bin/sh\nprintf %%s "$1" >>"%s/ran"\nexit 0\n' "$sandbox" >"$sandbox/pithead"
+    chmod +x "$sandbox/pithead"
+    cmd="$(printf '%s' "$1" | sed "s#/srv/code/baseline#$sandbox/no-such-dir#")"
+    (cd "$sandbox" && eval "$cmd") >/dev/null 2>&1
+    rc=$?
+    [ -s "$sandbox/ran" ] && ran=ran || ran=clean
+    rm -rf "$sandbox"
+    printf '%s %s' "$rc" "$ran"
+}
+
+echo "== a failed cd must not run the restore anyway =="
+assert_eq "a failed cd fails the restore and executes nothing" "$(grouping_probe "$SRC_FULL")" "1 clean"
+
+# Negative control. Without it "1 clean" is equally consistent with a probe that never ran anything
+# at all, which is the likelier of the two failure modes and the one that reads exactly like a pass.
+# Assert the transform CHANGED the string first — an unapplied mutation reads as a guard that held.
+UNBRACED="$(printf '%s' "$SRC_FULL" | sed 's/&& { /\&\& /; s/; }$//')"
+assert_eq "negative control: the unbracing actually changed the command" \
+    "$(if [ "$UNBRACED" = "$SRC_FULL" ]; then echo unchanged; else echo changed; fi)" "changed"
+# ...and that it is still a RUNNABLE command. The first draft of this transform produced a syntax
+# error, which the probe reported as rc=2/clean — a control that fails to fire looks like the
+# defect being absent, so the shape has to be checked as well as the difference.
+assert_eq "negative control: the unbraced command still parses" \
+    "$(bash -n -c "$UNBRACED" 2>/dev/null && echo parses || echo broken)" "parses"
+assert_eq "negative control: the UNBRACED shape runs the fallback in the wrong dir, and returns 0" \
+    "$(grouping_probe "$UNBRACED")" "0 ran"
 
 # --- 3. Mutation battery ----------------------------------------------------------------------
 # Each entry restores a real defect in a COPY of the shipped module and requires the classifier

--- a/tests/integration/selftest-e2e-restore-proof.sh
+++ b/tests/integration/selftest-e2e-restore-proof.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+#
+# Self-test for the restore's image-identity check (#272, restore side) and for the restore command
+# e2e.sh chooses.
+#
+# The defect it locks down is an ABSENCE, like #1364's. e2e.sh's own comment at deploy_branch says
+# `pithead apply` "runs `compose up --pull` (never --build), so it would test whatever images were
+# last built on the box, not this branch" — and the restore, at the other end of the same run, used
+# exactly that pairing. On a box whose live install is a SOURCE CHECKOUT, `pithead` exports
+# STACK_VERSION=dev (export_build_provenance, pithead:4149), so the baseline and the branch under
+# test resolve to the SAME `:dev` tag; deploy_branch has already overwritten it, the source-checkout
+# pull policy is `never`, and `apply && up` therefore brings the BRANCH back up under the baseline's
+# name. Every other restore check stays green on that: the creds are read from the on-disk .env at
+# runtime, monerod answers with them, and the control units name RESTORE_DIR either way. The run
+# prints "restore complete."
+#
+# Two things are proven here, both against the SHIPPED files, never against a re-spelling:
+#   1. grade_image_census classifies correctly, sourced straight out of restore-proof.sh.
+#   2. restore_all, extracted out of e2e.sh and evaluated against stubs, picks `pithead upgrade` for
+#      a source-checkout baseline and the cheaper `apply && up` for a release bundle.
+# Then a mutation battery restores each defect in a COPY of the shipped module and requires the
+# assertions to RED. A classifier that cannot fail is a grep, not a guard.
+#
+# Standalone (not sourced by selftest.sh), same reasoning as selftest-e2e-phases.sh. Run directly or
+# via `make test-integration-selftest`. No server, no bench, no rig, no docker.
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+E2E_SRC="$HERE/e2e.sh"
+PROOF_SRC="$HERE/restore-proof.sh"
+
+# Fail CLOSED: if a refactor moves the classifier out of restore-proof.sh this must go red rather
+# than quietly stop testing anything — the exact shape of gate this file exists to catch.
+# shellcheck source=tests/integration/restore-proof.sh
+source "$PROOF_SRC"
+assert_eq "restore-proof.sh actually defines grade_image_census" "$(type -t grade_image_census)" "function"
+
+# --- Fixtures ---------------------------------------------------------------------------------
+# Five services. The branch build changed only two images (tor, dashboard) — the realistic case,
+# and the one that makes a whole-list comparison useless: monerod/p2pool/xmrig-proxy carry an ID
+# that matches the baseline AND the branch, so "the censuses differ" says nothing about them.
+BASE='dashboard=sha256:aaa
+monerod=sha256:mmm
+p2pool=sha256:ppp
+tor=sha256:ttt
+xmrig-proxy=sha256:xxx'
+BRANCH='dashboard=sha256:AAA
+monerod=sha256:mmm
+p2pool=sha256:ppp
+tor=sha256:TTT
+xmrig-proxy=sha256:xxx'
+
+verdict_for() { # <now-census> <service> -> the verdict word
+    grade_image_census "$BASE" "$1" "$BRANCH" | sed -n "s/ $2\$//p" | head -n1
+}
+
+# --- 1. The classifier ------------------------------------------------------------------------
+# Every assertion below is written so that ONE named mutation flips it; the battery at the bottom
+# runs those mutations for real.
+run_census_assertions() {
+    echo "== grade_image_census =="
+
+    # A faithful restore: every service back on the image it ran before.
+    assert_eq "an exact restore grades every service 'kept'" \
+        "$(grade_image_census "$BASE" "$BASE" "$BRANCH" | cut -d' ' -f1 | sort -u | tr '\n' ' ')" "kept "
+
+    # THE DEFECT. The branch's images are still up under the baseline's name. Kills the mutation
+    # that drops the branch census from the comparison (grading against the baseline alone): the
+    # two changed services differ from the baseline either way, so a baseline-only check calls this
+    # "rebuilt" and passes the run.
+    assert_eq "the branch's dashboard left running is 'stale', not 'rebuilt'" \
+        "$(verdict_for "$BRANCH" dashboard)" "stale"
+    assert_eq "the branch's tor left running is 'stale', not 'rebuilt'" \
+        "$(verdict_for "$BRANCH" tor)" "stale"
+
+    # The other three are indistinguishable between the two censuses and must NOT be accused.
+    # Kills a whole-list `[ "$now" = "$BASELINE_IMAGES" ]` comparison, which would condemn all five
+    # on any difference and make the check's output useless for locating the fault.
+    assert_eq "a service the branch never rebuilt is 'kept', even on a stale run" \
+        "$(verdict_for "$BRANCH" monerod)" "kept"
+
+    # A genuine rebuild from RESTORE_DIR's own tree: differs from the baseline AND from the branch.
+    REBUILT='dashboard=sha256:zzz
+monerod=sha256:mmm
+p2pool=sha256:ppp
+tor=sha256:yyy
+xmrig-proxy=sha256:xxx'
+    assert_eq "an image built from neither census is 'rebuilt'" \
+        "$(verdict_for "$REBUILT" dashboard)" "rebuilt"
+
+    # Ordering. This image differs from the baseline and equals the branch's; 'stale' must win.
+    # Kills a mutation that tests the rebuilt arm first, which would silently reclassify every
+    # stale service as a legitimate rebuild — a green run on the exact failure being guarded.
+    ONE_STALE='dashboard=sha256:AAA
+monerod=sha256:mmm
+p2pool=sha256:ppp
+tor=sha256:ttt
+xmrig-proxy=sha256:xxx'
+    assert_eq "'stale' beats 'rebuilt' when an image matches the branch" \
+        "$(verdict_for "$ONE_STALE" dashboard)" "stale"
+
+    # A service that ran before and is not running now is its own verdict, never a silent pass.
+    GONE='monerod=sha256:mmm
+p2pool=sha256:ppp
+tor=sha256:ttt
+xmrig-proxy=sha256:xxx'
+    assert_eq "a service that ran before and is gone now grades 'gone'" \
+        "$(verdict_for "$GONE" dashboard)" "gone"
+    # ...and the four that came back are still graded, so one absence does not mask the rest.
+    assert_eq "the other four are still graded when one service is gone" \
+        "$(grade_image_census "$BASE" "$GONE" "$BRANCH" | grep -c '^kept ')" "4"
+
+    # An empty branch census (deploy_branch never ran — e.g. --mode check) must not turn every
+    # changed image into a false 'stale'. Kills a mutation that drops the `[ -n "$branch" ]` guard,
+    # where an empty branch value would equal an empty `now` and mis-grade.
+    assert_eq "with no branch census, a changed image is 'rebuilt', not accused of being the branch's" \
+        "$(grade_image_census "$BASE" "$BRANCH" "" | sed -n 's/ dashboard$//p')" "rebuilt"
+
+    # census_get lives in here rather than beside the other unit assertions for a reason the
+    # battery below made concrete: the classifier fixtures cannot kill a census_get mutation. The
+    # service names it looks up come out of the census itself, so even an unanchored match resolves
+    # each line to itself and every verdict stays correct. Only a direct assertion sees the defect,
+    # so a direct assertion has to be inside the block the mutants re-run.
+    echo "== census_get =="
+    assert_eq "reads the id for a service" "$(census_get "$BASE" tor)" "sha256:ttt"
+    assert_eq "a service not in the census reads empty" "$(census_get "$BASE" caddy)" ""
+    # 'proxy' must not resolve off 'xmrig-proxy='.
+    assert_eq "the service name is matched from the start of the line, not anywhere in it" \
+        "$(census_get "$BASE" proxy)" ""
+}
+run_census_assertions
+
+# --- 2. Which restore command e2e.sh runs -----------------------------------------------------
+# The REAL restore_all out of the shipped e2e.sh, evaluated against stubs, so this reads the
+# command the box would actually have been given — not a re-implementation of the decision.
+RESTORE_SRC="$(sed -n '/^restore_all() {$/,/^}$/p' "$E2E_SRC")"
+assert_eq "the extraction is the whole function (opens and closes)" \
+    "$(printf '%s\n' "$RESTORE_SRC" | sed -n '1p;$p' | tr '\n' ' ')" "restore_all() { } "
+
+drive_restore() { # <is-source-checkout: yes|no> -> the `cd RESTORE_DIR && ...` command string
+    local cf
+    cf="$(mktemp)"
+    # shellcheck disable=SC2034,SC2329  # read/called by the eval'd restore_all, which shellcheck
+    # cannot follow into.
+    (
+        exec </dev/null
+        RESTORED=0 KEEP=0 MINER_CFG_BACKUP="" RESTORE_DIR=/srv/code/baseline
+        E2E_DIR=/srv/code/pithead-e2e BENCH_HOST=bench SAFETY_ARCHIVE=""
+        RESTORE_PROOF_FAILED=0 CONTROL_PROOF_FAILED=0 CONTROL_VERDICT_BEFORE=""
+        BASELINE_IMAGES="" BRANCH_IMAGES="" SRC_CHECKOUT="$1" CMD_FILE="$cf"
+        log() { :; }
+        step() { :; }
+        warn() { :; }
+        ok() { :; }
+        control_units_verdict() { echo on-target; }
+        wait_bench_healthy() { return 0; }
+        verify_restore_proof() { return 0; }
+        on_bench() {
+            case "$1" in
+            # The source-checkout probe: answer as the fixture says, and never record it as the
+            # restore command.
+            "test -f "*dashboard/Dockerfile*) [ "$SRC_CHECKOUT" = yes ] && return 0 || return 1 ;;
+            "cd '$RESTORE_DIR' && "*)
+                printf '%s' "${1#cd \'$RESTORE_DIR\' && }" >"$CMD_FILE"
+                return 0
+                ;;
+            esac
+            return 0
+        }
+        eval "$RESTORE_SRC"
+        restore_all
+    ) >/dev/null 2>&1
+    cat "$cf"
+    rm -f "$cf"
+}
+
+echo "== the restore command, by baseline kind =="
+SRC_CMD="$(drive_restore yes)"
+BUNDLE_CMD="$(drive_restore no)"
+
+# The fix. A source-checkout baseline shares `:dev` with the branch, so the restore must REBUILD
+# from the baseline's tree. Kills the mutation that reverts the restore to `apply && up`.
+assert_contains "a source-checkout baseline is restored with 'pithead upgrade'" "$SRC_CMD" "./pithead upgrade"
+# ...and keeps the old pairing as a fallback, so a failed rebuild is not worse than the status quo.
+assert_contains "the source-checkout restore falls back to apply/up if the rebuild fails" \
+    "$SRC_CMD" "|| { ./pithead apply -y"
+# A release bundle's images are versioned tags the branch never touched: rebuilding there is waste,
+# and forcing it would make every release-box restore minutes longer for nothing.
+assert_eq "a release-bundle baseline is NOT rebuilt" \
+    "$(case "$BUNDLE_CMD" in *upgrade*) echo yes ;; *) echo no ;; esac)" "no"
+assert_contains "a release-bundle baseline still gets apply + up" "$BUNDLE_CMD" "./pithead apply -y"
+
+# --- 3. Mutation battery ----------------------------------------------------------------------
+# Each entry restores a real defect in a COPY of the shipped module and requires the classifier
+# assertions above to RED. A guard that survives its own defect being put back is decoration.
+echo "== mutation battery: every mutant must kill at least one assertion =="
+# A sed expression that matches nothing produces an unmutated copy, whose assertions all pass —
+# indistinguishable from a mutant the guard survived, and the more likely of the two. So the
+# mutation is asserted to have CHANGED the file before its result is believed; without this the
+# battery's own failure mode is a green.
+mutant_applies() { # <sed-expr> -> yes|no
+    if [ "$(sed "$1" "$PROOF_SRC" | diff -q - "$PROOF_SRC" >/dev/null 2>&1 && echo same || echo differs)" = differs ]; then
+        echo yes
+    else echo no; fi
+}
+mutate_and_count_fails() { # <sed-expr> -> the number of failed assertions under the mutant
+    local mutant
+    [ "$(mutant_applies "$1")" = yes ] || {
+        echo "MUTANT DID NOT APPLY"
+        return 0
+    }
+    mutant="$(mktemp)"
+    sed "$1" "$PROOF_SRC" >"$mutant"
+    (
+        IT_PASS=0 IT_FAIL=0
+        # shellcheck disable=SC1090
+        source "$mutant"
+        run_census_assertions >/dev/null 2>&1
+        printf '%s' "$IT_FAIL"
+    )
+    rm -f "$mutant"
+}
+
+# M1 — grade against the baseline alone, dropping the branch census. This is the pre-fix world:
+# every changed image reads as a rebuild and the run passes on the defect.
+assert_num_ge "M1 (no branch comparison) is killed" \
+    "$(mutate_and_count_fails 's/elif \[ "$now" = "$branch" \]; then/elif false; then/')" 1
+# M2 — never emit 'stale': grade a branch image as an ordinary rebuild. The first spelling of this
+# mutant did not match the file at all and read as a survivor; each expression below is asserted to
+# actually change the module before it is trusted (mutant_applies).
+assert_num_ge "M2 (branch image graded 'rebuilt') is killed" \
+    "$(mutate_and_count_fails "s/'stale %s/'rebuilt %s/")" 1
+# M3 — unanchor census_get, so one service name resolves off another's line.
+assert_num_ge "M3 (unanchored census_get) is killed" \
+    "$(mutate_and_count_fails 's|sed -n "s/\^\$2=//p"|sed -n "s/.*$2=//p"|')" 1
+
+echo ""
+printf 'restore-proof self-test: %s passed, %s failed\n' "$IT_PASS" "$IT_FAIL"
+[ "$IT_FAIL" -eq 0 ]


### PR DESCRIPTION
Fixes the defect reported in #1448. No closing keyword on purpose: PRs merge to `develop-v2` while the default branch is `develop`, so the keyword would not fire — and a negated one ("does not close") is read as the keyword anyway. #1448 gets closed by hand, naming this PR.

## The finding

`e2e.sh` already knew the shape of this bug and had written it down. `deploy_branch` refuses `pithead apply` because it

> runs `compose up --pull` (never `--build`), so it would test whatever images were last built on the box, not this branch

(#272). The restore, at the other end of the same run, used exactly that pairing: `./pithead apply -y && ./pithead up`.

It only bites when the live install is a **source checkout**, and there it bites completely: `pithead` exports `STACK_VERSION=dev` for a source checkout, so the baseline and the branch under test resolve to the same `:dev` tag; the branch deploy has already overwritten it; the source-checkout pull policy is `never`; and `apply` + `up` starts the branch's images under the baseline's name.

All three existing restore checks stay green on that. The credentials are read from the on-disk `.env` at runtime, so the bake matches; monerod answers with them; the control units name the install either way. The run prints `restore complete.`

## What was RUN

- `for t in tests/integration/selftest*.sh` — all eight green (`selftest-e2e-restore-proof` 22/0, `selftest-e2e-phases` 63/0, `selftest` 214/0, `selftest-skip-accounting` 70/0, `selftest-rigforge-writable-keys` 50/0, `selftest-rig-key-ledger` 31/0, `selftest-rigforge-apply-settle` 5/0, `selftest-compose-profiles` 5/0).
- `shellcheck --severity=warning tests/integration/*.sh` (0.11.0, from the repo root over the whole glob) — clean. `shfmt -i 4 -d` over the same glob — clean.
- `make lint-md` 0 errors, `make lint-docs-voice` clean, `make lint-operator-strings` clean, `bash scripts/lint-file-budget.sh` OK.
- `make lint-sh` was **not** run whole: it is this box's OOM path and is serialised. The targeted shellcheck + shfmt above is the substitute, and it covers both halves.
- The census command was run against a **real running stack**, not only against fixtures: it returned ten `service=sha256:…` rows whose IDs match the images that stack is pinned to.

## What it does

Two halves.

**The restore rebuilds when the baseline is a source checkout** — `pithead upgrade`, the same command the deploy uses, pointed at the baseline's own tree, falling back to `apply` + `up` if the rebuild fails so a baseline that cannot rebuild is no worse off than today. A release bundle keeps the cheap path: its images are versioned tags the branch never touched, and rebuilding there would add minutes for nothing.

**The proof grades what is actually running.** Each service's image ID is censused before anything is touched, again after the branch deploys, and again after the restore, then graded per service: kept / rebuilt / still-the-branch's / gone. IDs, not tags, because a moved tag is the defect and so cannot be the instrument. Per service, not as one list, because a branch that changes two Dockerfiles rebuilds two images and the rest legitimately match both censuses — a whole-list comparison would either condemn all five or notice none.

## The mutation battery is the part worth reviewing

Its first run reported three survivors. **Two were the battery's own fault**: a `sed` that matches nothing produces an unmutated copy whose assertions all pass, which is indistinguishable from a guard that held and is the likelier of the two. It now asserts each mutant actually changes the file before believing its result.

**The third survivor was real, and it was about my own code.** A `[ -n "$branch" ]` guard on the stale arm could not change any outcome — reaching that arm already requires a non-empty value, so an absent branch census fails the equality on its own. Dead code, removed. An unkillable mutant turned out to be a claim about the code, not about the test.

## Said plainly: what this does NOT prove

That a rebuilt image was built from the install directory. Settling that needs the image's own build provenance, and the dashboard's `org.opencontainers.image.revision` ships **empty** while the other four images carry the right commit — filed separately as #1449. So a rebuilt image is reported as "not the branch's" and no more, and the run's wording says exactly that rather than implying more.

This change is also **not** backed by a live release-gate run. It is proven at the self-test tier — the real functions extracted from the shipped files, driven against stubs, with the mutation battery above — plus the census command run against a real stack. A full gate run is the natural next item for this lane and is what the live #1236/#1364/#1378 proofs need anyway.

## Shared files touched

`docs/dev/integration-testing.md` (the harness doc, updated with both halves) and `docs/dev/file-budget.tsv`, whose `tests/integration/e2e.sh` ceiling drops **766 → 691**: the restore proof moved into its own `restore-proof.sh`, because `e2e.sh` had one line of headroom and the classifier has to be drivable with no ssh and no docker anyway — that is the tier its mutation proof runs at.

## Over-engineering pass

Run against this diff before opening. One cut, three considered and rejected with reasons:

- `selftest-e2e-restore-proof.sh:L41: delete:` existence assertion for `stack_image_census`, a function this file never exercises (it needs ssh). The fail-closed guard is meaningful for `grade_image_census`, whose disappearance would silently stop the assertions; for a function nothing here calls it is decoration. **Cut.**
- `restore-proof.sh: shrink:` the caller re-parses the classifier's `"<verdict> <service>"` lines with a `case`. **Rejected** — it needs both halves, so `${line%% *}` plus `${line#* }` is the same line count with worse names.
- `selftest-e2e-restore-proof.sh: yagni:` `drive_restore` extracts and evals the whole ~90-line `restore_all` to read one command string. **Rejected** — it is this directory's established pattern (`selftest-e2e-phases.sh` does the same for `run_harness`), and the point is asserting against the *shipped* function rather than a re-spelling of it, which is exactly the failure mode this PR is about.
- `restore-proof.sh: yagni:` the `upgrade` → `apply`/`up` fallback. **Rejected** — it runs inside the EXIT trap, where the alternative to a fallback is leaving the box down.

`net: -2 lines.`


---

## Added after an adversarial pass over my own diff (`a8fe483`)

The source-checkout arm this PR adds put an `||` into the restore command for the first time, and that changed how the whole thing groups. `cd D && upgrade || { apply && up; }` binds the `||` to the *whole* `cd D && upgrade`, so a **`cd` that fails runs the fallback anyway** — in the ssh session's default directory — and the command **still exits 0**. A restore that never entered the install directory would have reported as having run, and a `./pithead apply -y` would have executed wherever the session landed. Before this branch there was no `||` in that command, so a failed `cd` simply failed; the defect is this branch's own.

Braced the group. The explanation folds into the existing `#272` comment rather than adding lines, because `e2e.sh` sits at exactly its 691-line ceiling.

**Proven by driving it, not by reading precedence rules.** The self-test runs the *shipped* command string against a `cd` that cannot succeed, with a `pithead` stub in the default directory that records every invocation: braced gives `rc=1` and nothing executed. The **negative control** unbraces that same string and gets `rc=0` with the fallback executed — the failure the guard exists to catch.

That control earned its place immediately: its first draft's unbracing produced a syntax error, which the probe reported as `rc=2`/nothing-ran. A control that fails to fire looks exactly like the defect being absent. It now asserts the transform both *changed* the command and left it *runnable*.

`selftest-e2e-restore-proof: 26 passed, 0 failed` (was 21). All seven integration self-tests green; shellcheck 0.11.0, `shfmt -i 4`, file budget, `lint-md`, `lint-docs-voice`, `lint-operator-strings` clean. `e2e.sh` is unchanged in length at 691.
