### PR TITLE
refactor(dashboard): split the chart/window hub out of views.py (#1105 Phase 3 D1, develop-v2)

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -49,8 +49,9 @@ mining_dashboard/
 │                      #   metrics (typed computed domain values consumed by the view layer)
 ├── sim/               # donation_model (the XvB donation simulator; property-tested, #284)
 ├── web/               # server.py (transport: / shell + /api/state + middleware),
-│                      #   views.py (build_state: the JSON state object), templates/index.html
-│                      #   (static shell), static/ (Preact app + dashboard.css + vendored libs)
+│                      #   views.py (build_state: the JSON state object), charts.py (the chart
+│                      #   window/range hub views.py re-exports), templates/index.html (static
+│                      #   shell), static/ (Preact app + dashboard.css + vendored libs)
 └── helper/            # formatting utilities
 ```
 

--- a/dashboard/mining_dashboard/web/charts.py
+++ b/dashboard/mining_dashboard/web/charts.py
@@ -1,0 +1,381 @@
+"""Chart series for the dashboard: the window/range hub the ``/api/state`` chart payload is
+built from (Issues #47, #65).
+
+Split out of ``web/views.py`` (#1105) as the hub every other view cluster leans on: window
+parsing and canonicalisation, range filtering, adaptive point-count/tension tiers, bucket
+downsampling, and the marker series (shares, degradation events, raffle wins, payouts) that ride
+their own hidden 0-1 axis. ``views.py`` stays the facade — it re-exports the names its callers
+(``server.py``, ``worker_detail.py``) already import — so this move is invisible to consumers.
+
+Nothing here formats display strings; it emits chart-ready points and lets the client render.
+"""
+
+import bisect
+import logging
+import math
+import time
+
+from mining_dashboard.config.config import (
+    DEFAULT_HASHRATE_WINDOW,
+    HASHRATE_WINDOW_COLUMNS,
+    HASHRATE_WINDOWS,
+    UPDATE_INTERVAL,
+)
+from mining_dashboard.helper.utils import format_hashrate
+from mining_dashboard.service.earnings import ATOMIC_PER_XMR
+
+# Deliberately the *views* logger name: _payout_points' marker-cap line is operator-visible, and
+# the split must not rename the record it arrives under.
+logger = logging.getLogger("WebViews")
+
+# Preset range -> window length in seconds. 'all'/unknown -> use the data's own extent.
+_RANGE_SECONDS = {"1h": 3600, "24h": 86400, "1w": 604800, "1m": 2592000}
+
+# Adaptive chart resolution (Issue #47). Point count and line smoothing are chosen from the
+# *visible window duration*: a wide span is a smooth, high-level overview (fewer points, more
+# curve smoothing); a short span keeps full 30s detail (choppier but accurate). The point count
+# is capped near the canvas pixel width — more points than pixels just slows hit-testing.
+# (limit_seconds, target_points); 0 target = send native resolution (no downsampling).
+_POINT_TIERS = ((3600, 0), (21600, 360), (86400, 480), (604800, 600))
+_MAX_CHART_POINTS = 700  # > 1w, and the hard ceiling (~1 point per canvas pixel)
+
+# (limit_seconds, tension). Chart.js line tension = curve smoothing.
+_TENSION_TIERS = ((3600, 0.0), (86400, 0.2), (604800, 0.35))
+_MAX_TENSION = 0.4  # > 1w: smooth / high-level
+
+
+def _target_points(duration_s):
+    """Target chart-point count for a window of ``duration_s`` seconds (0 = native resolution)."""
+    for limit, points in _POINT_TIERS:
+        if duration_s <= limit:
+            return points
+    return _MAX_CHART_POINTS
+
+
+def _chart_tension(duration_s):
+    """Chart.js line tension (curve smoothing) for a window of ``duration_s`` seconds."""
+    for limit, tension in _TENSION_TIERS:
+        if duration_s <= limit:
+            return tension
+    return _MAX_TENSION
+
+
+def parse_window(from_arg, to_arg):
+    """Parse optional ``from``/``to`` query params (epoch seconds) into a ``(from, to)`` window,
+    or ``None`` if absent or malformed. Defensive — any bad input falls back to ``None`` so the
+    caller uses the preset ``range`` instead of erroring (Issue #47)."""
+    if from_arg is None or to_arg is None:
+        return None
+    try:
+        lo, hi = float(from_arg), float(to_arg)
+    except (TypeError, ValueError):
+        return None
+    if not (math.isfinite(lo) and math.isfinite(hi)) or lo <= 0 or hi <= 0 or lo >= hi:
+        return None
+    return (lo, hi)
+
+
+# A run of missing samples longer than this is drawn as a real break in the line rather than a
+# segment spanning the outage (Issue #65). Adaptive: a multiple of the series' own median
+# spacing (so it works for both live 30s samples and heavily downsampled long ranges), floored
+# at a couple of sample intervals so ordinary jitter doesn't fragment the line.
+_GAP_FACTOR = 3
+
+
+# --------------------------------------------------------------------------------------
+# Chart series (Issue #65: positioned by real time, with outage gaps as breaks).
+# --------------------------------------------------------------------------------------
+
+
+def build_chart(
+    history,
+    shares,
+    range_arg,
+    window=None,
+    avg_window=DEFAULT_HASHRATE_WINDOW,
+    events=None,
+    raffle_wins=None,
+    payouts=None,
+):
+    """Build the Chart.js datasets from history. Each point carries its real timestamp as the
+    x value (epoch ms) so a linear time axis spaces points to scale; runs of missing samples
+    (outages) are split by a ``null`` break so the line doesn't connect across the gap.
+
+    ``window`` is an optional ``(from, to)`` epoch-second pair (a manual zoom) that bounds both
+    ends and overrides ``range_arg``. Point density and ``tension`` adapt to the visible window
+    duration (Issue #47). ``avg_window`` (#168) selects which hashrate-averaging window's columns
+    to plot (1m / 10m / 1h / 12h / 24h); 10m is the default headline series.
+
+    ``payouts`` (#381), when the view-only wallet feature is on, is the stored confirmed-payout
+    list — one gold coin marker per Monero payout, on the same hidden 0–1 axis as the raffle
+    stars; ``None`` (feature off) yields an empty ``payouts`` list.
+
+    Returns ``{"p2pool": [{x, y}], "xvb": [{x, y}], "shares": [{x, y, r, c}], "events": [...],
+    "raffle": [...], "payouts": [...], "tension": float}``
+    — the P2Pool/XvB series are stacked on the client (they sum to the total hashrate) and may
+    contain ``{x, y: None}`` break markers, kept index-aligned across both series so stacking
+    stays correct; ``shares`` is a sparse scatter (rendered un-stacked)."""
+    filtered_history, filtered_shares = _filter_range(history, shares, range_arg, window)
+    duration_s = _window_duration(filtered_history, range_arg, window)
+    filtered_history = _downsample_history(filtered_history, duration_s)
+
+    timestamps = [x["timestamp"] for x in filtered_history]
+    gap_after = _gap_after_indices(timestamps)
+
+    p2pool = []
+    xvb = []
+    for i, x in enumerate(filtered_history):
+        vp, vx = _split_values(x, avg_window)
+        x_ms = int(timestamps[i] * 1000)
+        p2pool.append({"x": x_ms, "y": vp})
+        xvb.append({"x": x_ms, "y": vx})
+        if i in gap_after:
+            mid_ms = int(((timestamps[i] + timestamps[i + 1]) / 2) * 1000)
+            p2pool.append({"x": mid_ms, "y": None})
+            xvb.append({"x": mid_ms, "y": None})
+
+    return {
+        "p2pool": p2pool,
+        "xvb": xvb,
+        "shares": _share_points(filtered_history, filtered_shares),
+        "events": _event_points(_filter_events(events or [], range_arg, window)),
+        # _filter_events bounds any ts-keyed list, so the raffle wins reuse it as-is.
+        "raffle": _raffle_points(_filter_events(raffle_wins or [], range_arg, window)),
+        # Confirmed on-chain payout markers (#381); newest-first order is preserved by the filter,
+        # so _payout_points' most-recent cap keeps the newest in range.
+        "payouts": _payout_points(_filter_events(payouts or [], range_arg, window)),
+        "tension": _chart_tension(duration_s),
+    }
+
+
+def _filter_range(history, shares, range_arg, window=None):
+    """Restrict history/shares to the selected window. A custom ``window`` (from, to) epoch
+    seconds bounds both ends; otherwise the preset ``range`` bounds only the lower end (``all``
+    keeps everything)."""
+    if window is not None:
+        lo, hi = window
+        return (
+            [x for x in history if lo <= x["timestamp"] <= hi],
+            [s for s in shares if lo <= s["ts"] <= hi],
+        )
+    if range_arg == "all":
+        return history, shares
+    target_seconds = _RANGE_SECONDS.get(range_arg, 0)
+    if target_seconds <= 0:
+        return history, shares
+    cutoff = time.time() - target_seconds
+    return (
+        [x for x in history if x["timestamp"] >= cutoff],
+        [s for s in shares if s["ts"] >= cutoff],
+    )
+
+
+def _filter_events(events, range_arg, window=None):
+    """Restrict degradation events (#99) to the selected window — same bounds as ``_filter_range``,
+    but for the ``ts``-keyed events list."""
+    if window is not None:
+        lo, hi = window
+        return [e for e in events if lo <= e["ts"] <= hi]
+    if range_arg == "all":
+        return events
+    secs = _RANGE_SECONDS.get(range_arg, 0)
+    if secs <= 0:
+        return events
+    cutoff = time.time() - secs
+    return [e for e in events if e["ts"] >= cutoff]
+
+
+def _window_duration(filtered_history, range_arg, window):
+    """Seconds the chart currently spans — drives adaptive resolution/smoothing. From the
+    window if zoomed, else the preset length, else (``all``/unknown) the actual data extent."""
+    if window is not None:
+        return max(0, window[1] - window[0])
+    secs = _RANGE_SECONDS.get(range_arg, 0)
+    if secs > 0:
+        return secs
+    if len(filtered_history) >= 2:
+        return filtered_history[-1]["timestamp"] - filtered_history[0]["timestamp"]
+    return 0
+
+
+def _split_values(x, avg_window=DEFAULT_HASHRATE_WINDOW):
+    """(p2pool, xvb) hashrate for a history row at the selected averaging window (#168).
+
+    Defaults to 10m — the original headline series — which also keeps the legacy-data fallback
+    (older rows stored only the un-split total ``v``). The other windows read their own columns,
+    which are 0 on pre-#168 rows (per-window capture is forward-only)."""
+    p_col, x_col = HASHRATE_WINDOW_COLUMNS.get(
+        avg_window, HASHRATE_WINDOW_COLUMNS[DEFAULT_HASHRATE_WINDOW]
+    )
+    vp = x.get(p_col, 0) or 0
+    vx = x.get(x_col, 0) or 0
+    # The fallback only makes sense for the default window, where ``v`` is that window's total.
+    if avg_window == DEFAULT_HASHRATE_WINDOW and vp == 0 and vx == 0:
+        v = x.get("v", 0)
+        if v > 0:
+            vp = v
+    return vp, vx
+
+
+def canonical_window(avg_arg):
+    """Validate an ``avg`` query param against the known windows (#168), falling back to the default
+    for anything unknown or missing — a stale bookmark or bad input can't break the chart."""
+    return avg_arg if avg_arg in HASHRATE_WINDOWS else DEFAULT_HASHRATE_WINDOW
+
+
+def _gap_after_indices(timestamps):
+    """Indices ``i`` after which the gap to ``i+1`` is large enough to be an outage break."""
+    if len(timestamps) < 2:
+        return set()
+    deltas = [timestamps[i + 1] - timestamps[i] for i in range(len(timestamps) - 1)]
+    median = sorted(deltas)[len(deltas) // 2]
+    threshold = max(_GAP_FACTOR * median, 2 * UPDATE_INTERVAL)
+    return {i for i, d in enumerate(deltas) if d > threshold}
+
+
+# Value columns carried through downsampling: the legacy total ``v`` plus every per-window
+# p2pool/xvb column (#168), derived from the window map so a newly-added averaging window is
+# bucket-averaged automatically instead of being silently dropped. (Bug: the old downsampler kept
+# only v/v_p2pool/v_xvb, so the 1m/1h/12h/24h Avg series went flat at 0 on any range wide enough to
+# downsample — e.g. the 24h/1w/1mo ranges — while the default 10m window happened to survive.)
+_DOWNSAMPLE_VALUE_COLUMNS = tuple(
+    dict.fromkeys(("v",) + tuple(col for cols in HASHRATE_WINDOW_COLUMNS.values() for col in cols))
+)
+
+
+def _downsample_history(filtered_history, duration_s):
+    """Bucket-averages history down to the duration's target point count (Issue #47). A target
+    of 0, or a series already at/under target, is returned untouched — so short/zoomed-in
+    windows keep their native 30s detail. Every per-window hashrate column (#168) is carried
+    through, so the selected Avg window plots correctly even on downsampled wide ranges."""
+    target = _target_points(duration_s)
+    if target <= 0 or len(filtered_history) <= target:
+        return filtered_history
+
+    chunk_size = len(filtered_history) / target
+    downsampled = []
+    for i in range(target):
+        chunk = filtered_history[int(i * chunk_size) : int((i + 1) * chunk_size)]
+        if not chunk:
+            continue
+        mid = chunk[len(chunk) // 2]
+        row = {"t": mid["t"], "timestamp": mid["timestamp"]}
+        for col in _DOWNSAMPLE_VALUE_COLUMNS:
+            row[col] = round(sum(x.get(col, 0) or 0 for x in chunk) / len(chunk), 2)
+        downsampled.append(row)
+    return downsampled
+
+
+# Where the share markers ride on their own hidden 0–1 axis on the client: a constant near the
+# top, so they form a "rug" along the top edge instead of riding the hashrate line. Pinning them
+# off the hashrate axis keeps a single tall marker from inflating the y-range and burying a flat
+# line at the bottom of the card (Issue #145).
+_SHARE_MARKER_Y = 0.93
+
+
+def _share_points(filtered_history, filtered_shares):
+    """Sparse share markers: bucket each share onto its nearest history sample and emit one
+    ``{x, y, r, c}`` point per sample that has shares (x = sample time ms, y = the fixed top-of-
+    chart position on the client's dedicated share axis, r = radius scaled by count, c = count)."""
+    if not (filtered_history and filtered_shares):
+        return []
+
+    hist_ts = [x["timestamp"] for x in filtered_history]
+    counts = {}
+    for s in filtered_shares:
+        s_ts = s["ts"]
+        idx = bisect.bisect_left(hist_ts, s_ts)
+        candidates = []
+        if idx < len(hist_ts):
+            candidates.append(idx)
+        if idx > 0:
+            candidates.append(idx - 1)
+        if candidates:
+            closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
+            counts[closest_idx] = counts.get(closest_idx, 0) + 1
+
+    points = []
+    for idx in sorted(counts):
+        count = counts[idx]
+        # y is fixed (a fraction of the dedicated 0–1 share axis): the marker no longer tracks the
+        # hashrate, so it never stretches the y-range. Radius still scales with the share count.
+        points.append(
+            {
+                "x": int(hist_ts[idx] * 1000),
+                "y": _SHARE_MARKER_Y,
+                "r": min(6 + (count * 3), 15),
+                "c": count,
+            }
+        )
+    return points
+
+
+# Event markers ride just below the share rug on their own hidden 0–1 axis (#99), so a "something
+# went wrong" marker sits at the event's real time without touching the hashrate y-range.
+_EVENT_MARKER_Y = 0.82
+
+
+def _event_points(filtered_events):
+    """Sparse degradation/recovery markers (#99): one point per event at its timestamp, carrying the
+    tooltip ``label`` and ``kind`` (e.g. ``hashrate_loss`` vs ``hashrate_recovered``) so the client
+    can colour a loss vs a recovery."""
+    return [
+        {
+            "x": int(e["ts"] * 1000),
+            "y": _EVENT_MARKER_Y,
+            "kind": e.get("type", ""),
+            "label": e.get("detail") or e.get("type", "event"),
+        }
+        for e in filtered_events
+    ]
+
+
+# Raffle-win markers ride the same hidden 0–1 axis as the event markers, one step below them, so a
+# win sits at its real time without touching the hashrate y-range.
+_RAFFLE_MARKER_Y = 0.70
+
+
+def _raffle_points(filtered_wins):
+    """Sparse XvB raffle-win markers: one gold star per round this wallet won, at the round's
+    timestamp, with the tooltip carrying the round type and the credited hashrate."""
+    return [
+        {
+            "x": int(w["ts"] * 1000),
+            "y": _RAFFLE_MARKER_Y,
+            "label": f"XvB raffle win — {w['tier']} round at {format_hashrate(w['hashrate'])}",
+        }
+        for w in filtered_wins
+    ]
+
+
+# Confirmed on-chain payout markers ride the same hidden 0–1 axis as the raffle stars, one step
+# below them (#381), so a payout sits at its real block time without touching the hashrate y-range.
+_PAYOUT_MARKER_Y = 0.58
+
+# A long-lived wallet can accrue many payouts; the chart shows the most-recent-in-range so a busy
+# marker row can't bloat every /api/state payload. The EarningsCard totals still count them all.
+_PAYOUT_MARKER_LIMIT = 200
+
+
+def _payout_points(filtered_payouts, divisor=ATOMIC_PER_XMR):
+    """Sparse confirmed-payout markers (#381): one gold coin per on-chain Monero payout at its
+    block time, the tooltip carrying the whole-XMR amount (atomic→XMR at this edge, ``divisor``)
+    and the payout date. ``filtered_payouts`` is the range-bounded stored-payout list, newest
+    first (``storage.get_payouts``); capped at ``_PAYOUT_MARKER_LIMIT`` most-recent — the overflow
+    is logged, never silently dropped."""
+    if len(filtered_payouts) > _PAYOUT_MARKER_LIMIT:
+        logger.info(
+            "Chart payout markers capped at %d of %d (most recent kept)",
+            _PAYOUT_MARKER_LIMIT,
+            len(filtered_payouts),
+        )
+        filtered_payouts = filtered_payouts[:_PAYOUT_MARKER_LIMIT]
+    return [
+        {
+            "x": int(p["ts"] * 1000),
+            "y": _PAYOUT_MARKER_Y,
+            "label": f"{(p.get('amount_atomic', 0) or 0) / divisor:.6f} XMR — "
+            f"{time.strftime('%Y-%m-%d', time.localtime(p.get('ts', 0)))}",
+        }
+        for p in filtered_payouts
+    ]

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -10,10 +10,8 @@ emits HTML. The client maps tokens to CSS classes and builds the DOM.
 the client share; ``server.py`` stays pure transport.
 """
 
-import bisect
 import json
 import logging
-import math
 import os
 import time
 
@@ -22,11 +20,9 @@ from mining_dashboard.config.config import (
     DEFAULT_HASHRATE_WINDOW,
     DISK_CRITICAL_PERCENT,
     DISK_WARN_PERCENT,
-    HASHRATE_WINDOW_COLUMNS,
     HASHRATE_WINDOWS,
     HOST_IP,
     LOW_RAM_AVAILABLE_GB,
-    UPDATE_INTERVAL,
     XVB_MAX_DONATION_FRACTION,
     low_ram_floor_gb,
     monero_is_local,
@@ -56,60 +52,19 @@ from mining_dashboard.service.metrics import build_metrics, share_reject_pct
 from mining_dashboard.service.update_checker import compute_update, parse_semver
 from mining_dashboard.version import resolve_version
 
+# The chart/window hub lives in web/charts.py (#1105). views.py stays the facade: the last two
+# are re-exported unused so `server.py`'s existing `from ...web.views import` keeps resolving.
+from mining_dashboard.web.charts import (
+    _MAX_CHART_POINTS,
+    _RANGE_SECONDS,
+    _filter_events,
+    build_chart,
+    canonical_window,  # noqa: F401 — re-export for server.py
+    parse_window,  # noqa: F401 — re-export for server.py
+)
+
 logger = logging.getLogger("WebViews")
 
-# Preset range -> window length in seconds. 'all'/unknown -> use the data's own extent.
-_RANGE_SECONDS = {"1h": 3600, "24h": 86400, "1w": 604800, "1m": 2592000}
-
-# Adaptive chart resolution (Issue #47). Point count and line smoothing are chosen from the
-# *visible window duration*: a wide span is a smooth, high-level overview (fewer points, more
-# curve smoothing); a short span keeps full 30s detail (choppier but accurate). The point count
-# is capped near the canvas pixel width — more points than pixels just slows hit-testing.
-# (limit_seconds, target_points); 0 target = send native resolution (no downsampling).
-_POINT_TIERS = ((3600, 0), (21600, 360), (86400, 480), (604800, 600))
-_MAX_CHART_POINTS = 700  # > 1w, and the hard ceiling (~1 point per canvas pixel)
-
-# (limit_seconds, tension). Chart.js line tension = curve smoothing.
-_TENSION_TIERS = ((3600, 0.0), (86400, 0.2), (604800, 0.35))
-_MAX_TENSION = 0.4  # > 1w: smooth / high-level
-
-
-def _target_points(duration_s):
-    """Target chart-point count for a window of ``duration_s`` seconds (0 = native resolution)."""
-    for limit, points in _POINT_TIERS:
-        if duration_s <= limit:
-            return points
-    return _MAX_CHART_POINTS
-
-
-def _chart_tension(duration_s):
-    """Chart.js line tension (curve smoothing) for a window of ``duration_s`` seconds."""
-    for limit, tension in _TENSION_TIERS:
-        if duration_s <= limit:
-            return tension
-    return _MAX_TENSION
-
-
-def parse_window(from_arg, to_arg):
-    """Parse optional ``from``/``to`` query params (epoch seconds) into a ``(from, to)`` window,
-    or ``None`` if absent or malformed. Defensive — any bad input falls back to ``None`` so the
-    caller uses the preset ``range`` instead of erroring (Issue #47)."""
-    if from_arg is None or to_arg is None:
-        return None
-    try:
-        lo, hi = float(from_arg), float(to_arg)
-    except (TypeError, ValueError):
-        return None
-    if not (math.isfinite(lo) and math.isfinite(hi)) or lo <= 0 or hi <= 0 or lo >= hi:
-        return None
-    return (lo, hi)
-
-
-# A run of missing samples longer than this is drawn as a real break in the line rather than a
-# segment spanning the outage (Issue #65). Adaptive: a multiple of the series' own median
-# spacing (so it works for both live 30s samples and heavily downsampled long ranges), floored
-# at a couple of sample intervals so ordinary jitter doesn't fragment the line.
-_GAP_FACTOR = 3
 
 # Pool/mode palette *tokens* -> CSS colour classes on the client (``.c-<token>``/``.bg-<token>``).
 # The active pool is coloured, the inactive one muted (Issue #27).
@@ -182,109 +137,6 @@ def build_raffle_eligibility(metrics):
     in_tier = metrics.current_tier not in ("None", "Disabled")
     eligible = in_tier and metrics.shares_in_window > 0
     return {"applies": True, "eligible": eligible, "label": "Yes" if eligible else "No"}
-
-
-# --------------------------------------------------------------------------------------
-# Chart series (Issue #65: positioned by real time, with outage gaps as breaks).
-# --------------------------------------------------------------------------------------
-
-
-def build_chart(
-    history,
-    shares,
-    range_arg,
-    window=None,
-    avg_window=DEFAULT_HASHRATE_WINDOW,
-    events=None,
-    raffle_wins=None,
-    payouts=None,
-):
-    """Build the Chart.js datasets from history. Each point carries its real timestamp as the
-    x value (epoch ms) so a linear time axis spaces points to scale; runs of missing samples
-    (outages) are split by a ``null`` break so the line doesn't connect across the gap.
-
-    ``window`` is an optional ``(from, to)`` epoch-second pair (a manual zoom) that bounds both
-    ends and overrides ``range_arg``. Point density and ``tension`` adapt to the visible window
-    duration (Issue #47). ``avg_window`` (#168) selects which hashrate-averaging window's columns
-    to plot (1m / 10m / 1h / 12h / 24h); 10m is the default headline series.
-
-    ``payouts`` (#381), when the view-only wallet feature is on, is the stored confirmed-payout
-    list — one gold coin marker per Monero payout, on the same hidden 0–1 axis as the raffle
-    stars; ``None`` (feature off) yields an empty ``payouts`` list.
-
-    Returns ``{"p2pool": [{x, y}], "xvb": [{x, y}], "shares": [{x, y, r, c}], "events": [...],
-    "raffle": [...], "payouts": [...], "tension": float}``
-    — the P2Pool/XvB series are stacked on the client (they sum to the total hashrate) and may
-    contain ``{x, y: None}`` break markers, kept index-aligned across both series so stacking
-    stays correct; ``shares`` is a sparse scatter (rendered un-stacked)."""
-    filtered_history, filtered_shares = _filter_range(history, shares, range_arg, window)
-    duration_s = _window_duration(filtered_history, range_arg, window)
-    filtered_history = _downsample_history(filtered_history, duration_s)
-
-    timestamps = [x["timestamp"] for x in filtered_history]
-    gap_after = _gap_after_indices(timestamps)
-
-    p2pool = []
-    xvb = []
-    for i, x in enumerate(filtered_history):
-        vp, vx = _split_values(x, avg_window)
-        x_ms = int(timestamps[i] * 1000)
-        p2pool.append({"x": x_ms, "y": vp})
-        xvb.append({"x": x_ms, "y": vx})
-        if i in gap_after:
-            mid_ms = int(((timestamps[i] + timestamps[i + 1]) / 2) * 1000)
-            p2pool.append({"x": mid_ms, "y": None})
-            xvb.append({"x": mid_ms, "y": None})
-
-    return {
-        "p2pool": p2pool,
-        "xvb": xvb,
-        "shares": _share_points(filtered_history, filtered_shares),
-        "events": _event_points(_filter_events(events or [], range_arg, window)),
-        # _filter_events bounds any ts-keyed list, so the raffle wins reuse it as-is.
-        "raffle": _raffle_points(_filter_events(raffle_wins or [], range_arg, window)),
-        # Confirmed on-chain payout markers (#381); newest-first order is preserved by the filter,
-        # so _payout_points' most-recent cap keeps the newest in range.
-        "payouts": _payout_points(_filter_events(payouts or [], range_arg, window)),
-        "tension": _chart_tension(duration_s),
-    }
-
-
-def _filter_range(history, shares, range_arg, window=None):
-    """Restrict history/shares to the selected window. A custom ``window`` (from, to) epoch
-    seconds bounds both ends; otherwise the preset ``range`` bounds only the lower end (``all``
-    keeps everything)."""
-    if window is not None:
-        lo, hi = window
-        return (
-            [x for x in history if lo <= x["timestamp"] <= hi],
-            [s for s in shares if lo <= s["ts"] <= hi],
-        )
-    if range_arg == "all":
-        return history, shares
-    target_seconds = _RANGE_SECONDS.get(range_arg, 0)
-    if target_seconds <= 0:
-        return history, shares
-    cutoff = time.time() - target_seconds
-    return (
-        [x for x in history if x["timestamp"] >= cutoff],
-        [s for s in shares if s["ts"] >= cutoff],
-    )
-
-
-def _filter_events(events, range_arg, window=None):
-    """Restrict degradation events (#99) to the selected window — same bounds as ``_filter_range``,
-    but for the ``ts``-keyed events list."""
-    if window is not None:
-        lo, hi = window
-        return [e for e in events if lo <= e["ts"] <= hi]
-    if range_arg == "all":
-        return events
-    secs = _RANGE_SECONDS.get(range_arg, 0)
-    if secs <= 0:
-        return events
-    cutoff = time.time() - secs
-    return [e for e in events if e["ts"] >= cutoff]
 
 
 def build_share_stats(share_stats, range_arg, window=None):
@@ -440,202 +292,6 @@ def build_xvb_history(rows, range_arg, window=None):
     return _gauge_series(
         rows, range_arg, window, ("avg_1h", "avg_24h", "fail_count", "donation_fraction")
     )
-
-
-def _window_duration(filtered_history, range_arg, window):
-    """Seconds the chart currently spans — drives adaptive resolution/smoothing. From the
-    window if zoomed, else the preset length, else (``all``/unknown) the actual data extent."""
-    if window is not None:
-        return max(0, window[1] - window[0])
-    secs = _RANGE_SECONDS.get(range_arg, 0)
-    if secs > 0:
-        return secs
-    if len(filtered_history) >= 2:
-        return filtered_history[-1]["timestamp"] - filtered_history[0]["timestamp"]
-    return 0
-
-
-def _split_values(x, avg_window=DEFAULT_HASHRATE_WINDOW):
-    """(p2pool, xvb) hashrate for a history row at the selected averaging window (#168).
-
-    Defaults to 10m — the original headline series — which also keeps the legacy-data fallback
-    (older rows stored only the un-split total ``v``). The other windows read their own columns,
-    which are 0 on pre-#168 rows (per-window capture is forward-only)."""
-    p_col, x_col = HASHRATE_WINDOW_COLUMNS.get(
-        avg_window, HASHRATE_WINDOW_COLUMNS[DEFAULT_HASHRATE_WINDOW]
-    )
-    vp = x.get(p_col, 0) or 0
-    vx = x.get(x_col, 0) or 0
-    # The fallback only makes sense for the default window, where ``v`` is that window's total.
-    if avg_window == DEFAULT_HASHRATE_WINDOW and vp == 0 and vx == 0:
-        v = x.get("v", 0)
-        if v > 0:
-            vp = v
-    return vp, vx
-
-
-def canonical_window(avg_arg):
-    """Validate an ``avg`` query param against the known windows (#168), falling back to the default
-    for anything unknown or missing — a stale bookmark or bad input can't break the chart."""
-    return avg_arg if avg_arg in HASHRATE_WINDOWS else DEFAULT_HASHRATE_WINDOW
-
-
-def _gap_after_indices(timestamps):
-    """Indices ``i`` after which the gap to ``i+1`` is large enough to be an outage break."""
-    if len(timestamps) < 2:
-        return set()
-    deltas = [timestamps[i + 1] - timestamps[i] for i in range(len(timestamps) - 1)]
-    median = sorted(deltas)[len(deltas) // 2]
-    threshold = max(_GAP_FACTOR * median, 2 * UPDATE_INTERVAL)
-    return {i for i, d in enumerate(deltas) if d > threshold}
-
-
-# Value columns carried through downsampling: the legacy total ``v`` plus every per-window
-# p2pool/xvb column (#168), derived from the window map so a newly-added averaging window is
-# bucket-averaged automatically instead of being silently dropped. (Bug: the old downsampler kept
-# only v/v_p2pool/v_xvb, so the 1m/1h/12h/24h Avg series went flat at 0 on any range wide enough to
-# downsample — e.g. the 24h/1w/1mo ranges — while the default 10m window happened to survive.)
-_DOWNSAMPLE_VALUE_COLUMNS = tuple(
-    dict.fromkeys(("v",) + tuple(col for cols in HASHRATE_WINDOW_COLUMNS.values() for col in cols))
-)
-
-
-def _downsample_history(filtered_history, duration_s):
-    """Bucket-averages history down to the duration's target point count (Issue #47). A target
-    of 0, or a series already at/under target, is returned untouched — so short/zoomed-in
-    windows keep their native 30s detail. Every per-window hashrate column (#168) is carried
-    through, so the selected Avg window plots correctly even on downsampled wide ranges."""
-    target = _target_points(duration_s)
-    if target <= 0 or len(filtered_history) <= target:
-        return filtered_history
-
-    chunk_size = len(filtered_history) / target
-    downsampled = []
-    for i in range(target):
-        chunk = filtered_history[int(i * chunk_size) : int((i + 1) * chunk_size)]
-        if not chunk:
-            continue
-        mid = chunk[len(chunk) // 2]
-        row = {"t": mid["t"], "timestamp": mid["timestamp"]}
-        for col in _DOWNSAMPLE_VALUE_COLUMNS:
-            row[col] = round(sum(x.get(col, 0) or 0 for x in chunk) / len(chunk), 2)
-        downsampled.append(row)
-    return downsampled
-
-
-# Where the share markers ride on their own hidden 0–1 axis on the client: a constant near the
-# top, so they form a "rug" along the top edge instead of riding the hashrate line. Pinning them
-# off the hashrate axis keeps a single tall marker from inflating the y-range and burying a flat
-# line at the bottom of the card (Issue #145).
-_SHARE_MARKER_Y = 0.93
-
-
-def _share_points(filtered_history, filtered_shares):
-    """Sparse share markers: bucket each share onto its nearest history sample and emit one
-    ``{x, y, r, c}`` point per sample that has shares (x = sample time ms, y = the fixed top-of-
-    chart position on the client's dedicated share axis, r = radius scaled by count, c = count)."""
-    if not (filtered_history and filtered_shares):
-        return []
-
-    hist_ts = [x["timestamp"] for x in filtered_history]
-    counts = {}
-    for s in filtered_shares:
-        s_ts = s["ts"]
-        idx = bisect.bisect_left(hist_ts, s_ts)
-        candidates = []
-        if idx < len(hist_ts):
-            candidates.append(idx)
-        if idx > 0:
-            candidates.append(idx - 1)
-        if candidates:
-            closest_idx = min(candidates, key=lambda i: abs(hist_ts[i] - s_ts))
-            counts[closest_idx] = counts.get(closest_idx, 0) + 1
-
-    points = []
-    for idx in sorted(counts):
-        count = counts[idx]
-        # y is fixed (a fraction of the dedicated 0–1 share axis): the marker no longer tracks the
-        # hashrate, so it never stretches the y-range. Radius still scales with the share count.
-        points.append(
-            {
-                "x": int(hist_ts[idx] * 1000),
-                "y": _SHARE_MARKER_Y,
-                "r": min(6 + (count * 3), 15),
-                "c": count,
-            }
-        )
-    return points
-
-
-# Event markers ride just below the share rug on their own hidden 0–1 axis (#99), so a "something
-# went wrong" marker sits at the event's real time without touching the hashrate y-range.
-_EVENT_MARKER_Y = 0.82
-
-
-def _event_points(filtered_events):
-    """Sparse degradation/recovery markers (#99): one point per event at its timestamp, carrying the
-    tooltip ``label`` and ``kind`` (e.g. ``hashrate_loss`` vs ``hashrate_recovered``) so the client
-    can colour a loss vs a recovery."""
-    return [
-        {
-            "x": int(e["ts"] * 1000),
-            "y": _EVENT_MARKER_Y,
-            "kind": e.get("type", ""),
-            "label": e.get("detail") or e.get("type", "event"),
-        }
-        for e in filtered_events
-    ]
-
-
-# Raffle-win markers ride the same hidden 0–1 axis as the event markers, one step below them, so a
-# win sits at its real time without touching the hashrate y-range.
-_RAFFLE_MARKER_Y = 0.70
-
-
-def _raffle_points(filtered_wins):
-    """Sparse XvB raffle-win markers: one gold star per round this wallet won, at the round's
-    timestamp, with the tooltip carrying the round type and the credited hashrate."""
-    return [
-        {
-            "x": int(w["ts"] * 1000),
-            "y": _RAFFLE_MARKER_Y,
-            "label": f"XvB raffle win — {w['tier']} round at {format_hashrate(w['hashrate'])}",
-        }
-        for w in filtered_wins
-    ]
-
-
-# Confirmed on-chain payout markers ride the same hidden 0–1 axis as the raffle stars, one step
-# below them (#381), so a payout sits at its real block time without touching the hashrate y-range.
-_PAYOUT_MARKER_Y = 0.58
-
-# A long-lived wallet can accrue many payouts; the chart shows the most-recent-in-range so a busy
-# marker row can't bloat every /api/state payload. The EarningsCard totals still count them all.
-_PAYOUT_MARKER_LIMIT = 200
-
-
-def _payout_points(filtered_payouts, divisor=ATOMIC_PER_XMR):
-    """Sparse confirmed-payout markers (#381): one gold coin per on-chain Monero payout at its
-    block time, the tooltip carrying the whole-XMR amount (atomic→XMR at this edge, ``divisor``)
-    and the payout date. ``filtered_payouts`` is the range-bounded stored-payout list, newest
-    first (``storage.get_payouts``); capped at ``_PAYOUT_MARKER_LIMIT`` most-recent — the overflow
-    is logged, never silently dropped."""
-    if len(filtered_payouts) > _PAYOUT_MARKER_LIMIT:
-        logger.info(
-            "Chart payout markers capped at %d of %d (most recent kept)",
-            _PAYOUT_MARKER_LIMIT,
-            len(filtered_payouts),
-        )
-        filtered_payouts = filtered_payouts[:_PAYOUT_MARKER_LIMIT]
-    return [
-        {
-            "x": int(p["ts"] * 1000),
-            "y": _PAYOUT_MARKER_Y,
-            "label": f"{(p.get('amount_atomic', 0) or 0) / divisor:.6f} XMR — "
-            f"{time.strftime('%Y-%m-%d', time.localtime(p.get('ts', 0)))}",
-        }
-        for p in filtered_payouts
-    ]
 
 
 # --------------------------------------------------------------------------------------

--- a/dashboard/tests/web/test_charts.py
+++ b/dashboard/tests/web/test_charts.py
@@ -1,0 +1,396 @@
+"""Unit tests for the chart/window hub (mining_dashboard/web/charts.py).
+
+Moved verbatim out of tests/web/test_views.py with the hub itself (#1105); the only edit is the
+module alias on the four marker-constant reads, which follow their constants.
+"""
+
+import time
+
+import pytest
+
+import mining_dashboard.web.charts as charts
+from mining_dashboard.web.charts import (
+    _chart_tension,
+    _target_points,
+    build_chart,
+    parse_window,
+)
+
+
+class TestChart:
+    def _line(self, n, start_ts, step=30):
+        return [
+            {
+                "timestamp": start_ts + i * step,
+                "v": 100 + i,
+                "v_p2pool": 100 + i,
+                "v_xvb": 0,
+                "t": "x",
+            }
+            for i in range(n)
+        ]
+
+    def test_point_shape_is_xy_with_epoch_ms(self):
+        chart = build_chart(
+            [{"timestamp": 1000, "v": 800, "v_p2pool": 500, "v_xvb": 300, "t": "a"}], [], "all"
+        )
+        assert chart["p2pool"] == [{"x": 1_000_000, "y": 500}]
+        assert chart["xvb"] == [{"x": 1_000_000, "y": 300}]
+
+    def test_legacy_rows_attributed_to_p2pool(self):
+        chart = build_chart(
+            [{"timestamp": 1, "v": 800, "v_p2pool": 0, "v_xvb": 0, "t": "a"}], [], "all"
+        )
+        assert chart["p2pool"][0]["y"] == 800
+        assert chart["xvb"][0]["y"] == 0
+
+    def test_range_filtering(self):
+        now = time.time()
+        history = [
+            {"timestamp": now - 7200, "v": 1, "v_p2pool": 1, "v_xvb": 0, "t": "x"},
+            {"timestamp": now - 60, "v": 2, "v_p2pool": 2, "v_xvb": 0, "t": "x"},
+        ]
+        chart = build_chart(history, [], "1h")
+        assert len(chart["p2pool"]) == 1  # the 2h-old point is dropped
+
+    def test_downsampling_caps_points(self):
+        now = time.time()
+        chart = build_chart(self._line(2000, now - 60000), [], "all")
+        # Adaptive cap (Issue #47): never more than the ceiling, and actually downsampled.
+        real = [p for p in chart["p2pool"] if p["y"] is not None]
+        assert len(real) <= 700
+        assert len(real) < 2000
+
+    def test_outage_inserts_null_break(self):
+        # 10 regular 30s samples, a 2-hour outage, then 5 more.
+        hist = self._line(10, 1_000_000)
+        t = hist[-1]["timestamp"] + 7200
+        hist += [
+            {"timestamp": t + i * 30, "v": 200, "v_p2pool": 200, "v_xvb": 0, "t": "x"}
+            for i in range(5)
+        ]
+        chart = build_chart(hist, [], "all")
+        nulls = [p for p in chart["p2pool"] if p["y"] is None]
+        assert len(nulls) == 1  # exactly one break, in the gap
+        xs = [p["x"] for p in chart["p2pool"]]
+        assert xs == sorted(xs)  # still chronological
+        # both series break at the same place
+        assert sum(1 for p in chart["xvb"] if p["y"] is None) == 1
+
+    def test_regular_data_has_no_breaks(self):
+        chart = build_chart(self._line(50, 1_000_000), [], "all")
+        assert all(p["y"] is not None for p in chart["p2pool"])
+
+    def test_single_missing_sample_does_not_break(self):
+        # One dropped sample (a ~60s gap in 30s data) is below the outage threshold — a brief
+        # blip shouldn't fragment the line, only a real outage should.
+        ts = [1_000_000 + i * 30 for i in range(10)]
+        del ts[5]
+        hist = [{"timestamp": t, "v": 100, "v_p2pool": 100, "v_xvb": 0, "t": "x"} for t in ts]
+        assert all(p["y"] is not None for p in build_chart(hist, [], "all")["p2pool"])
+
+    def test_break_sits_inside_the_gap(self):
+        # The break marker must land between the two surrounding samples (so it renders inside
+        # the empty span, making the gap visible) — not at an endpoint.
+        hist = self._line(5, 1_000_000)
+        t = hist[-1]["timestamp"] + 7200
+        hist += [
+            {"timestamp": t + i * 30, "v": 200, "v_p2pool": 200, "v_xvb": 0, "t": "x"}
+            for i in range(5)
+        ]
+        pts = build_chart(hist, [], "all")["p2pool"]
+        i = next(k for k, p in enumerate(pts) if p["y"] is None)
+        assert pts[i - 1]["x"] < pts[i]["x"] < pts[i + 1]["x"]
+
+    def test_threshold_adapts_to_spacing(self):
+        # Uniformly *wide* spacing (as after downsampling a long range): a fixed 90s threshold
+        # would break on every interval; the adaptive (median-based) one must not break regular
+        # data at all, no matter how wide the spacing.
+        chart = build_chart(self._line(30, 1_000_000, step=600), [], "all")
+        assert all(p["y"] is not None for p in chart["p2pool"])
+
+    def test_downsampled_outage_still_breaks(self):
+        # The real #65 scenario: a long range that gets downsampled, with an outage in it. The
+        # break must survive downsampling (gap detected on the post-downsample timestamps).
+        now = time.time()
+        hist = self._line(1000, now - 100000, step=30)  # dense, will downsample
+        gap_start = hist[-1]["timestamp"] + 6 * 3600  # 6h outage
+        hist += self._line(1000, gap_start, step=30)
+        chart = build_chart(hist, [], "all")
+        assert any(p["y"] is None for p in chart["p2pool"])
+
+    def test_single_point_no_break(self):
+        chart = build_chart(
+            [{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all"
+        )
+        assert len(chart["p2pool"]) == 1
+
+    def test_share_points_sparse_and_top_pinned(self):
+        # Markers ride a dedicated 0–1 axis pinned near the top, independent of hashrate, so they
+        # don't inflate the y-range and bury a flat line (Issue #145). Radius still scales by count.
+        history = [
+            {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},
+            {"timestamp": 1030, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "b"},
+        ]
+        shares = [{"ts": 1001}, {"ts": 1029}]  # one near each sample
+        pts = build_chart(history, shares, "all")["shares"]
+        assert pts == [
+            {"x": 1_000_000, "y": 0.93, "r": 9, "c": 1},  # fixed top position, radius 6+3
+            {"x": 1_030_000, "y": 0.93, "r": 9, "c": 1},
+        ]
+
+    def test_share_marker_top_pinned_when_value_zero(self):
+        # Same fixed position even at zero hashrate — the marker stays visible without a floor hack.
+        pts = build_chart(
+            [{"timestamp": 1000, "v": 0, "v_p2pool": 0, "v_xvb": 0, "t": "a"}],
+            [{"ts": 1000}],
+            "all",
+        )["shares"]
+        assert pts == [{"x": 1_000_000, "y": 0.93, "r": 9, "c": 1}]
+
+    def test_no_shares_no_points(self):
+        assert (
+            build_chart([{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all")[
+                "shares"
+            ]
+            == []
+        )
+
+    def test_unknown_range_keeps_everything(self):
+        # An unrecognized range value falls through to "no filtering" (same as 'all').
+        now = time.time()
+        history = self._line(3, now - 90)
+        assert len(build_chart(history, [], "bogus")["p2pool"]) == 3
+
+    def test_empty_history(self):
+        assert build_chart([], [], "all") == {
+            "p2pool": [],
+            "xvb": [],
+            "shares": [],
+            "events": [],
+            "raffle": [],
+            "payouts": [],
+            "tension": 0.0,
+        }
+
+    # --- Issue #47: custom zoom window + duration-adaptive resolution/smoothing ---------
+
+    def test_custom_window_filters_both_bounds(self):
+        # A preset bounds only the lower end; a custom window clips BOTH ends.
+        hist = self._line(10, 1000)  # timestamps 1000..1270 (step 30)
+        chart = build_chart(hist, [], "all", window=(1060, 1150))
+        xs = [p["x"] for p in chart["p2pool"]]
+        assert xs == [1060_000, 1090_000, 1120_000, 1150_000]  # only ts in [1060, 1150]
+
+    def test_window_overrides_range(self):
+        # When both a window and a range are given, the window wins.
+        hist = self._line(10, 1000)
+        windowed = build_chart(hist, [], "1h", window=(1060, 1150))
+        assert len(windowed["p2pool"]) == 4
+
+    def test_short_window_kept_at_native_resolution(self):
+        # A <=1h window is never downsampled — full 30s detail (the "more detail zoomed in" goal).
+        now = time.time()
+        hist = self._line(120, now - 119 * 30, step=30)  # ~1h of 30s samples, ending now
+        chart = build_chart(hist, [], "1h")
+        assert len([p for p in chart["p2pool"] if p["y"] is not None]) == 120
+
+    def test_long_window_downsamples_to_tier(self):
+        now = time.time()
+        # ~1 week of 30s data (20160 pts) -> capped at the <=1w tier (600).
+        chart = build_chart(self._line(20160, now - 604800, step=30), [], "1w")
+        assert len([p for p in chart["p2pool"] if p["y"] is not None]) <= 600
+
+    def test_target_points_tiers(self):
+        assert _target_points(3600) == 0  # <= 1h: native
+        assert _target_points(3601) == 360  # <= 6h
+        assert _target_points(86400) == 480  # <= 24h
+        assert _target_points(604800) == 600  # <= 1w
+        assert _target_points(604801) == 700  # > 1w
+        assert _target_points(30 * 86400) == 700  # ceiling
+
+    def test_chart_tension_tiers(self):
+        assert _chart_tension(3600) == 0.0
+        assert _chart_tension(86400) == 0.2
+        assert _chart_tension(604800) == 0.35
+        assert _chart_tension(604801) == 0.4
+        # The payload carries the duration-derived tension the client applies.
+        assert build_chart(self._line(5, 1000), [], "1h")["tension"] == 0.0
+
+    def test_stacked_series_sum_to_the_total(self):
+        # The client stacks P2Pool + XvB so the top edge is the total. That's correct only
+        # because at each sample the full hashrate goes to one pool (v_p2pool + v_xvb == v).
+        # Guard that invariant on the emitted points so a future data change can't silently
+        # break the stack (Issue #47).
+        hist = [
+            {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},  # P2Pool sample
+            {"timestamp": 1030, "v": 700, "v_p2pool": 0, "v_xvb": 700, "t": "b"},  # XvB sample
+            {"timestamp": 1060, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "c"},
+        ]
+        chart = build_chart(hist, [], "all")
+        for p2p, xvb, row in zip(chart["p2pool"], chart["xvb"], hist, strict=False):
+            assert p2p["y"] + xvb["y"] == row["v"]  # stack top == total at every point
+
+    def test_zoom_reveals_more_detail(self):
+        # Core intent (Issue #47): zooming into a sub-window shows finer data than the wide view
+        # of the same history. 8h of dense 30s samples — a ~1h window stays native resolution
+        # while the full 8h downsamples, so the narrow window has more points per hour.
+        now = time.time()
+        dense = self._line(960, now - 8 * 3600, step=30)  # 8h @ 30s
+        wide = build_chart(dense, [], "all", window=(dense[0]["timestamp"], dense[-1]["timestamp"]))
+        narrow = build_chart(
+            dense, [], "all", window=(dense[-120]["timestamp"], dense[-1]["timestamp"])
+        )
+        wide_pts = len([p for p in wide["p2pool"] if p["y"] is not None])
+        narrow_pts = len([p for p in narrow["p2pool"] if p["y"] is not None])
+        assert narrow_pts == 120  # 1h window: native, untouched
+        assert narrow_pts / 1 > wide_pts / 8  # more points per hour zoomed in
+
+    def test_all_range_adapts_density_to_data_extent(self):
+        # With "all" (no preset length, no window) the adaptive density keys off the actual data
+        # extent (_window_duration). A ~2-week span lands in the widest tier and downsamples.
+        now = time.time()
+        dense = self._line(5000, now - 14 * 86400, step=int(14 * 86400 / 5000))
+        real = [p for p in build_chart(dense, [], "all")["p2pool"] if p["y"] is not None]
+        assert len(real) <= 700 and len(real) < 5000
+
+
+class TestParseWindow:
+    def test_valid_pair(self):
+        assert parse_window("1000", "2000") == (1000.0, 2000.0)
+
+    def test_absent_is_none(self):
+        assert parse_window(None, None) is None
+        assert parse_window("1000", None) is None
+
+    @pytest.mark.parametrize(
+        "frm,to",
+        [
+            ("bad", "2000"),  # non-numeric
+            ("2000", "1000"),  # from >= to
+            ("1000", "1000"),  # zero-width
+            ("-5", "2000"),  # non-positive
+            ("nan", "2000"),  # not finite
+            ("inf", "2000"),
+        ],
+    )
+    def test_malformed_falls_back_to_none(self, frm, to):
+        assert parse_window(frm, to) is None
+
+
+class TestChartEvents:
+    """Degradation/recovery markers (#99) flow through build_chart's new `events` kwarg: shaped as
+    xy points on the hidden 0-1 event axis, carrying kind+label, and window-filtered like history."""
+
+    def _hist(self, now):
+        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
+
+    def test_absent_events_default_to_empty(self):
+        now = time.time()
+        assert build_chart(self._hist(now), [], "all")["events"] == []
+
+    def test_event_point_shape(self):
+        now = time.time()
+        events = [{"ts": now, "type": "loss", "detail": "-62%"}]
+        pt = build_chart(self._hist(now), [], "all", events=events)["events"]
+        assert pt == [
+            {"x": int(now * 1000), "y": charts._EVENT_MARKER_Y, "kind": "loss", "label": "-62%"}
+        ]
+
+    def test_label_falls_back_to_type(self):
+        now = time.time()
+        events = [{"ts": now, "type": "recovered", "detail": ""}]
+        assert build_chart(self._hist(now), [], "all", events=events)["events"][0]["label"] == (
+            "recovered"
+        )
+
+    def test_events_filtered_by_range(self):
+        now = time.time()
+        events = [
+            {"ts": now - 7200, "type": "loss", "detail": "old"},  # 2h ago
+            {"ts": now - 60, "type": "recovered", "detail": "recent"},
+        ]
+        labels = [
+            e["label"] for e in build_chart(self._hist(now), [], "1h", events=events)["events"]
+        ]
+        assert labels == ["recent"]  # the 2h-old marker is outside the 1h window
+
+
+class TestChartRaffle:
+    """XvB raffle-win markers flow through build_chart's `raffle_wins` kwarg: gold-star points on
+    the hidden 0-1 event axis, tooltip carrying tier + credited rate, window-filtered like events."""
+
+    def _hist(self, now):
+        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
+
+    def _win(self, ts):
+        return {"ts": ts, "hashrate": 4.2e6, "height": 100, "block_id": "aa11", "tier": "donor"}
+
+    def test_absent_wins_default_to_empty(self):
+        now = time.time()
+        assert build_chart(self._hist(now), [], "all")["raffle"] == []
+
+    def test_raffle_point_shape(self):
+        now = time.time()
+        pt = build_chart(self._hist(now), [], "all", raffle_wins=[self._win(now)])["raffle"]
+        assert pt == [
+            {
+                "x": int(now * 1000),
+                "y": charts._RAFFLE_MARKER_Y,
+                "label": "XvB raffle win — donor round at 4.20 MH/s",
+            }
+        ]
+
+    def test_wins_filtered_by_range(self):
+        now = time.time()
+        wins = [self._win(now - 7200), self._win(now - 60)]
+        pts = build_chart(self._hist(now), [], "1h", raffle_wins=wins)["raffle"]
+        assert len(pts) == 1  # the 2h-old win is outside the 1h window
+
+
+class TestChartPayouts:
+    """Confirmed on-chain payout markers (#381) flow through build_chart's `payouts` kwarg: gold
+    coins on the hidden 0-1 axis below the raffle stars, tooltip carrying the whole-XMR amount,
+    range-filtered like events, and capped at the most-recent by _payout_points."""
+
+    def _hist(self, now):
+        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
+
+    def _payout(self, ts, atomic=1_500_000_000_000):  # 1.5 XMR in piconero
+        return {"chain": "monero", "txid": "aa", "height": 100, "ts": ts, "amount_atomic": atomic}
+
+    def test_absent_payouts_default_to_empty(self):
+        # Feature off (build_state passes payouts=None) → empty marker list, estimate stands alone.
+        now = time.time()
+        assert build_chart(self._hist(now), [], "all")["payouts"] == []
+        assert build_chart(self._hist(now), [], "all", payouts=None)["payouts"] == []
+
+    def test_payout_point_shape_carries_formatted_amount(self):
+        now = time.time()
+        pt = build_chart(self._hist(now), [], "all", payouts=[self._payout(now)])["payouts"]
+        assert len(pt) == 1
+        assert pt[0]["x"] == int(now * 1000)
+        assert pt[0]["y"] == charts._PAYOUT_MARKER_Y
+        # The label carries the whole-XMR amount (atomic→XMR at the edge) — the load-bearing bit.
+        assert pt[0]["label"].startswith("1.500000 XMR — ")
+
+    def test_payouts_filtered_by_range(self):
+        now = time.time()
+        payouts = [self._payout(now - 7200), self._payout(now - 60)]
+        pts = build_chart(self._hist(now), [], "1h", payouts=payouts)["payouts"]
+        assert len(pts) == 1  # the 2h-old payout is outside the 1h window
+
+    def test_markers_capped_at_most_recent(self):
+        # More than the cap → only the newest _PAYOUT_MARKER_LIMIT are kept (never silently all,
+        # and the NEWEST — not the oldest — survive). Input is newest-first (storage.get_payouts).
+        now = time.time()
+        limit = charts._PAYOUT_MARKER_LIMIT
+        payouts = [self._payout(now - i) for i in range(limit + 5)]  # [0]=newest … [-1]=oldest
+        pts = build_chart(self._hist(now), [], "all", payouts=payouts)["payouts"]
+        assert len(pts) == limit
+        kept_x = {p["x"] for p in pts}
+        # The newest survives and the oldest 5 (beyond the cap) are the ones dropped.
+        assert pts[0]["x"] == int(now * 1000)  # newest kept, first
+        assert pts[-1]["x"] == int((now - (limit - 1)) * 1000)  # limit-th newest kept, last
+        assert int((now - limit) * 1000) not in kept_x  # first over the cap → dropped
+        assert int((now - (limit + 4)) * 1000) not in kept_x  # oldest → dropped

--- a/dashboard/tests/web/test_views.py
+++ b/dashboard/tests/web/test_views.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import mining_dashboard.service.metrics as service_metrics
+import mining_dashboard.web.charts as charts
 import mining_dashboard.web.views as views
 from mining_dashboard.config import config as egress_config
 from mining_dashboard.config.config import (
@@ -27,11 +28,9 @@ from mining_dashboard.config.config import (
 from mining_dashboard.service.metrics import Metrics, SyncMetric, _sync_metric
 from mining_dashboard.web.views import (
     _MAX_CHART_POINTS,
-    _chart_tension,
     _mode_palette,
     _reject_flag,
     _rigforge_display,
-    _target_points,
     _window_reject_pct,
     build_badges,
     build_blocks,
@@ -56,7 +55,6 @@ from mining_dashboard.web.views import (
     canonical_window,
     get_shell_html,
     host_display_addr,
-    parse_window,
     recent_wallet_change,
     rigforge_update_for,
     visible_update,
@@ -149,244 +147,6 @@ def _xvb_archive():
 _XVB_ARCHIVE = _xvb_archive()
 
 
-class TestChart:
-    def _line(self, n, start_ts, step=30):
-        return [
-            {
-                "timestamp": start_ts + i * step,
-                "v": 100 + i,
-                "v_p2pool": 100 + i,
-                "v_xvb": 0,
-                "t": "x",
-            }
-            for i in range(n)
-        ]
-
-    def test_point_shape_is_xy_with_epoch_ms(self):
-        chart = build_chart(
-            [{"timestamp": 1000, "v": 800, "v_p2pool": 500, "v_xvb": 300, "t": "a"}], [], "all"
-        )
-        assert chart["p2pool"] == [{"x": 1_000_000, "y": 500}]
-        assert chart["xvb"] == [{"x": 1_000_000, "y": 300}]
-
-    def test_legacy_rows_attributed_to_p2pool(self):
-        chart = build_chart(
-            [{"timestamp": 1, "v": 800, "v_p2pool": 0, "v_xvb": 0, "t": "a"}], [], "all"
-        )
-        assert chart["p2pool"][0]["y"] == 800
-        assert chart["xvb"][0]["y"] == 0
-
-    def test_range_filtering(self):
-        now = time.time()
-        history = [
-            {"timestamp": now - 7200, "v": 1, "v_p2pool": 1, "v_xvb": 0, "t": "x"},
-            {"timestamp": now - 60, "v": 2, "v_p2pool": 2, "v_xvb": 0, "t": "x"},
-        ]
-        chart = build_chart(history, [], "1h")
-        assert len(chart["p2pool"]) == 1  # the 2h-old point is dropped
-
-    def test_downsampling_caps_points(self):
-        now = time.time()
-        chart = build_chart(self._line(2000, now - 60000), [], "all")
-        # Adaptive cap (Issue #47): never more than the ceiling, and actually downsampled.
-        real = [p for p in chart["p2pool"] if p["y"] is not None]
-        assert len(real) <= 700
-        assert len(real) < 2000
-
-    def test_outage_inserts_null_break(self):
-        # 10 regular 30s samples, a 2-hour outage, then 5 more.
-        hist = self._line(10, 1_000_000)
-        t = hist[-1]["timestamp"] + 7200
-        hist += [
-            {"timestamp": t + i * 30, "v": 200, "v_p2pool": 200, "v_xvb": 0, "t": "x"}
-            for i in range(5)
-        ]
-        chart = build_chart(hist, [], "all")
-        nulls = [p for p in chart["p2pool"] if p["y"] is None]
-        assert len(nulls) == 1  # exactly one break, in the gap
-        xs = [p["x"] for p in chart["p2pool"]]
-        assert xs == sorted(xs)  # still chronological
-        # both series break at the same place
-        assert sum(1 for p in chart["xvb"] if p["y"] is None) == 1
-
-    def test_regular_data_has_no_breaks(self):
-        chart = build_chart(self._line(50, 1_000_000), [], "all")
-        assert all(p["y"] is not None for p in chart["p2pool"])
-
-    def test_single_missing_sample_does_not_break(self):
-        # One dropped sample (a ~60s gap in 30s data) is below the outage threshold — a brief
-        # blip shouldn't fragment the line, only a real outage should.
-        ts = [1_000_000 + i * 30 for i in range(10)]
-        del ts[5]
-        hist = [{"timestamp": t, "v": 100, "v_p2pool": 100, "v_xvb": 0, "t": "x"} for t in ts]
-        assert all(p["y"] is not None for p in build_chart(hist, [], "all")["p2pool"])
-
-    def test_break_sits_inside_the_gap(self):
-        # The break marker must land between the two surrounding samples (so it renders inside
-        # the empty span, making the gap visible) — not at an endpoint.
-        hist = self._line(5, 1_000_000)
-        t = hist[-1]["timestamp"] + 7200
-        hist += [
-            {"timestamp": t + i * 30, "v": 200, "v_p2pool": 200, "v_xvb": 0, "t": "x"}
-            for i in range(5)
-        ]
-        pts = build_chart(hist, [], "all")["p2pool"]
-        i = next(k for k, p in enumerate(pts) if p["y"] is None)
-        assert pts[i - 1]["x"] < pts[i]["x"] < pts[i + 1]["x"]
-
-    def test_threshold_adapts_to_spacing(self):
-        # Uniformly *wide* spacing (as after downsampling a long range): a fixed 90s threshold
-        # would break on every interval; the adaptive (median-based) one must not break regular
-        # data at all, no matter how wide the spacing.
-        chart = build_chart(self._line(30, 1_000_000, step=600), [], "all")
-        assert all(p["y"] is not None for p in chart["p2pool"])
-
-    def test_downsampled_outage_still_breaks(self):
-        # The real #65 scenario: a long range that gets downsampled, with an outage in it. The
-        # break must survive downsampling (gap detected on the post-downsample timestamps).
-        now = time.time()
-        hist = self._line(1000, now - 100000, step=30)  # dense, will downsample
-        gap_start = hist[-1]["timestamp"] + 6 * 3600  # 6h outage
-        hist += self._line(1000, gap_start, step=30)
-        chart = build_chart(hist, [], "all")
-        assert any(p["y"] is None for p in chart["p2pool"])
-
-    def test_single_point_no_break(self):
-        chart = build_chart(
-            [{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all"
-        )
-        assert len(chart["p2pool"]) == 1
-
-    def test_share_points_sparse_and_top_pinned(self):
-        # Markers ride a dedicated 0–1 axis pinned near the top, independent of hashrate, so they
-        # don't inflate the y-range and bury a flat line (Issue #145). Radius still scales by count.
-        history = [
-            {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},
-            {"timestamp": 1030, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "b"},
-        ]
-        shares = [{"ts": 1001}, {"ts": 1029}]  # one near each sample
-        pts = build_chart(history, shares, "all")["shares"]
-        assert pts == [
-            {"x": 1_000_000, "y": 0.93, "r": 9, "c": 1},  # fixed top position, radius 6+3
-            {"x": 1_030_000, "y": 0.93, "r": 9, "c": 1},
-        ]
-
-    def test_share_marker_top_pinned_when_value_zero(self):
-        # Same fixed position even at zero hashrate — the marker stays visible without a floor hack.
-        pts = build_chart(
-            [{"timestamp": 1000, "v": 0, "v_p2pool": 0, "v_xvb": 0, "t": "a"}],
-            [{"ts": 1000}],
-            "all",
-        )["shares"]
-        assert pts == [{"x": 1_000_000, "y": 0.93, "r": 9, "c": 1}]
-
-    def test_no_shares_no_points(self):
-        assert (
-            build_chart([{"timestamp": 1, "v": 5, "v_p2pool": 5, "v_xvb": 0, "t": "a"}], [], "all")[
-                "shares"
-            ]
-            == []
-        )
-
-    def test_unknown_range_keeps_everything(self):
-        # An unrecognized range value falls through to "no filtering" (same as 'all').
-        now = time.time()
-        history = self._line(3, now - 90)
-        assert len(build_chart(history, [], "bogus")["p2pool"]) == 3
-
-    def test_empty_history(self):
-        assert build_chart([], [], "all") == {
-            "p2pool": [],
-            "xvb": [],
-            "shares": [],
-            "events": [],
-            "raffle": [],
-            "payouts": [],
-            "tension": 0.0,
-        }
-
-    # --- Issue #47: custom zoom window + duration-adaptive resolution/smoothing ---------
-
-    def test_custom_window_filters_both_bounds(self):
-        # A preset bounds only the lower end; a custom window clips BOTH ends.
-        hist = self._line(10, 1000)  # timestamps 1000..1270 (step 30)
-        chart = build_chart(hist, [], "all", window=(1060, 1150))
-        xs = [p["x"] for p in chart["p2pool"]]
-        assert xs == [1060_000, 1090_000, 1120_000, 1150_000]  # only ts in [1060, 1150]
-
-    def test_window_overrides_range(self):
-        # When both a window and a range are given, the window wins.
-        hist = self._line(10, 1000)
-        windowed = build_chart(hist, [], "1h", window=(1060, 1150))
-        assert len(windowed["p2pool"]) == 4
-
-    def test_short_window_kept_at_native_resolution(self):
-        # A <=1h window is never downsampled — full 30s detail (the "more detail zoomed in" goal).
-        now = time.time()
-        hist = self._line(120, now - 119 * 30, step=30)  # ~1h of 30s samples, ending now
-        chart = build_chart(hist, [], "1h")
-        assert len([p for p in chart["p2pool"] if p["y"] is not None]) == 120
-
-    def test_long_window_downsamples_to_tier(self):
-        now = time.time()
-        # ~1 week of 30s data (20160 pts) -> capped at the <=1w tier (600).
-        chart = build_chart(self._line(20160, now - 604800, step=30), [], "1w")
-        assert len([p for p in chart["p2pool"] if p["y"] is not None]) <= 600
-
-    def test_target_points_tiers(self):
-        assert _target_points(3600) == 0  # <= 1h: native
-        assert _target_points(3601) == 360  # <= 6h
-        assert _target_points(86400) == 480  # <= 24h
-        assert _target_points(604800) == 600  # <= 1w
-        assert _target_points(604801) == 700  # > 1w
-        assert _target_points(30 * 86400) == 700  # ceiling
-
-    def test_chart_tension_tiers(self):
-        assert _chart_tension(3600) == 0.0
-        assert _chart_tension(86400) == 0.2
-        assert _chart_tension(604800) == 0.35
-        assert _chart_tension(604801) == 0.4
-        # The payload carries the duration-derived tension the client applies.
-        assert build_chart(self._line(5, 1000), [], "1h")["tension"] == 0.0
-
-    def test_stacked_series_sum_to_the_total(self):
-        # The client stacks P2Pool + XvB so the top edge is the total. That's correct only
-        # because at each sample the full hashrate goes to one pool (v_p2pool + v_xvb == v).
-        # Guard that invariant on the emitted points so a future data change can't silently
-        # break the stack (Issue #47).
-        hist = [
-            {"timestamp": 1000, "v": 500, "v_p2pool": 500, "v_xvb": 0, "t": "a"},  # P2Pool sample
-            {"timestamp": 1030, "v": 700, "v_p2pool": 0, "v_xvb": 700, "t": "b"},  # XvB sample
-            {"timestamp": 1060, "v": 600, "v_p2pool": 600, "v_xvb": 0, "t": "c"},
-        ]
-        chart = build_chart(hist, [], "all")
-        for p2p, xvb, row in zip(chart["p2pool"], chart["xvb"], hist, strict=False):
-            assert p2p["y"] + xvb["y"] == row["v"]  # stack top == total at every point
-
-    def test_zoom_reveals_more_detail(self):
-        # Core intent (Issue #47): zooming into a sub-window shows finer data than the wide view
-        # of the same history. 8h of dense 30s samples — a ~1h window stays native resolution
-        # while the full 8h downsamples, so the narrow window has more points per hour.
-        now = time.time()
-        dense = self._line(960, now - 8 * 3600, step=30)  # 8h @ 30s
-        wide = build_chart(dense, [], "all", window=(dense[0]["timestamp"], dense[-1]["timestamp"]))
-        narrow = build_chart(
-            dense, [], "all", window=(dense[-120]["timestamp"], dense[-1]["timestamp"])
-        )
-        wide_pts = len([p for p in wide["p2pool"] if p["y"] is not None])
-        narrow_pts = len([p for p in narrow["p2pool"] if p["y"] is not None])
-        assert narrow_pts == 120  # 1h window: native, untouched
-        assert narrow_pts / 1 > wide_pts / 8  # more points per hour zoomed in
-
-    def test_all_range_adapts_density_to_data_extent(self):
-        # With "all" (no preset length, no window) the adaptive density keys off the actual data
-        # extent (_window_duration). A ~2-week span lands in the widest tier and downsamples.
-        now = time.time()
-        dense = self._line(5000, now - 14 * 86400, step=int(14 * 86400 / 5000))
-        real = [p for p in build_chart(dense, [], "all")["p2pool"] if p["y"] is not None]
-        assert len(real) <= 700 and len(real) < 5000
-
-
 class TestChartWindow:
     """The averaging-window toggle (#168): build_chart plots the selected window's columns, and the
     `avg` param is validated. 10m (default) keeps the legacy un-split fallback; the others don't."""
@@ -448,7 +208,7 @@ class TestChartWindow:
         # range wide enough to downsample (24h/1w/1mo).
         base = self._row()
         rows = [{**base, "timestamp": i} for i in range(600)]  # 600 > target(480) for a 24h span
-        out = views._downsample_history(rows, 86400)
+        out = charts._downsample_history(rows, 86400)
         assert len(out) < len(rows)  # actually downsampled
         assert out[0]["v_p2pool_1m"] == 900 and out[-1]["v_p2pool_1m"] == 900
         assert out[0]["v_p2pool_1h"] == 1100 and out[0]["v_p2pool_24h"] == 10
@@ -3074,29 +2834,6 @@ class TestEgressTopology:
         json.dumps(build_state(_data(), _state_mgr(), "all"))
 
 
-class TestParseWindow:
-    def test_valid_pair(self):
-        assert parse_window("1000", "2000") == (1000.0, 2000.0)
-
-    def test_absent_is_none(self):
-        assert parse_window(None, None) is None
-        assert parse_window("1000", None) is None
-
-    @pytest.mark.parametrize(
-        "frm,to",
-        [
-            ("bad", "2000"),  # non-numeric
-            ("2000", "1000"),  # from >= to
-            ("1000", "1000"),  # zero-width
-            ("-5", "2000"),  # non-positive
-            ("nan", "2000"),  # not finite
-            ("inf", "2000"),
-        ],
-    )
-    def test_malformed_falls_back_to_none(self, frm, to):
-        assert parse_window(frm, to) is None
-
-
 class TestShell:
     def test_returns_html_referencing_module(self):
         shell = get_shell_html()
@@ -3133,124 +2870,6 @@ class TestRaffleEligible:
             "eligible": False,
             "label": "N/A (XvB off)",
         }
-
-
-class TestChartEvents:
-    """Degradation/recovery markers (#99) flow through build_chart's new `events` kwarg: shaped as
-    xy points on the hidden 0-1 event axis, carrying kind+label, and window-filtered like history."""
-
-    def _hist(self, now):
-        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
-
-    def test_absent_events_default_to_empty(self):
-        now = time.time()
-        assert build_chart(self._hist(now), [], "all")["events"] == []
-
-    def test_event_point_shape(self):
-        now = time.time()
-        events = [{"ts": now, "type": "loss", "detail": "-62%"}]
-        pt = build_chart(self._hist(now), [], "all", events=events)["events"]
-        assert pt == [
-            {"x": int(now * 1000), "y": views._EVENT_MARKER_Y, "kind": "loss", "label": "-62%"}
-        ]
-
-    def test_label_falls_back_to_type(self):
-        now = time.time()
-        events = [{"ts": now, "type": "recovered", "detail": ""}]
-        assert build_chart(self._hist(now), [], "all", events=events)["events"][0]["label"] == (
-            "recovered"
-        )
-
-    def test_events_filtered_by_range(self):
-        now = time.time()
-        events = [
-            {"ts": now - 7200, "type": "loss", "detail": "old"},  # 2h ago
-            {"ts": now - 60, "type": "recovered", "detail": "recent"},
-        ]
-        labels = [
-            e["label"] for e in build_chart(self._hist(now), [], "1h", events=events)["events"]
-        ]
-        assert labels == ["recent"]  # the 2h-old marker is outside the 1h window
-
-
-class TestChartRaffle:
-    """XvB raffle-win markers flow through build_chart's `raffle_wins` kwarg: gold-star points on
-    the hidden 0-1 event axis, tooltip carrying tier + credited rate, window-filtered like events."""
-
-    def _hist(self, now):
-        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
-
-    def _win(self, ts):
-        return {"ts": ts, "hashrate": 4.2e6, "height": 100, "block_id": "aa11", "tier": "donor"}
-
-    def test_absent_wins_default_to_empty(self):
-        now = time.time()
-        assert build_chart(self._hist(now), [], "all")["raffle"] == []
-
-    def test_raffle_point_shape(self):
-        now = time.time()
-        pt = build_chart(self._hist(now), [], "all", raffle_wins=[self._win(now)])["raffle"]
-        assert pt == [
-            {
-                "x": int(now * 1000),
-                "y": views._RAFFLE_MARKER_Y,
-                "label": "XvB raffle win — donor round at 4.20 MH/s",
-            }
-        ]
-
-    def test_wins_filtered_by_range(self):
-        now = time.time()
-        wins = [self._win(now - 7200), self._win(now - 60)]
-        pts = build_chart(self._hist(now), [], "1h", raffle_wins=wins)["raffle"]
-        assert len(pts) == 1  # the 2h-old win is outside the 1h window
-
-
-class TestChartPayouts:
-    """Confirmed on-chain payout markers (#381) flow through build_chart's `payouts` kwarg: gold
-    coins on the hidden 0-1 axis below the raffle stars, tooltip carrying the whole-XMR amount,
-    range-filtered like events, and capped at the most-recent by _payout_points."""
-
-    def _hist(self, now):
-        return [{"timestamp": now, "v": 800, "v_p2pool": 800, "v_xvb": 0, "t": "a"}]
-
-    def _payout(self, ts, atomic=1_500_000_000_000):  # 1.5 XMR in piconero
-        return {"chain": "monero", "txid": "aa", "height": 100, "ts": ts, "amount_atomic": atomic}
-
-    def test_absent_payouts_default_to_empty(self):
-        # Feature off (build_state passes payouts=None) → empty marker list, estimate stands alone.
-        now = time.time()
-        assert build_chart(self._hist(now), [], "all")["payouts"] == []
-        assert build_chart(self._hist(now), [], "all", payouts=None)["payouts"] == []
-
-    def test_payout_point_shape_carries_formatted_amount(self):
-        now = time.time()
-        pt = build_chart(self._hist(now), [], "all", payouts=[self._payout(now)])["payouts"]
-        assert len(pt) == 1
-        assert pt[0]["x"] == int(now * 1000)
-        assert pt[0]["y"] == views._PAYOUT_MARKER_Y
-        # The label carries the whole-XMR amount (atomic→XMR at the edge) — the load-bearing bit.
-        assert pt[0]["label"].startswith("1.500000 XMR — ")
-
-    def test_payouts_filtered_by_range(self):
-        now = time.time()
-        payouts = [self._payout(now - 7200), self._payout(now - 60)]
-        pts = build_chart(self._hist(now), [], "1h", payouts=payouts)["payouts"]
-        assert len(pts) == 1  # the 2h-old payout is outside the 1h window
-
-    def test_markers_capped_at_most_recent(self):
-        # More than the cap → only the newest _PAYOUT_MARKER_LIMIT are kept (never silently all,
-        # and the NEWEST — not the oldest — survive). Input is newest-first (storage.get_payouts).
-        now = time.time()
-        limit = views._PAYOUT_MARKER_LIMIT
-        payouts = [self._payout(now - i) for i in range(limit + 5)]  # [0]=newest … [-1]=oldest
-        pts = build_chart(self._hist(now), [], "all", payouts=payouts)["payouts"]
-        assert len(pts) == limit
-        kept_x = {p["x"] for p in pts}
-        # The newest survives and the oldest 5 (beyond the cap) are the ones dropped.
-        assert pts[0]["x"] == int(now * 1000)  # newest kept, first
-        assert pts[-1]["x"] == int((now - (limit - 1)) * 1000)  # limit-th newest kept, last
-        assert int((now - limit) * 1000) not in kept_x  # first over the cap → dropped
-        assert int((now - (limit + 4)) * 1000) not in kept_x  # oldest → dropped
 
 
 class TestBuildRaffleLog:

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -19,7 +19,7 @@ dashboard/mining_dashboard/web/static/logic.mjs	534
 dashboard/mining_dashboard/web/static/osupdate.mjs	415
 dashboard/mining_dashboard/web/static/wizard.mjs	889
 dashboard/mining_dashboard/web/static/workerview.mjs	443
-dashboard/mining_dashboard/web/views.py	2263
+dashboard/mining_dashboard/web/views.py	1919
 dashboard/mining_dashboard/wizard.py	674
 dashboard/tests/client/test_xmrig_client.py	504
 dashboard/tests/config/test_config.py	458
@@ -38,7 +38,7 @@ dashboard/tests/service/test_metrics.py	463
 dashboard/tests/service/test_storage_service.py	1646
 dashboard/tests/service/test_telegram_commands.py	1240
 dashboard/tests/web/test_server.py	1319
-dashboard/tests/web/test_views.py	3576
+dashboard/tests/web/test_views.py	3195
 dashboard/tests/web/test_wizard.py	974
 .github/workflows/ci.yml	513
 os/rootfs/Dockerfile	406


### PR DESCRIPTION
**W3 / D1 of the #1105 dashboard cluster** — the chart/window hub leaves `views.py`, and its tests
leave `test_views.py` with it. Mechanical cut: no behaviour change, no new tests, nothing renamed.

## What moved, and why these boundaries

The cut map's line range for D1 was explicitly an approximation, so the boundary was **re-derived
from the dependency graph** rather than taken from it: I seeded the closure with the obvious
chart/window names and took the transitive closure of top-level references in `views.py`. That
came back as 28 names in three contiguous blocks, with only five edges leaving the cluster — the
clean cut the map predicted, at slightly different lines.

| block | contents |
|---|---|
| `_RANGE_SECONDS` .. `_GAP_FACTOR` | range presets, point/tension tiers, `parse_window` |
| chart-series header .. `_filter_events` | `build_chart`, `_filter_range`, `_filter_events` |
| `_window_duration` .. `_payout_points` | window duration, `_split_values`, `canonical_window`, gap/downsample helpers, and the four marker series |

Two deliberate departures from the map's approximate ranges, both dependency-driven:
`_split_values` (map: D4's range) is pulled in by `_downsample_history` and moves with the hub;
`build_share_stats` / `build_blocks` / `build_payouts` / `_gauge_series` / `build_disk_growth` /
`build_xvb_history` (map: inside D1's range) are *consumers* of the hub, not part of it, and stay.

## Identity proof

**No byte-identity claim for the file — a byte-identity claim for the moved text**, which is what
a Python cut can honestly assert.

- **Moved half:** all three blocks byte-identical to their `views.py` source at the base commit —
  52 lines / 42 non-blank, 102 / 89, 194 / 163.
- **Retained half:** `views.py` minus the moved blocks is byte-identical to the base on **every one
  of its 1,705 non-blank lines**, after accounting for exactly two declared deltas: the new
  `from ...web.charts import (...)` stanza, and four imports (`bisect`, `math`,
  `HASHRATE_WINDOW_COLUMNS`, `UPDATE_INTERVAL`) that the move left unused and ruff flagged.
- **Firing control:** flipping `_MAX_TENSION` 0.4 → 0.5 in a copy of `charts.py` was verified to
  actually change the file (md5 before ≠ after) and the identity check then **failed** on that
  block and passed on the other two. A check that cannot fail proves nothing; this one fails.

**Test move is 1:1.** `pytest --collect-only`: **2120 IDs before, 2120 after**, and after rewriting
only the module path `test_charts.py` → `test_views.py` the two sorted ID lists are **identical** —
44 tests moved, nothing added, renamed or dropped. The raw (un-normalised) diff is 88 lines, which
is that same proof's positive control: it does distinguish the two files.

**Import surface holds.** `server.py` (`parse_window`, `canonical_window`) and `worker_detail.py`
(`_filter_events`) are **not touched** — `views.py` re-exports those names, so their existing
imports resolve unchanged. Verified by grepping `mining_dashboard/` for every one of the 28 moved
names and by importing both modules and calling the facade names.

## Gates

| gate | result |
|---|---|
| `pytest` (dashboard) | **2120 passed, 0 failed**, rc=0 — same total as the baseline at this tip |
| coverage | **96.99%** total (bar ≥80); `charts.py` 99%, `views.py` 99% |
| `test-patch-coverage` | **96%** (bar ≥90), and its anti-vacuous check reported positively — 80 changed files present in `coverage.xml`, not "no lines with coverage information" |
| `node --test tests/frontend/` | **480 passed, 0 failed** |
| `lint-py js yaml md docs-voice operator-strings topology file-budget trivy-parity proto toml` | all rc=0 |
| `scripts/lint-file-budget.sh` | pass, **run locally** |

`charts.py`'s one uncovered line is `_downsample_history`'s empty-chunk `continue`. It was
unreachable before the move too: `chunk_size = len/target` is only computed when `len > target`, so
it exceeds 1 and no slice is empty. Same code, same tests — no coverage was lost here.

## Budget

Hand-curated, lowering **only** the two rows this diff shrank:
`web/views.py` 2263 → 1919, `tests/web/test_views.py` 3576 → 3195. `charts.py` (381) and
`test_charts.py` (396) are both under the 400 floor and correctly take **no row**.

**The monotonic half of that gate does not run in CI (#1452), so the budget proof above is
LOCAL-ONLY.** CI green proves the per-file half and nothing more.

## Named deferrals — things this PR did NOT do

- **`TestChartWindow` stays in `test_views.py`.** Its last three methods assert the `build_state`
  contract end to end and depend on the `_state_mgr` / `_data` assembly fixtures. Moving the class
  whole would duplicate those fixtures into a second module; splitting it would rename a class and
  churn test IDs beyond a module-path change. The map's own ruling keeps `build_state` and its
  tests in `views.py`. It now reads `charts._downsample_history` instead of `views._downsample_history`
  — the only edit inside a retained test.
- **A section comment in `test_views.py` reading `# --- Chart (Issue #65 ...) ---` now sits above
  `_xvb_archive`, which is not chart code.** It mislabelled that helper before this PR too. Left
  alone to keep the cut mechanical; worth one line in a later D-cut.
- **`make lint-sh` was not run.** It is the serialized OOM path and this diff contains zero shell
  files, so it cannot be affected. Stated rather than implied.
- **Nothing was seen on screen.** This is a refactor with no rendering change, but this lane still
  has no browser, so "the chart still draws" rests on the suite, not on a look.

Part of #1105.
