### PR TITLE
fix(integration): the settle's own progress banner was being read back as its result (#1454)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -400,6 +400,24 @@ loudly without its prerequisite:
 - Auto-rollback ([#517](https://github.com/p2pool-starter-stack/pithead/issues/517), rigforge#236):
   a change the rig rolls back is recorded as `rolled_back` in the worker-apply result and history.
 
+### Settling an apply that comes back `accepted`
+
+RigForge answers a worker-apply immediately and applies asynchronously (rigforge#344), so the dial
+result is often `accepted` rather than a terminal `applied`. The harness settles that itself: it
+polls the rig's own reported value until the requested change shows up, then treats the change as
+applied, and leaves a genuine `rejected` / `failed` / timeout exactly as it found it. The `#513`
+`max_temp_c` leg and both `#1236` legs share one settle for this
+([#1309](https://github.com/p2pool-starter-stack/pithead/issues/1309)).
+
+That settle hands its result back on stdout, which makes its output discipline load-bearing rather
+than cosmetic. The wait's progress line goes to stderr for that reason; on stdout it would be read
+back as the result itself, and every assertion downstream would fail whatever the rig had done. The
+first hardware run to exercise the wait hit precisely that
+([#1454](https://github.com/p2pool-starter-stack/pithead/issues/1454)): the rig recorded both
+`DONATION` changes applied, eighteen seconds apart, while the gate reported four failures. The
+self-test that covers the settle now runs the real wait rather than a silent stub, because a stub
+that prints nothing cannot see this class at all.
+
 ### The abort-safe unwind
 
 Every leg above restores what it changed when it finishes. That covers a leg that *fails*; it does

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -37,18 +37,13 @@ _settle_worker_apply() { # <ckeys-on-success> <wait-desc> <dial-result-json> <pr
     status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
     ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
     change_id="$(printf '%s' "$res" | jq -r '.change_id // empty' 2>/dev/null)"
-    # `>&2` is load-bearing, not tidiness (#1454). This function's stdout IS its return value —
-    # every call site captures it with `$(...)` and splits it with `IFS='|' read`. wait_for's own
-    # progress banner goes through it_step, which writes to STDOUT, so without this redirection the
-    # banner lands in the capture as the FIRST line and `read` takes it as $status: the caller then
-    # sees status = "  → waiting for the rig to report …", ckeys = "" and change_id = "", and reds
-    # all three assertions no matter what the rig did. It fires on every settle that actually waits
-    # — i.e. exactly the RigForge #344 async path this module exists for — so the settle looked
-    # correct only while it was never exercised. Confirmed on hardware: the rig's own
-    # /var/lib/rigforge-control/changes/<cid>.json recorded both DONATION changes "applied", 18s
-    # apart, while the gate reported four reds. The banner keeps its visibility on stderr, which is
-    # where wait_for's matching "timed out after Ns" warning already goes, and e2e.sh merges both
-    # into the harness log (2>&1).
+    # `>&2` is load-bearing (#1454). This function's stdout IS its return value — every call site
+    # captures it with `$(...)` and splits it with `IFS='|' read` — and wait_for opens with an
+    # it_step banner, which goes to STDOUT. Without the redirection that banner is the FIRST line of
+    # the capture, `read` takes it as $status, ckeys and change_id come back empty, and all three
+    # of the caller's assertions red whatever the rig did. It fires only on a settle that actually
+    # waits, i.e. exactly the RigForge #344 path this module exists for. stderr is where wait_for's
+    # own "timed out after Ns" warning already goes, and e2e.sh merges both into the harness log.
     if [ "$status" = "accepted" ] && wait_for 90 5 "$desc" "$@" >&2; then
         status="applied"
         ckeys="$key"

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -37,7 +37,19 @@ _settle_worker_apply() { # <ckeys-on-success> <wait-desc> <dial-result-json> <pr
     status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"
     ckeys="$(printf '%s' "$res" | jq -r '(.changed_keys // []) | join(",")' 2>/dev/null)"
     change_id="$(printf '%s' "$res" | jq -r '.change_id // empty' 2>/dev/null)"
-    if [ "$status" = "accepted" ] && wait_for 90 5 "$desc" "$@"; then
+    # `>&2` is load-bearing, not tidiness (#1454). This function's stdout IS its return value —
+    # every call site captures it with `$(...)` and splits it with `IFS='|' read`. wait_for's own
+    # progress banner goes through it_step, which writes to STDOUT, so without this redirection the
+    # banner lands in the capture as the FIRST line and `read` takes it as $status: the caller then
+    # sees status = "  → waiting for the rig to report …", ckeys = "" and change_id = "", and reds
+    # all three assertions no matter what the rig did. It fires on every settle that actually waits
+    # — i.e. exactly the RigForge #344 async path this module exists for — so the settle looked
+    # correct only while it was never exercised. Confirmed on hardware: the rig's own
+    # /var/lib/rigforge-control/changes/<cid>.json recorded both DONATION changes "applied", 18s
+    # apart, while the gate reported four reds. The banner keeps its visibility on stderr, which is
+    # where wait_for's matching "timed out after Ns" warning already goes, and e2e.sh merges both
+    # into the harness log (2>&1).
+    if [ "$status" = "accepted" ] && wait_for 90 5 "$desc" "$@" >&2; then
         status="applied"
         ckeys="$key"
     fi

--- a/tests/integration/selftest-rigforge-apply-settle.sh
+++ b/tests/integration/selftest-rigforge-apply-settle.sh
@@ -19,6 +19,30 @@ res='{"status":"applied","changed_keys":["max_temp_c"],"change_id":"c1"}'
 out="$(_settle_worker_apply_maxt rig1 101 "$res")"
 assert_eq "an immediate 'applied' passes through untouched" "$out" "applied|max_temp_c|c1"
 
+echo "== _settle_worker_apply: wait_for's banner must not reach the RESULT (#1454) =="
+# The one case in this file that does NOT stub wait_for, and that is the whole point. Every other
+# case below replaces it with a silent `return 0` / `return 1`, and that silence is what let #1454
+# ship: the REAL wait_for opens with an it_step progress banner on STDOUT, and this function's
+# stdout is its return value. So the stubbed cases prove the settle's logic and are blind to the
+# only defect the settle has ever actually had on hardware.
+#
+# Driven through the generic _settle_worker_apply with a trivially-true predicate rather than
+# _settle_worker_apply_maxt, so it stays hermetic (no dashboard, no rig) while still running the
+# genuine lib.sh wait_for — including its genuine banner.
+#
+# Kills the mutant precisely: drop the `>&2` in rigforge-apply-settle.sh and the capture becomes two
+# lines, `read` takes the banner as $status, and both assertions red with the exact strings the
+# 2026-08-28 gate run printed ("expected [applied], got [  → waiting for …]" and "[] missing").
+_pred_settles_now() { return 0; }
+res='{"status":"accepted","change_id":"c-banner"}'
+out="$(_settle_worker_apply max_temp_c "the rig to report max_temp_c=101 applied" "$res" _pred_settles_now)"
+assert_eq "the settle's stdout is the result and nothing else" "$out" "applied|max_temp_c|c-banner"
+# Second conjunct, and a DIFFERENT mechanism on purpose: the wrong fix for the above is to delete
+# the banner from wait_for, which would silence progress reporting for every other wait in the
+# harness. Assert it is still emitted — on stderr, where wait_for's own timeout warning goes.
+err="$(_settle_worker_apply max_temp_c "the rig to report max_temp_c=101 applied" "$res" _pred_settles_now 2>&1 >/dev/null)"
+assert_contains "the progress banner is redirected, not deleted" "$err" "waiting for the rig to report max_temp_c=101 applied"
+
 echo "== _settle_worker_apply_maxt: RigForge #344 async apply (#1309) =="
 # This is the load-bearing mutation-kill: if the "accepted is terminal" bug (#1309) were
 # reintroduced — treating status verbatim instead of polling for it to settle — this would still

--- a/tests/integration/selftest-rigforge-apply-settle.sh
+++ b/tests/integration/selftest-rigforge-apply-settle.sh
@@ -21,18 +21,12 @@ assert_eq "an immediate 'applied' passes through untouched" "$out" "applied|max_
 
 echo "== _settle_worker_apply: wait_for's banner must not reach the RESULT (#1454) =="
 # The one case in this file that does NOT stub wait_for, and that is the whole point. Every other
-# case below replaces it with a silent `return 0` / `return 1`, and that silence is what let #1454
-# ship: the REAL wait_for opens with an it_step progress banner on STDOUT, and this function's
-# stdout is its return value. So the stubbed cases prove the settle's logic and are blind to the
-# only defect the settle has ever actually had on hardware.
-#
-# Driven through the generic _settle_worker_apply with a trivially-true predicate rather than
-# _settle_worker_apply_maxt, so it stays hermetic (no dashboard, no rig) while still running the
-# genuine lib.sh wait_for — including its genuine banner.
-#
-# Kills the mutant precisely: drop the `>&2` in rigforge-apply-settle.sh and the capture becomes two
-# lines, `read` takes the banner as $status, and both assertions red with the exact strings the
-# 2026-08-28 gate run printed ("expected [applied], got [  → waiting for …]" and "[] missing").
+# case replaces it with a silent `return 0` / `return 1`, and that silence is what let #1454 ship:
+# the real wait_for opens with an it_step banner on stdout, and this function's stdout is its
+# return value. Drop the `>&2` in rigforge-apply-settle.sh and the capture becomes two lines, so
+# `read` takes the banner as $status — the exact four reds the 2026-08-28 gate run printed.
+# Driven through the generic _settle_worker_apply with a trivially-true predicate so it stays
+# hermetic (no dashboard, no rig) while still running the genuine lib.sh wait_for.
 _pred_settles_now() { return 0; }
 res='{"status":"accepted","change_id":"c-banner"}'
 out="$(_settle_worker_apply max_temp_c "the rig to report max_temp_c=101 applied" "$res" _pred_settles_now)"

--- a/tests/integration/selftest-rigforge-writable-keys.sh
+++ b/tests/integration/selftest-rigforge-writable-keys.sh
@@ -54,6 +54,10 @@ _worker_apply() { # <rig> <changes-json> — record it, then answer as a converg
     printf '%s\n' "$2" >>"$APPLY_LOG"
     printf '{"status":"accepted","change_id":"c-%s"}' "$(printf '%s' "$2" | jq -r 'keys[0]')"
 }
+# Silent on purpose, and blind on purpose: these stubs prove the LEGS' logic, not the settle's
+# stream discipline. The real wait_for opens with a progress banner on stdout, and a stub that
+# omits it cannot see #1454 (the banner landing in the settle's captured result). That case is
+# covered where the defect lives — selftest-rigforge-apply-settle.sh, with the REAL wait_for.
 wait_for() { return 0; } # the rig converges; the timeout half is exercised explicitly below
 
 # Drive something whose asserts are expected to red, without polluting this file's own verdict.


### PR DESCRIPTION
## What this fixes

`_settle_worker_apply` (`tests/integration/rigforge-apply-settle.sh`) returns
`"<status>|<ckeys>|<change_id>"` **on stdout**. All four call sites capture it with `$(...)` and
split it with `IFS='|' read`:

- `run.sh:2224`, `run.sh:2232` — the #513 `max_temp_c` legs
- `rigforge-writable-keys.sh:77`, `:86` — the #1236 `DONATION` / `watchdog_interval_min` legs

`wait_for` (`lib.sh:488`) opens with `it_step "waiting for …"`, and `it_step` writes to **stdout**
(`lib.sh:33`). So whenever the settle actually waited, the captured value was two lines, `read` took
the banner as `$status`, and `ckeys` / `change_id` came back empty. Every assertion downstream then
red — whatever the rig had done.

That is the whole of #1454. It is not `DONATION`-specific, and it is not an async-timing problem.
`DONATION` is simply the key whose dial came back `accepted`; `watchdog_interval_min`'s came back
terminal, so `wait_for` was never called and its legs passed.

## Why it survived until now

The defect only fires when the settle is genuinely exercised — that is, on the RigForge #344 async
path this module was written for. Until the #1236 legs ran on real hardware, it never was.

And the self-tests could not see it. **Every `wait_for` stub in `tests/integration/` is silent**
(`wait_for() { return 0; }`, in three files). A stub that prints nothing cannot catch a defect about
printing, so the settle's own self-test called its stubbed case "the load-bearing mutation-kill"
while being blind to the only defect the settle has ever actually had.

## Evidence — derived at source, not inferred

**On the rig.** The loaner's own terminal records, `/var/lib/rigforge-control/changes/<cid>.json`:

```
7267df0a97cf2730  applied  2026-08-28T21:18:20Z  ["DONATION"]              reason: null
bc9b2bf5df836fe3  applied  2026-08-28T21:18:38Z  ["DONATION"]              reason: null
dc3a5df4377e85f5  applied  2026-08-28T21:18:44Z  ["watchdog_interval_min"] reason: null
7f5769547f066bba  applied  2026-08-28T21:18:52Z  ["watchdog_interval_min"] reason: null
```

Both `DONATION` changes committed and applied, no rollback, no reason string — while the gate
reported four failures. **18 seconds apart**, which does not fit a 90s timeout: the wait had
converged and the rig had done exactly what was asked.

**Standalone repro**, run against the real function with a predicate that returns true immediately:

```
RAW CAPTURED OUTPUT >>>
  → waiting for the rig to report DONATION=1 applied (timeout 90s)…
applied|DONATION|c9
<<<
status=[  → waiting for the rig to report DONATION=1 applied (timeout 90s)…]
ckeys=[]
change_id=[]
```

Those three values reproduce all four logged failures exactly: the `expected [applied], got [ →
waiting …]` on the apply and the revert, the `[] missing [DONATION]` on the confirm (that `[]` is
`ckeys`, not a readback — it carries no information about the rig at all), and the empty
per-worker-history status (looked up by an empty `change_id`).

## The fix

`wait_for … >&2` in `_settle_worker_apply`. The banner keeps its visibility on stderr, which is
where `wait_for`'s matching `timed out after Ns` warning already goes, and which `e2e.sh:637` merges
into the harness log with `2>&1`.

## The guard, and its mutation proof

`selftest-rigforge-apply-settle.sh` gains one case that does **not** stub `wait_for` — it drives the
generic `_settle_worker_apply` through the real `lib.sh` `wait_for` with a trivially-true predicate,
so the genuine banner is emitted. Hermetic: no dashboard, no rig.

Two conjuncts on two different mechanisms, and two mutants, each verified to have actually changed
the file before its run was graded:

| Mutant | Result |
|---|---|
| drop the `>&2` (restore the shipped defect) | `5 passed, 2 failed` — both new assertions red |
| delete `wait_for`'s banner (the *wrong* fix) | `6 passed, 1 failed` — only the stderr assertion reds |

The second mutant is why the second assertion exists: silencing the banner would "fix" this while
breaking progress reporting for every other wait in the harness.

## What was run

- `make test-integration-selftest` — 214 + 7 + 50 + 70 + 63 + 31 + 26 + 5, **0 failed**
  (`selftest-rigforge-apply-settle` 5 → 7)
- `shellcheck --severity=warning tests/integration/*.sh tests/integration/mini-stack/*.sh` — rc=0
- `shfmt -i 4 -d` over the Makefile's exact glob — rc=0
- `make lint-md`, `make lint-docs-voice`, `make lint-file-budget`, `make lint-operator-strings` — all pass
- `make lint-sh` NOT run as a whole: it is this box's OOM path and is serialized; the targeted
  shellcheck + full-glob shfmt above are the standing substitute.

## What was NOT done, and is owed

A full gate re-run to watch the four #1236 `DONATION` legs go green end to end. The **diagnosis** is
discharged on hardware; the **fix** is discharged at tier 3 with the real `wait_for` and two killed
mutants. Nobody has yet seen the corrected legs pass on a rig.

## Shared files

`docs/dev/integration-testing.md` (`_shared.paths`) gains a short section on the settle and why its
output discipline is load-bearing. No other lane's paths touched.

Refs #1454, #1236, #1309.

## Over-engineering pass (ponytail)

Two `shrink` findings on my own comments — the fix's 12-line block restated evidence this body
already carries, and the guard's third paragraph restated its first. Both cut (net 11 lines) in a
follow-up commit; the two mutants were re-run after the trim and are still killed. Everything else
was reviewed and kept, with the reason: `_pred_settles_now` and the second assertion are not
speculative — mutant 2 proved the second assertion is the only one that catches the wrong fix.
