### PR TITLE
fix(gate): let the un-split-remainder row rise, so pithead can still be fixed (#1464)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,12 +58,19 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      deliberate, justified addition to a budgeted file therefore has exactly one legal path:
      split or shrink the file so the addition fits under a ceiling that stays put or drops —
      see issue #1258 for the worked example, where a security test that outgrew its file moved
-     into its own — and note the gate runs locally and in `make lint` but is not yet wired into
-     CI (issue #1257), so two same-wave merges can each pass alone and fail together: re-run
-     `make lint` after merging onto the tip. Generated
+     into its own — and note that two same-wave merges can each pass alone and fail together, so
+     re-run `make lint` after merging onto the tip. Generated
      code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
      the script — and so is the shipped `pithead` artifact itself: it is generated, and the gate
-     governs its `lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it),
+     governs its `lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it.
+     One row is exempt from the ceilings-only-move-down half, and only that half:
+     `lib/pithead/99-remainder.sh` measures how much of that generated artifact Phase 2 has not
+     split out yet, not the size of a file anyone writes, so it tracks the artifact both ways.
+     Without that, `pithead`'s own exemption became a freeze — the CLI could not gain a line,
+     because the row refused to rise and the file refused to grow past it (issue #1464). The row
+     is still checked against the file on every PR, so a change that grows the artifact has to
+     record the new count, and every Phase 2 cut lowers it; it retires when the remainder reaches
+     the 400 target. See `monotonic_exempt()` in the script),
      `lint-pithead-parity` (the shipped `pithead` must be exactly what `lib/pithead/*.sh`
      concatenate to: edit a slice, run `scripts/build-pithead.sh`, and commit both — issue #1105
      Phase 2), `lint-trivy-parity` (the CVE

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -48,7 +48,6 @@ dashboard/tests/web/test_xvb_views.py	1342
 lib/pithead/99-remainder.sh	11870
 os/rootfs/Dockerfile	406
 scripts/build-pithead.sh	437
-scripts/lint-file-budget.sh	407
 scripts/release.sh	851
 scripts/shipped-image-sweep-report.sh	429
 scripts/trivyignore-watch.sh	599

--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Fixtures for the file-budget ratchet gate — every failure mode it has, each against a throwaway
+# git repo built for it. Split out of scripts/lint-file-budget.sh for issue #1464: the gate was
+# 407 lines at a recorded ceiling of 407, so it was closed to any addition, and the gate's own
+# header rule says a file back under the 400 target must drop its budget entry. Splitting is
+# therefore the remedy the gate itself documents, not a way around it.
+#
+# Run it directly, or as `scripts/lint-file-budget.sh --self-test`, which execs this file.
+# The gate is SOURCED for its functions, so it carries a guard that keeps sourcing from running
+# anything; see the bottom of that script.
+set -euo pipefail
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/lint-file-budget.sh
+source "$HERE/lint-file-budget.sh"
+
+# --- self-test: every failure mode against fixtures, in an isolated throwaway git repo ----------
+self_test() {
+    local tmp out st_fail=0 rc=0
+    tmp=$(mktemp -d)
+    out=$(mktemp)
+    # Double-quoted so $tmp/$out are embedded now, as literal paths — the trap still fires after
+    # self_test's own locals have gone out of scope, so a deferred expansion would see them unset.
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp' '$out'" EXIT
+    git -C "$tmp" init -q -b develop
+    git -C "$tmp" config user.email test@example.invalid
+    git -C "$tmp" config user.name test
+
+    expect() { # <desc> <expected-rc> <actual-rc>
+        if [ "$2" -eq "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (expected rc $2, got $3)"
+            st_fail=1
+        fi
+    }
+    seq 1 500 >"$tmp/budgeted.sh"
+    mkdir -p "$tmp/$(dirname "$BUDGET_FILE")"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
+    git -C "$tmp" add budgeted.sh "$BUDGET_FILE"
+    git -C "$tmp" commit -q -m base
+
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "calibration: budgeted file at its ceiling passes" 0 "$rc"
+
+    seq 1 501 >"$tmp/budgeted.sh"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "growing a budgeted file past its ceiling FAILS" 1 "$rc"
+    if grep -q "budgeted.sh is 501" "$out"; then
+        echo "  self-test ok: names the offending file"
+    else
+        echo "  self-test FAIL: did not name the offending file"
+        st_fail=1
+    fi
+
+    seq 1 500 >"$tmp/budgeted.sh"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "reverting the growth passes again" 0 "$rc"
+
+    seq 1 800 >"$tmp/new.sh"
+    git -C "$tmp" add new.sh
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "an over-target file with NO entry FAILS (800, inside the hard ceiling)" 1 "$rc"
+    if grep -q "new.sh is 800 lines (> 400 target) but has no" "$out"; then
+        echo "  self-test ok: names the missing entry, not the hard ceiling"
+    else
+        echo "  self-test FAIL: did not name the missing entry"
+        st_fail=1
+    fi
+    printf '# test budget\nbudgeted.sh\t500\nnew.sh\t800\n' >"$tmp/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "recording the entry is the fix — the same file then passes" 0 "$rc"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
+    seq 1 801 >"$tmp/new.sh"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a new 801-line file FAILS the hard ceiling" 1 "$rc"
+    rm -f "$tmp/new.sh"
+    git -C "$tmp" rm -q --cached new.sh >/dev/null 2>&1 || true
+
+    printf '# test budget\nbudgeted.sh\t400\n' >"$tmp/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "lowering a ceiling below the file's real size FAILS (reality check)" 1 "$rc"
+
+    printf '# test budget\nbudgeted.sh\t900\n' >"$tmp/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "raising a ceiling FAILS (monotonicity, vs the committed base)" 1 "$rc"
+    if grep -q "raises budgeted.sh's ceiling" "$out"; then
+        echo "  self-test ok: names the ceiling raise"
+    else
+        echo "  self-test FAIL: did not name the ceiling raise"
+        st_fail=1
+    fi
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
+
+    seq 1 300 >"$tmp/budgeted.sh"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a budgeted file dropped below target still listed FAILS (stale entry)" 1 "$rc"
+    seq 1 500 >"$tmp/budgeted.sh"
+
+    # Two-lane shape: a develop-v2 branch cut BEFORE the lane tip advanced must still
+    # ratchet against develop-v2, not fall back to develop and read this lane's larger
+    # ceiling as a raise — the false RED that bit two live PRs the day the tip moved.
+    local tmp3
+    tmp3=$(mktemp -d)
+    git -C "$tmp3" init -q -b develop
+    git -C "$tmp3" config user.email test@example.invalid
+    git -C "$tmp3" config user.name test
+    mkdir -p "$tmp3/$(dirname "$BUDGET_FILE")"
+    seq 1 500 >"$tmp3/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp3/$BUDGET_FILE"
+    git -C "$tmp3" add -A && git -C "$tmp3" commit -q -m dev-base
+    git -C "$tmp3" checkout -q -b develop-v2
+    seq 1 600 >"$tmp3/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t600\n' >"$tmp3/$BUDGET_FILE"
+    git -C "$tmp3" add -A && git -C "$tmp3" commit -q -m v2-larger
+    git -C "$tmp3" checkout -q -b feature
+    git -C "$tmp3" checkout -q develop-v2
+    echo x >"$tmp3/other.txt"
+    git -C "$tmp3" add other.txt && git -C "$tmp3" commit -q -m v2-advances
+    git -C "$tmp3" checkout -q feature
+    seq 1 580 >"$tmp3/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t580\n' >"$tmp3/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp3" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a v2-lane branch behind the moved lane tip still ratchets against develop-v2" 0 "$rc"
+    rc=0
+    (cd "$tmp3" && [ "$(resolve_base_ref)" = develop-v2 ]) || rc=1
+    expect "lane detection reads history, not tip-levelness" 0 "$rc"
+    git -C "$tmp3" checkout -q -f develop
+    rc=0
+    (cd "$tmp3" && [ "$(resolve_base_ref)" = develop ]) || rc=1
+    expect "a develop-lane checkout still resolves to develop" 0 "$rc"
+    rm -rf "$tmp3"
+
+    # #1464 — the un-split-remainder row is the one ceiling allowed to RISE, because it measures
+    # what of the generated pithead artifact is not split out YET rather than the size of a file
+    # anyone writes. Three cases in their own repo, so they cannot perturb what the cases above
+    # prove: the exempt row rising, a firing control, and the ratchet still biting from the
+    # other side.
+    local tmp4
+    tmp4=$(mktemp -d)
+    git -C "$tmp4" init -q -b develop
+    git -C "$tmp4" config user.email test@example.invalid
+    git -C "$tmp4" config user.name test
+    mkdir -p "$tmp4/$(dirname "$BUDGET_FILE")" "$tmp4/lib/pithead"
+    seq 1 500 >"$tmp4/budgeted.sh"
+    seq 1 500 >"$tmp4/lib/pithead/99-remainder.sh"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t500\n' >"$tmp4/$BUDGET_FILE"
+    git -C "$tmp4" add -A && git -C "$tmp4" commit -q -m remainder-base
+    # The shape a pithead bug fix produces: the artifact grows, the row is updated to match.
+    seq 1 600 >"$tmp4/lib/pithead/99-remainder.sh"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "the un-split-remainder ceiling may rise with the artifact it measures (#1464)" 0 "$rc"
+
+    # THE LOAD-BEARING CASE. Without it the pass above is indistinguishable from a monotonic
+    # check that stopped checking: same raise, a row that is NOT exempt, in the same run.
+    printf '# test budget\nbudgeted.sh\t900\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "control: a NON-exempt ceiling raise still FAILS in the same run" 1 "$rc"
+    if grep -q "raises budgeted.sh's ceiling" "$out" &&
+        ! grep -q "raises lib/pithead/99-remainder.sh's ceiling" "$out"; then
+        echo "  self-test ok: refuses the non-exempt raise, and only that one"
+    else
+        echo "  self-test FAIL: named the wrong row, or refused the exempt row too"
+        st_fail=1
+    fi
+
+    # The exempt row is still a real per-PR measurement: run_gate's `lines > ceiling` rule is
+    # untouched, so growing the artifact without recording the new count still REDs.
+    seq 1 700 >"$tmp4/lib/pithead/99-remainder.sh"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "the exempt row is not a free pass: growing past it still FAILS" 1 "$rc"
+    if grep -q "99-remainder.sh is 700 lines, over its recorded ceiling of 600" "$out"; then
+        echo "  self-test ok: names the unrecorded growth"
+    else
+        echo "  self-test FAIL: did not name the unrecorded growth"
+        st_fail=1
+    fi
+    rm -rf "$tmp4"
+
+    rc=0
+    (
+        cd "$tmp" || exit 90
+        list_candidates() { :; }
+        run_gate
+    ) >"$out" 2>&1 || rc=$?
+    expect "an empty candidate scan FAILS loudly, never a vacuous pass" 1 "$rc"
+
+    local tmp2
+    tmp2=$(mktemp -d)
+    git -C "$tmp2" init -q -b develop
+    git -C "$tmp2" config user.email test@example.invalid
+    git -C "$tmp2" config user.name test
+    rc=0
+    (cd "$tmp2" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a repo with zero tracked files FAILS loudly (enumeration guard)" 1 "$rc"
+    rm -rf "$tmp2"
+
+    if [ "$st_fail" -eq 0 ]; then
+        echo "lint-file-budget self-test OK"
+        return 0
+    fi
+    echo "lint-file-budget self-test FAILED"
+    return 1
+}
+
+self_test
+exit $?

--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -10,7 +10,9 @@
 # anything; see the bottom of that script.
 set -euo pipefail
 
-HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# readlink -f for the same reason the gate's --self-test dispatch uses it: through a symlink the
+# bare dirname would point at the link's directory and the source below would miss.
+HERE=$(cd -- "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")" && pwd)
 # shellcheck source=scripts/lint-file-budget.sh
 source "$HERE/lint-file-budget.sh"
 
@@ -155,18 +157,26 @@ self_test() {
     mkdir -p "$tmp4/$(dirname "$BUDGET_FILE")" "$tmp4/lib/pithead"
     seq 1 500 >"$tmp4/budgeted.sh"
     seq 1 500 >"$tmp4/lib/pithead/99-remainder.sh"
-    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t500\n' >"$tmp4/$BUDGET_FILE"
+    # A SIBLING SLICE, and it is the reason this fixture has three files rather than two.
+    # #1105 Phase 2 keeps adding real source files under lib/pithead/, so the plausible future
+    # mistake is not deleting the exemption — it is widening its pattern to lib/pithead/*.
+    # With only the remainder here, that widening kept every case green.
+    seq 1 500 >"$tmp4/lib/pithead/01-prelude.sh"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/01-prelude.sh\t500\nlib/pithead/99-remainder.sh\t500\n' \
+        >"$tmp4/$BUDGET_FILE"
     git -C "$tmp4" add -A && git -C "$tmp4" commit -q -m remainder-base
     # The shape a pithead bug fix produces: the artifact grows, the row is updated to match.
     seq 1 600 >"$tmp4/lib/pithead/99-remainder.sh"
-    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/01-prelude.sh\t500\nlib/pithead/99-remainder.sh\t600\n' \
+        >"$tmp4/$BUDGET_FILE"
     rc=0
     (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
     expect "the un-split-remainder ceiling may rise with the artifact it measures (#1464)" 0 "$rc"
 
     # THE LOAD-BEARING CASE. Without it the pass above is indistinguishable from a monotonic
     # check that stopped checking: same raise, a row that is NOT exempt, in the same run.
-    printf '# test budget\nbudgeted.sh\t900\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    printf '# test budget\nbudgeted.sh\t900\nlib/pithead/01-prelude.sh\t500\nlib/pithead/99-remainder.sh\t600\n' \
+        >"$tmp4/$BUDGET_FILE"
     rc=0
     (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
     expect "control: a NON-exempt ceiling raise still FAILS in the same run" 1 "$rc"
@@ -178,10 +188,43 @@ self_test() {
         st_fail=1
     fi
 
+    # NARROWNESS CONTROL: the sibling slice is a real source file that happens to live in the
+    # same directory. Raising ITS ceiling must still be refused — the exemption is one row, not
+    # a directory. This is the case that reddens if the pattern is ever widened to lib/pithead/*.
+    seq 1 600 >"$tmp4/lib/pithead/01-prelude.sh"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/01-prelude.sh\t600\nlib/pithead/99-remainder.sh\t600\n' \
+        >"$tmp4/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "control: the exemption is ONE row, not lib/pithead/ — a sibling slice still FAILS" 1 "$rc"
+    if grep -q "raises lib/pithead/01-prelude.sh's ceiling" "$out"; then
+        echo "  self-test ok: names the sibling slice, so the exemption did not leak to it"
+    else
+        echo "  self-test FAIL: the exemption leaked to a sibling lib/pithead slice"
+        st_fail=1
+    fi
+    seq 1 500 >"$tmp4/lib/pithead/01-prelude.sh"
+
+    # A rise must RECORD the artifact, never reserve headroom. Otherwise one PR sets the row to
+    # any number it likes and nothing objects again until the file reaches it — a ratchet in
+    # name only. The file is 600 here, so a row of 999999 is a headroom grant, not a measurement.
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/01-prelude.sh\t500\nlib/pithead/99-remainder.sh\t999999\n' \
+        >"$tmp4/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a rise on the exempt row must match the file, not reserve headroom" 1 "$rc"
+    if grep -q "but the file is 600 lines" "$out"; then
+        echo "  self-test ok: names the count the row should have stated"
+    else
+        echo "  self-test FAIL: did not name the mismatch between row and file"
+        st_fail=1
+    fi
+
     # The exempt row is still a real per-PR measurement: run_gate's `lines > ceiling` rule is
     # untouched, so growing the artifact without recording the new count still REDs.
     seq 1 700 >"$tmp4/lib/pithead/99-remainder.sh"
-    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/99-remainder.sh\t600\n' >"$tmp4/$BUDGET_FILE"
+    printf '# test budget\nbudgeted.sh\t500\nlib/pithead/01-prelude.sh\t500\nlib/pithead/99-remainder.sh\t600\n' \
+        >"$tmp4/$BUDGET_FILE"
     rc=0
     (cd "$tmp4" && run_gate) >"$out" 2>&1 || rc=$?
     expect "the exempt row is not a free pass: growing past it still FAILS" 1 "$rc"

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -9,6 +9,8 @@
 #      ceiling. A PR may not grow that file past its recorded ceiling. Ceilings only ever go
 #      DOWN — this script rejects any budget edit that raises one (checked against the base
 #      branch, $BASE_REF below) — and a file that shrinks back to <=400 must drop its entry.
+#      One row is exempt from the "only DOWN" half, because it measures work remaining rather
+#      than a file: monotonic_exempt() carries the reasoning.
 #
 # Exemptions are enumerated by path/glob in is_exempt() below, each with its own reason —
 # generated code, vendored files, data/config, prose docs, and the shipped `pithead` artifact
@@ -196,6 +198,28 @@ run_gate() {
     return 0
 }
 
+# The one row whose ceiling may RISE, and why that is not a loosened ratchet (#1464).
+#
+# lib/pithead/99-remainder.sh is not a file anyone writes. It is whatever of the generated
+# `pithead` artifact #1105 Phase 2 has not split out yet, so its ceiling measures work
+# REMAINING, not the size of a source file. `pithead` itself is exempt in is_exempt() precisely
+# so a CLI bug fix may add lines; routing those same lines through a ratcheting row turned that
+# exemption into a hard freeze, because no value of the row passed — run_gate refused the growth
+# and check_monotonic refused the raise.
+#
+# What keeps it honest is what is NOT changed here: run_gate's `lines > ceiling` rule is
+# untouched, so a PR that grows the artifact must still record the new count, and the row stays a
+# per-PR measurement rather than a ceiling nobody reads. Every Phase 2 slice cut LOWERS it —
+# the progress signal the row exists for — and it retires itself when the remainder drops to the
+# target. Keep this list to rows with that property; a row naming a real source file does not
+# have it.
+monotonic_exempt() {
+    case "$1" in
+    lib/pithead/99-remainder.sh) return 0 ;;
+    *) return 1 ;;
+    esac
+}
+
 # Ceilings only ever go down. Compare the working-tree budget against the base branch's: any
 # path present in both whose ceiling ROSE is a rejected edit, proving the ratchet is real.
 check_monotonic() {
@@ -214,6 +238,13 @@ check_monotonic() {
         [ -n "$path" ] || continue
         new_ceiling=$(parse_budget <"$BUDGET_FILE" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
         if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
+            if monotonic_exempt "$path"; then
+                echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling." \
+                    "That row measures the un-split remainder of the generated pithead artifact," \
+                    "so it tracks the artifact both ways and is exempt from the ratchet (#1464)." \
+                    "Every Phase 2 cut must lower it." >&2
+                continue
+            fi
             echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
                 "$new_ceiling. Ceilings only go down."
             fail=1
@@ -233,164 +264,19 @@ generate_budget() {
     list_candidates | awk -F'\t' -v t="$TARGET_LINES" '$2 > t {print}' | sort
 }
 
-# --- self-test: every failure mode against fixtures, in an isolated throwaway git repo ----------
-self_test() {
-    local tmp out st_fail=0 rc=0
-    tmp=$(mktemp -d)
-    out=$(mktemp)
-    # Double-quoted so $tmp/$out are embedded now, as literal paths — the trap still fires after
-    # self_test's own locals have gone out of scope, so a deferred expansion would see them unset.
-    # shellcheck disable=SC2064
-    trap "rm -rf '$tmp' '$out'" EXIT
-    git -C "$tmp" init -q -b develop
-    git -C "$tmp" config user.email test@example.invalid
-    git -C "$tmp" config user.name test
-
-    expect() { # <desc> <expected-rc> <actual-rc>
-        if [ "$2" -eq "$3" ]; then
-            echo "  self-test ok: $1"
-        else
-            echo "  self-test FAIL: $1 (expected rc $2, got $3)"
-            st_fail=1
-        fi
-    }
-    seq 1 500 >"$tmp/budgeted.sh"
-    mkdir -p "$tmp/$(dirname "$BUDGET_FILE")"
-    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
-    git -C "$tmp" add budgeted.sh "$BUDGET_FILE"
-    git -C "$tmp" commit -q -m base
-
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "calibration: budgeted file at its ceiling passes" 0 "$rc"
-
-    seq 1 501 >"$tmp/budgeted.sh"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "growing a budgeted file past its ceiling FAILS" 1 "$rc"
-    if grep -q "budgeted.sh is 501" "$out"; then
-        echo "  self-test ok: names the offending file"
-    else
-        echo "  self-test FAIL: did not name the offending file"
-        st_fail=1
-    fi
-
-    seq 1 500 >"$tmp/budgeted.sh"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "reverting the growth passes again" 0 "$rc"
-
-    seq 1 800 >"$tmp/new.sh"
-    git -C "$tmp" add new.sh
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "an over-target file with NO entry FAILS (800, inside the hard ceiling)" 1 "$rc"
-    if grep -q "new.sh is 800 lines (> 400 target) but has no" "$out"; then
-        echo "  self-test ok: names the missing entry, not the hard ceiling"
-    else
-        echo "  self-test FAIL: did not name the missing entry"
-        st_fail=1
-    fi
-    printf '# test budget\nbudgeted.sh\t500\nnew.sh\t800\n' >"$tmp/$BUDGET_FILE"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "recording the entry is the fix — the same file then passes" 0 "$rc"
-    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
-    seq 1 801 >"$tmp/new.sh"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "a new 801-line file FAILS the hard ceiling" 1 "$rc"
-    rm -f "$tmp/new.sh"
-    git -C "$tmp" rm -q --cached new.sh >/dev/null 2>&1 || true
-
-    printf '# test budget\nbudgeted.sh\t400\n' >"$tmp/$BUDGET_FILE"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "lowering a ceiling below the file's real size FAILS (reality check)" 1 "$rc"
-
-    printf '# test budget\nbudgeted.sh\t900\n' >"$tmp/$BUDGET_FILE"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "raising a ceiling FAILS (monotonicity, vs the committed base)" 1 "$rc"
-    if grep -q "raises budgeted.sh's ceiling" "$out"; then
-        echo "  self-test ok: names the ceiling raise"
-    else
-        echo "  self-test FAIL: did not name the ceiling raise"
-        st_fail=1
-    fi
-    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
-
-    seq 1 300 >"$tmp/budgeted.sh"
-    rc=0
-    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "a budgeted file dropped below target still listed FAILS (stale entry)" 1 "$rc"
-    seq 1 500 >"$tmp/budgeted.sh"
-
-    # Two-lane shape: a develop-v2 branch cut BEFORE the lane tip advanced must still
-    # ratchet against develop-v2, not fall back to develop and read this lane's larger
-    # ceiling as a raise — the false RED that bit two live PRs the day the tip moved.
-    local tmp3
-    tmp3=$(mktemp -d)
-    git -C "$tmp3" init -q -b develop
-    git -C "$tmp3" config user.email test@example.invalid
-    git -C "$tmp3" config user.name test
-    mkdir -p "$tmp3/$(dirname "$BUDGET_FILE")"
-    seq 1 500 >"$tmp3/budgeted.sh"
-    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp3/$BUDGET_FILE"
-    git -C "$tmp3" add -A && git -C "$tmp3" commit -q -m dev-base
-    git -C "$tmp3" checkout -q -b develop-v2
-    seq 1 600 >"$tmp3/budgeted.sh"
-    printf '# test budget\nbudgeted.sh\t600\n' >"$tmp3/$BUDGET_FILE"
-    git -C "$tmp3" add -A && git -C "$tmp3" commit -q -m v2-larger
-    git -C "$tmp3" checkout -q -b feature
-    git -C "$tmp3" checkout -q develop-v2
-    echo x >"$tmp3/other.txt"
-    git -C "$tmp3" add other.txt && git -C "$tmp3" commit -q -m v2-advances
-    git -C "$tmp3" checkout -q feature
-    seq 1 580 >"$tmp3/budgeted.sh"
-    printf '# test budget\nbudgeted.sh\t580\n' >"$tmp3/$BUDGET_FILE"
-    rc=0
-    (cd "$tmp3" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "a v2-lane branch behind the moved lane tip still ratchets against develop-v2" 0 "$rc"
-    rc=0
-    (cd "$tmp3" && [ "$(resolve_base_ref)" = develop-v2 ]) || rc=1
-    expect "lane detection reads history, not tip-levelness" 0 "$rc"
-    git -C "$tmp3" checkout -q -f develop
-    rc=0
-    (cd "$tmp3" && [ "$(resolve_base_ref)" = develop ]) || rc=1
-    expect "a develop-lane checkout still resolves to develop" 0 "$rc"
-    rm -rf "$tmp3"
-
-    rc=0
-    (
-        cd "$tmp" || exit 90
-        list_candidates() { :; }
-        run_gate
-    ) >"$out" 2>&1 || rc=$?
-    expect "an empty candidate scan FAILS loudly, never a vacuous pass" 1 "$rc"
-
-    local tmp2
-    tmp2=$(mktemp -d)
-    git -C "$tmp2" init -q -b develop
-    git -C "$tmp2" config user.email test@example.invalid
-    git -C "$tmp2" config user.name test
-    rc=0
-    (cd "$tmp2" && run_gate) >"$out" 2>&1 || rc=$?
-    expect "a repo with zero tracked files FAILS loudly (enumeration guard)" 1 "$rc"
-    rm -rf "$tmp2"
-
-    if [ "$st_fail" -eq 0 ]; then
-        echo "lint-file-budget self-test OK"
-        return 0
-    fi
-    echo "lint-file-budget self-test FAILED"
-    return 1
-}
+# The fixtures live in lint-file-budget-selftest.sh, which SOURCES this file for the functions
+# above (#1464 — this script sat at a ceiling equal to its own length, and its own header rule
+# says a file back under the target drops its entry, so the split is the documented remedy).
+# Sourcing must therefore define everything and run nothing: without this guard, `source` would
+# fall straight into the dispatch below and run the gate against whatever directory the caller
+# happened to be in. Executing this script directly dispatches exactly as it always did.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    return 0
+fi
 
 case "${1:-}" in
 --self-test)
-    self_test
-    exit $?
+    exec bash "$(dirname -- "$0")/lint-file-budget-selftest.sh"
     ;;
 --generate)
     generate_budget

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -223,7 +223,7 @@ monotonic_exempt() {
 # Ceilings only ever go down. Compare the working-tree budget against the base branch's: any
 # path present in both whose ceiling ROSE is a rejected edit, proving the ratchet is real.
 check_monotonic() {
-    local base old_lines fail=0 path old_ceiling new_ceiling
+    local base old_lines fail=0 path old_ceiling new_ceiling actual
     base=$(resolve_base_ref)
     if [ -z "$base" ]; then
         echo "file-budget: NOTE — no base ref (origin/develop or develop) resolvable; skipping the" \
@@ -239,9 +239,21 @@ check_monotonic() {
         new_ceiling=$(parse_budget <"$BUDGET_FILE" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
         if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
             if monotonic_exempt "$path"; then
-                echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling." \
-                    "That row measures the un-split remainder of the generated pithead artifact, so" \
-                    "it tracks the artifact both ways (#1464). Every Phase 2 cut must lower it." >&2
+                # A rise must RECORD the artifact, not grant it headroom. Without this the
+                # exemption would let one PR set the row to any number it liked, and nothing
+                # mechanical would object again until the file actually reached it — which
+                # would retire the per-PR measurement while still reading as a ratchet.
+                actual=$(count_lines "$path")
+                if [ "$new_ceiling" != "$actual" ]; then
+                    echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling to $new_ceiling," \
+                        "but the file is $actual lines. That row records the un-split remainder, so a" \
+                        "rise must state the real count, not reserve headroom."
+                    fail=1
+                    continue
+                fi
+                echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling," \
+                    "matching the file. That row records the un-split remainder of the generated" \
+                    "pithead artifact, so it tracks it both ways (#1464). Every Phase 2 cut lowers it." >&2
                 continue
             fi
             echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
@@ -275,7 +287,13 @@ fi
 
 case "${1:-}" in
 --self-test)
-    exec bash "$(dirname -- "$0")/lint-file-budget-selftest.sh"
+    # Resolve the link before taking the dirname: through a symlink, `dirname "$0"` gives the
+    # LINK's directory, so the exec misses and the gate exits 127 — a mis-typed failure rather
+    # than a self-test verdict. No call site symlinks this today (the Makefile and CI both run
+    # the tracked file), so this is closing a hole rather than fixing a live break. There is
+    # deliberately no fixture for it: a case that ran --self-test through a symlink would
+    # re-enter the self-test and recurse.
+    exec bash "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")/lint-file-budget-selftest.sh"
     ;;
 --generate)
     generate_budget

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -240,9 +240,8 @@ check_monotonic() {
         if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
             if monotonic_exempt "$path"; then
                 echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling." \
-                    "That row measures the un-split remainder of the generated pithead artifact," \
-                    "so it tracks the artifact both ways and is exempt from the ratchet (#1464)." \
-                    "Every Phase 2 cut must lower it." >&2
+                    "That row measures the un-split remainder of the generated pithead artifact, so" \
+                    "it tracks the artifact both ways (#1464). Every Phase 2 cut must lower it." >&2
                 continue
             fi
             echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \


### PR DESCRIPTION
## What this fixes

`pithead` is exempt from the file budget so that a CLI bug fix may add lines to it. Since #1105 Phase 2, its content lives in `lib/pithead/99-remainder.sh`, which carries a **ratcheting** budget row — and a ratchet can never rise. The exemption silently became a hard freeze: `pithead` could not gain a single line.

**Measured on a real branch (`fix/1342-mutation-lock`), both halves, by me — there is no third option, the two checks close on each other:**

| tsv row | what refuses |
|---|---|
| left at `11870` | `run_gate`: `99-remainder.sh is 12123 lines, over its recorded ceiling of 11870` |
| raised to `12123` | `check_monotonic`: `raises ... from 11870 to 12123. Ceilings only go down.` |

This blocks **every** lane with a line-adding `pithead` change, not just the appliance lane.

## The fix

A narrow monotonic exemption for that one row, in `check_monotonic` only.

The row measures **what of the generated artifact is not split out yet**, not the size of a file anyone writes, so it has to track the artifact up as well as down. `monotonic_exempt()` carries that reasoning in-code so the next reader cannot mistake it for a weakened ratchet, and the gate prints a `NOTE` naming the rise.

**`run_gate`'s `lines > ceiling` rule is deliberately UNTOUCHED.** That is what keeps the row an honest per-PR measurement rather than a ceiling nobody reads: a PR that grows the artifact must still record the new count, every Phase 2 cut still lowers it, and it retires itself when the remainder reaches the 400 target.

Rejected, with reasons, so they are not reopened: full exemption of the row (loses the progress signal) and cut-per-PR (makes bug fixes carry refactors). **Accepted residual, stated rather than hidden:** an un-split PR now passes the budget gate; `lint-pithead-parity` forces the books to balance and non-author review is the backstop.

## Why this PR also splits the gate's self-test

Not a drive-by refactor — the fix could not land without it, and the gate itself documents the remedy.

`scripts/lint-file-budget.sh` was **407 lines against a recorded ceiling of 407**: closed to any addition. The row cannot be raised either, and that refusal is *correct* — this one is a real source file, so exempting it would hollow out the very argument this PR makes. The gate's own header rule says a file back under the 400 target **must drop its entry**, so splitting is the remedy the gate prescribes (the same path CONTRIBUTING.md already documents, with #1258 as the worked example).

Result: gate **293** lines and its row **dropped** from the tsv; fixtures move to `scripts/lint-file-budget-selftest.sh` at **223**. Neither needs a row. The fixtures `source` the gate, so the dispatch now sits behind a `BASH_SOURCE` guard; `--self-test` still works as the entry point, so **the Makefile is unchanged and no CI wiring moves.**

## What was RUN

- `make lint-file-budget` — green through the Makefile path, post-split: self-test **22/22**, then `file budget OK`.
- `make lint` — full run, see below.
- `shellcheck --severity=warning` **and** `-S info`, plus `shfmt -i 4 -d`, on both scripts: clean at both severities.
- **Source guard, proven both ways with a firing control.** Sourced from a non-git directory: `rc=0`, **zero output**, all five gate functions defined, `self_test` correctly absent. *Executed* in that same directory: `rc=1` and loud (`FATAL: git ls-files enumerated zero tracked files`). The silence is the guard working, not a dead script.
- **Mutation proof, run pre-split and RE-RUN post-split, identical reds both times.** Two one-line mutants at the exemption branch:

| variant | rc | self-test | which case reddens |
|---|---|---|---|
| clean | 0 | 22 ok / 0 fail | — |
| `if false` (exemption never applies) | 1 | 20 / 2 | the new "may rise" case |
| `if true` (exemption applies to everything) | 1 | 18 / 4 | the new **firing control**, plus the pre-existing monotonicity case |

  Neither new case is vacuous: the first dies without the exemption, the control dies when the exemption is over-broad.
- tsv diff is **exactly one deletion** (`scripts/lint-file-budget.sh 407`); no new rows, no foreign row touched.

## Self-test cases added

1. The exempt row rising **passes**.
2. **The load-bearing one** — a NON-exempt row raised *in the same run* still **FAILS**, and is the only row named. Without it, case 1 is indistinguishable from a monotonic check that stopped checking.
3. Growing the exempt file past its recorded row still **FAILS** — proving `run_gate` really was left alone.

## Disclosure

- **Two per-item grants**, both from the controller, both expiring when this PR merges: `scripts/lint-file-budget.sh` (w10) and `scripts/lint-file-budget-selftest.sh` (w11, granted specifically because the fix could not land without the split). Gate scripts are owned by no lane.
- **`CONTRIBUTING.md` is a shared root file no lane owns**, so it rides the one-shot `.lane-override`, in its own commit so the hatch covers exactly that one file.
- **`docs/dev/file-budget.tsv`** is the per-lane regenerated shared file; the change here is one deletion.
- The docs commit also **drops a stale claim**: the paragraph said the gate "is not yet wired into CI (issue #1257)". #1257 is closed and `.github/workflows/ci.yml:512` runs `make lint-file-budget`. That was stale in the direction that matters — it told authors CI would not catch this. The same-wave-merge hazard it warned about is real and is kept.

## What I did NOT do

- The **300s/appliance-first-boot reasoning in #1391 is untouched here**; this PR is only the gate.
- I did **not** change the freeze for any other file. I did sweep for it, because `scripts/lint-file-budget.sh` was found frozen by accident while fixing this: **75 of the 79 budgeted files sit at a ceiling exactly equal to their current line count** at `develop-v2` `3d61f24`, so they are closed to any addition. That is the ratchet working as designed — the intended answer is to split or shrink — but it is worth stating plainly, because it means "add a few lines here" is not available almost anywhere in the budgeted surface, and the remedy has to be planned into the change rather than discovered at the gate. Only `lib/pithead/99-remainder.sh` gets the exemption in this PR, and only for the monotonic half.
- No bench, no hardware, no `fleet.sh` claim — this change needs none.

## Review brief

The controller asked that the non-author pass treat these as **two separate axes**:

- **(a) Exemption semantics** — is `monotonic_exempt` narrow enough, and does the mutant evidence actually support the claim that both new cases can fail?
- **(b) Split mechanics** — is the `BASH_SOURCE` guard right, does anything else source or invoke this script, and does the dropped tsv row behave (`check_monotonic` skips a path absent from the working tree, `[ -n "$new_ceiling" ]`)?

Refs #1464

## Over-engineering pass (ponytail policy, run on this diff)

- `scripts/lint-file-budget.sh:L221-223: shrink: exemption NOTE spanned four continuation lines. Three, same content.` — **applied** (`9cabefd`).
- `scripts/lint-file-budget.sh:L214-220: yagni: monotonic_exempt() is a one-arm case with a single caller. Inlining [ "$path" = lib/pithead/99-remainder.sh ] saves ~5 lines.` — **noted and kept, deliberately.** It mirrors `is_exempt()`'s shape in the same file, so it reads as the file's own idiom; and the binding condition on this fix is an in-code rationale a later reader cannot miss, which needs a named thing to hang on. Inlining would push a 14-line justification into the middle of `check_monotonic`'s loop, which is worse on both counts.
- The third self-test case was considered for cutting and kept: it is the only thing proving `run_gate` was left alone, and the policy exempts self-checks from deletion.

`net: -7 lines possible, -4 taken.`

---

## Non-author review round (both axes) — three findings, all fixed at `ddafecd`

Two independent non-author passes ran, one per axis. **Both found real gaps, and I reproduced every one before acting rather than taking the reviewer's word.**

**(a1) The exemption had no fixture proving it is NARROW — the serious one.** Widening the case arm from the literal path to `lib/pithead/*` kept **all 22 cases green**, while silently exempting every real source slice Phase 2 is adding under that directory. Confirmed by running the mutant myself. The fixture now carries a sibling slice, `lib/pithead/01-prelude.sh`, whose ceiling raise must still be refused; that mutant now reds on it. This was the answer to "construct a change that keeps everything green while breaking the intent" — and there was one.

**(a2) The exemption placed no bound on the size of a raise.** The row could be set to any number and nothing mechanical would object again until the file reached it — a ratchet in name only, and the opposite of the per-PR measurement the row is meant to be. **A rise is now allowed only to the file's real current line count**; one that reserves headroom FAILS and names the count the row should have stated. My original "stays an honest per-PR measurement" claim was aspirational as written; it is now enforced.

**(b1) `--self-test` through a symlink exited 127** instead of running, because `dirname "$0"` gives the link's directory. The `exec` now resolves the link first, as does the fixtures file's own source path. No call site symlinks this, so this closes a hole rather than fixing a live break — and there is **deliberately no fixture**, because a case running `--self-test` through a symlink would re-enter the self-test and recurse. Said plainly rather than left as an implied gap.

**Also raised and NOT treated as a code change:** the reviewer noted that `lint-pithead-parity` contributes nothing to bounding the un-split residual — it is a drift check between artifact and slices, satisfied by any edit-then-rebuild. That is correct, and confirmed by running. The real backstop for that residual is non-author review, which this PR already named in the same sentence; the wording above overstated parity's part, and this note is the correction.

**Self-test is now 26 cases. Four mutants, each red on exactly the intended case:**

| mutant | reds on |
|---|---|
| exemption widened to `lib/pithead/*` | the new narrowness control (was 22/22 GREEN before this round) |
| exemption never applies (`if false`) | the "may rise" case |
| exemption applies to everything (`if true`) | the narrowness control |
| the new headroom bound removed | the new "must match the file" case |

Gate is 310 lines, fixtures 266 — both still under the 400 target, so neither takes a budget row. `make lint-file-budget` green through the Makefile path; shellcheck clean at `--severity=warning` and `-S info`; `shfmt` clean.
