### PR TITLE
fix(e2e): match compose service names as whole lines, never substrings (#1478)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -310,6 +310,10 @@ and `--list` prints it).
 - Expected containers up, unexpected absent. Every service for that config is running and
   healthy; in `remote` mode there is no `monerod` (and, independently, no `tari` when
   `tari.mode=remote`); `wallet-rpc`/`tari-wallet` appear only when their view key is set.
+  Presence is decided by `service_present`, which matches a compose service name as a whole
+  line and never as a substring ([#1478](https://github.com/p2pool-starter-stack/pithead/issues/1478)).
+  That distinction is load-bearing: `tari` is a prefix of `tari-wallet`, so a substring match
+  would report a stopped `tari` as running whenever the payout-confirm container is up.
 - `pithead status` exit code: `0` for a healthy config.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -243,6 +243,11 @@ absent_services() {
     return 0
 }
 
+# Membership against running_services()'s output: compose SERVICE NAMES, one per line. EXACT-LINE,
+# never substring (#1478) — "tari" prefixes "tari-wallet" (#381/#462), so a loose match calls a DOWN
+# tari up wherever payout-confirm runs. One place, so the three call sites cannot drift apart.
+service_present() { printf '%s\n' "$2" | grep -Fqx -- "$1"; }
+
 # Human-readable pool label as the dashboard reports it, from the config pool key.
 pool_label() {
     case "$1" in

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -537,23 +537,25 @@ assert_running_state() {
     expected="$(expected_services "$config")"
     while IFS= read -r svc; do
         [ -z "$svc" ] && continue
-        case "$running" in
-        *"$svc"*) it_pass "container up: $svc" ;;
-        *) it_fail "container up: $svc" "not in running services" ;;
-        esac
+        if service_present "$svc" "$running"; then
+            it_pass "container up: $svc"
+        else
+            it_fail "container up: $svc" "not in running services"
+        fi
     done <<<"$expected"
     if [ "$mode" = "remote" ]; then
-        case "$running" in
-        *monerod*) it_fail "monerod absent in remote mode" "monerod is running" ;;
-        *) it_pass "monerod absent in remote mode" ;;
-        esac
+        if service_present monerod "$running"; then
+            it_fail "monerod absent in remote mode" "monerod is running"
+        else
+            it_pass "monerod absent in remote mode"
+        fi
     fi
     # tari.mode is an independent axis from monero.mode (#103/#942): the bundled tari container
-    # must be absent whenever it's remote, same as monerod above. Exact-line match, not a
-    # substring case — "tari" is a prefix of "tari-wallet" (the payout-confirm container, #462),
-    # so a loose `*tari*` pattern would false-positive on a box also running that.
+    # must be absent whenever it's remote, same as monerod above. The exact-line matching all
+    # three sites depend on lives in service_present (#1478) — "tari" is a prefix of "tari-wallet"
+    # (the payout-confirm container, #462), so a substring match would speak for the wrong one.
     if [ "$tmode" = "remote" ]; then
-        if printf '%s\n' "$running" | grep -qx tari; then
+        if service_present tari "$running"; then
             it_fail "tari absent in remote mode (#103/#942)" "tari is running"
         else
             it_pass "tari absent in remote mode (#103/#942)"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -551,9 +551,7 @@ assert_running_state() {
         fi
     fi
     # tari.mode is an independent axis from monero.mode (#103/#942): the bundled tari container
-    # must be absent whenever it's remote, same as monerod above. The exact-line matching all
-    # three sites depend on lives in service_present (#1478) — "tari" is a prefix of "tari-wallet"
-    # (the payout-confirm container, #462), so a substring match would speak for the wrong one.
+    # must be absent whenever it's remote, same as monerod above.
     if [ "$tmode" = "remote" ]; then
         if service_present tari "$running"; then
             it_fail "tari absent in remote mode (#103/#942)" "tari is running"

--- a/tests/integration/selftest-service-present.sh
+++ b/tests/integration/selftest-service-present.sh
@@ -36,9 +36,7 @@ check "the needle is a literal, not a pattern" "ta.i" "$(printf 'caddy\ntari\nto
 check "a neighbour named *monerod* is not monerod" monerod "$(printf 'caddy\nmonerod-remote\ntor')" 1
 check "monerod itself is still found" monerod "$(printf 'caddy\nmonerod\ntor')" 0
 
-EMPTY=""
-service_present tari "$EMPTY" && it_fail "nothing running -> not present" "matched empty input" ||
-    it_pass "nothing running -> not present"
+check "nothing running -> not present" tari "" 1
 
 echo ""
 echo "selftest-service-present: $IT_PASS passed, $IT_FAIL failed"

--- a/tests/integration/selftest-service-present.sh
+++ b/tests/integration/selftest-service-present.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Self-test for service_present (#1478) — the exact-line membership test the three
+# container-presence assertions in run.sh share.
+#
+# These cases live in their own file rather than in selftest.sh because that file sits
+# exactly on its recorded budget ceiling, and ceilings only go down.
+#
+# Run: tests/integration/selftest-service-present.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+echo "== service_present: exact-line membership, never substring (#1478) =="
+
+# running_services() emits compose SERVICE NAMES one per line. Exactly one pair nests —
+# "tari" inside "tari-wallet" — so that pair is the whole point of these cases. The longer
+# sibling has to be IN the fixture or the assertion is blind to the bug it exists to catch.
+# want: 0 = present, 1 = absent.
+check() {
+    local name="$1" needle="$2" hay="$3" want="$4" got
+    service_present "$needle" "$hay"
+    got=$?
+    if [ "$got" = "$want" ]; then it_pass "$name"; else it_fail "$name" "want rc=$want, got rc=$got"; fi
+}
+
+check "a running tari-wallet does not mean tari is up" tari "$(printf 'caddy\ntari-wallet\ntor')" 1
+check "tari alongside tari-wallet is still found" tari "$(printf 'caddy\ntari\ntari-wallet\ntor')" 0
+check "tari alone is found" tari "$(printf 'caddy\ntari\ntor')" 0
+check "the needle is a literal, not a pattern" "ta.i" "$(printf 'caddy\ntari\ntor')" 1
+# The monerod direction is the one #1478 calls latent: nothing is named *monerod* today, but a
+# remote-mode fixture adding a node container on the same box would arm it.
+check "a neighbour named *monerod* is not monerod" monerod "$(printf 'caddy\nmonerod-remote\ntor')" 1
+check "monerod itself is still found" monerod "$(printf 'caddy\nmonerod\ntor')" 0
+
+EMPTY=""
+service_present tari "$EMPTY" && it_fail "nothing running -> not present" "matched empty input" ||
+    it_pass "nothing running -> not present"
+
+echo ""
+echo "selftest-service-present: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1478 (by hand after merge — `Closes #N` does not fire here, since PRs merge to
`develop-v2` while the default branch is `develop`).

## The defect

`assert_running_state` compared compose service names with **substring** matching in two of the
three places it checks container presence. The third got it right, and its comment says why:

```bash
# ... "tari" is a prefix of "tari-wallet" (the payout-confirm container, #462),
# so a loose `*tari*` pattern would false-positive on a box also running that.
if printf '%s\n' "$running" | grep -qx tari; then
```

`running_services()` is `docker compose ps --services --status running | sort` — one service name
per line. Of `caddy dashboard docker-control docker-proxy monerod p2pool tari tari-wallet tor
wallet-rpc xmrig-proxy`, exactly one pair nests: **`tari` inside `tari-wallet`**.

- `container up: tari` was a **false PASS** when `tari` was down and `tari-wallet` was up.
- `monerod absent in remote mode` had the same looseness in the **failing** direction.

## Honest scope — latent today, not currently lying

`tari-wallet` only starts under the `tari_payout_confirm` profile, which `pithead` activates only
when `tari.view_key` is set (`lib/pithead/99-remainder.sh:6816`). The harness supplies that from
`IT_TARI_VIEW_KEY` + `IT_TARI_SPEND_PUBLIC_KEY` (`lib.sh:206-207`), and **no caller sets either** —
they are read, documented, and set in selftest fixtures, nowhere else.

So this is not producing false greens in the routine gate today. It arms the moment someone
supplies those keys, which is the natural next step for the payout-confirmation coverage already
listed as owed — and at that point the assertion goes quietly green rather than failing. That is
the reason to fix it before, not after.

## The fix

One helper, `service_present`, beside `expected_services`/`absent_services` in `lib.sh` (the pure
module `selftest.sh` already drives), used at all three sites so they cannot drift apart again.
It matches a whole line and treats the needle as a **fixed string**, not a regex.

The `-F` was not in my first draft. A case I wrote for completeness — "the needle is a literal,
not a pattern" — failed, because `grep -qx ta.i` matches `tari`. Service names are `[a-z-]+`
today so nothing was reachable through it, but the helper is now correct rather than
incidentally correct.

## Proof it can fail

`tests/integration/selftest-service-present.sh`, **7 cases**. The fixture carries the longer
sibling `tari-wallet` alongside `tari` — without it in the fixture the assertion is blind to the
bug it exists to catch.

Mutation battery, run against the shipped helper, control green and the file restored after:

| Mutation | Result |
|---|---|
| substring match (the original defect) | **killed** by 2 cases |
| drop `-F` (needle becomes a regex) | **killed** by 1 |
| drop `-x` (line anchor gone) | **killed** by 2 |
| always true | **killed** by 4 |
| always false | **killed** by 3 |

The mutator asserts the pattern is present *before* writing and treats a non-match as a loud
failure, so a mutation that silently did not apply cannot read as a survived assertion.

## Stated limitation

The cases cover **`service_present` itself**, not the three call sites in `assert_running_state` —
that function needs a live box and is not unit-driven today (`git grep` for `assert_running_state`
and `running_services` returns only `run.sh` and `skip-accounting.sh`). The call sites are proven
by reading, not by a test. I did not add a static grep guard for them, because a text assertion
would read as behavioural coverage it does not provide.

## Budget

`selftest.sh` sits **exactly** on its recorded ceiling (686), so the new cases went into their own
file rather than raising it. `lib.sh` was trimmed to fit 692. **No ceiling was raised.**

## Run locally, from the repo root

- `tests/integration/selftest-service-present.sh` — 7 passed, 0 failed
- `make test-integration-selftest` — every suite green (`selftest: 214 passed, 0 failed`)
- `shellcheck --severity=warning -x` and `shfmt -i 4 -d` on all changed files — clean
- `make lint-file-budget lint-md lint-docs-voice lint-topology lint-operator-strings` — all OK

## Ponytail pass

Run on this diff before opening. Two findings, both applied: the empty-haystack case used a
different idiom (`EMPTY` plus an `&&`/`||` chain) from the six `check` calls above it, and the
tari site comment restated what `service_present`'s own comment now carries. `net: -4 lines.`
