### PR TITLE
fix(dashboard): a failed history read is no longer rendered as another dashboard's change (#1409)

### DIFF
--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -105,7 +105,9 @@ def parse_config_meta(meta):
     return out if any(out.values()) else None
 
 
-def config_origin(meta, change_id_known, change_status=None, history_truncated=False):
+def config_origin(
+    meta, change_id_known, change_status=None, history_truncated=False, history_unread=False
+):
     """Where the rig's current config came from, as far as we can honestly tell.
 
     ``change_id_known`` is whether this dashboard has a ``worker_config`` row for the rig's
@@ -136,9 +138,18 @@ def config_origin(meta, change_id_known, change_status=None, history_truncated=F
                       ``history_truncated`` is what separates the two, and it is deliberately the
                       only thing this argument may do: when it is False every verdict is exactly
                       what it was before, so a caller that cannot tell loses nothing. That matters
-                      most on the error path — ``get_worker_config_history`` returns ``[]`` on a
-                      ``sqlite3.Error``, and an empty list is NOT a full window, so a DB hiccup
-                      keeps today's ``elsewhere`` instead of being upgraded into a confident one.
+                      most on the error path, which since #1409 is ``history_unread``'s to answer:
+                      a failed read returns None, not ``[]``, so it never reaches this comparison
+                      at all rather than arriving as a window that merely looks short.
+    - ``unread``    — applied over a control channel, and we could not read our own history at all
+                      (#1409). ``get_worker_config_history`` returns None when the read failed, and
+                      that is a different fact from an empty history: a miss we never got to look
+                      for cannot support ``elsewhere``, which renders as "Last changed from another
+                      dashboard" — an accusation sourced from our own broken DB rather than from
+                      anything the rig did. Distinct from ``untraced`` too: that one is a read that
+                      WORKED and came back full, so it is about the rig having changed often. This
+                      one is about us. Checked FIRST inside this branch, because a read that did not
+                      happen settles nothing further down it.
     - ``rig``       — applied on the rig itself.
     - ``restored``  — restored from a saved config by the operator-run ``restore`` command.
                       Deliberately not folded into ``rig``: a restore is not someone editing the rig.
@@ -154,6 +165,8 @@ def config_origin(meta, change_id_known, change_status=None, history_truncated=F
         return None
     source = meta.get("source")
     if source == "control":
+        if history_unread:
+            return "unread"
         if not change_id_known:
             return "untraced" if history_truncated else "elsewhere"
         if change_status in HELD_STATUSES:

--- a/dashboard/mining_dashboard/service/storage_service.py
+++ b/dashboard/mining_dashboard/service/storage_service.py
@@ -879,14 +879,14 @@ class StateManager:
         except (sqlite3.Error, TypeError, ValueError) as e:
             self._db_error("Worker Config Write Error", e)
 
-    def get_worker_config_history(self, worker: str, limit: int = 50) -> list[dict[str, Any]]:
-        """The change history for ``worker``, newest first, with ``changes`` parsed back to a dict.
-        ``type`` is ``"apply"`` or ``"upgrade"`` (#1014); a row from before that column existed
-        reads back ``"apply"`` too (the migration backfills it, same as a fresh insert's default)."""
+    def get_worker_config_history(self, worker: str, limit: int = 50) -> list[dict] | None:
+        """The change history for ``worker``, newest first, ``changes`` parsed back to a dict.
+        ``type`` is ``"apply"``/``"upgrade"`` (#1014); a pre-column row reads back ``"apply"``.
+        None means the read FAILED (no connection, or ``sqlite3.Error``); ``[]`` = no history."""
         try:
             with self._db_lock:
                 if not self._conn:
-                    return []
+                    return None
                 cursor = self._conn.cursor()
                 cursor.execute(
                     "SELECT change_id, ts, status, changes, reason, type FROM worker_config "
@@ -905,7 +905,7 @@ class StateManager:
                 return out
         except sqlite3.Error as e:
             self.logger.error(f"Worker Config Read Error: {e}")
-            return []
+            return None
 
     def reconcile_worker_config_status(
         self, change_id: str, status: str, reason: str | None = None
@@ -1002,7 +1002,7 @@ class StateManager:
         Upgrade rows (#1014) are excluded — their ``changes`` is a ``{"version": ...}`` marker, not
         writable-key config, and must never leak into the editor prefill."""
         merged: dict[str, Any] = {}
-        for row in reversed(self.get_worker_config_history(worker, limit=200)):
+        for row in reversed(self.get_worker_config_history(worker, limit=200) or []):
             if (
                 row.get("status") == "applied"
                 and row.get("type", "apply") == "apply"
@@ -1344,7 +1344,7 @@ class StateManager:
         at pre-history config."""
         versions = [
             row
-            for row in reversed(self.get_worker_config_history(worker, limit=200))
+            for row in reversed(self.get_worker_config_history(worker, limit=200) or [])
             if row.get("status") == "applied"
         ]
         if not versions:

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -188,6 +188,20 @@ const CONFIG_ORIGIN_TEXT = {
     detail:
       "too many changes since to tell whether it was this dashboard — the id is older than the history read",
   },
+  // `unread` is the one verdict that is about US, not the rig (#1409). The server sends it when
+  // its own history read failed outright — no DB connection, or a `sqlite3.Error` — so it never got
+  // to look for the id. Before this it fell through to `elsewhere` and printed "Last changed from
+  // another dashboard" over a change that may well have been ours: an accusation sourced from our
+  // own broken database. `text-muted` for the same reason `untraced` is muted — the muted verdicts
+  // are the ones that claim nothing, and a warning colour over "we could not tell" is the same
+  // overclaim in a different medium. This adds a verdict STATE, deliberately not a new COLOUR: the
+  // text carries the distinction, the colour carries the class.
+  unread: {
+    cls: "text-muted",
+    label: "Cannot tell — this dashboard could not read its own history",
+    detail:
+      "the change-history read failed here, so nothing was compared — this says nothing about the rig",
+  },
   rig: { cls: "status-warn", label: "Last changed on the rig itself" },
   restored: {
     cls: "status-warn",

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -70,7 +70,7 @@ def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
             "reason": row.get("reason"),
         }
         for row in _filter_events(
-            state_mgr.get_worker_config_history(worker, limit=200), range_arg, window
+            state_mgr.get_worker_config_history(worker, limit=200) or [], range_arg, window
         )
     ]
     return {"hashrate": hashrate, "markers": markers}
@@ -92,6 +92,10 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     worker = next((w for w in workers if w.get("name") == name), None)
     descriptor = next((e for e in config.DASHBOARD_WORKERS if e["name"] == name), None)
     history = state_mgr.get_worker_config_history(name, limit=_HISTORY_LIMIT)
+    # None means the read FAILED; [] means the rig genuinely has no recorded changes (#1409). The
+    # two are the same object downstream, so the distinction has to be captured HERE or it is gone.
+    history_unread = history is None
+    history = history or []
     for row in history:
         ts = row.get("ts")
         row["applied_at"] = format_time_abs(ts) if ts else ""
@@ -113,7 +117,8 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # a rig. Here the same two properties invert into the one answer this feature must never give
     # wrongly: a change id spooled for a DIFFERENT rig, or a transient DB error, would print "Last
     # changed from this dashboard" over a change this dashboard never made. Scanning the rig's own
-    # rows is worker-scoped by construction and fails closed, because the read returns [] on error.
+    # rows is worker-scoped by construction and fails closed, because a failed read is now a
+    # ``None`` the verdict answers separately (#1409) rather than a ``[]`` it cannot tell from a miss.
     #
     # It also makes the verdict checkable: "here" now means precisely "the id is one of the rows
     # rendered directly below this line, and that row records the change as having held", so an
@@ -124,8 +129,8 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # row past the end rather than an id nobody here spooled — and "elsewhere" reads as "Last
     # changed from another dashboard", an accusation the read cannot support (#1369). Passing the
     # fullness of the window lets that case say "we do not know" instead. Only that case changes:
-    # a short read is still conclusive, which is what keeps the ``sqlite3.Error`` path (a ``[]``
-    # return, and 0 is not full) answering exactly as it does today rather than more confidently.
+    # a short read is still conclusive. The ``sqlite3.Error`` path no longer arrives here at all:
+    # it returns ``None`` and is answered by ``unread`` before fullness is consulted (#1409).
     #
     # The matched ROW, not merely whether one exists: RigForge's rollback re-apply re-stamps the id
     # it just reverted, so a rolled-back change still matches by id. The row's status is the only
@@ -158,6 +163,7 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
             matched is not None,
             (matched or {}).get("status"),
             history_truncated=len(history) >= _HISTORY_LIMIT,
+            history_unread=history_unread,
         ),
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -151,12 +151,13 @@ def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():
     # dashboard's history. Another host applied it, or our record of it is gone. Reporting it as
     # "applied from here" would be the exact lie this issue exists to stop.
     #
-    # This is also the case that keeps a FAILED read where it is (#1369). A short window still
-    # settles the miss, and `get_worker_config_history` returns [] on a sqlite3.Error — an empty
-    # list is not a full window, so a DB hiccup keeps exactly this verdict rather than being handed
-    # a stronger claim. That is why the rule is written as ">= limit -> soften" and not as a
-    # separate "we read the whole history" assurance. Caller-side twin:
-    # `test_a_history_read_that_fails_never_manufactures_trust`.
+    # A read that WORKED and came back short. That is what makes the miss conclusive, and it is now
+    # the only way to reach this verdict: since #1409 a failed read returns None rather than [], so
+    # it is answered by `history_unread` above and never arrives here dressed as a short window.
+    # This comment used to say the opposite — that a sqlite3.Error's [] "keeps exactly this verdict
+    # rather than being handed a stronger claim" — which read as a safety property while being the
+    # bug: `elsewhere` renders as "Last changed from another dashboard", so a DB hiccup printed an
+    # accusation. Caller-side twin: `test_a_history_read_that_fails_never_manufactures_trust`.
     assert config_origin(GOOD, change_id_known=False) == "elsewhere"
 
 
@@ -184,6 +185,44 @@ def test_the_new_argument_can_only_ever_soften_the_miss():
                 )
                 == expected
             )
+
+
+def test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard():
+    # #1409. `elsewhere` renders as "Last changed from another dashboard" — an accusation. Reaching
+    # it because our OWN database would not answer sources that accusation from our fault, not from
+    # anything the rig did. The verdict has to say which of the two it is.
+    assert config_origin(GOOD, change_id_known=False, history_unread=True) == "unread"
+
+
+def test_a_read_that_did_not_happen_settles_nothing_further_down_the_branch():
+    # Why `history_unread` is checked FIRST and not folded in beside the miss: when the read failed
+    # there is no history, so `change_id_known` and `change_status` are not weak evidence, they are
+    # NO evidence — they are what the caller passes when it found nothing because it looked nowhere.
+    # Any verdict computed from them would be manufactured. Moving the check below either of the
+    # branches below reds this.
+    for status in (None, "applied", "rolled_back", "accepted"):
+        assert (
+            config_origin(GOOD, change_id_known=True, change_status=status, history_unread=True)
+            == "unread"
+        )
+
+
+def test_unread_is_a_control_channel_verdict_only():
+    # It answers "did the change come from this dashboard", a question only `control` raises. A rig
+    # edit is still a rig edit whether or not our history read worked, and saying "cannot tell" over
+    # one would lose a verdict we can support.
+    for source, expected in (("local", "rig"), ("restore", "restored")):
+        meta = {**GOOD, "source": source}
+        assert config_origin(meta, change_id_known=False, history_unread=True) == expected
+
+
+def test_an_empty_history_is_not_an_unread_one():
+    # The two-states-one-output trap, at the layer that decides. A rig with genuinely no recorded
+    # changes and a rig whose history we could not read both leave the caller holding no rows; only
+    # the None-vs-[] distinction separates them. Paired with the storage-level test that None and []
+    # really are different return values (`TestWorkerConfigHistoryReadFailure`) and with the
+    # caller-level twin in test_worker_detail_meta.py.
+    assert config_origin(GOOD, change_id_known=False, history_unread=False) == "elsewhere"
 
 
 def test_a_change_made_on_the_rig_says_so():

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -60,6 +60,25 @@ test("elsewhere is flagged and never claimed as ours", () => {
   assert.match(note.title, /no record of/);
 });
 
+test("a history we could not read points at us, never at another dashboard", () => {
+  // #1409. The server sends `unread` when its OWN change-history read failed, so it never got to
+  // look for the rig's change id. Before this it fell through to `elsewhere`, whose line reads
+  // "Last changed from another dashboard" — an accusation whose real source was our broken DB.
+  const out = renderToString(ConfigProvenance({ origin: "unread", meta: META }));
+  const note = configOriginNote("unread", META);
+  assert.doesNotMatch(out, /another dashboard/i);
+  assert.doesNotMatch(out, /Last changed from this dashboard/);
+  // Muted, not warn: it claims nothing, and a warning colour over "we could not tell" is the same
+  // overclaim in a different medium. This adds a verdict STATE, deliberately not a new COLOUR.
+  assert.match(out, /text-muted/);
+  assert.doesNotMatch(out, /status-warn/);
+  // The text is what has to carry the distinction, since the colour deliberately does not: this
+  // must not be confusable with `untraced`, the OTHER muted "we cannot tell" — that one is about
+  // the rig having changed too often to see back that far, this one is about us.
+  assert.notEqual(note.label, configOriginNote("untraced", META).label);
+  assert.match(note.label, /this dashboard could not read/i);
+});
+
 test("rig edits are flagged — noticing one is the whole point of the feature", () => {
   const out = renderToString(ConfigProvenance({ origin: "rig", meta: { ...META, source: "local" } }));
   assert.match(out, /Last changed on the rig itself/);

--- a/dashboard/tests/service/test_storage_worker_read_contract.py
+++ b/dashboard/tests/service/test_storage_worker_read_contract.py
@@ -1,0 +1,46 @@
+"""The return contract of ``StateManager.get_worker_config_history`` (#1409).
+
+A new module rather than three more tests in ``test_storage_worker.py``: that file is 378 lines and
+#1105 Phase 3 D6 cut it specifically to land under the 400-line budget target, so growing it by a
+third of a class would buy it back a ceiling row three days after the split removed one.
+
+What is being pinned here is one distinction, and only that: **None means the read FAILED; ``[]``
+means the rig genuinely has no recorded changes.** Before #1409 both failure paths returned ``[]``,
+which is indistinguishable from an empty history to every caller — so ``build_worker_detail`` read
+"we hold no row for the rig's last change id" off a list that was empty because the read never ran,
+and rendered the accusation "Last changed from another dashboard" over it.
+
+Separating the two return values is what makes that answerable AT ALL; it is not itself the fix.
+The verdict this feeds is tested in ``tests/client/test_rig_config_meta.py`` (the decision) and
+``tests/web/test_worker_detail_meta.py`` (what the operator actually reads).
+"""
+
+
+class TestWorkerConfigHistoryReadFailure:
+    def test_a_db_error_returns_none_not_an_empty_list(self, state_manager):
+        # The `except sqlite3.Error` arm, made to raise for real rather than through a mocked
+        # handler — this is the path an operator with a corrupt or migrating DB actually hits.
+        state_manager.add_worker_config_version("rig1", "cid-1", "applied", {"DONATION": 5}, None)
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_config")
+        assert state_manager.get_worker_config_history("rig1") is None
+
+    def test_no_connection_returns_none_not_an_empty_list(self, state_manager):
+        # The other failure path, and the quieter one: `if not self._conn` raises nothing and logs
+        # nothing, so it is invisible even to someone looking. The two are not equally observable,
+        # which is most of why this was hard to see — and a test covering only the arm above goes
+        # green against a fix to only the loud half.
+        conn, state_manager._conn = state_manager._conn, None
+        try:
+            assert state_manager.get_worker_config_history("rig1") is None
+        finally:
+            state_manager._conn = conn
+
+    def test_a_rig_with_no_recorded_changes_still_returns_an_empty_list(self, state_manager):
+        # The REVERSE direction, and the reason this class is not one test. Make the method return
+        # None whenever it has nothing to hand back and every assertion above still passes, while
+        # "we could not read" and "there is nothing to read" collapse into one answer again — the
+        # original defect, restored by way of its own fix.
+        out = state_manager.get_worker_config_history("rig-never-touched")
+        assert out == []
+        assert out is not None

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -133,6 +133,11 @@ class TestConfigOrigin:
         assert d["config_origin"] == "elsewhere"
 
     def test_control_change_with_no_history_at_all_is_elsewhere(self, monkeypatch):
+        # Also the REVERSE-direction guard for #1409, which is why it must not be folded into any
+        # of the tests above it: a healthy DB holding no rows is a real answer, so this rig keeps
+        # `elsewhere` and must never drift to `unread`. Make the storage layer return None for a
+        # genuinely empty result and this reds — without it, `unread` could absorb the empty case
+        # and the verdict would stop distinguishing anything.
         d = _detail(monkeypatch, {"config_meta": _META})
         assert d["config_origin"] == "elsewhere"
 
@@ -284,6 +289,11 @@ class TestConfigOrigin:
         # A DB the dashboard cannot read must not print "you did this". The #530 audit path fails
         # OPEN on a read error (a false "known" there only declines to accuse a rig); the same
         # direction here would hand a hostile rig the one verdict this feature exists to protect.
+        #
+        # #1409 corrected the OTHER direction of this same test. It used to assert `elsewhere`,
+        # which is not neutral — it renders as "Last changed from another dashboard". Failing away
+        # from `here` was right; landing on an accusation sourced from our own broken database was
+        # not. `unread` fails closed without inventing a culprit.
         from mining_dashboard.web import views
 
         monkeypatch.setattr(
@@ -306,7 +316,51 @@ class TestConfigOrigin:
         finally:
             sm._conn = None  # already closed above; keep sm.close() from raising on it
             sm.close()
-        assert d["config_origin"] == "elsewhere"
+        assert d["config_origin"] == "unread"
+        # The mutation target, named: this reds if the storage layer ever returns [] on error.
+        assert d["config_origin"] != "elsewhere"
+
+    def test_a_history_read_with_no_connection_at_all_is_the_same_verdict(self, monkeypatch):
+        # The second failure path, and the one nobody sees: `if not self._conn` raises nothing and
+        # logs nothing. The test above keeps `_conn` SET to reach the `except sqlite3.Error` arm,
+        # so it never covers this one — and a fix to only the loud path leaves this one accusing.
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.add_worker_config_version(
+                "rig1", _META["last_change_id"], "applied", {"DONATION": 5}, None
+            )
+            sm.close()  # drops the connection; _conn is None from here on
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert d["config_origin"] == "unread"
+
+    def test_a_failed_read_still_hands_the_client_a_list_to_render(self, monkeypatch):
+        # None is the storage layer's signal, not a payload value. `history` is iterated by the
+        # client, so leaking the None past this boundary would trade a wrong verdict for a broken
+        # page — the fix must not be visible anywhere except the verdict.
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.close()
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert d["history"] == []
+        assert d["hashrate_history"]["markers"] == []
 
     def test_a_hand_edit_underneath_rigforge_is_not_detected_known_gap(self, monkeypatch):
         """CHARACTERIZATION, not an endorsement — this asserts a KNOWN-WRONG answer (#1367).

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -444,6 +444,12 @@ rows — the table directly below — so the verdict is one you can check by eye
   says only that the record cannot tell you which, and it can still resolve on a later reading.
 - **Last changed from another dashboard** — applied over a control channel, but with an id this
   dashboard has never issued. Another host drove this rig, or its record here is gone.
+- **Last changed over a control channel** — applied over a control channel with an id that was not
+  found, on a rig with more recorded changes than the line reads back. The id may sit just past the
+  end of what was read, so the dashboard cannot honestly say the change was not its own.
+- **Cannot tell — this dashboard could not read its own history** — the dashboard's own change
+  history would not open. It is the one line here that is about this dashboard rather than the rig:
+  nothing was compared, so nothing is claimed either way. It says nothing about what the rig did.
 - **Last changed on the rig itself** — applied on the rig, not over a control channel at all.
 - **Last restored from a saved config** — someone ran RigForge's restore command on the rig. This
   covers only that command; the rig's own rollback after a failed change reads as the rolled-back
@@ -467,8 +473,13 @@ all-clear: it can tell you a change happened elsewhere, but its silence is not p
 Everything behind it is the rig's own account, so a rig that has been taken over can also say
 whatever it likes, including replaying a change id you really did send it. Within what the rig does
 report honestly, the dashboard's own half errs one way only: a change id belonging to a different
-rig, or a history it cannot read at that moment, both land on "another dashboard" rather than on a
-false reassurance.
+rig lands on "another dashboard" rather than on a false reassurance.
+
+A history the dashboard cannot read at that moment used to land there too, and that was wrong in a
+way worth naming. "Another dashboard" is not a neutral fallback — it is an accusation, and reaching
+it because our own database would not open sources that accusation from a fault on this side rather
+than from anything the rig did. That case now gets its own line, above: the dashboard says it could
+not tell, and says why.
 
 How it stays safe:
 


### PR DESCRIPTION
## What this fixes

`get_worker_config_history` returned `[]` on both of its failure paths, which is the same value it
returns when a rig genuinely has no recorded changes. `build_worker_detail` reads that list to decide
where the rig's running config came from, so a read that never happened was indistinguishable from a
read that came back empty — and an empty result means "we hold no row for the rig's `last_change_id`",
which is the `elsewhere` verdict, which renders as **"Last changed from another dashboard"**.

That is an accusation, and on this path its real source was our own database failing to open.

## The reproduction

Driven through `build_worker_detail` against a real `StateManager` on a temp DB, not against
`config_origin` directly — nothing is mocked on the method under test.

| leg | how | history | verdict before | rendered before |
|---|---|---|---|---|
| **A — control** | healthy DB, change id present | 1 row | `here` | `text-muted` · Last changed from this dashboard |
| **B** | real `sqlite3.Error` — `DROP TABLE worker_config` | `[]` | `elsewhere` | **`status-warn` · Last changed from another dashboard** |
| **C** | no connection (`storage_service.py:888-889`) | `[]` | `elsewhere` | identical to B |

**Leg A is the load-bearing row.** Same fixture, same id, correct verdict when the read works — so B
and C are attributable to the failed read rather than to a fixture that could never have reached
`here` in the first place. Leg B's handler is confirmed by its own log line (`no such table:
worker_config`), not inferred. **Leg C raises nothing and logs nothing**, so the two failure routes
are not equally observable; that asymmetry is most of why this was hard to see, and it is why the
tests cover them separately rather than through one representative case.

## The change

- `get_worker_config_history` returns **`None` on both failure paths** (`:888-889` and the
  `except sqlite3.Error` at `:906-908`). `[]` keeps meaning **genuinely no history**.
- `config_origin` gains a `history_unread=False` knob and a new **`unread`** verdict, returned as the
  first check inside the `source == "control"` branch. When the read worked, every verdict is exactly
  what it was before, so a caller that does not pass the flag loses nothing.
- `unread` renders **muted, not warn**. Muted is an EXISTING treatment here — `here`, `untraced` and
  `unrecorded` already use it, and the client's own comment says the muted verdicts are the ones that
  claim nothing. So this adds a verdict **state**, deliberately not a new **colour**: the text carries
  the distinction, the colour carries the class. Please do not later give it its own hue.
- Its label points at us, not the rig, and is deliberately not `untraced`'s wording: `untraced` is a
  read that WORKED and came back full (the rig changed too often to see back that far); `unread` is a
  read that did not happen.

### The signature had to stay on one line

`storage_service.py` is at its budget ceiling of 1603 with ZERO headroom, and `ruff`'s
`line-length = 100` is the binding constraint. `-> list[dict[str, Any]] | None` is **101 characters**,
so the formatter wraps it to three lines and the file blows its ceiling. `-> list[dict] | None` is
**91** and stays on one line. The docstring then had exactly three lines to carry the new contract.
Counted after the formatter, not as typed: the file is 1603 lines before and after this PR.

## Three call sites are NOT fixed — this is a named deferral, not a considered no-op

The other three readers take `or []` in place, which is line-neutral and keeps today's behaviour
exactly. **Each one still renders a failed read as an empty result**, and `or []` in a diff is
indistinguishable from someone having decided it was fine, so they are named here rather than left for
the next reader to interpret:

| call site | what a failed read produces | how that renders |
|---|---|---|
| `worker_detail.py:73` (chart markers) | `markers == []` | the hashrate chart draws no config-change markers |
| `storage_service.py:1005` `get_last_applied_worker_config` | `{}` | no last-applied config; the editor prefill falls back as if nothing was ever applied |
| `storage_service.py:1347` `get_worker_hashrate_by_config` | `[]` (early return at `:1351`) | the version timeline shows no rows |

**The accusation is the loudest symptom, not the only one.** Fixing all four in one PR would mean four
different renderings to design and defend; the audit issue filed alongside this asks the mechanism
question instead.

## Tests — and the mutation battery in BOTH directions

New module `tests/service/test_storage_worker_read_contract.py` (46 lines, unrowed). It is a new file
rather than three more tests in `test_storage_worker.py` because that file is 378 lines and D6 cut it
specifically to land under the 400 target — growing it here would buy back a ceiling row three days
after the split removed one. `git add`ed BEFORE any lint or budget run, or the gate would not have
enumerated it at all (see the issue filed with this PR).

A forward-only battery passes clean against exactly the defect being fixed, so both directions are run:

- **FORWARD** — undo the fix one path at a time; require a NAMED kill.
- **REVERSE** — make a genuinely EMPTY history return `None`, and widen `unread` to swallow the
  ordinary miss and the truncated miss; require a named kill. Without this direction `unread` could
  absorb the empty case and nothing would notice — the two-states-one-output trap, restored by way of
  its own fix.

**16 rows, 16 KILLED, 0 survived, 0 unapplied.** Every row names a test it was aimed at, and that
test is among the ones that died. Both runners were green at baseline before each run, both green
after, and the tree was verified byte-identical to pre-run at the end of each run.

| row | direction | mutation | verdict | the aimed test that died |
|---|---|---|---|---|
| **F1** | forward | the `sqlite3.Error` arm returns `[]` again — the original defect, loud half | **KILLED** | `test_a_db_error_returns_none_not_an_empty_list` |
| **F2** | forward | the no-connection arm returns `[]` again — the original defect, **silent** half | **KILLED** | `test_no_connection_returns_none_not_an_empty_list` |
| **F2b** | forward | F2 again, aimed at the RENDERED verdict rather than the return value | **KILLED** | `test_a_history_read_with_no_connection_at_all_is_the_same_verdict` |
| **F3** | forward | F1 again, aimed at the RENDERED verdict rather than the return value | **KILLED** | `test_a_db_error_returns_none_not_an_empty_list` |
| **F4** | forward | the caller never notices the failed read (`history_unread` pinned `False`) | **KILLED** | `test_a_history_read_that_fails_never_manufactures_trust` |
| **F5** | forward | the flag is computed but never passed to the verdict | **KILLED** | `test_a_history_read_that_fails_never_manufactures_trust` |
| **F6** | forward | `unread` falls back to the accusation it exists to remove | **KILLED** | `test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard` |
| **F7** | forward | the `unread` check moves BELOW the miss, so a failed read accuses first | **KILLED** | `test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard` |
| **F8** | forward | the marker read drops its `or []`, leaking `None` into the chart payload | **KILLED** | `test_a_failed_read_still_hands_the_client_a_list_to_render` |
| **R1** | **reverse** | a genuinely EMPTY history returns `None` too — the two states collapse | **KILLED** | `test_a_rig_with_no_recorded_changes_still_returns_an_empty_list` |
| **R2** | **reverse** | R1 again, aimed at the RENDERED verdict — a never-changed rig would read `unread` | **KILLED** | `test_control_change_with_no_history_at_all_is_elsewhere` |
| **R3** | **reverse** | `unread` widened to swallow every miss, working read or not | **KILLED** | `test_an_empty_history_is_not_an_unread_one` |
| **R4** | **reverse** | `unread` widened to swallow the TRUNCATED miss, erasing #1369's `untraced` | **KILLED** | `test_the_new_argument_can_only_ever_soften_the_miss` |
| **M1** | render | `unread` takes `status-warn` — a warning colour over *we could not tell* | **KILLED** | *a history we could not read points at us, never at another dashboard* |
| **M2** | render | `unread` reuses `untraced`'s label, so the two muted verdicts are confusable | **KILLED** | *(same frontend test)* |
| **M3** | render | the `unread` entry is gone, so the line renders nothing at all | **KILLED** | *(same frontend test)* |

**F2 is the row that nearly did not count, and it was the most important one.** Its first attempt
scored **HARNESS-FAIL, not SURVIVED** — the harness refuses a pattern that does not match exactly
once, and `if not self._conn:\n    return None` occurs THREE times in `storage_service.py`. A harness
using a plain `.replace()` would have mutated all three sites (a larger change than the one claimed);
one using `replace(..., 1)` would have silently hit the FIRST occurrence — a different method
entirely — and reported either a clean SURVIVED or a bystander kill. **An unapplied mutation is not a
weaker kill, it is no evidence at all**, and the row it hit was the silent failure path this whole
issue is about being invisible. Re-run anchored on a docstring line unique to the method (verified: 1
occurrence) — `mutate-1409-f2.py`.

**R1 and R2 were re-run after the fact, and the reason is disclosed rather than papered over.** The
first battery ran BEFORE a duplicate test was removed, so its logged kill lists for those two rows
name a test that no longer exists. Rather than assert the evidence still stood, both rows were re-run
against the current tree with R2 re-aimed at the surviving guard
(`test_control_change_with_no_history_at_all_is_elsewhere`, which the row also killed originally):
both KILLED, 8 named kills each, tree byte-identical after.

**R3 and R4 were re-run for the same reason**, after the review-driven test deletion described below
removed R4's original aimed test. R4 re-aimed at that test's surviving twin
(`test_the_new_argument_can_only_ever_soften_the_miss`, which the row also killed originally): both
KILLED, tree byte-identical after. **No row in this table rests on a log produced against a tree
that is not the tree in this PR.**

<details>
<summary>Raw harness output — all three runs</summary>

Run 1 — the 15-row battery (`mutate-1409.log`). F2's HARNESS-FAIL is left in view; R1/R2 here are the
pre-dedup runs superseded by run 3.

```
=== TABLE ===
ok  KILLED               F1  storage: the sqlite3.Error arm returns [] again (the original defect, loud half)
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_db_error_returns_none_not_an_empty_list
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
BAD HARNESS-FAIL         F2  storage: the no-connection arm returns [] again (the original defect, SILENT half)
ok  KILLED               F3  storage: F1 again, aimed at the RENDERED verdict rather than the return value
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_db_error_returns_none_not_an_empty_list
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
ok  KILLED               F4  caller: the failed read is never noticed (history_unread pinned False)
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               F5  caller: the flag is computed but never passed to the verdict
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               F6  verdict: unread falls back to the accusation it exists to remove
        killed: tests/client/test_rig_config_meta.py::test_a_read_that_did_not_happen_settles_nothing_further_down_the_branch
        killed: tests/client/test_rig_config_meta.py::test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               F7  verdict: the unread check is moved BELOW the miss, so a failed read accuses first
        killed: tests/client/test_rig_config_meta.py::test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               F8  caller: the marker read drops its `or []`, leaking None into the chart payload
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_failed_read_still_hands_the_client_a_list_to_render
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_that_fails_never_manufactures_trust
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               R1  storage: a genuinely EMPTY history returns None too — the two states collapse
        killed: tests/service/test_data_service.py::TestRigEditDetection::test_unknown_change_id_records_rig_edit
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_rig_with_no_recorded_changes_still_returns_an_empty_list
        killed: tests/web/test_server.py::TestWorkerApplyEdgeCases::test_apply_pending_when_runner_silent
        killed: tests/web/test_server.py::TestWorkerUpgrade::test_noop_when_rig_already_reports_the_version
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_runner_never_answering_records_nothing
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_wait_result_error_is_swallowed_not_raised
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_rig_we_have_simply_never_changed_is_not_reported_as_unread
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
ok  KILLED               R2  storage: R1 again, aimed at the RENDERED verdict — a never-changed rig reads `unread`
        killed: tests/service/test_data_service.py::TestRigEditDetection::test_unknown_change_id_records_rig_edit
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_rig_with_no_recorded_changes_still_returns_an_empty_list
        killed: tests/web/test_server.py::TestWorkerApplyEdgeCases::test_apply_pending_when_runner_silent
        killed: tests/web/test_server.py::TestWorkerUpgrade::test_noop_when_rig_already_reports_the_version
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_runner_never_answering_records_nothing
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_wait_result_error_is_swallowed_not_raised
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_rig_we_have_simply_never_changed_is_not_reported_as_unread
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
ok  KILLED               R3  verdict: unread widened to swallow every miss, working read or not
        killed: tests/client/test_rig_config_meta.py::test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours
        killed: tests/client/test_rig_config_meta.py::test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard
        killed: tests/client/test_rig_config_meta.py::test_an_empty_history_is_not_an_unread_one
        killed: tests/client/test_rig_config_meta.py::test_the_unread_flag_can_only_ever_change_the_answer_when_it_is_set
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[50-untraced]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_rig_we_have_simply_never_changed_is_not_reported_as_unread
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_we_never_spooled_is_elsewhere
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
ok  KILLED               R4  verdict: unread widened to swallow the TRUNCATED miss, erasing #1369's untraced
        killed: tests/client/test_rig_config_meta.py::test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard
        killed: tests/client/test_rig_config_meta.py::test_the_new_argument_can_only_ever_soften_the_miss
        killed: tests/client/test_rig_config_meta.py::test_the_unread_flag_can_only_ever_change_the_answer_when_it_is_set
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[49-here]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[50-untraced]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_rolled_back_change_still_reads_as_reverted_on_a_long_history
ok  KILLED               M1  render: unread takes status-warn — a warning colour over 'we could not tell'
        killed: a history we could not read points at us, never at another dashboard
ok  KILLED               M2  render: unread reuses untraced's label, so the two muted verdicts are confusable
        killed: a history we could not read points at us, never at another dashboard
ok  KILLED               M3  render: the unread entry is gone, so the line renders nothing at all
        killed: a history we could not read points at us, never at another dashboard
```

Run 2 — F2 re-anchored, plus F2b (`mutate-1409-f2.log`):

```
=== TABLE ===
ok  KILLED               F2  storage: the no-connection arm returns [] again (the original defect, SILENT half)
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_no_connection_returns_none_not_an_empty_list
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
ok  KILLED               F2b storage: F2 again, aimed at the RENDERED verdict rather than the return value
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_no_connection_returns_none_not_an_empty_list
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_history_read_with_no_connection_at_all_is_the_same_verdict
```

Run 3 — R1/R2 re-run at the current tree, R2 re-aimed (`mutate-1409-r12.log`):

```
=== TABLE ===
ok  KILLED               R1  storage: a genuinely EMPTY history returns None too — the two states collapse
        killed: tests/service/test_data_service.py::TestRigEditDetection::test_unknown_change_id_records_rig_edit
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_rig_with_no_recorded_changes_still_returns_an_empty_list
        killed: tests/web/test_server.py::TestWorkerApplyEdgeCases::test_apply_pending_when_runner_silent
        killed: tests/web/test_server.py::TestWorkerUpgrade::test_noop_when_rig_already_reports_the_version
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_runner_never_answering_records_nothing
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_wait_result_error_is_swallowed_not_raised
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
ok  KILLED               R2  storage: R1 again, aimed at the RENDERED verdict — a never-changed rig reads `unread`
        killed: tests/service/test_data_service.py::TestRigEditDetection::test_unknown_change_id_records_rig_edit
        killed: tests/service/test_storage_worker_read_contract.py::TestWorkerConfigHistoryReadFailure::test_a_rig_with_no_recorded_changes_still_returns_an_empty_list
        killed: tests/web/test_server.py::TestWorkerApplyEdgeCases::test_apply_pending_when_runner_silent
        killed: tests/web/test_server.py::TestWorkerUpgrade::test_noop_when_rig_already_reports_the_version
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_runner_never_answering_records_nothing
        killed: tests/web/test_server.py::TestWorkerUpgradeRecordsHistory::test_wait_result_error_is_swallowed_not_raised
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
```

Run 4 — R3/R4 re-run after the test deletion, R4 re-aimed (`mutate-1409-r34.log`):

```
=== TABLE ===
ok  KILLED               R3  verdict: unread widened to swallow every miss, working read or not
        killed: tests/client/test_rig_config_meta.py::test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours
        killed: tests/client/test_rig_config_meta.py::test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard
        killed: tests/client/test_rig_config_meta.py::test_an_empty_history_is_not_an_unread_one
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[50-untraced]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_another_rigs_change_id_is_never_claimed_as_this_rigs
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_we_never_spooled_is_elsewhere
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_control_change_with_no_history_at_all_is_elsewhere
ok  KILLED               R4  verdict: unread widened to swallow the TRUNCATED miss, erasing #1369's untraced
        killed: tests/client/test_rig_config_meta.py::test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard
        killed: tests/client/test_rig_config_meta.py::test_the_new_argument_can_only_ever_soften_the_miss
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[49-here]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses[50-untraced]
        killed: tests/web/test_worker_detail_meta.py::TestConfigOrigin::test_a_rolled_back_change_still_reads_as_reverted_on_a_long_history
```

</details>

## Docs

`docs/dashboard.md` **stated this defect as a safety property**: *"a change id belonging to a different
rig, or a history it cannot read at that moment, both land on 'another dashboard' rather than on a
false reassurance."* The failed-read half of that sentence was the bug, written down as the reassuring
direction. Corrected, with the reason named.

Disclosed because it is adjacent scope, not asked for: the same verdict list was **missing `untraced`
entirely** (#1369 shipped the verdict and never documented it). Added in the same list rather than
leave the list knowingly wrong while editing it.

**A review pass then found the same thing a THIRD time, in the code.** The explanatory comment inside
`build_worker_detail` (`web/worker_detail.py`) made two claims that this very commit falsified and
that the commit had left standing:

- *"...fails closed, because the read returns `[]` on error"* — it returns `None` on error as of this
  change.
- *"...which is what keeps the `sqlite3.Error` path (a `[]` return, and 0 is not full) answering
  exactly as it does today rather than more confidently"* — that path no longer reaches the fullness
  logic at all; it returns `None` and is answered by `unread` first.

The second one is the sharper of the two: like the doc sentence, **it wrote the defect down as a
deliberate property** — the `[]`-on-error return described as the thing that keeps the verdict
honest. Both corrected here. Three artefacts of ours agreed with each other about a behaviour and
none of them agreed with what the code did to an operator's screen; that is the same shape COMMON
records from #1345, and it is worth noticing that the count only went from two to three because
someone re-read the diff adversarially after it was already green.

## The over-engineering review, and what it changed

Run against the diff before this PR opened, adversarially and against my own work. Its verdict was
*proportionate — yes, with one loose end*, and it produced three findings worth acting on or
answering here:

- **The stale comment above** — accepted and fixed. It was the only finding that made the diff
  actively wrong about itself.
- **One test deleted.** `test_the_unread_flag_can_only_ever_change_the_answer_when_it_is_set` passed
  `history_unread=False` explicitly across five outcomes that five pre-existing tests in the same
  file already assert with the kwarg omitted. Explicit-`False` is not a distinct code path from
  default-`False`, so it killed no mutant those five do not — and against a mutation that flipped the
  DEFAULT it would have been the one test that stayed green. Strictly weaker, not complementary.
  Deleted; its named twin `test_the_new_argument_can_only_ever_soften_the_miss` carries the contract.
  **Battery rows R3 and R4 were re-run afterwards** (R4 re-aimed at that twin): both still KILLED.
- **One finding declined, with a reason rather than a preference.** The review also called
  `test_a_history_read_with_no_connection_at_all_is_the_same_verdict` redundant — the storage tier
  proves no-connection returns `None`, the sibling web test proves `None` renders as `unread`, so
  composition covers it. That argument is sound as far as it goes, and it is kept anyway: deleting it
  would strand mutation row **F2b**, which is the only row that mutates the RENDERED verdict on the
  SILENT failure path. This lane's standing rule from #1350 is that a rendering has no signal of its
  own — nothing goes red when it is wrong — so the rendered verdict needs a mutation with a named
  kill, not an inference from two tiers that individually pass. The composition argument is exactly
  the sort of by-inspection reasoning this issue exists because someone once trusted.

## What was RUN

Every figure below was measured on the tree in this PR, in one session, after the review-driven
edits — not carried forward from an earlier run on an earlier tree.

**Base note.** `origin/develop-v2` moved from `6fb4ccb` to `976a4ab` (#1484) while this was being
finished, so the branch was rebased onto `976a4ab` and the **budget gate, `ruff check` and the full
suite were re-run there**: gate rc=0, ruff clean, **pytest rc=0 with 2129 passed, 0 skipped, 0
failed**. The coverage pair and the mutation battery were run at `6fb4ccb` before the rebase, on a
tree identical in every file this PR touches; that is stated rather than smoothed over. Re-deriving
the base before pushing is not optional here — a stale base makes this repo's budget gate FAIL while
naming files the diff never touched.

- **Python suite: 2129 passed, 0 skipped, 0 failed, rc=0.** That is the `develop-v2` baseline of 2120 plus the 10 new
  tests this PR keeps (11 written, one deleted on the review finding above, and one earlier duplicate
  of a pre-existing test removed before the commit).
- **Frontend: 481 passed / 0 failed** — the baseline of 480 plus this PR's one new logic test.
- **`ruff format --check`: 143 files already formatted. `ruff check`: all checks passed.** Re-run
  after the comment fix and the test deletion, not before.
- **`make lint-file-budget`: rc=0.** Run LOCALLY, because its monotonic leg does not run in CI
  (#1452). `service/storage_service.py` is **1603 lines before and after** this PR — line-neutral at
  a ceiling with zero headroom, which is why the return signature had to stay on one line.
  `tests/web/test_worker_detail_meta.py` is 395 and `tests/client/test_rig_config_meta.py` 262, both
  under the 400 target.
- **`make lint-docs-voice`: clean, 40 prose docs.**
- **Coverage: 6841 statements, 204 missed, 97%** — and the same three files this PR touches read
  `client/rig_config_meta.py` **100%**, `web/worker_detail.py` **100%**,
  `service/storage_service.py` 93% (unchanged; its misses are pre-existing and elsewhere in the file).
- **The coverage comparison was run as a controlled pair**, because the deleted test made "no coverage
  was lost" a claim rather than an observation: the two changed files were reverted to `f4eca13`, the
  suite re-run, and the two reports diffed. **They are identical, per-file and in total.** The
  deletion cost nothing.
- **One honest wobble, and it is not caused by this change:** two runs of the UNMODIFIED head gave
  203 and 204 missed statements. So this suite has about one line of run-to-run coverage variance.
  The comparison above is like-for-like within one session and is unaffected by it, but a reader
  comparing against a number from another day should expect ±1.
- **Mutation battery: 16 rows, 16 killed, 0 survived, 0 unapplied**, across four runs, each verified
  green at baseline and byte-identical afterwards. Table above.

## What was NOT run

- **`make lint-sh` NOT run** — no shell files in the diff, and it is the serialized OOM path.
- **`make test` in full NOT run** — the stack/compose/integration tiers are not exercised.
- **Nothing was seen on screen.** This lane has no browser. The `unread` line's *rendering* is proven
  by the frontend logic tests (muted class, label distinct from `untraced`'s, no accusation text); that
  its colour is legible next to the other muted verdicts is NOT proven here and cannot be by this lane.
- `tests/web/test_worker_detail_meta.py` lands at **395 lines**, under the 400 target with a little
  margin. It reached 400 first; one of the tests I had added there was mechanically identical to
  `test_control_change_with_no_history_at_all_is_elsewhere` 150 lines above it — same fixture, same
  assertion — and was deleted rather than kept for the sake of a bigger diff. The surviving test now
  carries a comment naming it as the reverse-direction guard so nobody deletes IT later.
