### PR TITLE
fix(e2e): compact-chain.sh's header denied the swap the tool performs (#1489)

### DIFF
--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -334,10 +334,27 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 > NOTE: a pruned chain's file stays large. An in-place prune does not shrink the LMDB file: it
 > stays at the full-chain high-water mark (~250 GiB) with the freed space sitting as internal
 > free pages (Monero reuses them as the chain grows). To reclaim it you must rewrite the DB with
-> `monero-blockchain-prune --copy-pruned-database` (see
+> `monero-blockchain-prune` (see
 > [`compact-chain.sh`](../../tests/integration/compact-chain.sh)). It's slow (it copies every block
-> over hours), though it reads through a snapshot so monerod keeps mining; you then swap the
-> compact copy in during a ~2 min window. The generic `mdb_copy -c` does not work: Monero ships a
+> over hours), though it reads through a snapshot so monerod keeps mining.
+>
+> **The tool is copy-then-swap, so it does not leave the swap to you.** After building
+> `<data-dir>/lmdb-pruned` it renames `<data-dir>/lmdb` to `<data-dir>/lmdb-old` and moves the
+> pruned DB into place. Pointed at a live node's data dir it therefore renames the live chain out
+> from under a running monerod — nothing fails at the time, because the process keeps its open
+> descriptors, and the next restart silently comes up pruned. To run it against a live chain,
+> bind-mount the source so the kernel refuses the rename with `EBUSY`:
+>
+> ```bash
+> mkdir -p <build-dir>/lmdb
+> mount --bind <live-data-dir>/lmdb <build-dir>/lmdb
+> tests/integration/compact-chain.sh <build-dir>   # result at <build-dir>/lmdb-pruned
+> ```
+>
+> Prove the guard before relying on it: `mv <build-dir>/lmdb <build-dir>/x` must answer `Device or
+> resource busy`.
+>
+> The generic `mdb_copy -c` does not work: Monero ships a
 > patched LMDB and stock mdb_copy rejects the format (`MDB_VERSION_MISMATCH`). Often it's simplest
 > to leave the free pages.
 

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -338,21 +338,11 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 > [`compact-chain.sh`](../../tests/integration/compact-chain.sh)). It's slow (it copies every block
 > over hours), though it reads through a snapshot so monerod keeps mining.
 >
-> **The tool is copy-then-swap, so it does not leave the swap to you.** After building
-> `<data-dir>/lmdb-pruned` it renames `<data-dir>/lmdb` to `<data-dir>/lmdb-old` and moves the
-> pruned DB into place. Pointed at a live node's data dir it therefore renames the live chain out
-> from under a running monerod — nothing fails at the time, because the process keeps its open
-> descriptors, and the next restart silently comes up pruned. To run it against a live chain,
-> bind-mount the source so the kernel refuses the rename with `EBUSY`:
->
-> ```bash
-> mkdir -p <build-dir>/lmdb
-> mount --bind <live-data-dir>/lmdb <build-dir>/lmdb
-> tests/integration/compact-chain.sh <build-dir>   # result at <build-dir>/lmdb-pruned
-> ```
->
-> Prove the guard before relying on it: `mv <build-dir>/lmdb <build-dir>/x` must answer `Device or
-> resource busy`.
+> **The tool is copy-then-swap, so it does not leave the swap to you.** It renames
+> `<data-dir>/lmdb` aside and moves the pruned DB into place — pointed at a live node's data dir
+> that renames the live chain out from under a running monerod, silently until the next restart.
+> To run it against a live chain, bind-mount the source so the kernel refuses the rename; the
+> recipe and its guard are in `compact-chain.sh`'s header.
 >
 > The generic `mdb_copy -c` does not work: Monero ships a
 > patched LMDB and stock mdb_copy rejects the format (`MDB_VERSION_MISMATCH`). Often it's simplest

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -58,7 +58,8 @@ of pruned pushes that toward ~425 GB. Pruning Monero doesn't shrink Tari, so bud
 whenever it runs here. (A *freshly synced* pruned node is ~100 GB, but pruning an existing full
 chain doesn't
 reclaim space in place — run `monero-blockchain-prune` to write a new pruned DB; until then it sits
-at full size.)
+at full size. Stop monerod first: the tool moves the new DB into place itself, renaming the old
+chain aside, and it will do that under a running daemon.)
 
 Both chains keep growing, ~100+ GB/year combined (Tari, a young chain, grows fastest; Monero adds
 tens of GB/year). That's why the table lists a ~330 GB (pruned) / ~530 GB (full) minimum but

--- a/tests/integration/build-pruned-chain.sh
+++ b/tests/integration/build-pruned-chain.sh
@@ -9,11 +9,9 @@
 #   3. start monerod           -> mining resumes immediately after the copy
 #   4. prune the COPY          -> shrinks ~250G -> ~95G, full chain untouched
 #
-# Step 4 is safe here because it runs against the COPY, never the canonical chain. Note that
-# `monero-blockchain-prune` is copy-then-swap, not an in-place rewrite (#1489): it builds
-# $DST_DIR/lmdb-pruned and then renames it over $DST_DIR/lmdb. That is why the size is read
-# back from $DST_DIR/lmdb below. Never point that tool at a live node's data dir — see the
-# bind-mount guard in compact-chain.sh.
+# Step 4 targets the COPY, never the canonical chain. `monero-blockchain-prune` is
+# copy-then-swap (#1489) — it renames its result over $DST_DIR/lmdb, which is why the size is
+# read back from there. Never point it at a live data dir; see compact-chain.sh's bind-mount guard.
 #
 # Self-contained + idempotent-ish: logs with timestamps, writes a status sentinel,
 # and always restarts monerod even if the copy fails. Designed to be run under nohup.

--- a/tests/integration/build-pruned-chain.sh
+++ b/tests/integration/build-pruned-chain.sh
@@ -7,7 +7,13 @@
 #   1. stop monerod            -> makes the live LMDB consistent for copying
 #   2. copy full data.mdb      -> onto the CoW (btrfs) volume   [downtime window]
 #   3. start monerod           -> mining resumes immediately after the copy
-#   4. prune the COPY in place -> shrinks ~250G -> ~95G, full chain untouched
+#   4. prune the COPY          -> shrinks ~250G -> ~95G, full chain untouched
+#
+# Step 4 is safe here because it runs against the COPY, never the canonical chain. Note that
+# `monero-blockchain-prune` is copy-then-swap, not an in-place rewrite (#1489): it builds
+# $DST_DIR/lmdb-pruned and then renames it over $DST_DIR/lmdb. That is why the size is read
+# back from $DST_DIR/lmdb below. Never point that tool at a live node's data dir — see the
+# bind-mount guard in compact-chain.sh.
 #
 # Self-contained + idempotent-ish: logs with timestamps, writes a status sentinel,
 # and always restarts monerod even if the copy fails. Designed to be run under nohup.

--- a/tests/integration/compact-chain.sh
+++ b/tests/integration/compact-chain.sh
@@ -1,28 +1,41 @@
 #!/usr/bin/env bash
 #
-# compact-chain.sh — reclaim LMDB file bloat from an already-pruned Monero chain.
+# compact-chain.sh — build a compact pruned Monero chain from an existing chain.
 #
 # An in-place prune leaves the LMDB file at its full-chain high-water mark (LMDB never shrinks
 # its file), so a pruned chain can sit at ~270 GiB on disk while holding only ~95 GiB of live
-# data. `monero-blockchain-prune --copy-pruned-database` rewrites the chain into a fresh DB at
-# <data-dir>/lmdb-pruned, which comes out at its true compact size.
+# data. `monero-blockchain-prune` rewrites the chain into a fresh DB at <data-dir>/lmdb-pruned,
+# which comes out at its true compact size.
 #
-# IMPORTANT — speed & safety:
-#  * It copies every block one-by-one, so it is SLOW (multiple HOURS for a mainnet chain). It is
-#    NOT a page-level copy.
-#  * It only READS the source, through a consistent LMDB snapshot, so it is safe to run while
-#    monerod is up and mining — zero downtime during the copy; the source is never modified.
-#  * The generic `mdb_copy -c` does NOT work on a Monero chain: Monero ships a patched LMDB and
-#    stock mdb_copy rejects the on-disk format (MDB_VERSION_MISMATCH). This tool is the only path.
+# THE TOOL IS COPY-THEN-SWAP — IT DOES NOT ONLY READ THE SOURCE (#1489).
+#   After building <data-dir>/lmdb-pruned it renames <data-dir>/lmdb to <data-dir>/lmdb-old and
+#   moves the pruned DB into its place. The binary carries the strings "Swapping databases,
+#   pre-pruning blockchain will be left in", "-old and can be removed if desired" and
+#   "Blockchain pruned OK, but renaming failed". `--copy-pruned-database` does not change that:
+#   its help text is "Copy database anyway if already pruned", so it lifts an early-exit guard on
+#   an already-pruned source rather than selecting a copy-only mode.
 #
-# When it finishes, swap the compact copy in (brief downtime) and verify:
-#   docker stop monerod
-#   mv <data-dir>/lmdb <data-dir>/lmdb.bloated && mv <data-dir>/lmdb-pruned <data-dir>/lmdb
-#   docker start monerod      # re-syncs the few blocks added during the copy
-#   # confirm healthy (get_info: synchronized), then: rm -rf <data-dir>/lmdb.bloated
+#   So pointing this at a LIVE node's data dir renames the live chain out from under a running
+#   monerod. The running process keeps its open descriptors, so nothing fails at the time — the
+#   next restart silently comes up pruned, with the old chain left beside it eating disk.
 #
-# This script ONLY builds the compact copy; it does not stop/start containers or swap. Logs
-# before/after sizes and a status sentinel.
+# TO RUN IT AGAINST A LIVE CHAIN, BIND-MOUNT THE SOURCE (#1489):
+#   mkdir -p <build-dir>/lmdb
+#   mount --bind <live-data-dir>/lmdb <build-dir>/lmdb
+#   compact-chain.sh <build-dir>
+#
+#   The copy still reads the live chain through LMDB's consistent snapshot, so monerod keeps
+#   mining with no downtime; the final rename is refused by the kernel with EBUSY, so the live
+#   chain cannot be touched, and the pruned result is left at <build-dir>/lmdb-pruned. Prove the
+#   guard before you rely on it — `mv <build-dir>/lmdb <build-dir>/x` must answer "Device or
+#   resource busy".
+#
+# Speed: it copies every block one-by-one, so it is SLOW (many HOURS for a mainnet chain). It is
+# NOT a page-level copy. The generic `mdb_copy -c` does NOT work on a Monero chain: Monero ships
+# a patched LMDB and stock mdb_copy rejects the on-disk format (MDB_VERSION_MISMATCH).
+#
+# This script ONLY runs the tool; it does not stop or start containers. It logs before/after
+# sizes and writes a status sentinel.
 set -uo pipefail
 
 DATA_DIR="${1:?usage: compact-chain.sh <data-dir>}"

--- a/tests/integration/testbench-README.md
+++ b/tests/integration/testbench-README.md
@@ -47,13 +47,26 @@ A workable layout (adjust to taste):
   bloat, so there is nothing to compact. Shrinking it would mean pruning Tari (a config change plus
   re-sync), which is a product decision, not housekeeping.
 
-**Compacting the Monero chain** (reclaim bloat; takes hours, but no downtime until the swap):
+**Compacting the Monero chain** (reclaim bloat; takes hours, no downtime for the copy).
+
+`monero-blockchain-prune` is copy-then-swap: once it has built `lmdb-pruned` it renames `lmdb` to
+`lmdb-old` and moves the pruned DB into place itself (#1489). Pointed straight at a live data dir
+that renames the live chain out from under a running monerod, silently until the next restart. So
+run it against a bind mount, which makes the kernel refuse that rename:
 
 ```bash
-tests/integration/compact-chain.sh <data-dir>/monero   # builds lmdb-pruned/ (monerod stays up)
-# when DONE, swap it in (brief downtime):
+mkdir -p <build-dir>/lmdb
+sudo mount --bind <data-dir>/monero/lmdb <build-dir>/lmdb
+mv <build-dir>/lmdb <build-dir>/x   # MUST answer "Device or resource busy" — prove the guard first
+tests/integration/compact-chain.sh <build-dir>   # monerod stays up; result at <build-dir>/lmdb-pruned
+```
+
+Then swap the compact copy in (brief downtime):
+
+```bash
 docker stop monerod
-cd <data-dir>/monero && mv lmdb lmdb.bloated && mv lmdb-pruned lmdb
+sudo umount <build-dir>/lmdb
+cd <data-dir>/monero && mv lmdb lmdb.bloated && mv <build-dir>/lmdb-pruned lmdb
 docker start monerod        # re-syncs the few blocks added during the copy
 # confirm `pithead status` healthy, then: rm -rf lmdb.bloated
 ```


### PR DESCRIPTION
Addresses #1489 — kept open deliberately until the guarded-build outcome is posted there (closing keyword removed at merge by the controller, per the standing ruling).

## The defect

`tests/integration/compact-chain.sh`'s header asserted a safety property the underlying tool does not have:

```
#  * It only READS the source, through a consistent LMDB snapshot, so it is safe to run while
#    monerod is up and mining — zero downtime during the copy; the source is never modified.
```

`monero-blockchain-prune` (v0.18.5.0) is **copy-then-swap**. After building `<data-dir>/lmdb-pruned` it renames `<data-dir>/lmdb` to `<data-dir>/lmdb-old` and moves the pruned DB into place.

Pointed at a live node's data dir, that renames the live chain out from under a running `monerod`. Nothing fails at the time — the process keeps its open descriptors — and the next restart silently comes up pruned, with a full-size stale chain beside it eating disk. The header then told the reader to perform the swap by hand, which is the tell that its author did not know the tool does it.

## What was RUN

- **Extracted the code path from the binary.** It carries `Swapping databases, pre-pruning blockchain will be left in`, `-old and can be removed if desired`, `Blockchain pruned OK, but renaming failed` and `Error renaming`.
- **Read the flag's help text.** `--copy-pruned-database` is *"Copy database anyway if already pruned"* — it lifts an early-exit guard on an already-pruned source, it is not a copy-only mode switch.
- **Corroborated by an independent route inside this repo.** `build-pruned-chain.sh` reads its result back from `$DST_DIR/lmdb`, not `$DST_DIR/lmdb-pruned` — only correct if the tool swapped. The two scripts contradicted each other about the same binary, and the one agreeing with the binary's strings is the one expecting a swap.
- **Proved the bind-mount guard before relying on it**, as a positive control rather than an assumption:
  ```
  mv: cannot move '<build-dir>/lmdb' to '<build-dir>/lmdb-renametest': Device or resource busy
  ```
- **Lints, all green:** `shellcheck --severity=warning` on both changed scripts; `shfmt -i 4 -d` over the Makefile's exact glob; `make lint-md` (0 errors, 47 files); `make lint-docs-voice` (40 prose docs); `make lint-file-budget`.
- A pruned-chain build is running right now on the harness box under the bind-mount guard, reading the live chain with monerod up and mining. The live node stayed `synchronized` at the same height across the start of the copy.

## What was NOT run, and what is inferred

- **`make lint-sh` was not run** — it is this box's OOM path and is serialized across lanes. Substituted with targeted `shellcheck` over both changed files plus `shfmt` over the Makefile's exact glob, which is the standing substitute here.
- **No new test.** These are one-shot operator tools with no assertions to hang a tier on, and a test that asserts the content of a comment would prove nothing. The evidence that carries this change is the binary's own strings plus the `EBUSY` guard demonstrated above. Naming that rather than inventing coverage.
- **Inferred, not yet confirmed:** that the swap fires at the end of *this* code path, as opposed to only some other path. Everything above establishes the tool contains the swap and that the header's flat "the source is never modified" is unsupportable; it does not by itself prove the rename executes on every completion. The running build settles it safely — under the bind mount, a firing swap logs `Blockchain pruned OK, but renaming failed`. I will post the result on #1489 either way.

The fix does not depend on that outcome: a header asserting the source is never modified, on a binary that contains explicit code to rename it, is wrong as written.

## Scope

- `tests/integration/compact-chain.sh` — header corrected; bind-mount recipe documented (lane path).
- `tests/integration/build-pruned-chain.sh` — notes that step 4 is safe because it targets the copy, and why the size is read back from `lmdb/` (lane path).
- `docs/dev/release-server.md` — the same false premise appeared there, telling the reader to "swap the compact copy in during a ~2 min window". Shared `docs/`, disclosed here as required.
- `docs/hardware.md` — one clause folded into the existing sizing parenthetical: stop monerod before running the tool. Shared `docs/`, disclosed here (addendum added at merge; delta commit `1e12d6c`).
- `tests/integration/testbench-README.md` — the fourth-artefact recipe replaced with the guarded bind-mount recipe matching `compact-chain.sh`'s header (delta commit `b9d0549`, addressing the round-one blocking finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8qHpoXBs7pMX7Tq19GEiq

## Ponytail pass

The plugin's skill is not registered in this session, so I read its definition and ran the pass against the diff myself:

```
release-server.md:L333-350: shrink: the bind-mount recipe duplicates compact-chain.sh's
  header verbatim — the exact duplication that let the original false claim drift between
  script and doc. Warning + pointer to the script.
build-pruned-chain.sh:L12-17: shrink: 6-line note, 3 lines carry it.
net: -13 lines possible.
```

Both applied in `398a3d0`. The first finding indicts the fix itself: #1489 exists *because* a safety claim was duplicated between a script header and a runbook and the copies drifted. Restating the recipe in both places would have rebuilt that trap, so the runbook now carries the warning and points at the script for the recipe — one canonical copy.

