### PR TITLE
feat(e2e): let remote-mode scenarios target a non-default node port (#1491)

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -126,7 +126,7 @@ render_scenario_config() {
 # the final override string and returns 0; on a missing prerequisite sets SKIP_REASON and
 # returns 1 — no silent drops, and never a prune flip on the canonical synced DB (which would
 # invalidate it). Reads the globals BASELINE_PRUNE / PRUNED_DATA_DIR / FULL_DATA_DIR /
-# REMOTE_MONERO_HOST / REMOTE_TARI_HOST / IT_MONERO_VIEW_KEY / IT_TARI_VIEW_KEY /
+# REMOTE_MONERO_HOST (+_RPC_PORT/_ZMQ_PORT) / REMOTE_TARI_HOST / IT_MONERO_VIEW_KEY / IT_TARI_VIEW_KEY /
 # IT_TARI_SPEND_PUBLIC_KEY (all optional). Pure given those globals, so the self-test exercises it.
 RESOLVED=""
 SKIP_REASON=""
@@ -169,17 +169,17 @@ resolve_overrides() {
         out="$out monero.data_dir=$FULL_DATA_DIR"
     fi
 
-    # Remote mode needs an external endpoint to point at.
+    # Remote mode needs an external endpoint; the host must be BARE, never host:port (#1491).
     if [ "$mode" = "remote" ]; then
         [ -n "${REMOTE_MONERO_HOST:-}" ] || {
             SKIP_REASON="needs --remote-monero-host"
             return 1
         }
         out="$out monero.remote.host=$REMOTE_MONERO_HOST"
+        out="$out${REMOTE_MONERO_RPC_PORT:+ monero.remote.rpc_port=$REMOTE_MONERO_RPC_PORT}${REMOTE_MONERO_ZMQ_PORT:+ monero.remote.zmq_port=$REMOTE_MONERO_ZMQ_PORT}"
     fi
 
-    # tari.mode remote (#103/#942) needs its own external endpoint — same shape as monero's above,
-    # a separate global since the two chains can point at different remote hosts.
+    # tari.mode remote (#103/#942) needs its own endpoint — same shape, its own global.
     if [ "$tari_mode" = "remote" ]; then
         [ -n "${REMOTE_TARI_HOST:-}" ] || {
             SKIP_REASON="needs --remote-tari-host"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -57,6 +57,8 @@ KEEP_STATE=0
 EXPECTED_WORKERS=2
 SKIP_MINING_ASSERTS=0
 REMOTE_MONERO_HOST=""
+REMOTE_MONERO_RPC_PORT=""
+REMOTE_MONERO_ZMQ_PORT=""
 REMOTE_TARI_HOST=""
 PRUNED_DATA_DIR=""
 FULL_DATA_DIR=""
@@ -95,8 +97,10 @@ MATRIX:
   --no-mining-asserts    SKIP the two mining assertions (workers online, stratum hashes) with a
                          logged notice — for a box with no miner connected (e2e --no-miner, #905).
                          Every other assertion stays binding.
-  --remote-monero-host <h>  external node endpoint for the remote-mode scenario
-                            (e.g. the box's own synced node on its LAN IP)
+  --remote-monero-host <h>  external node for the remote-mode scenario — a BARE host or IP, never
+                            host:port (pithead appends the port itself, #1491)
+  --remote-monero-rpc-port <p>  that node's RPC port, when it is not the default 18081
+  --remote-monero-zmq-port <p>  that node's ZMQ port, when it is not the default 18083
   --remote-tari-host <h>  external Tari node endpoint for the tari.mode=remote scenario (#103;
                          e.g. an already-synced Tari node on the LAN)
   --pruned-data-dir <d>  synced PRUNED monero data dir (enables the pruned case when the
@@ -229,7 +233,31 @@ parse_args() {
             shift
             ;;
         --remote-monero-host)
+            case "${2:-}" in
+            *:*)
+                it_err "--remote-monero-host takes a BARE host or IP, not host:port — pithead renders the port separately (--remote-monero-rpc-port). Got \"$2\"."
+                exit 2
+                ;;
+            esac
             REMOTE_MONERO_HOST="$2"
+            shift 2
+            ;;
+        --remote-monero-rpc-port | --remote-monero-zmq-port)
+            case "${2:-}" in
+            "" | *[!0-9]*)
+                it_err "$1 takes a TCP port 1-65535. Got \"${2:-}\"."
+                exit 2
+                ;;
+            esac
+            if [ "$2" -lt 1 ] || [ "$2" -gt 65535 ]; then
+                it_err "$1 takes a TCP port 1-65535. Got \"$2\"."
+                exit 2
+            fi
+            if [ "$1" = "--remote-monero-rpc-port" ]; then
+                REMOTE_MONERO_RPC_PORT="$2"
+            else
+                REMOTE_MONERO_ZMQ_PORT="$2"
+            fi
             shift 2
             ;;
         --remote-tari-host)

--- a/tests/integration/selftest-remote-endpoint.sh
+++ b/tests/integration/selftest-remote-endpoint.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Self-test for the remote-node endpoint overrides (#1491) — the ports resolve_overrides emits
+# for monero.mode=remote, and run.sh's refusal of a host:port string.
+#
+# pithead renders monero.remote.host and monero.remote.rpc_port SEPARATELY
+# (lib/pithead/99-remainder.sh), so a "host:port" passed as the host is appended to a second
+# time and reaches the box as host:port:port. The harness could not express a non-default port
+# at all before #1491, which is why remote mode could only ever be pointed at 18081/18083.
+#
+# These cases live in their own file rather than in selftest.sh because that file sits
+# exactly on its recorded budget ceiling, and ceilings only go down.
+#
+# Run: tests/integration/selftest-remote-endpoint.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+assert_absent() { case "$2" in *"$3"*) it_fail "$1" "[$2] should not carry [$3]" ;; *) it_pass "$1" ;; esac }
+
+echo "== remote endpoint: ports are emitted only when set, and only in remote mode (#1491) =="
+
+BASELINE_PRUNE=1
+REMOTE_MONERO_HOST="10.0.0.5"
+
+# Unset ports must emit nothing, so the product's own defaults stand. A test that only checked
+# the "set" case would pass just as well against code that hardcoded the defaults.
+REMOTE_MONERO_RPC_PORT="" REMOTE_MONERO_ZMQ_PORT=""
+resolve_overrides "monero.mode=remote"
+assert_rc "remote resolves with a bare host" "$?" "0"
+assert_contains "bare host is passed through" "$RESOLVED" "monero.remote.host=10.0.0.5"
+assert_absent "no rpc_port override when unset" "$RESOLVED" "monero.remote.rpc_port"
+assert_absent "no zmq_port override when unset" "$RESOLVED" "monero.remote.zmq_port"
+
+REMOTE_MONERO_RPC_PORT="28081" REMOTE_MONERO_ZMQ_PORT="28083"
+resolve_overrides "monero.mode=remote"
+assert_rc "remote resolves with ports" "$?" "0"
+assert_contains "rpc_port override is emitted" "$RESOLVED" "monero.remote.rpc_port=28081"
+assert_contains "zmq_port override is emitted" "$RESOLVED" "monero.remote.zmq_port=28083"
+assert_contains "host survives alongside the ports" "$RESOLVED" "monero.remote.host=10.0.0.5"
+
+# The near-miss sibling: local mode must not pick the ports up just because they are set.
+# Without this case the emission could be unconditional and every assertion above still passes.
+resolve_overrides "monero.mode=local monero.prune=true"
+assert_absent "local mode ignores rpc_port" "$RESOLVED" "monero.remote.rpc_port"
+assert_absent "local mode ignores zmq_port" "$RESOLVED" "monero.remote.zmq_port"
+
+# Ports are not a substitute for the host: the skip must still fire, naming the flag.
+REMOTE_MONERO_HOST=""
+resolve_overrides "monero.mode=remote"
+assert_rc "ports alone do not satisfy remote mode" "$?" "1"
+assert_contains "skip still names --remote-monero-host" "$SKIP_REASON" "--remote-monero-host"
+
+echo "== run.sh refuses a host:port string for --remote-monero-host (#1491) =="
+
+# Assert the REASON, not the exit code: run.sh also exits non-zero for "no --host/--local", so an
+# rc-only case passes whether or not the host:port guard exists at all.
+out=$(bash "$HERE/run.sh" --remote-monero-host 10.0.0.5:18081 2>&1)
+assert_rc "host:port is refused" "$?" "2"
+assert_contains "refusal explains the bare-host rule" "$out" "BARE host or IP"
+
+out=$(bash "$HERE/run.sh" --remote-monero-rpc-port 0 --local 2>&1)
+assert_rc "port 0 is refused" "$?" "2"
+assert_contains "port refusal names the range" "$out" "1-65535"
+
+out=$(bash "$HERE/run.sh" --remote-monero-rpc-port 99999 --local 2>&1)
+assert_rc "port 99999 is refused" "$?" "2"
+assert_contains "out-of-range port names the range" "$out" "1-65535"
+
+echo ""
+echo "selftest-remote-endpoint: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-remote-endpoint.sh
+++ b/tests/integration/selftest-remote-endpoint.sh
@@ -70,6 +70,16 @@ out=$(bash "$HERE/run.sh" --remote-monero-rpc-port 99999 --local 2>&1)
 assert_rc "port 99999 is refused" "$?" "2"
 assert_contains "out-of-range port names the range" "$out" "1-65535"
 
+# A non-numeric port needs its own case: without the *[!0-9]* guard the range check below it
+# runs "[ abc -lt 1 ]", which errors rather than returning false, so the value is ACCEPTED.
+out=$(bash "$HERE/run.sh" --remote-monero-rpc-port abc --local 2>&1)
+assert_rc "non-numeric port is refused" "$?" "2"
+assert_contains "non-numeric port names the range" "$out" "1-65535"
+
+out=$(bash "$HERE/run.sh" --remote-monero-zmq-port 1x --local 2>&1)
+assert_rc "part-numeric zmq port is refused" "$?" "2"
+assert_contains "part-numeric port names the range" "$out" "1-65535"
+
 echo ""
 echo "selftest-remote-endpoint: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Fixes #1491.

## The defect

`resolve_overrides` emitted only `monero.remote.host`, so `monero.remote.rpc_port` and `monero.remote.zmq_port` always fell back to their defaults. The gate could therefore only ever point remote mode at a node on 18081/18083 — while `pithead` itself ships, validates and renders both ports (`99-remainder.sh:5852-5854` keeps `mono_host` and `rpc_port` separate). A gate that cannot express its own product's supported configuration.

Passing `host:port` as the host is the natural workaround and it fails silently: `is_valid_host` permits `:`, and both product and harness append the port themselves, so `lib.sh:384` builds `http://<host>:<port>:18081`. `run.sh` now refuses that outright and says why.

## Why it matters beyond tidiness

It blocks #1446. The standalone-node topology needs the remote node on a non-default port, because the live stack's `monerod` runs with `rpc_lan_access: true` and binds `0.0.0.0:18081` — and the matrix's own `local-pruned-main-rpclan` row makes the stack under test take the same wildcard bind during a run. There is no arrangement where the remote node sits on 18081.

## What was RUN

- **22 tier-1 cases** (the count below was corrected 18→22 at merge by the controller; the review pass executed the file: 22 passed, 0 failed, matching CI's own job log), in a new `selftest-remote-endpoint.sh`. `selftest.sh` sits exactly on its recorded budget ceiling and ceilings only go down, so new cases cannot go there; the runner globs `selftest*.sh` (`Makefile:29`), so a new file needs no registration.
- **A 7-mutation battery, all 7 killed.** The battery asserts each pattern matches before writing, so a no-op replace fails loudly instead of reading as "the test survived".

```
M1 drop rpc_port emission              KILLED by: rpc_port override is emitted
M2 drop zmq_port emission              KILLED by: zmq_port override is emitted
M3 emit rpc_port unconditionally       KILLED by: no rpc_port override when unset
M4 emit ports outside the remote block KILLED by: local mode ignores rpc_port / zmq_port
M5 drop the host:port refusal          KILLED by: refusal explains the bare-host rule
M6 drop the port range check           KILLED by: port 0 / 99999 refused, refusal names the range
M7 accept a non-numeric port           KILLED by: non-numeric port is refused, names the range
```

Two of those are worth reading rather than counting:

- **M5 was killed only by the message assertion, never by the exit code.** With the guard gone `run.sh` still exits 2, via "Provide --host/--local" — so an rc-only case would have passed whether or not the guard existed. Assert the reason, not the count.
- **M7 SURVIVED the first battery, and the code was right.** Dropping the `*[!0-9]*` guard changed no outcome because I had no non-numeric case. Without that guard the range check below runs `[ abc -lt 1 ]`, which *errors* rather than returning false, so the `if` body is skipped and the bad value is accepted. The fix was the two missing cases, not a change to the guard.

- **Lints green:** `selftest.sh` itself 214 passed / 0 failed (that file's own count, not the suite total; the full 11-file selftest run is green — clarified at merge), `shellcheck --severity=warning` over `tests/integration/*.sh`, `shfmt -i 4 -d` over the Makefile's exact glob, `make lint-file-budget`, `make lint-topology`, `make lint-md`.

## What was NOT run

- **`make lint-sh` was not run** — it is this box's OOM path and is serialized across lanes. Substituted with the targeted `shellcheck` + full-glob `shfmt` above, which is the standing substitute here.
- **No live run against a real remote node.** That is #1446 and it is blocked on a chain build in progress. This change is what unblocks it; it does not itself prove remote mode passes.
- `tari.remote.grpc_port` has the identical gap behind `--remote-tari-host`. Deliberately left out rather than bundled unproven — recorded in #1491.

## Budget, disclosed

`tests/integration/lib.sh` was at 692 lines against a ceiling of 692, so this change had to pay for itself. It does: the two port overrides go on one `${VAR:+…}` line, the remote-mode comment stays one line (the full reasoning lives in the new selftest's header and in #1491), and the adjacent Tari comment is tightened from two lines to one. The file lands back at exactly 692. **It is now full** — the `tari.remote.grpc_port` sibling above will need a split before it can land.

`shfmt` reverts the compact `{ …; return 1; }` brace form, so that is not available as headroom; both guards keep the expanded form.

## Ponytail pass

The plugin's skill is not registered in this session, so I read its definition and ran the pass myself:

```
run.sh:L256-260: shrink: 5-line if/else assigns one of two vars from a shared case arm.
  case "$1" in *rpc-port) A="$2";; *) B="$2";; esac — 4 lines.
run.sh:L248,253: delete: the "1-65535" refusal text appears twice.
net: -2 lines possible.
```

**Noted, not applied**, which the gate allows. The two refusal texts are reached by two genuinely different rejections (non-numeric vs out-of-range) and the mutation battery kills them independently — collapsing them would couple two cases that currently fail for distinct reasons. The `if/else` saves one line at the cost of matching flag names by glob, and both alternatives are net-negative for `run.sh`, which has 31 lines of headroom and is not the constrained file here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8qHpoXBs7pMX7Tq19GEiq

