### PR TITLE
test(e2e): assert the Monero node actually publishes ZMQ block notifications (#1497)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -317,6 +317,17 @@ and `--list` prints it).
 - `pithead status` exit code: `0` for a healthy config.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.
+- The Monero node publishes block notifications. A ZMTP handshake against the node's ZMQ port
+  succeeds and the peer advertises a publisher socket type ([#1497](https://github.com/p2pool-starter-stack/pithead/issues/1497)). This is a separate
+  assertion from "Monero is synced" because the sync check cannot fail for a node that can never
+  publish: an `--offline` monerod reports `status: OK` with `target_height: 0`, which satisfies
+  both halves of the caught-up predicate. Nothing downstream covered the gap either — p2pool's
+  healthcheck is a TCP connect to its own stratum port — so a ZMQ-dead node brought the stack up
+  green and starved p2pool with nothing able to notice. A bare TCP dial does not close it: a
+  docker-published port with nothing behind it accepts the connection in `docker-proxy` itself and
+  answers a dial with rc 0. Measured on one host, three targets: the live node and the
+  published-but-dead port were indistinguishable to a dial (both rc 0) and separated by the
+  handshake. Real nodes advertise `XPUB` rather than `PUB`; both are accepted.
 - End-to-end mining. Workers are online (`proxy_workers >= --workers`), stratum has connections,
   and total hashes are accumulating ([#28](https://github.com/p2pool-starter-stack/pithead/issues/28)).
 - Posture propagated. `MONERO_RPC_BIND`, `DASHBOARD_SECURE`, `XVB_ENABLED`, and `TARI_REQUIRED`
@@ -610,6 +621,9 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 `selftest-skip-accounting.sh` is the one that keeps the skip accounting honest: besides checking
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
+`selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures, so
+every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
+READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack.
 
 ---
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -31,6 +31,8 @@ source "$HERE/rig-key-ledger.sh" # must precede any module that marks a write (#
 source "$HERE/rigforge-writable-keys.sh"
 # shellcheck source=tests/integration/rigforge-upgrade.sh
 source "$HERE/rigforge-upgrade.sh"
+# shellcheck source=tests/integration/zmq-probe.sh
+source "$HERE/zmq-probe.sh"
 
 # --- Defaults / globals -----------------------------------------------------
 IT_MODE="ssh"
@@ -626,6 +628,25 @@ assert_running_state() {
 
     # 4. Monero caught up — per monerod's own get_info, not the dashboard UI field.
     if monero_caught_up; then it_pass "monerod reports synced (RPC)"; else it_fail "monerod reports synced (RPC)" "get_info not synchronized"; fi
+    # 4b. The node actually PUBLISHES block notifications (#1497). The check above is satisfied by
+    #     a node that can never publish one — an --offline monerod reports status OK with
+    #     target_height 0, so both disjuncts of monero_caught_up pass. Nothing downstream covers
+    #     the gap either: p2pool's healthcheck is a TCP connect to its OWN stratum port, so a
+    #     stack whose node is ZMQ-dead comes up green and starves p2pool silently. Neither does
+    #     the installer preflight, whose reachability dial is a bare TCP connect and therefore
+    #     passes on a docker-published port with nothing behind it (measured). This is a
+    #     protocol-level ZMTP handshake, which an accept() cannot satisfy.
+    #     Tier A only — asserting an OBSERVED notification needs a MOVING tip, and a height
+    #     comparison cannot discriminate against a STATIC node (#1497).
+    local zmq_host zmq_port zv
+    if [ "$mode" = "remote" ]; then
+        zmq_host="$REMOTE_MONERO_HOST"
+        zmq_port="${REMOTE_MONERO_ZMQ_PORT:-18083}"
+    else
+        zmq_host="127.0.0.1"
+        zmq_port="18083"
+    fi
+    if zv=$(zmq_pub_probe "$zmq_host" "$zmq_port" 8); then it_pass "monero ZMQ publishes block notifications (#1497)"; else it_fail "monero ZMQ publishes block notifications (#1497)" "$zv"; fi
     # The dashboard's sync panel must also read "done" for a synced node — not stay stuck at
     # "loading". A synced monerod reports target_height 0, so the panel has to trust the caught-up
     # flag, not percent-vs-target; getting that wrong left a synced node "loading" forever (the real

--- a/tests/integration/selftest-zmq-probe.sh
+++ b/tests/integration/selftest-zmq-probe.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# Self-test for the ZMTP PUB probe (#1497) — the verdicts, driven from captured and hand-built
+# wire fixtures, with no socket and no stack.
+#
+# The probe exists because a bare TCP dial cannot tell a live ZMQ publisher from a
+# docker-published port with nothing behind it. Proven on the bench 2026-08-29, one host, three
+# targets, the preflight's exact gesture (`timeout 5 bash -c "</dev/tcp/host/port"`) beside it:
+#
+#   live monerod ZMQ 18083     preflight rc=0   probe: ok … Socket-Type XPUB
+#   published-but-dead 28099   preflight rc=0   probe: no-greeting            <- the finding
+#   closed 28098               preflight rc=1   probe: connect-refused
+#
+# The middle row is the whole point: the dial passes, the probe reds.
+#
+# These cases live in their own file because selftest.sh sits exactly on its recorded budget
+# ceiling, and ceilings only go down.
+#
+# Run: tests/integration/selftest-zmq-probe.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+# shellcheck source=tests/integration/zmq-probe.sh
+source "$HERE/zmq-probe.sh"
+
+# CAPTURED from the live monerod on the bench, 2026-08-29 — not hand-built, so these two cases
+# fail if the real wire format ever moves out from under the parser.
+LIVE_GREETING=ff00000000000000017f03014e554c4c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+LIVE_READY=041a0552454144590b536f636b65742d547970650000000458505542
+# Hand-built frames for the cases a live node will not produce.
+READY_SUB=04190552454144590b536f636b65742d5479706500000003535542
+READY_NO_SOCKET_TYPE=0413055245414459084964656e7469747900000000
+READY_DECOY=043005524541445906582d4e6f74650000000b536f636b65742d547970650b536f636b65742d547970650000000458505542
+READY_LONG=06000000000000001a0552454144590b536f636b65742d547970650000000458505542
+GREETING_ZMTP2=ff00000000000000007f01004e554c4c000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+GREETING_HTTP=485454502f312e312034303020426164205265717565737400000000000000000000000000000000000000000000000000000000000000000000000000000000
+
+echo "== wire constants are the shape ZMTP 3.x demands (#1497) =="
+
+# A greeting that is not exactly 64 bytes is rejected by the peer, and the failure would look
+# like a dead node. Assert the literal rather than trusting a hand count.
+assert_eq "greeting is 64 bytes" "$(printf "$ZMQ_GREETING_BYTES" | wc -c)" "64"
+assert_eq "READY frame is 27 bytes" "$(printf "$ZMQ_READY_BYTES" | wc -c)" "27"
+assert_eq "READY frame declares its 25-byte body" \
+    "$(printf "$ZMQ_READY_BYTES" | head -c 2 | tail -c 1 | od -An -tu1 | tr -d ' ')" "25"
+
+echo "== greeting verdict =="
+
+v=$(zmq_greeting_verdict "$LIVE_GREETING")
+rc=$?
+assert_rc "live monerod greeting is accepted" "$rc" "0"
+assert_eq "live greeting reports ZMTP 3.1 / NULL" "$v" "ok 3.1 NULL"
+
+# The class that matters: an accept() with no bytes. This is what the preflight's dial cannot see.
+v=$(zmq_greeting_verdict "")
+rc=$?
+assert_rc "silent peer is refused" "$rc" "1"
+assert_contains "silent peer is named no-greeting" "$v" "no-greeting"
+
+v=$(zmq_greeting_verdict "ff00000000")
+rc=$?
+assert_rc "truncated greeting is refused" "$rc" "1"
+assert_contains "truncated greeting is named short-greeting" "$v" "short-greeting"
+
+# A full-length reply from a listener that is not ZMQ at all must not slip through on length.
+v=$(zmq_greeting_verdict "$GREETING_HTTP")
+rc=$?
+assert_rc "non-ZMTP listener is refused" "$rc" "1"
+assert_contains "non-ZMTP listener is named bad-signature" "$v" "bad-signature"
+
+# ZMTP 2.0 carries a correct signature, so only the version check rejects it.
+v=$(zmq_greeting_verdict "$GREETING_ZMTP2")
+rc=$?
+assert_rc "ZMTP 2.0 peer is refused" "$rc" "1"
+assert_contains "ZMTP 2.0 peer is named bad-version" "$v" "bad-version"
+
+echo "== READY / Socket-Type verdict =="
+
+v=$(zmq_ready_socket_type "$LIVE_READY")
+rc=$?
+assert_rc "live monerod READY parses" "$rc" "0"
+assert_eq "live monerod advertises XPUB" "$v" "ok XPUB"
+
+# Reads the VALUE, not a constant: the same parser must report a different socket type.
+assert_eq "a SUB peer is reported as SUB" "$(zmq_ready_socket_type "$READY_SUB")" "ok SUB"
+
+# Long-frame encoding is legal ZMTP and no live node here produces it, so it needs its own case.
+assert_eq "a LONG-framed READY parses" "$(zmq_ready_socket_type "$READY_LONG")" "ok XPUB"
+
+# The near-miss sibling: a property whose VALUE is the literal "Socket-Type" precedes the real
+# one. A substring match would answer with the decoy; walking the metadata answers XPUB.
+assert_eq "a decoy Socket-Type VALUE does not win" "$(zmq_ready_socket_type "$READY_DECOY")" "ok XPUB"
+
+v=$(zmq_ready_socket_type "")
+rc=$?
+assert_rc "greeting-then-silence is refused" "$rc" "1"
+assert_contains "greeting-then-silence is named no-ready" "$v" "no-ready"
+
+v=$(zmq_ready_socket_type "$READY_NO_SOCKET_TYPE")
+rc=$?
+assert_rc "READY without Socket-Type is refused" "$rc" "1"
+assert_contains "missing Socket-Type is named" "$v" "no-socket-type"
+
+v=$(zmq_ready_socket_type "0019$(printf '%s' "$READY_SUB" | cut -c5-)")
+rc=$?
+assert_rc "a non-COMMAND first frame is refused" "$rc" "1"
+assert_contains "non-COMMAND frame is named malformed-ready" "$v" "malformed-ready"
+
+echo "== the composed verdict, over raw target output (pure — no socket) =="
+
+v=$(zmq_pub_verdict "GREETING $LIVE_GREETING
+READY $LIVE_READY" 10.0.0.5 18083)
+rc=$?
+assert_rc "a real XPUB publisher passes" "$rc" "0"
+assert_contains "the pass names the socket type" "$v" "XPUB"
+
+v=$(zmq_pub_verdict "GREETING $LIVE_GREETING
+READY $READY_SUB" 10.0.0.5 18083)
+rc=$?
+assert_rc "a ZMTP peer that is not a publisher is refused" "$rc" "1"
+assert_contains "non-publisher is named socket-type-mismatch" "$v" "socket-type-mismatch"
+
+v=$(zmq_pub_verdict "CONNECT-FAIL" 10.0.0.5 28098)
+rc=$?
+assert_rc "an unreachable port is refused" "$rc" "1"
+assert_contains "unreachable port is named connect-refused" "$v" "connect-refused"
+
+# The published-but-dead port, end to end: the snippet ran and the peer sent nothing. This is
+# the row the preflight's dial reports as reachable.
+v=$(zmq_pub_verdict "GREETING
+READY" 10.0.0.5 28099)
+rc=$?
+assert_rc "a published-but-dead port is refused" "$rc" "1"
+assert_contains "published-but-dead port is named no-greeting" "$v" "no-greeting"
+
+# The verdict must name the endpoint it judged — a bare reason in a matrix log is unattributable.
+assert_contains "the verdict names host:port" "$v" "28099"
+
+echo ""
+echo "selftest-zmq-probe: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/zmq-probe.sh
+++ b/tests/integration/zmq-probe.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# Protocol-level ZMQ (ZMTP 3.x) probe for monerod's block-notification PUB socket (#1497).
+#
+# Why a protocol probe and not a TCP dial. The installer preflight's reachability check for
+# monero.remote.zmq_port is a bare TCP connect, and a bare TCP connect SUCCEEDS against a
+# docker-published port with nothing behind it — docker-proxy accepts the connection itself.
+# Measured on the bench 2026-08-29: a `sleep` container publishing 127.0.0.1:28099->19999
+# answered the preflight's exact gesture with rc=0. Nothing downstream covers ZMQ either:
+# p2pool's healthcheck is a TCP connect to its OWN stratum port, and before this file
+# `git grep -niE zmq -- tests/integration/` returned ZERO. So an offline or ZMQ-dead node can
+# pass the preflight, pass monero_caught_up, bring the stack up, and starve p2pool with nothing
+# able to notice — a SKIPPED->PASSED with no failure mode, which is worse than the skip.
+#
+# An accept() cannot satisfy this probe: it speaks the ZMTP 3.x greeting and the NULL-mechanism
+# READY exchange, and it reads the peer's advertised Socket-Type.
+#
+# Deliberately stops at the handshake (tier A). Asserting an OBSERVED block notification needs a
+# MOVING chain tip, and a height comparison cannot discriminate against a STATIC node — a frozen
+# p2pool view and a frozen monerod agree forever. That tier is not buildable on a static node;
+# see #1497.
+#
+# Split: the socket I/O runs ON THE TARGET through rx (the harness ships shell snippets, never
+# files), and returns hex. Every verdict below it is a PURE function of that hex, so the
+# self-test can drive each failure class from a fixture with no socket at all.
+#
+# shellcheck shell=bash
+
+# The 64-byte ZMTP 3.1 greeting: signature (0xff, 8 pad, 0x7f), version 3.1, mechanism "NULL"
+# NUL-padded to 20, as-server 0, 31 filler. Length is asserted by the self-test, not by eye.
+ZMQ_GREETING_BYTES='\xff\x00\x00\x00\x00\x00\x00\x00\x00\x7f\x03\x01NULL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+# A short COMMAND frame carrying READY with one property, Socket-Type=SUB (25-byte body).
+ZMQ_READY_BYTES='\x04\x19\x05READY\x0bSocket-Type\x00\x00\x00\x03SUB'
+
+# --- Pure verdicts over the hex the target returns ---------------------------
+
+# Two hex chars at byte offset $2 of hex string $1.
+zmq_hex_byte() { printf '%s' "${1:$(($2 * 2)):2}"; }
+
+# Decode a hex string to ASCII, dropping NUL padding. Pure.
+zmq_hex_ascii() {
+    local h="$1" out="" i pair
+    for ((i = 0; i < ${#h}; i += 2)); do
+        pair="${h:i:2}"
+        [ "$pair" = "00" ] && continue
+        out+=$(printf '\\x%s' "$pair")
+    done
+    printf '%b' "$out"
+}
+
+# zmq_greeting_verdict <hex> -> prints "ok <major>.<minor> <mechanism>" or "<reason> <detail>".
+# Returns 0 only for a well-formed ZMTP >=3 greeting. The `no-greeting` class is the one that
+# matters: it is exactly what a published-but-dead port looks like.
+zmq_greeting_verdict() {
+    local h="${1,,}"
+    if [ -z "$h" ]; then
+        echo "no-greeting peer accepted the connection but sent no ZMTP greeting — a docker-published port with nothing behind it, or a listener that is not ZMQ at all"
+        return 1
+    fi
+    if [ "${#h}" -lt 128 ]; then
+        echo "short-greeting peer sent ${#h} hex chars, want 128 (64 bytes)"
+        return 1
+    fi
+    if [ "$(zmq_hex_byte "$h" 0)" != "ff" ] || [ "$(zmq_hex_byte "$h" 9)" != "7f" ]; then
+        echo "bad-signature not a ZMTP peer (signature $(zmq_hex_byte "$h" 0)…$(zmq_hex_byte "$h" 9), want ff…7f)"
+        return 1
+    fi
+    local major minor
+    major=$((16#$(zmq_hex_byte "$h" 10)))
+    minor=$((16#$(zmq_hex_byte "$h" 11)))
+    if [ "$major" -lt 3 ]; then
+        echo "bad-version peer speaks ZMTP $major.$minor, want >=3"
+        return 1
+    fi
+    echo "ok $major.$minor $(zmq_hex_ascii "${h:24:40}")"
+}
+
+# zmq_ready_socket_type <hex of the peer's command frame> -> prints "ok <SOCKET-TYPE>" or
+# "<reason> <detail>". Walks the READY metadata rather than substring-matching it, so a
+# Socket-Type appearing inside another property's value cannot be mistaken for the real one.
+zmq_ready_socket_type() {
+    local h="${1,,}" flags size i=0 want
+    if [ -z "$h" ]; then
+        echo "no-ready peer completed the greeting then sent no READY command"
+        return 1
+    fi
+    flags=$((16#$(zmq_hex_byte "$h" 0)))
+    if ((flags & 0x04)); then :; else
+        echo "malformed-ready first frame is not a COMMAND (flags $(zmq_hex_byte "$h" 0))"
+        return 1
+    fi
+    if ((flags & 0x02)); then
+        size=$((16#${h:2:16}))
+        i=9
+    else
+        size=$((16#$(zmq_hex_byte "$h" 1)))
+        i=2
+    fi
+    local body="${h:$((i * 2)):$((size * 2))}"
+    if [ "${#body}" -lt $((size * 2)) ]; then
+        echo "malformed-ready frame claims $size bytes, got $((${#body} / 2))"
+        return 1
+    fi
+    local nlen name
+    nlen=$((16#$(zmq_hex_byte "$body" 0)))
+    name=$(zmq_hex_ascii "${body:2:$((nlen * 2))}")
+    if [ "${name^^}" != "READY" ]; then
+        echo "malformed-ready first command is [$name], want READY"
+        return 1
+    fi
+    local p=$((1 + nlen)) klen key vlen val
+    while [ "$p" -lt "$size" ]; do
+        klen=$((16#$(zmq_hex_byte "$body" "$p")))
+        p=$((p + 1))
+        key=$(zmq_hex_ascii "${body:$((p * 2)):$((klen * 2))}")
+        p=$((p + klen))
+        vlen=$((16#${body:$((p * 2)):8}))
+        p=$((p + 4))
+        val=$(zmq_hex_ascii "${body:$((p * 2)):$((vlen * 2))}")
+        p=$((p + vlen))
+        # ZMTP property names are case-insensitive (RFC 23).
+        if [ "${key,,}" = "socket-type" ]; then
+            echo "ok ${val^^}"
+            return 0
+        fi
+        want="$key"
+    done
+    echo "no-socket-type READY carried no Socket-Type property (last seen [$want])"
+    return 1
+}
+
+# --- Target-side I/O ---------------------------------------------------------
+
+# The snippet run ON THE TARGET. Bash only — the harness cannot ship files, and python3 is not
+# a dependency this harness may assume on an appliance. Reads the greeting, then the peer's
+# command frame in two steps (header, then exactly the declared body) so a silent PUB socket
+# does not cost a full timeout on the happy path.
+zmq_probe_snippet() { # <host> <port> <timeout_s>
+    cat <<EOF
+exec 3<>/dev/tcp/$1/$2 2>/dev/null || { echo "CONNECT-FAIL"; exit 0; }
+printf '$ZMQ_GREETING_BYTES' >&3
+echo "GREETING \$(timeout $3 head -c 64 <&3 | od -An -v -tx1 | tr -d ' \n')"
+printf '$ZMQ_READY_BYTES' >&3
+hdr=\$(timeout $3 head -c 2 <&3 | od -An -v -tx1 | tr -d ' \n')
+if [ \${#hdr} -eq 4 ] && [ \$((16#\${hdr:0:2} & 2)) -eq 0 ]; then
+  body=\$(timeout $3 head -c \$((16#\${hdr:2:2})) <&3 | od -An -v -tx1 | tr -d ' \n')
+else
+  body=\$(timeout $3 head -c 512 <&3 | od -An -v -tx1 | tr -d ' \n')
+fi
+echo "READY \$hdr\$body"
+exec 3<&-
+EOF
+}
+
+# zmq_pub_verdict <target-output> <host> <port> — PURE. Composes the two verdicts over the raw
+# text the target snippet printed, so every failure class is reachable in the self-test without a
+# socket. Returns 0 only for a ZMTP peer advertising a PUBLISHER socket type.
+zmq_pub_verdict() {
+    local out="$1" host="$2" port="$3" greeting ready v
+    case "$out" in *CONNECT-FAIL*)
+        echo "connect-refused no TCP connection to $host:$port"
+        return 1
+        ;;
+    esac
+    greeting=$(printf '%s\n' "$out" | sed -n 's/^GREETING //p')
+    ready=$(printf '%s\n' "$out" | sed -n 's/^READY //p')
+    # Re-emit sub-verdicts with the endpoint attached: in a matrix log a bare reason cannot be
+    # attributed to a row, and this probe runs once per scenario.
+    v=$(zmq_greeting_verdict "$greeting") || {
+        echo "${v%% *} $host:$port ${v#* }"
+        return 1
+    }
+    v=$(zmq_ready_socket_type "$ready") || {
+        echo "${v%% *} $host:$port ${v#* }"
+        return 1
+    }
+    # MEASURED, not assumed: monerod's --zmq-pub block-notification socket advertises XPUB, not
+    # PUB (Monero's zmq_pub is an XPUB so it can see subscriptions). Asserting PUB alone would
+    # have been false-red against every real node. Both are publishers; a SUB/REQ/REP/DEALER here
+    # means the port is not the block-notification feed.
+    case "$v" in "ok PUB" | "ok XPUB")
+        echo "ok $host:$port speaks ZMTP and advertises Socket-Type ${v#ok }"
+        return 0
+        ;;
+    esac
+    echo "socket-type-mismatch $host:$port is a ZMTP peer but advertises ${v#ok }, want PUB or XPUB"
+    return 1
+}
+
+# zmq_pub_probe <host> <port> [timeout_s] — the I/O shell: run the snippet on the target, then
+# hand its output to the pure verdict. Prints a one-line verdict; returns its code.
+zmq_pub_probe() {
+    local host="$1" port="$2" to="${3:-5}" out
+    out=$(rx "$(zmq_probe_snippet "$host" "$port" "$to")" 2>/dev/null)
+    zmq_pub_verdict "$out" "$host" "$port"
+}

--- a/tests/integration/zmq-probe.sh
+++ b/tests/integration/zmq-probe.sh
@@ -38,15 +38,7 @@ ZMQ_READY_BYTES='\x04\x19\x05READY\x0bSocket-Type\x00\x00\x00\x03SUB'
 zmq_hex_byte() { printf '%s' "${1:$(($2 * 2)):2}"; }
 
 # Decode a hex string to ASCII, dropping NUL padding. Pure.
-zmq_hex_ascii() {
-    local h="$1" out="" i pair
-    for ((i = 0; i < ${#h}; i += 2)); do
-        pair="${h:i:2}"
-        [ "$pair" = "00" ] && continue
-        out+=$(printf '\\x%s' "$pair")
-    done
-    printf '%b' "$out"
-}
+zmq_hex_ascii() { printf '%b' "$(printf '%s' "$1" | sed 's/../\\x&/g')" | tr -d '\0'; }
 
 # zmq_greeting_verdict <hex> -> prints "ok <major>.<minor> <mechanism>" or "<reason> <detail>".
 # Returns 0 only for a well-formed ZMTP >=3 greeting. The `no-greeting` class is the one that
@@ -79,7 +71,7 @@ zmq_greeting_verdict() {
 # "<reason> <detail>". Walks the READY metadata rather than substring-matching it, so a
 # Socket-Type appearing inside another property's value cannot be mistaken for the real one.
 zmq_ready_socket_type() {
-    local h="${1,,}" flags size i=0 want
+    local h="${1,,}" flags size i=0
     if [ -z "$h" ]; then
         echo "no-ready peer completed the greeting then sent no READY command"
         return 1
@@ -123,9 +115,8 @@ zmq_ready_socket_type() {
             echo "ok ${val^^}"
             return 0
         fi
-        want="$key"
     done
-    echo "no-socket-type READY carried no Socket-Type property (last seen [$want])"
+    echo "no-socket-type READY carried no Socket-Type property"
     return 1
 }
 


### PR DESCRIPTION
Closes nothing on its own — this is the harness half of #1497, filed against #1083/#1446.

## The hole

`git grep -niE zmq -- tests/integration/` returned **zero** at head (positive control: `sidechain` returns 22). Three separately verified findings compose into a silent failure:

1. **`monero_caught_up` cannot fail for a node that can never publish.** An `--offline` monerod reports `status: OK` with `target_height: 0` — measured on the stack's exact image, pinned by ID — so *both* disjuncts of the predicate pass.
2. **The installer preflight's reachability check is a bare TCP dial**, and a dial succeeds against a docker-published port with nothing behind it: `docker-proxy` accepts the connection itself.
3. **Nothing downstream covers it.** `build/p2pool/healthcheck.sh` is a TCP connect to p2pool's *own* stratum port. The preflight honestly defers to "the stack's own healthchecks", and the deferral lands nowhere.

Composed: a ZMQ-dead node passes the preflight, passes the sync assertion, brings the stack up green, and starves p2pool with nothing able to notice. That is a SKIPPED→PASSED with no failure mode — a silencing, which is worse than the skip, because a skip at least announces itself.

## What this adds

A ZMTP 3.x greeting plus NULL-mechanism READY exchange, which an `accept()` cannot satisfy, wired into `run.sh` as step 4b beside the existing sync assertion.

## What was RUN

**The discrimination proof — one host, three targets, the preflight's exact gesture (`timeout 5 bash -c "</dev/tcp/host/port"`) beside the probe:**

| target | preflight dial | `zmq_pub_probe` |
|---|---|---|
| live monerod ZMQ `:18083` | rc=0 | `ok … Socket-Type XPUB` |
| **published-but-dead `:28099`** | **rc=0** | **`no-greeting` (fail)** |
| closed/unpublished `:28098` | rc=1 | `connect-refused` (fail) |

The middle row is the whole point: the dial passes, the probe reds. The dead-port control was a container publishing a port with nothing listening inside it, torn down afterwards.

**Measured, not assumed:** real nodes advertise `XPUB`, not `PUB` (Monero's `zmq_pub` is an XPUB so it can observe subscriptions). Asserting `PUB` alone would have been false-red against every live node. Both are accepted; a SUB/REQ/REP peer is not.

**Mutation battery — four mutations of the probe, each killed by the case built for it,** every mutation asserted to have applied before the run:

| mutation | result |
|---|---|
| accept a silent peer | ✗ `silent peer is named no-greeting`, ✗ `published-but-dead port…` |
| substring-match `Socket-Type` instead of walking metadata | ✗ `a decoy Socket-Type VALUE does not win` |
| drop the signature check | ✗ `non-ZMTP listener is refused` (+1) |
| accept any socket type | ✗ `a ZMTP peer that is not a publisher is refused` (+1) |

Control restored: **33 passed, 0 failed.**

**Suite:** all 12 integration self-tests green, 565 cases, zero failures. The new file needs no registration — `Makefile:29` globs `tests/integration/selftest*.sh`.

**Lint:** `shellcheck 0.11.0 -x --severity=warning` clean; `shfmt -i 4 -d` clean over the Makefile's exact glob (it caught `v=$(…); rc=$?` on one line — the class that reddened #1444); `lint-file-budget`, `lint-md`, `lint-docs-voice`, `lint-operator-strings` all pass. `make lint-sh` was **not** run as a whole — it is this box's OOM path and is serialized; the targeted shellcheck plus the full shfmt glob is the documented substitute.

## Design notes worth reviewing

- **Split for testability.** The socket I/O runs on the target through `rx` (the harness ships shell snippets, never files — there is no file-shipping mechanism) and returns hex; every verdict above it is a **pure function of that hex**. The self-test stubs nothing.
- **Bash, not Python.** `rx` already guarantees bash on the target; python3 on an appliance is not a dependency this harness may assume.
- **Placement.** Cases live in a new `selftest-zmq-probe.sh` because `selftest.sh` sits exactly on its recorded budget ceiling and ceilings only go down. `run.sh` is at 2542 against a 2551 ceiling.

## What this does NOT do — stated rather than hidden

- **Tier B is not built.** Asserting an *observed* block notification requires a MOVING chain tip, and a height comparison cannot discriminate against a STATIC node — a frozen p2pool view and a frozen monerod agree forever. That is recorded on #1497, not silently omitted.
- **The preflight itself is unchanged.** The dial's blindness is real, but `lib/pithead/99-remainder.sh` is mid-cut under pure-move discipline and a behavioural change there would poison its byte-identity proofs. That fix is deliberately not on this branch.
- **The remote-mode path is wired but was exercised only in local mode.** The live positive control was a local-mode stack; the remote branch selects `$REMOTE_MONERO_HOST` / `${REMOTE_MONERO_ZMQ_PORT:-18083}` and has not yet met a real remote node.

## Shared paths

Touches `docs/dev/integration-testing.md` (`docs/` is shared, no lane owns it), per the standing rule that a change ships with its docs in the house voice. No other shared file is touched.

## Over-engineering pass (findings and what was done)

- `stdlib` — `zmq_hex_ascii` was a 9-line byte loop reinventing one `sed`+`printf` line. **Cut** (`72603f7`); identical output on every fixture including the empty string, and the 10 cases that exercise it all red when the replacement is broken.
- `delete` — the `last seen [$want]` diagnostic named an arbitrary property when there was more than one. **Cut.**
- `yagni` — the LONG-frame branch in `zmq_ready_socket_type` and its counterpart in the target snippet (9 lines). No libzmq peer sends a long READY, so it reads speculative. **Kept, deliberately:** without it a legal peer that did send one would parse as `malformed-ready`, and a false RED in the release gate is the exact failure this lane exists to prevent.

Net: **9 lines removed.** Re-verified after the cut — five mutations each killed, control 33/0, all 12 self-tests green, live probe still `ok XPUB`, shellcheck and shfmt clean.
