### PR TITLE
docs(e2e): correct the retired ~95 GiB pruned-chain figure and the patched-LMDB claim (#1446, #1489)

### DIFF
--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -351,8 +351,9 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 >
 > `MDB_VERSION_MISMATCH` from a stock LMDB tool is the **lock-file** format, not a patched on-disk
 > format: it appears while monerod holds the environment, and the same tool opens an idle copy of
-> the same chain (both DBs are magic `0xbeefc0de`, version 1). It is not corruption — do not stop
-> monerod over it. Often the best move is to leave the free pages alone.
+> the same chain. Measured here on monerod 0.18.5.1, where both DBs read magic `0xbeefc0de`,
+> version 1 (#1446) — one bench, one build, so treat the reading as ours rather than universal.
+> It is not corruption — do not stop monerod over it. Often the best move is to leave the free pages alone.
 
 ## Bench allocation and the rig lock
 

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -9,8 +9,10 @@ GitHub Actions runs on every PR, and how to harden the server. Operational compa
 
 GitHub-hosted runners can't do the real-chain tier. On a public repo the hosted Ubuntu runners
 are free (4 vCPU / 16 GiB RAM), but they are ephemeral: a fresh VM per job, ~14 GiB of free
-disk, and a 6-hour job ceiling. A Monero chain is ~95 GiB pruned / ~270 GiB full and takes days
-to sync; Tari adds ~50 GiB. There is nowhere to keep that synced state between runs, and no time
+disk, and a 6-hour job ceiling. A pruned Monero chain measures ~258 GiB on our own bench
+([#1446](https://github.com/p2pool-starter-stack/pithead/issues/1446)) and an unpruned one is
+larger still [TODO: verify upstream — no full-chain measurement exists on this bench]; either
+takes days to sync, and Tari adds ~50 GiB. There is nowhere to keep that synced state between runs, and no time
 to sync it inside a job. So the real-daemon, real merge-mining tier (tier 4) is not possible on
 hosted runners. That's the reason a dedicated, already-synced server exists
 ([#54](https://github.com/p2pool-starter-stack/pithead/issues/54)).
@@ -332,8 +334,11 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 ```
 
 > NOTE: a pruned chain's file stays large. An in-place prune does not shrink the LMDB file: it
-> stays at the full-chain high-water mark (~250 GiB) with the freed space sitting as internal
-> free pages (Monero reuses them as the chain grows). To reclaim it you must rewrite the DB with
+> stays at the full-chain high-water mark, with the freed space sitting as internal free pages
+> (Monero reuses them as the chain grows). **How much is actually reclaimable is a measurement,
+> not an assumption** — `mdb_stat -ef` on an idle copy reports the freelist, and on this bench it
+> is 10 pages out of 67,605,667, so there is nothing to reclaim (#1446). To reclaim it where there
+> is, you must rewrite the DB with
 > `monero-blockchain-prune` (see
 > [`compact-chain.sh`](../../tests/integration/compact-chain.sh)). It's slow (it copies every block
 > over hours), though it reads through a snapshot so monerod keeps mining.
@@ -344,9 +349,10 @@ tests/integration/run.sh --host you@server --dir pithead --readiness
 > To run it against a live chain, bind-mount the source so the kernel refuses the rename; the
 > recipe and its guard are in `compact-chain.sh`'s header.
 >
-> The generic `mdb_copy -c` does not work: Monero ships a
-> patched LMDB and stock mdb_copy rejects the format (`MDB_VERSION_MISMATCH`). Often it's simplest
-> to leave the free pages.
+> `MDB_VERSION_MISMATCH` from a stock LMDB tool is the **lock-file** format, not a patched on-disk
+> format: it appears while monerod holds the environment, and the same tool opens an idle copy of
+> the same chain (both DBs are magic `0xbeefc0de`, version 1). It is not corruption — do not stop
+> monerod over it. Often the best move is to leave the free pages alone.
 
 ## Bench allocation and the rig lock
 

--- a/docs/dev/test-server-architecture.md
+++ b/docs/dev/test-server-architecture.md
@@ -49,9 +49,9 @@ Sizing (a pruned-Monero test bench fits in ~1 TB):
 
 A 1 TB NVMe (~931 GiB usable) holds the pruned bench with ~490 GiB to spare.
 
-The Monero row is the size measured on this bench, not a compaction target. The table used to
-carry "~95 GB (compacted)" and a ~280 GB total; that under-budgeted the disk by ~160 GiB. See the
-freelist note below before planning around a smaller number.
+The Monero row is measured on this bench, not a compaction target — the table previously carried
+"~95 GB (compacted)", which under-budgeted the disk by ~160 GiB. Read the freelist note below
+before planning around a smaller number.
 
 > NOTE: verify the disk is actually fast. "SSD" in the model name is not enough; check the bus.
 > A drive sold as an "SSD" can enumerate on SATA rather than NVMe, on a link that negotiates down
@@ -77,8 +77,8 @@ freelist note below before planning around a smaller number.
 > pages (LMDB never shrinks its file), and
 > [`compact-chain.sh`](../../tests/integration/compact-chain.sh)
 > (`monero-blockchain-prune --copy-pruned-database`) rewrites the DB when it does — but measure the
-> freelist first. This paragraph used to promise compaction down to ~95 GB, which was a retired
-> expectation rather than a measurement (#1446).
+> freelist first; this paragraph used to promise compaction down to ~95 GB, which was never
+> measured (#1446).
 >
 > `MDB_VERSION_MISMATCH` from a stock LMDB tool is the **lock-file** format, not a patched on-disk
 > format: it appears while monerod holds the environment, and the same tool opens an idle copy of

--- a/docs/dev/test-server-architecture.md
+++ b/docs/dev/test-server-architecture.md
@@ -39,15 +39,19 @@ Sizing (a pruned-Monero test bench fits in ~1 TB):
 
 | Component | Size |
 |---|---|
-| Pruned Monero (compacted) | ~95 GB |
-| Tari (archival/full) | ~132 GB |
-| Docker images + cache | ~20 GB |
-| OS + working headroom | ~30 GB |
-| **Total** | **~280 GB** |
-| *+ optional full Monero node* | *+250 GB* |
-| *+ a few full chain copies* | *95–250 GB each* |
+| Pruned Monero | ~258 GiB |
+| Tari (archival/full) | ~132 GiB |
+| Docker images + cache | ~20 GiB |
+| OS + working headroom | ~30 GiB |
+| **Total** | **~440 GiB** |
+| *+ optional full Monero node* | *[TODO: verify upstream — no full-chain measurement on this bench]* |
+| *+ each extra pruned chain copy* | *~258 GiB* |
 
-A 1 TB NVMe holds the pruned bench with ~650 GB to spare, room for a full node and copies too.
+A 1 TB NVMe (~931 GiB usable) holds the pruned bench with ~490 GiB to spare.
+
+The Monero row is the size measured on this bench, not a compaction target. The table used to
+carry "~95 GB (compacted)" and a ~280 GB total; that under-budgeted the disk by ~160 GiB. See the
+freelist note below before planning around a smaller number.
 
 > NOTE: verify the disk is actually fast. "SSD" in the model name is not enough; check the bus.
 > A drive sold as an "SSD" can enumerate on SATA rather than NVMe, on a link that negotiates down
@@ -64,12 +68,21 @@ A 1 TB NVMe holds the pruned bench with ~650 GB to spare, room for a full node a
 >
 > The fix is to put the chains on a fast NVMe SSD. Add an m.2 PCIe NVMe and migrate the chains
 > onto it; mount the data dir by UUID via fstab (ext4, `noatime`, `nofail`) and keep the OS on a
-> separate disk. monerod then opens the ~266 GB pruned LMDB in seconds and the full integration
-> matrix runs green. Compaction to ~95 GB uses
+> separate disk. monerod then opens the pruned LMDB in seconds and the full integration matrix
+> runs green.
+>
+> **Do not budget for compaction to reclaim that size.** The chain is correctly pruned, and it is
+> also dense: `mdb_stat -ef` on an idle copy reports a freelist of 10 pages out of 67,605,667, and
+> `pages_used * 4096` equals the file size exactly. An in-place prune *can* leave reclaimable free
+> pages (LMDB never shrinks its file), and
 > [`compact-chain.sh`](../../tests/integration/compact-chain.sh)
-> (`monero-blockchain-prune --copy-pruned-database`) — the chain is correctly pruned; the extra
-> size is reclaimable free-page bloat, not a full chain. Stock `mdb_copy -c` does not work: Monero
-> ships a patched LMDB and stock `mdb_copy` rejects the format (`MDB_VERSION_MISMATCH`). CoW
+> (`monero-blockchain-prune --copy-pruned-database`) rewrites the DB when it does — but measure the
+> freelist first. This paragraph used to promise compaction down to ~95 GB, which was a retired
+> expectation rather than a measurement (#1446).
+>
+> `MDB_VERSION_MISMATCH` from a stock LMDB tool is the **lock-file** format, not a patched on-disk
+> format: it appears while monerod holds the environment, and the same tool opens an idle copy of
+> the same chain (both DBs are magic `0xbeefc0de`, version 1). Do not stop monerod over it. CoW
 > snapshots need btrfs/zfs on the NVMe (if it's ext4); see below.
 
 A second m.2 NVMe (PCIe) with btrfs/zfs additionally enables copy-on-write snapshots: instant,

--- a/docs/dev/test-server-architecture.md
+++ b/docs/dev/test-server-architecture.md
@@ -82,7 +82,8 @@ before planning around a smaller number.
 >
 > `MDB_VERSION_MISMATCH` from a stock LMDB tool is the **lock-file** format, not a patched on-disk
 > format: it appears while monerod holds the environment, and the same tool opens an idle copy of
-> the same chain (both DBs are magic `0xbeefc0de`, version 1). Do not stop monerod over it. CoW
+> the same chain. Measured here on monerod 0.18.5.1, where both DBs read magic `0xbeefc0de`,
+> version 1 (#1446) — one bench, one build. Do not stop monerod over it. CoW
 > snapshots need btrfs/zfs on the NVMe (if it's ext4); see below.
 
 A second m.2 NVMe (PCIe) with btrfs/zfs additionally enables copy-on-write snapshots: instant,
@@ -126,7 +127,8 @@ jq '.monero.data_dir="/srv/<you>/pithead/data/monero"
    network or a fast external drive:
 
 ```bash
-# from the new box, pulling from the old one (chains are ~230 GB; hours over GbE, faster over USB3/10G):
+# from the new box, pulling from the old one (chains measure ~390 GiB: ~258 Monero + ~132 Tari;
+# hours over GbE, faster over USB3/10G):
 rsync -aP --info=progress2 olduser@oldbox:/srv/code/pithead-data/ /srv/<you>/pithead/data/
 ```
 

--- a/tests/integration/build-pruned-chain.sh
+++ b/tests/integration/build-pruned-chain.sh
@@ -7,7 +7,13 @@
 #   1. stop monerod            -> makes the live LMDB consistent for copying
 #   2. copy full data.mdb      -> onto the CoW (btrfs) volume   [downtime window]
 #   3. start monerod           -> mining resumes immediately after the copy
-#   4. prune the COPY          -> shrinks ~250G -> ~95G, full chain untouched
+#   4. prune the COPY          -> full chain untouched; see the SIZE note below
+#
+# SIZE — DO NOT EXPECT A LARGE SHRINK (#1446). This header used to state step 4's outcome as
+# "shrinks ~250G -> ~95G". Both halves are retired: they were an expectation, never a measurement.
+# This bench's source chain is ALREADY pruned (`prune-blockchain=1`, `pruning_seed = 384` on both
+# sides), so step 4 repacks rather than prunes. The result measured ~258 GiB and is dense — a
+# freelist of 10 pages out of 67,605,667. Read the freelist before predicting any size change.
 #
 # Step 4 targets the COPY, never the canonical chain. `monero-blockchain-prune` is
 # copy-then-swap (#1489) — it renames its result over $DST_DIR/lmdb, which is why the size is

--- a/tests/integration/compact-chain.sh
+++ b/tests/integration/compact-chain.sh
@@ -8,12 +8,10 @@
 # comes out at its true compact size.
 #
 # DO NOT DIAGNOSE BLOAT FROM THE FILE SIZE ALONE — MEASURE THE FREELIST (#1446).
-#   This header used to put the bench's live data at "~95 GiB" inside a "~270 GiB" file. That was
-#   a retired expectation stated as a measurement, and it is wrong here: the bench's 258 GiB
-#   pruned chain carries a freelist of 10 pages out of 67,605,667, and `pages_used * 4096` equals
-#   the file size exactly. The file is dense, the chain is already pruned (`pruning_seed = 384`,
-#   `prune-blockchain=1`), and running this tool on it spends ~2.5 hours to reclaim nothing.
-#   Read the freelist with `mdb_stat -ef` on an IDLE copy before deciding a chain is bloated.
+#   This bench's 258 GiB pruned chain has a freelist of 10 pages out of 67,605,667 and
+#   `pages_used * 4096` == the file size: it is dense, already pruned, and this tool would spend
+#   ~2.5 hours reclaiming nothing. Read `mdb_stat -ef` on an IDLE copy first. (An earlier header
+#   here promised "~95 GiB of live data" — a retired expectation, never a measurement.)
 #
 # THE TOOL IS COPY-THEN-SWAP — IT DOES NOT ONLY READ THE SOURCE (#1489).
 #   After building <data-dir>/lmdb-pruned it renames <data-dir>/lmdb to <data-dir>/lmdb-old and
@@ -45,10 +43,10 @@
 # NOT a page-level copy.
 #
 # MDB_VERSION_MISMATCH IS THE LOCK-FILE FORMAT, NOT A PATCHED ON-DISK FORMAT (#1446).
-#   This header used to explain the error as "Monero ships a patched LMDB". Measured: the error
-#   appears while monerod holds the environment, and a stock LMDB tool opens an IDLE copy of the
-#   same chain (both DBs are magic 0xbeefc0de, version 1). It is not corruption; do not stop
-#   monerod over it. Note that mdb_stat REWRITES lock.mdb, so control on data.mdb specifically.
+#   The error appears while monerod HOLDS the environment; a stock LMDB tool opens an IDLE copy
+#   of the same chain (both DBs are magic 0xbeefc0de, version 1). Not corruption — do not stop
+#   monerod over it. An earlier header blamed "a patched LMDB"; that was wrong. Note mdb_stat
+#   REWRITES lock.mdb, so control on data.mdb specifically.
 #
 # This script ONLY runs the tool; it does not stop or start containers. It logs before/after
 # sizes and writes a status sentinel.

--- a/tests/integration/compact-chain.sh
+++ b/tests/integration/compact-chain.sh
@@ -3,9 +3,17 @@
 # compact-chain.sh — build a compact pruned Monero chain from an existing chain.
 #
 # An in-place prune leaves the LMDB file at its full-chain high-water mark (LMDB never shrinks
-# its file), so a pruned chain can sit at ~270 GiB on disk while holding only ~95 GiB of live
-# data. `monero-blockchain-prune` rewrites the chain into a fresh DB at <data-dir>/lmdb-pruned,
-# which comes out at its true compact size.
+# its file), so a pruned chain can sit on disk at a size its live data no longer justifies.
+# `monero-blockchain-prune` rewrites the chain into a fresh DB at <data-dir>/lmdb-pruned, which
+# comes out at its true compact size.
+#
+# DO NOT DIAGNOSE BLOAT FROM THE FILE SIZE ALONE — MEASURE THE FREELIST (#1446).
+#   This header used to put the bench's live data at "~95 GiB" inside a "~270 GiB" file. That was
+#   a retired expectation stated as a measurement, and it is wrong here: the bench's 258 GiB
+#   pruned chain carries a freelist of 10 pages out of 67,605,667, and `pages_used * 4096` equals
+#   the file size exactly. The file is dense, the chain is already pruned (`pruning_seed = 384`,
+#   `prune-blockchain=1`), and running this tool on it spends ~2.5 hours to reclaim nothing.
+#   Read the freelist with `mdb_stat -ef` on an IDLE copy before deciding a chain is bloated.
 #
 # THE TOOL IS COPY-THEN-SWAP — IT DOES NOT ONLY READ THE SOURCE (#1489).
 #   After building <data-dir>/lmdb-pruned it renames <data-dir>/lmdb to <data-dir>/lmdb-old and
@@ -30,9 +38,17 @@
 #   guard before you rely on it — `mv <build-dir>/lmdb <build-dir>/x` must answer "Device or
 #   resource busy".
 #
+#   The read is still a real LMDB reader on the live DB: a long read transaction pins freed pages,
+#   so the LIVE data.mdb can GROW while the copy runs. Watch `df` for the whole run.
+#
 # Speed: it copies every block one-by-one, so it is SLOW (many HOURS for a mainnet chain). It is
-# NOT a page-level copy. The generic `mdb_copy -c` does NOT work on a Monero chain: Monero ships
-# a patched LMDB and stock mdb_copy rejects the on-disk format (MDB_VERSION_MISMATCH).
+# NOT a page-level copy.
+#
+# MDB_VERSION_MISMATCH IS THE LOCK-FILE FORMAT, NOT A PATCHED ON-DISK FORMAT (#1446).
+#   This header used to explain the error as "Monero ships a patched LMDB". Measured: the error
+#   appears while monerod holds the environment, and a stock LMDB tool opens an IDLE copy of the
+#   same chain (both DBs are magic 0xbeefc0de, version 1). It is not corruption; do not stop
+#   monerod over it. Note that mdb_stat REWRITES lock.mdb, so control on data.mdb specifically.
 #
 # This script ONLY runs the tool; it does not stop or start containers. It logs before/after
 # sizes and writes a status sentinel.

--- a/tests/integration/system-info.sh
+++ b/tests/integration/system-info.sh
@@ -56,8 +56,9 @@ h "Chains"
     echo "Tari   : ${tdir:-?}"
     echo "         size $(du -sh "$tdir" 2>/dev/null | cut -f1)  |  archival/full (no pruning configured)"
 } | fence
-printf '\n_A pruned Monero chain that reads ~250 GiB on disk is LMDB free-page bloat, not a full chain;\n'
-printf 'see the build-server README for the compaction procedure._\n'
+printf '\n_A large pruned Monero chain is not automatically free-page bloat: this bench measured a\n'
+printf 'freelist of 10 pages out of 67,605,667, so its file is dense. Read the freelist with\n'
+printf '`mdb_stat -ef` on an idle copy before compacting; see the build-server README._\n'
 
 h "Docker & containers"
 docker --version 2>/dev/null | fence

--- a/tests/integration/testbench-README.md
+++ b/tests/integration/testbench-README.md
@@ -39,15 +39,24 @@ A workable layout (adjust to taste):
 
 ## The chains
 
-- **Monero is pruned** (`MONERO_PRUNE=1`) and compacted to its true size (~95 GiB). If it ever
-  reads back up near ~250 GiB, that is LMDB free-page bloat from an in-place prune, not a full
-  chain — compact it (below). The generic `mdb_copy` cannot read Monero's patched LMDB
-  (`MDB_VERSION_MISMATCH`); only `monero-blockchain-prune` works.
+- **Monero is pruned** (`MONERO_PRUNE=1`) and sits at ~258 GiB, which is its true compact size
+  here — measured, not estimated ([#1446](https://github.com/p2pool-starter-stack/pithead/issues/1446)).
+  An earlier version of this line put it at "~95 GiB" and told you to treat anything reading near
+  ~250 GiB as free-page bloat and compact it. That figure was a retired expectation, and the rule
+  built on it sends you into a multi-hour rebuild that reclaims nothing. **Size alone does not
+  diagnose bloat — read the freelist.** `mdb_stat -ef` on an idle copy reports 10 free pages out
+  of 67,605,667 here, and `pages_used * 4096` equals the file size exactly, so the file is dense.
+  Compact only when the freelist is genuinely large.
+- **`MDB_VERSION_MISMATCH` from a system LMDB tool is the lock-file format, not a patched data
+  format, and not corruption.** It appears while monerod holds the environment; the same tool
+  opens an idle copy of the same chain (both DBs are magic `0xbeefc0de`, version 1). Do not stop
+  monerod over it. `monero-blockchain-prune` remains the tool that compacts a Monero chain.
 - **Tari is archival/full** (~132 GiB, no pruning configured). That size is genuine data, not
   bloat, so there is nothing to compact. Shrinking it would mean pruning Tari (a config change plus
   re-sync), which is a product decision, not housekeeping.
 
-**Compacting the Monero chain** (reclaim bloat; takes hours, no downtime for the copy).
+**Compacting the Monero chain** — only when the freelist shows pages to reclaim (takes hours, no
+downtime for the copy).
 
 `monero-blockchain-prune` is copy-then-swap: once it has built `lmdb-pruned` it renames `lmdb` to
 `lmdb-old` and moves the pruned DB into place itself (#1489). Pointed straight at a live data dir

--- a/tests/integration/testbench-README.md
+++ b/tests/integration/testbench-README.md
@@ -39,14 +39,12 @@ A workable layout (adjust to taste):
 
 ## The chains
 
-- **Monero is pruned** (`MONERO_PRUNE=1`) and sits at ~258 GiB, which is its true compact size
-  here — measured, not estimated ([#1446](https://github.com/p2pool-starter-stack/pithead/issues/1446)).
-  An earlier version of this line put it at "~95 GiB" and told you to treat anything reading near
-  ~250 GiB as free-page bloat and compact it. That figure was a retired expectation, and the rule
-  built on it sends you into a multi-hour rebuild that reclaims nothing. **Size alone does not
-  diagnose bloat — read the freelist.** `mdb_stat -ef` on an idle copy reports 10 free pages out
-  of 67,605,667 here, and `pages_used * 4096` equals the file size exactly, so the file is dense.
-  Compact only when the freelist is genuinely large.
+- **Monero is pruned** (`MONERO_PRUNE=1`) and sits at ~258 GiB, its true compact size here —
+  measured ([#1446](https://github.com/p2pool-starter-stack/pithead/issues/1446)). **Size alone
+  does not diagnose bloat: read the freelist.** `mdb_stat -ef` on an idle copy reports 10 free
+  pages out of 67,605,667, and `pages_used * 4096` equals the file size exactly, so the file is
+  dense and compacting it would reclaim nothing. An earlier version of this line promised
+  "~95 GiB" and told you to compact anything reading ~250 GiB; that figure was never measured.
 - **`MDB_VERSION_MISMATCH` from a system LMDB tool is the lock-file format, not a patched data
   format, and not corruption.** It appears while monerod holds the environment; the same tool
   opens an idle copy of the same chain (both DBs are magic `0xbeefc0de`, version 1). Do not stop

--- a/tests/integration/testbench-README.md
+++ b/tests/integration/testbench-README.md
@@ -47,8 +47,8 @@ A workable layout (adjust to taste):
   "~95 GiB" and told you to compact anything reading ~250 GiB; that figure was never measured.
 - **`MDB_VERSION_MISMATCH` from a system LMDB tool is the lock-file format, not a patched data
   format, and not corruption.** It appears while monerod holds the environment; the same tool
-  opens an idle copy of the same chain (both DBs are magic `0xbeefc0de`, version 1). Do not stop
-  monerod over it. `monero-blockchain-prune` remains the tool that compacts a Monero chain.
+  opens an idle copy of the same chain. Measured here on monerod 0.18.5.1, where both DBs read
+  magic `0xbeefc0de`, version 1 (#1446) — one bench, one build. Do not stop monerod over it. `monero-blockchain-prune` remains the tool that compacts a Monero chain.
 - **Tari is archival/full** (~132 GiB, no pruning configured). That size is genuine data, not
   bloat, so there is nothing to compact. Shrinking it would mean pruning Tari (a config change plus
   re-sync), which is a product decision, not housekeeping.


### PR DESCRIPTION
## What this fixes

Two claims stated as measurements across five tracked files were false. Both were found while discharging the hold condition on #1489.

### 1. The `~95 GiB` pruned-chain figure — and it was wired to an operator ACTION

The bench's pruned Monero chain measures **258 GiB and is dense**. Measured, not estimated:

- `mdb_stat -ef` on an idle copy: **`Free pages: 10`** — ten, out of 67,605,667.
- `67,605,667 × 4096 = 276,912,812,032` — exactly the file size, so that figure is the high-water mark, not a bloated envelope.
- Correctly pruned: `pruning_seed = 384` on both the output and the source, and the running monerod's rendered `bitmonero.conf` carries `prune-blockchain=1`.

The docs said the chain held "~95 GiB of live data" inside a "~270 GiB" file. That was a retired expectation, never a measurement — and it was not merely stale. Both READMEs attached an imperative to it:

> If it ever reads back up near ~250 GiB, that is LMDB free-page bloat from an in-place prune, not a full chain — compact it.

The chain *does* read 258 GiB, and it *is* dense. That rule sends a reader into a ~2.5-hour rebuild that reclaims nothing. `tests/integration/system-info.sh` printed the same false diagnosis into **every system snapshot** it generated.

Replaced with the measured figure and the rule that actually discriminates: **read the freelist before concluding a chain is bloated.**

### 2. "Monero ships a patched LMDB"

Three files explained `MDB_VERSION_MISMATCH` as a patched on-disk format. Measured: it is the **lock-file** format, and it appears only while monerod holds the environment — a stock LMDB tool opens an idle copy of the same chain, and both DBs are magic `0xbeefc0de` version 1. It is not corruption and not a reason to stop monerod.

## What was checked and deliberately left alone

- **The general mechanism is TRUE and is kept everywhere**: LMDB never shrinks its file, so an in-place prune *can* leave reclaimable free pages. Only the fabricated magnitude and the unconditional imperative are gone.
- The #1489 copy-then-swap block in `compact-chain.sh`'s header, and `build-pruned-chain.sh`'s "full chain never modified", are true as scoped — checked line by line, untouched.
- **`docs/hardware.md` and `docs/getting-started.md` are NOT touched.** They promise ~100 GB pruned / ~270 GB full for a *general* Monero node. That is a different subject, and I have one bench measurement and no upstream one. See the open question below.

## Also in this diff

- **`docs/dev/test-server-architecture.md`'s sizing table under-budgeted the bench disk by ~160 GiB** (~280 GB total → a measured ~440 GiB), because the `~95 GB` figure was a row in it. Recomputed: 258 + 132 + 20 + 30 = 440 GiB; a 1 TB NVMe (~931 GiB usable) leaves ~490 GiB spare, not ~650 GB.
- The full-chain figure is **not** measured on this bench and is marked `[TODO: verify upstream — ...]` rather than guessed, per `docs/dev/STYLE.md`.
- Ported one true hazard note the deployed copy carried and the repo copy lacked: the compaction read is a real LMDB reader on the live DB, so a long read transaction pins freed pages and **the live `data.mdb` can grow while the copy runs**. Watch `df`.

## Deployed copies

`~/pithead-testbench/{compact-chain.sh,README.md}` carried both false claims and a repo-scoped sweep cannot see them (the trap this lane paid for in cycle 25). They have been patched **in place** — the deployed copies have diverged from the repo and carry content the repo lacks, so syncing over them would have destroyed it.

## What was RUN

- `make lint-docs-voice` — OK, 40 prose docs.
- `make lint-md` — 47 files, 0 errors.
- `make lint-topology`, `make lint-file-budget` — OK, both self-tests green.
- `shellcheck` (0.11.0) on both changed scripts — rc=0, only pre-existing SC2016 info notes matching the files' existing idiom.
- `bash -n` on all three changed scripts, repo and deployed.

**Not run:** the full `make lint` / `make test`. This diff is comments, prose and one `printf`; no executable path changed. `make lint-sh` is the documented OOM path on this box and is serialized fleet-wide, so I ran shellcheck on the changed files directly instead and am saying so rather than implying full-suite coverage.

The 258 GiB / freelist-10 figures were **re-derived from the primary record** (`pruned-chain-verdict.md`), not carried over from a summary.

## Shared paths

Touches `docs/dev/` (in `_shared.paths`, no override needed) alongside this lane's own `tests/integration/`.

## Open question this surfaced, not resolved

Our own user docs promise **~100 GB** for a pruned Monero node; this bench measures a correctly-pruned, dense **258 GiB** chain. Both cannot be right, and it is a 2.5× gap on a number people buy disks against. I did not touch the user docs — one bench measurement is not an upstream fact. Routed to the controller.

Refs #1446, #1489.
