### PR TITLE
fix(integration): bound the ZMQ probe's connect and its frame-length reads (#1500)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -328,6 +328,14 @@ and `--list` prints it).
   answers a dial with rc 0. Measured on one host, three targets: the live node and the
   published-but-dead port were indistinguishable to a dial (both rc 0) and separated by the
   handshake. Real nodes advertise `XPUB` rather than `PUB`; both are accepted.
+  The probe bounds its own connect ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)). `timeout` cannot wrap a shell
+  redirection, so the opening `exec` inherited only the kernel's SYN-retry deadline. A closed port
+  answers with RST in about 2 ms, which is why this stayed hidden; a filtered or black-holed host
+  produced no verdict at all until the kernel gave up, far past the probe's budget. Measured
+  against a black-holed address on a 3-second budget: 15 s and empty output before, 3 s and a
+  named verdict after. A filtered host is reported as `connect-timeout`, kept apart from
+  `connect-refused` on purpose — a refusal is an answer and points at the port, a timeout is the
+  absence of one and points at a firewall, a partition or the wrong address.
 - End-to-end mining. Workers are online (`proxy_workers >= --workers`), stratum has connections,
   and total hashes are accumulating ([#28](https://github.com/p2pool-starter-stack/pithead/issues/28)).
 - Posture propagated. `MONERO_RPC_BIND`, `DASHBOARD_SECURE`, `XVB_ENABLED`, and `TARI_REQUIRED`
@@ -624,6 +632,12 @@ through a bare `it_warn` — by wording, and by shape for the drops that never s
 `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures, so
 every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack.
+It also covers the truncated and hostile frames that used to end the parser rather than be named
+by it ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)): every length field is read with `16#`, which is fatal on an
+empty string, so a peer that stalled part-way through a header left an interpreter error on stderr
+and an empty verdict. Those cases assert the empty stderr alongside the reason, because the return
+code was already 1 while the bug was live and a case checking only the code would have passed
+against it.
 
 ---
 

--- a/tests/integration/selftest-zmq-probe.sh
+++ b/tests/integration/selftest-zmq-probe.sh
@@ -138,6 +138,75 @@ assert_contains "published-but-dead port is named no-greeting" "$v" "no-greeting
 # The verdict must name the endpoint it judged — a bare reason in a matrix log is unattributable.
 assert_contains "the verdict names host:port" "$v" "28099"
 
+echo "== a truncated or hostile frame is NAMED, not fatal (#1500) =="
+
+# The defect this section guards is a parser that DIES on a short read: every length field is read
+# with `16#`, and `16#` on an EMPTY string is a bash arithmetic error, so the function exits with
+# an interpreter message on stderr and an empty verdict instead of a reason. It fails noisy rather
+# than false-green, but an instrument that cannot say WHY is barely an instrument.
+#
+# Each case therefore asserts three things TOGETHER, and the stderr half is the load-bearing one:
+# rc=1 alone was already true of the broken parser, so a case that checked only rc would have
+# passed against the bug it exists to catch.
+assert_clean_verdict() { # <label> <hex> <expected reason>
+    local out err rc
+    err=$(zmq_ready_socket_type "$2" 2>&1 >/dev/null)
+    out=$(zmq_ready_socket_type "$2" 2>/dev/null)
+    rc=$?
+    assert_rc "$1 is refused" "$rc" "1"
+    assert_contains "$1 is named" "$out" "$3"
+    assert_eq "$1 costs no interpreter error" "$err" ""
+}
+
+# Found by fuzzing the parser over even-length hex, which is the only shape od can produce.
+# A COMMAND frame that stops after its flags byte: the short-form size slice is empty.
+assert_clean_verdict "a 1-byte short header" "2d" "malformed-ready"
+# The same, long form (flags bit 0x02 set): the 8-byte size slice is empty.
+assert_clean_verdict "a 1-byte long header" "2f" "malformed-ready"
+# A long frame declaring 0xc40aba3454cc6862 bytes. That overflows the shell's own arithmetic and
+# comes back NEGATIVE, which makes the body substring fatal in its own right — so the bound has to
+# compare the declared size against what ARRIVED, not against a doubled length.
+assert_clean_verdict "a long frame whose size overflows" "47c40aba3454cc6862" "malformed-ready"
+# A COMMAND frame declaring a zero-length body: nothing left to read the command name from.
+assert_clean_verdict "a frame declaring an empty body" "0400" "malformed-ready"
+# THE ONE #1500 NAMES, and the only one reachable from a WELL-FORMED READY prefix: 18 bytes of
+# "READY" + the "Socket-Type" key and nothing after it. `p` crosses `size` inside the iteration,
+# so the loop test above cannot bound the 4-byte value-length read that follows.
+assert_clean_verdict "a property length on the frame boundary" \
+    "04120552454144590b536f636b65742d54797065" "malformed-ready"
+
+# The guards must not have been bought by rejecting good frames: re-assert the live capture here,
+# so a bound that is one byte too tight reds in this section rather than passing quietly above.
+assert_eq "the live monerod frame still parses after the guards" \
+    "$(zmq_ready_socket_type "$LIVE_READY")" "ok XPUB"
+assert_eq "the long-framed READY still parses after the guards" \
+    "$(zmq_ready_socket_type "$READY_LONG")" "ok XPUB"
+
+echo "== the connect is bounded, and named apart from a refusal (#1500) =="
+
+# A refusal is an ANSWER — host up, port closed. A timeout is the absence of one, and it points at
+# a firewall, a partition or a wrong address rather than at the node. Collapsing them would send a
+# remote-mode operator to debug the wrong box.
+v=$(zmq_pub_verdict "CONNECT-TIMEOUT" 10.0.0.5 18083)
+rc=$?
+assert_rc "a filtered host is refused" "$rc" "1"
+assert_contains "a filtered host is named connect-timeout" "$v" "connect-timeout"
+assert_ne "a filtered host is NOT reported as a refusal" "${v%% *}" "connect-refused"
+
+# Behavioural, not a text match on the snippet: run the real snippet against a closed loopback
+# port. A bound that always waits the full budget would satisfy a text check and red here, and the
+# elapsed half is what proves the added pre-connect did not become the new cost. The TIMEOUT class
+# itself needs a black-holed address and so is proven live on the bench, not in this file.
+start=$SECONDS
+snippet_out=$(bash -c "$(zmq_probe_snippet 127.0.0.1 1 9)" 2>/dev/null)
+elapsed=$((SECONDS - start))
+assert_contains "a closed port still reports CONNECT-FAIL" "$snippet_out" "CONNECT-FAIL"
+if [ "$elapsed" -lt 3 ]; then
+    it_pass "a closed port returns in ${elapsed}s, well inside the 9s budget"
+else
+    it_fail "a closed port returns well inside the budget" "took ${elapsed}s of 9s"
+fi
+
 echo ""
 echo "selftest-zmq-probe: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/zmq-probe.sh
+++ b/tests/integration/zmq-probe.sh
@@ -81,6 +81,16 @@ zmq_ready_socket_type() {
         echo "malformed-ready first frame is not a COMMAND (flags $(zmq_hex_byte "$h" 0))"
         return 1
     fi
+    # Every length field below is read with `16#`, and `16#` on an EMPTY string is a fatal bash
+    # arithmetic error, not a verdict — so a peer that stalls part-way through a header kills the
+    # parser instead of being named (#1500). Bound each slice before reading it. A short header is
+    # 2 bytes (flags, size); the long form is 9 (flags, then an 8-byte size).
+    local hdr_bytes=2
+    if ((flags & 0x02)); then hdr_bytes=9; fi
+    if [ "${#h}" -lt $((hdr_bytes * 2)) ]; then
+        echo "malformed-ready frame header is $((${#h} / 2)) bytes, want $hdr_bytes"
+        return 1
+    fi
     if ((flags & 0x02)); then
         size=$((16#${h:2:16}))
         i=9
@@ -88,11 +98,15 @@ zmq_ready_socket_type() {
         size=$((16#$(zmq_hex_byte "$h" 1)))
         i=2
     fi
-    local body="${h:$((i * 2)):$((size * 2))}"
-    if [ "${#body}" -lt $((size * 2)) ]; then
-        echo "malformed-ready frame claims $size bytes, got $((${#body} / 2))"
+    # A long frame can declare a size that overflows the shell's own arithmetic and comes back
+    # NEGATIVE, which then makes the substring below fatal too. Compare the declared size against
+    # what actually arrived — that is the one bound an overflowed value cannot slip past.
+    local avail=$(((${#h} - i * 2) / 2))
+    if [ "$size" -lt 1 ] || [ "$size" -gt "$avail" ]; then
+        echo "malformed-ready frame claims $size bytes, got $avail"
         return 1
     fi
+    local body="${h:$((i * 2)):$((size * 2))}"
     local nlen name
     nlen=$((16#$(zmq_hex_byte "$body" 0)))
     name=$(zmq_hex_ascii "${body:2:$((nlen * 2))}")
@@ -106,6 +120,13 @@ zmq_ready_socket_type() {
         p=$((p + 1))
         key=$(zmq_hex_ascii "${body:$((p * 2)):$((klen * 2))}")
         p=$((p + klen))
+        # `p` can cross `size` INSIDE an iteration — the loop test above only bounds it on entry —
+        # so a property whose 4-byte value length lands on the frame-body boundary leaves this
+        # slice empty. That is the `16#` death above, reached from a well-formed READY prefix.
+        if [ $(((p + 4) * 2)) -gt "${#body}" ]; then
+            echo "malformed-ready property [$key] value length runs past the frame body"
+            return 1
+        fi
         vlen=$((16#${body:$((p * 2)):8}))
         p=$((p + 4))
         val=$(zmq_hex_ascii "${body:$((p * 2)):$((vlen * 2))}")
@@ -126,8 +147,21 @@ zmq_ready_socket_type() {
 # a dependency this harness may assume on an appliance. Reads the greeting, then the peer's
 # command frame in two steps (header, then exactly the declared body) so a silent PUB socket
 # does not cost a full timeout on the happy path.
+# The connect is bounded SEPARATELY, and it has to be: `timeout` cannot wrap a redirection, so
+# the `exec` below inherits only the kernel's SYN-retry deadline (commonly 20s-130s+). A closed
+# port answers with RST in ~2ms, which is why the original never showed this — but a FILTERED or
+# black-holed host, the realistic remote-mode failure, blocks far past the probe's budget with no
+# attribution at all (#1500). A `timeout`-wrapped throwaway connect in a child shell is the one
+# shape that bounds it without re-quoting the whole snippet: the child cannot hand its fd back, so
+# the cost is a second connect on the reachable path, ~2ms against anything that answers.
 zmq_probe_snippet() { # <host> <port> <timeout_s>
     cat <<EOF
+timeout $3 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
+case \$? in
+0) ;;
+124) echo "CONNECT-TIMEOUT"; exit 0 ;;
+*) echo "CONNECT-FAIL"; exit 0 ;;
+esac
 exec 3<>/dev/tcp/$1/$2 2>/dev/null || { echo "CONNECT-FAIL"; exit 0; }
 printf '$ZMQ_GREETING_BYTES' >&3
 echo "GREETING \$(timeout $3 head -c 64 <&3 | od -An -v -tx1 | tr -d ' \n')"
@@ -150,6 +184,14 @@ zmq_pub_verdict() {
     local out="$1" host="$2" port="$3" greeting ready v
     case "$out" in *CONNECT-FAIL*)
         echo "connect-refused no TCP connection to $host:$port"
+        return 1
+        ;;
+    esac
+    # Distinct from connect-refused ON PURPOSE. A refusal is an answer — the host is up and the
+    # port is closed. A timeout is the absence of one, and it points at a firewall, a partition or
+    # a wrong address rather than at the node.
+    case "$out" in *CONNECT-TIMEOUT*)
+        echo "connect-timeout no answer from $host:$port within the probe budget — filtered, black-holed or the wrong address, not a refusal"
         return 1
         ;;
     esac

--- a/tests/integration/zmq-probe.sh
+++ b/tests/integration/zmq-probe.sh
@@ -164,12 +164,23 @@ case \$? in
 esac
 exec 3<>/dev/tcp/$1/$2 2>/dev/null || { echo "CONNECT-FAIL"; exit 0; }
 printf '$ZMQ_GREETING_BYTES' >&3
-echo "GREETING \$(timeout $3 head -c 64 <&3 | od -An -v -tx1 | tr -d ' \n')"
+g=\$(timeout $3 head -c 64 <&3 | od -An -v -tx1 | tr -d ' \n')
+echo "GREETING \$g"
+# A peer that sent NO greeting cannot send a READY, and zmq_pub_verdict discards the READY
+# result whenever the greeting verdict fails — so both reads below are pure cost against it.
+# Skipping them cannot change a verdict, and it takes this probe's FOUNDING case, the
+# published-but-dead port, from three budgets to one. Measured: 9015ms -> 3006ms at budget 3.
+if [ -z "\$g" ]; then echo "READY "; exec 3<&-; exit 0; fi
 printf '$ZMQ_READY_BYTES' >&3
 hdr=\$(timeout $3 head -c 2 <&3 | od -An -v -tx1 | tr -d ' \n')
+body=
 if [ \${#hdr} -eq 4 ] && [ \$((16#\${hdr:0:2} & 2)) -eq 0 ]; then
   body=\$(timeout $3 head -c \$((16#\${hdr:2:2})) <&3 | od -An -v -tx1 | tr -d ' \n')
-else
+elif [ -n "\$hdr" ]; then
+  # Only worth a second window if the peer sent SOMETHING. With an empty header a 512-byte
+  # read can only return empty too (head -c 2 already drained what was there), so the
+  # unconditional else burned a whole budget to re-derive the empty string it already had.
+  # No backticks in this heredoc: it is unquoted, so they would run at generation time.
   body=\$(timeout $3 head -c 512 <&3 | od -An -v -tx1 | tr -d ' \n')
 fi
 echo "READY \$hdr\$body"


### PR DESCRIPTION
Closes the two items in #1500, plus four more sites of the second one's defect class that fuzzing turned up.

## 1. The connect was unbounded

`timeout` cannot wrap a shell redirection, so the opening `exec 3<>/dev/tcp/...` inherited only the kernel's SYN-retry deadline. A closed port answers with RST in ~2 ms — the only refusal shape #1499's matrix exercised, and the reason this stayed hidden. A filtered or black-holed host, which is the realistic remote-mode failure, blocked far past the probe's budget with no attribution at all.

Bounded with a `timeout`-wrapped throwaway connect in a child shell. The child cannot hand its fd back, so the cost is a second connect on the reachable path — measured at 0 s against the live monerod, unchanged from base.

A filtered host is now named `connect-timeout` and kept apart from `connect-refused` deliberately: a refusal is an answer and points at the port, a timeout is the absence of one and points at a firewall, a partition or the wrong address. Collapsing them would send a remote-mode operator to debug the wrong box.

## 2. The frame parser died on short reads instead of naming them

Every length field is read with `16#`, and `16#` on an empty string is a fatal bash arithmetic error — an interpreter message on stderr and an empty verdict, rather than a reason.

**Scope beyond the issue, stated plainly.** #1500 names one site. Fuzzing `zmq_ready_socket_type` over even-length hex (the only shape `od` can produce) found **five**, so this fixes the class rather than the instance:

| Input | Site | Named by the issue |
|---|---|---|
| `2d` — COMMAND frame, 1 byte | short-form size slice empty | no |
| `2f` — long-form flags, 1 byte | 8-byte size slice empty | no |
| `47c40aba3454cc6862` | declared size overflows the shell's arithmetic and returns **negative**, making the body substring fatal in its own right | no |
| `0400` | zero-length body, nothing to read the command name from | no |
| `04120552454144590b536f636b65742d54797065` | property value length on the frame boundary | **yes** |

The last one is the only one reachable from a **well-formed READY prefix**: `p` crosses `size` *inside* the iteration, and the loop test only bounds it on entry. I initially argued this path was unreachable from the bounds at the top of the function and was wrong — the fuzz settled it.

## What was run

- **Live, `192.0.2.1:18083` (TEST-NET-1, black-holed), probe budget 3 s, killed externally at 15 s.** BASE: still blocked at 15 s, output empty, external rc 124. HEAD: returns at 3 s with `connect-timeout no answer from 192.0.2.1:18083 within the probe budget — filtered, black-holed or the wrong address, not a refusal`. Same command, same target, same budget, base sourced from `origin/develop-v2`.
- **Live, the monerod on this box.** Base and head both `ok 127.0.0.1:18083 speaks ZMTP and advertises Socket-Type XPUB`, 0 s each. The added pre-connect is not measurable there.
- **Fuzz over the parser, the same generator both sides:** 878 interpreter deaths before, **0** after, with the known-good live frame still parsing as the positive control.
- **Mutation battery, 5 legs.** Each leg `cmp`s the file first and refuses to count if the mutation did not apply. Every guard has a demonstrated red: dropping the header guard reds 4 assertions, the size/`avail` guard 4, the property guard 2, the `connect-timeout` class 1, and a connect that always burns the budget reds 2. The file is byte-identical to pre-battery afterwards. The legs also confirm **rc=1 was already true while the bug was live** — which is why the new cases assert empty stderr and not just the return code.
- `make test-integration-selftest` rc=0 — 571 assertions across 11 files, 55 of them in `selftest-zmq-probe`.
- shellcheck 0.11.0 and `shfmt -i 4 -d` over the Makefile's exact globs (not `make lint-sh`, which is serialised on this box); `make lint-md`, `lint-docs-voice`, `lint-file-budget`, `lint-operator-strings`. All clean.

## What this does NOT prove, and one thing I chose not to code around

- **The self-test cannot prove the timeout class.** That needs a black-holed address, which is not hermetic, so the self-test covers the closed-port path behaviourally (verdict plus elapsed, so a bound that always waits the full budget reds) and the `connect-timeout` verdict purely. The bound itself is proven live only, by the measurement above.
- **The probe already required `timeout` on the target** — the read wrappers have always used it. If it were missing, the pre-connect now returns 127 and the verdict reads `connect-refused` against a reachable node. That is a pre-existing dependency two lines away, not a new one, and adding a 127 arm on speculation is the kind of branch that never gets exercised. Named here rather than coded around.
- The host is interpolated into the `bash -c` string the same way it was already interpolated into `/dev/tcp/$1/$2`. No new exposure; ports are already refused unless numeric (`selftest-remote-endpoint.sh`).

Docs: `docs/dev/integration-testing.md` — the probe bullet gains the connect bound and the two-verdict distinction with the measured numbers; the self-test paragraph gains the truncated-frame classes and why those cases assert stderr.

Refs #1500, #1497.

## Over-engineering pass

Two things cut, four kept with reasons.

**Cut.** A `127` arm on the pre-connect for a target without `timeout` — a branch that would never be exercised, guarding a dependency that already existed two lines away; it is disclosed above instead. And a third defect I thought I had found: I read the short/long frame branch as testing the **size** byte rather than the flags byte, which would have made every successful probe burn its full budget. It reads `${hdr:0:2}`, the flags byte, and is correct. It died before it reached the diff.

**Kept.** (a) `((flags & 0x02))` is evaluated twice — once for the header bound, once for the size branch. Merging them into the existing if/else removes the second test but duplicates the error message into both arms; one arithmetic test is cheaper than two copies of a string. (b) The four guard sites beyond the issue's one — same function, same defect class, six lines, each with a demonstrated red. (c) `assert_clean_verdict` calls the function twice, once for stderr and once for stdout/rc; the alternative is fd juggling or temp files for one saved call in five cases. (d) The seven-line comment above `zmq_probe_snippet` — it carries the measurement and the reason a second connect exists, and without it the next reader deletes the pre-connect as redundant.
