### PR TITLE
refactor(tests): split provisioning, appliance-defaults, rauc-loop-wait and render-quadlet out of run.sh (#1105 R10)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -63,7 +63,7 @@ tests/integration/selftest-e2e-phases.sh	507
 tests/integration/selftest.sh	686
 tests/os/failure-evidence.sh	567
 tests/os/run.sh	3437
-tests/stack/run.sh	1034
+tests/stack/run.sh	815
 tests/stack/test-appliance-boot.sh	641
 tests/stack/test-appliance-identity-boot.sh	465
 tests/stack/test-appliance-identity.sh	483

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -121,35 +121,8 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-cli.sh" && domain_ran test-cli.sh "$_
 # shellcheck source=tests/stack/test-config.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-config.sh" && domain_ran test-config.sh "$_d0" "$?" || domain_ran test-config.sh "$_d0" "$?"
 
-echo "== unit: render-quadlet parity vs os/quadlet fixtures (#77 phase 1) =="
-# The renderer must reproduce the spike-proven unit set byte-for-byte from the fixture env — the
-# os/quadlet files ran live in the #78 spike, so any drift here needs a bench re-proof, not just
-# an updated fixture.
-QOUT="$SANDBOX/quadlet-out"
-run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/fixture.env" "$QOUT" >/dev/null
-for f in mining.network proxy.network tor.container p2pool.container xmrig-proxy.container \
-    caddy.container docker-proxy.container docker-control.container dashboard.container; do
-    assert_eq "quadlet parity: $f" "$(diff -u "$ROOT/os/quadlet/$f" "$QOUT/$f" 2>&1 | head -c 300)" ""
-done
-assert_eq "remote render emits no node units" "$(find "$QOUT" -name 'monerod.container' -o -name 'tari.container' | wc -l | tr -d ' ')" "0"
-# The local-node variant (bench-proven 2026-07-24): profiles on, 11 files, node units included.
-QLOCAL="$SANDBOX/quadlet-local-out"
-run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/local/fixture.env" "$QLOCAL" >/dev/null
-for f in mining.network proxy.network tor.container monerod.container tari.container \
-    p2pool.container xmrig-proxy.container caddy.container docker-proxy.container \
-    docker-control.container dashboard.container; do
-    assert_eq "quadlet local parity: $f" "$(diff -u "$ROOT/os/quadlet/local/$f" "$QLOCAL/$f" 2>&1 | head -c 300)" ""
-done
-# The payout-confirm variant (bench-proven 2026-07-24): both wallet profiles, 13 files, the
-# dashboard gains the payout env keys only in this set (the others stay byte-identical).
-QPAY="$SANDBOX/quadlet-payout-out"
-run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/payout/fixture.env" "$QPAY" >/dev/null
-for f in mining.network proxy.network tor.container monerod.container tari.container \
-    wallet-rpc.container tari-wallet.container p2pool.container xmrig-proxy.container \
-    caddy.container docker-proxy.container docker-control.container dashboard.container; do
-    assert_eq "quadlet payout parity: $f" "$(diff -u "$ROOT/os/quadlet/payout/$f" "$QPAY/$f" 2>&1 | head -c 300)" ""
-done
-assert_eq "local render emits no wallet units" "$(find "$QLOCAL" -name 'wallet-rpc.container' -o -name 'tari-wallet.container' | wc -l | tr -d ' ')" "0"
+# shellcheck source=tests/stack/test-render-quadlet.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-render-quadlet.sh" && domain_ran test-render-quadlet.sh "$_d0" "$?" || domain_ran test-render-quadlet.sh "$_d0" "$?"
 
 # ---------------------------------------------------------------------------
 # shellcheck source=tests/stack/test-doctor-appliance.sh disable=SC2015
@@ -786,188 +759,14 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-control-backup.sh" && domain_ran test
 # shellcheck source=tests/stack/test-wizard-setup.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-wizard-setup.sh" && domain_ran test-wizard-setup.sh "$_d0" "$?" || domain_ran test-wizard-setup.sh "$_d0" "$?"
 
-echo "== unit: provision_control_runner only removes units this checkout owns (#33) =="
-# The pithead-control.{path,service} names are box-global, but a release bench holds several
-# checkouts at once (live stack + e2e harness + bundle-smoke tmp dirs). A checkout with control
-# disabled used to remove whatever units were installed — including the LIVE stack's runner,
-# stranding its dashboard control requests (config editor stuck at "Previewing…"). The removal
-# branch keys on the service unit's ExecStart: foreign owner → leave alone; own units → remove;
-# a dangling path unit with no service file → still reaped.
-PCR="$SANDBOX/pcr"
-mkdir -p "$PCR/units" "$PCR/bin"
-# uname stub: the OS gate reads `uname -s` at source time; report Linux so the branch runs on dev
-# Macs too. systemctl stub satisfies the command -v gate.
-printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCR/bin/uname"
-printf '#!/usr/bin/env bash\nexit 0\n' >"$PCR/bin/systemctl"
-chmod +x "$PCR/bin/uname" "$PCR/bin/systemctl"
-
-pcr_run() { # <owner-dir|-> <run-dir> — seed units owned by owner-dir ('-' = no service file), run the removal branch from run-dir, echo sudo calls
-    rm -f "$PCR/units/pithead-control.service" "$PCR/units/pithead-control.path"
-    [ "$1" != "-" ] && printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCR/units/pithead-control.service"
-    printf '[Path]\nPathExistsGlob=/x/requests/*.json\n' >"$PCR/units/pithead-control.path"
-    (
-        cd "$2" || exit
-        PATH="$PCR/bin:$PATH"
-        # shellcheck disable=SC1090
-        source "$STACK"
-        set +e
-        log() { :; }
-        sudo() { echo "sudo:$*"; } # record instead of executing; the disable call's output is redirected in-function
-        PITHEAD_UNIT_DIR="$PCR/units" DASHBOARD_CONTROL_ENABLED=false provision_control_runner
-    )
-}
-
-assert_eq "foreign owner -> units left alone (no sudo rm)" "$(pcr_run /srv/code/other-checkout "$PCR")" ""
-assert_contains "own units -> removed" "$(pcr_run "$PCR" "$PCR")" \
-    "sudo:rm -f $PCR/units/pithead-control.path $PCR/units/pithead-control.service"
-assert_contains "dangling path unit (no service file) -> still reaped" "$(pcr_run - "$PCR")" "sudo:rm -f"
-# Versioned install dirs carry dots (pithead-v1.9.3). Ownership must compare the ExecStart path
-# as an exact string, never a regex: with the dots read as "any char", a sibling whose path
-# differs only at those positions would falsely match as our own — and get removed.
-mkdir -p "$PCR/v1.9.3" "$PCR/v1x9y3"
-assert_eq "foreign owner differing only at regex-dot positions -> left alone" \
-    "$(pcr_run "$PCR/v1x9y3" "$PCR/v1.9.3")" ""
-# One checkout, two spellings: production units carry the versioned dir in ExecStart, and an
-# operator's disable apply runs through the `current` symlink. Ownership compares physical
-# paths, so the unit is recognized as our own and removed — a literal $PWD compare would call
-# it foreign and the disable would never converge.
-mkdir -p "$PCR/versions/pithead-v1.9.3"
-ln -s "$PCR/versions/pithead-v1.9.3" "$PCR/current"
-assert_contains "own unit under its versioned spelling, run via the current symlink -> removed" \
-    "$(pcr_run "$PCR/versions/pithead-v1.9.3" "$PCR/current")" "sudo:rm -f"
-unset PCR pcr_run
-
-echo "== unit: provision_control_runner refuses to overwrite a foreign install's units (#1190) =="
-# The removal branch above got its ownership check when a disable-apply deleted the live stack's
-# units; the INSTALL branch had none — any sibling checkout's apply/up with control enabled
-# overwrote the box-global units and silently repointed dashboard control at itself (the
-# production-stranding mechanism, this time via install instead of a failed upgrade). The guard:
-# foreign owner that still exists on disk → refuse and name it; owner directory gone → adopt
-# (that is how a new version takes over from a removed one); own unit → converge; unparseable
-# ExecStart → leave alone, fail safe; PITHEAD_STEAL_CONTROL_UNITS=1 → deliberate takeover.
-#
-# Mutation proof (each ran red against its assertion with the guard intact elsewhere):
-#   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
-#   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
-#   - drop the PITHEAD_STEAL_CONTROL_UNITS conjunct -> "steal escape -> overwritten" goes red
-#   - drop the `steal` argument conjunct           -> "upgrade repoint (steal arg)" goes red
-PCI="$SANDBOX/pci"
-mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
-printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
-printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
-chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
-
-pci_run() { # <owner-dir|-|garbage> <run-dir> [steal-env] [fn-arg] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
-    rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
-    case "$1" in
-    -) ;; # no pre-existing units
-    garbage) printf '[Service]\nExecStart=/usr/bin/env not-ours\n' >"$PCI/units/pithead-control.service" ;;
-    *) printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCI/units/pithead-control.service" ;;
-    esac
-    (
-        cd "$2" || exit
-        PATH="$PCI/bin:$PATH"
-        # shellcheck disable=SC1090
-        source "$STACK"
-        set +e
-        log() { :; }
-        # Record instead of executing — into a side file, because the install branch redirects
-        # `sudo tee`'s stdout to /dev/null, so an echoing stub would be invisible there.
-        sudo() { echo "sudo:$*" >>"$PCI/calls"; }
-        PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
-            CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
-            provision_control_runner ${4:+"$4"} 2>&1
-        cat "$PCI/calls" 2>/dev/null
-    )
-}
-
-out="$(pci_run "$PCI/other" "$PCI/mine")"
-assert_contains "install: foreign existing owner -> refused, names the owner" "$out" "belong to the install at $PCI/other"
-assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
-assert_contains "install: foreign existing owner + steal escape -> overwritten" \
-    "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
-# The upgrade callsite's spelling: after a successful upgrade the OLD versioned dir still exists
-# (it is the rollback), so the converge MUST take the units over — via the `steal` argument, not
-# the operator env var. Without it every one-click upgrade would refuse and strand the channel.
-assert_contains "install: foreign existing owner + upgrade repoint (steal arg) -> overwritten" \
-    "$(pci_run "$PCI/other" "$PCI/mine" 0 steal)" "sudo:tee $PCI/units/pithead-control.service"
-assert_contains "install: foreign owner whose directory is gone -> adopted" \
-    "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
-out="$(pci_run garbage "$PCI/mine")"
-assert_contains "install: unparseable ExecStart -> left alone, says so" "$out" "not one this tool wrote"
-assert_not_contains "install: unparseable ExecStart -> unit not overwritten" "$out" "sudo:tee"
-assert_contains "install: own drifted unit -> converged (rewritten in place)" \
-    "$(pci_run "$PCI/mine" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
-assert_contains "install: no units at all -> fresh install unaffected by the guard" \
-    "$(pci_run - "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
-unset PCI pci_run out
+# shellcheck source=tests/stack/test-control-provisioning.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-control-provisioning.sh" && domain_ran test-control-provisioning.sh "$_d0" "$?" || domain_ran test-control-provisioning.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-appliance-identity.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-identity.sh" && domain_ran test-appliance-identity.sh "$_d0" "$?" || domain_ran test-appliance-identity.sh "$_d0" "$?"
 
-echo "== unit: preflight_remote_nodes dials before provisioning commits =="
-PFSB=$(mktemp -d)
-printf '{"monero":{"mode":"local"},"tari":{"mode":"local"}}' >"$PFSB/local.json"
-run_sourced "$PFSB" preflight_remote_nodes "$PFSB/local.json" >/dev/null 2>&1
-assert_rc "all-local config -> nothing to dial, rc 0" "$?" "0"
-# 127.0.0.1:1 — reliably closed; the dial must fail fast and NAME the endpoint.
-printf '{"monero":{"mode":"local"},"tari":{"mode":"remote","remote":{"host":"127.0.0.1","grpc_port":1}}}' >"$PFSB/bad.json"
-out=$(run_sourced "$PFSB" preflight_remote_nodes "$PFSB/bad.json" 2>/dev/null)
-assert_rc "unreachable remote Tari -> rc 1" "$?" "1"
-assert_contains "failure names host and port" "$out" "127.0.0.1:1"
-assert_contains "failure points at the LAN-access switch" "$out" "grpc_lan_access"
-rm -rf "$PFSB"
-unset PFSB out
-
-echo "== unit: appliance defaults (tor.auto_heal) =="
-# Applied only where ABSENT: an operator who wrote false meant it.
-ADSB=$(mktemp -d)
-printf '{"monero":{"wallet_address":"x"}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "absent auto_heal -> enabled" "$(jq -r '.tor.auto_heal' "$ADSB/config.json")" "true"
-printf '{"tor":{"auto_heal":false}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "explicit false is respected" "$(jq -r '.tor.auto_heal' "$ADSB/config.json")" "false"
-printf '{"tor":{"data_dir":"/x"}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "other tor keys survive" "$(jq -r '.tor.data_dir' "$ADSB/config.json")" "/x"
-
-# dashboard.control.enabled had NO coverage, which is how #1066 shipped. The appliance turns the
-# control channel on because it has no other way in — but only behind a login, because an
-# unauthenticated config editor can change the payout wallet and run `apply`, which is exactly
-# what parse_and_validate_config refuses. The wizard's strip_defaults drops any answer equal to
-# the reference default, and the reference has control.enabled false, so the key is absent from
-# EVERY submission: injecting unconditionally built the forbidden pair on the "No login" answer
-# and dead-ended first boot after the operator was told provisioning had started.
-printf '{"dashboard":{"auth":{"password":"a-real-password"}}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "a password present -> the control channel is turned on" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "true"
-printf '{"dashboard":{"auth":{"password":""}}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "no password -> the control channel is NOT turned on (#1066)" "$(jq -r '.dashboard.control.enabled // "absent"' "$ADSB/config.json")" "absent"
-printf '{"dashboard":{"control":{"enabled":false},"auth":{"password":"a-real-password"}}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "an explicit control.enabled false is respected" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "false"
-# The whole first-boot sequence for the documented "No login" answer, in the order the appliance
-# runs it. The invariant is the one the validator enforces: this machine must never hand itself a
-# config carrying an enabled control channel and no password.
-mkdir -p "$ADSB/spool"
-printf 'none' >"$ADSB/spool/auth-mode"
-printf '{"monero":{"wallet_address":"x"},"dashboard":{"auth":{"username":"admin"}}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" ensure_appliance_dashboard_password "$ADSB/spool" >/dev/null 2>&1
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "\"No login\" leaves the password empty, as asked" "$(jq -r '.dashboard.auth.password // ""' "$ADSB/config.json")" ""
-assert_eq "\"No login\" never produces the pair the validator refuses (#1066)" \
-    "$(jq -r 'if (.dashboard.control.enabled == true) and ((.dashboard.auth.password // "") == "") then "forbidden-pair" else "ok" end' "$ADSB/config.json")" "ok"
-# ...and the same sequence WITH a login still ends up configurable, which is the whole reason the
-# appliance turns the channel on: no shell, no ssh, no other way to change a payout address.
-rm -f "$ADSB/spool/auth-mode"
-printf '{"monero":{"wallet_address":"x"},"dashboard":{"auth":{"username":"admin"}}}' >"$ADSB/config.json"
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" ensure_appliance_dashboard_password "$ADSB/spool" >/dev/null 2>&1
-PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
-assert_eq "a generated login leaves the machine configurable" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "true"
-rm -rf "$ADSB"
-unset ADSB
+# shellcheck source=tests/stack/test-appliance-defaults.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-appliance-defaults.sh" && domain_ran test-appliance-defaults.sh "$_d0" "$?" || domain_ran test-appliance-defaults.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-appliance-install.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-install.sh" && domain_ran test-appliance-install.sh "$_d0" "$?" || domain_ran test-appliance-install.sh "$_d0" "$?"
@@ -996,29 +795,8 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-identity-boot.sh" && domain
 # shellcheck source=tests/stack/test-appliance-media.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-media.sh" && domain_ran test-appliance-media.sh "$_d0" "$?" || domain_ran test-appliance-media.sh "$_d0" "$?"
 
-echo "== unit: os/rauc/loop-wait.sh — the partition wait demands block devices and polls its budget =="
-# The negative half of the contract — all a non-root tier can prove: absent nodes and
-# regular-file impostors both exhaust the poll and return 1. sleep/udevadm are function-stubbed
-# so the 25-poll budget runs instantly. The positive half (real nodes appearing) runs for real
-# on every image build — mkimage.sh and verify-image.sh both call this.
-LW="$SANDBOX/loop-wait"
-mkdir -p "$LW"
-lw_run() { # $1 device path
-    (
-        # shellcheck disable=SC1091  # path is dynamic by design
-        source "$ROOT/os/rauc/loop-wait.sh"
-        udevadm() { :; }
-        sleep() { echo x >>"$LW/sleeps"; }
-        wait_loop_partitions "$1"
-    )
-}
-: >"$LW/sleeps"
-lw_run "$LW/loop0"
-assert_rc "nodes that never appear -> rc 1" "$?" "1"
-assert_eq "the wait polls its full 25-try budget, not a single-shot check" "$(wc -l <"$LW/sleeps" | tr -d ' ')" "25"
-touch "$LW/loop0p1" "$LW/loop0p2"
-lw_run "$LW/loop0"
-assert_rc "regular files at p1/p2 do not satisfy the wait — block devices required" "$?" "1"
+# shellcheck source=tests/stack/test-rauc-loop-wait.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-rauc-loop-wait.sh" && domain_ran test-rauc-loop-wait.sh "$_d0" "$?" || domain_ran test-rauc-loop-wait.sh "$_d0" "$?"
 
 # ---------------------------------------------------------------------------
 # shellcheck source=tests/stack/test-lifecycle.sh disable=SC2015

--- a/tests/stack/test-appliance-defaults.sh
+++ b/tests/stack/test-appliance-defaults.sh
@@ -1,0 +1,96 @@
+# shellcheck shell=bash
+#
+# Appliance defaults domain (#1105 Phase 1, develop-v2 lane): two sections covering what a first
+# boot writes into a config the operator did not finish. apply_appliance_defaults fills tor
+# .auto_heal only where the key is ABSENT — an operator who wrote false meant it — and turns the
+# dashboard control channel on only when a password is actually present, because the appliance has
+# no shell and no ssh, so the channel is the only way to change a payout address, and an enabled
+# channel with an empty password is the exact pair parse_and_validate_config refuses (#1066). The
+# last case walks the documented "No login" first-boot sequence in the order the appliance runs it
+# and asserts the forbidden pair is never produced.
+# Sourced by tests/stack/run.sh.
+#
+# DISCLOSURE — the opening section is a provisioning preflight, and the file name does not say so.
+# preflight_remote_nodes (dial every configured remote node before provisioning commits; name the
+# host:port and point at the grpc_lan_access switch on failure) is thematically PROVISIONING and
+# belongs beside test-control-provisioning.sh. It is here because contiguity outranks the label:
+# the test-appliance-identity.sh source stanza sits BETWEEN that section and the provisioning
+# block, and moving this section across it would make the provisioning cut non-contiguous — which
+# would break the order-preserving-concat proof this whole split rests on. Ruled by the controller
+# rather than assumed; a 14-line file of its own is below any sensible floor. Direct precedent:
+# Phase 2's 21-doctor-stack-checks.sh carries three non-doctor helpers for the same reason.
+#
+# The block is contiguous and its source stanza sits at its exact former position, so execution
+# order is unchanged — a pure relocation, not a regrouping.
+#
+# Re-derivations. This file reads NO ambient name: every variable it reads it assigns itself —
+# $PFSB and $ADSB (both mktemp -d, both removed and unset at the end of their section) and $out.
+# Provider functions called: run_sourced, assert_rc, assert_eq, assert_contains. There is
+# deliberately no `: "${NAME:?}"` guard line, because there is nothing to guard. $PFSB is also
+# assigned in test-appliance-install.sh — its own mktemp -d, unset at the end of its own section.
+# That is a name reused downstream, not a value shared with it, and that file assigns before it
+# reads either way.
+
+echo "== unit: preflight_remote_nodes dials before provisioning commits =="
+PFSB=$(mktemp -d)
+printf '{"monero":{"mode":"local"},"tari":{"mode":"local"}}' >"$PFSB/local.json"
+run_sourced "$PFSB" preflight_remote_nodes "$PFSB/local.json" >/dev/null 2>&1
+assert_rc "all-local config -> nothing to dial, rc 0" "$?" "0"
+# 127.0.0.1:1 — reliably closed; the dial must fail fast and NAME the endpoint.
+printf '{"monero":{"mode":"local"},"tari":{"mode":"remote","remote":{"host":"127.0.0.1","grpc_port":1}}}' >"$PFSB/bad.json"
+out=$(run_sourced "$PFSB" preflight_remote_nodes "$PFSB/bad.json" 2>/dev/null)
+assert_rc "unreachable remote Tari -> rc 1" "$?" "1"
+assert_contains "failure names host and port" "$out" "127.0.0.1:1"
+assert_contains "failure points at the LAN-access switch" "$out" "grpc_lan_access"
+rm -rf "$PFSB"
+unset PFSB out
+
+echo "== unit: appliance defaults (tor.auto_heal) =="
+# Applied only where ABSENT: an operator who wrote false meant it.
+ADSB=$(mktemp -d)
+printf '{"monero":{"wallet_address":"x"}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "absent auto_heal -> enabled" "$(jq -r '.tor.auto_heal' "$ADSB/config.json")" "true"
+printf '{"tor":{"auto_heal":false}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "explicit false is respected" "$(jq -r '.tor.auto_heal' "$ADSB/config.json")" "false"
+printf '{"tor":{"data_dir":"/x"}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "other tor keys survive" "$(jq -r '.tor.data_dir' "$ADSB/config.json")" "/x"
+
+# dashboard.control.enabled had NO coverage, which is how #1066 shipped. The appliance turns the
+# control channel on because it has no other way in — but only behind a login, because an
+# unauthenticated config editor can change the payout wallet and run `apply`, which is exactly
+# what parse_and_validate_config refuses. The wizard's strip_defaults drops any answer equal to
+# the reference default, and the reference has control.enabled false, so the key is absent from
+# EVERY submission: injecting unconditionally built the forbidden pair on the "No login" answer
+# and dead-ended first boot after the operator was told provisioning had started.
+printf '{"dashboard":{"auth":{"password":"a-real-password"}}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "a password present -> the control channel is turned on" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "true"
+printf '{"dashboard":{"auth":{"password":""}}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "no password -> the control channel is NOT turned on (#1066)" "$(jq -r '.dashboard.control.enabled // "absent"' "$ADSB/config.json")" "absent"
+printf '{"dashboard":{"control":{"enabled":false},"auth":{"password":"a-real-password"}}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "an explicit control.enabled false is respected" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "false"
+# The whole first-boot sequence for the documented "No login" answer, in the order the appliance
+# runs it. The invariant is the one the validator enforces: this machine must never hand itself a
+# config carrying an enabled control channel and no password.
+mkdir -p "$ADSB/spool"
+printf 'none' >"$ADSB/spool/auth-mode"
+printf '{"monero":{"wallet_address":"x"},"dashboard":{"auth":{"username":"admin"}}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" ensure_appliance_dashboard_password "$ADSB/spool" >/dev/null 2>&1
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "\"No login\" leaves the password empty, as asked" "$(jq -r '.dashboard.auth.password // ""' "$ADSB/config.json")" ""
+assert_eq "\"No login\" never produces the pair the validator refuses (#1066)" \
+    "$(jq -r 'if (.dashboard.control.enabled == true) and ((.dashboard.auth.password // "") == "") then "forbidden-pair" else "ok" end' "$ADSB/config.json")" "ok"
+# ...and the same sequence WITH a login still ends up configurable, which is the whole reason the
+# appliance turns the channel on: no shell, no ssh, no other way to change a payout address.
+rm -f "$ADSB/spool/auth-mode"
+printf '{"monero":{"wallet_address":"x"},"dashboard":{"auth":{"username":"admin"}}}' >"$ADSB/config.json"
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" ensure_appliance_dashboard_password "$ADSB/spool" >/dev/null 2>&1
+PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
+assert_eq "a generated login leaves the machine configurable" "$(jq -r '.dashboard.control.enabled' "$ADSB/config.json")" "true"
+rm -rf "$ADSB"
+unset ADSB

--- a/tests/stack/test-control-provisioning.sh
+++ b/tests/stack/test-control-provisioning.sh
@@ -1,0 +1,150 @@
+# shellcheck shell=bash
+#
+# Control-runner provisioning domain (#1105 Phase 1, develop-v2 lane): the two sections that prove
+# provision_control_runner only ever touches the systemd units belonging to the checkout invoking
+# it. The unit names pithead-control.{path,service} are box-global, but a release bench holds
+# several checkouts at once — live stack, e2e harness, bundle-smoke temp dirs — so a checkout with
+# control disabled used to remove whatever units it found, including the live stack's runner (#33).
+# The second half is the install side of the same rule: an existing unit whose ExecStart names a
+# foreign directory is left alone and said so, an unparseable ExecStart is left alone, the tool's
+# own drifted unit is converged in place, and a bench that wants the steal is given an explicit
+# opt-in (#1190).
+# Sourced by tests/stack/run.sh.
+#
+# The block is contiguous and its source stanza sits at its exact former position, so execution
+# order is unchanged — a pure relocation, not a regrouping.
+#
+# THIS FILE IS STANDALONE-SOURCEABLE, and that is the correct call here — the OPPOSITE of the
+# spool-audit / confirm-approval disclosure precedent, which a reviewer coming from R9 will reach
+# for first. Those files are pure CONSUMERS of the shared control sandbox and are position-locked
+# by what a sibling section accumulated. This domain is not: it never calls build_control_sandbox
+# (grepped: zero in this file, one in run.sh), it reads nothing under $C/$RESULTS/$STAGED/$AUDIT,
+# and every fixture it needs it builds itself under its own two trees. Run out of position it
+# would still assert exactly what it asserts here.
+#
+# Re-derivations. $SANDBOX and $STACK come from lib.sh, both assigned at COLUMN 1 at top level,
+# outside every function body — so neither is the ordering dependency the $WALLET case turned out
+# to be. (Re-derive by reading the indent in lib.sh, not by line number.) Every other name is assigned here: $PCR
+# and $PCI (the two scratch trees), the pcr_run/pci_run helpers, and $out. Provider functions
+# called: assert_contains, assert_eq, assert_not_contains. A word-boundary sweep of all of
+# tests/stack/ finds $PCR and $PCI only inside this file — nothing else in the suite reads what
+# it creates. (Use a word boundary: a bare $PCR pattern also matches $PCR791 in
+# test-appliance-identity.sh, which is a different variable, not a coupling.)
+
+: "${SANDBOX:?}" "${STACK:?}"
+
+echo "== unit: provision_control_runner only removes units this checkout owns (#33) =="
+# The pithead-control.{path,service} names are box-global, but a release bench holds several
+# checkouts at once (live stack + e2e harness + bundle-smoke tmp dirs). A checkout with control
+# disabled used to remove whatever units were installed — including the LIVE stack's runner,
+# stranding its dashboard control requests (config editor stuck at "Previewing…"). The removal
+# branch keys on the service unit's ExecStart: foreign owner → leave alone; own units → remove;
+# a dangling path unit with no service file → still reaped.
+PCR="$SANDBOX/pcr"
+mkdir -p "$PCR/units" "$PCR/bin"
+# uname stub: the OS gate reads `uname -s` at source time; report Linux so the branch runs on dev
+# Macs too. systemctl stub satisfies the command -v gate.
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCR/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PCR/bin/systemctl"
+chmod +x "$PCR/bin/uname" "$PCR/bin/systemctl"
+
+pcr_run() { # <owner-dir|-> <run-dir> — seed units owned by owner-dir ('-' = no service file), run the removal branch from run-dir, echo sudo calls
+    rm -f "$PCR/units/pithead-control.service" "$PCR/units/pithead-control.path"
+    [ "$1" != "-" ] && printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCR/units/pithead-control.service"
+    printf '[Path]\nPathExistsGlob=/x/requests/*.json\n' >"$PCR/units/pithead-control.path"
+    (
+        cd "$2" || exit
+        PATH="$PCR/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        log() { :; }
+        sudo() { echo "sudo:$*"; } # record instead of executing; the disable call's output is redirected in-function
+        PITHEAD_UNIT_DIR="$PCR/units" DASHBOARD_CONTROL_ENABLED=false provision_control_runner
+    )
+}
+
+assert_eq "foreign owner -> units left alone (no sudo rm)" "$(pcr_run /srv/code/other-checkout "$PCR")" ""
+assert_contains "own units -> removed" "$(pcr_run "$PCR" "$PCR")" \
+    "sudo:rm -f $PCR/units/pithead-control.path $PCR/units/pithead-control.service"
+assert_contains "dangling path unit (no service file) -> still reaped" "$(pcr_run - "$PCR")" "sudo:rm -f"
+# Versioned install dirs carry dots (pithead-v1.9.3). Ownership must compare the ExecStart path
+# as an exact string, never a regex: with the dots read as "any char", a sibling whose path
+# differs only at those positions would falsely match as our own — and get removed.
+mkdir -p "$PCR/v1.9.3" "$PCR/v1x9y3"
+assert_eq "foreign owner differing only at regex-dot positions -> left alone" \
+    "$(pcr_run "$PCR/v1x9y3" "$PCR/v1.9.3")" ""
+# One checkout, two spellings: production units carry the versioned dir in ExecStart, and an
+# operator's disable apply runs through the `current` symlink. Ownership compares physical
+# paths, so the unit is recognized as our own and removed — a literal $PWD compare would call
+# it foreign and the disable would never converge.
+mkdir -p "$PCR/versions/pithead-v1.9.3"
+ln -s "$PCR/versions/pithead-v1.9.3" "$PCR/current"
+assert_contains "own unit under its versioned spelling, run via the current symlink -> removed" \
+    "$(pcr_run "$PCR/versions/pithead-v1.9.3" "$PCR/current")" "sudo:rm -f"
+unset PCR pcr_run
+
+echo "== unit: provision_control_runner refuses to overwrite a foreign install's units (#1190) =="
+# The removal branch above got its ownership check when a disable-apply deleted the live stack's
+# units; the INSTALL branch had none — any sibling checkout's apply/up with control enabled
+# overwrote the box-global units and silently repointed dashboard control at itself (the
+# production-stranding mechanism, this time via install instead of a failed upgrade). The guard:
+# foreign owner that still exists on disk → refuse and name it; owner directory gone → adopt
+# (that is how a new version takes over from a removed one); own unit → converge; unparseable
+# ExecStart → leave alone, fail safe; PITHEAD_STEAL_CONTROL_UNITS=1 → deliberate takeover.
+#
+# Mutation proof (each ran red against its assertion with the guard intact elsewhere):
+#   - drop the `[ -d "$install_owner" ]` conjunct  -> "owner directory gone -> adopted" goes red
+#   - flip the `!=` ownership compare to `=`       -> "foreign existing owner -> refused" goes red
+#   - drop the PITHEAD_STEAL_CONTROL_UNITS conjunct -> "steal escape -> overwritten" goes red
+#   - drop the `steal` argument conjunct           -> "upgrade repoint (steal arg)" goes red
+PCI="$SANDBOX/pci"
+mkdir -p "$PCI/units" "$PCI/bin" "$PCI/mine" "$PCI/other"
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCI/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PCI/bin/systemctl"
+chmod +x "$PCI/bin/uname" "$PCI/bin/systemctl"
+
+pci_run() { # <owner-dir|-|garbage> <run-dir> [steal-env] [fn-arg] — seed a service unit, run the INSTALL branch, echo warns + recorded sudo calls
+    rm -f "$PCI/units/pithead-control.service" "$PCI/units/pithead-control.path" "$PCI/calls"
+    case "$1" in
+    -) ;; # no pre-existing units
+    garbage) printf '[Service]\nExecStart=/usr/bin/env not-ours\n' >"$PCI/units/pithead-control.service" ;;
+    *) printf '[Service]\nExecStart=%s/pithead control-run-pending\n' "$1" >"$PCI/units/pithead-control.service" ;;
+    esac
+    (
+        cd "$2" || exit
+        PATH="$PCI/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        log() { :; }
+        # Record instead of executing — into a side file, because the install branch redirects
+        # `sudo tee`'s stdout to /dev/null, so an echoing stub would be invisible there.
+        sudo() { echo "sudo:$*" >>"$PCI/calls"; }
+        PITHEAD_UNIT_DIR="$PCI/units" DASHBOARD_CONTROL_ENABLED=true \
+            CONTROL_DIR="$2/data/control" PITHEAD_STEAL_CONTROL_UNITS="${3:-0}" \
+            provision_control_runner ${4:+"$4"} 2>&1
+        cat "$PCI/calls" 2>/dev/null
+    )
+}
+
+out="$(pci_run "$PCI/other" "$PCI/mine")"
+assert_contains "install: foreign existing owner -> refused, names the owner" "$out" "belong to the install at $PCI/other"
+assert_not_contains "install: foreign existing owner -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: foreign existing owner + steal escape -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 1)" "sudo:tee $PCI/units/pithead-control.service"
+# The upgrade callsite's spelling: after a successful upgrade the OLD versioned dir still exists
+# (it is the rollback), so the converge MUST take the units over — via the `steal` argument, not
+# the operator env var. Without it every one-click upgrade would refuse and strand the channel.
+assert_contains "install: foreign existing owner + upgrade repoint (steal arg) -> overwritten" \
+    "$(pci_run "$PCI/other" "$PCI/mine" 0 steal)" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: foreign owner whose directory is gone -> adopted" \
+    "$(pci_run "$PCI/long-gone" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+out="$(pci_run garbage "$PCI/mine")"
+assert_contains "install: unparseable ExecStart -> left alone, says so" "$out" "not one this tool wrote"
+assert_not_contains "install: unparseable ExecStart -> unit not overwritten" "$out" "sudo:tee"
+assert_contains "install: own drifted unit -> converged (rewritten in place)" \
+    "$(pci_run "$PCI/mine" "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+assert_contains "install: no units at all -> fresh install unaffected by the guard" \
+    "$(pci_run - "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
+unset PCI pci_run out

--- a/tests/stack/test-rauc-loop-wait.sh
+++ b/tests/stack/test-rauc-loop-wait.sh
@@ -1,0 +1,55 @@
+# shellcheck shell=bash
+#
+# RAUC loop-partition wait domain (#1105 Phase 1, develop-v2 lane): the one section covering
+# os/rauc/loop-wait.sh's wait_loop_partitions. It proves the negative half of that contract, which
+# is all a non-root tier honestly can: partition nodes that never appear exhaust the poll and
+# return 1, and regular files sitting at the p1/p2 paths do NOT satisfy the wait — block devices
+# are required. sleep and udevadm are function-stubbed inside a subshell, so the full 25-try budget
+# runs instantly and the sleep count is itself asserted, which is what distinguishes a real poll
+# from a single-shot check. The positive half (real nodes appearing) runs for real on every image
+# build — mkimage.sh and verify-image.sh both call this.
+# Sourced by tests/stack/run.sh.
+#
+# The block is contiguous and its source stanza sits at its exact former position, so execution
+# order is unchanged — a pure relocation, not a regrouping.
+#
+# NAMED FOR WHAT IT TESTS, deliberately. The cut map filed this section under a "boot-provisioning"
+# heading; there is no such domain, and the neighbouring test-appliance-boot.sh covers something
+# else. This file is small — smaller than any other domain file in the suite — and that is
+# preferred here over the alternative, which was to fold it into test-appliance-defaults.sh: the
+# two blocks are separated by NINE domain source stanzas, so folding them would have reordered
+# this section ahead of all nine. A zero-reorder cut is worth more than a round file count.
+#
+# Re-derivations. $ROOT and $SANDBOX come from lib.sh, both assigned at COLUMN 1 at top level,
+# outside every function body — so neither is the ordering dependency the $WALLET case turned out
+# to be. (Re-derive by reading the indent in lib.sh, not by line number.) $LW is assigned here, as is the lw_run helper; the udevadm and sleep stubs and
+# wait_loop_partitions itself live inside lw_run's subshell, sourced from
+# $ROOT/os/rauc/loop-wait.sh per call rather than relying on an ambient one. Provider functions
+# called: assert_rc, assert_eq. Every write lands under $LW ($SANDBOX/loop-wait), and a sweep of
+# all of tests/stack/ finds that path named ONLY in this block.
+
+: "${ROOT:?}" "${SANDBOX:?}"
+
+echo "== unit: os/rauc/loop-wait.sh — the partition wait demands block devices and polls its budget =="
+# The negative half of the contract — all a non-root tier can prove: absent nodes and
+# regular-file impostors both exhaust the poll and return 1. sleep/udevadm are function-stubbed
+# so the 25-poll budget runs instantly. The positive half (real nodes appearing) runs for real
+# on every image build — mkimage.sh and verify-image.sh both call this.
+LW="$SANDBOX/loop-wait"
+mkdir -p "$LW"
+lw_run() { # $1 device path
+    (
+        # shellcheck disable=SC1091  # path is dynamic by design
+        source "$ROOT/os/rauc/loop-wait.sh"
+        udevadm() { :; }
+        sleep() { echo x >>"$LW/sleeps"; }
+        wait_loop_partitions "$1"
+    )
+}
+: >"$LW/sleeps"
+lw_run "$LW/loop0"
+assert_rc "nodes that never appear -> rc 1" "$?" "1"
+assert_eq "the wait polls its full 25-try budget, not a single-shot check" "$(wc -l <"$LW/sleeps" | tr -d ' ')" "25"
+touch "$LW/loop0p1" "$LW/loop0p2"
+lw_run "$LW/loop0"
+assert_rc "regular files at p1/p2 do not satisfy the wait — block devices required" "$?" "1"

--- a/tests/stack/test-render-quadlet.sh
+++ b/tests/stack/test-render-quadlet.sh
@@ -1,0 +1,55 @@
+# shellcheck shell=bash
+#
+# Quadlet-render parity domain (#1105 Phase 1, develop-v2 lane): the one section that pins
+# render_quadlet_units against the os/quadlet fixtures committed from the #78 spike. It renders
+# each of its three modes off that mode's fixture env file — the default remote-node set, the
+# local-node set, and the payout-confirm set — and diffs every emitted unit against the
+# checked-in file byte-for-byte. Two negative assertions pin what each mode must NOT emit: the
+# remote render carries no node units, and the local render carries no wallet units. The fixtures ran live on the bench, so a
+# diff here means the renderer drifted from something proven, not that a fixture went stale
+# (#77 phase 1).
+# Sourced by tests/stack/run.sh.
+#
+# The block is contiguous and its source stanza sits at its exact former position, so execution
+# order is unchanged — a pure relocation, not a regrouping.
+#
+# Re-derivations. $ROOT and $SANDBOX come from lib.sh, where both are assigned at COLUMN 1 at top
+# level, outside every function body — so neither is the ordering dependency the $WALLET case
+# turned out to be. (Re-derive by grepping lib.sh for the assignment and reading the indent, not
+# by line number: a citation into another file is the perishable part of any claim here.) Every other name is assigned here: $QOUT, $QLOCAL, $QPAY and the loop's
+# own $f. The only provider functions called are run_sourced and assert_eq. Every write lands in
+# the three $SANDBOX/quadlet-*-out trees, and a sweep of all of tests/stack/ finds those three
+# paths named ONLY in this block — nothing else in the suite reads what this file creates, so it
+# carries no ambient-fixture coupling in either direction.
+
+: "${ROOT:?}" "${SANDBOX:?}"
+
+echo "== unit: render-quadlet parity vs os/quadlet fixtures (#77 phase 1) =="
+# The renderer must reproduce the spike-proven unit set byte-for-byte from the fixture env — the
+# os/quadlet files ran live in the #78 spike, so any drift here needs a bench re-proof, not just
+# an updated fixture.
+QOUT="$SANDBOX/quadlet-out"
+run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/fixture.env" "$QOUT" >/dev/null
+for f in mining.network proxy.network tor.container p2pool.container xmrig-proxy.container \
+    caddy.container docker-proxy.container docker-control.container dashboard.container; do
+    assert_eq "quadlet parity: $f" "$(diff -u "$ROOT/os/quadlet/$f" "$QOUT/$f" 2>&1 | head -c 300)" ""
+done
+assert_eq "remote render emits no node units" "$(find "$QOUT" -name 'monerod.container' -o -name 'tari.container' | wc -l | tr -d ' ')" "0"
+# The local-node variant (bench-proven 2026-07-24): profiles on, 11 files, node units included.
+QLOCAL="$SANDBOX/quadlet-local-out"
+run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/local/fixture.env" "$QLOCAL" >/dev/null
+for f in mining.network proxy.network tor.container monerod.container tari.container \
+    p2pool.container xmrig-proxy.container caddy.container docker-proxy.container \
+    docker-control.container dashboard.container; do
+    assert_eq "quadlet local parity: $f" "$(diff -u "$ROOT/os/quadlet/local/$f" "$QLOCAL/$f" 2>&1 | head -c 300)" ""
+done
+# The payout-confirm variant (bench-proven 2026-07-24): both wallet profiles, 13 files, the
+# dashboard gains the payout env keys only in this set (the others stay byte-identical).
+QPAY="$SANDBOX/quadlet-payout-out"
+run_sourced "$SANDBOX" render_quadlet_units "$ROOT/os/quadlet/payout/fixture.env" "$QPAY" >/dev/null
+for f in mining.network proxy.network tor.container monerod.container tari.container \
+    wallet-rpc.container tari-wallet.container p2pool.container xmrig-proxy.container \
+    caddy.container docker-proxy.container docker-control.container dashboard.container; do
+    assert_eq "quadlet payout parity: $f" "$(diff -u "$ROOT/os/quadlet/payout/$f" "$QPAY/$f" 2>&1 | head -c 300)" ""
+done
+assert_eq "local render emits no wallet units" "$(find "$QLOCAL" -name 'wallet-rpc.container' -o -name 'tari-wallet.container' | wc -l | tr -d ' ')" "0"


### PR DESCRIPTION
R10 of the #1105 Phase 1 `run.sh` split. Four contiguous blocks move into their own domain files.
`tests/stack/run.sh` goes **1034 → 812**.

| new file | lines | what moved | former run.sh range (at the base) |
|---|---|---|---|
| `tests/stack/test-render-quadlet.sh` | 55 | quadlet render parity vs the `os/quadlet` fixtures (#77 phase 1) | 124–152 |
| `tests/stack/test-control-provisioning.sh` | 150 | `provision_control_runner` ownership + install guard (#33, #1190) | 789–903 |
| `tests/stack/test-appliance-defaults.sh` | 96 | remote-node preflight + appliance defaults (#1066) | 908–970 |
| `tests/stack/test-rauc-loop-wait.sh` | 55 | `wait_loop_partitions` block-device + poll-budget contract | 999–1021 |

Every new file is under 400, so **no new file-budget rows**; the only tsv row that changes is
`run.sh`'s.

## Execution order is unchanged by construction, not by argument

Each block is contiguous, and each `source` stanza lands at that block's **exact former position**.
No block contains a `source "$HERE/` stanza, so nothing is nested and no domain loses its #1400
zero-assertion guard. Verified: 0 stanzas inside each of the four candidate ranges, against a
control of 39 across the whole file.

## The map's four ranges all overshot — all four were corrected before cutting

The cut map's END for each piece ran past the domain into the next one's introduction. Taken
literally, all four would have nested a domain file:

| piece | map range | last content line | what the tail would have nested |
|---|---|---|---|
| c14 | 1745–1863 | **1860** | `test-appliance-identity.sh` |
| c15 | 1864–1936 | **1927** | `test-appliance-install.sh`, `test-appliance-rig-miner.sh`, `test-appliance-boot.sh` |
| c18 | 2784–2815 | **2808** | `test-lifecycle.sh` — a file closed at its ceiling, so the repair would need a shrinking commit |
| render-quadlet | 124–~155 | **~154** | bounded by the stanza that must stay |

Those numbers are at the map's own sha. Every range was **re-located by section NAME at the tip**
and re-derived there before cutting; the ends above are the map's, the ends actually cut are the
tip's.

## Two judgement calls, stated rather than buried

**`test-appliance-defaults.sh` opens with a provisioning preflight, and its name does not say so.**
`preflight_remote_nodes` is thematically provisioning and belongs beside
`test-control-provisioning.sh`. It is here because contiguity outranks the label: the
`test-appliance-identity.sh` stanza sits *between* that section and the provisioning block, so
moving it would make the provisioning cut non-contiguous and break the order-preserving proof the
whole split rests on. Disclosed in the file's header. Precedent: Phase 2's
`21-doctor-stack-checks.sh` carrying three non-doctor helpers for the same reason.

**`test-rauc-loop-wait.sh` is the smallest domain file in the suite (55 lines, vs 67 for the
previous smallest), and that was preferred over the alternative.** The map suggested folding it
into the appliance-defaults family. The two blocks are separated by **nine** domain source
stanzas, so folding them would have reordered this section ahead of all nine. Riding an existing
neighbour was also unavailable: `test-appliance-media.sh` sits exactly at its recorded ceiling and
the budget ratchet only ever lowers. A zero-reorder cut was judged worth more than a round file
count.

## Proofs — every instrument fired a control first

**Byte-identity, both directions, derived from git rather than from the extraction.**
- Each new file below its header == `git show <base>:tests/stack/run.sh` at its stated range:
  **identical, 4/4**. Control: the same comparison with the range shifted one line **fires**.
- `run.sh` reconstructed independently by re-running the extractor over the base blob ==
  the committed `run.sh`: **identical**. Control: perturbing one line **fires**.

**Ordered section comparison (the only instrument that can see a permutation).** 274 headers both
sides; sorted multiset identical; **ordered diff identical; 0 of 274 positional mismatches**.
Control: permuting two adjacent headers makes the ordered diff **fire** while the sorted diff stays
**silent** — so the instrument discriminates.

**Whole-output residue: 2 lines**, a single pair — the #1325 ed25519 keygen fingerprint, which is
nondeterministic by construction. Control: deleting one assertion line grows the residue to 3.
(The normalizer also folds `/tmp/tmp.*` mktemp paths; without that, a second nondeterministic pair
sits in the residue and reads like a real difference.)

**Suite:** `rc=0, 2979 passed, 0 failed, 3292 log lines` — the same figures as the baseline.

**Baseline reuse, tested rather than assumed.** The BEFORE leg is R9's after-proof rather than a
fresh run. That is legal here because the executed program is byte-identical: the `tests/stack`
tree object and the built `pithead` blob are the **same objects** at R9's proven tree, at the tip
it merged to, and at this PR's base. The 15 paths that changed across that span are all under
`docs/`, `lib/pithead/` and `tests/integration/`; `git grep` finds **zero** references to
`lib/pithead` anywhere in `tests/stack/` (control: `./pithead` matches 30 times in `run.sh`), and
the three `file-budget` hits in `tests/stack/` are all comments. Both legs also ran in the **same
worktree**, so no cross-worktree path normalization is involved.

**Dependency audit, comments stripped, over the whole new files including headers.** `$ROOT`,
`$SANDBOX` and `$STACK` are the only ambient names read; each is assigned in `lib.sh` at column 1
outside every function body — re-derived by reading the indent, not taken from the tool, because
`-> PROVIDER` does not mean top-level. `test-appliance-defaults.sh` reads no ambient name at all
and so carries no guard line. The `(has ${..:-} default somewhere)` annotation the audit prints on
the guarded names is the known self-inflicted artifact of the `: "${NAME:?}"` guard itself;
confirmed by stripping the guard and re-auditing, at which point the annotation disappears.

**Coupling rules.** No block calls `build_control_sandbox` (0 in each; control: 1 in `run.sh`), and
none reads `$C`/`$RESULTS`/`$STAGED`/`$AUDIT`. Every scratch path these blocks write —
`$SANDBOX/quadlet-out`, `quadlet-local-out`, `quadlet-payout-out`, `loop-wait`, `pcr`, `pci` — was
swept across all of `tests/stack/` and appears **only inside its own block**. `$PFSB` is also used
by `test-appliance-install.sh`, which assigns its own `mktemp -d` before reading — a reused name,
not a shared value.

**#1400 guard set completeness.** 42 source stanzas, 42 `domain_ran` guards, and **zero stanzas
without one** — so the guarded set cannot omit a sourced domain by construction. This closes an
open question carried in from R9, which had proved the guards fire but not that the set omits
nothing.

**Gates.** `make lint` **rc=0**. File budget passes; the tsv diff is **exactly the `run.sh` row** —
`--generate` also wanted to lower `egress.py`, `ci.yml` and `tests/integration/run.sh`, rows this
diff never touches, and all three were restored by hand.

## `run.sh`'s ceiling is set to 815, not 812 — deliberately, and for a named consumer

`run.sh` is 812 lines; its recorded ceiling is **815**. That is three lines of headroom, the exact
size of one domain `source` stanza, and it is reserved for #1482.

The reason it can only be done here: `run.sh`'s ceiling has always equalled its exact size, so it
has zero headroom, so **a new domain file cannot be registered at all** — the three-line stanza a
new domain needs is itself refused by the budget gate. A new `tests/stack` file is therefore only
buildable inside a cut that is already rewriting `run.sh`'s row. The appliance lane hit exactly
this on #1482 (os-update mutation lock): both files that could host its coverage sit at their own
ceilings, and a new file was unbuildable. Rather than have it discovered at the gate, the slack is
planned in here and disclosed.

A stale-HIGH ceiling passes the gate by design (`:157` fails only when `lines -gt ceiling`), so
this is legal rather than merely tolerated. If #1482 does not land, the next cut that touches this
row should reclaim the three lines.

## Notes for the reviewer

- **The base moved under this branch mid-cut** (P7 / #1507 merged), and the budget gate flagged it
  the documented way: a NOTE naming `lib/pithead/99-remainder.sh`, a file this diff never touches.
  It was fixed by **rebasing**, not by an exemption, and every proof above was then re-derived at
  the new base rather than carried across. `tests/stack` is byte-identical either side of that
  move, so the cut itself was unaffected.
- **These four files ARE standalone-sourceable, which is the opposite of R9's three.** A reviewer
  arriving from R9 will reach for the spool-audit "deliberately not standalone" precedent; it is
  the wrong precedent for this shape. Those files are pure consumers of the shared control sandbox
  and are position-locked by what a sibling accumulated. These four build every fixture they need
  themselves and would assert the same thing run out of position.

## What was NOT done

- **`make test` did not complete.** It was killed by a harness timeout mid-run, and its `test-stack`
  target re-runs `tests/stack/run.sh`, which was already racing the detached after-proof. The
  `run.sh` leg is covered green by the after-proof above; the remaining legs — four standalone
  `tests/stack/test_*.sh` scripts, plus the dashboard and frontend suites — were not re-run. This
  diff touches no Python and none of those four scripts. CI covers them.
- No bench work, no hardware claimed, nothing under `os/` touched.
- **The base moved a second time during the proof** (P8 / #1508). The branch was rebased onto the
  new tip and re-pushed. The after-proof ran against the pre-rebase tree, and `tests/stack/` is
  **byte-identical** between that tree and the pushed head — the rebase moved only `lib/pithead/*`
  and the tsv row, neither of which the stack suite reads. So the proof is valid for what is
  pushed; that equivalence is the single claim here most worth attacking, and `git diff <proof-tree>
  HEAD -- tests/stack/` re-derives it in one command.
