### PR TITLE
fix(cli): serialise os-update and tell contention from a failed install (#1482)

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -323,7 +323,10 @@ reboot is a separately confirmed step, the only one that pauses mining — typic
 five minutes — and after it the machine runs its normal health checks before keeping the
 new version. A banner reports the outcome, including an automatic return to the previous
 version if the new one failed. The machine refuses images that are unsigned, built for
-different hardware, or older than what it runs; there is no override. See
+different hardware, or older than what it runs; there is no override. If another operation is changing the stack when you start an
+install, the install is not started at all: nothing is written to the idle copy and the
+dashboard says so rather than reporting a failed install. Start it again once that
+operation has finished. See
 [Dashboard › Updating the appliance OS](dashboard.md#updating-the-appliance-os) for the
 step-by-step. The one-click tarball upgrade other installs offer refuses on the
 appliance on purpose — it would apply the wrong kind of update.

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -49,7 +49,7 @@ dashboard/tests/web/test_xvb_views.py	1342
 .github/workflows/ci.yml	513
 lib/pithead/12-firstboot-wizard.sh	556
 lib/pithead/28-parse-and-validate-config.sh	485
-lib/pithead/99-remainder.sh	5427
+lib/pithead/99-remainder.sh	5440
 os/rootfs/Dockerfile	406
 scripts/build-pithead.sh	437
 scripts/release.sh	851

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -109,8 +109,9 @@ wait is the same either way: it is the lock that decides it, never the line.
 
 The lock covers the parts of a command that change things, not the whole command. A `backup`
 takes it after its prompts, so a passphrase you have not typed yet holds nothing up, and the
-first-boot wizard holds it only while it deploys. Read-only commands — `status`, `doctor` and
-`logs` among them — never take it and never wait.
+first-boot wizard holds it only while it deploys. `os-update` takes it just before it writes the
+spare slot, so a confirmation it is still waiting on holds nothing up either. Read-only
+commands — `status`, `doctor` and `logs` among them — never take it and never wait.
 
 The lock covers one stack, not one directory. A bundle install keeps each release in its own
 `pithead-vX.Y.Z` directory beside the one before it (see [The deploy-box

--- a/lib/pithead/15-os-update.sh
+++ b/lib/pithead/15-os-update.sh
@@ -218,6 +218,14 @@ os_update() {
             fi
         fi
     fi
+    # Serialise the mutating half against every other pithead operation (#1482). Taken HERE and
+    # deliberately not at the top of the function: everything above is read-only checking, and the
+    # variant confirmation just above blocks on the operator's keystroke — holding the lock across
+    # that would park every other verb for as long as nobody answers. That is the same reason
+    # firstboot_wizard is not wrapped (#1391), applied one caller over. A timeout exits
+    # PITHEAD_EX_LOCK_TIMEOUT, which the CLI reports itself and the dashboard's os-install runner
+    # routes to a "rejected" rather than a failed install.
+    mutation_lock_acquire os-update
     log "Installing OS update bundle: $bundle (running: $running, bundle: $target)"
     # Tee'd like the wizard's fatal path (#1028's idiom): a bare `rauc install` let RAUC's own
     # diagnosis (a signature mismatch, an incompatible bundle) vanish, leaving only the ERR
@@ -257,4 +265,5 @@ os_update() {
     else
         rm -f "$marker"
     fi
+    mutation_lock_release
 }

--- a/lib/pithead/99-remainder.sh
+++ b/lib/pithead/99-remainder.sh
@@ -4919,6 +4919,19 @@ control_os_install() { # <claimed-file> <id> <actor> <control-dir>
     done
     # Same wait shape as the download's: `if ! wait` would eat the subshell's exit code.
     wait "$pid" && rc=0 || rc=$?
+    # Contention, not a failed install: os_update timed out waiting for another pithead operation
+    # and exited before it reached rauc, so no slot was written. Falling through to the generic
+    # branch below would report a FAILED install whose message asserts the running system is
+    # untouched — true, and misleading, because nothing was attempted at all. Same shape and the
+    # same reasoning as the firstboot wizard's contention branch (wizard_setup_failed). "rejected"
+    # rather than "failed" matches this runner's own vocabulary for a request that never ran.
+    if [ "$rc" -eq "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        warn "OS install could not start: another pithead operation still held the machine."
+        control_os_refuse "$cdir" "$id" "$actor" "os-install" rejected "another pithead operation was already running, so the install was not started — nothing was changed. Try again once it has finished."
+        rm -f "$logf"
+        os_state_write "$cdir" '{"step":"idle"}'
+        return 0
+    fi
     if [ "$rc" -ne 0 ]; then
         # The raw install log is a host detail (staging paths, slot devices) and stays host-side:
         # the full tail goes to the journal, and the container-visible result carries only the

--- a/pithead
+++ b/pithead
@@ -3567,6 +3567,14 @@ os_update() {
             fi
         fi
     fi
+    # Serialise the mutating half against every other pithead operation (#1482). Taken HERE and
+    # deliberately not at the top of the function: everything above is read-only checking, and the
+    # variant confirmation just above blocks on the operator's keystroke — holding the lock across
+    # that would park every other verb for as long as nobody answers. That is the same reason
+    # firstboot_wizard is not wrapped (#1391), applied one caller over. A timeout exits
+    # PITHEAD_EX_LOCK_TIMEOUT, which the CLI reports itself and the dashboard's os-install runner
+    # routes to a "rejected" rather than a failed install.
+    mutation_lock_acquire os-update
     log "Installing OS update bundle: $bundle (running: $running, bundle: $target)"
     # Tee'd like the wizard's fatal path (#1028's idiom): a bare `rauc install` let RAUC's own
     # diagnosis (a signature mismatch, an incompatible bundle) vanish, leaving only the ERR
@@ -3606,6 +3614,7 @@ os_update() {
     else
         rm -f "$marker"
     fi
+    mutation_lock_release
 }
 
 reset_dashboard() {
@@ -11776,6 +11785,19 @@ control_os_install() { # <claimed-file> <id> <actor> <control-dir>
     done
     # Same wait shape as the download's: `if ! wait` would eat the subshell's exit code.
     wait "$pid" && rc=0 || rc=$?
+    # Contention, not a failed install: os_update timed out waiting for another pithead operation
+    # and exited before it reached rauc, so no slot was written. Falling through to the generic
+    # branch below would report a FAILED install whose message asserts the running system is
+    # untouched — true, and misleading, because nothing was attempted at all. Same shape and the
+    # same reasoning as the firstboot wizard's contention branch (wizard_setup_failed). "rejected"
+    # rather than "failed" matches this runner's own vocabulary for a request that never ran.
+    if [ "$rc" -eq "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        warn "OS install could not start: another pithead operation still held the machine."
+        control_os_refuse "$cdir" "$id" "$actor" "os-install" rejected "another pithead operation was already running, so the install was not started — nothing was changed. Try again once it has finished."
+        rm -f "$logf"
+        os_state_write "$cdir" '{"step":"idle"}'
+        return 0
+    fi
     if [ "$rc" -ne 0 ]; then
         # The raw install log is a host detail (staging paths, slot devices) and stays host-side:
         # the full tail goes to the journal, and the container-visible result carries only the


### PR DESCRIPTION
## What this fixes

`os_update` took no mutation lock, so a dashboard-driven OS install could run alongside another
mutating pithead verb. Wrapping it alone would have been **worse than the gap**:

- `mutation_lock_acquire` **exits** with `PITHEAD_EX_LOCK_TIMEOUT` rather than returning
  (`lib/pithead/00-prelude.sh:276`),
- the os-install runner does `wait "$pid" && rc=0 || rc=$?`,
- and it routes **any** non-zero rc to `control_os_refuse ... failed "the install did not complete
  — the running system is untouched and mining continues."`

So a lock timeout would have reported a **FAILED OS INSTALL** whose message asserts the system is
untouched — true, and misleading, because nothing was attempted at all. That is the class #1391's
F3 closed for `setup`, one caller over.

## The two edits

**`lib/pithead/15-os-update.sh`** — take the window immediately before the `Installing OS update
bundle` line, release it at the end of the function.

Deliberately **not** at the top of the function. Everything above is read-only checking, and the
variant confirmation blocks on the operator's keystroke; holding the lock across that would park
every other verb for as long as nobody answers. That is the reason `firstboot_wizard` is not
wrapped (#1391), applied one caller over.

**`lib/pithead/99-remainder.sh`** — a `PITHEAD_EX_LOCK_TIMEOUT` branch **before** the generic
non-zero branch, modelled on `wizard_setup_failed` (`lib/pithead/08-uninstall-firstboot.sh:143`).

It reports `rejected`, not `failed`. That matches this runner's own vocabulary for a request that
never ran (its staging and gate refusals already use it), and the frontend renders the reason
either way — `osupdate.mjs:252` treats any status but `installed` as a failure and shows
`out.error`, so no dashboard change is owed. `error()` exits 1 and `PITHEAD_EX_LOCK_TIMEOUT` is
the only `PITHEAD_EX_*` constant in the tree, so 75 is unambiguous inside that subshell.

## What was RUN

A sandbox that extracts the shipped os-update-verbs fixture **verbatim** from
`tests/stack/test-appliance-os-update-verbs.sh` (so the fixture cannot drift from what ships) and
drives the real `control-run-pending` path. **15 assertions, 0 failures.**

| | case | result |
|---|---|---|
| **CONTROL A** | no lock held | `installed`; `rauc install` actually ran; state → `reboot-pending` |
| **CLAIM** | lock held, `PITHEAD_LOCK_TIMEOUT=1` | `rejected`; reason says *not started* and *nothing was changed*; does **not** say *did not complete*; `rauc install` never ran; no in-flight flag; state `reboot-pending` → `idle`; staged bundle **kept** for the retry; host-side log names the contention |
| **CONTROL B** | lock held, 75-branch **removed** | `failed`, wrongly saying the install *did not complete* and the system is *untouched* |

CONTROL A and the CLAIM differ **only** by the held lock — that contrast is what proves the
acquire is wired in, since without it the held lock is irrelevant and the run would simply
install. CONTROL B isolates the routing branch with Edit 1 still in place. The mutation was proven
applied before running (448 bytes removed at a named offset), not assumed.

**The first run of this harness failed, and the failure is why it is trustworthy.** CONTROL A went
red with *"no fully downloaded update bundle is staged"* — no `os-check` had armed the target — and
in that state the CLAIM's `rejected` **passed for the wrong reason**, off the staging door rather
than contention. Identical refusal text on all three cases is the fixture-never-armed signature.
Without CONTROL A this PR would have shipped a false green.

## Mechanical gates

- `scripts/build-pithead.sh` + `make lint-pithead-parity` — OK, 31 slices.
- Per-slice `bash -n` — 31/31. Artifact `bash -n` rc=0.
- `shellcheck --severity=warning pithead` — clean, **with a positive control fired**: an injected
  unassigned expansion reported SC2154 at the edited artifact line, rc=1. A clean report is not
  evidence until the instrument has been seen reporting dirty.
- `shfmt -i 4 -d` — 0 bytes on both edited slices and on the artifact.
- `lint-docs-voice`, `lint-md`, `lint-operator-strings`, `lint-topology` — all OK.
- `lint-file-budget` — OK. `lib/pithead/99-remainder.sh` rises **5427 → 5440**, which is the
  both-ways behaviour #1464 gave that row; the gate prints its NOTE and passes. `origin/develop-v2`
  probed unmoved either side of the run.

**Byte-identity does NOT apply here and is not claimed** — unlike the #1105 P-series cuts, this
change alters the artifact on purpose.

## Over-engineering pass (by hand)

The ponytail gate cannot do this from this worktree: it reads the branch name in the pinned shell
cwd, which is `fix/1342-mutation-lock` — a branch that no longer exists — not the branch this PR
is cut from. Disclosed rather than left to look reviewed.

- **Is the change minimal?** 22 artifact lines across two hunks. Neither half stands alone: the
  acquire without the branch actively misreports contention as a failed install, and the branch
  without the acquire is dead code.
- **Should the two contention branches share a helper?** No. `wizard_setup_failed` returns 1 to
  reopen the setup window and decides whether to keep a failed config; this one writes a control
  result and a state transition. Same shape, different decisions — merging them would couple two
  call sites that have no reason to move together.
- **A simpler placement was available and was rejected**: taking the lock in `control_os_install`
  instead of in `os_update` is one edit rather than two, but it leaves the `pithead os-update` CLI
  verb unserialised. Taking it inside `os_update` covers both doors at once.
- **Pure addition** — no line is removed or rewritten; the diff is `+52/-4`, and the 4 removals are
  the budget row and two re-wrapped doc lines.

## NOT DONE — owed coverage, named rather than hidden

The permanent `tests/stack` coverage is **not in this PR**, and the reason is a gate, not an
oversight.

- `tests/stack/run.sh` is **1034/1034** — zero headroom — so the 3-line `source` stanza a new
  domain file needs is itself refused by the budget gate. **PR #1509** takes `run.sh` to 812 and
  records its ceiling at **815**, reserving exactly those three lines for this change. Once #1509
  merges, the CLAIM case above lands as `tests/stack/test-os-update-mutation-lock.sh` with its own
  new row. Placement ruled by the `tests` lane.
- **Behaviour A (that `os_update` takes the window at all) stays owed beyond that.**
  `lock_wiring_pair` is a *local* helper in `test-lifecycle.sh:756`, not in `lib.sh`; a new file
  could only reach it by being sourced after that file's stanza, which would work by ordering
  accident. `test-lifecycle.sh` is closed at 1032/1032, so an append needs a shrinking commit
  first. The `tests` lane has recorded a lifecycle split as a queue candidate.

The harness above proves both behaviours today; what is owed is that the proof becomes a
*standing* one. It is attached to this PR's evidence, not to the repo, until #1509 lands.
