### PR TITLE
refactor(tests): split the unit-helper cluster out of run.sh (#1105 R11)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -63,7 +63,7 @@ tests/integration/selftest-e2e-phases.sh	507
 tests/integration/selftest.sh	686
 tests/os/failure-evidence.sh	567
 tests/os/run.sh	3437
-tests/stack/run.sh	815
+tests/stack/run.sh	739
 tests/stack/test-appliance-boot.sh	641
 tests/stack/test-appliance-identity-boot.sh	465
 tests/stack/test-appliance-identity.sh	483

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -18,49 +18,12 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-harness-tooling.sh" && domain_ran tes
 # shellcheck source=tests/stack/test-doctor.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-doctor.sh" && domain_ran test-doctor.sh "$_d0" "$?" || domain_ran test-doctor.sh "$_d0" "$?"
 
-echo "== unit: docker_boot_enabled (#137) =="
-# A systemctl stub on PATH; FAKE_BOOT picks which unit reports "enabled". Docker counts as
-# boot-enabled if EITHER docker.service or docker.socket is enabled.
-BOOT="$SANDBOX/boot"
-mkdir -p "$BOOT/bin"
-cat >"$BOOT/bin/systemctl" <<'EOF'
-#!/usr/bin/env bash
-case "$1 $2" in
-  "is-enabled docker.service") [ "${FAKE_BOOT:-}" = "service" ] && exit 0 || exit 1 ;;
-  "is-enabled docker.socket")  [ "${FAKE_BOOT:-}" = "socket"  ] && exit 0 || exit 1 ;;
-  *) exit 1 ;;
-esac
-EOF
-chmod +x "$BOOT/bin/systemctl"
-PATH="$BOOT/bin:$PATH" FAKE_BOOT=service run_sourced "$SANDBOX" docker_boot_enabled
-assert_rc "docker.service enabled -> 0" "$?" "0"
-PATH="$BOOT/bin:$PATH" FAKE_BOOT=socket run_sourced "$SANDBOX" docker_boot_enabled
-assert_rc "docker.socket enabled -> 0" "$?" "0"
-PATH="$BOOT/bin:$PATH" FAKE_BOOT=none run_sourced "$SANDBOX" docker_boot_enabled
-assert_rc "neither enabled -> 1" "$?" "1"
-
 # ---------------------------------------------------------------------------
 # shellcheck source=tests/stack/test-control-upgrade.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-control-upgrade.sh" && domain_ran test-control-upgrade.sh "$_d0" "$?" || domain_ran test-control-upgrade.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-release-signing.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-release-signing.sh" && domain_ran test-release-signing.sh "$_d0" "$?" || domain_ran test-release-signing.sh "$_d0" "$?"
-
-echo "== unit: config_bool honours an explicit false (jq // false-coercion guard, #294) =="
-# Regression for #294: `.x // true` returns true even when x is explicitly false (jq treats false as
-# empty), which silently broke the #270 firewall opt-out (config false → .env stayed true) and
-# xvb.tor=false. config_bool null-checks instead. CONFIG_FILE is the relative "config.json", so a
-# fixture in the cwd is what the sourced helper reads.
-CB="$SANDBOX/cb"
-mkdir -p "$CB"
-printf '{"network":{"tor_egress_firewall":false},"xvb":{"tor":false}}' >"$CB/config.json"
-assert_eq "explicit false honoured (firewall)" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "false"
-assert_eq "explicit false honoured (xvb.tor)" "$(run_sourced "$CB" config_bool '.xvb.tor' true)" "false"
-printf '{"network":{"tor_egress_firewall":true}}' >"$CB/config.json"
-assert_eq "explicit true honoured" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "true"
-printf '{}' >"$CB/config.json"
-assert_eq "absent -> default true" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "true"
-assert_eq "absent -> default false" "$(run_sourced "$CB" config_bool '.xvb.tor' false)" "false"
 
 # ---------------------------------------------------------------------------
 # shellcheck source=tests/stack/test-dashboard.sh disable=SC2015
@@ -72,47 +35,8 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard-onion.sh" && domain_ran tes
 # shellcheck source=tests/stack/test-release.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-release.sh" && domain_ran test-release.sh "$_d0" "$?" || domain_ran test-release.sh "$_d0" "$?"
 
-# The XvB tier thresholds are hard-coded in config.py (TIER_DEFAULTS) and stated explicitly in
-# docs/architecture.md. Drift guard: each config value must match the doc's human form, so the
-# user-facing table can't silently fall out of sync if TIER_DEFAULTS ever changes.
-tier_cfg="$ROOT/dashboard/mining_dashboard/config/config.py"
-tier_doc="$ROOT/docs/architecture.md"
-for tier in "donor:1_000:1 kH/s" "vip:10_000:10 kH/s" "whale:100_000:100 kH/s" "mega:1_000_000:1 MH/s"; do
-    t_name="${tier%%:*}"
-    t_rest="${tier#*:}"
-    t_val="${t_rest%%:*}"
-    t_human="${t_rest#*:}"
-    if grep -qE ": ${t_val}[ ,]" "$tier_cfg" && grep -qF "$t_human" "$tier_doc"; then
-        ok "XvB $t_name tier: config.py $t_val matches docs '$t_human'"
-    else
-        bad "XvB $t_name tier docs match TIER_DEFAULTS" "config $t_val / doc '$t_human' out of sync"
-    fi
-done
-
-echo "== unit: env helpers =="
-printf 'A=1\nB=two\nPROXY_AUTH_TOKEN=keep=me\n' >"$SANDBOX/old.env"
-printf 'A=1\nB=three\nC=4\nPROXY_AUTH_TOKEN=keep=me\n' >"$SANDBOX/new.env"
-assert_eq "env_get_file reads value" "$(run_sourced "$SANDBOX" env_get_file "$SANDBOX/old.env" B)" "two"
-assert_eq "env_get_file value with =" "$(run_sourced "$SANDBOX" env_get_file "$SANDBOX/old.env" PROXY_AUTH_TOKEN)" "keep=me"
-changed="$(run_sourced "$SANDBOX" env_changed_keys "$SANDBOX/old.env" "$SANDBOX/new.env" | sort | tr '\n' ' ')"
-assert_eq "env_changed_keys finds B and C" "$changed" "B C "
-
-echo "== unit: export_build_provenance (Issue #58) =="
-# Exports the stack version (from the top-level VERSION file, whitespace-trimmed) plus git
-# branch/commit for the dashboard build args — deliberately NOT written into .env, since the
-# volatile commit would otherwise churn `apply`. The sandbox isn't a git repo, so branch/commit
-# come back empty here; the release/dev split is unit-tested in dashboard/tests/test_version.py.
-PROV="$SANDBOX/prov"
-mkdir -p "$PROV"
-printf '  9.9.9 \n' >"$PROV/VERSION"
-# shellcheck disable=SC1090  # STACK path is dynamic by design
-ver="$(cd "$PROV" && source "$STACK" && set +e && export_build_provenance && printf '%s' "$PITHEAD_VERSION")"
-assert_eq "export_build_provenance reads VERSION (trimmed)" "$ver" "9.9.9"
-NOVER="$SANDBOX/nover"
-mkdir -p "$NOVER"
-# shellcheck disable=SC1090  # STACK path is dynamic by design
-ver="$(cd "$NOVER" && source "$STACK" && set +e && export_build_provenance && printf '%s' "$PITHEAD_VERSION")"
-assert_eq "export_build_provenance empty when no VERSION" "$ver" ""
+# shellcheck source=tests/stack/test-unit-helpers.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-unit-helpers.sh" && domain_ran test-unit-helpers.sh "$_d0" "$?" || domain_ran test-unit-helpers.sh "$_d0" "$?"
 
 # ---------------------------------------------------------------------------
 # shellcheck source=tests/stack/test-cli.sh disable=SC2015

--- a/tests/stack/test-unit-helpers.sh
+++ b/tests/stack/test-unit-helpers.sh
@@ -1,0 +1,136 @@
+# shellcheck shell=bash
+#
+# Unit-helper domain (#1105 Phase 1, develop-v2 lane): the cluster of small helper tests that sat
+# at the head of run.sh. Four of them drive a pithead function through run_sourced and assert its
+# return code or its stdout — docker_boot_enabled (a systemctl stub on PATH decides which unit
+# reports enabled, and docker.service or docker.socket each count on their own), config_bool (a
+# config value written explicitly false must stay false rather than be coerced by jq's // default,
+# the #294 regression that silently re-enabled the firewall opt-out), env_get_file and
+# env_changed_keys (a value containing an "=" survives intact, and only the keys that differ are
+# reported), and export_build_provenance (the VERSION file is read and whitespace-trimmed, and an
+# absent VERSION yields an empty version rather than an error). The fifth block is a drift guard
+# rather than a unit test: it pins the XvB tier thresholds in the dashboard's config.py against the
+# human forms written in docs/architecture.md, so the user-facing table cannot fall out of sync
+# with TIER_DEFAULTS unnoticed.
+# Sourced by tests/stack/run.sh.
+#
+# NAMED FOR WHAT IT HOLDS. The cut map filed this range under "config-helpers"; of the five blocks
+# only config_bool is a config helper, the XvB block is not a helper test at all, and
+# tests/stack/test-config.sh already exists — a near-identical neighbour name would send a reader
+# to the wrong file.
+#
+# THIS CUT REORDERS, and saying so is the point. The range is NOT contiguous: domain source
+# stanzas are interleaved between these blocks, and every one of them is EXCLUDED from the cut
+# rather than nested. (Nesting a stanza would leave the outer domain_ran guard reading the value
+# the nested stanza set, so the extracted content would carry zero zero-assertion coverage — not
+# narrowed coverage, zero.) Excluding them leaves three pieces, so one vacated position takes the
+# source stanza and the others close up. The anchor is the last piece's position, chosen because it
+# leaves the most sections standing: the XvB, env-helper and provenance blocks execute exactly
+# where they always did, and only the docker_boot_enabled and config_bool blocks move later. They
+# do not cross the same set. docker_boot_enabled now runs after test-control-upgrade.sh,
+# test-release-signing.sh, test-dashboard.sh, test-dashboard-onion.sh and test-release.sh;
+# config_bool after the last three of those. Every other domain file keeps its position.
+#
+# WHY THAT REORDER IS SAFE, argued in both directions.
+#   Outward: the names these blocks assign — $BOOT, $tier_cfg, $tier_doc, $changed, $PROV, $NOVER,
+#   $ver and the drift loop's own $tier, $t_name, $t_rest, $t_val and $t_human — are read nowhere
+#   else, in run.sh or anywhere else under tests/stack. Swept per name over every tests/stack/*.sh
+#   with comments stripped first, because a comment naming a variable is not a read and this lane
+#   has been bitten by that three times; the surviving hits were then read individually rather than
+#   counted. The
+#   one shared name is $CB: this file's config_bool block and tests/stack/test-monero-tari.sh both
+#   work in $SANDBOX/cb. That file assigns $CB, mkdir -p's it and writes its own config.json, so it
+#   inherits nothing from here — and its stanza is sourced after this file's stanza both before and
+#   after the cut.
+#   Inward: these blocks read only $SANDBOX, $ROOT and $STACK, each assigned at COLUMN 1 at top
+#   level in lib.sh, outside every function body — so none of them is the ordering dependency the
+#   $WALLET case turned out to be. (Re-derive by grepping lib.sh for the assignment and reading the
+#   indent, not by line number: a citation into another file is the perishable part of any claim
+#   here.) The domain files the two moved blocks now run after reassign none of those three and
+#   create no systemctl stub that could shadow this file's own; every PATH replacement and every cd
+#   in them is confined to a subshell or to a function whose whole body is a subshell. Every path
+#   this file writes or reads is anchored on $SANDBOX, $ROOT or $STACK, or is reached by an
+#   explicit cd inside a command substitution, so a leaked working directory could not reach them
+#   either.
+#   The provider functions called are run_sourced, assert_rc, assert_eq, ok and bad.
+
+: "${ROOT:?}" "${SANDBOX:?}" "${STACK:?}"
+
+echo "== unit: docker_boot_enabled (#137) =="
+# A systemctl stub on PATH; FAKE_BOOT picks which unit reports "enabled". Docker counts as
+# boot-enabled if EITHER docker.service or docker.socket is enabled.
+BOOT="$SANDBOX/boot"
+mkdir -p "$BOOT/bin"
+cat >"$BOOT/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "is-enabled docker.service") [ "${FAKE_BOOT:-}" = "service" ] && exit 0 || exit 1 ;;
+  "is-enabled docker.socket")  [ "${FAKE_BOOT:-}" = "socket"  ] && exit 0 || exit 1 ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$BOOT/bin/systemctl"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=service run_sourced "$SANDBOX" docker_boot_enabled
+assert_rc "docker.service enabled -> 0" "$?" "0"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=socket run_sourced "$SANDBOX" docker_boot_enabled
+assert_rc "docker.socket enabled -> 0" "$?" "0"
+PATH="$BOOT/bin:$PATH" FAKE_BOOT=none run_sourced "$SANDBOX" docker_boot_enabled
+assert_rc "neither enabled -> 1" "$?" "1"
+
+echo "== unit: config_bool honours an explicit false (jq // false-coercion guard, #294) =="
+# Regression for #294: `.x // true` returns true even when x is explicitly false (jq treats false as
+# empty), which silently broke the #270 firewall opt-out (config false → .env stayed true) and
+# xvb.tor=false. config_bool null-checks instead. CONFIG_FILE is the relative "config.json", so a
+# fixture in the cwd is what the sourced helper reads.
+CB="$SANDBOX/cb"
+mkdir -p "$CB"
+printf '{"network":{"tor_egress_firewall":false},"xvb":{"tor":false}}' >"$CB/config.json"
+assert_eq "explicit false honoured (firewall)" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "false"
+assert_eq "explicit false honoured (xvb.tor)" "$(run_sourced "$CB" config_bool '.xvb.tor' true)" "false"
+printf '{"network":{"tor_egress_firewall":true}}' >"$CB/config.json"
+assert_eq "explicit true honoured" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "true"
+printf '{}' >"$CB/config.json"
+assert_eq "absent -> default true" "$(run_sourced "$CB" config_bool '.network.tor_egress_firewall' true)" "true"
+assert_eq "absent -> default false" "$(run_sourced "$CB" config_bool '.xvb.tor' false)" "false"
+
+# The XvB tier thresholds are hard-coded in config.py (TIER_DEFAULTS) and stated explicitly in
+# docs/architecture.md. Drift guard: each config value must match the doc's human form, so the
+# user-facing table can't silently fall out of sync if TIER_DEFAULTS ever changes.
+tier_cfg="$ROOT/dashboard/mining_dashboard/config/config.py"
+tier_doc="$ROOT/docs/architecture.md"
+for tier in "donor:1_000:1 kH/s" "vip:10_000:10 kH/s" "whale:100_000:100 kH/s" "mega:1_000_000:1 MH/s"; do
+    t_name="${tier%%:*}"
+    t_rest="${tier#*:}"
+    t_val="${t_rest%%:*}"
+    t_human="${t_rest#*:}"
+    if grep -qE ": ${t_val}[ ,]" "$tier_cfg" && grep -qF "$t_human" "$tier_doc"; then
+        ok "XvB $t_name tier: config.py $t_val matches docs '$t_human'"
+    else
+        bad "XvB $t_name tier docs match TIER_DEFAULTS" "config $t_val / doc '$t_human' out of sync"
+    fi
+done
+
+echo "== unit: env helpers =="
+printf 'A=1\nB=two\nPROXY_AUTH_TOKEN=keep=me\n' >"$SANDBOX/old.env"
+printf 'A=1\nB=three\nC=4\nPROXY_AUTH_TOKEN=keep=me\n' >"$SANDBOX/new.env"
+assert_eq "env_get_file reads value" "$(run_sourced "$SANDBOX" env_get_file "$SANDBOX/old.env" B)" "two"
+assert_eq "env_get_file value with =" "$(run_sourced "$SANDBOX" env_get_file "$SANDBOX/old.env" PROXY_AUTH_TOKEN)" "keep=me"
+changed="$(run_sourced "$SANDBOX" env_changed_keys "$SANDBOX/old.env" "$SANDBOX/new.env" | sort | tr '\n' ' ')"
+assert_eq "env_changed_keys finds B and C" "$changed" "B C "
+
+echo "== unit: export_build_provenance (Issue #58) =="
+# Exports the stack version (from the top-level VERSION file, whitespace-trimmed) plus git
+# branch/commit for the dashboard build args — deliberately NOT written into .env, since the
+# volatile commit would otherwise churn `apply`. The sandbox isn't a git repo, so branch/commit
+# come back empty here; the release/dev split is unit-tested in dashboard/tests/test_version.py.
+PROV="$SANDBOX/prov"
+mkdir -p "$PROV"
+printf '  9.9.9 \n' >"$PROV/VERSION"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+ver="$(cd "$PROV" && source "$STACK" && set +e && export_build_provenance && printf '%s' "$PITHEAD_VERSION")"
+assert_eq "export_build_provenance reads VERSION (trimmed)" "$ver" "9.9.9"
+NOVER="$SANDBOX/nover"
+mkdir -p "$NOVER"
+# shellcheck disable=SC1090  # STACK path is dynamic by design
+ver="$(cd "$NOVER" && source "$STACK" && set +e && export_build_provenance && printf '%s' "$PITHEAD_VERSION")"
+assert_eq "export_build_provenance empty when no VERSION" "$ver" ""


### PR DESCRIPTION
Splits the unit-helper cluster at the head of `tests/stack/run.sh` into
`tests/stack/test-unit-helpers.sh` (#1105 R11, W1 cut queue).

Five blocks move: `docker_boot_enabled` (#137), `config_bool` (#294), the XvB tier
docs-drift guard, the `env_get_file`/`env_changed_keys` helpers, and
`export_build_provenance` (#58). `run.sh` goes 812 -> 736 lines; the new file is 131
lines including its header, under the 400-line floor, so it takes no budget row.

## THIS CUT REORDERS — disclosed, measured, and argued

The cut range is **not contiguous**. Seven domain `source` stanzas are interleaved
between these blocks. Every one of them is **excluded** from the cut rather than nested:
nesting a stanza would leave the outer `domain_ran` guard reading the value the nested
stanza set, so the extracted content would carry **zero** zero-assertion coverage — not
narrowed coverage, zero.

Excluding them leaves three pieces, so one vacated position takes the source stanza and
the others close up. **The anchor is the last piece's position**, chosen because it
leaves the most sections standing.

- **Blocks that do not move at all:** the XvB drift guard, the env helpers and the
  provenance block execute exactly where they always did.
- **Blocks that move later:** `docker_boot_enabled` and `config_bool`.
- **Largest displacement:** `docker_boot_enabled` now runs after five domain files that
  used to sit after it — `test-control-upgrade.sh`, `test-release-signing.sh`,
  `test-dashboard.sh`, `test-dashboard-onion.sh`, `test-release.sh`. `config_bool` moves
  past the last three of those.

### Why the reorder is safe, argued in both directions

**Outward — what the moved blocks give the suite.** The names they assign (`$BOOT`,
`$tier_cfg`, `$tier_doc`, `$changed`, `$PROV`, `$NOVER`, `$ver`, and the drift loop's own
`$tier`/`$t_name`/`$t_rest`/`$t_val`/`$t_human`) are read nowhere else in `run.sh` or
anywhere else under `tests/stack/`, with comments stripped before counting. The one
shared name is `$CB`: the `config_bool` block and `tests/stack/test-monero-tari.sh` both
work in `$SANDBOX/cb`. That file assigns `$CB`, `mkdir -p`s it and writes its own
`config.json` — its own header records that it deliberately stopped depending on this
block — and its stanza is sourced after this file's stanza both before and after the cut.

**Inward — what the moved blocks take from the suite.** They read only `$SANDBOX`,
`$ROOT` and `$STACK`. All three are assigned in `lib.sh` at **column 1 at top level**,
outside every function body (re-derived at source, with a control confirming none of the
three is also assigned indented) — so none is the ordering dependency the `$WALLET` case
turned out to be. The five domain files the two blocks now run after:

- reassign none of `$SANDBOX`, `$ROOT`, `$STACK`;
- create **no** `systemctl` stub that could shadow this file's own (and the block
  *prepends* its stub directory to `PATH`, so it would win regardless);
- confine every `PATH` replacement and every `cd` to a subshell or to a function whose
  entire body is a subshell — including the one `PATH` assignment that *replaces* rather
  than prepends, which is inside a command substitution's subshell.

Every path this file reads or writes is anchored on `$SANDBOX`, `$ROOT` or `$STACK`, or
is reached by an explicit `cd` inside a command substitution, so a leaked working
directory could not reach them either.

## Naming — a deliberate departure from the cut map

The cut map files this range as `test-config-helpers.sh`. The file is named
`test-unit-helpers.sh` instead: of the five blocks only `config_bool` is a config helper,
the XvB block is a docs-drift guard rather than a helper test, and
`tests/stack/test-config.sh` already exists — a near-identical neighbour name would send
a reader to the wrong file. Same reasoning the R10 row applied to its loop-wait section.

## Budget — R10's headroom is carried forward, not reclaimed

**This cut CARRIES R10's three-line bank FORWARD. It does not reclaim it, and saying so is
a condition of the ruling that created it, not a footnote.** `run.sh`'s row goes 815 ->
**739** for a 736-line file. R10 banked three lines because `run.sh`'s ceiling has always
equalled its exact size, so the row has zero headroom, so the three-line `source` stanza a
new domain file needs is itself refused by the budget gate — which is why a new
`tests/stack` file can only be born inside a cut that is already rewriting that row.

**#1482 is still live** (PR #1510 open and unmerged at the time of this cut), so the bank
still has its beneficiary and is carried forward unchanged. **The trigger to reclaim is
the named change LANDING or DYING — never "the next cut happened".** A cut that reclaims a
live bank has simply re-imposed the coupling the ruling removed. **The obligation to
disclose the carry-forward passes to R12**, or the three lines decay into anonymous slack
that the next reader cannot tell from an error.

`--generate` would also have silently lowered three rows this cut never touches
(`dashboard/mining_dashboard/service/egress.py` 424->423, `.github/workflows/ci.yml`
513->512, `tests/integration/run.sh` 2551->2541). All three are **restored to their
committed values**; lowering a row reds every un-rebased branch in every lane, naming a
file their diff never touched, and a stale-HIGH ceiling passes the gate by design.

## Proof

**Byte-identity, re-derived from git rather than from the extraction, both directions,
each with a control that provably fires.**

- The new file below its header, rebuilt out of `git show <base>:tests/stack/run.sh` at
  the three stated ranges, is byte-identical to what is committed. Control: shifting one
  range by a single line makes the diff fire.
- `run.sh` rebuilt independently by re-running the extractor over the base blob is
  byte-identical to the committed `run.sh`. Control: perturbing one line of the
  reconstruction makes the diff fire.

**Guard-set closure re-counted after the cut**: 43 domain `source` stanzas, 43
`domain_ran` guards, **zero** stanzas without one — the set cannot omit a sourced domain
by construction. (R10 closed this at 42/42; this cut adds one of each.)

**The ordering claim in the header was checked in both trees, not asserted**:
post-cut, `test-unit-helpers.sh`'s stanza is sourced before `test-monero-tari.sh`'s;
pre-cut, the `config_bool` block ran before that same stanza. The `$SANDBOX/cb`
relationship is therefore unchanged in direction.

**Static checks on the new file**: `shfmt -i 4 -d` clean, `shellcheck --severity=warning`
clean.

**Name audit** (`split-name-audit.py`, self-test 21/21 first) over the whole file,
header included. Three results, all adjudicated rather than accepted:

- `$ROOT`, `$SANDBOX`, `$STACK` annotated `PROVIDER (has ${..:-} default somewhere)`.
  That annotation is **self-inflicted by this file's own `: "${NAME:?}"` guard** — a
  known limitation where the tool's regex counts a `${..:?}` expansion as a defaulted
  one. Isolated: stripping the guard line and re-auditing makes the suffix disappear.
  Re-derived from source anyway — all three are assigned in `lib.sh` at column 1, and a
  control confirms none is also assigned indented inside a function body.
- `PITHEAD_VERSION` read, assigned nowhere. Correct and not a coupling: it is set by
  `export_build_provenance` itself, inside the command substitution that sources the
  script under test. Same shape it had in `run.sh`.
- `ORPHAN-CALL export_build_provenance`. The tool's known over-report: it is a pithead
  function reached after `source "$STACK"` inside that substitution, not a missing name.

## Instrument defect found while proving this cut — disclosed, not worked around

`~/split-tools/compare-proof.sh`'s **"VERDICT MULTISET" check is vacuous**. It compares
`grep -aE '^(ok|bad|FAIL|PASS)'` on both logs, but the suite writes per-test verdicts as
`  ✓ …` / `  ✗ …`, so that pattern matches **zero** lines on either side and the check
prints "IDENTICAL VERDICTS" unconditionally. Measured on this cut's own baseline log:
`^(ok|bad|FAIL|PASS)` → 0 lines, `^  [✓✗]` → the full verdict set.

This does not weaken R7–R10: the whole-output sorted multiset diff covers every log line
including the verdicts, so it subsumes what that check was meant to prove. What was wrong
is the framing — the proof standard names header multiset and per-test verdicts as two
checks, and one of the two could not fail. **The correct `^  [✓✗]` comparison is run and
reported below alongside the comparator's own output.** The tool is not rebuilt here;
the fix is routed to the controller.

## Suite pair — run at this cut's exact base, both legs, in parallel

**I did not reuse R10's after-proof as this cut's baseline, and the reason is worth
recording**: the tree-object test failed. `~/split-baselines/r10-2186a1f/`'s `tests/stack`
tree object is identical to *pre-R10* develop-v2, so that directory is named for R10's
**base**, not its proof tree, and the reuse could not be licensed from git. R10's own PR
discloses that its after-proof ran on a pre-rebase tree and names that equivalence as its
weakest claim. So this cut ran its own BEFORE leg at its own base instead.

| | before | after |
|---|---|---|
| exit code | 0 | 0 |
| verdict | 2979 passed, 0 failed | 2979 passed, 0 failed |
| log lines | 3292 | 3292 |
| section headers | 274 | 274 |
| `^  ✗` (post-norm) | 0 | 0 |

**Whole-output sorted multiset residue: exactly 2 lines** — one #1325 ed25519 keygen
fingerprint pair, the known nondeterministic class. Nothing else.

**Header SET (sorted): IDENTICAL.**

**Header ORDER — the check this cut turns on.** It fires, by design:

```
21d20   < == unit: docker_boot_enabled (#137) ==
34d32   < == unit: config_bool honours an explicit false (#294) ==
57a56,57 > == unit: docker_boot_enabled (#137) ==
         > == unit: config_bool honours an explicit false (#294) ==
37 of 274 positions differ
```

**Exactly two headers move**, and they are the two the anchor choice predicted.
Displacement: `docker_boot_enabled` +35 header positions, `config_bool` +23. The 37
differing *positions* are the arithmetic consequence of two blocks leaving early slots —
every header between the old and new sites shifts by two — not 37 relocated sections.

**Permutation control, fired.** Built from the before log against itself with exactly two
adjacent headers swapped, so content is identical and only order differs:

- sorted header diff: **SILENT** — blind to the permutation, as claimed
- ordered header diff on the same input: **FIRES**

That is the proof the instrument discriminates, and it is the only one of the two checks
that noticed. For a cut with no ambient coupling, the ordered comparison is not a backup
to the multiset — it is the only thing that can see a reorder at all.

**Verdict multiset (post-norm `^  [✓✗]`, 2979 lines each side): residue is the same single
keygen pair.** This check is reported here for the first time by an instrument that can
actually fail — see the section above.

## Rebase — the proof is not stale, and that is checkable

This branch was cut on R10's head and rebased onto develop-v2 after #1509 merged. **The
rebased commit's tree object is byte-identical to the pre-rebase commit's tree** — the
whole tree, not just `tests/stack`. develop-v2's `tests/stack` tree object and `pithead`
blob were already identical to the cut's base, so the merge changed nothing the suite
executes and the measured pair remains valid for exactly what is pushed.

## What was NOT run

- **`make lint` and `make test` were not run locally.** The session was over its context
  bar and the controller bounded the seat to finishing the proof and opening the PR;
  `make lint-sh` is the serialized shellcheck path with a history of OOM-killing sessions
  on this box, and it was not worth a fresh crossing of that bar. CI runs both on a fresh
  checkout and is the backstop. What *was* run on the new file: `shfmt -i 4 -d` clean and
  `shellcheck --severity=warning` clean.
- **No adversarial non-author review.** This lane authored the cut; the pass and the merge
  belong to the controller seat.

## Header amended after the proof — disclosed, bounded, and being re-proven

The over-engineering pass on this branch found a real defect in the header and it was
fixed before opening the PR. The original sentence said the two moved blocks run past
"the release-signing, dashboard and release domain files". That was wrong twice: it named
three files when `docker_boot_enabled` crosses **five**, and it conflated the two blocks,
which cross **different sets**. Corrected to state each block's own set. Two weaker claims
were tightened in the same amend: the outward name sweep now says what was actually done
(per name over every `tests/stack/*.sh` with comments stripped first, surviving hits read
individually rather than counted), and the drift loop's own `$tier`/`$t_*` names — which
the header asserted were read nowhere else without my ever having swept them — were then
actually swept, and the claim holds at zero.

**The amend is comment-only, proven**: zero non-comment lines differ between the pre-amend
and post-amend file, with a control confirming the instrument sees the 11 changed comment
lines. The body below the header is still byte-identical to the base run.sh at the stated
ranges. `shfmt` and `shellcheck` re-run clean.

**Even so, a comment-only amend to a file the suite SOURCES re-stales that PR's own
after-proof** (the R9 precedent, which ran a third proof for exactly this). The pair above
was measured on the pre-amend tree. **A re-proof of the after leg is running now**; its
verdict lands at `~/split-baselines/r11-3611427/after2.{log,rc}` and should reproduce
rc=0 / 2979 passed / 0 failed / 3292 lines / 274 headers. **Do not merge on the pair above
alone — read that verdict first.** The before leg is unaffected: its base did not move.
