### PR TITLE
fix(integration): trap aborts on EXIT alone, so a signalled run dies instead of resuming (#1401)

### DIFF
--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -191,7 +191,7 @@ CONTROL_VERDICT_BEFORE=""
 # so the EXIT trap always has a target even if it fires before preflight refines it.
 RESTORE_DIR="$CANONICAL_DIR"
 
-# --- Restore (runs on EXIT, even on failure / Ctrl-C) -----------------------
+# --- Restore: fires ONCE on EXIT, Ctrl-C included. Never add INT/TERM (#1401) ----
 restore_all() {
     local rc=$?
     [ "$RESTORED" = "1" ] && return
@@ -300,7 +300,7 @@ restore_all() {
     fi
     if [ "$rc" -eq 0 ]; then ok "restore complete."; else warn "restore complete (the run itself failed — see above)."; fi
 }
-trap restore_all EXIT INT TERM
+trap restore_all EXIT
 
 # --- Small waiters / helpers ------------------------------------------------
 wait_bench_healthy() { # <timeout_s>

--- a/tests/integration/rig-key-ledger.sh
+++ b/tests/integration/rig-key-ledger.sh
@@ -41,10 +41,12 @@
 # ever changes, this copy reds rather than drifting quietly.
 #
 # WHY `EXIT` ALONE AND NOT `EXIT INT TERM`. Measured on this box rather than assumed: a bare EXIT
-# trap DOES run when the shell dies of SIGINT or SIGTERM, and `trap … EXIT INT TERM` runs the
-# handler TWICE for one signal — once for the signal, once for the exit that follows. `EXIT` covers
-# Ctrl-C, a `kill`, and a cancelled CI job with exactly one firing. The unwind is written to be
-# idempotent anyway, because a trap that assumes it runs once is a trap nobody can safely change.
+# trap DOES run when the shell dies of SIGINT or SIGTERM, so naming the signals adds no coverage.
+# What it adds is worse than the second firing it is usually described as — a bash INT/TERM handler
+# that RETURNS does not die, so the script RESUMES at the next command, runs on to the end and exits
+# 0 (#1401; proof in selftest-abort-traps.sh). `EXIT` covers Ctrl-C, a `kill`, and a cancelled CI job
+# with exactly one firing. The unwind is written to be idempotent anyway, because a trap that assumes
+# it runs once is a trap nobody can safely change.
 #
 # ROUTES. Two, because the write surface is not all one path: `dash` is the dashboard's
 # /api/control/worker-apply (the #513, #1236 and #1002b legs) and `rig` is a direct dial at the

--- a/tests/integration/selftest-abort-traps.sh
+++ b/tests/integration/selftest-abort-traps.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 #
-# Self-test for the harness's ABORT TRAPS (#1401): every `trap` in tests/integration/ that exists to
-# unwind on an abort must name `EXIT` and nothing else. Standalone (not sourced by selftest.sh) so it
-# never touches that file's budget ceiling — the #1258/#1301 "moved into its own file" precedent. Run
-# directly, or via `make test-integration-selftest`. No server needed.
+# Self-test for the harness's ABORT TRAPS (#1401): checks exactly two named sites — e2e.sh's
+# `restore_all` trap and tor-client/probe.sh's `kill`-tor trap — and asserts each names `EXIT` and
+# nothing else. This is NOT a directory-wide sweep: it is two hardcoded (file, handler) pairs, not a
+# walk over tests/integration/, so a third file adding the same `EXIT INT TERM` idiom would pass this
+# file unnoticed (#1515, filed to widen this to a real walk). Standalone (not sourced by selftest.sh)
+# so it never touches that file's budget ceiling — the #1258/#1301 "moved into its own file"
+# precedent. Run directly, or via `make test-integration-selftest`. No server needed.
 #
 # WHAT THIS EXISTS TO STOP, and why a comment alone would not have. `trap handler EXIT INT TERM` is
 # the common idiom and it READS as more careful than bare `EXIT`, so it gets re-added by anyone who

--- a/tests/integration/selftest-abort-traps.sh
+++ b/tests/integration/selftest-abort-traps.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Self-test for the harness's ABORT TRAPS (#1401): every `trap` in tests/integration/ that exists to
+# unwind on an abort must name `EXIT` and nothing else. Standalone (not sourced by selftest.sh) so it
+# never touches that file's budget ceiling — the #1258/#1301 "moved into its own file" precedent. Run
+# directly, or via `make test-integration-selftest`. No server needed.
+#
+# WHAT THIS EXISTS TO STOP, and why a comment alone would not have. `trap handler EXIT INT TERM` is
+# the common idiom and it READS as more careful than bare `EXIT`, so it gets re-added by anyone who
+# has not measured it. Measured here rather than assumed: a bare EXIT trap already runs when the
+# shell dies of SIGINT or SIGTERM, so naming the signals adds no coverage — what it adds is that
+# **a bash INT/TERM handler that RETURNS does not die.** The shell resumes at the next command.
+#
+# For e2e.sh that was a FALSE GREEN, not a redundant teardown: on a Ctrl-C or a cancelled CI job,
+# restore_all ran the full unwind (miner pool restored, baseline stack redeployed), set its RESTORED
+# guard, returned — and the run CARRIED ON, measuring the restored baseline stack instead of the
+# branch under test, then exited 0. The guard is what made the second firing a no-op, so nothing
+# unwound the continuation either. An aborted release-gate run reporting success is this harness's
+# founding defect class, which is why the guard is a behavioural test and not a comment.
+#
+# THE CONTROLS ARE THE POINT. "Did the signal kill it" is unmeasurable without a row whose only
+# correct answer is death: two plausible harnesses each reported a confident, wrong "it survived"
+# before this one. An async job inherits SIGINT **ignored** and `trap - INT` cannot undo it (a signal
+# ignored at shell entry stays ignored), and a bash waiting on a foreground child **swallows** a
+# SIGINT the child never received — so signalling the shell's pid alone does not model a Ctrl-C.
+# `set -m` fixes both: it puts each background job in its own process group AND leaves its signal
+# dispositions at default, so the trial can signal the GROUP, as a terminal does. If the no-trap
+# rows below ever stop dying, the instrument is broken and nothing under it means anything.
+#
+set -m -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+TRIAL_DIR="$(mktemp -d)"
+TRIAL_FIRED=0
+TRIAL_CONTINUED=0
+TRIAL_RC=0
+trap 'rm -rf "$TRIAL_DIR"' EXIT # bare EXIT, for the reason this whole file is about
+
+# Run one trial: a victim script with trap spec $1, signalled with $2 delivered to its process
+# GROUP, as a terminal does. Sets TRIAL_FIRED / TRIAL_CONTINUED / TRIAL_RC.
+#
+# It must run in THIS shell and hand its results back through globals rather than through $(...),
+# because command substitution is a SUBSHELL and job control does not cross into one: measured, a
+# background child started inside $(...) is left in the PARENT's process group even with `set -m`
+# re-issued there. Two ways that matters. The group kill then finds no such group and every trial
+# reports "it survived" — which is what the controls below caught when this file was first written.
+# And had the group existed, `kill -- -$pid` would have signalled THIS suite instead of the victim.
+abort_trial() { # <trap-spec, "" for none> <signal>
+    local spec="$1" sig="$2" tag out src pid spun
+    tag="$(printf '%s.%s' "${spec// /_}" "$sig")"
+    out="$TRIAL_DIR/${tag:-none}.out"
+    src="$TRIAL_DIR/${tag:-none}.sh"
+    printf 'h() { echo FIRED >>"%s"; }\n' "$out" >"$src"
+    [ -n "$spec" ] && printf 'trap h %s\n' "$spec" >>"$src"
+    printf 'echo READY >>"%s"\n' "$out" >>"$src"
+    printf 'for _ in $(seq 150); do sleep 0.02; done\n' >>"$src"
+    printf 'echo CONTINUED >>"%s"\n' "$out" >>"$src"
+    : >"$out"
+    bash "$src" &
+    pid=$!
+    spun=0
+    while ! grep -q READY "$out" 2>/dev/null; do
+        sleep 0.01
+        spun=$((spun + 1))
+        [ "$spun" -gt 1000 ] && break # never hang the suite on a victim that failed to start
+    done
+    # The victim is a process-group leader (`set -m`, top of file) so this reaches it and nothing
+    # else. Job-control notices for the reap are noise; the caller drops them.
+    kill -"$sig" -- "-$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null
+    TRIAL_RC=$?
+    TRIAL_FIRED="$(grep -c FIRED "$out")"
+    TRIAL_CONTINUED="$(grep -c CONTINUED "$out")"
+}
+
+# The signal list of a `trap` line: everything after the handler argument.
+trap_signals() { # <file> <extended-regex matching the whole trap line>
+    local line
+    line="$(grep -hE "$2" "$1" | head -n1)"
+    [ -n "$line" ] || {
+        echo "__NO_TRAP_LINE_MATCHED__"
+        return
+    }
+    # Strip the leading `trap` and the handler (quoted or bare), leaving the signal names.
+    printf '%s\n' "$line" | sed -E "s/^trap[[:space:]]+('[^']*'|\"[^\"]*\"|[^[:space:]]+)[[:space:]]*//"
+}
+
+echo "== CONTROLS: with no trap at all, the signal MUST kill the victim (#1401) =="
+# Without these two rows a "survived" reading cannot be told from a signal that never landed.
+for sig in INT TERM; do
+    abort_trial "" "$sig" 2>/dev/null
+    if [ "$TRIAL_CONTINUED" = "0" ] && [ "$TRIAL_FIRED" = "0" ]; then
+        it_pass "control: SIG$sig kills an untrapped script, so the signal really lands"
+    else
+        it_fail "control: SIG$sig kills an untrapped script, so the signal really lands" \
+            "the instrument is broken (fired=$TRIAL_FIRED continued=$TRIAL_CONTINUED) — every case below is meaningless"
+    fi
+done
+
+echo "== a bare EXIT trap: fires ONCE and the script still dies (#1401) =="
+for sig in INT TERM; do
+    abort_trial "EXIT" "$sig" 2>/dev/null
+    assert_eq "bare EXIT still runs the handler on SIG$sig — naming the signal adds no coverage" \
+        "$TRIAL_FIRED" "1"
+    assert_eq "and the script does NOT survive SIG$sig" "$TRIAL_CONTINUED" "0"
+done
+
+echo "== EXIT INT TERM: the handler returns, so the script RESUMES — the #1401 defect =="
+for sig in INT TERM; do
+    abort_trial "EXIT INT TERM" "$sig" 2>/dev/null
+    assert_eq "EXIT INT TERM lets the script carry on past SIG$sig" "$TRIAL_CONTINUED" "1"
+    assert_eq "  ...and exit 0, so an aborted run reports SUCCESS" "$TRIAL_RC" "0"
+    assert_eq "  ...having fired the handler twice, the second a no-op behind any guard" \
+        "$TRIAL_FIRED" "2"
+done
+
+echo "== the shipped abort traps name EXIT and nothing else =="
+# e2e.sh: restore_all is the borrowed rig's only unwind. If this reds, read the block above before
+# "fixing" it by re-adding the signals — that is the change this file exists to refuse.
+sigs="$(trap_signals "$HERE/e2e.sh" '^trap[[:space:]]+restore_all[[:space:]]')"
+assert_ne "e2e.sh's restore_all trap line was found at all" "$sigs" "__NO_TRAP_LINE_MATCHED__"
+assert_eq "e2e.sh traps restore_all on EXIT alone (#1401)" "$sigs" "EXIT"
+
+# tor-client/probe.sh: same class, different consequence — naming the signals would kill tor and
+# then carry on into the bootstrap wait, spending BOOT_TIMEOUT to report a wrong diagnosis.
+sigs="$(trap_signals "$HERE/tor-client/probe.sh" "^trap[[:space:]]+'kill")"
+assert_ne "probe.sh's tor-kill trap line was found at all" "$sigs" "__NO_TRAP_LINE_MATCHED__"
+assert_eq "probe.sh traps the tor kill on EXIT alone (#1401)" "$sigs" "EXIT"
+
+echo ""
+echo "selftest-abort-traps: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -85,8 +85,9 @@ assert_eq "the outstanding key is restored to its original, via the dash route (
 
 echo "== Ctrl-C — the failure mode the issue leads with =="
 # Measured, not assumed: a bare EXIT trap DOES run when bash dies of SIGINT, and `EXIT INT TERM`
-# would run the handler TWICE for one signal. This asserts both halves at once — the restore
-# happened, and it happened exactly once.
+# would both fire the handler twice AND let the run resume past the signal (#1401; the matrix is in
+# selftest-abort-traps.sh). This asserts both halves at once — the restore happened, and it happened
+# exactly once.
 scenario 'rig_key_mark dash rig1 max_temp_c 100' 'kill -INT $$' 'sleep 30' >/dev/null
 assert_eq "SIGINT mid-change restores the key (#1379)" \
     "$(restores)" 'dash|{"max_temp_c":100}'

--- a/tests/integration/tor-client/probe.sh
+++ b/tests/integration/tor-client/probe.sh
@@ -53,7 +53,12 @@ fi
 
 tor -f "$CFG" >"$DATA/tor.log" 2>&1 &
 TORPID=$!
-trap 'kill "$TORPID" 2>/dev/null || true' EXIT INT TERM
+# Bare EXIT on purpose, and it already covers Ctrl-C, a kill and a cancelled CI job. Naming
+# INT/TERM as well does NOT add coverage: a bash signal handler that RETURNS does not die, so the
+# probe would kill tor and then CARRY ON into the bootstrap wait below, grep a log nothing is
+# writing any more, and spend BOOT_TIMEOUT before reporting "tor did not bootstrap" — a wrong
+# diagnosis for what was really an abort. Proof: selftest-abort-traps.sh (#1401).
+trap 'kill "$TORPID" 2>/dev/null || true' EXIT
 
 # Wait for a fully-bootstrapped client before any fetch — a partial bootstrap can't reach an onion.
 waited=0


### PR DESCRIPTION
Fixes #1401.

## What this fixes

`trap restore_all EXIT INT TERM` reads as the more careful idiom, and it is wrong. Measured (not
assumed) by signalling the process group the way a terminal Ctrl-C does: a bash `INT`/`TERM` handler
that **returns** does not die — the shell resumes at the next command. So naming the signals does not
add a second teardown to an aborting run; it converts the abort into "tear down, then carry on."

For `tests/integration/e2e.sh` that is a **false green**, not the redundant double-teardown #1401
originally graded as latent. On a Ctrl-C or a cancelled CI job, `restore_all` ran its full unwind
(miner pool restored, baseline stack redeployed), set its `RESTORED` re-entrancy guard, returned — and
the run **carried on**, measuring the restored baseline stack instead of the branch under test, then
exited 0. The guard made the later real `EXIT` firing a no-op, so nothing unwound the continuation
either. An aborted release-gate run reporting success is this harness's founding defect class, not a
tidiness point, and that grading is ratified — it is not softened here.

A second live instance of the same spelling, found by enumerating the class rather than stopping at
the site the issue named: `tests/integration/tor-client/probe.sh:56`. Different consequence — it would
kill tor and continue into the bootstrap wait, grepping a log nothing is writing any more, and spend
the full `BOOT_TIMEOUT` reporting "tor did not bootstrap" for what was really an abort.

Two other comments (`rig-key-ledger.sh`, `selftest-rig-key-ledger.sh`) already chose bare `EXIT` for
an earlier issue (#1379) but described the reason in the incomplete, safe-direction form ("runs the
handler twice"). Their conclusion was already right; the wording is sharpened to state why, rather than
swept.

## The method note, because it generalizes past this fix

"Did the signal kill it" is unmeasurable without a **no-trap positive control** whose only correct
answer is death. Two plausible harnesses each gave a confident, wrong "it survived" before landing on
one that didn't: an async job (`cmd &`) inherits `SIGINT` ignored, and `trap -` cannot undo that; and a
bash shell waiting on a foreground child swallows a `SIGINT` the child itself never received, so
signalling the parent pid is not signalling a Ctrl-C. Signalling the **process group**, with a no-trap
row in the matrix, is what caught both at once — without it the contaminated matrix reads identically
to the real one.

## What was run (this session did not re-run any of it — see below)

Relayed from the branch's own proof round, published in full on the issue
(`issuecomment-5461074966`, the re-grading, and `issuecomment-5461137483`, what shipped):

- `make test-integration-selftest` rc=0 — new file `selftest-abort-traps.sh` 16/0, ten files total, 0
  failures.
- A three-leg mutation battery, each leg gated on `cmp` proving the edit actually applied before it
  counts: re-adding `INT TERM` to `e2e.sh` reds its own assertion; the same edit to `probe.sh` reds
  its own; deleting `e2e.sh`'s trap line reds the extraction guard rather than passing vacuously. Both
  files restored byte-identical afterward and the suite re-run green.
- `shellcheck --severity=warning tests/integration/*.sh` rc=0 from the repo root over the whole glob
  (`probe.sh` checked separately — it isn't in `lint-sh`'s glob).
- `shfmt -i 4 -d` over the Makefile's exact glob: rc=0.
- `scripts/lint-file-budget.sh` rc=0 — `e2e.sh` sits at 691 lines against a 691 ceiling (the issue's
  own 766/766 figure is stale), so the comment-only change there is line-neutral by necessity, not
  incidentally.

Docs needed no change, and that is the finding rather than an omission:
`docs/dev/integration-testing.md:171` already promised the `EXIT`-trap behaviour. The doc was right
and the code disagreed with it.

## What I did NOT do (this session)

This session's only job was opening this PR from the already-pushed, already-proven branch
(`a6ec29c`) — not rebuilding, re-cutting, or amending the fix.

- **Did not re-run the proof round or the mutation battery.** Every figure under "What was run" above
  is relayed from the issue comment, not re-executed here.
- **Did not touch #1022** (unrelated, open).
- **Did not touch #1236**, which stays parked on operator-supplied values.

## What I re-derived this session, rather than relayed

- Branch tip `a6ec29c` is exactly **one** commit ahead of `origin/develop-v2`
  (`git log origin/develop-v2..HEAD`), with merge-base `cf6a888`. `develop-v2` itself has moved 10
  commits since that merge-base (unrelated merged PRs) — the "1 commit ahead" figure is about new
  commits on this branch, not the raw `rev-list --count`, which reads 10/1 because of that shared
  history.
- Diffstat re-measured at `git diff --stat origin/develop-v2...HEAD`: 5 files changed, 152 insertions,
  9 deletions — `tests/integration/e2e.sh`, `tests/integration/rig-key-ledger.sh`,
  `tests/integration/selftest-rig-key-ledger.sh`, `tests/integration/tor-client/probe.sh`, and the new
  `tests/integration/selftest-abort-traps.sh`. Matches the branch's own accounting exactly.
  - **File-count check I ran, not merely accepted:** `selftest-abort-traps.sh` (135 lines) is a
    genuinely new file — `selftest.sh` sits on its own 686-line ceiling with zero slack, so the new
    cases could not have landed there; the runner globs `tests/integration/selftest*.sh`
    (`Makefile:29`), so the new file needs no registration.
- Working tree is clean, nothing unpushed, no existing PR was open for this branch or head ref.
- Issue #1401 is still OPEN.

All paths touched are under `tests/integration/`, which this lane owns exclusively — no lane-guard or
shared-file question here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
