### PR TITLE
docs: the 99-remainder budget row retired — say so in the past tense (#1522)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,14 +63,14 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
      the script — and so is the shipped `pithead` artifact itself: it is generated, and the gate
      governs its `lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it.
-     One row is exempt from the ceilings-only-move-down half, and only that half:
-     `lib/pithead/99-remainder.sh` measures how much of that generated artifact Phase 2 has not
-     split out yet, not the size of a file anyone writes, so it tracks the artifact both ways.
-     Without that, `pithead`'s own exemption became a freeze — the CLI could not gain a line,
-     because the row refused to rise and the file refused to grow past it (issue #1464). The row
-     is still checked against the file on every PR, so a change that grows the artifact has to
-     record the new count, and every Phase 2 cut lowers it; it retires when the remainder reaches
-     the 400 target. See `monotonic_exempt()` in the script),
+     One row was exempt from the ceilings-only-move-down half, and only that half:
+     `lib/pithead/99-remainder.sh` measured how much of that generated artifact Phase 2 had not
+     split out yet, not the size of a file anyone writes. Without that, `pithead`'s own exemption
+     became a freeze — the CLI could not gain a line, because the row refused to rise and the file
+     refused to grow past it (issue #1464). That row has retired, and not by reaching the 400
+     target: Phase 2 split the remainder out completely, so the file was deleted at 949 lines and
+     nothing in `docs/dev/file-budget.tsv` names it now. `monotonic_exempt()` in the script still
+     carries the arm and the reasoning behind it),
      `lint-pithead-parity` (the shipped `pithead` must be exactly what `lib/pithead/*.sh`
      concatenate to: edit a slice, run `scripts/build-pithead.sh`, and commit both — issue #1105
      Phase 2), `lint-trivy-parity` (the CVE

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -207,12 +207,19 @@ run_gate() {
 # exemption into a hard freeze, because no value of the row passed — run_gate refused the growth
 # and check_monotonic refused the raise.
 #
-# What keeps it honest is what is NOT changed here: run_gate's `lines > ceiling` rule is
-# untouched, so a PR that grows the artifact must still record the new count, and the row stays a
-# per-PR measurement rather than a ceiling nobody reads. Every Phase 2 slice cut LOWERS it —
-# the progress signal the row exists for — and it retires itself when the remainder drops to the
-# target. Keep this list to rows with that property; a row naming a real source file does not
-# have it.
+# What kept it honest is what was NOT changed for it: run_gate's `lines > ceiling` rule is
+# untouched, so a PR that grows the artifact must still record the new count, and the row stayed a
+# per-PR measurement rather than a ceiling nobody reads. Every Phase 2 slice cut LOWERED it — the
+# progress signal the row existed for. Keep this list to rows with that property; a row naming a
+# real source file does not have it.
+#
+# THE ROW HAS RETIRED, and not by reaching the target: Phase 2 split the remainder out completely
+# (#1105 P13), so lib/pithead/99-remainder.sh was deleted at 949 lines and no row in
+# docs/dev/file-budget.tsv names that path. The arm below therefore matches nothing. Before
+# removing it: lint-file-budget-selftest.sh exercises monotonic_exempt() against a synthetic repo
+# of its own, and as that self-test records, the plausible mistake here is not deleting this arm
+# but widening it to lib/pithead/*. The reasoning above is what governs whether a future row
+# earns the same treatment.
 monotonic_exempt() {
     case "$1" in
     lib/pithead/99-remainder.sh) return 0 ;;


### PR DESCRIPTION
Closes #1522 — except that a closing keyword is inert into `develop-v2`, so the issue is closed by
hand after merge.

`lib/pithead/99-remainder.sh` and its `docs/dev/file-budget.tsv` row retired in #1105 P13 (#1521).
Two sites still described that row in the present tense, so a contributor reading them goes looking
for a mechanism that is not there.

## What changed

**`CONTRIBUTING.md` — the load-bearing site.** It said the row "is still checked against the file on
every PR" and that "it retires when the remainder reaches the 400 target". Both are now false, and the
second was never how it went: the file was deleted at **949 lines**, never passing through the 400
target, because Phase 2 split the remainder out completely. The paragraph is in the past tense and
says nothing in `docs/dev/file-budget.tsv` names that path now.

**`scripts/lint-file-budget.sh` — `monotonic_exempt()`'s comment.** Same correction. **The arm itself
stays.** It matches nothing now, but the reasoning above it is what governs whether a future row earns
the same treatment, and `lint-file-budget-selftest.sh` exercises the function against a synthetic repo
of its own — as that self-test's own comment records, the plausible future mistake is not deleting
this arm but widening it to `lib/pithead/*`.

## What was RUN

- **The script change is comment-ONLY, proven not asserted.** Comparing both revisions with comment
  lines stripped gives an EMPTY diff; **the control fires** — the same comparison with comments
  included differs. So no behaviour changed.
- `bash scripts/lint-file-budget.sh` → rc 0.
- `bash scripts/lint-file-budget-selftest.sh` → `lint-file-budget self-test OK`, including its
  empty-candidate-scan and zero-tracked-files enumeration guards.
- `shfmt -i 4 -d` clean; `shellcheck --severity=warning` clean.
- `make lint-docs-voice` → `docs voice OK — no banned words in 40 prose docs`.
- `docs/dev/file-budget.tsv` is untouched: this cut adds no file and crosses no ceiling.
  `scripts/lint-file-budget.sh` has no ceiling row (317 lines, under the 400 target) — checked as a
  tab-delimited field-1 match, because a plain grep for that path also hits the tsv's own generated
  header comment.

The **949** figure was re-derived rather than taken from the issue: at the deleting commit's parent
the file is 949 lines and its tsv ceiling reads 949.

## Deliberately NOT in scope

- **`scripts/lint-file-budget-selftest.sh` (11 mentions) is not stale.** Verified: it writes its own
  synthetic `lib/pithead/99-remainder.sh` into a temp repo and exercises `monotonic_exempt()` in
  isolation, so it does not depend on the real file existing. Do not "fix" it.
- **`tests/integration/selftest-remote-endpoint.sh:7` is stale but PRE-EXISTING, and belongs to
  #1520.** Verified at the commit *before* the deletion: `99-remainder.sh` had **zero** hits for that
  rendering there, which actually lived in `lib/pithead/28-parse-and-validate-config.sh` and
  `lib/pithead/10-installer-preseed.sh`. So the pointer was already wrong and #1521 did not cause it.
  This is the control that separates fresh debris from an earlier round's — the two look identical
  until you check whether the claim was ever true.

## Lane disclosure

`CONTRIBUTING.md` and `scripts/lint-file-budget.sh` sit in trees no lane owns. Both are covered by a
per-file, per-item grant for #1522 in `roles/tests.paths`, which expires on merge. No one-shot
override was used and the scope was not widened past those two files.
