### PR TITLE
test(stack): name the file each moved section actually lives in (#1520)

### DIFF
--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -210,10 +210,10 @@ EOF
 # The control-channel sandbox: builds $C, defines CTRL_LOG, seed_control_env, control_config.
 build_control_sandbox() {
     # control_config() below reads $WALLET, but $WALLET was only ever assigned by
-    # build_val_sandbox(). In run.sh the two calls sit hundreds of lines apart in ONE process and
-    # val happens to run first, so control has always worked by accident of ordering. (No exact
-    # distance here on purpose — every #1105 module moves it, and a number nobody re-measures is
-    # how a comment starts lying.) A domain file
+    # build_val_sandbox(). The two calls have always landed in ONE process with val running first,
+    # so control worked by accident of ordering — first inside run.sh, and now across the domain
+    # files run.sh sources. (No file or distance named on purpose: #1105 keeps moving both, and a
+    # location nobody re-measures is how a comment starts lying.) A domain file
     # that calls this builder without val — or any section that crosses a process boundary into a
     # bash-invoked file — would abort on an unbound variable under `set -u`. Defaulting it here
     # makes this builder self-contained and retires the whole class (#1305); it fails loud rather

--- a/tests/stack/test-appliance-identity.sh
+++ b/tests/stack/test-appliance-identity.sh
@@ -19,11 +19,11 @@
 #
 # Taken deliberately, and worth naming because it is the one arguable member: the control-runner
 # units rendering into /run (#791). Its topical neighbours — provision_control_runner's ownership
-# and foreign-install guards — stay behind in run.sh, so a reader looking for control-runner work
-# will find most of it there. It travels here because it is a consequence of the appliance's
-# read-only root rather than of the control channel, and because it sits inside the contiguous
-# run: excluding it would buy a tidier topic at the cost of the property that makes this cut
-# cheap, namely that nothing executes in a different order afterwards. If a reviewer disagrees,
+# and foreign-install guards — live in tests/stack/test-control-provisioning.sh, so a reader looking
+# for control-runner work will find most of it there. It travels here because it is a consequence of
+# the appliance's read-only root rather than of the control channel, and because it sits inside the
+# contiguous run: excluding it would buy a tidier topic at the cost of the property that makes this
+# cut cheap, namely that nothing executes in a different order afterwards. If a reviewer disagrees,
 # moving it to a control file later is independent of this cut and costs one range.
 #
 # Left behind, deliberately: preflight_remote_nodes' dial-before-commit check, which follows this

--- a/tests/stack/test-backup.sh
+++ b/tests/stack/test-backup.sh
@@ -26,14 +26,14 @@
 # and nothing between those two original positions reads anything this file's fixtures produce.
 #
 # Re-derivations (the sandbox-builder WALLET trap — see #1305, still open on this lane):
-# - $WALLET: set by lib.sh's build_val_sandbox() (as the checksum-valid $VALID_PRIMARY constant),
-#   which run.sh's "config validation" black-box calls once, far earlier than every section below
-#   that reads it as a config.json field value. That section stays in run.sh (a generic multi-field
-#   validator, not a backup concern), and this file never needs $V itself (each fixture above builds
-#   its own sandbox instead of reusing the shared one) — so re-deriving the bare string is enough;
-#   calling the heavier build_val_sandbox() would build a $V this file never touches.
-# - $VALID_TARI is a plain lib.sh top-level constant (not build_val_sandbox()-scoped), so it needs no
-#   re-derivation here or anywhere else.
+# - $WALLET: set by lib.sh's build_val_sandbox() (as the checksum-valid $VALID_PRIMARY constant), which
+#   the "config validation" black-box calls once, ahead of every section below that reads it as a
+#   config.json field value. That section lives in test-config.sh, sourced ahead of this file (a
+#   generic multi-field validator, not a backup concern), and this file never needs $V itself (each
+#   fixture above builds its own sandbox instead of reusing the shared one) — so re-deriving the bare
+#   string is enough; calling the heavier build_val_sandbox() would build a $V this file never touches.
+# - $VALID_TARI is a plain lib.sh top-level constant (not
+#   build_val_sandbox()-scoped), so it needs no re-derivation here or anywhere else.
 WALLET="$VALID_PRIMARY" # checksum-valid mainnet primary (the XMRig donation address) — see #1305
 
 echo "== unit: stack_backup — one bounded retry on a tar race (#970) =="

--- a/tests/stack/test-control-upgrade.sh
+++ b/tests/stack/test-control-upgrade.sh
@@ -15,12 +15,12 @@
 # control channel (#33)" setup, and define $REQS/$RESULTS the same way (not lib.sh globals; only
 # these two are read below).
 #
-# $WALLET, set explicitly: lib.sh's control_config() closure reads it (lib.sh:207) without ever
-# setting it — in run.sh it was already set globally by build_val_sandbox()'s far-earlier
-# config-validation section. Same trap as module 7's onion-report fix: $VALID_PRIMARY is what
-# WALLET equals there, and it's always bound. Since FIXED in lib.sh (#1305): both sandbox builders
-# default WALLET now, so a future control-sandbox domain file no longer has to set it. The line
-# below is kept because it is correct and harmless, not because anything still requires it.
+# $WALLET, set explicitly: lib.sh's control_config() closure reads it without ever setting it — it used
+# to arrive already set globally, from the config-validation section's far-earlier build_val_sandbox()
+# call back when that section was inline in run.sh. Same trap as module 7's onion-report fix:
+# $VALID_PRIMARY is what WALLET equals there, and it's always bound. Since FIXED in lib.sh (#1305): both
+# sandbox builders default WALLET now, so a future control-sandbox domain file no longer has to set it.
+# The line below is kept because it is correct and harmless, not because anything still requires it.
 build_control_sandbox
 # shellcheck disable=SC2034  # read by lib.sh's control_config() closure, unseen here
 WALLET="$VALID_PRIMARY"

--- a/tests/stack/test-dashboard.sh
+++ b/tests/stack/test-dashboard.sh
@@ -19,10 +19,10 @@
 # Sourced by tests/stack/run.sh.
 #
 # Re-derivations:
-# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; run.sh's "config validation" black-box
-#   calls it once, far earlier than the dashboard-auth-lifecycle black-box below (docker-compose.yml
-#   copy, .env/config.json writes via `seed_env`, $V/bin stubs) — that section stays in run.sh (a
-#   generic multi-field validator, not a dashboard concern), so this file needs its own copy.
+# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; the "config validation" black-box calls
+#   it once, but that section lives in test-config.sh, sourced AFTER this file — so nothing has
+#   built $V by the time the dashboard-auth-lifecycle black-box below runs (docker-compose.yml
+#   copy, .env/config.json writes via `seed_env`, $V/bin stubs), so this file needs its own copy.
 #   build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies), so
 #   calling it again here is a safe no-op re-affirm, the same re-derivation test-lifecycle.sh uses.
 # - Everything else below sources the real $STACK fresh per subshell against a throwaway dir under

--- a/tests/stack/test-doctor-appliance.sh
+++ b/tests/stack/test-doctor-appliance.sh
@@ -26,11 +26,11 @@ assert_eq "docker boot persistence ignores podman.socket" "$out" "disabled"
 
 echo "== black-box: doctor --json + support-bundle (#77 phase 1) =="
 # Fresh, uniquely-named sandbox — deliberately NOT the shared $V that build_val_sandbox() (lib.sh,
-# module 1b) builds: that sandbox is threaded through ~2500 lines of run.sh's config-validation /
-# dashboard / payout sections that still live there, so calling build_val_sandbox() again from
-# this file would reset the SAME "$SANDBOX/val" directory out from under them no matter where this
-# file is sourced from. Mirrors build_val_sandbox's body under a non-colliding name instead — the
-# same re-derive-locally move module 8 makes for the shared control sandbox.
+# module 1b) builds: that sandbox is threaded through every domain file calling the builder —
+# config validation, dashboard, secrets and monero/tari among them — all sourced into the same
+# shell, so calling it again here would reset the SAME "$SANDBOX/val" directory out from under
+# them wherever this file is sourced from. Mirrors build_val_sandbox's body under a non-colliding
+# name instead — the same re-derive-locally move module 8 makes for the shared control sandbox.
 DJ="$SANDBOX/doctor-json"
 mkdir -p "$DJ/build/tari" "$DJ/dashboard"
 : >"$DJ/dashboard/Dockerfile"

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -14,13 +14,13 @@
 # Sourced by tests/stack/run.sh.
 #
 # Re-derivations:
-# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; run.sh's "config validation" black-box
-#   calls it once, far earlier than the migration-hold/upgrade/apply-recovery sections below that
-#   read them — that section stays in run.sh (a generic multi-field validator, not a lifecycle
-#   concern). build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p, template
-#   copies), so calling it again here is a safe no-op re-affirm as currently sourced.
-# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log) and
-#   stays in run.sh (a generic multi-key regression, not a lifecycle concern).
+# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; the "config validation" black-box calls it once,
+#   ahead of the migration-hold/upgrade/apply-recovery sections below that read them — that section lives
+#   in tests/stack/test-config.sh, whose stanza run.sh sources before this file (a generic multi-field
+#   validator, not a lifecycle concern). build_val_sandbox() is idempotent (a fixed $SANDBOX/val path,
+#   mkdir -p, template copies), so calling it again here is a safe no-op re-affirm as currently sourced.
+# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log); it lives in
+#   test-secrets.sh, sourced ahead of this file (a generic multi-key regression, not a lifecycle concern).
 # - Everything else below (restart, the two ownership sections, upgrade re-render, apply-recovery,
 #   up's relocated-dir warning, and the control-units convergence check) builds its own throwaway
 #   dir under $SANDBOX (or runs a fully stubbed subshell against $SANDBOX directly) and needs no

--- a/tests/stack/test-monero-tari.sh
+++ b/tests/stack/test-monero-tari.sh
@@ -14,18 +14,18 @@
 # Sourced by tests/stack/run.sh.
 #
 # Re-derivations (the sandbox-builder WALLET/$V trap — see #1305, still open on this lane):
-# - $CB: the "config_bool" unit test builds it ($SANDBOX/cb) immediately before this file's old
-#   position in run.sh, but that section is a generic jq-coercion helper test (also exercises
-#   xvb.tor), not monero-specific, so it stays in run.sh. Re-derived here rather than reaching back
-#   for the ambient one.
-# - $V / $WALLET: both are set by lib.sh's build_val_sandbox(), which run.sh's "config validation"
-#   black-box calls once, far earlier than every section below that reads them — that section stays
-#   in run.sh too (a generic multi-field validator, not monero-specific). build_val_sandbox() is
-#   idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies) so calling it again here is a
-#   safe no-op re-affirm as currently sourced, and makes this file correct on its own if a future
-#   reorder ever moves its source line earlier than that section.
-# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log) and
-#   stays in run.sh (another generic multi-key regression, not monero-specific).
+# - $CB: the "config_bool" unit test builds it ($SANDBOX/cb), but that section is a
+#   generic jq-coercion helper test (also exercises xvb.tor), not monero-specific, so
+#   it stays where it is: tests/stack/test-unit-helpers.sh, whose stanza run.sh sources
+#   before this file. Re-derived here rather than reaching back for the ambient one.
+# - $V / $WALLET: both are set by lib.sh's build_val_sandbox(), which the "config validation"
+#   black-box calls once, ahead of every section below that reads them — that section lives in
+#   test-config.sh, sourced ahead of this file (a generic multi-field validator, not monero-specific).
+#   build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies) so
+#   calling it again here is a safe no-op re-affirm as currently sourced, and makes this file correct
+#   on its own if a future reorder ever moves its source line earlier than that section.
+# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log); it lives
+#   in test-secrets.sh, sourced ahead of this file (generic multi-key regression, not monero-specific).
 CB="$SANDBOX/cb"
 mkdir -p "$CB"
 build_val_sandbox

--- a/tests/stack/test-release-signing.sh
+++ b/tests/stack/test-release-signing.sh
@@ -4,11 +4,11 @@
 # gate, cosign_container_path's host-to-container path mapping, and release.sh's signing/refusal/
 # pinned-verifier-image checks (sign the promoted digests, refuse to publish unsigned, validate
 # the pinned cosign verifier before publish). Sourced by tests/stack/run.sh after lib.sh. (The
-# #291 firewall-ordering assertions trailing cosign_container_path stay in run.sh — tor/network,
-# not signing, the documented map trap. The control-channel upgrade's own bundle-signature check
-# and its trailing control-disabled probe also stay in run.sh in full: that section runs the
-# control-run-pending verb against the $C control sandbox, the same run-against-its-own-sandbox
-# reasoning module 4 used for apply --dry-run/symlink-invocation.)
+# #291 firewall-ordering assertions trailing cosign_container_path are not here — tor/network, not
+# signing, the documented map trap; they live in test-tor-network.sh. The control-channel upgrade's
+# own bundle-signature check and its trailing control-disabled probe live in test-control-upgrade.sh
+# in full: that section runs the control-run-pending verb against the $C control sandbox, the same
+# run-against-its-own-sandbox reasoning module 4 used for apply --dry-run/symlink-invocation.)
 
 echo "== black-box: verify_release_images fail-closed gate (#376) =="
 # The verification decision itself, against a fake docker on a PINNED PATH ($VRI/bin:/usr/bin:/bin

--- a/tests/stack/test-rig-worker.sh
+++ b/tests/stack/test-rig-worker.sh
@@ -35,13 +35,13 @@
 #   evidence, argued in test-control-core.sh and in the consumer domains own headers.
 #
 # Re-derivations:
-# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; run.sh's "config validation" black-box
-#   calls it once, far earlier than the stratum/xmrig/miner-announce sections below that read
-#   them — that section stays in run.sh (a generic multi-field validator, not rig-specific).
-#   build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies), so
-#   calling it again here is a safe no-op re-affirm as currently sourced.
-# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log) and
-#   stays in run.sh (a generic multi-key regression, not rig-specific).
+# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; the "config validation" black-box calls
+#   it once, ahead of the stratum/xmrig/miner-announce sections below that read them — that
+#   section lives in test-config.sh, sourced ahead of this file (a generic multi-field validator,
+#   not rig-specific). build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p,
+#   template copies), so calling it again here is a safe no-op re-affirm as currently sourced.
+# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log); it lives
+#   in test-secrets.sh, sourced ahead of this file (a generic multi-key regression, not rig-specific).
 # - The worker-config/worker-upgrade verbs below need no control-sandbox re-derivation at all:
 #   each case builds its own throwaway dir under $SANDBOX and points PITHEAD_CONFIG_FILE at it,
 #   never touching $C — proven by exactly this after-proof once the token-mask pair above was

--- a/tests/stack/test-secrets.sh
+++ b/tests/stack/test-secrets.sh
@@ -34,11 +34,11 @@
 # either domain (most likely a future rig/worker-domain follow-up, since that is what its code does).
 #
 # Re-derivations:
-# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; run.sh's "config validation" black-box
-#   calls it once, far earlier than the sections below that read them — that section stays in run.sh
-#   (a generic multi-field validator, not a secrets concern). build_val_sandbox() is idempotent (a
-#   fixed $SANDBOX/val path, mkdir -p, template copies), so calling it again here is a safe no-op
-#   re-affirm, the same re-derivation test-monero-tari.sh/test-rig-worker.sh/test-lifecycle.sh use.
+# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; the "config validation" black-box calls it
+#   once, ahead of the sections below that read them — that section lives in test-config.sh, sourced
+#   ahead of this file (a generic multi-field validator, not a secrets concern). build_val_sandbox() is
+#   idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies), so calling it again here is a safe
+#   no-op re-affirm, the same re-derivation test-monero-tari.sh/test-rig-worker.sh/test-lifecycle.sh use.
 # - $DOCKER_LOG: this file's own first section ("apply preserves secrets + propagates") is DOCKER_LOG's
 #   original definition site ($V/docker.log) — every other domain file that reads it re-derives its
 #   own copy instead of reaching back here, per each of their own header notes. Set again explicitly

--- a/tests/stack/test-tor-network.sh
+++ b/tests/stack/test-tor-network.sh
@@ -16,14 +16,14 @@
 # Sourced by tests/stack/run.sh.
 #
 # Re-derivations (the sandbox-builder WALLET/$V trap — see #1305, still open on this lane):
-# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; run.sh's "config validation" black-box
-#   calls it once, far earlier than the two sections below that read them — that section stays in
-#   run.sh (a generic multi-field validator, not tor-specific). build_val_sandbox() is idempotent
-#   (a fixed $SANDBOX/val path, mkdir -p, template copies), so calling it again here is a safe
-#   no-op re-affirm as currently sourced, and correct on its own if a future reorder ever moves
-#   this file's source line earlier than that section.
-# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log) and
-#   stays in run.sh (a generic multi-key regression, not tor-specific).
+# - $V / $WALLET: lib.sh's build_val_sandbox() sets both; the "config validation" black-box calls
+#   it once, ahead of the two sections below that read them — that section lives in test-config.sh,
+#   sourced ahead of this file (a generic multi-field validator, not tor-specific).
+#   build_val_sandbox() is idempotent (a fixed $SANDBOX/val path, mkdir -p, template copies), so
+#   calling it again here is a safe no-op re-affirm as currently sourced, and correct on its own if
+#   a future reorder ever moves this file's source line earlier than that section.
+# - $DOCKER_LOG: the "apply preserves secrets + propagates" black-box sets it ($V/docker.log); it lives
+#   in test-secrets.sh, sourced ahead of this file (a generic multi-key regression, not tor-specific).
 # No section here reads $C — the control-channel sandbox is untouched by this cut.
 build_val_sandbox
 DOCKER_LOG="$V/docker.log"


### PR DESCRIPTION
Closes #1520. Comment-only across twelve files in `tests/stack`, line-count neutral in every one.

Earlier #1105 rounds moved sections out of `run.sh` and left prose behind that still locates them there. A per-cut sweep cannot see this class by construction — it keys on what the *current* cut moved, so every round reports clean over the accumulated pile. This is the one suite-wide pass the issue asks for.

## What was RUN

A fresh before/after suite pair, both legs in the **same worktree** (`/tmp/tests-1520`), base leg detached at `fa49be1` and branch leg at `5f3b5fc`. Verdict files: `~/split-baselines/1520-fa49be13/{before,after}.rc`, logs alongside; heads recorded in `before.head` / `after.head` before each leg.

| | before (`fa49be1`) | after (`5f3b5fc`) |
|---|---|---|
| rc | 0 | 0 |
| verdict | 2992 passed, 0 failed | 2992 passed, 0 failed |
| log lines | 3306 | 3306 |
| section headers | 275 | 275 |

- **Header set:** identical. **Header order: identical, 0 of 275 positions differ.**
- **Full-output multiset diff: exactly 4 lines = 2 pairs**, both known-nondeterministic and neither attributable to the change: the #1325 ed25519 keygen fingerprint, and one `mktemp -d` path in an ingredients-manifest line.
- **Every check fired.** Per-side match counts: 275 headers and 2992 verdict lines on *each* side (a check that never matched is not evidence).
- **Controls fired.** Permuting two adjacent headers takes the ordered diff to 2 differing lines while the sorted diff stays at 0 — so the order check discriminates and the sorted one is blind to order, as intended. Perturbing one line of the after-log takes the full-output diff 4 → 6.

The same-worktree design is deliberate: it removes cross-worktree path residue outright rather than normalising it away. An earlier run of this branch against a borrowed baseline from another worktree produced 16–18 differing lines that were pure normalisation asymmetry — the same shape R12 hit.

**The baseline was re-run rather than reused.** `#1523` and `#1524` landed while the first proof was in flight, and `#1523` rewrites `run.sh`, so the previously recorded baseline measured a program that no longer exists at this base.

## What this pair does NOT prove

It shows the suite runs the same sections in the same order and makes the same assertions. It does **not** prove the prose is now *correct* — that every relocated claim names the right file. Those are re-derived at source below and are the review's job to check.

## Prose claims, re-derived at source at this base

`run.sh` was rewritten by #1523, so every ordering claim in this diff is perishable and none were carried over. All 46 source stanzas were enumerated at `fa49be1` and each claim checked against that order:

- The `$V`/`$WALLET` "config validation" paragraph in **seven** files → `test-config.sh`; the `$DOCKER_LOG` "apply preserves secrets + propagates" sentence in **four** files → `test-secrets.sh`. Both counts derived from a **joined** (reflow-proof) read of each file's removed comment text — a line-oriented grep undercounts this by one, missing `test-monero-tari.sh` where the phrase spans a line break.
- Every "sourced ahead of / after this file" claim holds, **including the inverted one**: `test-config.sh` is stanza 11 and `test-dashboard.sh` is stanza 6, so `test-dashboard.sh`'s paragraph was wrong in the opposite direction from the other six and now says so.
- Location claims verified with **zero** surviving hits in `run.sh`, control being `run.sh`'s own 2 remaining headers: config-validation → `test-config.sh`; apply-preserves-secrets → `test-secrets.sh`; `config_bool` → `test-unit-helpers.sh`; #291 firewall-ordering → `test-tor-network.sh:237`; control-upgrade bundle-signature → `test-control-upgrade.sh:730`; `provision_control_runner` ownership (#33) and foreign-install (#1190) guards → `test-control-provisioning.sh:37,88`.
- `test-control-upgrade.sh` cited `lib.sh:207` for `control_config()`. That line is a `WALLET` default inside `build_val_sandbox()` (lib.sh 186-208); `control_config()` is at `lib.sh:246`, inside `build_control_sandbox()` (211-253). The cross-file line number is replaced with the name rather than corrected.

## Mechanical sweep

Needles derived at this tree, not guessed: every `^echo "== ` header and every `name()` definition in `tests/stack/*.sh` **absent** from `run.sh`, matched against a reflow-proof join of each file's comment block. **657 needles; 68 flagged sites before this change, 49 after.** The sweep fires on the pre-change side, so the drop is a measurement and not a null instrument. The 49 that remain are true statements (`Sourced by tests/stack/run.sh`, `$ROOT/$SANDBOX/$HERE come from run.sh's harness`) or already past-tensed — a phrase-sweep that "fixed" those would break correct text.

## Over-engineering pass — two defects found and fixed

The only authored content here is the prose, so that is what the pass targeted. Both of these were live in the first cut of this branch:

1. **The reflow broke the house wrap width.** Every touched file is budgeted with zero headroom, so each rewrite must hold its original line count. That was done by pushing freed words onto each hunk's *last* line, producing 10 comment lines over 110 chars — one at 163 — against a suite where only **7 of 5286** comment lines in `tests/stack` exceed 110. Eight of twelve files had their widest comment line grow, by up to +61. Now rewrapped across the whole paragraph: **102-106 chars per file, against 101-111 at base**, still exactly line-count neutral.
2. **An enumeration that read as exhaustive.** `test-doctor-appliance.sh`'s replacement named three files as the consumers of the shared `$V`. **Eight** domain files call `build_val_sandbox()` and read `$V` — `test-secrets.sh` alone has 136 `$V` reads, more than `test-monero-tari.sh`'s 128. The old text was vague and false; the replacement was precise and incomplete, which is worse in a comment that exists to stop the next person re-deriving. It now names no list.

## Rebase and gates

Rebased from `99f343a` onto `fa49be1`. **Content-neutrality was checked by patch identity, not tree identity** — the base carries #1523 and #1524, so the trees *must* differ and a tree comparison would report a false positive. `git diff 99f343a 2898e5d` is byte-identical to `git diff fa49be1 5333beb`, with a control against a deliberately different patch. File disjointness confirmed mechanically: zero intersection between the six files the tip moved and the twelve here, with a self-intersection control. (The sixth was `docs/dev/file-budget.tsv`; its only change removed the `tests/stack/run.sh` row, and no row was lowered for any file touched here.)

- **Budget gate rc 0**, re-run *after* the rebase because `resolve_base_ref()` reads the local `origin/develop-v2`. `origin/develop-v2` probed before and after the run: unmoved. The tsv is untouched by this branch. **Control:** appending one line to `test-secrets.sh` (401 lines against a 401 ceiling) fails the gate **by name** at 402/401; restoring it byte-identical returns rc 0.
- `shfmt -i 4 -d` clean, `shellcheck --severity=warning` clean, `bash -n` clean per file, `lint-docs-voice` clean.
- **Comment-only, re-proved per file at this base:** comments stripped → empty diff in all twelve, with the raw diff non-zero in all twelve as the per-file control. Pinned to each file rather than to the set. The one thing a comment-strip cannot see is a `#` line that is actually heredoc *data* — which is precisely what the suite pair covers.
