### PR TITLE
fix(cli): take the mutation lock for the three reset verbs (#1482)

### DIFF
--- a/lib/pithead/16-reset.sh
+++ b/lib/pithead/16-reset.sh
@@ -17,6 +17,12 @@ reset_dashboard() {
         fi
     fi
 
+    # After the confirmation, never before it: the hold must not span a human wait, which is the
+    # placement rule `setup` already follows (#1391). Everything below this line mutates — the
+    # containers are removed and both data directories are deleted — so a lock timeout here has
+    # genuinely changed nothing, which is exactly what the timeout message promises the operator.
+    mutation_lock_acquire reset-dashboard
+
     log "Resetting dashboard and p2pool..."
     # Resolve what to delete from .env (the LIVE deployment's data dirs), NOT a fresh config.json
     # parse — otherwise editing a *.data_dir in config.json before `reset-dashboard` (without an
@@ -61,6 +67,7 @@ reset_dashboard() {
         warn "Fix the cause shown above, then re-run '$0 up' to bring them back."
         exit 1
     fi
+    mutation_lock_release
 }
 
 # --- Two-tier reset (config / factory) -----------------------------------------------------------
@@ -108,13 +115,22 @@ config_reset() {
         }
     fi
 
+    # After the typed confirmation, so the hold never spans a human wait (#1391), and before the
+    # first mutation below — this verb REMOVES config.json, so a window taken any later would let a
+    # timeout abandon a box whose configuration was already half gone.
+    mutation_lock_acquire config-reset
+
     detect_os 2>/dev/null || true
     docker compose down --remove-orphans 2>/dev/null ||
         warn "compose down failed (engine not running?) — continuing with the config wipe."
     remove_tor_egress_firewall 2>/dev/null || true
     rm -f "$CONFIG_FILE" "$ENV_FILE" Caddyfile
     log "Configuration cleared — the first-boot wizard owns the next boot."
+    # The reboot stays INSIDE the window on purpose. Releasing after the wipe but before the reboot
+    # would leave a gap in which another verb could start against a box that has no config.json yet
+    # still has its old containers' state — the half-reset window this lock exists to prevent.
     reset_reboot_or_hint
+    mutation_lock_release
 }
 
 # factory-reset: the deep wipe. /data cannot be reformatted while it is mounted and holding the
@@ -145,6 +161,12 @@ factory_reset() {
         }
     fi
 
+    # Taken after the typed confirmation so the hold never spans a human wait (#1391). The marker
+    # write below is a single line, but it is not the mutation that matters: arming it commits the
+    # machine to a reboot that reformats /data, and an operation already holding the window would
+    # otherwise be rebooted out from under itself mid-write.
+    mutation_lock_acquire factory-reset
+
     # Arm the boot-time wipe. The marker lives on the ESP, not /data, precisely because /data is
     # what gets erased. If the ESP is not writable the wipe cannot be armed, so refuse loudly
     # rather than reboot into a box that quietly did nothing.
@@ -152,5 +174,8 @@ factory_reset() {
     : >"$marker" 2>/dev/null ||
         error "Could not arm the reset marker at $marker (ESP not mounted?) — nothing was wiped."
     log "Reset armed. Rebooting to reformat /data and reopen the wizard..."
+    # Held across the reboot for the same reason as config-reset: the gap between arming the wipe
+    # and the reboot is precisely when another verb must not start.
     reset_reboot_or_hint
+    mutation_lock_release
 }

--- a/pithead
+++ b/pithead
@@ -3636,6 +3636,12 @@ reset_dashboard() {
         fi
     fi
 
+    # After the confirmation, never before it: the hold must not span a human wait, which is the
+    # placement rule `setup` already follows (#1391). Everything below this line mutates — the
+    # containers are removed and both data directories are deleted — so a lock timeout here has
+    # genuinely changed nothing, which is exactly what the timeout message promises the operator.
+    mutation_lock_acquire reset-dashboard
+
     log "Resetting dashboard and p2pool..."
     # Resolve what to delete from .env (the LIVE deployment's data dirs), NOT a fresh config.json
     # parse — otherwise editing a *.data_dir in config.json before `reset-dashboard` (without an
@@ -3680,6 +3686,7 @@ reset_dashboard() {
         warn "Fix the cause shown above, then re-run '$0 up' to bring them back."
         exit 1
     fi
+    mutation_lock_release
 }
 
 # --- Two-tier reset (config / factory) -----------------------------------------------------------
@@ -3727,13 +3734,22 @@ config_reset() {
         }
     fi
 
+    # After the typed confirmation, so the hold never spans a human wait (#1391), and before the
+    # first mutation below — this verb REMOVES config.json, so a window taken any later would let a
+    # timeout abandon a box whose configuration was already half gone.
+    mutation_lock_acquire config-reset
+
     detect_os 2>/dev/null || true
     docker compose down --remove-orphans 2>/dev/null ||
         warn "compose down failed (engine not running?) — continuing with the config wipe."
     remove_tor_egress_firewall 2>/dev/null || true
     rm -f "$CONFIG_FILE" "$ENV_FILE" Caddyfile
     log "Configuration cleared — the first-boot wizard owns the next boot."
+    # The reboot stays INSIDE the window on purpose. Releasing after the wipe but before the reboot
+    # would leave a gap in which another verb could start against a box that has no config.json yet
+    # still has its old containers' state — the half-reset window this lock exists to prevent.
     reset_reboot_or_hint
+    mutation_lock_release
 }
 
 # factory-reset: the deep wipe. /data cannot be reformatted while it is mounted and holding the
@@ -3764,6 +3780,12 @@ factory_reset() {
         }
     fi
 
+    # Taken after the typed confirmation so the hold never spans a human wait (#1391). The marker
+    # write below is a single line, but it is not the mutation that matters: arming it commits the
+    # machine to a reboot that reformats /data, and an operation already holding the window would
+    # otherwise be rebooted out from under itself mid-write.
+    mutation_lock_acquire factory-reset
+
     # Arm the boot-time wipe. The marker lives on the ESP, not /data, precisely because /data is
     # what gets erased. If the ESP is not writable the wipe cannot be armed, so refuse loudly
     # rather than reboot into a box that quietly did nothing.
@@ -3771,7 +3793,10 @@ factory_reset() {
     : >"$marker" 2>/dev/null ||
         error "Could not arm the reset marker at $marker (ESP not mounted?) — nothing was wiped."
     log "Reset armed. Rebooting to reformat /data and reopen the wizard..."
+    # Held across the reboot for the same reason as config-reset: the gap between arming the wipe
+    # and the reboot is precisely when another verb must not start.
     reset_reboot_or_hint
+    mutation_lock_release
 }
 
 # --- Backup / Restore ---

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -214,6 +214,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-kernel-boot.sh" && domain_r
 # shellcheck source=tests/stack/test-appliance-reset.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-reset.sh" && domain_ran test-appliance-reset.sh "$_d0" "$?" || domain_ran test-appliance-reset.sh "$_d0" "$?"
 
+# shellcheck source=tests/stack/test-appliance-reset-lock.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-appliance-reset-lock.sh" && domain_ran test-appliance-reset-lock.sh "$_d0" "$?" || domain_ran test-appliance-reset-lock.sh "$_d0" "$?"
+
 # shellcheck source=tests/stack/test-appliance-identity-boot.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-identity-boot.sh" && domain_ran test-appliance-identity-boot.sh "$_d0" "$?" || domain_ran test-appliance-identity-boot.sh "$_d0" "$?"
 

--- a/tests/stack/test-appliance-reset-lock.sh
+++ b/tests/stack/test-appliance-reset-lock.sh
@@ -1,0 +1,186 @@
+# shellcheck shell=bash
+#
+# Reset-verb lock wiring (#1482): factory-reset, config-reset and reset-dashboard each take the
+# mutation lock, and take it in the one place that is correct. Sourced by tests/stack/run.sh.
+#
+# SCOPE, stated so this is not read as duplicating test-lifecycle.sh. That file proves the lock
+# MECHANISM — the holder record, the announced wait, the refusal, the rc, the release — driven
+# through `stack_down`. None of it says whether any OTHER verb is wired to that mechanism, and the
+# three reset verbs were not: they mutated the machine holding nothing. So what is asserted here is
+# WIRING and PLACEMENT, one verb at a time, and nothing about how the lock itself behaves. The rc
+# assertions are the cheapest proof that a verb reaches mutation_lock_acquire at all, not a second
+# opinion on the exit status.
+#
+# PLACEMENT is the half a plain "does it take the lock" test would miss, and it is pinned from both
+# sides. Before the first mutation: on a held machine each verb must leave config.json, the ESP
+# marker, the containers and the data directories exactly as it found them, because the refusal
+# tells the operator nothing was changed and that has to be literally true. After the confirmation:
+# a verb given the wrong confirmation word on a held machine must abort on the word, not sit in the
+# lock wait — the hold must never span a human wait. Move the acquire past the first mutation and
+# the first group fails; move it above the prompt and the second does.
+#
+# Every case runs against a POSITIVE CONTROL that the same fixture, uncontended, really does perform
+# the mutation being looked for. Without that, "config.json is still here" is equally consistent with
+# a fixture that never armed — and the two read identically.
+#
+# This lives beside test-appliance-reset.sh rather than inside it because tests/stack ceilings only
+# go down, and the sibling-file shape is the one #1514 established for the os-install half of #1482.
+#
+# Re-derivations: $SANDBOX, $STACK, make_stubs, bad and the assert_* helpers come from lib.sh; every
+# other name is assigned here, under an RSL/rsl_ prefix chosen because test-lifecycle.sh already
+# owns $RL and both files are sourced into ONE shell. Unlike its sibling this file needs no $WALLET
+# seed: config-reset only checks that config.json EXISTS before removing it, and the other two verbs
+# never read it, so no case here writes a wallet address of any kind.
+
+: "${SANDBOX:?}"
+: "${STACK:?}"
+
+RSL="$SANDBOX/reset-lock"
+RSLBIN="$RSL/bin"
+mkdir -p "$RSLBIN" "$RSL/esp" "$RSL/envdir/dashboard" "$RSL/envdir/p2pool"
+cp "$STACK" "$RSL/pithead"
+make_stubs "$RSLBIN"
+# lib.sh's sudo stub is a silent `exit 0`, which is what keeps the wipe from running for real — but
+# it also means the deletion leaves no trace to assert on. Log it instead: the sudo line is the
+# observation point for "did this verb delete a data directory", in both directions.
+cat >"$RSLBIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "[sudo] $*" >>"${SUDO_LOG:-/dev/null}"
+exit 0
+EOF
+chmod +x "$RSLBIN/sudo"
+
+RSLFREE="$SANDBOX/reset-lock-free.lock" # never held: the positive controls run through it
+RSLHELD="$SANDBOX/reset-lock-held.lock" # held by rsl_hold for the contended cases
+RSLDOCKER="$RSL/docker.log"
+RSLSUDO="$RSL/sudo.log"
+RSLMARKER="$RSL/esp/pithead-reset"
+RSLREBOOTED="$RSL/.rebooted"
+
+rsl_seed() { # a provisioned box with clean logs: re-armed before EVERY run, contended or not
+    printf '{}\n' >"$RSL/config.json"
+    cat >"$RSL/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+HOST_IP=box.lan
+DASHBOARD_DATA_DIR=$RSL/envdir/dashboard
+P2POOL_DATA_DIR=$RSL/envdir/p2pool
+EOF
+    : >"$RSL/Caddyfile"
+    mkdir -p "$RSL/envdir/dashboard" "$RSL/envdir/p2pool"
+    rm -f "$RSLMARKER" "$RSLREBOOTED"
+    : >"$RSLDOCKER"
+    : >"$RSLSUDO"
+}
+
+rsl_run() { # <lock file> <extra env pairs...> -- <verb args...>
+    local lk="$1" env_pairs=()
+    shift
+    while [ "$1" != "--" ]; do
+        env_pairs+=("$1")
+        shift
+    done
+    shift
+    (cd "$RSL" && PATH="$RSLBIN:$PATH" DOCKER_LOG="$RSLDOCKER" SUDO_LOG="$RSLSUDO" \
+        PITHEAD_LOCK_FILE="$lk" PITHEAD_PRESEED_DIR="$RSL/esp" \
+        PITHEAD_REBOOT_CMD="touch $RSLREBOOTED" \
+        env "${env_pairs[@]}" ./pithead "$@" 2>&1)
+}
+
+# Sets RSLHOLDER rather than echoing it: `$(...)` around a function that backgrounds a long-lived
+# holder blocks the substitution for that holder's whole lifetime. `exec sleep` rather than a plain
+# one so the holder is a single killable process owning the descriptor.
+RSLHOLDER=""
+rsl_hold() { # <lock file> -> sets RSLHOLDER
+    local lk="$1" i=0
+    : >"$lk"
+    (
+        exec 9>>"$lk"
+        flock -w 20 9 || exit 1
+        exec sleep 120
+    ) >/dev/null 2>&1 &
+    RSLHOLDER=$!
+    while [ "$i" -lt 200 ]; do
+        flock -n "$lk" true 2>/dev/null || break
+        sleep 0.05
+        i=$((i + 1))
+    done
+    if flock -n "$lk" true 2>/dev/null; then
+        bad "the holder takes the lock window" "the lock is still free — every contended case below would prove nothing"
+    fi
+}
+
+echo "== black-box: the fixture arms — uncontended, each reset verb performs its mutation (#1482) =="
+# Read every assertion here as the control for its contended twin further down. Each one names the
+# mutation that must NOT happen once the machine is held.
+rsl_seed
+rsl_out=$(rsl_run "$RSLFREE" PITHEAD_APPLIANCE=0 -- reset-dashboard -y)
+rsl_rc=$?
+assert_rc "uncontended reset-dashboard succeeds" "$rsl_rc" "0"
+assert_contains "uncontended reset-dashboard really removes the containers" "$(cat "$RSLDOCKER")" "compose rm -s -f -v dashboard p2pool"
+assert_contains "uncontended reset-dashboard really deletes the .env data directory" "$(cat "$RSLSUDO")" "rm -rf $RSL/envdir/dashboard"
+
+rsl_seed
+rsl_out=$(rsl_run "$RSLFREE" PITHEAD_APPLIANCE=1 -- factory-reset -y)
+rsl_rc=$?
+assert_rc "uncontended factory-reset succeeds" "$rsl_rc" "0"
+assert_eq "uncontended factory-reset really arms the ESP marker AND reboots" \
+    "$([ -f "$RSLMARKER" ] && [ -f "$RSLREBOOTED" ] && echo armed-and-rebooting)" "armed-and-rebooting"
+
+rsl_seed
+rsl_out=$(rsl_run "$RSLFREE" PITHEAD_APPLIANCE=0 -- config-reset -y)
+rsl_rc=$?
+assert_rc "uncontended config-reset succeeds" "$rsl_rc" "0"
+assert_eq "uncontended config-reset really removes config.json" "$([ -f "$RSL/config.json" ] || echo gone)" "gone"
+assert_contains "uncontended config-reset really stops the stack" "$(cat "$RSLDOCKER")" "compose down"
+
+echo "== black-box: a held machine refuses all three reset verbs and changes nothing (#1482) =="
+rsl_hold "$RSLHELD"
+
+rsl_seed
+rsl_out=$(rsl_run "$RSLHELD" PITHEAD_APPLIANCE=0 PITHEAD_LOCK_TIMEOUT=1 -- reset-dashboard -y)
+rsl_rc=$?
+assert_rc "contended reset-dashboard refuses rather than interleaving with the held window" "$rsl_rc" "75"
+assert_contains "contended reset-dashboard tells the operator which verb to re-run" "$rsl_out" "reset-dashboard' once it has finished"
+assert_eq "contended reset-dashboard removes no container" "$(grep -c 'compose rm' "$RSLDOCKER" || true)" "0"
+assert_eq "contended reset-dashboard deletes no data directory" "$(grep -c 'rm -rf' "$RSLSUDO" || true)" "0"
+
+rsl_seed
+rsl_out=$(rsl_run "$RSLHELD" PITHEAD_APPLIANCE=1 PITHEAD_LOCK_TIMEOUT=1 -- factory-reset -y)
+rsl_rc=$?
+assert_rc "contended factory-reset refuses rather than interleaving with the held window" "$rsl_rc" "75"
+assert_contains "contended factory-reset tells the operator which verb to re-run" "$rsl_out" "factory-reset' once it has finished"
+assert_eq "contended factory-reset arms no ESP marker" "$([ -f "$RSLMARKER" ] || echo none)" "none"
+assert_eq "contended factory-reset does not reboot the box" "$([ -f "$RSLREBOOTED" ] || echo no)" "no"
+
+rsl_seed
+rsl_out=$(rsl_run "$RSLHELD" PITHEAD_APPLIANCE=0 PITHEAD_LOCK_TIMEOUT=1 -- config-reset -y)
+rsl_rc=$?
+assert_rc "contended config-reset refuses rather than interleaving with the held window" "$rsl_rc" "75"
+assert_contains "contended config-reset tells the operator which verb to re-run" "$rsl_out" "config-reset' once it has finished"
+assert_eq "contended config-reset KEEPS config.json" "$([ -f "$RSL/config.json" ] && echo kept)" "kept"
+assert_eq "contended config-reset KEEPS the rendered .env" "$([ -f "$RSL/.env" ] && echo kept)" "kept"
+assert_eq "contended config-reset KEEPS the rendered Caddyfile" "$([ -f "$RSL/Caddyfile" ] && echo kept)" "kept"
+assert_eq "contended config-reset never stops the stack" "$(grep -c 'compose down' "$RSLDOCKER" || true)" "0"
+
+echo "== black-box: the reset window opens AFTER the confirmation, so no hold spans a human wait (#1482) =="
+# The other side of the placement. Each verb is given the wrong confirmation word while the machine
+# is held: it must come back on the WORD, having never entered the lock wait. If the acquire were
+# moved above the prompt these three would time out instead — and an operator answering "no" would
+# have been made to wait for a window the verb was about to decline to use.
+rsl_seed
+rsl_out=$(printf 'n\n' | rsl_run "$RSLHELD" PITHEAD_APPLIANCE=0 PITHEAD_LOCK_TIMEOUT=1 -- reset-dashboard)
+assert_contains "reset-dashboard declined on a held machine reports the decline" "$rsl_out" "Reset cancelled"
+assert_not_contains "reset-dashboard never waited for the window it was not going to use" "$rsl_out" "Timed out"
+
+rsl_seed
+rsl_out=$(printf 'nope\n' | rsl_run "$RSLHELD" PITHEAD_APPLIANCE=1 PITHEAD_LOCK_TIMEOUT=1 -- factory-reset)
+assert_contains "factory-reset declined on a held machine reports the decline" "$rsl_out" "Aborted"
+assert_not_contains "factory-reset never waited for the window it was not going to use" "$rsl_out" "Timed out"
+
+rsl_seed
+rsl_out=$(printf 'nope\n' | rsl_run "$RSLHELD" PITHEAD_APPLIANCE=0 PITHEAD_LOCK_TIMEOUT=1 -- config-reset)
+assert_contains "config-reset declined on a held machine reports the decline" "$rsl_out" "Aborted"
+assert_not_contains "config-reset never waited for the window it was not going to use" "$rsl_out" "Timed out"
+
+kill "$RSLHOLDER" 2>/dev/null || true
+wait "$RSLHOLDER" 2>/dev/null || true


### PR DESCRIPTION
**DRAFT — do not merge yet, and not by me: the controller routes the non-author pass.** The regression test AND its `tests/stack/run.sh` registration are both in, and both commits are rebased onto the post-R14 tip. Read `Shell tests (shellcheck + pithead suite)` before anything else — it is the only check that exercises this diff, and now the only one that runs the 28 new assertions.

## What this changes

`factory_reset`, `config_reset` and `reset_dashboard` each mutate the machine while holding no mutation lock, so a concurrent `pithead` verb can interleave with a wipe. This takes the window for all three.

`os_update` was already locked (`15-os-update.sh:228`). That leaves `rotate_secrets` and the firstboot installer path still unlocked, so **this PR does not close #1482** — it is a slice, and the residual is named rather than left for a reader to discover.

## Placement, and why it is where it is

Copied from the rule `setup` already follows:

- **After each verb's confirmation prompt**, so the hold never spans a human wait.
- **Before its first mutation**, so the timeout message's promise that nothing has changed is literally true.

`config_reset` is the sharpest of the three: it removes `config.json`, so a window taken any later would let a timeout abandon a box whose configuration was already half gone.

**Both reboot paths keep `reset_reboot_or_hint` INSIDE the window deliberately.** Releasing between arming the wipe and the reboot is precisely the half-reset gap the lock exists to prevent.

## Two judgement calls, stated rather than left silent

**No per-verb exit-status routing, and that is deliberate.** #1391's F3 hazard arises because `firstboot_wizard` wraps `setup` and interprets its exit status. `51-main-dispatch.sh:121-124` is the only call site of each reset verb and calls all three **bare**, so `mutation_lock_acquire`'s own exit with `PITHEAD_EX_LOCK_TIMEOUT` reaches the operator unmodified. Re-derived at this head, not carried from the issue. Accepted as a ruling by the controller.

**`reset_dashboard` has an `exit 1` path that bypasses the explicit `mutation_lock_release`.** I checked this rather than assuming: the lock is an `exec 9>>` file descriptor on the shell process (`00-prelude.sh:259`), so process exit closes it and the OS drops the flock. No leak, and adding a trap would diverge from the `os_update` precedent (`15-os-update.sh:228`/`:268`) for no gain.

"The fd closes" is only half of what `mutation_lock_release` does, so the other half is stated here rather than left for a reviewer to find. It also runs `: >"$_PITHEAD_LOCK_PATH"`, clearing the **holder record**, and the bypassing `exit 1` path leaves that line in place. That is handled by design and not by luck: `mutation_lock_holder` gates the record on `[ -d /proc/$pid ] || kill -0 $pid` and reports `holder unrecorded` for a dead pid, and the next acquire appends over it regardless. The only consequence is that a concurrent waiter sees `holder unrecorded` instead of a name, on a path that is already erroring out. Not a defect, and not a reason to add a trap.

## What was run, at this head

Everything below was re-run **after** the rebase onto `origin/develop-v2` (`9f0fe17`), not carried over from the pre-rebase evidence — a moved base invalidates the proof set, not just the suite.

- `bash -n` — clean on both the slice and the artifact.
- `shfmt -i 4` — diff of **0 bytes**.
- `make lint-pithead-parity` — OK, 52 slices.
- `scripts/lint-file-budget.sh` — OK. `16-reset.sh` 156 -> 181 lines (via the gate's own `awk 'END{print NR+0}'`, not `wc -l`), no tsv row, under 400.
- Base ref probed **before and after** the gate run — identical both times, so no lane's fetch moved it mid-run.
- Added lines are identical in the slice and the artifact. The artifact was regenerated by `scripts/build-pithead.sh` only and never hand-edited; parity is what proves that.

## The regression test

`tests/stack/test-appliance-reset-lock.sh`, a new sibling file — 186 lines, no budget row needed.

**Scope, stated so it is not read as duplicating `test-lifecycle.sh`.** That file proves the lock *mechanism* — holder record, announced wait, refusal, rc, release — driven through `stack_down`. None of it says whether any *other* verb reaches that mechanism, and these three did not. So this asserts **wiring and placement**, one verb at a time, and nothing about how the lock itself behaves. The rc assertions are the cheapest proof that a verb reaches `mutation_lock_acquire` at all, not a second opinion on the exit status.

**Placement is pinned from both sides**, because a test that only asks "does it take the lock" passes with the acquire in the wrong place:

- *Before the first mutation* — on a held machine each verb must leave `config.json`, the ESP marker, the containers and the data directories exactly as it found them. The refusal promises the operator nothing changed; these assertions are what make that literally true.
- *After the confirmation* — a verb given the wrong confirmation word on a held machine must come back on the word, never having entered the lock wait. Move the acquire above the prompt and an operator answering "no" is made to wait for a window the verb was about to decline.

**Every contended case has an uncontended positive control** asserting the same fixture really does perform the mutation being looked for. Without it, "`config.json` is still here" is equally consistent with a fixture that never armed — and the two read identically.

### Proven able to fail

Run through a standalone driver mirroring `run.sh`'s contract (`set -uo pipefail`, `lib.sh` first, verdict from the PASS/FAIL counters), because the file is not registered in the suite yet. Each mutant was proven **applied** by `git diff --numstat` on the artifact before its run, and judged by its expected text rather than by rc.

| leg | result |
|---|---|
| clean | 28 passed, 0 failed |
| **M1** — the three `mutation_lock_acquire` lines deleted (the pre-#1528 state) | **14 failed**, every one in the contended block, each naming the real mutation that got through: `config.json` gone, ESP marker armed, containers removed, data dirs deleted |
| **M2** — `config-reset`'s acquire moved above its confirmation prompt | **2 failed**, only the two `config-reset` placement rows; that run timed out (`Timed out after 1s ... nothing was changed`) instead of reporting the decline |
| clean re-run, after restore | 28 passed, 0 failed |

The two mutants kill **disjoint** row sets, so they are two instruments rather than one printed twice. The restore between legs was verified byte-identical (`cmp` against a pre-mutation copy), which is what makes the closing green a control rather than a repeat.

Also run on the test file at this head: `bash -n` clean, `shfmt -i 4` diff **0 bytes**, `shellcheck --severity=warning` (rc 0, run alongside `tests/stack/lib.sh` exactly as the real recipe pairs them), and `scripts/lint-file-budget.sh` OK **with the file staged** — the gate enumerates `git ls-files`, so an unstaged file is invisible to it and the run would have passed while proving nothing. Base ref probed before and after: unmoved.

## Registration, and the ordering it waited on

`tests/stack/run.sh` +3 lines, 237 -> 240, registering the new file immediately after
`test-appliance-reset.sh`. No tsv row either way. The new file needs nothing from any sibling — only `lib.sh` names — so unlike the editable-allowlist file it carries no adjacency constraint.

This was serialised behind the tests lane's R14 (**PR #1529**) by agreement, because R14 rewrote the region the stanza lands in. **R14 has merged.** Both commits are rebased onto the tip it produced, and the whole mechanical proof set was **re-run at the BRANCH head** rather than carried: a green merged tree answers what lands, not whether this PR's own evidence still stands. Base ref probed identical either side of the gate run.

## What to check that I have not

**A full local `tests/stack/run.sh` at the rebased head was still running when this was written, so I am not claiming it green.** CI's `Shell tests` job is the instrument to read here, and it is now the run that actually executes the 28 assertions — before the stanza they were linted but never run.

*Corrections to earlier versions of this section:* it named the lane guard as a blocker (the `tests/stack/` grant is armed — verified by **running** the guard against a staged file, rc 0), and later said the stanza was still missing (it is committed). Both are recorded here rather than quietly edited away.

## Provenance of the evidence above

Stated because a relay reads as recall. The slice-half proof set — `bash -n` and `shfmt` on `16-reset.sh` and the artifact, `lint-pithead-parity` at 52 slices, the budget figures for `16-reset.sh`, the artifact regeneration — was run by the previous session at this same base. That base has since MOVED (R14), so I did not carry it: after rebasing onto `90f5f53` I re-ran the slice-half gates myself at the branch head — `lint-pithead-parity` OK at 52 slices, budget gate OK, base probed identical either side. Everything in "The regression test" above I ran myself.

