### PR TITLE
test(stack): cut the editable-allowlist round-trip to its own domain file (#1105 R14)

### DIFF
--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -138,48 +138,8 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-data-management.sh" && domain_ran tes
 # shellcheck source=tests/stack/test-control-add-only-ssrf.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-control-add-only-ssrf.sh" && domain_ran test-control-add-only-ssrf.sh "$_d0" "$?" || domain_ran test-control-add-only-ssrf.sh "$_d0" "$?"
 
-echo "== black-box: editable-allowlist commit round-trip, every key (#522) =="
-# Every key on CONTROL_DASHBOARD_EDITABLE_KEYS must actually round-trip a real preview->commit
-# through the approval gate and land in config.json — not just pass a describe_change unit check.
-# Fresh baseline with each tunable at a known value so every row below is a genuine single-key
-# env diff (pool flips P2POOL_FLAGS + P2POOL_PORT, both allowlisted).
-jq -n --arg w "$WALLET" '{
-    monero:{mode:"local",wallet_address:$w,node_username:"u",node_password:"p",mem_limit:"4g",prep_blocks_threads:4},
-    tari:{wallet_address:"'"$VALID_TARI"'",mem_limit:"3g"}, p2pool:{pool:"main"},
-    xvb:{enabled:true,donation_level:"donor"}, telegram:{daily_summary_time:"08:00"},
-    dashboard:{secure:true,host:"box.lan",tari_required:true,check_for_updates:true,timezone:"UTC",
-               hashrate_drop_threshold:50,hashrate_drop_minutes:10,
-               auth:{username:"admin",password:"a control passphrase"},control:{enabled:true}}}' >"$C/config.json"
-(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
-roundtrip_key() { # <label> <jq-set> <jq-read> <expected>
-    jq "$2" "$C/config.json" >"$C/cand.json"
-    gate_try "$C/cand.json"
-    assert_eq "$1 commit applies through the gate" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
-    assert_eq "$1 landed in config.json" "$(jq -r "$3" "$C/config.json")" "$4"
-}
-roundtrip_key "XVB_ENABLED" '.xvb.enabled=false' '.xvb.enabled' "false"
-roundtrip_key "XVB_DONATION_LEVEL" '.xvb.donation_level="whale"' '.xvb.donation_level' "whale"
-roundtrip_key "TARI_REQUIRED" '.dashboard.tari_required=false' '.dashboard.tari_required' "false"
-roundtrip_key "DASHBOARD_FAIL_CLOSED" '.dashboard.fail_closed=true' '.dashboard.fail_closed' "true"
-roundtrip_key "DASHBOARD_CHECK_UPDATES" '.dashboard.check_for_updates=false' '.dashboard.check_for_updates' "false"
-roundtrip_key "DASHBOARD_TZ" '.dashboard.timezone="Europe/Paris"' '.dashboard.timezone' "Europe/Paris"
-roundtrip_key "MONERO_MEM_LIMIT" '.monero.mem_limit="5g"' '.monero.mem_limit' "5g"
-roundtrip_key "TARI_MEM_LIMIT" '.tari.mem_limit="2g"' '.tari.mem_limit' "2g"
-roundtrip_key "MONERO_PREP_THREADS" '.monero.prep_blocks_threads=8' '.monero.prep_blocks_threads' "8"
-roundtrip_key "HASHRATE_DROP_THRESHOLD_PCT" '.dashboard.hashrate_drop_threshold=40' '.dashboard.hashrate_drop_threshold' "40"
-roundtrip_key "HASHRATE_DROP_MINUTES" '.dashboard.hashrate_drop_minutes=15' '.dashboard.hashrate_drop_minutes' "15"
-roundtrip_key "TELEGRAM_DAILY_SUMMARY_TIME" '.telegram.daily_summary_time="09:30"' '.telegram.daily_summary_time' "09:30"
-roundtrip_key "P2POOL_FLAGS/P2POOL_PORT" '.p2pool.pool="mini"' '.p2pool.pool' "mini"
-# The 25 allowlisted TELEGRAM_EVENT_* toggles (raffle_win added 2026-08: audit found it was the one
-# event toggle missing from its siblings, all otherwise editable). wallet_changed + clearnet_exposed
-# are deliberately NOT on the allowlist (tamper-evidence alarms; their refusal is asserted above),
-# so they are excluded here. Each flips true->false as a single-key diff.
-for ev in node_down node_recovered worker_offline worker_recovered worker_joined worker_left \
-    sync_finished disk_space db_unhealthy db_reset xvb_no_share xvb_registration new_release \
-    stack_online daily_summary hashrate_low hashrate_loss hugepages low_ram high_reject_rate \
-    block_found payout_found payout_confirmed container_unhealthy raffle_win; do
-    roundtrip_key "TELEGRAM_EVENT ${ev}" ".telegram.events.${ev}=false" ".telegram.events.${ev}" "false"
-done
+# shellcheck source=tests/stack/test-control-editable-allowlist.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-control-editable-allowlist.sh" && domain_ran test-control-editable-allowlist.sh "$_d0" "$?" || domain_ran test-control-editable-allowlist.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-worker-config.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-worker-config.sh" && domain_ran test-worker-config.sh "$_d0" "$?" || domain_ran test-worker-config.sh "$_d0" "$?"

--- a/tests/stack/test-config.sh
+++ b/tests/stack/test-config.sh
@@ -32,8 +32,8 @@
 #   helper probes the #1252 domain map does not name for this module, and this PR moves exactly what
 #   the map names.
 # - "black-box: editable-allowlist commit round-trip, every key (#522)" — the multi-key
-#   describe_change exercise. It is a control-channel black-box against the ambient $C sandbox and
-#   stays for the $C-cluster pass, per the map's "clusters last" rule.
+#   describe_change exercise. A control-channel black-box against the ambient $C sandbox, so it was
+#   left for the $C-cluster pass; #1105 R14 has since cut it to test-control-editable-allowlist.sh.
 # - "unit: render-quadlet parity vs os/quadlet fixtures (#77 phase 1)" — a render test by name, but
 #   it checks the appliance's Quadlet unit set against the os/quadlet fixtures; it belongs to the
 #   appliance module, cut next.

--- a/tests/stack/test-control-add-only-ssrf.sh
+++ b/tests/stack/test-control-add-only-ssrf.sh
@@ -24,8 +24,8 @@
 # false — that file's own header states its sections are fully self-contained (#1462).
 #
 # WHAT OUTLIVES THE SOURCE. gate_try() and $UUID5 are defined here and not unset at the end, so they
-# outlive the source as they outlived the old in-run.sh position: run.sh's #522 section still calls
-# gate_try() and reads $UUID5, and test-spool-audit.sh reuses $UUID5. Hence the stanza stays put.
+# outlive the source as they outlived the old in-run.sh position: the editable-allowlist domain file
+# run.sh sources next reads both, as test-spool-audit.sh reuses $UUID5. Hence the stanza stays put.
 #
 # MUTATION PROOF: reverting pithead's add-only prefix check back to "refuse any workers.list
 # diff" turns the ADD-ONLY-append assertion red; reverting _control_host_is_internal's

--- a/tests/stack/test-control-editable-allowlist.sh
+++ b/tests/stack/test-control-editable-allowlist.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash
+#
+# Every key on CONTROL_DASHBOARD_EDITABLE_KEYS must actually round-trip a real preview->commit
+# through the approval gate and land in config.json (#522) — not just pass a describe_change unit
+# check. Split out of run.sh by #1105 R14; the section's own contract is stated at its header below.
+#
+# WHY THE CONTROL FAMILY, AND NOT THE CONFIG FAMILY THE CUT MAP GUESSED. The map homed this row
+# with the config family on the strength of its subject: it flips config keys and reads them back
+# out of config.json. Its FIXTURE says otherwise, and the fixture is what a domain file actually
+# has to reproduce. Every assertion here goes through gate_try() against the control channel's
+# sandbox and its request/result spool, so this section's dependencies are the control channel's,
+# and it is homed with them. The map's row left the target to be decided at cut time by fixture
+# affinity; this is that decision, recorded rather than assumed.
+#
+# AMBIENT BY DESIGN — AND THE REASON IS NOT THAT ARMING WOULD BREAK IT. This file inherits $C,
+# $CTRL_LOG and $WALLET from the build_control_sandbox() call a control-family domain file makes
+# ahead of it, and re-derives only its own spool path from $C. Calling the builder here would most
+# likely be harmless — it creates rather than clears and never touches the control spool — but it
+# would add a call that does not exist today, and it would buy nothing, because gate_try() is a
+# function defined in another domain file and no arm written here can supply it. The cut that
+# changes nothing about what executes is the one whose proof is strongest, so that is the one
+# taken; the ambient inheritance is disclosed here instead, which is the shipped
+# test-control-add-only-ssrf.sh precedent. $VALID_TARI is a top-level lib.sh constant.
+#
+# POSITION-LOCKED IN run.sh's SOURCE ORDER, not merely position-preferring. gate_try() and $UUID5
+# are defined by test-control-add-only-ssrf.sh and deliberately outlive its source; run.sh sources
+# that file immediately ahead of this one. That is the other half of the dependency its own header
+# already discloses from its side. The carry-over guard below fails by name rather than silently,
+# but it cannot make this file sourceable standalone — a missing gate_try() is loud (command not
+# found, then the status assertions fail by name) and that is the honest state of it.
+#
+# WHAT THE INHERITANCE COSTS, stated so the next cut near here need not re-derive it: the gate_try()
+# calls below write result files into the shared control spool, and a control-family file run.sh
+# sources AHEAD of this one asserts that spool's exact result count. That assertion runs before this
+# section writes anything, so it is untouched while this file stays where run.sh sources it.
+#
+# CONCURRENCY PROVENANCE, carried across the move because it is exactly what a move loses: this is
+# the fork-heavy section — a per-key round-trip, each one a real preview->commit through the spool —
+# that the fleet's notes name as the contention point when two suite runs share a box. A concurrent
+# pair that reddens like cross-talk should be looked for here first.
+
+: "${C:?}" "${CTRL_LOG:?}" "${WALLET:?}" "${VALID_TARI:?}" "${UUID5:?}"
+RESULTS="$C/data/control/results"
+
+echo "== black-box: editable-allowlist commit round-trip, every key (#522) =="
+# Every key on CONTROL_DASHBOARD_EDITABLE_KEYS must actually round-trip a real preview->commit
+# through the approval gate and land in config.json — not just pass a describe_change unit check.
+# Fresh baseline with each tunable at a known value so every row below is a genuine single-key
+# env diff (pool flips P2POOL_FLAGS + P2POOL_PORT, both allowlisted).
+jq -n --arg w "$WALLET" '{
+    monero:{mode:"local",wallet_address:$w,node_username:"u",node_password:"p",mem_limit:"4g",prep_blocks_threads:4},
+    tari:{wallet_address:"'"$VALID_TARI"'",mem_limit:"3g"}, p2pool:{pool:"main"},
+    xvb:{enabled:true,donation_level:"donor"}, telegram:{daily_summary_time:"08:00"},
+    dashboard:{secure:true,host:"box.lan",tari_required:true,check_for_updates:true,timezone:"UTC",
+               hashrate_drop_threshold:50,hashrate_drop_minutes:10,
+               auth:{username:"admin",password:"a control passphrase"},control:{enabled:true}}}' >"$C/config.json"
+(cd "$C" && DOCKER_LOG="$CTRL_LOG" PATH="$C/bin:$PATH" ./pithead apply -y >/dev/null 2>&1)
+roundtrip_key() { # <label> <jq-set> <jq-read> <expected>
+    jq "$2" "$C/config.json" >"$C/cand.json"
+    gate_try "$C/cand.json"
+    assert_eq "$1 commit applies through the gate" "$(jq -r '.status' "$RESULTS/$UUID5.json" 2>/dev/null)" "applied"
+    assert_eq "$1 landed in config.json" "$(jq -r "$3" "$C/config.json")" "$4"
+}
+roundtrip_key "XVB_ENABLED" '.xvb.enabled=false' '.xvb.enabled' "false"
+roundtrip_key "XVB_DONATION_LEVEL" '.xvb.donation_level="whale"' '.xvb.donation_level' "whale"
+roundtrip_key "TARI_REQUIRED" '.dashboard.tari_required=false' '.dashboard.tari_required' "false"
+roundtrip_key "DASHBOARD_FAIL_CLOSED" '.dashboard.fail_closed=true' '.dashboard.fail_closed' "true"
+roundtrip_key "DASHBOARD_CHECK_UPDATES" '.dashboard.check_for_updates=false' '.dashboard.check_for_updates' "false"
+roundtrip_key "DASHBOARD_TZ" '.dashboard.timezone="Europe/Paris"' '.dashboard.timezone' "Europe/Paris"
+roundtrip_key "MONERO_MEM_LIMIT" '.monero.mem_limit="5g"' '.monero.mem_limit' "5g"
+roundtrip_key "TARI_MEM_LIMIT" '.tari.mem_limit="2g"' '.tari.mem_limit' "2g"
+roundtrip_key "MONERO_PREP_THREADS" '.monero.prep_blocks_threads=8' '.monero.prep_blocks_threads' "8"
+roundtrip_key "HASHRATE_DROP_THRESHOLD_PCT" '.dashboard.hashrate_drop_threshold=40' '.dashboard.hashrate_drop_threshold' "40"
+roundtrip_key "HASHRATE_DROP_MINUTES" '.dashboard.hashrate_drop_minutes=15' '.dashboard.hashrate_drop_minutes' "15"
+roundtrip_key "TELEGRAM_DAILY_SUMMARY_TIME" '.telegram.daily_summary_time="09:30"' '.telegram.daily_summary_time' "09:30"
+roundtrip_key "P2POOL_FLAGS/P2POOL_PORT" '.p2pool.pool="mini"' '.p2pool.pool' "mini"
+# The 25 allowlisted TELEGRAM_EVENT_* toggles (raffle_win added 2026-08: audit found it was the one
+# event toggle missing from its siblings, all otherwise editable). wallet_changed + clearnet_exposed
+# are deliberately NOT on the allowlist (tamper-evidence alarms; their refusal is asserted above),
+# so they are excluded here. Each flips true->false as a single-key diff.
+for ev in node_down node_recovered worker_offline worker_recovered worker_joined worker_left \
+    sync_finished disk_space db_unhealthy db_reset xvb_no_share xvb_registration new_release \
+    stack_online daily_summary hashrate_low hashrate_loss hugepages low_ram high_reject_rate \
+    block_found payout_found payout_confirmed container_unhealthy raffle_win; do
+    roundtrip_key "TELEGRAM_EVENT ${ev}" ".telegram.events.${ev}=false" ".telegram.events.${ev}" "false"
+done


### PR DESCRIPTION
## What this is

`#1105` R14. The `#522` editable-allowlist commit round-trip moves out of `tests/stack/run.sh`
into its own domain file, `tests/stack/test-control-editable-allowlist.sh`.

`run.sh` 277 -> 237. The moved content is byte-identical and the source stanza sits at the
section's exact former position, so **execution order is unchanged** — no reorder, no anchor
decision, no nested stanza in the range.

## The two decisions this PR makes, and the grounds

**Homed in the control family, not the config family.** The cut map put this row with the config
family on its subject: it flips config keys. Its fixture says otherwise. Every assertion goes
through `gate_try()` against the control channel's sandbox and its request/result spool, and the
fixture is what a domain file has to reproduce. The map left the target to be decided at cut time
by fixture affinity; this is that decision, recorded rather than assumed.

A second, mechanical reason not to fold it into `test-control-add-only-ssrf.sh` (which defines
`gate_try()` and would have internalised the dependency): that file is **398 lines against the
gate's 400-line target**, so an append would push it to 441 and force a new budget row on a file
the split exists to keep small.

**The new file deliberately does NOT self-arm, and the reason is not that arming would break it.**
I checked `build_control_sandbox()` at source rather than relaying the cut map's "self-arm is the
defect" note: it `mkdir -p`s `data/monero`, `data/tari`, `data/p2pool/stats`, `data/tor` and
`data/dashboard`, and copies static repo inputs. **It never touches `data/control/`**, so the
map's recorded coupling-rule-A RED does not transfer to this position and I am not claiming it
does. The actual argument is narrower: arming here would add a call that does not exist today, and
would buy nothing, because `gate_try()` is a function defined in another domain file and no arm
written here can supply it. The cut that changes nothing about what executes is the one whose
proof is strongest. The ambient inheritance is disclosed in the header instead, on the shipped
`test-control-add-only-ssrf.sh` precedent.

## What was RUN

**Suite pair, both legs in the SAME worktree** (`/tmp/tests-522`), base leg at `546d56b6`, branch
leg at `d1153159`. Verdicts `~/split-baselines/r14-546d56b6/{before,after}.rc`, both **rc 0**.

The four figures were **predicted from the code before the run** and the run had to satisfy them:
the range holds exactly one `^echo "== ` header and zero mktemp/keygen/date nondeterminism, and
`domain_ran` emits an assertion only on failure, so nothing should move. It did not:

| | before | after |
|---|---|---|
| passed / failed | 2992 / 0 | 2992 / 0 |
| log lines | 3306 | 3306 |
| section headers | 275 | 275 |
| verdict lines | 2992 | 2992 |

- **Header set identical; header ORDER identical, 0 of 275 positions differ.** Match counts are
  non-zero per side (275 / 275) — checked first, because a zero-match pattern is not an instrument.
- **Permutation control FIRED** (adjacent swap: ordered diff fires, sorted diff stays silent).
- **Full-output diff: 2 lines = 1 pair**, the known `#1325` ed25519 keygen fingerprint. Both legs
  ran in one worktree, so there is no cross-worktree path-normalisation residue to explain away.
  **Perturbation control FIRED** (one injected line takes the diff 2 -> 4).
- **Byte-identity of the moved content re-derived FROM GIT**, not from the extraction: base
  `run.sh` 141-182 against the new file's body is identical, with a control against a shifted
  range that FIRED.
- **Conservation exact:** 237 + 42 moved + 1 blank - 3 stanza = 277.
- **Rebase content-neutral by PATCH identity**, not tree — the base moved, so the trees must
  differ. Byte-identical patches, control against a path-scoped patch FIRED.
- `shellcheck --severity=warning` rc 0 on **both** Makefile invocations, run separately and in the
  exact form the Makefile writes them (the pairing is load-bearing: a truncated first invocation
  reported three SC2034 in `test-appliance-boot.sh` that vanish once `os/overlay/pithead-boot` is
  named alongside it, which is the documented pairing, not a defect). `bash -n` rc 0 on all four
  files; `shfmt -i 4 -d` rc 0.
- **Budget gate rc 0, with its `--self-test` run first and a control that FAILED BY NAME**
  (`test-config.sh` forced to 754 against its 753 ceiling). No tsv row changes: the new file (86
  lines) and `run.sh` (237) both sit under the 400 target. Base ref probed identical before and
  after the gate run.
- **Ruling 8a: this is CASE 2 — the tip moved under me** (`#1527`, docs-only), so both runs were
  made rather than one measurement reported twice. Merged tree: gate **rc 0**, `run.sh` 237, merge
  clean, `file-budget.tsv` untouched. Branch head: gate **rc 0**. `#1527` touches no file under
  `tests/stack/`, so the pair still measures the branch's program.

## Prose this cut falsifies, fixed here

A cut falsifies comments in files it never touches, so the moved header was swept mechanically
(base-vs-head header diff, then `grep -F` on the name with the `black-box: ` prefix stripped). The
sweep **fired on the pre-change side**, which is what licenses reading its post-change result.

Two sites, both fixed, both comment-only and **line-count neutral**, with max COMMENT-line length
unchanged per file (107 and 115) — the reflow trap is to hold the line count by pushing freed words
onto the last line and silently blow the wrap width:

- `test-control-add-only-ssrf.sh` said `run.sh`'s `#522` section reads `gate_try()`/`$UUID5`.
- `test-config.sh` listed the section among what it left behind in `run.sh`.

The name grep alone found only the second; the first was found by widening to `#522` and reading
the neighbourhood, which is exactly the documented floor behaviour of that instrument.

## What is NOT proven

- The pair proves the suite runs the same sections in the same order and makes the same
  assertions. It does **not** prove the new header's prose is correct — that is the review's job.
  Every claim in it was re-derived at source (including `run.sh`'s `set -uo pipefail`, which is why
  a missing `gate_try()` is loud rather than fatal), but that is a separate argument from the run.
- **No mutation proof.** The header deliberately claims none: I did not run one, and asserting a
  kill I have not seen would be worse than the gap.
- The file is **not sourceable standalone** and the header says so plainly. The carry-over guard
  fails by name, but no guard written here can supply `gate_try()`.

## Over-engineering pass — what it actually changed

Run against the only authored content in this diff (the new file's header) plus the two comment
fixes. Four outcomes, three of them removals:

1. **An unearned assertion was narrowed.** The header was going to carry the cut map's "self-arm
   here is the defect — a fresh `$C` reproduces the recorded RED". I read `build_control_sandbox()`
   at source instead of relaying it and found it never touches `data/control/`, so that RED does
   not transfer to this position. The claim is now the narrower one I can actually defend. This was
   the single biggest finding: a relayed claim reads exactly like a derived one.
2. **A guard was considered and rejected.** A `declare -F gate_try` check would make the
   cross-file dependency machine-enforced, but there is no such guard anywhere in this suite, and
   inventing a convention inside a move PR is the definition of widening. The failure is already
   loud (`set -uo pipefail`, no `-e`), so the header states it rather than guarding it.
3. **No mutation-proof paragraph was written**, because no mutation was run. The sibling file's
   header has one; copying that shape without the run would have been the worst option available.
4. **Header kept at its length** (41 lines against the shipped sibling's 35). Every paragraph
   carries a decision a reviewer would otherwise have to re-derive, so it stays.
