### PR TITLE
fix(dashboard): answer config provenance by change id, not by window scan (#1369)

### DIFF
--- a/dashboard/mining_dashboard/client/rig_config_meta.py
+++ b/dashboard/mining_dashboard/client/rig_config_meta.py
@@ -105,9 +105,7 @@ def parse_config_meta(meta):
     return out if any(out.values()) else None
 
 
-def config_origin(
-    meta, change_id_known, change_status=None, history_truncated=False, history_unread=False
-):
+def config_origin(meta, change_id_known, change_status=None, history_unread=False):
     """Where the rig's current config came from, as far as we can honestly tell.
 
     ``change_id_known`` is whether this dashboard has a ``worker_config`` row for the rig's
@@ -131,25 +129,19 @@ def config_origin(
                       into either would state something we cannot support.
     - ``elsewhere`` — applied over a control channel, with an id we have never seen. Another host,
                       or our record of it is gone. Either way it is not something to present as ours.
-    - ``untraced``  — applied over a control channel, with an id we did not find, *and* the history
-                      we searched was full to its limit (#1369). The id may sit one row past the
-                      window, so "we have never seen it" is a claim the read cannot support and
-                      ``elsewhere`` would print an accusation over a change that may well be ours.
-                      ``history_truncated`` is what separates the two, and it is deliberately the
-                      only thing this argument may do: when it is False every verdict is exactly
-                      what it was before, so a caller that cannot tell loses nothing. That matters
-                      most on the error path, which since #1409 is ``history_unread``'s to answer:
-                      a failed read returns None, not ``[]``, so it never reaches this comparison
-                      at all rather than arriving as a window that merely looks short.
     - ``unread``    — applied over a control channel, and we could not read our own history at all
                       (#1409). ``get_worker_config_history`` returns None when the read failed, and
                       that is a different fact from an empty history: a miss we never got to look
                       for cannot support ``elsewhere``, which renders as "Last changed from another
                       dashboard" — an accusation sourced from our own broken DB rather than from
-                      anything the rig did. Distinct from ``untraced`` too: that one is a read that
-                      WORKED and came back full, so it is about the rig having changed often. This
-                      one is about us. Checked FIRST inside this branch, because a read that did not
-                      happen settles nothing further down it.
+                      anything the rig did. Checked FIRST inside this branch, because a read that
+                      did not happen settles nothing further down it.
+
+                      A miss that is NOT this is conclusive: since #1369 the caller asks for the
+                      id directly rather than looking for it in the window it renders, so there is
+                      no longer a "we could not see that far back" between ``here`` and
+                      ``elsewhere``. The ``untraced`` verdict that held that middle ground was
+                      removed with the window scan that produced it.
     - ``rig``       — applied on the rig itself.
     - ``restored``  — restored from a saved config by the operator-run ``restore`` command.
                       Deliberately not folded into ``rig``: a restore is not someone editing the rig.
@@ -168,7 +160,7 @@ def config_origin(
         if history_unread:
             return "unread"
         if not change_id_known:
-            return "untraced" if history_truncated else "elsewhere"
+            return "elsewhere"
         if change_status in HELD_STATUSES:
             return "here"
         if change_status in REVERTED_STATUSES:

--- a/dashboard/mining_dashboard/service/worker_config_store.py
+++ b/dashboard/mining_dashboard/service/worker_config_store.py
@@ -33,6 +33,24 @@ from typing import Any
 # `storage_service` so that import surface is unchanged by the split (#1369).
 _RECONCILE_TERMINAL = ("applied", "rejected", "rolled_back", "failed", "noop", "throttled")
 
+# One column list for every read of this table that returns a ROW, so a windowed read and an
+# exact-id read cannot drift into returning differently-shaped rows for the same change
+# (#1369). `worker_config_change_known` deliberately does not use it — see its docstring.
+_SELECT_CHANGE = "SELECT change_id, ts, status, changes, reason, type FROM worker_config"
+
+
+def _shaped(row: sqlite3.Row) -> dict:
+    """One ``worker_config`` row as the rest of the app reads it: ``changes`` parsed back to a
+    dict (unparseable JSON reads as ``{}`` rather than raising), and a row written before the
+    ``type`` column existed (#1014) reading back as ``"apply"``."""
+    d = dict(row)
+    try:
+        d["changes"] = json.loads(d["changes"]) if d["changes"] else {}
+    except (TypeError, ValueError):
+        d["changes"] = {}
+    d["type"] = d.get("type") or "apply"
+    return d
+
 
 class WorkerConfigStoreMixin:
     """The `worker_config` accessors of `StateManager`. Never instantiated on its own."""
@@ -82,20 +100,10 @@ class WorkerConfigStoreMixin:
                     return None
                 cursor = self._conn.cursor()
                 cursor.execute(
-                    "SELECT change_id, ts, status, changes, reason, type FROM worker_config "
-                    "WHERE worker = ? ORDER BY ts DESC, id DESC LIMIT ?",
+                    f"{_SELECT_CHANGE} WHERE worker = ? ORDER BY ts DESC, id DESC LIMIT ?",
                     (worker, limit),
                 )
-                out = []
-                for row in cursor.fetchall():
-                    d = dict(row)
-                    try:
-                        d["changes"] = json.loads(d["changes"]) if d["changes"] else {}
-                    except (TypeError, ValueError):
-                        d["changes"] = {}
-                    d["type"] = d.get("type") or "apply"
-                    out.append(d)
-                return out
+                return [_shaped(row) for row in cursor.fetchall()]
         except sqlite3.Error as e:
             self.logger.error(f"Worker Config Read Error: {e}")
             return None
@@ -129,11 +137,64 @@ class WorkerConfigStoreMixin:
         except sqlite3.Error as e:
             self._db_error("Worker Config Reconcile Error", e)
 
+    def get_worker_config_change(self, worker: str, change_id: str) -> dict | None:
+        """This rig's own row for ``change_id``, looked up by id rather than searched for in a
+        window (#1369).
+
+        The provenance verdict needs to know whether a change id the rig names is one we spooled
+        for THIS rig, and what became of it. Scanning the bounded history the page renders could
+        only answer that for a rig whose change was still inside the window; past it the feature
+        stopped working in both directions at once — it could neither claim a change that was ours
+        nor name one that was not. A lookup by id has no such horizon: `EXPLAIN QUERY PLAN`
+        reports `SEARCH worker_config USING INDEX idx_worker_config (worker=?)`, so it seeks
+        this rig's rows and walks only those, in the order that index already supplies.
+
+        Three-valued on the #1409 contract, and it fails CLOSED: ``None`` means the read FAILED
+        (no connection, or ``sqlite3.Error``), ``{}`` means there is genuinely no such row for
+        this worker, and a dict is the row. Worker-scoped on purpose — ``worker_config_change_known``
+        below asks the deliberately unscoped question for #530, and answering this one with it
+        would let a change spooled for a DIFFERENT rig read as this rig's own.
+
+        Ordering matches ``get_worker_config_history``, so this returns the same row the window
+        scan it replaces would have matched.
+        """
+        if not change_id:
+            return {}
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return None
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    f"{_SELECT_CHANGE} WHERE worker = ? AND change_id = ? "
+                    "ORDER BY ts DESC, id DESC LIMIT 1",
+                    (worker, change_id),
+                )
+                row = cursor.fetchone()
+                return _shaped(row) if row is not None else {}
+        except sqlite3.Error as e:
+            self.logger.error(f"Worker Config Change Read Error: {e}")
+            return None
+
     def worker_config_change_known(self, change_id: str) -> bool:
         """Whether ``change_id`` was ever spooled by THIS dashboard (#530): a row exists in
         ``worker_config`` — the table only ``add_worker_config_version`` writes to, one row per
         change the dashboard itself sent. A rig reporting a terminal outcome for a change_id NOT
-        found here is reporting something it applied on its own — an out-of-band rig edit."""
+        found here is reporting something it applied on its own — an out-of-band rig edit.
+
+        Unscoped, and it fails OPEN, both deliberately and both the opposite of
+        ``get_worker_config_change`` above — this method must return ``False`` on a closed handle
+        and ``True`` on a ``sqlite3.Error``, where the provenance path needs the same answer for
+        both, so no one three-valued helper can serve them.
+
+        It keeps its own query too, and that is the point rather than an oversight: this asks only
+        whether a row EXISTS. It never reads ``ts``, so it needs no ``ORDER BY``, and it never
+        reads the row, so it needs neither the column list nor ``_shaped``. Answering it through
+        the provenance query cost a temp B-tree sort per call for nothing — measured with
+        `EXPLAIN QUERY PLAN`, and `_reconcile_worker_config` calls this once per reporting rig per
+        poll. What the two genuinely must share is the ROW SHAPE, and only the reads that return a
+        row have that in common; ``_SELECT_CHANGE`` is where they share it.
+        """
         if not change_id:
             return False
         try:

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -176,26 +176,21 @@ const CONFIG_ORIGIN_TEXT = {
     label: "Last changed from another dashboard",
     detail: "applied over a control channel, with a change id this dashboard has no record of",
   },
-  // `untraced` is `elsewhere` with the accusation taken back out. The server reaches it when the id
-  // was not found AND the history it searched was full, so the id may simply sit past the end of
-  // the window. `text-muted` rather than `status-warn` on purpose: the two muted verdicts are the
-  // ones that claim nothing, and a warning colour over "we could not tell" is the same overclaim in
-  // a different medium. The cost is stated where it belongs — a genuinely foreign change on a
-  // long-history rig lands here too, so a true alarm is traded for a statement that is always true.
-  untraced: {
-    cls: "text-muted",
-    label: "Last changed over a control channel",
-    detail:
-      "too many changes since to tell whether it was this dashboard — the id is older than the history read",
-  },
+  // There was a third muted verdict here, `untraced`: `elsewhere` with the accusation taken back
+  // out, sent when the id was not found AND the history the server searched was full, so the id
+  // might merely have sat past the end of the window. It was a trade — a genuinely foreign change
+  // on a long-history rig landed there too, so a true alarm was swapped for a statement that was
+  // always true. #1369 made the server look the id up directly instead of searching the window it
+  // renders, which removes the doubt rather than wording it, so the verdict has no producer and
+  // is gone from both sides.
+  //
   // `unread` is the one verdict that is about US, not the rig (#1409). The server sends it when
   // its own history read failed outright — no DB connection, or a `sqlite3.Error` — so it never got
   // to look for the id. Before this it fell through to `elsewhere` and printed "Last changed from
   // another dashboard" over a change that may well have been ours: an accusation sourced from our
-  // own broken database. `text-muted` for the same reason `untraced` is muted — the muted verdicts
-  // are the ones that claim nothing, and a warning colour over "we could not tell" is the same
-  // overclaim in a different medium. This adds a verdict STATE, deliberately not a new COLOUR: the
-  // text carries the distinction, the colour carries the class.
+  // own broken database. `text-muted` because it claims nothing, and a warning colour over "we
+  // could not tell" is the same overclaim in a different medium. This adds a verdict STATE,
+  // deliberately not a new COLOUR: the text carries the distinction, the colour carries the class.
   unread: {
     cls: "text-muted",
     label: "Cannot tell — this dashboard could not read its own history",

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -108,38 +108,32 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # Already filtered to RigForge's own vocabulary by the client layer, so this is a read, not a
     # second parse — re-validating here would be a second place to get the allowlist wrong.
     rig_meta = (worker.get("rigforge") or {}).get("config_meta") if worker else None
-    # Matched against THIS rig's own history rows, which is both the correct scope and the cheapest
-    # one: ``history`` is already in hand, so this costs no extra query.
+    # Looked up by id against THIS rig's own ``worker_config`` rows, unbounded — NOT searched for
+    # among the ``history`` rows already in hand (#1369). Those are the 50 the page renders, and a
+    # rig with more changes than that pushed its own row off the end: past the window the verdict
+    # stopped working in BOTH directions at once, unable to claim a change that was ours and
+    # unable to name one that was not. The window is a rendering limit; it was never a fact about
+    # what this dashboard spooled, and letting it bound the verdict made it one. The extra query
+    # is an index seek on `worker` — `EXPLAIN QUERY PLAN` reports `SEARCH worker_config USING
+    # INDEX idx_worker_config (worker=?)` — walking that rig's own rows in the order the index
+    # already supplies, so it costs no sort. On a MISS it walks all of them, and the miss is the
+    # foreign-change case this line exists to catch: bounded by one rig's history rather than by
+    # nothing. Reusing a list already in hand was the only thing the old shape actually bought.
     #
     # Deliberately NOT ``worker_config_change_known``, which the #530 rig-edit audit uses. That
     # lookup is unscoped — it asks whether ANY rig's change carried this id — and it fails OPEN
     # (True) on a DB error, both correct for #530, where a false "known" merely declines to accuse
     # a rig. Here the same two properties invert into the one answer this feature must never give
     # wrongly: a change id spooled for a DIFFERENT rig, or a transient DB error, would print "Last
-    # changed from this dashboard" over a change this dashboard never made. Scanning the rig's own
-    # rows is worker-scoped by construction and fails closed, because a failed read is now a
-    # ``None`` the verdict answers separately (#1409) rather than a ``[]`` it cannot tell from a miss.
-    #
-    # It also makes the verdict checkable: "here" now means precisely "the id is one of the rows
-    # rendered directly below this line, and that row records the change as having held", so an
-    # operator can confirm it by eye rather than trust it.
-    #
-    # But a bounded window can only settle a MISS when it saw the whole history. Reading exactly
-    # ``_HISTORY_LIMIT`` rows means there may be more we did not read, so a miss could be an id one
-    # row past the end rather than an id nobody here spooled — and "elsewhere" reads as "Last
-    # changed from another dashboard", an accusation the read cannot support (#1369). Passing the
-    # fullness of the window lets that case say "we do not know" instead. Only that case changes:
-    # a short read is still conclusive. The ``sqlite3.Error`` path no longer arrives here at all:
-    # it returns ``None`` and is answered by ``unread`` before fullness is consulted (#1409).
+    # changed from this dashboard" over a change this dashboard never made.
+    # ``get_worker_config_change`` is worker-scoped by construction and fails closed, returning a
+    # ``None`` the verdict answers separately (#1409) rather than a ``{}`` it cannot tell from a miss.
     #
     # The matched ROW, not merely whether one exists: RigForge's rollback re-apply re-stamps the id
     # it just reverted, so a rolled-back change still matches by id. The row's status is the only
     # thing separating a change that held from one the rig threw away (``REVERTED_STATUSES``).
     last_change_id = (rig_meta or {}).get("last_change_id")
-    matched = next(
-        (row for row in history if last_change_id and row.get("change_id") == last_change_id),
-        None,
-    )
+    matched = state_mgr.get_worker_config_change(name, last_change_id)
     return {
         "name": name,
         "found": worker is not None,
@@ -158,12 +152,14 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         # The rig's own record of its last config change, and our verdict on it (#1345). Both None
         # for a rig that cannot answer — the client renders that as silence, not as "unknown".
         "rig_config_meta": rig_meta,
+        # ``matched``: a row = found, ``{}`` = no such row, ``None`` = the lookup itself failed.
+        # Either failed read still fails closed — the rendered list going unread does not make the
+        # verdict trustworthy, and both come off the same handle, so they fail together in practice.
         "config_origin": config_origin(
             rig_meta,
-            matched is not None,
+            bool(matched),
             (matched or {}).get("status"),
-            history_truncated=len(history) >= _HISTORY_LIMIT,
-            history_unread=history_unread,
+            history_unread=matched is None or history_unread,
         ),
         "last_applied": state_mgr.get_last_applied_worker_config(name),
         "history": history,

--- a/dashboard/tests/client/test_rig_config_meta.py
+++ b/dashboard/tests/client/test_rig_config_meta.py
@@ -11,6 +11,7 @@ reaches us wearing the same ``source`` and the same change id as the one that he
 import pytest
 
 from mining_dashboard.client.rig_config_meta import (
+    CONFIG_SOURCES,
     HELD_STATUSES,
     REVERTED_STATUSES,
     config_origin,
@@ -161,30 +162,43 @@ def test_a_control_change_we_have_no_record_of_is_not_claimed_as_ours():
     assert config_origin(GOOD, change_id_known=False) == "elsewhere"
 
 
-def test_a_miss_in_a_window_that_was_full_does_not_get_to_call_it_another_dashboard():
-    # #1369: "we did not find it" only means "it is not there" if we could see the whole history.
-    # A full window means the id may sit one row past the end, so `elsewhere` — which renders as
-    # "Last changed from another dashboard" — is an accusation the read cannot support.
-    assert config_origin(GOOD, change_id_known=False, history_truncated=True) == "untraced"
+def test_a_miss_is_conclusive_again_now_that_the_lookup_is_by_id():
+    # #1369 removed the middle ground. While the caller searched the 50-row window it renders, a
+    # miss could mean "the id sits one row past the end", and `untraced` existed to say so rather
+    # than print `elsewhere`'s "Last changed from another dashboard" over a change that may well
+    # have been ours. The caller now asks for the id directly, so a miss means the row is not
+    # there — and this asserts the verdict does not hedge a read that has nothing left to hedge.
+    assert config_origin(GOOD, change_id_known=False) == "elsewhere"
 
 
-def test_the_new_argument_can_only_ever_soften_the_miss():
-    # The whole safety property of this fix in one assertion: `history_truncated` may change the
-    # verdict for a MISS and nothing else. Every case where we found the id keeps the answer it
-    # had, so a caller that starts passing the flag cannot silently move a verdict it was right
-    # about. Mutating the flag's use into any of these branches reds this test.
-    for status, expected in (
-        ("applied", "here"),
-        ("rolled_back", "reverted"),
-        ("accepted", "unconfirmed"),
-    ):
-        for truncated in (False, True):
-            assert (
-                config_origin(
-                    GOOD, change_id_known=True, change_status=status, history_truncated=truncated
-                )
-                == expected
-            )
+def test_no_input_reaches_the_removed_untraced_verdict():
+    # The removal asserted rather than described. A verdict with no producer is not gone, it is
+    # unreachable — and unreachable is what nobody notices going stale. This sweeps every
+    # combination of the surviving arguments; the second assertion is its control, because a sweep
+    # that produced nothing would satisfy the first one for exactly the wrong reason.
+    seen = {
+        config_origin(
+            {**GOOD, "source": source},
+            change_id_known=known,
+            change_status=status,
+            history_unread=unread,
+        )
+        for source in (*CONFIG_SOURCES, "something-we-never-defined")
+        for known in (True, False)
+        for status in (None, "", "applied", "rolled_back", "failed", "accepted", "pending")
+        for unread in (True, False)
+    }
+    assert "untraced" not in seen
+    assert seen == {
+        "here",
+        "reverted",
+        "unconfirmed",
+        "elsewhere",
+        "unread",
+        "rig",
+        "restored",
+        "unrecorded",
+    }
 
 
 def test_a_read_we_never_got_to_make_is_not_reported_as_another_dashboard():

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -72,11 +72,10 @@ test("a history we could not read points at us, never at another dashboard", () 
   // overclaim in a different medium. This adds a verdict STATE, deliberately not a new COLOUR.
   assert.match(out, /text-muted/);
   assert.doesNotMatch(out, /status-warn/);
-  // The text is what has to carry the distinction, since the colour deliberately does not: this
-  // must not be confusable with `untraced`, the OTHER muted "we cannot tell" — that one is about
-  // the rig having changed too often to see back that far, this one is about us.
-  assert.notEqual(note.label, configOriginNote("untraced", META).label);
+  // The text is what has to carry the distinction, since the colour deliberately does not: the
+  // muted verdict has to say the failure was OURS, not report something about the rig.
   assert.match(note.label, /this dashboard could not read/i);
+  assert.doesNotMatch(note.label, /control channel/i);
 });
 
 test("rig edits are flagged — noticing one is the whole point of the feature", () => {
@@ -123,19 +122,13 @@ test("an unconfirmed change of ours neither claims it held nor accuses the rig",
   assert.match(note.title, /has not reported an outcome/i);
 });
 
-test("untraced withdraws the accusation elsewhere makes, without making the opposite one", () => {
-  const out = renderToString(ConfigProvenance({ origin: "untraced", meta: META }));
-  const note = configOriginNote("untraced", META);
-  // The server reaches this when the id was not found in a history window that was FULL, so the
-  // one thing it must not do is repeat `elsewhere`'s claim that another dashboard did it.
-  assert.doesNotMatch(out, /from another dashboard/);
-  assert.notEqual(note.label, configOriginNote("elsewhere", META).label);
-  // Nor may it swing the other way and claim the change as ours.
-  assert.doesNotMatch(out, /Last changed from this dashboard/);
-  // Muted, not warned: the two verdicts that claim nothing are the two that are not coloured as a
-  // problem, and a warning over "we could not tell" is the same overclaim in a different medium.
-  assert.doesNotMatch(out, /status-warn/);
-  assert.match(note.title, /older than the history read/i);
+test("the retired untraced verdict is gone from this side too, not merely unsent", () => {
+  // #1369 removed it server-side: it hedged a miss found by searching the 50-row window the page
+  // renders, and the server now looks the id up directly, so a miss is conclusive again. A label
+  // left behind here would be a verdict nothing can produce — which is what goes stale unnoticed,
+  // and what would quietly re-render if a later change started sending the token again.
+  assert.equal(configOriginNote("untraced", META), null);
+  assert.doesNotMatch(renderToString(ConfigProvenance({ origin: "untraced", meta: META })), /control channel/i);
 });
 
 test("an unknown verdict token renders nothing rather than a blank warning", () => {
@@ -143,7 +136,7 @@ test("an unknown verdict token renders nothing rather than a blank warning", () 
   // added without its label here would vanish silently instead of failing loudly. This pins that
   // behaviour so the silence stays a deliberate choice for absent verdicts only.
   assert.equal(configOriginNote("a-token-no-client-knows", META), null);
-  assert.notEqual(configOriginNote("untraced", META), null);
+  assert.notEqual(configOriginNote("unread", META), null);
 });
 
 test("unrecorded claims no change happened and no change did not", () => {

--- a/dashboard/tests/service/test_storage_worker.py
+++ b/dashboard/tests/service/test_storage_worker.py
@@ -336,6 +336,79 @@ class TestWorkerConfigChangeKnown:
         assert state_manager.worker_config_change_known("cid-1") is True
 
 
+class TestGetWorkerConfigChange:
+    """#1369: the provenance lookup — this rig's own row for one change id, found by id rather
+    than searched for in the 50-row window the page renders.
+
+    The contract is deliberately the OPPOSITE of ``worker_config_change_known`` above in both
+    respects a lookup can differ: it is worker-SCOPED, and it fails CLOSED. Those two properties
+    are why the two methods share a query and nothing else — the tests below pin each one to a
+    failure a single three-valued helper could not serve both ways.
+    """
+
+    def test_a_spooled_change_comes_back_as_its_row(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid-1", "applied", {"DONATION": 5}, None)
+        row = state_manager.get_worker_config_change("rig1", "cid-1")
+        assert row["status"] == "applied"
+        assert row["changes"] == {"DONATION": 5}
+        assert row["type"] == "apply"  # the shape a history row has, not a second shape
+
+    def test_a_row_far_past_the_rendered_window_is_still_found(self, state_manager):
+        # The whole point of the method: 200 later changes cannot hide the one being asked about.
+        state_manager.add_worker_config_version(
+            "rig1", "cid-1", "applied", {"DONATION": 5}, None, ts=1000.0
+        )
+        for i in range(200):
+            state_manager.add_worker_config_version(
+                "rig1", f"later{i:04d}", "rejected", {}, None, ts=2000.0 + i
+            )
+        assert state_manager.get_worker_config_change("rig1", "cid-1")["status"] == "applied"
+        # ...and the windowed read really does NOT hold it, or the line above proves nothing.
+        history = state_manager.get_worker_config_history("rig1", limit=50)
+        assert "cid-1" not in [row["change_id"] for row in history]
+
+    def test_another_rigs_change_is_not_this_rigs(self, state_manager):
+        # Scoping, which #530's unscoped lookup deliberately does not do. Claiming this row for
+        # rig1 would print "Last changed from this dashboard" over a change rig1 never got.
+        state_manager.add_worker_config_version("rig2", "cid-1", "applied", {}, None)
+        assert state_manager.get_worker_config_change("rig1", "cid-1") == {}
+        assert state_manager.worker_config_change_known("cid-1") is True  # the contrast, asserted
+
+    def test_the_newest_row_wins_when_an_id_was_written_twice(self, state_manager):
+        # RigForge re-stamps the id it reverted, so the same id can carry two rows. The verdict
+        # must read the latest outcome — the same row the newest-first window scan would match.
+        state_manager.add_worker_config_version("rig1", "cid-1", "applied", {}, None, ts=1000.0)
+        state_manager.add_worker_config_version("rig1", "cid-1", "rolled_back", {}, None, ts=2000.0)
+        assert state_manager.get_worker_config_change("rig1", "cid-1")["status"] == "rolled_back"
+
+    def test_no_such_row_is_an_empty_dict_not_none(self, state_manager):
+        # `{}` and None are different facts (#1409): a healthy DB holding no such row is a real
+        # answer, and folding it into the failure value would make every miss read as "we could
+        # not tell" — which is the accusation-withdrawal this issue is about, applied to the case
+        # that does not need it.
+        assert state_manager.get_worker_config_change("rig1", "no-such-id") == {}
+
+    def test_an_empty_change_id_is_a_miss_not_a_failure(self, state_manager):
+        assert state_manager.get_worker_config_change("rig1", "") == {}
+        assert state_manager.get_worker_config_change("rig1", None) == {}
+
+    def test_after_close_is_none(self, state_manager):
+        # Fails CLOSED, and this is the exact point #530 goes the other way: there a closed handle
+        # is False (not known / quiet), here it must be None (we do not know) so the verdict can
+        # say so instead of naming another dashboard.
+        state_manager.add_worker_config_version("rig1", "cid-1", "applied", {}, None)
+        state_manager.close()
+        assert state_manager.get_worker_config_change("rig1", "cid-1") is None
+
+    def test_lookup_error_is_none_not_a_miss(self, state_manager):
+        # The loud failure path, and #530's other inversion: it returns True here, we return None.
+        # Returning `{}` would source an accusation from our own broken database.
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_config")
+        assert state_manager.get_worker_config_change("rig1", "cid-1") is None
+        assert state_manager.worker_config_change_known("cid-1") is True  # the contrast, asserted
+
+
 class TestWorkerConfigType:
     """worker_config.type (#1014) distinguishes a config apply from a one-click rig upgrade so
     the change history can show it and hashrate_by_config can attribute a build change correctly."""

--- a/dashboard/tests/web/test_worker_detail_meta.py
+++ b/dashboard/tests/web/test_worker_detail_meta.py
@@ -214,17 +214,14 @@ class TestConfigOrigin:
             sm.close()
         assert d["config_origin"] == "elsewhere"
 
-    @pytest.mark.parametrize(
-        "filler,expected",
-        [(48, "here"), (49, "here"), (50, "untraced")],
-    )
+    @pytest.mark.parametrize("filler", [48, 49, 50, 120])
     def test_a_change_pushed_out_of_the_history_window_is_not_reported_as_someone_elses(
-        self, monkeypatch, filler, expected
+        self, monkeypatch, filler
     ):
-        """#1369, at the boundary. The provenance match reads a bounded window of this rig's
-        history. Once enough later changes exist, our own `applied` row falls off the end and the
-        id stops being found — and before this fix that printed "Last changed from another
-        dashboard" over a change this dashboard *did* make.
+        """#1369, at the boundary. The provenance verdict used to read a bounded window of this
+        rig's history: once enough later changes existed, our own `applied` row fell off the end
+        and the id stopped being found. The verdict is an exact-id lookup now, so the row is found
+        wherever it sits and every row here reads `here`.
 
         The filler rows are `rejected` on purpose. A rejected change returns before the rig's
         config is touched, so nothing is re-stamped and `last_change_id` stays pinned to the good
@@ -233,8 +230,10 @@ class TestConfigOrigin:
         would mostly exercise the `reverted` path and this test could pass for a reason that has
         nothing to do with windowing.
 
-        49 filler rows leaves the good row as the 50th and last readable one; 50 pushes it out.
-        The cliff is exact, which is what makes the off-by-one worth pinning.
+        49 filler rows leaves the good row as the 50th and last readable one; 50 pushes it out;
+        120 is well past any off-by-one. The two assertions under the verdict are what stop this
+        passing for the wrong reason — the window has to still be BOUNDED and the good row has to
+        have really fallen out of it, or `here` at 50 would only mean the window grew.
         """
         from mining_dashboard.web import views
 
@@ -255,9 +254,40 @@ class TestConfigOrigin:
             d = build_worker_detail("rig1", {"workers": workers}, sm)
         finally:
             sm.close()
-        assert d["config_origin"] == expected
-        # The window really is the mechanism, not an accident of row count.
+        assert d["config_origin"] == "here"
+        # The window really is still bounded, and past 49 fillers the row the verdict just claimed
+        # is NOT among the ones rendered — which is precisely the case that used to be unanswerable.
         assert len(d["history"]) == min(filler + 1, 50)
+        rendered = [row["change_id"] for row in d["history"]]
+        assert (_META["last_change_id"] in rendered) is (filler < 50)
+
+    def test_a_foreign_change_on_a_long_history_rig_is_still_named_as_foreign(self, monkeypatch):
+        """#1369's OTHER half, and the dangerous one — a true alarm the window used to silence.
+
+        The issue text only describes the direction where we under-claim our own change. Past the
+        window the verdict was unanswerable both ways, so this rig — genuinely driven by another
+        host — got the same "we cannot tell" as one whose row had merely aged out. That withdrew a
+        warning the read could in fact support. An exact-id lookup answers it: the id is not in
+        this rig's rows at all, and no amount of later history makes that less true.
+        """
+        from mining_dashboard.web import views
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "1.2.3.4"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            for i in range(50):
+                sm.add_worker_config_version(
+                    "rig1", f"later{i:04d}", "rejected", {"DONATION": 6}, None, ts=2000.0 + i
+                )
+            workers = [{"name": "rig1", "status": "online", "rigforge": {"config_meta": _META}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        assert len(d["history"]) == 50  # the window IS full, so the old softening was available...
+        assert d["config_origin"] == "elsewhere"  # ...and is no longer reached
 
     def test_a_rolled_back_change_still_reads_as_reverted_on_a_long_history(self, monkeypatch):
         # The truncation verdict must not swallow the case where we DID find the row. The rig

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -445,9 +445,6 @@ with more changes than that table shows:
   says only that the record cannot tell you which, and it can still resolve on a later reading.
 - **Last changed from another dashboard** — applied over a control channel, but with an id this
   dashboard has never issued. Another host drove this rig, or its record here is gone.
-- **Last changed over a control channel** — applied over a control channel with an id that was not
-  found, on a rig with more recorded changes than the line reads back. The id may sit just past the
-  end of what was read, so the dashboard cannot honestly say the change was not its own.
 - **Cannot tell — this dashboard could not read its own history** — the dashboard's own change
   history would not open. It is the one line here that is about this dashboard rather than the rig:
   nothing was compared, so nothing is claimed either way. It says nothing about what the rig did.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -426,19 +426,20 @@ must enable and how the target is derived.
 Above the history, a line says **where the rig's current config came from** — the rig's own
 account, not ours. The history table below it can only list what this dashboard did; this line is
 the one place a change it never saw can show up. RigForge stamps each config change it records with
-what applied it and a change id, and the dashboard looks for that id among this rig's own history
-rows — the table directly below — so the verdict is one you can check by eye:
+what applied it and a change id, and the dashboard looks that id up among the changes it recorded
+for this rig. The lookup is by id, not a search of the table below, so it still answers on a rig
+with more changes than that table shows:
 
-- **Last changed from this dashboard** — the id matches a change in the history below, and that
+- **Last changed from this dashboard** — the id matches a change recorded for this rig, and that
   change is recorded as having been applied. Only that outcome earns this line: every other one,
   including an outcome that was never recorded at all, gets one of the lines below instead.
-- **Last change from this dashboard was rolled back** — the id matches a change the history below
+- **Last change from this dashboard was rolled back** — the id matches a change this dashboard
   records as rolled back or failed. When a control change does not come back live, RigForge
   restores the previous config and stamps that restore with the *same* change id it just reverted,
   so the rig goes on naming a change it is no longer running. The rig is on whatever config came
   before it.
-- **Last change from this dashboard is unconfirmed** — the id matches a change in the history
-  below, and no outcome was ever recorded for it. The dashboard waits on the rig for the result of
+- **Last change from this dashboard is unconfirmed** — the id matches a change recorded for this
+  rig, and no outcome was ever recorded for it. The dashboard waits on the rig for the result of
   a change it sends; when the rig has not said what it did within that wait, the change is recorded
   as acknowledged but unsettled. It may be running, or the rig may have rolled it back. This line
   says only that the record cannot tell you which, and it can still resolve on a later reading.

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -39,12 +39,14 @@ dashboard/tests/service/test_data_helpers.py	622
 dashboard/tests/service/test_data_service.py	2542
 dashboard/tests/service/test_egress.py	480
 dashboard/tests/service/test_metrics.py	463
+dashboard/tests/service/test_storage_worker.py	451
 dashboard/tests/service/test_telegram_commands.py	1240
 dashboard/tests/web/test_infra_views.py	865
 dashboard/tests/web/test_series_views.py	484
 dashboard/tests/web/test_server.py	1319
 dashboard/tests/web/test_views.py	861
 dashboard/tests/web/test_wizard.py	974
+dashboard/tests/web/test_worker_detail_meta.py	425
 dashboard/tests/web/test_xvb_views.py	1342
 .github/workflows/ci.yml	513
 lib/pithead/12-firstboot-wizard.sh	556


### PR DESCRIPTION
Third and last PR for #1369, on the room the first two freed. **Does not close #1369** (`do-not-close`).

## What was wrong

The Worker Inspect provenance line asked whether the rig's `last_change_id` appeared among the 50
history rows the page renders. Past that window the verdict stopped working in **both** directions
at once — it could neither claim a change that was ours nor name one that was not.

**The issue text is stale, and the half nobody wrote down is the dangerous one.** #1369 says the
verdict "flips to `elsewhere`", a false accusation. It does not any more: `untraced` shipped after
the issue was filed and took the accusation back out. What was left is symmetric, and the residue on
the other side is a false *reassurance* — a genuinely foreign change on a long-history rig also
landed on "we cannot tell", so the softening **silenced a true alarm**. `workerlogic.mjs` already
documented that as an accepted trade.

Reproduced before writing anything, four legs in one run, both controls fired:

| leg | history | filler rows | verdict | truth |
|---|---|---|---|---|
| **A (control)** | ours | 49 | `here` | correct |
| **B** | ours | 50 | `untraced` | should be `here` |
| **C (control)** | foreign | 49 | `elsewhere` | correct |
| **D** | foreign | 50 | `untraced` | should be `elsewhere` |

The window is a *rendering* limit. It was never a fact about what this dashboard spooled, and
letting it bound the verdict made it one.

## The fix — commit 1

`get_worker_config_change(worker, change_id)` looks the id up directly against this rig's own
`worker_config` rows, unbounded. Three-valued on the #1409 contract and failing **closed**: `None` =
the read failed, `{}` = no such row, a dict = the row. It lands in `worker_config_store.py` — the
module that owns the table, which is what PR 2's mixin extraction freed it to do.

`worker_detail.py` now passes `bool(matched)` and `history_unread=matched is None or history_unread`,
and no longer passes `history_truncated` — which is what leaves `untraced` with no producer.

**`worker_config_change_known` (#530) keeps its own query, and that is the one design point worth
reading.** The two methods must disagree about failure: #530 returns `False` on a closed handle and
`True` on a `sqlite3.Error` — both correct there, where a false "known" merely declines to accuse a
rig — while the provenance path needs "we do not know" for *both*, because the same two properties
invert into the one answer this feature must never give wrongly. So no single three-valued helper
can serve them. **Sharing the SQL as well was this change's first draft; measuring it is what took it
back out** — see the review section below. What the two genuinely must share is the row *shape*, and
only the reads that return a row have that in common: `_SELECT_CHANGE` is where they share it.

**Fallbacks costed and rejected, so nobody re-derives them:** raising the limit moves the cliff
rather than removing it, and makes every Inspect load read more rows to answer a single-id question;
a larger second read on a miss has the same defect one cliff further out; answering the under-claim
alone via `worker_config_change_known` fixes half and re-introduces the unscoped, fail-open trap the
comment beside that method warns against.

## The judgment call — commit 2, deliberately separable

`untraced` existed to hedge a miss commit 1 makes impossible, so the fix leaves it with no producer.
Commit 2 retires it from the verdict layer, `workerlogic.mjs`, both test tiers and `docs/dashboard.md`.
**Drop commit 2 and a working fix remains** — exercised, not asserted; see below.

Kept as a removal rather than a producer-less branch on purpose: a verdict nothing can emit is not
gone, it is *unreachable*, and unreachable is what goes stale unnoticed — the docs would go on
describing a line no operator can see. The unreachability claim is **enumerated, not asserted**: the
only production caller of `config_origin` is `worker_detail.py:155`, and a new sweep over every
surviving argument combination pins it, with its own non-empty control (which caught a wrong expected
set on its first run).

## A review finding, measured and acted on before opening

The first draft routed `worker_config_change_known` through the same row query as the provenance
lookup, under a "share the query and nothing else" story. **That story was wrong, and it cost
something.** #530 asks only whether a row EXISTS — it never reads `ts` — so the shared query imported
an `ORDER BY` it has no use for, six columns instead of one, and a `json.loads` on the matched row.

Measured with `EXPLAIN QUERY PLAN` against the SQL the shipped methods actually execute (captured
through a `sqlite3` trace callback, not transcribed by hand). There is no index on `change_id`; the
only index on the table is `idx_worker_config(worker, ts)`:

| query | plan |
|---|---|
| **before this PR** — `SELECT 1 … WHERE change_id=? LIMIT 1` | `SCAN worker_config` |
| **first draft** — #530 through the shared row query | `SCAN worker_config` + `USE TEMP B-TREE FOR ORDER BY` |
| **as shipped now** — #530 back on its own `SELECT 1` | `SCAN worker_config` |
| **as shipped now** — the provenance lookup | `SEARCH worker_config USING INDEX idx_worker_config (worker=?)` |

`_reconcile_worker_config` calls `worker_config_change_known` once per reporting rig per poll, so the
first draft added a temp B-tree sort per rig per cycle and bought #530 nothing. **Control:** adding a
`change_id` index visibly flips that plan to a covering-index search, so the instrument reports index
use rather than one fixed answer — and it does **not** remove the temp B-tree, which is how the sort
is attributable to the `ORDER BY` rather than to the missing index. Not a benchmark and not a claim
of user-visible slowdown: `worker_config` grows one row per operator config change, so the table is
small today. It was gratuitous, and the fix was to delete a helper.

**The same measurement falsified a comment I had written.** `worker_detail.py` said the new read was
"a single indexed row". It is an index *seek* on `worker` and then a walk of that rig's own rows, and
on the **miss** path — exactly the foreign-change case this line exists to catch — it walks all of
them. Still better than the window scan (no horizon, and no sort, because `(worker, ts)` already
supplies the ordering), but the comment overstated it, so both it and the matching docstring line now
say what was measured. Found by the reviewing controller; re-derived at source by me before acting.

## Evidence — PROVEN BY ME at this head, instrument shown to fire first in every case

- **Positive control for the fix.** Reverting the two runtime files to `origin/develop-v2` and
  running `test_worker_detail_meta.py` gives **3 failed, 25 passed** — failing exactly `[50]`,
  `[120]` and the leg-D foreign-change case, while `[48]`/`[49]` stay green, so the new tests are not
  red for a blanket reason. Both files restored byte-identical afterwards (sha256 checked against
  `HEAD`'s blobs; working tree *and* index verified clean — `git checkout <ref> -- path` stages as
  well as writes, so restoring from the index would have silently kept the reverted copy).
- **Suite:** `2146 passed`, rc 0. Total coverage **97.03%** against the ≥80% bar.
- **Frontend:** `481 pass, 0 fail`.
- **Patch coverage, with the vacuous pass ruled out.** `diff-cover` vs `origin/develop-v2`:
  **92% over 27 measured lines**, against the ≥90% bar. The line count is the part that matters —
  `diff-cover` exits **0** printing "No lines with coverage information in this diff", so rc alone is
  no pass. Control run, same command against an empty diff: rc 0, zero lines, that exact message.
  `make test-patch-coverage` as CI invokes it also exits 0 — but **that rc is not evidence about this
  patch**, and I should not have listed it as though it were: it grades 1769 lines across 86 files
  because of #1537 below, so it clears 90% on `develop-v2`'s aggregate rather than on my 27 lines.
  The `origin/develop-v2` figure above is the one that means anything here. Its overlap self-test
  passes 4/4, which is a real check of the wrapper's own logic and nothing more.
- **Lint:** `lint-py lint-js lint-md lint-docs-voice lint-operator-strings lint-topology
  lint-file-budget` all rc **0**, measured per target rather than read off a pipeline. No shell files
  in this diff, so `lint-sh` does not apply.
- **Commit 1 alone is green:** `103 passed` across `test_worker_detail_meta.py`,
  `test_rig_config_meta.py` and `test_storage_worker.py` at commit 1's tree.

## Evidence — RELAYED, and what I bridged

The separability claim was first exercised by the reviewing controller, in its own worktree, and the
coupling risk it tested is one my own runs could not see: **commit 1 ships the new
`test_worker_detail_meta.py` against the OLD `config_origin`**, because `rig_config_meta.py` is
touched only by commit 2. Its result: leg A `103 passed, rc 0`; control (reverting `worker_detail.py`)
rc 1 with exactly those three failures; `history_truncated` has a default at commit 1 so dropping the
argument cannot `TypeError`, and at commit 2 `git grep -F history_truncated` over the tree is zero.
**Proof log — check this rather than take my word:**
`~/split-baselines/1369-pr3-separability-controller-w41.md`.

That run predates the fix above, so I bridged it rather than relaying it across a moved tree: I
re-ran leg A myself at the new commit 1 (same `103 passed`) and re-ran the reverted-file control
myself (the 3 failed / 25 passed above). `worker_detail.py` is **AST-identical** across the amend —
comment-only, with a seeded one-argument control confirming the comparison can report a difference,
and `worker_config_store.py` correctly reporting as changed.

The control's failure text, `AssertionError: assert 'untraced' == 'elsewhere'`, is also a second and
better-grounded route to commit 2's premise, and it now sits in commit 2's message: at commit 1,
where `untraced` is still fully wired, the old `worker_detail.py` still *reaches* it. A sweep proving
nothing reaches a branch says more when the branch is demonstrably still live.

## Named gaps — what I did NOT do

- **Two lines of this patch are uncovered**, and they are why the number is 92% rather than 100%:
  `worker_config_store.py:49-50`, the `except (TypeError, ValueError)` fallback in `_shaped` that
  turns unparseable `changes` JSON into `{}`. That code is **not new** — it exists verbatim at the
  base inside `get_worker_config_history`, and the collapse into `_shaped` relocated it, which is why
  a line-based diff counts it as added. I did not add a test because
  `tests/service/test_storage_worker.py` sits on a **zero-headroom** budget row (below), and a ratchet
  raise is not something covering a pre-existing defensive branch justifies. I did not measure
  whether the base covered its own copy.
- **No review of the final tree by anyone but me.** The controller reviewed the previous head; the
  regression fix above landed after that review and has not been read by anyone else.
- **No benchmark.** The query-plan work above is a plan comparison, not a wall-clock measurement.
- **Nothing seen on screen — this lane has no browser.** The retired `untraced` line's absence is
  proven in the verdict layer and in both test tiers, but not visually.

## Disclosures

- **`docs/` is shared** and this PR edits `docs/dashboard.md`. Its "so the verdict is one you can
  check by eye" claim was **falsified by the fix** — the verdict no longer comes from the table
  below it — so the paragraph is rewritten rather than trimmed, and the `untraced` bullet is deleted
  in commit 2.
- **Two new file-budget rows, both at zero headroom by the gate's own rule 2:**
  `dashboard/tests/service/test_storage_worker.py 451` and
  `dashboard/tests/web/test_worker_detail_meta.py 425`. Both crossed the 400 target. `run_gate` fails
  on `lines -gt ceiling`, so equal passes — but neither can grow again. If either must,
  `worker_config_store.py` being its own module makes a `test_worker_config_store.py` split the
  natural cut. **`worker_config_store.py` itself is 227 lines and correctly takes no row** — a file
  under the target must not have one. (Corrected from 226 after review: that figure was measured
  before the last edit to this branch and never re-taken. Counted the way the gate counts, by
  record — `awk 'END{print NR}'` — not by trailing newline.)
- **The boundary test was extended, not replaced.** `tests/web/test_worker_detail_meta.py` was
  already parametrized `[(48, "here"), (49, "here"), (50, "untraced")]`; it is now `[48, 49, 50, 120]`
  all expecting `here`, **with two anti-false-pass assertions** — that the rendered window is still
  bounded, and that the claimed row is *not* among the rendered ones past 49. Without those, the new
  rows would pass if the fix had worked by simply rendering more history.
- **The base moved under this branch.** Merge-base is `abb23ee`; `origin/develop-v2` is now `f2e0bde`
  (#1534 landed after the cut). Its two commits touch `lib/`, `pithead`, `tests/stack/` and two docs
  — no file this PR touches, and no budget row lowered, added or removed. Not rebased, per the
  controller's ruling; re-running at merge time is the merger's call.

## One finding filed, not fixed here

`scripts/patch-coverage.sh` hardcodes `COMPARE=origin/develop`, while the CI step that calls it
fetches `${GITHUB_BASE_REF:-develop}` and its comment states the gate grades "vs the PR's own base".
Nothing under `scripts/` or the `Makefile` reads that variable — verified by grep. So every PR into
`develop-v2` is graded against the frozen `develop`: this one measures over **1769 lines across 86
files** instead of its own 27. It passes today only because the aggregate is 98%, and the failure it
is supposed to prevent — a PR failing on lines it never touched — is the one it can still produce.
`scripts/` is not this lane's path, so it is filed rather than touched.