### PR TITLE
fix(cli): serialise every firstboot install path behind the mutation lock (#1482)

### DIFF
--- a/lib/pithead/12-firstboot-wizard.sh
+++ b/lib/pithead/12-firstboot-wizard.sh
@@ -33,6 +33,36 @@ stage_wizard_spool() { # <spool-dir> -> fingerprint on stdout
     wizard_mint_cert "$spool" 2>/dev/null || true
 }
 
+# The lock and the marker that OPEN every install path: taken before the first write, which is `installing` itself, so
+# the lock timeout's promise that nothing was changed is literally true. No caller holds it across a human wait — the
+# two card paths sit past their handoff-ack, and the bare keep-reinstall has no card and never waits (#1482).
+wizard_install_begin() { # <spool-dir>
+    mutation_lock_acquire firstboot-install
+    touch "$1/installing"
+    chown 1000:1000 "$1/installing" 2>/dev/null || true
+}
+
+# The switch-off every install path ends on, and where the window closes — held across the poweroff for the reason
+# factory-reset holds across its reboot: the gap before the machine goes dark is precisely when another verb must not
+# start. No confirmation step, deliberately — an operator who removes the stick BEFORE pressing anything takes the
+# running filesystem with it, and a machine already dark by the time anyone reaches it removes that mistake entirely.
+wizard_install_finish() { # <engine> <headline> <closing line>
+    _console "" "$2" "When the machine is dark, remove the USB stick and switch it back on." "$3"
+    sleep 8 # long enough for the page's poll to show the switch-off steps
+    "$1" rm -f pithead-wizard >/dev/null 2>&1 || true
+    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
+    sleep 3
+    systemctl poweroff
+    mutation_lock_release
+}
+
+wizard_install_failed_page() { # <spool-dir> <what failed> — the page gets the disk list and the reason back; the window closes here
+    publish_disk_inventory "$1"
+    warn "$2 failed — the page shows the reason."
+    mutation_lock_release
+    sleep 2
+}
+
 firstboot_wizard() {
     local arg
     for arg in "$@"; do
@@ -234,25 +264,15 @@ firstboot_wizard() {
             if [ "$installer" -eq 1 ] && [ -f "$spool/install-request" ] &&
                 [ "$(cut -f2 "$spool/install-request" 2>/dev/null)" = "keep" ] &&
                 [ ! -f "$spool/config.json" ] && [ ! -f "$spool/restore-archive" ]; then
-                touch "$spool/installing"
-                chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                wizard_install_begin "$spool"
                 local irc=0
                 consume_install_request "$spool" || irc=$?
                 if [ "$irc" -ne 0 ]; then
                     rm -f "$spool/installing"
-                    publish_disk_inventory "$spool"
-                    warn "Reinstall failed — the page shows the reason."
-                    sleep 2
+                    wizard_install_failed_page "$spool" "Reinstall"
                     continue
                 fi
-                _console "" "Reinstall complete — switching off now." \
-                    "When the machine is dark, remove the USB stick and switch it back on." \
-                    "Everything it knew — settings, wallets, login, chains — is still there."
-                sleep 8
-                "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                sleep 3
-                systemctl poweroff
+                wizard_install_finish "$engine" "Reinstall complete — switching off now." "Everything it knew — settings, wallets, login, chains — is still there."
                 return
             fi
             # The rig role's submission travels on its own channel — no pithead config exists
@@ -290,8 +310,7 @@ firstboot_wizard() {
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
                         continue
                     fi
-                    touch "$spool/installing"
-                    chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                    wizard_install_begin "$spool"
                     # Stage the accepted settings onto the running ESP: the installer carries
                     # them to the target's ESP, and the first boot from disk lands them on its
                     # /data (the top of this function). The stick keeps NEITHER copy — rig.json
@@ -302,6 +321,7 @@ firstboot_wizard() {
                         rm -f "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack" "$spool/install-request" "$PWD/rig.json"
                         printf 'Could not stage the rig settings for the installed system — nothing was installed.' >"$spool/error.txt"
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
+                        mutation_lock_release
                         continue
                     fi
                     local irc=0
@@ -309,19 +329,10 @@ firstboot_wizard() {
                     rm -f "$PWD/rig.json" /boot/efi/pithead-rig.json
                     if [ "$irc" -ne 0 ]; then
                         rm -f "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack"
-                        publish_disk_inventory "$spool"
-                        warn "Install failed — the page shows the reason."
-                        sleep 2
+                        wizard_install_failed_page "$spool" "Install"
                         continue
                     fi
-                    _console "" "Installation complete — switching off now." \
-                        "When the machine is dark, remove the USB stick and switch it back on." \
-                        "It will come up as the rig you just confirmed."
-                    sleep 8
-                    "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                    sleep 3
-                    systemctl poweroff
+                    wizard_install_finish "$engine" "Installation complete — switching off now." "It will come up as the rig you just confirmed."
                     return
                 fi
                 # Run from this medium — or an installed machine choosing the rig role: the
@@ -422,8 +433,7 @@ firstboot_wizard() {
                         rm -f "$PWD/config.json"
                         continue
                     fi
-                    touch "$spool/installing"
-                    chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                    wizard_install_begin "$spool"
                     # Stage the ACCEPTED config (password already baked) onto the running ESP —
                     # the installer carries pre-seed files to the target's ESP, and the first
                     # boot from disk provisions itself headlessly from it. The credentials the
@@ -456,6 +466,7 @@ firstboot_wizard() {
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
                         rm -f "$PWD/config.json" /boot/efi/pithead-restore.enc /boot/efi/pithead-restore-pass
                         rm -rf "$carry"
+                        mutation_lock_release
                         continue
                     fi
                     local irc=0
@@ -479,21 +490,10 @@ firstboot_wizard() {
                     if [ "$irc" -ne 0 ]; then
                         rm -f /boot/efi/pithead-config.json "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack"
                         jq -c . "$spool/last-attempt.json" >/dev/null 2>&1 || true
-                        publish_disk_inventory "$spool"
-                        warn "Install failed — the page shows the reason."
-                        sleep 2
+                        wizard_install_failed_page "$spool" "Install"
                         continue
                     fi
-                    _console "" "Installation complete — switching off now." "When the machine is dark, remove the USB stick and switch it back on." "It will provision itself with the configuration you just confirmed."
-                    # No confirmation step. An operator who removes the stick BEFORE pressing
-                    # anything takes the running filesystem with it — powering off unprompted
-                    # removes the ordering mistake entirely: by the time anyone reaches the
-                    # machine it is already dark and the stick is safe to pull.
-                    sleep 8 # long enough for the page's poll to show the switch-off steps
-                    "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                    sleep 3
-                    systemctl poweroff
+                    wizard_install_finish "$engine" "Installation complete — switching off now." "It will provision itself with the configuration you just confirmed."
                     return
                 fi
                 # Installed machine, config accepted: record what it IS. The installer path

--- a/pithead
+++ b/pithead
@@ -2542,6 +2542,36 @@ stage_wizard_spool() { # <spool-dir> -> fingerprint on stdout
     wizard_mint_cert "$spool" 2>/dev/null || true
 }
 
+# The lock and the marker that OPEN every install path: taken before the first write, which is `installing` itself, so
+# the lock timeout's promise that nothing was changed is literally true. No caller holds it across a human wait — the
+# two card paths sit past their handoff-ack, and the bare keep-reinstall has no card and never waits (#1482).
+wizard_install_begin() { # <spool-dir>
+    mutation_lock_acquire firstboot-install
+    touch "$1/installing"
+    chown 1000:1000 "$1/installing" 2>/dev/null || true
+}
+
+# The switch-off every install path ends on, and where the window closes — held across the poweroff for the reason
+# factory-reset holds across its reboot: the gap before the machine goes dark is precisely when another verb must not
+# start. No confirmation step, deliberately — an operator who removes the stick BEFORE pressing anything takes the
+# running filesystem with it, and a machine already dark by the time anyone reaches it removes that mistake entirely.
+wizard_install_finish() { # <engine> <headline> <closing line>
+    _console "" "$2" "When the machine is dark, remove the USB stick and switch it back on." "$3"
+    sleep 8 # long enough for the page's poll to show the switch-off steps
+    "$1" rm -f pithead-wizard >/dev/null 2>&1 || true
+    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
+    sleep 3
+    systemctl poweroff
+    mutation_lock_release
+}
+
+wizard_install_failed_page() { # <spool-dir> <what failed> — the page gets the disk list and the reason back; the window closes here
+    publish_disk_inventory "$1"
+    warn "$2 failed — the page shows the reason."
+    mutation_lock_release
+    sleep 2
+}
+
 firstboot_wizard() {
     local arg
     for arg in "$@"; do
@@ -2743,25 +2773,15 @@ firstboot_wizard() {
             if [ "$installer" -eq 1 ] && [ -f "$spool/install-request" ] &&
                 [ "$(cut -f2 "$spool/install-request" 2>/dev/null)" = "keep" ] &&
                 [ ! -f "$spool/config.json" ] && [ ! -f "$spool/restore-archive" ]; then
-                touch "$spool/installing"
-                chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                wizard_install_begin "$spool"
                 local irc=0
                 consume_install_request "$spool" || irc=$?
                 if [ "$irc" -ne 0 ]; then
                     rm -f "$spool/installing"
-                    publish_disk_inventory "$spool"
-                    warn "Reinstall failed — the page shows the reason."
-                    sleep 2
+                    wizard_install_failed_page "$spool" "Reinstall"
                     continue
                 fi
-                _console "" "Reinstall complete — switching off now." \
-                    "When the machine is dark, remove the USB stick and switch it back on." \
-                    "Everything it knew — settings, wallets, login, chains — is still there."
-                sleep 8
-                "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                sleep 3
-                systemctl poweroff
+                wizard_install_finish "$engine" "Reinstall complete — switching off now." "Everything it knew — settings, wallets, login, chains — is still there."
                 return
             fi
             # The rig role's submission travels on its own channel — no pithead config exists
@@ -2799,8 +2819,7 @@ firstboot_wizard() {
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
                         continue
                     fi
-                    touch "$spool/installing"
-                    chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                    wizard_install_begin "$spool"
                     # Stage the accepted settings onto the running ESP: the installer carries
                     # them to the target's ESP, and the first boot from disk lands them on its
                     # /data (the top of this function). The stick keeps NEITHER copy — rig.json
@@ -2811,6 +2830,7 @@ firstboot_wizard() {
                         rm -f "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack" "$spool/install-request" "$PWD/rig.json"
                         printf 'Could not stage the rig settings for the installed system — nothing was installed.' >"$spool/error.txt"
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
+                        mutation_lock_release
                         continue
                     fi
                     local irc=0
@@ -2818,19 +2838,10 @@ firstboot_wizard() {
                     rm -f "$PWD/rig.json" /boot/efi/pithead-rig.json
                     if [ "$irc" -ne 0 ]; then
                         rm -f "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack"
-                        publish_disk_inventory "$spool"
-                        warn "Install failed — the page shows the reason."
-                        sleep 2
+                        wizard_install_failed_page "$spool" "Install"
                         continue
                     fi
-                    _console "" "Installation complete — switching off now." \
-                        "When the machine is dark, remove the USB stick and switch it back on." \
-                        "It will come up as the rig you just confirmed."
-                    sleep 8
-                    "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                    sleep 3
-                    systemctl poweroff
+                    wizard_install_finish "$engine" "Installation complete — switching off now." "It will come up as the rig you just confirmed."
                     return
                 fi
                 # Run from this medium — or an installed machine choosing the rig role: the
@@ -2931,8 +2942,7 @@ firstboot_wizard() {
                         rm -f "$PWD/config.json"
                         continue
                     fi
-                    touch "$spool/installing"
-                    chown 1000:1000 "$spool/installing" 2>/dev/null || true
+                    wizard_install_begin "$spool"
                     # Stage the ACCEPTED config (password already baked) onto the running ESP —
                     # the installer carries pre-seed files to the target's ESP, and the first
                     # boot from disk provisions itself headlessly from it. The credentials the
@@ -2965,6 +2975,7 @@ firstboot_wizard() {
                         chown 1000:1000 "$spool/error.txt" 2>/dev/null || true
                         rm -f "$PWD/config.json" /boot/efi/pithead-restore.enc /boot/efi/pithead-restore-pass
                         rm -rf "$carry"
+                        mutation_lock_release
                         continue
                     fi
                     local irc=0
@@ -2988,21 +2999,10 @@ firstboot_wizard() {
                     if [ "$irc" -ne 0 ]; then
                         rm -f /boot/efi/pithead-config.json "$spool/installing" "$spool/handoff.json" "$spool/handoff-ack"
                         jq -c . "$spool/last-attempt.json" >/dev/null 2>&1 || true
-                        publish_disk_inventory "$spool"
-                        warn "Install failed — the page shows the reason."
-                        sleep 2
+                        wizard_install_failed_page "$spool" "Install"
                         continue
                     fi
-                    _console "" "Installation complete — switching off now." "When the machine is dark, remove the USB stick and switch it back on." "It will provision itself with the configuration you just confirmed."
-                    # No confirmation step. An operator who removes the stick BEFORE pressing
-                    # anything takes the running filesystem with it — powering off unprompted
-                    # removes the ordering mistake entirely: by the time anyone reaches the
-                    # machine it is already dark and the stick is safe to pull.
-                    sleep 8 # long enough for the page's poll to show the switch-off steps
-                    "$engine" rm -f pithead-wizard >/dev/null 2>&1 || true
-                    _console "" "Shutting down. Remove the USB stick, then switch the machine on."
-                    sleep 3
-                    systemctl poweroff
+                    wizard_install_finish "$engine" "Installation complete — switching off now." "It will provision itself with the configuration you just confirmed."
                     return
                 fi
                 # Installed machine, config accepted: record what it IS. The installer path

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -223,6 +223,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-caddyfile-optional-env.sh" 
 # shellcheck source=tests/stack/test-appliance-rotate-secrets-lock.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-rotate-secrets-lock.sh" && domain_ran test-appliance-rotate-secrets-lock.sh "$_d0" "$?" || domain_ran test-appliance-rotate-secrets-lock.sh "$_d0" "$?"
 
+# shellcheck source=tests/stack/test-appliance-firstboot-install-lock.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-appliance-firstboot-install-lock.sh" && domain_ran test-appliance-firstboot-install-lock.sh "$_d0" "$?" || domain_ran test-appliance-firstboot-install-lock.sh "$_d0" "$?"
+
 # shellcheck source=tests/stack/test-appliance-identity-boot.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-identity-boot.sh" && domain_ran test-appliance-identity-boot.sh "$_d0" "$?" || domain_ran test-appliance-identity-boot.sh "$_d0" "$?"
 

--- a/tests/stack/test-appliance-firstboot-install-lock.sh
+++ b/tests/stack/test-appliance-firstboot-install-lock.sh
@@ -1,0 +1,173 @@
+# shellcheck shell=bash
+#
+# firstboot install-path lock wiring (#1482): the wizard's install paths take the mutation lock, and
+# take it in the one place that is correct. Sourced by tests/stack/run.sh.
+#
+# SCOPE, stated so this is not read as duplicating its neighbours. test-lifecycle.sh proves the lock
+# MECHANISM — the holder record, the announced wait, the refusal, the rc, the release — and says
+# nothing about which verbs are wired to it. test-wizard-setup.sh proves what the wizard DOES and
+# says nothing about mutual exclusion. What is asserted here is WIRING and PLACEMENT for the
+# firstboot install paths, and nothing about how the lock itself behaves.
+#
+# THERE ARE THREE INSTALL PATHS, NOT ONE, and that is the finding this file exists to pin. Every
+# call to `consume_install_request` erases and repartitions a disk, and `firstboot_wizard` makes
+# three of them: the BARE KEEP-REINSTALL (no card, no handoff-ack, no human wait at all), the RIG
+# install, and the COORDINATOR install+configure. Wiring only the last would leave a verb that reads
+# as locked with two unlocked doors, so the coverage row at the bottom checks all three.
+#
+# PLACEMENT is the half a plain "does it take the lock" test would miss. `wizard_install_begin` takes
+# the window and then writes `$spool/installing` — that marker is the install path's FIRST write, so
+# its ABSENCE on a held machine is what pins the acquire above it. Move the acquire below the touch
+# and the contended marker row fails; drop the acquire entirely and the contended rc row fails too.
+#
+# THE WINDOW MUST ALSO CLOSE, and on the failure exits that is load-bearing rather than cosmetic: a
+# failed install does `continue` back into the wizard's polling loop, so a leaked hold would wedge
+# every later attempt on the same boot. The success exit powers the machine off, where a leak cannot
+# be observed by anything — which is exactly why the release rows below drive the FAILURE helper as
+# well as the finish helper.
+#
+# `systemctl` IS OVERRIDDEN AS AN IN-PROCESS SHELL FUNCTION, NEVER A PATH STUB. `wizard_install_finish`
+# ends in `systemctl poweroff`; a PATH stub that failed to resolve for any reason would power off the
+# machine running the suite. A shell function is looked up before PATH and cannot be bypassed, so the
+# real binary is unreachable by construction rather than by convention. `sleep` is overridden in the
+# same shells for the same reason of construction, not speed — and deliberately NOT on PATH, because
+# the lock holder below depends on a REAL `exec sleep` to keep owning its descriptor.
+#
+# Re-derivations: $SANDBOX, $STACK, $ROOT, make_stubs and the assert_* helpers come from lib.sh.
+# Every other name is assigned here under an FB/fb_ prefix, because this file and its neighbours are
+# sourced into ONE shell.
+
+: "${SANDBOX:?}"
+: "${STACK:?}"
+
+FB="$SANDBOX/firstboot-lock"
+FBSPOOL="$FB/data/firstboot"
+FBLOG="$FB/calls.log"
+mkdir -p "$FB/bin" "$FBSPOOL"
+cp "$STACK" "$FB/pithead"
+make_stubs "$FB/bin"
+
+FBFREE="$SANDBOX/firstboot-lock-free.lock" # never held: the positive controls run through it
+FBHELD="$SANDBOX/firstboot-lock-held.lock" # held by fb_hold for the contended cases
+
+fb_reset() { # a clean spool before EVERY case: `installing` must be absent for its absence to mean anything
+    rm -rf "$FBSPOOL"
+    mkdir -p "$FBSPOOL"
+    : >"$FBLOG"
+}
+
+# Runs one helper in a NESTED subshell so a lock timeout's `exit` cannot take the prober with it,
+# then reports the helper's rc. The nested shell owns any descriptor the helper opened, so this
+# form deliberately says nothing about whether the window stayed held — fb_window below does that.
+fb_rc() { # <lock file> <fn> <args...> -> rc on stdout
+    local lk="$1"
+    shift
+    (
+        cd "$FB" || return
+        export PITHEAD_LOCK_FILE="$lk" PITHEAD_LOCK_TIMEOUT=1
+        PATH="$FB/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$FB/pithead"
+        set +e
+        systemctl() { echo "[systemctl] $*" >>"$FBLOG"; }
+        sleep() { :; }
+        ("$@") >>"$FBLOG" 2>&1
+        echo "$?"
+    )
+}
+
+# Opens the window with the real helper, CONFIRMS it actually took it, then runs the closing helper
+# and reports whether the window came back. The middle step is the point: without it, "released"
+# would be indistinguishable from a begin that never armed, and the two read identically.
+fb_window() { # <closing fn> <args...> -> begin-did-not-hold | released | still-held
+    (
+        cd "$FB" || return
+        export PITHEAD_LOCK_FILE="$FBFREE" PITHEAD_LOCK_TIMEOUT=1
+        PATH="$FB/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$FB/pithead"
+        set +e
+        systemctl() { echo "[systemctl] $*" >>"$FBLOG"; }
+        sleep() { :; }
+        wizard_install_begin "$FBSPOOL" >>"$FBLOG" 2>&1
+        if flock -n "$FBFREE" true 2>/dev/null; then
+            echo begin-did-not-hold
+            exit 0
+        fi
+        "$@" >>"$FBLOG" 2>&1
+        if flock -n "$FBFREE" true 2>/dev/null; then echo released; else echo still-held; fi
+    )
+}
+
+# Sets FBHOLDER rather than echoing it: `$(...)` around a function that backgrounds a long-lived
+# holder blocks the substitution for that holder's whole lifetime.
+FBHOLDER=""
+fb_hold() { # <lock file> -> sets FBHOLDER
+    local lk="$1" i=0
+    : >"$lk"
+    (
+        exec 9>>"$lk"
+        flock -w 20 9 || exit 1
+        exec sleep 120
+    ) >/dev/null 2>&1 &
+    FBHOLDER=$!
+    while [ "$i" -lt 200 ]; do
+        flock -n "$lk" true 2>/dev/null || break
+        sleep 0.05
+        i=$((i + 1))
+    done
+    if flock -n "$lk" true 2>/dev/null; then
+        bad "the holder takes the firstboot lock window" "the lock is still free — every contended case below would prove nothing"
+    fi
+}
+
+echo "== black-box: the fixture arms — uncontended, the install window opens and writes its marker (#1482) =="
+# Read both rows here as the controls for their contended twins below.
+fb_reset
+: >"$FBFREE"
+fb_rc_out=$(fb_rc "$FBFREE" wizard_install_begin "$FBSPOOL")
+assert_rc "uncontended wizard_install_begin succeeds" "$fb_rc_out" "0"
+assert_eq "uncontended wizard_install_begin really writes the installing marker" \
+    "$([ -f "$FBSPOOL/installing" ] && echo written)" "written"
+
+echo "== black-box: a held machine refuses the install window and writes nothing (#1482) =="
+fb_hold "$FBHELD"
+
+fb_reset
+fb_rc_out=$(fb_rc "$FBHELD" wizard_install_begin "$FBSPOOL")
+assert_rc "contended wizard_install_begin refuses rather than interleaving with the held window" "$fb_rc_out" "75"
+# The marker is the install path's FIRST write, so its absence is what pins the acquire above it —
+# not merely above consume_install_request, which is where a symmetry argument would have put it.
+assert_eq "contended wizard_install_begin writes NO installing marker" \
+    "$([ -f "$FBSPOOL/installing" ] || echo none)" "none"
+assert_contains "contended wizard_install_begin names the operation it is waiting on" \
+    "$(cat "$FBLOG")" "Another pithead operation is in progress"
+
+kill "$FBHOLDER" 2>/dev/null || true
+wait "$FBHOLDER" 2>/dev/null || true
+
+echo "== black-box: both install exits give the window back (#1482) =="
+# A failed install continues back into the wizard's polling loop, so a leak here wedges the boot.
+fb_reset
+assert_eq "wizard_install_failed_page gives the window back" \
+    "$(fb_window wizard_install_failed_page "$FBSPOOL" "Install")" "released"
+fb_reset
+assert_eq "wizard_install_finish gives the window back" \
+    "$(fb_window wizard_install_finish docker "Installation complete" "closing line")" "released"
+assert_contains "wizard_install_finish really reaches the switch-off it holds the window across" \
+    "$(cat "$FBLOG")" "[systemctl] poweroff"
+
+echo "== structural: all three install paths sit behind the window, none excepted (#1482) =="
+# STATED AS WHAT IT IS: this row reads the shipped artifact's text, so it proves WIRING COVERAGE and
+# not behaviour — the behaviour is proven by the rows above, which drive the real helpers. It exists
+# because those rows exercise the helpers directly and would stay green if a call site stopped using
+# them. In file order the two tokens must alternate; two consecutive consume_install_request means an
+# install path reaches the erase without the window.
+fb_tokens=$(awk '/^firstboot_wizard\(\) \{/ { f = 1 } f { print } f && /^\}$/ { exit }' "$STACK" |
+    grep -o 'wizard_install_begin\|consume_install_request' | tr '\n' ' ')
+# Control: an extractor that matched nothing would make the row below vacuous, so prove it matched.
+assert_eq "the artifact scan really found the firstboot install sites" \
+    "$([ -n "$fb_tokens" ] && echo found)" "found"
+assert_eq "every consume_install_request in firstboot_wizard is opened by wizard_install_begin" \
+    "$fb_tokens" \
+    "wizard_install_begin consume_install_request wizard_install_begin consume_install_request wizard_install_begin consume_install_request "


### PR DESCRIPTION
## What this changes

`firstboot_wizard` reaches `consume_install_request` — the call that erases and repartitions a
disk — from **three** places, and none of them held the mutation lock. All three are now serialised
behind it.

The three paths, derived from `git grep -n consume_install_request -- lib/` rather than by reading
around, each with its own `systemctl poweroff`:

| path | confirmation before the erase |
|---|---|
| bare keep-everything reinstall | none — no card, no `handoff-ack`, no human wait at all |
| rig install | the rig card's `handoff-ack` |
| coordinator install + configure | the credentials card's `handoff-ack` |

**This is the part worth reviewing first.** #1482's own text, the lane's handoff and the controller's
summary all describe `firstboot_wizard` as having *one* installer path. Wiring only the third — the
one everybody means by "the installer path" — would have shipped a verb that reads as locked with
two unlocked doors. The bare keep-reinstall is the easiest of the three to miss and the only one
with no human in the loop at all.

## Where the window opens and closes, and why there

`wizard_install_begin` takes the lock and then writes `$spool/installing`.

- **After the confirmation.** A hold must never span a human wait. The two card paths call it past
  their `handoff-ack` loop; the bare keep-reinstall never waits, so there is no wait to span.
- **Before the first write.** `installing` *is* the install path's first write — the page reads it.
  Acquiring above it is what makes the lock timeout's promise that nothing was changed literally
  true. Putting the acquire just above `consume_install_request` instead would pass a naive "does it
  take the lock" test while having already written a file in a window it did not hold. This is the
  same trap `rotate_secrets` had, where the first write was the pre-rotation safety copies rather
  than the credential rewrite.

`wizard_install_finish` releases, held across the `systemctl poweroff` for the same reason
`factory_reset` holds across its reboot: the gap before the machine goes dark is precisely when
another verb must not start.

`wizard_install_failed_page` releases on the failure exits, and **there it is load-bearing rather
than cosmetic** — a failed install does `continue` back into the wizard's polling loop, so a leaked
hold would wedge every later attempt on that boot. On the success path the machine powers off and a
leak could not be observed by anything, which is why the tests drive the failure helper too.

Every exit between a `wizard_install_begin` and the next `continue`/`return` passes through exactly
one release: three success exits via `wizard_install_finish`, three failure exits via
`wizard_install_failed_page`, two staging-failure exits via an explicit `mutation_lock_release`.

## Why this is a refactor and not just an insertion

`lib/pithead/12-firstboot-wizard.sh` was **556 lines against a 556 ceiling — closed both ways.**
Three acquires, seven releases and their comments is about +14 lines, and ceilings only go down.

Rather than route around the gate, the acquire and release each got a named home *on the install
path's own axis*. Both helpers absorb triplication that was already there: the switch-off sequence
was byte-identical across all three paths apart from two strings, and the publish/warn/sleep failure
tail was identical across three more. **The file lands at exactly 556**, so
`docs/dev/file-budget.tsv` needs no edit, no row moves, and no new row is spent.

Stated plainly because it should be checked: the poweroff sequence was extracted, not rewritten. The
middle console line is character-for-character the same string all three sites passed, the argument
count to `_console` is unchanged at four, and the `sleep 8` / `sleep 3` pauses are unchanged. The
only behavioural addition anywhere in the extracted code is the lock.

## Over-engineering pass (run by hand)

The ponytail gate cannot do this here — it keys off the pinned shell's branch, not the branch under
review, and it clears on a retry without checking that any review happened. So, by hand:

- **Was a smaller change available?** Yes: insert 3 acquires and 7 releases inline. It was rejected
  because it does not fit the ceiling, and the alternatives to fitting it were worse — a new slice
  file (needs a new path grant and re-opens #1105 Phase 2, declared complete) or deleting earned
  comments from a disk-erasing code path.
- **Was a larger one considered and rejected?** Yes — collapsing the three failure-cleanup blocks
  into one parameterised helper. **Rejected: the three `rm -f` lists genuinely differ**, and the
  cost of being wrong in code that erases disks is not worth ~4 lines. Saying so rather than letting
  it look overlooked.
- **Is the extraction a pure move?** Everything moved into the two helpers is byte-identical to what
  it replaced except the two parameterised strings and the added lock calls. The artifact proof
  below is the mechanical check.

## Evidence — what was RUN

Base: `f2e0bde8` (re-derived with `git ls-remote origin develop-v2`; the branch was rebased onto it
after #1534 merged, which invalidated the earlier proof set and so none of it is quoted here).

**The artifact, with the control that matters.** #1534 also changed `pithead`, and the rebase merged
both changes into the 12k-line generated file *textually, without a conflict* — the shape where a
generated artifact merges clean and is wrong. So parity alone was not accepted: the committed
artifact was copied aside, `scripts/build-pithead.sh` re-run from source, and `cmp` used — **byte
identical**. A byte was then appended to the copy and `cmp` re-run, which reported the difference,
so the identity is an absence the instrument was shown able to break. `lint-pithead-parity` also
green over 52 slices.

- `bash -n` on the slice, `run.sh` and the new test — rc 0 each
- `shfmt -i 4 -d` — clean on all three
- **`make lint-sh` — rc 0**, read as an rc FILE from a detached run, under the fleet's serialised
  lint lock. **shellcheck prints nothing when it is clean, so rc 0 alone is equally consistent
  with these files never being in the argument set** — inclusion was therefore proved directly,
  each leg with a negative control returning 0: the `tests/stack/test-*.sh` glob really does
  expand to the new test file; the slice, the new test and `run.sh` are each named in the logged
  `shfmt` argument list; and the slice is analysed in context through the first shellcheck
  argument, the built `pithead`. `dmesg` shows no OOM kill, which is the failure shape this path
  actually has — it would present as a missing rc file, not a red one
- `scripts/lint-file-budget.sh` at the **branch** head — pass, monotonic, no row moved
- `bash tests/inventory.sh` — rc 0, new file listed as `test-appliance-firstboot-install-lock.sh — 4`
  (non-zero section count, so CI's inventory drift check has nothing to refuse)
- `lane-guard` — rc 0 on the staged set; **negative control** `test-appliance-firstboot-other.sh`
  staged → rc 1 naming that file, so the grant is armed for the file and not a prefix
- 50 `_d0` stanzas in `run.sh`, **zero indented**, so no domain nests and `_d0` is not clobbered

**Full suite, read as an artifact and not as a process.** Launched detached (`setsid nohup`) so it
could not die with a session, and a run is finished when its rc FILE exists:

    <logs>/1482-firstboot-20260829T184949Z.log
    <logs>/1482-firstboot-20260829T184949Z.log.rc   -> 0

`pithead tests: 3053 passed, 0 failed`, and `grep -c '✗'` = 0 against a control fired on a seeded
failure glyph (ANSI codes and all) through the same command, so the zero is an absence the
instrument was shown able to break. The summary line is read with `grep -aF 'pithead tests'`, never
`passed,.*failed` — the ANSI reset sits between `passed` and the comma and that pattern matches
nothing here.

**The figure reconciles exactly: 3053 - 3043 = 10, and this PR adds exactly 10 assertions.** 3043 is
the merged tip's figure from #1534. All four of this domain's `== section ==` headers appear in the
log by name.

## Mutation battery — five mutants, five axes

Each mutant was applied to the slice, **proved applied** by `git diff --numstat` before running (a
replace that does not match writes an unchanged file), the artifact rebuilt so the test's `$STACK`
really carried it, and judged by **which named rows died** rather than by rc. Per-mutant logs:
`<logs>/1482-firstboot-mutants/M{1..5}.log`.

| mutant | numstat | kills | which rows |
|---|---|---|---|
| M1 acquire removed entirely | 0/1 | **6** | the 3 contended rows + all 3 release rows |
| M2 **acquire moved BELOW the first write** | 1/1 | **1** | *contended writes NO installing marker* |
| M3 release removed from `wizard_install_finish` | 0/1 | **1** | *finish gives the window back* |
| M4 release removed from `wizard_install_failed_page` | 0/1 | **1** | *failed_page gives the window back* |
| M5 **one call site bypasses the helper** | 1/1 | **1** | *every `consume_install_request` is opened by `wizard_install_begin`* |

**M2 is the row that pins the acquire's lower bound.** It moves the acquire below `touch
installing` and nothing else — rc stays 75, the waiting message still prints, and only the
no-marker row dies. That is the difference between "takes the lock" and "takes the lock before its
first write", and no other mutant here can see it.

**M5 is the only mutant that can discriminate coverage, and it is why the structural row exists.**
M1-M4 all move the same variable — where the acquire sits inside the helper — so any of them going
red is equally consistent with one call site being wired and the other two unguarded. M5 leaves the
helper untouched and makes a single call site write the marker directly; it kills the structural row
and nothing else. Had M5 come back green that would have been a finding about the test, not a pass.

**M1 killing the release rows is the test's internal control working, not spillover.** `fb_window`
opens the window with the real helper and then *checks the window is actually held* before running
the closing helper; with no acquire it reports `begin-did-not-hold` instead of `released`. Without
that step, "released" would be indistinguishable from a begin that never armed.

**Accounting, so no row is unexplained: 7 of 10 rows are killed by some mutant. The other 3 are the
deliberate controls** — the two uncontended fixture rows and the extractor-found-something row —
which assert that the fixture and the instrument work, so they must survive every mutant that
changes only the lock. Naming the mutant that would kill each is the test before deleting any
assertion, and for these three that mutant would be a broken fixture, not a defect shape.

## Artifacts

Every artifact below is held locally outside git, mode 0700, and its full path is named in the
routing message to the reviewer rather than here — a host path is a leak class in a public body, and
the detector flagged exactly these lines before this was published. `<logs>` is that directory.

| what | file |
|---|---|
| full-suite log | `<logs>/1482-firstboot-20260829T184949Z.log` |
| its rc file | `<logs>/1482-firstboot-20260829T184949Z.log.rc` |
| five mutant logs | `<logs>/1482-firstboot-mutants/M1..M5.log` |
| lane-guard, negative control | `<logs>/1482-firstboot-lane-guard-negative.txt` |
| lane-guard, positive | `<logs>/1482-firstboot-lane-guard-positive.txt` |

**The positive lane-guard capture is 0 bytes and that is not a defect — the guard prints nothing
when it passes.** An empty file is not evidence on its own; what makes it evidence is the paired
negative capture, which names the refused near-miss file, plus the rc of 0. Stated because a
reviewer finding an empty "proof" file should know it was expected.

## PROVEN BY ME versus RELAYED

**Proven here, instruments named and fired:** the three `consume_install_request` call sites; the
556-line count with the gate's own counter; parity plus the from-source `cmp` and its fired control;
the budget gate; `bash tests/inventory.sh`; `make lint-sh` and its inclusion proof; `lane-guard` both directions; the 50/0 `_d0` stanza
count; the full-suite rc and glyph count with its control; all five mutants and their numstats; the
topology detector clean **with a control fired on a seeded file**.

**Relayed, not re-derived here:** that 3043 is the merged tip's suite figure (from #1534's merge,
not a run I made). If that leg matters to you, the base's own `pithead tests` line settles it in one
command; I did not run it.

**Also relayed, and worth having precisely because it is not mine:** a second session independently
re-derived the suite figures from the same log — rc file 0, 3053 `✓` and 0 `✗` counted without
reference to the summary line, its own control fired on the `✗` needle, and the 10-assertion delta
confirmed against 3043. **I did not re-run any of that**, so it is a second party on the arithmetic
rather than a second proof by the author. The one claim of theirs I did re-derive by my own route,
at the pushed ref rather than the working tree, is that `mutation_lock_acquire` appears exactly once
in the slice — it does, so no call site bypasses `wizard_install_begin`.

## What was NOT done

- **No bench run.** Nothing here touches `os/`, and no image was built.
- **The three install paths are not driven end-to-end.** Doing so needs a real installation medium, a
  wizard container and a disk to erase. The tests drive the extracted helpers directly and prove the
  call sites structurally; the structural row is labelled as structural in the file itself, and it
  exists precisely because the behavioural rows would stay green if a call site stopped using the
  helpers.
- **`systemctl` is overridden as an in-process shell function, never a PATH stub.**
  `wizard_install_finish` ends in `systemctl poweroff`, and a PATH stub that failed to resolve would
  power off the machine running the suite. A function is found before PATH and cannot be bypassed.
- **Corrected after publication, in place rather than quietly:** an earlier version of this line said
  #1482's text "still says one installer path" and offered it to the controller as an error to fix.
  **That was wrong, and I had relayed it rather than reading the issue.** #1482 says *"the
  installer-path **mutations** inside `firstboot_wizard` outside `(setup)`"* — plural, and entirely
  compatible with three paths. The phrase I attributed to it appears there zero times. Nothing in the
  issue needs correcting.
  What is still worth recording, as a fact rather than a correction, is the finding itself: that entry
  covers **three** distinct install paths, each ending in its own `poweroff`, which is why wiring only
  the one everybody means by "the installer path" would have shipped a verb reading as locked with two
  unlocked doors.
- **This PR does NOT complete #1482.** It finishes list item 1's sixth and last verb. **Item 2 is
  separate and untouched** — the in-place upgrade fallback overwrites the install dir before it
  re-invokes `pithead`, outside any window — as is the trailing note that "read-only verbs take
  nothing" is structurally true but not proven behaviourally by any test. **Read this as "the sixth
  and last of six verbs is locked", not as "#1482 is code-complete"**, and do not let a close trigger
  bundle #1059 into the same sentence — that is how a partial landing reads as a full one.
