### PR TITLE
test(dashboard): let the atomicity walk see every shape state can be bound in (#1535)

### DIFF
--- a/dashboard/tests/service/test_mixin_atomicity.py
+++ b/dashboard/tests/service/test_mixin_atomicity.py
@@ -87,19 +87,85 @@ def _guarded_calls(method: ast.AST, targets: set[str]) -> list[str]:
     return sorted(hits)
 
 
-def _retained_state(subject: str) -> set[str]:
-    """Every attribute ``StateManager`` assigns to itself, minus the shared DB handle."""
-    return {
-        target.attr
-        for node in ast.walk(ast.parse(subject))
-        if isinstance(node, ast.ClassDef) and node.name == "StateManager"
-        for assign in ast.walk(node)
-        if isinstance(assign, ast.Assign)
-        for target in assign.targets
-        if isinstance(target, ast.Attribute)
+def _self_attr_names(target: ast.AST) -> set[str]:
+    """The ``self.<name>`` attributes one assignment target binds.
+
+    Recursive because a target can nest: ``self.a, (self.b, self.c) = ...`` is a ``Tuple`` holding
+    a ``Tuple``, and ``self.a, *self.rest = ...`` puts one of them behind a ``Starred``. Anything
+    that is not an attribute on ``self`` — a bare local, an attribute on some other object —
+    contributes nothing, which is what keeps the walk narrow rather than merely wide.
+    """
+    if isinstance(target, (ast.Tuple, ast.List)):
+        return {name for element in target.elts for name in _self_attr_names(element)}
+    if isinstance(target, ast.Starred):
+        return _self_attr_names(target.value)
+    if (
+        isinstance(target, ast.Attribute)
         and isinstance(target.value, ast.Name)
         and target.value.id == "self"
-    } - _SHARED_HANDLE
+    ):
+        return {target.attr}
+    return set()
+
+
+def _retained_state(subject: str) -> set[str]:
+    """Every attribute ``StateManager`` assigns to itself, minus the shared DB handle.
+
+    Four binding shapes, not one (#1535). The first version read only ``ast.Assign`` targets that
+    were themselves ``ast.Attribute``, which is blind to tuple/list unpacking, to ``ast.AnnAssign``,
+    and to ``setattr(self, "x", v)`` — none of them contrived: the tuple shape is in production use
+    two modules over in ``data_service.py``.
+
+    **A shape this misses cannot be reported, and the silence is indistinguishable from a clean
+    result.** Q2 below asks whether a moved method touches state that stayed behind, and it answers
+    by name: a name the needle set never contains produces no finding no matter how badly a method
+    reaches for it. So the failure mode of a narrow walk here is a false PASS, which is the one this
+    file exists to prevent — hence the controls below covering every shape, and a near-miss sibling
+    proving the widened walk did not simply become "any attribute anywhere".
+    """
+    state: set[str] = set()
+    for node in ast.walk(ast.parse(subject)):
+        if not (isinstance(node, ast.ClassDef) and node.name == "StateManager"):
+            continue
+        for statement in ast.walk(node):
+            if isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    state |= _self_attr_names(target)
+            elif isinstance(statement, ast.AnnAssign):
+                state |= _self_attr_names(statement.target)
+            elif _is_self_setattr(statement):
+                state.add(statement.args[1].value)
+    return state - _SHARED_HANDLE
+
+
+def _self_setattr_calls(subject: str) -> list[ast.Call]:
+    """Every ``setattr(self, ...)`` inside ``StateManager``, resolvable name or not."""
+    return [
+        statement
+        for node in ast.walk(ast.parse(subject))
+        if isinstance(node, ast.ClassDef) and node.name == "StateManager"
+        for statement in ast.walk(node)
+        if isinstance(statement, ast.Call)
+        and isinstance(statement.func, ast.Name)
+        and statement.func.id == "setattr"
+        and statement.args
+        and isinstance(statement.args[0], ast.Name)
+        and statement.args[0].id == "self"
+    ]
+
+
+def _is_self_setattr(node: ast.AST) -> bool:
+    """``setattr(self, "literal", value)`` — a static walk can only resolve a literal name."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "setattr"
+        and len(node.args) == 3
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "self"
+        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1].value, str)
+    )
 
 
 def _state_reads(method: ast.AST, retained_state: set[str]) -> list[str]:
@@ -151,6 +217,21 @@ class TestTheSplitHoldsItsAtomicityProperty:
         _, moved, state = split
         reaching = {n: s for n, fn in moved.items() if (s := _state_reads(fn, state))}
         assert reaching == {}
+
+    def test_no_state_is_bound_through_a_name_the_walk_cannot_resolve(self):
+        """The one shape a static walk cannot follow, checked rather than assumed (#1535).
+
+        ``setattr(self, name, value)`` with a COMPUTED name puts a retained attribute outside the
+        needle set, and Q2 then goes quiet about it — the same false pass the widened walk above
+        exists to close, arriving by the one door the widening cannot shut. Nothing in the subject
+        does this today. This asserts that, so the limit is a measured fact with a test naming it
+        rather than a gap someone meets by surprise."""
+        unresolvable = [
+            ast.unparse(call)
+            for call in _self_setattr_calls(_SUBJECT.read_text())
+            if not _is_self_setattr(call)
+        ]
+        assert unresolvable == []
 
 
 class TestTheCheckerCanSeeWhatItIsBeingAskedAbout:
@@ -210,3 +291,97 @@ class SeededMixin:
         _, _, state = split
         seeded = _methods("class M:\n    def f(self):\n        return self.state['x']\n")["f"]
         assert _state_reads(seeded, state) == ["state"]
+
+
+class TestTheStateWalkSeesEveryShapeStateCanBeBoundIn:
+    """#1535. ``_retained_state`` decides what Q2 is ABLE to report, so a shape it cannot see is a
+    violation that passes silently — and a walk that reports nothing looks exactly like a split
+    that touches nothing. These seed each shape rather than describing it, and the near-miss case
+    is what separates a walk that is complete from one that is merely wide."""
+
+    # Every shape a `self.` attribute can be bound in. The class must literally be named
+    # `StateManager`: `_retained_state` filters on that name, so a control in a differently-named
+    # class comes back empty and reads as a broken walk rather than a broken fixture.
+    _EVERY_SHAPE = """
+class StateManager:
+    def __init__(self):
+        self.plain = 1
+        self.tuple_a, self.tuple_b = 1, 2
+        [self.list_a, self.list_b] = [1, 2]
+        self.nested_a, (self.nested_b, self.nested_c) = 1, (2, 3)
+        self.starred_head, *self.starred_rest = [1, 2, 3]
+        self.annotated: int = 0
+        setattr(self, "by_setattr", 1)
+"""
+
+    # The same shapes aimed one step off target, so widening cannot quietly become "any attribute".
+    _NEAR_MISSES = """
+class StateManager:
+    def __init__(self, other):
+        other.on_another_object = 1
+        local_only, self.mixed_with_a_local = 1, 2
+        setattr(other, "on_another_object_too", 1)
+
+
+class NotTheStateManager:
+    def __init__(self):
+        self.in_a_different_class = 1
+"""
+
+    def test_every_binding_shape_reaches_the_needle_set(self):
+        """POSITIVE CONTROL, one seeded name per shape. Before #1535 this returned only ``plain``:
+        tuple and list targets, the annotated assignment and the ``setattr`` were all invisible,
+        and the three the issue named are in ordinary use in this codebase."""
+        assert _retained_state(self._EVERY_SHAPE) == {
+            "plain",
+            "tuple_a",
+            "tuple_b",
+            "list_a",
+            "list_b",
+            "nested_a",
+            "nested_b",
+            "nested_c",
+            "starred_head",
+            "starred_rest",
+            "annotated",
+            "by_setattr",
+        }
+
+    def test_the_widened_walk_stays_narrow(self):
+        """NEGATIVE CONTROL. Every name here is a near miss — another object's attribute, a bare
+        local sharing a tuple target with a real one, a ``setattr`` on something else, an identical
+        assignment in a class this walk is not asked about. Only the one genuine ``self.`` target
+        inside ``StateManager`` survives. Without this, widening the walk could have admitted
+        everything and the positive control above would still pass."""
+        assert _retained_state(self._NEAR_MISSES) == {"mixed_with_a_local"}
+
+    def test_the_shared_db_handle_is_still_subtracted_through_the_new_shapes(self):
+        """The handle the mixins legitimately share must not read as retained state — through a
+        tuple target as much as through a plain one, which is where widening could have leaked it
+        back in."""
+        seeded = (
+            "class StateManager:\n"
+            "    def __init__(self):\n"
+            "        self._conn, self.kept = None, 1\n"
+        )
+        assert _retained_state(seeded) == {"kept"}
+
+    def test_the_unresolvable_setattr_probe_can_see_one(self):
+        """POSITIVE CONTROL for the subject assertion above, whose product is an ABSENCE — an
+        empty result there means nothing until the probe is shown able to return a non-empty one.
+
+        It also pins the limit honestly: the computed name is NOT in the needle set, and no static
+        walk can put it there. That is why the subject test asserts none exists rather than
+        pretending to cover it."""
+        seeded = (
+            "class StateManager:\n"
+            "    def __init__(self, name):\n"
+            '        setattr(self, "literal", 1)\n'
+            "        setattr(self, name, 2)\n"
+        )
+        calls = _self_setattr_calls(seeded)
+        assert len(calls) == 2
+        assert [ast.unparse(c) for c in calls if not _is_self_setattr(c)] == [
+            "setattr(self, name, 2)"
+        ]
+        assert _retained_state(seeded) == {"literal"}

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -10,7 +10,7 @@
 #   (a) refreshes the enriched feed's live watchdog value (served at /api/state, read by
 #       _pred_feed_maxt in run.sh), and
 #   (b) reconciles a still-"accepted" #185 worker-config history row to its real terminal status
-#       (storage_service.py:reconcile_worker_config_status, #579/#604) — step 3a in that poll,
+#       (worker_config_store.py:reconcile_worker_config_status, #579/#604) — step 3a in that poll,
 #       strictly BEFORE the enriched-feed merge at step 3b.
 # So observing the feed converge to the requested max_temp_c is proof the requested key (the only
 # key in a max_temp_c change) is what changed, and the #185 history row for that change_id is


### PR DESCRIPTION
Both items from #1535, one commit each, both filed off the non-author review of #1532. Decoupled
from #1369 PR 3 (#1536) by the controller's w41 ruling — they share no boundary with it, and this
branch is cut from `origin/develop-v2` rather than stacked, so the two can merge in either order.

## Item 1 — the atomicity walk could not see three ordinary ways to bind state

`_retained_state()` in `dashboard/tests/service/test_mixin_atomicity.py` read only `ast.Assign`
targets that were themselves `ast.Attribute`. That is blind to tuple and list unpacking, to
`ast.AnnAssign`, and to `setattr(self, "x", v)`.

**The failure mode is what makes this worth fixing rather than noting.** Q2 in that file asks
whether a method that moved to a mixin touches in-memory state that stayed behind, and it answers
**by name**: a name the needle set never contains produces no finding no matter how badly a method
reaches for it. So a narrow walk here fails as a clean **PASS** — in the one file whose entire
purpose is to stop a split reading as safe when it is not.

**It does not make #1532's `Q2 = 0` a false clean, and I re-derived that before writing anything:**
the merged `StateManager` has 128 plain `self.X = …` assignments, one `AnnAssign`, one `AugAssign`
and **zero** of the three blind shapes. This is prophylaxis before a third mixin extraction reuses
the file as its template, which `docs/dev/repo-map.md` notes #1367 may.

### The controls, because a walk that reports nothing looks exactly like a split that touches nothing

- **Positive control** — every shape seeded, one name each, in a class **literally named
  `StateManager`** (the walk filters on that name, so a control in a differently-named class comes
  back empty and reads as a broken walk rather than a broken fixture). It covers more than the three
  the issue names: nested tuple targets and a `Starred` target too, since the fix is recursive and an
  untested recursion is an assumption.
- **Negative control, the sibling that makes the widening safe** — a near-miss fixture where every
  name is one step off target: another object's attribute, a bare local sharing a tuple target with
  a real one, a `setattr` on something else, the same assignment in a differently-named class. Only
  the one genuine `self.` target survives. Widening a walk is only useful if it did not become "any
  attribute anywhere", and the positive control alone cannot tell those two apart.
- **The shared DB handle, still subtracted through a tuple target** — the place widening could have
  leaked it back in.
- **A probe shown able to see an unresolvable `setattr`**, because the subject assertion it supports
  has an *absence* for a product.

### The controlled pair — the new controls fail against the old walk

Run as a pair with both implementations loaded side by side, the old one taken from
`origin/develop-v2` rather than retyped, and the fixture read **out of the shipped test file** so the
experiment cannot drift from what CI runs:

| walk | names seen in the 12-name fixture |
|---|---|
| **old** | `plain` — one of twelve |
| **new** | all twelve |

Eleven of the twelve were invisible. Without that pair the new tests would be assertions that the
current code does what it does.

### One limit stated rather than papered over

`setattr(self, name, v)` with a **computed** name cannot be resolved by any static walk, so it stays
outside the needle set — the same false pass arriving through the one door widening cannot shut. A
new test asserts the subject contains none today, which turns the limit into a checked fact with a
test naming it instead of a gap someone meets by surprise.

## Item 2 — a stale file-location comment, and it is out of this lane

`tests/integration/rigforge-apply-settle.sh:13` named
`storage_service.py:reconcile_worker_config_status`; #1532 moved that method into the
`worker_config_store.py` mixin. The comment is load-bearing prose — it explains why observing the
enriched feed converge proves the #185 history row is already reconciled — so the wrong module sends
a reader looking for the mechanism in a file that no longer has it.

**Checked at the base before changing it**, which is what separates a fresh breakage from
pre-existing rot: the comment was true at `develop-v2` and became false at #1532's head, and #1532
does not touch this file.

**Swept mechanically rather than fixed one-off**, since a cut falsifies prose in files it never
touches and a per-item sweep is blind to earlier rounds' debris: every `storage_service.py:<name>`
reference in the repo, each name checked against the current module. This is the only stale one. The
two neighbouring `storage_service` mentions in `tests/integration/lib.sh` and `run.sh` are about the
`db_healthy` latch, and I re-derived them as still true — `is_db_healthy` is still defined in
`storage_service.py`.

### Out-of-lane disclosure

**`tests/integration/` is the `e2e` lane's path, not `dashboard`'s.** No e2e lane is running, so this
was taken under a **one-shot `.lane-override`, in its own commit**, per the controller's w41 ruling.
Prose only — a `#` comment, no executable reader.

**The override was verified rather than assumed, in both directions:** committing without it was
refused, with the guard naming exactly this file and nothing else; committing with it printed
`override CONSUMED (one-shot)`; and the marker is gone afterwards, checked directly, because it lives
in `.git/info/exclude` and a leftover would be **invisible in `git status`** while silently disarming
the guard for this worktree.

## Evidence — PROVEN BY ME at this head

- **Suite:** `2141 passed`, rc 0 — `develop-v2`'s 2136 plus the five tests added here, which is the
  arithmetic that says nothing else moved. Total coverage **97.04%** against the ≥80% bar.
- **The changed file alone:** `12 passed`.
- **The controlled pair above**, old implementation loaded from git, fixture read from the shipped
  file.
- **Lint:** `lint-py lint-js lint-md lint-docs-voice lint-operator-strings lint-topology
  lint-file-budget` each rc **0**, run by name.
- **The shell file:** `shellcheck` 0.11.0 rc 0 at **default severity**, which is stricter than the
  gate's own `--severity=warning`; `shfmt -d` prints nothing. Run on the single changed file rather
  than through `make lint-sh`, which is the serialized OOM path and cannot be affected by a
  comment-text change — stated because it is a target I did not run in full.
- **File budget:** `test_mixin_atomicity.py` is **387 lines** and takes no row, correctly — it is
  under the 400 target, and a file under the target must not have one. Worth naming that it now has
  only ~13 lines of headroom before it would need one.

## Named gaps

- **Patch coverage is NOT APPLICABLE here, and that is different from passing it.** Against the real
  base, `diff-cover` reports "No lines with coverage information in this diff" over **zero** measured
  lines — correct, since this PR changes a test file and a shell comment, and coverage measures only
  `mining_dashboard/`. **I am not claiming the ≥90% bar was met; there was nothing to meet it with.**
- **No review by anyone but me.**
- **The new walk is proven against seeded fixtures and against today's subject, not against a real
  violation** — there is no moved method that reaches back through one of these shapes, because there
  is no such method at all. The controls are what stand in for that.

## This sharpens #1537, which I filed while opening #1536

#1537 reports that `scripts/patch-coverage.sh` hardcodes `COMPARE=origin/develop` while CI fetches
`${GITHUB_BASE_REF}` and nothing reads it. **This PR is a cleaner demonstration than the one in that
issue.** Against its real base the honest verdict is "not applicable — zero measured lines". Run as
CI runs it, the same wrapper instead reports **`all 86 changed file(s) ... present in coverage.xml`
and `Coverage: 98%`** — a 90%-bar *pass* over 86 files this PR does not touch.

So the wrapper's not-applicable branch, added by #1000 precisely to stop a diff with nothing
measurable from reading as a coverage pass, **is unreachable for any PR into `develop-v2`**: the
hardcoded compare always drags in the whole divergence. The vacuous pass #1000 closed is open again
one level up. Posting this on #1537 as well.
