### PR TITLE
feat(dashboard): detect a rig running something other than what we applied (#1367)

### DIFF
--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -121,7 +121,7 @@ _POOL_CREDENTIAL_KEYS = ("pass", "tls-fingerprint")
 _MAX_CONFIG_DEPTH = 6
 
 
-def _strip_credentials(value, depth=0):
+def strip_credentials(value, depth=0):
     """Drop the credential keys from ``value`` at ANY depth and in ANY container shape.
 
     Shape-agnostic deliberately. Stripping only ``pools`` when it arrived as a list of dicts was a
@@ -134,12 +134,12 @@ def _strip_credentials(value, depth=0):
         return None
     if isinstance(value, dict):
         return {
-            k: _strip_credentials(v, depth + 1)
+            k: strip_credentials(v, depth + 1)
             for k, v in value.items()
             if k not in _POOL_CREDENTIAL_KEYS
         }
     if isinstance(value, list):
-        return [_strip_credentials(v, depth + 1) for v in value]
+        return [strip_credentials(v, depth + 1) for v in value]
     return value
 
 
@@ -155,7 +155,7 @@ def _rig_writable_config(cfg):
     if not isinstance(cfg, dict):
         return None
     out = {k: v for k, v in cfg.items() if k in WORKER_WRITABLE_KEYS}
-    return _strip_credentials(out) or None
+    return strip_credentials(out) or None
 
 
 # Terminal control outcomes the rig may mirror: applied/rejected/rolled_back/failed from a

--- a/dashboard/mining_dashboard/web/static/confighistory.mjs
+++ b/dashboard/mining_dashboard/web/static/confighistory.mjs
@@ -6,7 +6,7 @@
 // it", which is one subject. workerview.mjs imports these; nothing here imports back.
 
 import { html } from "./preact.mjs";
-import { configOriginNote } from "./workerlogic.mjs";
+import { configDriftNote, configOriginNote } from "./workerlogic.mjs";
 
 // A terminal status → a display variant + label. rolled_back and rejected/failed read as bad;
 // applied is good; accepted/pending are in-flight.
@@ -50,12 +50,22 @@ export function HistoryRow({ row }) {
 // THIS dashboard did; this line is the rig's own account, which is the only thing that can reveal
 // a change the table cannot contain. Renders nothing at all when the rig cannot answer — a rig
 // with no RigForge, or one older than the block, must not be made to look suspicious.
-export function ConfigProvenance({ origin, meta }) {
+export function ConfigProvenance({ origin, meta, drift }) {
   const note = configOriginNote(origin, meta);
-  if (!note) return null;
+  // #1367: the drift note QUALIFIES the origin line — it is the only thing on the page that can
+  // contradict a calm "Last changed from this dashboard" over a config nothing recorded. So it is
+  // rendered independently rather than nested: a rig serving a config but no ``config_meta`` has no
+  // origin line at all, and can still be running something other than what we applied.
+  const driftNote = configDriftNote(drift);
+  if (!note && !driftNote) return null;
   return html`
-    <p class=${"text-small " + note.cls} title=${note.title}>
+    ${
+      note
+        ? html`<p class=${"text-small " + note.cls} title=${note.title}>
         ${note.label}
         ${meta?.changed_at ? html` · <span class="text-muted text-xs">${meta.changed_at}</span>` : null}
-    </p>`;
+    </p>`
+        : null
+    }
+    ${driftNote ? html`<p class=${"text-small " + driftNote.cls} title=${driftNote.title}>${driftNote.label}</p>` : null}`;
 }

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -222,3 +222,33 @@ export function configOriginNote(origin, meta) {
   if (text.detail) parts.push(text.detail);
   return { cls: text.cls, label: text.label, title: parts.join(" · ") };
 }
+
+// #1367: the per-key disagreement between what this dashboard applied and what the rig reports it
+// is running — the case configOriginNote structurally cannot see, because a config edited underneath
+// RigForge records nothing for the provenance line to read.
+//
+// Renders ONLY a disagreement. `null` (could not check) and `[]` (checked, agrees) both say nothing,
+// deliberately and for different reasons: `null` is the same "say nothing" posture the rest of this
+// block takes, and `[]` is withheld because an all-clear here would be a reassurance bounded by
+// three narrowings the operator cannot see from a badge — it judges only keys we have set, never
+// pool passwords, and never mid-flight. This feature exists to stop a false reassurance; printing a
+// qualified one in the same place would be the same defect wearing the opposite label.
+export function configDriftNote(drift) {
+  if (!Array.isArray(drift) || drift.length === 0) return null;
+  const show = (v) =>
+    v === null || v === undefined
+      ? "not set"
+      : typeof v === "object"
+        ? JSON.stringify(v)
+        : String(v);
+  return {
+    cls: "text-warn",
+    label:
+      drift.length === 1
+        ? `The rig is not running what we applied: ${drift[0].key}`
+        : `The rig is not running what we applied: ${drift.length} keys`,
+    title: drift
+      .map((d) => `${d.key}: we applied ${show(d.applied)}, the rig has ${show(d.rig)}`)
+      .join(" · "),
+  };
+}

--- a/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -387,7 +387,7 @@ export class WorkerInspect extends Component {
             }
 
             <h4 class="mt-2">History</h4>
-            <${ConfigProvenance} origin=${detail.config_origin} meta=${detail.rig_config_meta} />
+            <${ConfigProvenance} origin=${detail.config_origin} meta=${detail.rig_config_meta} drift=${detail.config_drift} />
             ${
               (detail.history || []).length
                 ? html`

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -14,13 +14,19 @@ fact only this side holds — whether the rig's ``last_change_id`` matches a cha
 spooled *for this rig*. The rig mints those ids in its control server and hands them back in the
 202, so an id in this rig's own history is an id we asked for.
 
-The comparison is evidence, not proof, and one case escapes it entirely. RigForge serves ``revision``
+The comparison is evidence, not proof, and one case escapes it. RigForge serves ``revision``
 recomputed live but takes the other three from a marker file it writes only when a change is
 *recorded* (``_stamp_config_meta``), and the marker's own stored revision is overwritten by the live
 one before it goes on the wire. So a config hand-edited underneath RigForge moves the revision while
-the provenance stays stale, and this reports the change before it — reading as "here" over a config
-we did not set. Catching that needs the last revision we OBSERVED per rig, which is persistence this
-does not add; see the follow-up issue.
+the provenance stays stale, and ``config_origin`` reports the change before it — reading as "here"
+over a config we did not set.
+
+**``config_drift`` (#1367) answers that one directly, and without the persistence this module was
+once expected to need.** Both halves of a value comparison are already in this payload —
+``last_applied`` from our own history, ``rig_config`` from the rig's feed (#1235) — so asking "is
+the rig running what we applied?" needs no revision hash reproduced byte for byte, no new column and
+no RigForge change. It answers on keys we have set; a hand-edit to a key we never applied still
+moves only the revision, and still needs the observed-revision persistence to catch.
 
 A rig that is lying can also replay an id we really did send it. Within what a rig reports honestly,
 the dashboard's own half errs one way only: every input it cannot vouch for lands on "not ours".
@@ -31,6 +37,7 @@ the same answer persistent and specific — it survives a restart, and it surviv
 """
 
 from mining_dashboard.client.rig_config_meta import config_origin
+from mining_dashboard.client.xmrig_client import strip_credentials
 from mining_dashboard.config import config
 from mining_dashboard.helper.utils import format_hashrate, format_time_abs
 from mining_dashboard.service.control_service import WORKER_WRITABLE_KEYS
@@ -46,6 +53,104 @@ from mining_dashboard.web.views import (
 # it meant anything (#1369). A bare call would leave the second use comparing against a number
 # written down somewhere else, which is how the two drift apart.
 _HISTORY_LIMIT = 50
+
+
+# RigForge fixes the JSON type of every writable scalar as it builds the config it serves
+# (``_writable_config_canonical``): ``--argjson`` for ``DONATION`` and ``watchdog_interval_min``,
+# ``--arg`` for ``autotune`` and ``watchdog``, and ``max_temp_c`` through ``tonumber`` unless it is
+# unset, which serves a literal ``null``. Our own side has no such discipline: nothing between the
+# editor and the DB coerces anything — ``validate_worker_changes`` checks key names only — and four
+# reachable editor paths store a string where the rig serves a number (#1367). Comparing the two
+# raw would report drift on a rig running exactly what we applied, which is the same false alarm
+# this feature exists to avoid, arriving through a different door.
+_CANONICAL_NUMBER = frozenset({"DONATION", "watchdog_interval_min", "max_temp_c"})
+_CANONICAL_STRING = frozenset({"autotune", "watchdog"})
+
+# Statuses that mean a change is still in flight. Deliberately the complement of a terminal outcome
+# rather than a list of terminal ones: a status we do not recognise is not evidence that a change
+# settled, and reading it as settled is what would compare against a config mid-write.
+_UNSETTLED_STATUSES = ("accepted", "running")
+
+
+def _comparable(key, value):
+    """A comparison key for ``value`` in the JSON type RigForge would have served it as.
+
+    Returns a ``(tag, value)`` PAIR rather than a bare coerced value, because Python's own equality
+    would otherwise launder a difference back in: ``1 == 1.0`` and ``True == 1.0`` are both true,
+    but only the first is a match the rig would agree with. ``bool`` is an ``int`` in Python and is
+    not a value RigForge ever serves for these keys, so returning it uncoerced is not enough — it
+    still compares equal to the number. The tag is what actually keeps the two apart.
+
+    A value that refuses to coerce keeps the ``raw`` tag rather than being dropped. It is a real
+    disagreement — the editor lets a non-numeric string through deliberately, for the rig to reject
+    — and the rig is then running something else, so it must stay comparable and compare unequal.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return ("raw", value)
+    if key in _CANONICAL_NUMBER:
+        try:
+            return ("num", float(value))
+        except (TypeError, ValueError):
+            return ("raw", value)
+    if key in _CANONICAL_STRING:
+        return ("str", str(value))
+    return ("raw", value)
+
+
+def config_drift(last_applied, rig_config, unsettled=False):
+    """Keys where the rig's current writable config disagrees with what this dashboard last applied.
+
+    The question #1367 asks — *is the rig running what we last applied?* — answered by comparing the
+    two values already in this payload, with no revision hash to reproduce byte for byte, no new
+    column and no RigForge change. #1345's provenance line reports the last change the rig
+    **recorded**; a config edited underneath RigForge records nothing, so the line keeps reading
+    "Last changed from this dashboard" over a config we did not set. This is the check that catches
+    that, and it works on rigs already deployed.
+
+    Returns a list of ``{key, applied, rig}`` — empty meaning checked and in agreement — or ``None``
+    when the comparison could not honestly be made. The UI must keep those apart: ``[]`` is a
+    finding, ``None`` is silence.
+
+    Three things bound what it can claim, each a deliberate narrowing rather than an oversight:
+
+    - **Only keys we have applied.** ``last_applied`` is a merge of DIFFS, not a config, so it holds
+      exactly the keys this dashboard has ever set. A hand-edit to a writable key we never touched
+      moves the rig's revision and is invisible here — that is option A's coverage, not this one's.
+    - **Never the pool credentials.** ``strip_credentials`` runs over our side for the same reason
+      the rig's side already runs through it: RigForge deletes ``pass`` and ``tls-fingerprint``
+      before serving, so a password we once applied would be permanent, uncloseable drift. Stripping
+      both sides costs the ability to notice a changed pool password, which nothing on this side can
+      see anyway.
+    - **Never mid-flight.** A submitted change sits at ``accepted`` until the reconciler settles it,
+      and is not in ``last_applied`` while the rig may already be running it — so comparing inside
+      that window reports drift on a key we ourselves just set. Judged on the NEWEST apply row
+      rather than on whether any unsettled row exists anywhere: an old ``accepted`` row that never
+      settled is a stuck record, not a change in flight, and letting one suppress this check forever
+      would trade a false alarm for permanent silence.
+    """
+    if unsettled or not isinstance(rig_config, dict) or not isinstance(last_applied, dict):
+        return None
+    drift = []
+    for key, applied in sorted(strip_credentials(last_applied).items()):
+        # ABSENT and ``None`` are different answers and must not be folded together. A rig with no
+        # thermal cutoff serves ``max_temp_c: null`` — a real value, and real drift if we set one —
+        # whereas a key missing outright is a rig too old to report it or a read we only got part
+        # of, which cannot support an accusation either way.
+        if key not in rig_config:
+            continue
+        rig = rig_config[key]
+        if _comparable(key, applied) != _comparable(key, rig):
+            drift.append({"key": key, "applied": applied, "rig": rig})
+    return drift
+
+
+def _has_unsettled_apply(history):
+    """Whether this rig's most recent config apply is still in flight — see ``config_drift``."""
+    for row in history or []:
+        if row.get("type", "apply") != "apply":
+            continue
+        return row.get("status") in _UNSETTLED_STATUSES
+    return False
 
 
 def build_worker_hashrate_history(state_mgr, worker, range_arg, window=None):
@@ -134,6 +239,8 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
     # thing separating a change that held from one the rig threw away (``REVERTED_STATUSES``).
     last_change_id = (rig_meta or {}).get("last_change_id")
     matched = state_mgr.get_worker_config_change(name, last_change_id)
+    last_applied = state_mgr.get_last_applied_worker_config(name)
+    rig_config = (worker.get("rigforge") or {}).get("config") if worker else None
     return {
         "name": name,
         "found": worker is not None,
@@ -148,7 +255,7 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         "rigforge_update": rigforge_update_for(worker, (data or {}).get("rigforge_release")),
         "writable_keys": sorted(WORKER_WRITABLE_KEYS),
         # Rig's own current writable-key values (#1235); None means "could not read", not empty.
-        "rig_config": (worker.get("rigforge") or {}).get("config") if worker else None,
+        "rig_config": rig_config,
         # The rig's own record of its last config change, and our verdict on it (#1345). Both None
         # for a rig that cannot answer — the client renders that as silence, not as "unknown".
         "rig_config_meta": rig_meta,
@@ -161,7 +268,13 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
             (matched or {}).get("status"),
             history_unread=matched is None or history_unread,
         ),
-        "last_applied": state_mgr.get_last_applied_worker_config(name),
+        "last_applied": last_applied,
+        # Per-key disagreement between what we applied and what the rig is running (#1367) — the
+        # case ``config_origin`` structurally cannot see, because nothing recorded the change.
+        # ``[]`` means checked and in agreement; ``None`` means we could not honestly check.
+        "config_drift": config_drift(
+            last_applied, rig_config, unsettled=_has_unsettled_apply(history)
+        ),
         "history": history,
         "hashrate_by_config": hashrate_by_config,
         "hashrate_history": build_worker_hashrate_history(state_mgr, name, range_arg, window),

--- a/dashboard/tests/frontend/workerlogic.test.mjs
+++ b/dashboard/tests/frontend/workerlogic.test.mjs
@@ -11,6 +11,7 @@ import {
   buildChartMarkers,
   buildFields,
   buildTableChanges,
+  configDriftNote,
   fieldNote,
   jsonSyntaxError,
   markerLabel,
@@ -249,4 +250,41 @@ test('fieldNote: an unknown source says the value could not be read (#1235)', ()
 
 test('fieldNote: any unrecognised source falls back to could-not-read, never null (#1235)', () => {
     assert.equal(fieldNote('bogus'), 'could not read from the rig');
+});
+
+// #1367 — the value-drift note beside the provenance line.
+test("configDriftNote says nothing when it could not check or found nothing", () => {
+  // null (not checked) and [] (checked, agrees) both render silence, for different reasons: an
+  // all-clear here would be a reassurance bounded by three narrowings a badge cannot show.
+  assert.equal(configDriftNote(null), null);
+  assert.equal(configDriftNote([]), null);
+  assert.equal(configDriftNote(undefined), null);
+  assert.equal(configDriftNote("nonsense"), null);
+});
+
+test("configDriftNote names the key on a single disagreement", () => {
+  const note = configDriftNote([{ key: "max_temp_c", applied: 75, rig: 80 }]);
+  assert.match(note.label, /max_temp_c/);
+  assert.match(note.title, /we applied 75, the rig has 80/);
+});
+
+test("configDriftNote counts rather than lists when several keys disagree", () => {
+  const note = configDriftNote([
+    { key: "DONATION", applied: 1, rig: 2 },
+    { key: "max_temp_c", applied: 75, rig: 80 },
+  ]);
+  assert.match(note.label, /2 keys/);
+  assert.match(note.title, /DONATION: we applied 1, the rig has 2/);
+});
+
+test("configDriftNote renders an absent rig value as 'not set', never as empty", () => {
+  // A rig with no thermal cutoff serves null. An unlabelled blank reads as "0" and invites the
+  // operator to overwrite a good value — the same trap fieldNote exists to close.
+  const note = configDriftNote([{ key: "max_temp_c", applied: 75, rig: null }]);
+  assert.match(note.title, /the rig has not set/);
+});
+
+test("configDriftNote renders an object value readably", () => {
+  const note = configDriftNote([{ key: "pools", applied: [{ url: "a" }], rig: [{ url: "b" }] }]);
+  assert.match(note.title, /\{"url":"a"\}/);
 });

--- a/dashboard/tests/web/test_worker_config_drift.py
+++ b/dashboard/tests/web/test_worker_config_drift.py
@@ -1,0 +1,228 @@
+"""Value-level config drift for Worker Inspect (#1367).
+
+``config_origin`` (#1345) reports the last change RigForge *recorded*. A config edited underneath
+RigForge records nothing, so on a rig where this dashboard applied the previous change the line
+keeps reading "Last changed from this dashboard" while the rig runs something else — a false
+reassurance, the one direction that feature exists to avoid. ``config_drift`` catches that by
+comparing the two values already in the payload.
+
+The bulk of what is tested here is the TYPE discipline, because that is where a value comparison
+re-opens the very false-positive the issue rejects the revision-hash fix for. RigForge fixes the
+JSON type of every writable scalar as it serves it; nothing on this side coerces anything, and four
+reachable editor paths store a string where the rig serves a number. Comparing those raw reports
+drift on a rig running exactly what we applied.
+"""
+
+import pytest
+
+from mining_dashboard.web.worker_detail import (
+    _comparable,
+    _has_unsettled_apply,
+    config_drift,
+)
+
+
+class TestTypeDiscipline:
+    """A stored string must not read as drift against the number RigForge serves."""
+
+    @pytest.mark.parametrize(
+        "key,applied,rig",
+        [
+            # Route 1: rig serves max_temp_c: null, so the editor row is a free-form JSON box and
+            # an operator typing "80" (quoted) stores a string.
+            ("max_temp_c", "80", 80),
+            # Route 3: last_applied already holds a string, so the row types as text and every
+            # later edit stays one. This is the self-perpetuating case.
+            ("max_temp_c", "101", 101),
+            # Route 4: JSON mode does no per-key typing at all.
+            ("DONATION", "1", 1),
+            ("watchdog_interval_min", "5", 5),
+            # And the mirror image, since nothing guarantees which side is which.
+            ("DONATION", 1, "1"),
+            # A float against the int the rig serves is the same value, not drift.
+            ("max_temp_c", 80.0, 80),
+        ],
+    )
+    def test_string_and_number_forms_of_the_same_value_are_not_drift(self, key, applied, rig):
+        assert config_drift({key: applied}, {key: rig}) == []
+
+    @pytest.mark.parametrize(
+        "key,applied,rig",
+        [
+            ("autotune", "disabled", "disabled"),
+            ("watchdog", "enabled", "enabled"),
+        ],
+    )
+    def test_the_string_typed_keys_compare_as_strings(self, key, applied, rig):
+        assert config_drift({key: applied}, {key: rig}) == []
+
+    def test_a_number_stored_for_a_string_typed_key_is_not_drift(self):
+        # RigForge serves autotune/watchdog through ``--arg``, so they are ALWAYS strings on the
+        # rig side. JSON mode does no per-key typing, so an operator can store a number for one.
+        # Without the string canonicalisation this reports drift on a rig running what we set.
+        assert config_drift({"autotune": 1}, {"autotune": "1"}) == []
+        assert config_drift({"watchdog": 0}, {"watchdog": "0"}) == []
+
+    def test_a_value_that_will_not_coerce_is_real_drift(self):
+        # The editor lets a non-numeric string through deliberately, for the rig to reject. The rig
+        # is then running something else, so this MUST report — coercion must not swallow it.
+        drift = config_drift({"max_temp_c": "80c"}, {"max_temp_c": 80})
+        assert drift == [{"key": "max_temp_c", "applied": "80c", "rig": 80}]
+
+    def test_a_genuinely_different_number_is_drift(self):
+        drift = config_drift({"max_temp_c": 75}, {"max_temp_c": 80})
+        assert drift == [{"key": "max_temp_c", "applied": 75, "rig": 80}]
+
+    def test_a_bool_is_not_laundered_into_the_number_it_equals(self):
+        # bool is an int in Python, so a naive float() would turn True into 1.0 and call a rig
+        # running DONATION 1 a match. It is not a value the rig would ever serve for this key.
+        drift = config_drift({"DONATION": True}, {"DONATION": 1})
+        assert drift == [{"key": "DONATION", "applied": True, "rig": 1}]
+
+    def test_a_scalar_under_a_non_canonical_key_keeps_its_own_shape(self):
+        # pools is the only writable key with no canonical scalar type, so a scalar arriving there
+        # is a malformed shape from a rig that picks its own response. It must stay comparable
+        # rather than being coerced toward either canonical form.
+        assert _comparable("pools", "not-a-list") == ("raw", "not-a-list")
+        assert config_drift({"pools": "x"}, {"pools": "x"}) == []
+
+    def test_comparable_leaves_an_unknown_key_alone(self):
+        # pools passes through RigForge's canonical form verbatim; nothing to normalise.
+        assert _comparable("pools", [{"url": "a"}]) == ("raw", [{"url": "a"}])
+
+
+class TestWhatItRefusesToClaim:
+    def test_an_absent_key_is_skipped_but_an_explicit_none_is_compared(self):
+        # These are different answers. A rig with no thermal cutoff serves max_temp_c: null — real
+        # drift if we set one — whereas a key missing outright is a rig too old to report it.
+        assert config_drift({"max_temp_c": 75}, {"DONATION": 1}) == []
+        assert config_drift({"max_temp_c": 75}, {"max_temp_c": None}) == [
+            {"key": "max_temp_c", "applied": 75, "rig": None}
+        ]
+
+    def test_only_keys_we_applied_are_compared(self):
+        # last_applied is a merge of DIFFS, so a rig key we never set is not ours to judge.
+        assert config_drift({"DONATION": 1}, {"DONATION": 1, "max_temp_c": 90}) == []
+
+    def test_pool_credentials_are_stripped_from_our_side_too(self):
+        # RigForge deletes pass/tls-fingerprint before serving. A password we once applied would
+        # otherwise be permanent, uncloseable drift on a rig that has none.
+        applied = {"pools": [{"url": "a", "pass": "secret", "tls-fingerprint": "ff"}]}
+        rig = {"pools": [{"url": "a"}]}
+        assert config_drift(applied, rig) == []
+
+    def test_a_real_pool_change_still_reports(self):
+        applied = {"pools": [{"url": "a", "pass": "secret"}]}
+        rig = {"pools": [{"url": "b"}]}
+        drift = config_drift(applied, rig)
+        assert [d["key"] for d in drift] == ["pools"]
+        # The reported value must be the STRIPPED one — this lands in an API payload.
+        assert "pass" not in drift[0]["applied"][0]
+
+    def test_an_unsettled_change_suppresses_the_whole_comparison(self):
+        # A submitted change is not in last_applied while the rig may already be running it, so
+        # comparing inside that window reports drift on a key we ourselves just set.
+        assert config_drift({"DONATION": 1}, {"DONATION": 2}, unsettled=True) is None
+
+    @pytest.mark.parametrize("rig_config", [None, "not-a-dict", 42, []])
+    def test_an_unreadable_rig_config_is_silence_not_a_finding(self, rig_config):
+        # None and [] must stay apart: [] is "checked, agrees", None is "could not check".
+        assert config_drift({"DONATION": 1}, rig_config) is None
+
+    def test_an_unreadable_last_applied_is_silence_too(self):
+        assert config_drift(None, {"DONATION": 1}) is None
+
+    def test_agreement_returns_an_empty_list_not_none(self):
+        assert config_drift({"DONATION": 1}, {"DONATION": 1}) == []
+
+
+class TestUnsettledDetection:
+    def test_the_newest_apply_row_governs(self):
+        history = [{"type": "apply", "status": "accepted"}, {"type": "apply", "status": "applied"}]
+        assert _has_unsettled_apply(history) is True
+
+    def test_a_stale_unsettled_row_behind_a_settled_one_does_not_suppress(self):
+        # An old accepted row that never settled is a stuck record, not a change in flight. Letting
+        # one suppress this check forever would trade a false alarm for permanent silence.
+        history = [{"type": "apply", "status": "applied"}, {"type": "apply", "status": "accepted"}]
+        assert _has_unsettled_apply(history) is False
+
+    def test_upgrade_rows_are_not_config_applies(self):
+        # An upgrade row's changes is a {"version": ...} marker, never writable-key config.
+        history = [
+            {"type": "upgrade", "status": "accepted"},
+            {"type": "apply", "status": "applied"},
+        ]
+        assert _has_unsettled_apply(history) is False
+
+    def test_an_unrecognised_status_is_not_read_as_settled(self):
+        # The list is the complement of a terminal outcome deliberately: a status we do not know is
+        # not evidence that a change settled.
+        assert _has_unsettled_apply([{"type": "apply", "status": "running"}]) is True
+
+    @pytest.mark.parametrize("history", [None, [], [{"type": "upgrade", "status": "applied"}]])
+    def test_no_apply_row_at_all_is_not_unsettled(self, history):
+        assert _has_unsettled_apply(history) is False
+
+    def test_a_row_without_a_type_is_an_apply(self):
+        # worker_config defaults type to 'apply'; rows predating #1014 have it absent.
+        assert _has_unsettled_apply([{"status": "accepted"}]) is True
+
+
+class TestThroughTheWholePayload:
+    """The wiring, not the function: a unit test of ``config_drift`` proves nothing about whether
+    ``build_worker_detail`` reaches it with the two values it needs, or publishes the answer."""
+
+    @staticmethod
+    def _detail(monkeypatch, rig_config, *, applied=None, status="applied"):
+        from mining_dashboard.service.storage_service import StateManager
+        from mining_dashboard.web import views
+        from mining_dashboard.web.worker_detail import build_worker_detail
+
+        # setattr on the shared ``config`` module object, never on ``views`` itself — a rebinding
+        # in views' own globals would patch the wrong module the moment anything here moves.
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            if applied is not None:
+                sm.add_worker_config_version("rig1", "cid1", status, applied, None)
+            workers = [
+                {"name": "rig1", "status": "online", "h60": 1, "rigforge": {"config": rig_config}}
+            ]
+            return build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+
+    def test_a_stored_string_does_not_read_as_drift_against_the_number_the_rig_serves(
+        self, monkeypatch
+    ):
+        # The whole point of the type discipline, proven through the real store and the real
+        # payload rather than against config_drift directly. Nothing between the editor and the DB
+        # coerces anything, so this is the shape a real row can hold.
+        d = self._detail(monkeypatch, {"max_temp_c": 80}, applied={"max_temp_c": "80"})
+        assert d["last_applied"] == {"max_temp_c": "80"}
+        assert d["config_drift"] == []
+
+    def test_a_real_disagreement_reaches_the_payload(self, monkeypatch):
+        d = self._detail(monkeypatch, {"max_temp_c": 80}, applied={"max_temp_c": 75})
+        assert d["config_drift"] == [{"key": "max_temp_c", "applied": 75, "rig": 80}]
+
+    def test_a_change_still_in_flight_publishes_silence_not_a_finding(self, monkeypatch):
+        # 'accepted' keeps the row out of last_applied while the rig may already be running it.
+        d = self._detail(
+            monkeypatch, {"max_temp_c": 80}, applied={"max_temp_c": 75}, status="accepted"
+        )
+        assert d["config_drift"] is None
+
+    def test_a_rig_that_serves_no_config_publishes_silence(self, monkeypatch):
+        d = self._detail(monkeypatch, None, applied={"max_temp_c": 75})
+        assert d["config_drift"] is None
+
+    def test_the_key_is_always_present_so_the_client_can_tell_silence_from_agreement(
+        self, monkeypatch
+    ):
+        d = self._detail(monkeypatch, {"max_temp_c": 80})
+        assert "config_drift" in d

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -461,12 +461,31 @@ than a guess. The words come from a fixed set the dashboard controls, never from
 cannot write its own provenance in text you would read as ours. The line carries the rig's own
 timestamp beside it; hover it for the revision of the config the rig is running.
 
-Read it as evidence, not as proof, and know the one case it gets wrong. The line reports the last
+Read it as evidence, not as proof, and know the case it gets wrong. The line reports the last
 change RigForge **recorded**. A config file edited underneath RigForge — by hand, with nothing
 running to record it — is not a recorded change, so the line keeps naming whatever came before it.
 On a rig where the dashboard applied the previous change, that reads as "Last changed from this
-dashboard" while the rig runs something else. Treat the line as an alarm that fires, not as an
-all-clear: it can tell you a change happened elsewhere, but its silence is not proof that none did.
+dashboard" while the rig runs something else.
+
+**A second check answers that one directly.** Beside the provenance line, the dashboard compares
+what it last applied to this rig against the values the rig reports it is running, key by key, and
+names each key that disagrees — "we applied `max_temp_c` 75, the rig is running 80". It needs
+nothing recorded on the rig, so it sees the hand-edit the provenance line cannot.
+
+Three things bound what the comparison claims, and each bound is deliberate:
+
+- **It judges only keys this dashboard has set.** What it compares against is a record of the
+  changes we pushed, not a copy of the rig's config, so a hand-edit to a key we have never applied
+  has nothing to disagree with and stays invisible.
+- **It never compares pool passwords.** RigForge strips the pool password and TLS fingerprint before
+  serving its config, so the dashboard strips them from its own side too. A changed pool password
+  would otherwise read as drift on every rig, forever. Nothing on this side can see one either way.
+- **It says nothing while a change is in flight.** A change that has been sent and not yet settled
+  is not in the applied record, though the rig may already be running it, so the comparison is held
+  back until the outcome lands rather than reporting a key we ourselves just set.
+
+Where it is silent, the older reading still holds: treat the provenance line as an alarm that fires,
+not as an all-clear. Its silence is not proof that nothing changed.
 
 Everything behind it is the rig's own account, so a rig that has been taken over can also say
 whatever it likes, including replaying a change id you really did send it. Within what the rig does


### PR DESCRIPTION
Closes #1367.

## What it does

The provenance line (#1345) reports the last change RigForge **recorded**. A config edited
underneath RigForge records nothing, so on a rig where this dashboard applied the previous change
the line keeps reading "Last changed from this dashboard" while the rig runs something else. That
is a false reassurance, the one direction the feature exists to avoid.

Both halves of a value comparison were already in the Inspect payload — `last_applied` from our own
history, `rig_config` from the rig's feed (#1235). `config_drift` compares them key by key and names
each disagreement. No revision hash reproduced byte for byte, no new column, no migration, no
RigForge change, no version gate. It works on rigs already deployed.

Design and its alternatives are on the issue (comment 5464392447); this is option C.

## The part that is load-bearing: the comparison is TYPED

I settled the open question that gated this (posted as #1367 comment 5464729916). Summary:

**There is no coercion anywhere between the browser and the DB.** `handle_worker_apply` takes
`changes` off `await request.json()`; `validate_worker_changes` checks key *names* only and never
inspects a value; `get_last_applied_worker_config` merges rows with `merged.update(...)`. The type
stored is the type sent.

**RigForge, by contrast, fixes the type per key** (`rigforge.sh:4808`) — `--argjson` for `DONATION`
and `watchdog_interval_min`, `--arg` for `autotune` and `watchdog`, `max_temp_c` through `tonumber`
unless unset, which serves a literal `null`.

**Four reachable editor paths store a string where the rig serves a number.** Run against the real
`workerlogic.mjs` exports, with the type-correct path as a negative control:

| route | condition | result |
|---|---|---|
| control | rig serves a number, so the row types `number` | `80` → number ✅ |
| 1 | rig has no thermal cutoff, so it serves `null` and the row types `json` | `"80"` → string ⚠ |
| 2 | number row, non-finite input falls through to raw (deliberate, documented) | `"80c"` → string ⚠ |
| 3 | `last_applied` already holds a string, so the row types `text` — self-perpetuating | `"80"` → string ⚠ |
| 4 | JSON mode does no per-key typing at all | `"80"` → string ⚠ |

Comparing those raw would report drift on a rig running exactly what we applied — the same false
alarm the issue rejects the hash fix for, arriving through a different door.

`_comparable` returns a `(tag, value)` **pair** rather than a coerced value. That is not decoration:
my first version returned the bool uncoerced and my own test caught it failing, because
`True == 1.0` in Python, so a `DONATION` of `True` matched a rig running `1`. The tag is what keeps
them apart.

## Three narrowings, each stated where a reader meets the code

- **Only keys we have set.** `last_applied` is a merge of diffs, not a config. A hand-edit to a key
  we never applied still moves only the revision and still needs option A to catch.
- **Never the pool credentials.** `strip_credentials` runs over our side because RigForge already
  strips `pass`/`tls-fingerprint` before serving. A password we once applied would otherwise be
  permanent, uncloseable drift. Cost: a changed pool password is invisible — nothing on this side
  can see one anyway.
- **Never mid-flight.** Judged on the **newest** apply row, not on whether any unsettled row exists:
  an old `accepted` row that never settled is a stuck record, not a change in flight, and letting
  one suppress the check forever would trade a false alarm for permanent silence.

The UI renders **only** a disagreement. `null` (could not check) and `[]` (checked, agrees) both say
nothing — an all-clear here would be a reassurance bounded by three narrowings a badge cannot show,
which is the same defect wearing the opposite label.

## Evidence — PROVEN BY ME

- **Full suite: 2182 passed, rc 0.** That is the base's 2151 plus this PR's 31 new tests, exactly,
  which is the arithmetic that says nothing else moved. (Re-run after the end-to-end tests: 36 in
  the new module.)
- **Frontend: 486 pass, 0 fail.**
- **Mutation battery, 6 mutations, all KILLED**, each checked for aim-uniqueness first (a pattern
  matching other than exactly once scores harness-fail, not a weak kill) and the file restored to
  its base sha256 after each:

  | # | mutation | result |
  |---|---|---|
  | M1 | drop the type canonicalisation, compare raw | 7 failed |
  | M2 | drop the bool tag | 1 failed |
  | M3 | drop the unsettled guard | 2 failed |
  | M4 | drop the credential strip from our side | 2 failed |
  | M5 | fold absent-key into compared-as-`None` | 1 failed |
  | M6 | newest-row-governs → any-unsettled-row-anywhere | 1 failed |
| M7 | delete the `_CANONICAL_STRING` branch | **SURVIVED** → see below |
| M8 | delete the `math.isfinite` guard | **SURVIVED** → see below |

- **Tests at two tiers deliberately:** the pure comparator, and then the same claims through
  `build_worker_detail` with a real in-memory `StateManager`, because a unit test of `config_drift`
  proves nothing about whether the payload reaches it or publishes the answer.
- **The empirical leg:** I read the live DB's 21 `worker_config` rows, extracting JSON *types* not
  values. All are type-correct (`max_temp_c`/`DONATION`/`watchdog_interval_min` int, `pools` list).
  **I did not read that clean sweep as evidence** — all 21 came through one route, so it says the
  common path is type-correct and nothing about whether the string paths are reachable. They are;
  see the table above.
- **Lints, each rc 0 by name:** `lint-py`, `lint-js`, `lint-md`, `lint-docs-voice`,
  `lint-operator-strings`, `lint-topology`, `lint-file-budget`. **`lint-sh` NOT run** — no shell
  file in this diff, and it is the OOM path.
- **Budget: no tsv change, and that is the correct outcome.** Every file I touched is under its
  target or unchanged in size. `workerview.mjs` has a row at 443 and my first draft took it to 453;
  I moved the rendering into `ConfigProvenance` in `confighistory.mjs` (no row, 61→71) and passed a
  prop instead, which lands `workerview.mjs` back at exactly 443. That is also the better home — the
  note qualifies the line it sits under.

## What the over-engineering pass found — in my own diff

The PR gate asks for this, so I ran it rather than pressing the button twice. It found two branches
I had shipped with **100% line coverage and no proof**, which is the failure mode line coverage is
worst at: a one-line ternary and an untested branch both read as covered.

- **`math.isfinite` guard: REMOVED.** I asked what real input reaches it with an *effect*, and there
  is none. The rig side of every numeric key is a finite JSON number, `null`, or absent — it cannot
  serve `Infinity` or `NaN` — so on every reachable input the guard produces the same verdict as its
  absence. Defensive code for a case that cannot arise. Gone, along with the `math` import.
- **`_CANONICAL_STRING` branch: KEPT, and now proven.** It survived deletion too, but here the
  answer to the same question is different: RigForge serves `autotune`/`watchdog` through `--arg`,
  so they are always strings on the rig side, while JSON mode does no per-key typing — an operator
  can store a number for one. Without the branch that reports drift on a rig running what we set.
  The branch was real; my test was missing. Added, and M7 now kills.

That is the honest version of "no findings": there were two, one deleted the code and one deleted my
confidence in a test.

## Docs

`docs/dashboard.md` and the `worker_detail.py` module docstring both described this gap as needing
persistence this module does not add. That was not merely stale — **it argued for the defect**,
which is why it survived being read. Both corrected. I grepped the source comments for the same
belief, as this lane's own rule requires: the two other sites (`rig_config_meta.py`,
`workerlogic.mjs`) describe the **revision** comparison, which this PR does not change, so they are
still true and are left alone.

## A pre-existing finding I am reporting, not fixing here

**`last_applied` is served in the Inspect payload unmasked**, and `pools` is writable, so a pool
password applied through the editor would be stored in `worker_config.changes` in plain text and
served back. `mask_secrets` is not applied on this path.

Confidence, stated precisely: **the code path allows it** (traced at source); **no instance exists
in the one real DB I can read** — I checked all 21 rows for `pass`/`tls-fingerprint` key presence,
never values, and found none. So this is an unfired hazard, not an observed leak. Out of scope for
this PR, and I will file it. Note it cuts the other way for this change: `config_drift` strips both
sides, so the drift note can never carry a credential even though the field beside it could.

## Said plainly: what I did NOT do

- **No live-rig verification.** Every RigForge claim is re-derived at source, not observed on a
  feed. `pools` is the one key whose round-trip shape I could not confirm against a real rig — if a
  rig adds defaults to a pool entry when writing, `pools` could report spurious drift. I included it
  rather than excluding it silently, because a per-key finding lets an operator judge that where a
  boolean could not; a reviewer may reasonably want it excluded until a live rig confirms it.
- **Patch coverage** — see the comment below; `scripts/patch-coverage.sh` hardcodes
  `COMPARE=origin/develop` while this PR is on `develop-v2`, so **CI's `make test-patch-coverage`
  rc 0 is no evidence here** (#1537, still open). I ran diff-cover by hand against the real base.
- **No security-reviewer subagent.** This lane normally requires one for control/credential-surface
  changes. This session was instructed not to spawn agents unasked, so I did the pass myself and
  state it as mine rather than as an independent review: the drift payload re-exposes no data the
  payload did not already carry (`rig_config` is already a field, already filtered to
  `WORKER_WRITABLE_KEYS` and already credential-stripped by `_rig_writable_config`); both sides of
  the comparison are depth-bounded by `strip_credentials`' `_MAX_CONFIG_DEPTH`; `float()` on
  rig-supplied strings cannot execute anything and non-finite results fall back to raw; the frontend
  puts values through preact's escaping with no `dangerouslySetInnerHTML`. **An independent pass is
  still owed and I am not claiming to have replaced it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
