### PR TITLE
test(dashboard): make the duplicated service test builders real fixtures (#1541)

### DIFF
--- a/dashboard/tests/service/conftest.py
+++ b/dashboard/tests/service/conftest.py
@@ -1,5 +1,48 @@
-"""Shared fixtures for dashboard/tests/service/. Currently just ``algo``, used by
-AlgoService's tests, split across test_algo_service.py and test_projected_steering.py (#1285)."""
+"""Shared fixtures and builders for the ``dashboard/tests/service/`` tests.
+
+``algo`` predates this file's second purpose: it is the AlgoService under test, split across
+test_algo_service.py and test_projected_steering.py (#1285).
+
+Everything below it is the ``tests/service/`` half of the fixture consolidation (#1541). #1459 did
+``tests/web/`` and closed; the pointer in ``test_data_helpers.py`` that named it as tracking
+``_totals`` was left behind by that close, which is why #1541 exists. Until now each of six modules
+carried its own copy of one of these builders. Duplicating them was the standing ruling while the
+#1105 cuts were in flight, because those cuts proved themselves by moving test bodies verbatim and
+converting the builders would have rewritten every call site inside the same change. The cuts
+finished with #1529, so the copies are consolidated here.
+
+The fixtures are FACTORIES, following #1459: each yields the callable the modules used to define
+for themselves, so every call site reads exactly as it did before and only the signatures change.
+
+``_SAFE`` stays a module constant rather than a fixture because no test asks for it directly; it is
+read only by ``_posture`` and ``_topo``.
+
+**``_SAFE`` is the UNION of the two dicts it replaces, and that changes what one module tracks.**
+``test_egress.SAFE`` carried three keys ``test_node_route.SAFE`` did not — ``notify_sinks_enabled``,
+``notify_tor``, ``notify_sinks_private`` — and no shared key disagreed. Passing those three is a
+no-op *by construction*: ``compute_egress_posture`` and ``compute_topology`` both default them to
+``False``/``True``/``False``, which is exactly what the egress dict supplies (egress.py, both
+signatures). The consequence to know about: the node-route tests now PIN those three rather than
+inheriting them, so a change to those defaults no longer reaches them. That was measured before the
+merge, not assumed — every override set those tests pass produced byte-identical output under
+either dict, while seeding ``notify_sinks_enabled=True`` moved it.
+
+Deliberately NOT consolidated — the name is shared, the code is not:
+
+* ``_monitor`` is defined by test_worker_presence.py, test_node_health.py and
+  test_container_health.py, and all three build a DIFFERENT class with a different signature
+  (``WorkerPresenceMonitor``, ``NodeHealthMonitor``, ``ContainerHealthMonitor``). Same name, three
+  builders.
+* ``_conn`` (test_egress.py) and ``_from`` (test_egress.py) have one definition each and stay with
+  their module; a conftest entry for a single caller buys nothing.
+* ``tests/service/test_metrics.py`` keeps its own ``_state_mgr``/``_data``, and
+  ``test_telegram_commands.py`` its own ``_metrics``. Those are the ``tests/web/`` conftest's
+  exclusions and its docstring records why; they are out of this file's reach anyway.
+
+A note carried over from ``test_data_helpers.py``, which used to state it beside its own copy: the
+``_totals`` there was a duplicate of ``test_data_service.py``'s, and it named #1459 as tracking the
+merge. #1459 shipped ``tests/web/`` only, so that pointer went stale on its close. This is the fix.
+"""
 
 from unittest.mock import MagicMock
 
@@ -7,6 +50,25 @@ import pytest
 
 from mining_dashboard.config.config import TIER_DEFAULTS
 from mining_dashboard.service.algo_service import AlgoService
+from mining_dashboard.service.egress import LOCAL, compute_egress_posture, compute_topology
+
+# The privacy-safe resting config: firewall on, p2pool over Tor, XvB over Tor, local node, no sync,
+# healthchecks off (no ping URL configured), no alert sinks configured. Any leak an assertion sees
+# was caused by the override under test and not by an unrelated knob.
+_SAFE = {
+    "firewall": True,
+    "p2pool_clearnet": False,
+    "xvb_enabled": True,
+    "xvb_tor": True,
+    "monero_clearnet_sync": False,
+    "tari_clearnet_sync": False,
+    "monero_route": LOCAL,
+    "healthchecks_enabled": False,
+    "telegram_enabled": False,
+    "notify_sinks_enabled": False,
+    "notify_tor": True,
+    "notify_sinks_private": False,
+}
 
 
 @pytest.fixture
@@ -24,3 +86,70 @@ def algo():
     data_service = MagicMock()
     data_service.workers_rejected = False  # not rejecting workers (Issue #31 guard off)
     return AlgoService(state_manager, proxy_client, data_service)
+
+
+@pytest.fixture
+def _totals():
+    """Factory for the ``_totals`` test_data_helpers.py and test_data_service.py each defined."""
+
+    def _totals(accepted=0, rejected=0, invalid=0, expired=0):
+        return {"accepted": accepted, "rejected": rejected, "invalid": invalid, "expired": expired}
+
+    return _totals
+
+
+@pytest.fixture
+def _posture():
+    """Factory for the ``_posture`` test_egress.py and test_node_route.py each defined."""
+
+    def _posture(**overrides):
+        return compute_egress_posture(**{**_SAFE, **overrides})
+
+    return _posture
+
+
+@pytest.fixture
+def _topo():
+    """Factory for the ``_topo`` test_egress.py and test_node_route.py each defined."""
+
+    def _topo(**overrides):
+        return compute_topology(**{**_SAFE, **overrides})
+
+    return _topo
+
+
+@pytest.fixture
+def _edge():
+    """Factory for the ``_edge`` test_egress.py and test_node_route.py each defined."""
+
+    def _edge(topo, src, dst):
+        return next(e for e in topo["edges"] if e["from"] == src and e["to"] == dst)
+
+    return _edge
+
+
+@pytest.fixture
+def _on():
+    """Factory for the ``_on`` test_alert_service.py and test_worker_presence.py each defined.
+
+    Worker rows the proxy reports online.
+    """
+
+    def _on(*names):
+        return [{"name": n, "status": "online"} for n in names]
+
+    return _on
+
+
+@pytest.fixture
+def _down():
+    """Factory for the ``_down`` test_alert_service.py and test_worker_presence.py each defined.
+
+    Worker rows still listed by the proxy but disconnected — the DOWN state the dashboard shows.
+    The two copies this replaces differed only in the wording of that sentence.
+    """
+
+    def _down(*names):
+        return [{"name": n, "status": "offline"} for n in names]
+
+    return _down

--- a/dashboard/tests/service/test_alert_service.py
+++ b/dashboard/tests/service/test_alert_service.py
@@ -109,16 +109,6 @@ def _keys(alerts):
     return [k for k, _ in alerts]
 
 
-def _on(*names):
-    """Worker rows the proxy reports online."""
-    return [{"name": n, "status": "online"} for n in names]
-
-
-def _down(*names):
-    """Worker rows still listed but disconnected — the DOWN state the dashboard shows."""
-    return [{"name": n, "status": "offline"} for n in names]
-
-
 class TestNodeEdges:
     def test_first_cycle_seeds_baseline_silently(self):
         svc = _svc()
@@ -278,7 +268,7 @@ class TestSyncFinished:
 
 
 class TestWorkerEdges:
-    def test_offline_then_recovered(self):
+    def test_offline_then_recovered(self, _down, _on):
         # Offline is driven by the DOWN status the dashboard shows, not by the rig vanishing.
         svc = _svc()
         assert _ev(svc, workers=_on("rig-1"), workers_expected=True, now=0) == []
@@ -291,7 +281,7 @@ class TestWorkerEdges:
             AlertService.EVT_WORKER_RECOVERED
         ]
 
-    def test_not_expected_resets_and_silences(self):
+    def test_not_expected_resets_and_silences(self, _down, _on):
         svc = _svc()
         _ev(svc, workers=_on("rig-1"), workers_expected=True, now=0)
         _ev(svc, workers=_down("rig-1"), workers_expected=True, now=0)
@@ -303,14 +293,14 @@ class TestWorkerEdges:
 
 
 class TestWorkerMembership:
-    def test_joined_after_baseline(self):
+    def test_joined_after_baseline(self, _on):
         svc = _svc()
         _ev(svc, workers=_on("rig-1"), workers_expected=True)  # prime
         assert _keys(_ev(svc, workers=_on("rig-1", "rig-2"), workers_expected=True)) == [
             AlertService.EVT_WORKER_JOINED
         ]
 
-    def test_left_when_rig_drops_off_the_table(self):
+    def test_left_when_rig_drops_off_the_table(self, _on):
         svc = _svc()
         _ev(svc, workers=_on("rig-1", "rig-2"), workers_expected=True)  # prime
         assert _keys(_ev(svc, workers=_on("rig-1"), workers_expected=True)) == [
@@ -636,7 +626,7 @@ class TestIncidentLog:
         _ev(svc, monero_down=False)  # recovery — not counted
         assert svc.drain_incidents() == {"node_down": 1}
 
-    def test_worker_offline_counts_once(self):
+    def test_worker_offline_counts_once(self, _down, _on):
         svc = _svc()
         _ev(svc, workers=_on("r"), workers_expected=True, now=0)  # prime
         _ev(svc, workers=_down("r"), workers_expected=True, now=0)  # DOWN streak
@@ -647,7 +637,7 @@ class TestIncidentLog:
 
 
 class TestEventFiltering:
-    def test_disabled_events_are_dropped(self):
+    def test_disabled_events_are_dropped(self, _down, _on):
         svc = _svc(notifier=_FakeNotifier(allow={AlertService.EVT_NODE_DOWN}))
         _ev(svc, workers=_on("rig-1"), workers_expected=True, now=0)
         _ev(svc, workers=_down("rig-1"), workers_expected=True, now=0)

--- a/dashboard/tests/service/test_data_helpers.py
+++ b/dashboard/tests/service/test_data_helpers.py
@@ -3,12 +3,12 @@
 The 14 classes here moved 1:1 and byte-identical out of ``tests/service/test_data_service.py``
 when their subjects moved into ``mining_dashboard/service/data_helpers.py``.
 
-``_totals`` below is a DUPLICATE of the builder in ``tests/service/test_data_service.py``, which
-remains the master copy.  Duplicating shared module-level test builders into each new test module
-is the standing ruling for this split (real pytest fixtures would rewrite the call sites and kill
-the byte-identity claim the split rests on); #1459 tracks consolidating them once byte-identity no
-longer binds.  Here the copy is a single 2-line builder, because these helpers take plain data
-rather than a service.
+``_totals`` used to be defined here, a DUPLICATE of the builder in
+``tests/service/test_data_service.py``.  Duplicating shared module-level test builders into each
+new test module was the standing ruling while the #1105 cuts were in flight, because those cuts
+proved themselves by moving test bodies verbatim and real pytest fixtures would have rewritten the
+call sites inside the same change.  The cuts are finished, so #1541 moved both copies into
+``tests/service/conftest.py`` as a factory fixture; the tests below take it as a parameter.
 
 ``TestXvbWinnersGate`` carries one wiring test that drives ``DataService._sync_xvb_winners``; the
 class moves whole rather than being split, to keep the 1:1 byte-identical property, which is why
@@ -43,10 +43,6 @@ from mining_dashboard.service.data_helpers import (
 from mining_dashboard.service.data_service import DataService
 
 
-def _totals(accepted=0, rejected=0, invalid=0, expired=0):
-    return {"accepted": accepted, "rejected": rejected, "invalid": invalid, "expired": expired}
-
-
 class TestSharesToRecord:
     """#129: how many P2Pool shares to record from the cumulative shares_found counter, + the new baseline."""
 
@@ -69,23 +65,23 @@ class TestSharesToRecord:
 class TestSummaryDeltas:
     """#116: per-poll share-health deltas from consecutive cumulative proxy /summary totals."""
 
-    def test_first_poll_baselines_without_backfill(self):
+    def test_first_poll_baselines_without_backfill(self, _totals):
         cur = _totals(accepted=1000, rejected=5)
         assert _summary_deltas(None, cur) == (None, cur)
 
-    def test_normal_delta(self):
+    def test_normal_delta(self, _totals):
         deltas, baseline = _summary_deltas(
             _totals(accepted=100, rejected=5), _totals(accepted=110, rejected=6, invalid=1)
         )
         assert deltas == _totals(accepted=10, rejected=1, invalid=1)
         assert baseline == _totals(accepted=110, rejected=6, invalid=1)
 
-    def test_any_counter_backwards_rebaselines_without_negative_delta(self):
+    def test_any_counter_backwards_rebaselines_without_negative_delta(self, _totals):
         # Proxy restart: accepted went backwards while rejected advanced — segment break, no row.
         cur = _totals(accepted=3, rejected=9)
         assert _summary_deltas(_totals(accepted=100, rejected=5), cur) == (None, cur)
 
-    def test_all_zero_deltas_skipped(self):
+    def test_all_zero_deltas_skipped(self, _totals):
         # _merge_proxy_summary repeats last-good totals on a bad poll and an idle proxy submits
         # nothing — neither may write an empty row every cycle.
         cur = _totals(accepted=100, rejected=5)

--- a/dashboard/tests/service/test_data_service.py
+++ b/dashboard/tests/service/test_data_service.py
@@ -50,10 +50,6 @@ def _make_service():
     return svc, state_manager, proxy_client
 
 
-def _totals(accepted=0, rejected=0, invalid=0, expired=0):
-    return {"accepted": accepted, "rejected": rejected, "invalid": invalid, "expired": expired}
-
-
 class TestInit:
     def test_restores_snapshot(self):
         sm = MagicMock()
@@ -494,7 +490,7 @@ class TestRunIteration:
         sm.update_history.assert_called()
         sm.save_snapshot.assert_called()
 
-    async def test_share_stat_deltas_persisted(self):
+    async def test_share_stat_deltas_persisted(self, _totals):
         # #116 wiring: with a baseline from a previous poll, one iteration writes the counters'
         # deltas via add_share_stats (the delta rules themselves are unit-tested above).
         svc, sm, proxy = _make_service()

--- a/dashboard/tests/service/test_egress.py
+++ b/dashboard/tests/service/test_egress.py
@@ -14,34 +14,13 @@ from mining_dashboard.service.egress import (
 )
 from mining_dashboard.service.topology_graph import NODE_ROUTES
 
-# The privacy-safe resting config: firewall on, p2pool over Tor, XvB over Tor, local node, no sync,
-# healthchecks off (no ping URL configured), no alert sinks configured.
-SAFE = {
-    "firewall": True,
-    "p2pool_clearnet": False,
-    "xvb_enabled": True,
-    "xvb_tor": True,
-    "monero_clearnet_sync": False,
-    "tari_clearnet_sync": False,
-    "monero_route": LOCAL,
-    "healthchecks_enabled": False,
-    "telegram_enabled": False,
-    "notify_sinks_enabled": False,
-    "notify_tor": True,
-    "notify_sinks_private": False,
-}
-
-
-def _posture(**overrides):
-    return compute_egress_posture(**{**SAFE, **overrides})
-
 
 def _conn(posture, component, needle):
     comp = next(c for c in posture["components"] if c["name"] == component)
     return next(c for c in comp["conns"] if needle in c["to"])
 
 
-def test_safe_config_is_all_tor():
+def test_safe_config_is_all_tor(_posture):
     p = _posture()
     assert p["summary"] == {
         "firewall": True,
@@ -53,7 +32,7 @@ def test_safe_config_is_all_tor():
     }
 
 
-def test_p2pool_clearnet_blocked_by_firewall_is_not_a_leak():
+def test_p2pool_clearnet_blocked_by_firewall_is_not_a_leak(_posture):
     p = _posture(p2pool_clearnet=True, firewall=True)
     assert _conn(p, "p2pool", "sidechain")["route"] == CLEARNET
     assert _conn(p, "p2pool", "sidechain")["blocked_by_firewall"] is True
@@ -62,14 +41,14 @@ def test_p2pool_clearnet_blocked_by_firewall_is_not_a_leak():
     assert p["summary"]["all_tor"] is True  # fail-closed: configured-clearnet can't actually leave
 
 
-def test_p2pool_clearnet_without_firewall_is_a_leak():
+def test_p2pool_clearnet_without_firewall_is_a_leak(_posture):
     p = _posture(p2pool_clearnet=True, firewall=False)
     assert p["summary"]["leaks"] == 1
     assert p["summary"]["level"] == "warn"
     assert "exposing your IP" in p["summary"]["label"]
 
 
-def test_dashboard_xvb_stats_stays_tor_when_xvb_tor_is_off():
+def test_dashboard_xvb_stats_stays_tor_when_xvb_tor_is_off(_posture):
     # xvb.tor gates only the xmrig-proxy donation dial (#166); the dashboard's stats fetch is
     # unconditionally socks5h over Tor (#163/#701), so turning xvb.tor off must not show a leak.
     p = _posture(xvb_tor=False, firewall=True)
@@ -81,13 +60,13 @@ def test_dashboard_xvb_stats_stays_tor_when_xvb_tor_is_off():
     assert p["summary"]["all_tor"] is True
 
 
-def test_xvb_disabled_routes_are_inactive():
+def test_xvb_disabled_routes_are_inactive(_posture):
     p = _posture(xvb_enabled=False)
     assert _conn(p, "dashboard", "XvB stats")["route"] == INACTIVE
     assert _conn(p, "xmrig-proxy", "XvB donation")["route"] == INACTIVE
 
 
-def test_healthchecks_ping_is_tor_when_configured_inactive_otherwise():
+def test_healthchecks_ping_is_tor_when_configured_inactive_otherwise(_posture):
     # A configured ping URL adds a dashboard Tor egress (#79); no URL → inactive, never a leak.
     assert (
         _conn(_posture(healthchecks_enabled=False), "dashboard", "Healthchecks")["route"]
@@ -99,7 +78,7 @@ def test_healthchecks_ping_is_tor_when_configured_inactive_otherwise():
     assert on["summary"]["leaks"] == 0
 
 
-def test_telegram_bot_is_tor_when_enabled_inactive_otherwise():
+def test_telegram_bot_is_tor_when_enabled_inactive_otherwise(_posture):
     # Enabling Telegram adds a dashboard Tor egress (#121/#340); off → inactive, never a leak.
     assert _conn(_posture(telegram_enabled=False), "dashboard", "Telegram")["route"] == INACTIVE
     on = _posture(telegram_enabled=True, firewall=True)
@@ -107,7 +86,7 @@ def test_telegram_bot_is_tor_when_enabled_inactive_otherwise():
     assert on["summary"]["leaks"] == 0  # Tor-routed, so never a leak
 
 
-def test_price_feed_is_tor_when_enabled_inactive_otherwise():
+def test_price_feed_is_tor_when_enabled_inactive_otherwise(_posture):
     # Opting into the price feed adds a dashboard Tor egress (#520); off → inactive, never a leak.
     assert _conn(_posture(price_feed_enabled=False), "dashboard", "price feed")["route"] == INACTIVE
     on = _posture(price_feed_enabled=True, firewall=True)
@@ -115,7 +94,7 @@ def test_price_feed_is_tor_when_enabled_inactive_otherwise():
     assert on["summary"]["leaks"] == 0  # Tor-routed, so never a leak
 
 
-def test_alert_sinks_tor_when_configured_inactive_otherwise():
+def test_alert_sinks_tor_when_configured_inactive_otherwise(_posture):
     # Configuring a webhook/ntfy sink adds a dashboard Tor egress (#380); off → inactive.
     assert _conn(_posture(), "dashboard", "alert sinks")["route"] == INACTIVE
     on = _posture(notify_sinks_enabled=True)
@@ -123,7 +102,7 @@ def test_alert_sinks_tor_when_configured_inactive_otherwise():
     assert on["summary"]["leaks"] == 0  # Tor-routed, so never a leak
 
 
-def test_alert_sinks_clearnet_public_endpoint_leaks_despite_firewall():
+def test_alert_sinks_clearnet_public_endpoint_leaks_despite_firewall(_posture):
     # notifications.tor=false with a public endpoint: the dashboard is host-networked, so the #270
     # firewall can't cover it — every alert POST exposes the host IP.
     p = _posture(notify_sinks_enabled=True, notify_tor=False, firewall=True)
@@ -134,7 +113,7 @@ def test_alert_sinks_clearnet_public_endpoint_leaks_despite_firewall():
     assert p["summary"]["all_tor"] is False
 
 
-def test_alert_sinks_lan_carveout_is_local_not_a_leak():
+def test_alert_sinks_lan_carveout_is_local_not_a_leak(_posture):
     # The LAN carve-out: notifications.tor=false with every sink on a private IP. The POST never
     # leaves your network — route is local, and it must NOT count toward the leak total.
     p = _posture(notify_sinks_enabled=True, notify_tor=False, notify_sinks_private=True)
@@ -165,7 +144,7 @@ def test_sinks_all_private_requires_ip_literal_proof():
     assert _sinks_all_private(["not a url"]) is False
 
 
-def test_xvb_standby_route_classification():
+def test_xvb_standby_route_classification(_posture):
     # The #249 backup→primary pull: onion or any non-private source → Tor (socks5h, no IP leak);
     # a private-IP-literal primary → local (LAN hop); unset → inactive. Never clearnet.
     def route(src):
@@ -184,7 +163,7 @@ def test_xvb_standby_route_classification():
         assert _posture(xvb_standby_source=src)["summary"]["leaks"] == 0
 
 
-def test_xvb_standby_topology_edge_tracks_route():
+def test_xvb_standby_topology_edge_tracks_route(_topo):
     # onion/public source → an edge into the tor hub (never the internet node); a private-IP
     # primary is a LAN hop with no placeable node, so it draws no edge (like the alert-sink case).
     def standby_edges(topo):
@@ -198,12 +177,12 @@ def test_xvb_standby_topology_edge_tracks_route():
     assert standby_edges(_topo(xvb_standby_source="http://192.168.1.5/x")) == []  # LAN, no node
 
 
-def test_the_monerod_rpc_conn_carries_the_route_it_was_given():
+def test_the_monerod_rpc_conn_carries_the_route_it_was_given(_posture):
     assert _conn(_posture(monero_route=LOCAL), "p2pool", "monerod RPC")["route"] == LOCAL
     assert _conn(_posture(monero_route=CLEARNET), "p2pool", "monerod RPC")["route"] == CLEARNET
 
 
-def test_clearnet_initial_sync_surfaces_only_when_enabled():
+def test_clearnet_initial_sync_surfaces_only_when_enabled(_posture):
     base = _posture()
     assert not any(
         "initial" in c["to"]
@@ -213,32 +192,24 @@ def test_clearnet_initial_sync_surfaces_only_when_enabled():
     assert _conn(synced, "monerod", "initial block download")["route"] == CLEARNET
 
 
-def test_monerod_p2p_always_tor():
+def test_monerod_p2p_always_tor(_posture):
     assert _conn(_posture(firewall=False), "monerod", "Monero P2P")["route"] == TOR
 
 
 # --- Topology (#170 trust-boundary view) -----------------------------------------------
 
 
-def _topo(**overrides):
-    return compute_topology(**{**SAFE, **overrides})
-
-
-def _edge(topo, src, dst):
-    return next(e for e in topo["edges"] if e["from"] == src and e["to"] == dst)
-
-
 def _from(topo, src):
     return [e for e in topo["edges"] if e["from"] == src]
 
 
-def test_topology_summary_is_shared_with_egress_list():
+def test_topology_summary_is_shared_with_egress_list(_posture, _topo):
     # The badge can never disagree with the map: same knobs in, identical summary out.
     for overrides in ({}, {"xvb_tor": False}, {"p2pool_clearnet": True, "firewall": False}):
         assert _topo(**overrides)["summary"] == _posture(**overrides)["summary"]
 
 
-def test_topology_safe_has_no_leaks_and_hub_nodes():
+def test_topology_safe_has_no_leaks_and_hub_nodes(_topo):
     topo = _topo()
     ids = {n["id"] for n in topo["nodes"]}
     assert {"tor", "internet", "rigs", "browser"} <= ids
@@ -246,14 +217,14 @@ def test_topology_safe_has_no_leaks_and_hub_nodes():
     assert topo["summary"]["all_tor"] is True
 
 
-def test_topology_lan_ingress_edges():
+def test_topology_lan_ingress_edges(_edge, _topo):
     topo = _topo()
     rigs = _edge(topo, "rigs", "xmrig-proxy")
     assert rigs["kind"] == "ingress" and rigs["route"] == "local"
     assert _edge(topo, "browser", "caddy")["kind"] == "ingress"
 
 
-def test_topology_daemon_p2p_is_bidirectional_over_tor():
+def test_topology_daemon_p2p_is_bidirectional_over_tor(_edge, _topo):
     topo = _topo()
     for daemon in ("monerod", "tari", "p2pool"):
         edge = _edge(topo, daemon, "tor")
@@ -261,7 +232,7 @@ def test_topology_daemon_p2p_is_bidirectional_over_tor():
         assert edge["route"] == TOR, daemon
 
 
-def test_topology_clearnet_link_bypasses_the_tor_hub():
+def test_topology_clearnet_link_bypasses_the_tor_hub(_edge, _topo):
     # A clearnet route must land on `internet`, not `tor`, so a leak visibly skips the hub.
     topo = _topo(p2pool_clearnet=True, firewall=False)
     edge = _edge(topo, "p2pool", "internet")
@@ -269,14 +240,14 @@ def test_topology_clearnet_link_bypasses_the_tor_hub():
     assert not any(e["to"] == "tor" and e["from"] == "p2pool" for e in topo["edges"])
 
 
-def test_topology_clearnet_blocked_by_firewall_is_not_a_leak():
+def test_topology_clearnet_blocked_by_firewall_is_not_a_leak(_edge, _topo):
     topo = _topo(p2pool_clearnet=True, firewall=True)
     edge = _edge(topo, "p2pool", "internet")
     assert edge.get("blocked_by_firewall") is True and edge.get("leak") is None
     assert topo["summary"]["all_tor"] is True
 
 
-def test_topology_dashboard_xvb_stats_stays_on_the_tor_hub_when_xvb_tor_is_off():
+def test_topology_dashboard_xvb_stats_stays_on_the_tor_hub_when_xvb_tor_is_off(_edge, _topo):
     topo = _topo(xvb_tor=False, firewall=True)
     # The dashboard's stats fetch is unconditionally Tor (#163/#701) — it must terminate at the
     # tor hub, never bypass to the internet node.
@@ -288,7 +259,7 @@ def test_topology_dashboard_xvb_stats_stays_on_the_tor_hub_when_xvb_tor_is_off()
     assert not any(e.get("leak") for e in topo["edges"])
 
 
-def test_topology_xvb_disabled_is_inactive_not_a_leak():
+def test_topology_xvb_disabled_is_inactive_not_a_leak(_edge, _topo):
     topo = _topo(xvb_enabled=False)
     assert _edge(topo, "xmrig-proxy", "tor")["route"] == INACTIVE
     assert next(e for e in topo["edges"] if e["label"] == "XvB stats")["route"] == INACTIVE
@@ -296,7 +267,7 @@ def test_topology_xvb_disabled_is_inactive_not_a_leak():
     assert not any(e.get("leak") for e in topo["edges"])
 
 
-def test_topology_internal_mesh_is_flagged_and_includes_merge_mining():
+def test_topology_internal_mesh_is_flagged_and_includes_merge_mining(_edge, _topo):
     topo = _topo()
     merge = _edge(topo, "p2pool", "tari")
     assert merge["kind"] == "internal" and "merge-mine" in merge["label"]
@@ -304,7 +275,7 @@ def test_topology_internal_mesh_is_flagged_and_includes_merge_mining():
     assert docker.get("internal") is True
 
 
-def test_topology_alert_sinks_edge_tracks_the_route():
+def test_topology_alert_sinks_edge_tracks_the_route(_topo):
     # Tor (or unconfigured) → an edge into the tor hub, same as healthchecks.
     def sink_edges(topo):
         return [e for e in topo["edges"] if e["label"] == "alert sinks"]
@@ -322,13 +293,13 @@ def test_topology_alert_sinks_edge_tracks_the_route():
     assert local["summary"]["leaks"] == 0 and local["summary"]["all_tor"] is True
 
 
-def test_topology_clearnet_sync_adds_bypass_edge():
+def test_topology_clearnet_sync_adds_bypass_edge(_edge, _topo):
     topo = _topo(monero_clearnet_sync=True, firewall=False)
     edge = _edge(topo, "monerod", "internet")
     assert edge["route"] == CLEARNET and edge["leak"] is True
 
 
-def test_tari_clearnet_sync_surfaces_in_egress_and_topology():
+def test_tari_clearnet_sync_surfaces_in_egress_and_topology(_edge, _posture, _topo):
     # The Tari clearnet-sync branch is symmetric with Monero's — exercise it explicitly so the
     # tari path can't regress unnoticed (only the monerod one was covered before).
     base = _posture()
@@ -422,7 +393,7 @@ def test_topology_summary_matches_egress_for_all_configs():
         assert compute_topology(**cfg)["summary"] == compute_egress_posture(**cfg)["summary"], cfg
 
 
-def test_firewall_off_counts_every_clearnet_path_as_a_leak():
+def test_firewall_off_counts_every_clearnet_path_as_a_leak(_posture):
     # Firewall down + every clearnet knob on: there's no backstop, so each clearnet path is a real,
     # counted leak — leaks must equal the number of clearnet connections, with nothing "blocked".
     p = _posture(
@@ -441,7 +412,7 @@ def test_firewall_off_counts_every_clearnet_path_as_a_leak():
     assert "exposing your IP" in p["summary"]["label"]
 
 
-def test_firewall_on_blocks_every_clearnet_path():
+def test_firewall_on_blocks_every_clearnet_path(_posture):
     # Same clearnet-everywhere config with the firewall ON: every clearnet path belongs to a
     # container, so all are blocked and nothing leaks — the dashboard's own egress is Tor-only
     # (#163/#701), so the host-networked firewall bypass has nothing clearnet to expose.

--- a/dashboard/tests/service/test_node_route.py
+++ b/dashboard/tests/service/test_node_route.py
@@ -7,44 +7,18 @@ The four edges this is really about (`p2pool`->`monerod`, `p2pool`->`tari`, `das
 `dashboard`->`tari`) all claimed `local` before this, three of them hardcoded. One render could
 already contradict itself: with a remote monerod the node was marked `remote` and p2pool's hop to
 it said `clearnet`, while the dashboard's hop to the SAME daemon still said `local`.
+
+The resting config these tests build on used to be a local ``SAFE`` dict mirroring
+``test_egress.SAFE``.  #1541 merged the two into ``tests/service/conftest.py``, which is what the
+``_posture``, ``_topo`` and ``_edge`` fixtures below read; the merged dict is the UNION, so these
+tests now pin three notify-* keys they used to leave at their signature defaults.  The conftest
+docstring records why that is a no-op and what it costs.
 """
 
 import pytest
 
-from mining_dashboard.service.egress import (
-    CLEARNET,
-    LOCAL,
-    compute_egress_posture,
-    compute_topology,
-)
+from mining_dashboard.service.egress import CLEARNET, LOCAL
 from mining_dashboard.service.topology_graph import LAN, NODE_ROUTES, UNKNOWN, node_route
-
-# The resting config, mirroring test_egress.SAFE: everything private-by-default, so any leak the
-# assertions below see was caused by the route under test and not by an unrelated knob.
-SAFE = {
-    "firewall": True,
-    "p2pool_clearnet": False,
-    "xvb_enabled": True,
-    "xvb_tor": True,
-    "monero_clearnet_sync": False,
-    "tari_clearnet_sync": False,
-    "monero_route": LOCAL,
-    "healthchecks_enabled": False,
-    "telegram_enabled": False,
-}
-
-
-def _posture(**overrides):
-    return compute_egress_posture(**{**SAFE, **overrides})
-
-
-def _topo(**overrides):
-    return compute_topology(**{**SAFE, **overrides})
-
-
-def _edge(topo, src, dst):
-    return next(e for e in topo["edges"] if e["from"] == src and e["to"] == dst)
-
 
 # --- The classifier ----------------------------------------------------------------------
 
@@ -157,7 +131,7 @@ def test_the_classifier_returns_only_declared_routes():
 
 @pytest.mark.parametrize("firewall", [True, False])
 @pytest.mark.parametrize("route", [LAN, UNKNOWN])
-def test_a_lan_or_unknown_node_hop_moves_neither_security_counter(route, firewall):
+def test_a_lan_or_unknown_node_hop_moves_neither_security_counter(route, firewall, _posture):
     # `leaks` is defined at its own declaration as "clearnet egress that actually exposes the host
     # IP". A node on your own LAN does not expose it, so counting one would be inventing a leak —
     # and inventing a leak is as wrong as hiding one. `unknown` must not be counted either: we do
@@ -174,7 +148,7 @@ def test_a_lan_or_unknown_node_hop_moves_neither_security_counter(route, firewal
 
 
 @pytest.mark.parametrize("firewall", [True, False])
-def test_a_clearnet_node_hop_still_moves_a_counter(firewall):
+def test_a_clearnet_node_hop_still_moves_a_counter(firewall, _posture):
     # The control for the test above. Without this, "the counters did not move" would be equally
     # consistent with the monerod hop having stopped reaching the counter at all — which is what
     # a careless edit to the conn at egress.py's p2pool component would actually do.
@@ -183,7 +157,7 @@ def test_a_clearnet_node_hop_still_moves_a_counter(firewall):
     assert summary["blocked_by_firewall"] == (1 if firewall else 0)
 
 
-def test_a_lan_node_visibly_changes_the_count_that_used_to_be_charged(monkeypatch):
+def test_a_lan_node_visibly_changes_the_count_that_used_to_be_charged(monkeypatch, _posture):
     # The behaviour change this PR ships, stated as a test rather than left for an operator to
     # notice. A remote monerod on a private address was charged to the security summary before
     # this (blocked with the firewall on, a LEAK with it off); it now moves neither counter.
@@ -195,7 +169,7 @@ def test_a_lan_node_visibly_changes_the_count_that_used_to_be_charged(monkeypatc
 
 
 @pytest.mark.parametrize("route", NODE_ROUTES)
-def test_every_hop_to_a_relocatable_node_carries_that_node_s_route(route):
+def test_every_hop_to_a_relocatable_node_carries_that_node_s_route(route, _edge, _topo):
     # All four edges, including the three that were hardcoded `local`. Parametrised over every
     # route so a fix that special-cases one state and drops the others cannot pass.
     topo = _topo(monero_route=route, tari_route=route)
@@ -205,7 +179,7 @@ def test_every_hop_to_a_relocatable_node_carries_that_node_s_route(route):
     assert _edge(topo, "dashboard", "tari")["route"] == route
 
 
-def test_the_two_hops_to_one_daemon_can_never_disagree():
+def test_the_two_hops_to_one_daemon_can_never_disagree(_topo):
     # The self-contradiction #1350 is really about: before this, `p2pool`->`monerod` followed the
     # remote knob while `dashboard`->`monerod` was hardcoded local, so one render described the
     # SAME daemon as two different things. They are now derived from one value and cannot drift.
@@ -215,7 +189,7 @@ def test_the_two_hops_to_one_daemon_can_never_disagree():
         assert hops == {"p2pool": route, "dashboard": route}, route
 
 
-def test_a_lan_or_unknown_edge_is_never_tagged_as_a_leak():
+def test_a_lan_or_unknown_edge_is_never_tagged_as_a_leak(_edge, _topo):
     # `leak` / `blocked_by_firewall` are the diagram's own red-flag tags, set by a separate loop
     # from the summary counters — so they need their own assertion, not an inference from the
     # count. Only clearnet may carry either.
@@ -228,7 +202,7 @@ def test_a_lan_or_unknown_edge_is_never_tagged_as_a_leak():
                 assert edge.get("blocked_by_firewall") is None, (route, firewall, src)
 
 
-def test_a_lan_node_still_reads_as_remote_in_the_diagram():
+def test_a_lan_node_still_reads_as_remote_in_the_diagram(_edge, _topo):
     # The node caption and the edge colour answer different questions and must not be conflated:
     # "is it on this machine" (no) and "does reaching it expose me" (no). An operator needs both.
     nodes = {n["id"]: n for n in _topo(monero_route=LAN, tari_route=UNKNOWN)["nodes"]}

--- a/dashboard/tests/service/test_worker_presence.py
+++ b/dashboard/tests/service/test_worker_presence.py
@@ -22,29 +22,19 @@ def _monitor(offline_after=300, recovery_after=120):
     return m, clock
 
 
-def _on(*names):
-    """Worker rows the proxy reports online."""
-    return [{"name": n, "status": "online"} for n in names]
-
-
-def _down(*names):
-    """Worker rows still listed by the proxy but disconnected — the DOWN state the UI shows."""
-    return [{"name": n, "status": "offline"} for n in names]
-
-
 class TestBaseline:
-    def test_first_sighting_online_is_silent(self):
+    def test_first_sighting_online_is_silent(self, _on):
         # A brand-new worker is baselined ONLINE with no edge — it's not a "recovery".
         m, _ = _monitor()
         assert m.update(_on("rig-1")) == []
 
-    def test_first_sighting_down_is_silent(self):
+    def test_first_sighting_down_is_silent(self, _down):
         # A rig already DOWN at startup baselines OFFLINE silently — a restart must not replay it.
         m, _ = _monitor()
         assert m.update(_down("rig-1")) == []
         assert m._workers["rig-1"]["state"] == "offline"
 
-    def test_steady_online_emits_nothing(self):
+    def test_steady_online_emits_nothing(self, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         for _ in range(5):
@@ -53,7 +43,7 @@ class TestBaseline:
 
 
 class TestOfflineDebounce:
-    def test_not_offline_before_threshold(self):
+    def test_not_offline_before_threshold(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))  # baseline online
         clock.advance(30)
@@ -61,14 +51,14 @@ class TestOfflineDebounce:
         clock.advance(269)
         assert m.update(_down("rig-1")) == []  # 269s DOWN — still under the 300s threshold
 
-    def test_offline_after_threshold(self):
+    def test_offline_after_threshold(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         m.update(_down("rig-1"))  # DOWN streak starts here
         clock.advance(300)
         assert m.update(_down("rig-1")) == [("rig-1", "offline")]
 
-    def test_offline_emitted_once(self):
+    def test_offline_emitted_once(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         m.update(_down("rig-1"))
@@ -77,7 +67,7 @@ class TestOfflineDebounce:
         clock.advance(300)
         assert m.update(_down("rig-1")) == []  # already offline — no repeat
 
-    def test_brief_down_does_not_trip(self):
+    def test_brief_down_does_not_trip(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         clock.advance(60)
@@ -85,7 +75,7 @@ class TestOfflineDebounce:
         clock.advance(30)
         assert m.update(_on("rig-1")) == []  # back well before 300s
 
-    def test_vanishing_from_table_is_left_not_offline(self):
+    def test_vanishing_from_table_is_left_not_offline(self, _on):
         # A rig the proxy stops listing entirely (fell off the worker table) is reported as having
         # LEFT — never aged to "offline", which is reserved for the DOWN-but-still-listed state.
         m, clock = _monitor()
@@ -96,15 +86,15 @@ class TestOfflineDebounce:
 
 
 class TestRecoveryHysteresis:
-    def _take_offline(self, m, clock):
+    def _take_offline(self, m, clock, _down, _on):
         m.update(_on("rig-1"))
         m.update(_down("rig-1"))
         clock.advance(300)
         assert m.update(_down("rig-1")) == [("rig-1", "offline")]
 
-    def test_recovered_only_after_stable_window(self):
+    def test_recovered_only_after_stable_window(self, _down, _on):
         m, clock = _monitor()
-        self._take_offline(m, clock)
+        self._take_offline(m, clock, _down, _on)
         # Reappears online, but "back online" holds until it's been present for recovery_after.
         assert m.update(_on("rig-1")) == []
         clock.advance(119)
@@ -112,10 +102,10 @@ class TestRecoveryHysteresis:
         clock.advance(1)
         assert m.update(_on("rig-1")) == [("rig-1", "recovered")]
 
-    def test_flap_during_recovery_does_not_emit(self):
+    def test_flap_during_recovery_does_not_emit(self, _down, _on):
         # A one-cycle reconnect during an outage must not produce a recovered→offline spam.
         m, clock = _monitor()
-        self._take_offline(m, clock)
+        self._take_offline(m, clock, _down, _on)
         clock.advance(30)
         assert m.update(_on("rig-1")) == []  # blink online (still offline)
         clock.advance(30)
@@ -125,7 +115,7 @@ class TestRecoveryHysteresis:
 
 
 class TestMultipleWorkers:
-    def test_independent_per_worker_state(self):
+    def test_independent_per_worker_state(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1", "rig-2"))
         # rig-2 stays online; rig-1 goes DOWN.
@@ -135,7 +125,7 @@ class TestMultipleWorkers:
 
 
 class TestReset:
-    def test_reset_clears_state_and_rebaselines_silently(self):
+    def test_reset_clears_state_and_rebaselines_silently(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         m.update(_down("rig-1"))
@@ -148,7 +138,7 @@ class TestReset:
 
 
 class TestFalloff:
-    def test_worker_forgotten_when_it_leaves_the_table(self):
+    def test_worker_forgotten_when_it_leaves_the_table(self, _down, _on):
         m, clock = _monitor()
         m.update(_on("rig-1"))
         m.update(_down("rig-1"))
@@ -162,22 +152,22 @@ class TestFalloff:
 
 
 class TestJoinLeave:
-    def test_first_cycle_baselines_silently(self):
+    def test_first_cycle_baselines_silently(self, _on):
         # The startup roster is baselined without joined edges — a restart isn't a fleet change.
         m, _ = _monitor()
         assert m.update(_on("rig-1", "rig-2")) == []
 
-    def test_new_worker_after_prime_joins(self):
+    def test_new_worker_after_prime_joins(self, _on):
         m, _ = _monitor()
         m.update(_on("rig-1"))  # prime
         assert m.update(_on("rig-1", "rig-2")) == [("rig-2", "joined")]
 
-    def test_worker_leaving_emits_left(self):
+    def test_worker_leaving_emits_left(self, _on):
         m, _ = _monitor()
         m.update(_on("rig-1", "rig-2"))  # prime
         assert m.update(_on("rig-1")) == [("rig-2", "left")]
 
-    def test_reset_reprimes_without_joins(self):
+    def test_reset_reprimes_without_joins(self, _on):
         m, _ = _monitor()
         m.update(_on("rig-1"))  # prime
         m.reset()  # e.g. proxy stopped for a failover — clears the prime flag

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -32,12 +32,12 @@ dashboard/tests/frontend/logic.test.mjs	727
 dashboard/tests/frontend/wizard.test.mjs	765
 dashboard/tests/frontend/workerview.test.mjs	518
 dashboard/tests/frontend/xvbview.test.mjs	431
-dashboard/tests/service/test_alert_service.py	1102
+dashboard/tests/service/test_alert_service.py	1092
 dashboard/tests/service/test_algo_service.py	822
 dashboard/tests/service/test_control_service.py	500
-dashboard/tests/service/test_data_helpers.py	622
-dashboard/tests/service/test_data_service.py	2542
-dashboard/tests/service/test_egress.py	480
+dashboard/tests/service/test_data_helpers.py	618
+dashboard/tests/service/test_data_service.py	2538
+dashboard/tests/service/test_egress.py	451
 dashboard/tests/service/test_metrics.py	463
 dashboard/tests/service/test_storage_worker.py	451
 dashboard/tests/service/test_telegram_commands.py	1240

--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -49,10 +49,14 @@ make test-integration ARGS="--host user@box --dir pithead --check"   # tier-4 li
 
 Add a `test_*` to the matching file under `dashboard/tests/`. Name it for the behavior, add
 a one-line docstring stating the intent, mock at the client boundary (the conftest gives you an
-in-memory `state_manager`). Run `make test-dashboard`; coverage must stay ≥ 80%. Under `dashboard/tests/web/`,
-`conftest.py` supplies the view-layer builders — `_metrics`, `_sync`, `_hashrate`, `_state_mgr`
-and `_data` — as factory fixtures. Take the one you need as a parameter instead of writing
-another copy; what is deliberately not shared, and why, is recorded in that file.
+in-memory `state_manager`). Run `make test-dashboard`; coverage must stay ≥ 80%. Both test directories keep their shared
+builders in a `conftest.py`. Under `dashboard/tests/web/` those are the view-layer builders —
+`_metrics`, `_sync`, `_hashrate`, `_state_mgr` and `_data`; under `dashboard/tests/service/` they
+are `_totals`, `_posture`, `_topo`, `_edge`, `_on` and `_down`, plus the `algo` service and the
+`_SAFE` resting config the posture builders read. All of them are factory fixtures: take the one
+you need as a parameter instead of writing another copy. What is deliberately not shared, and why,
+is recorded in each file — several builders share a name across modules while building different
+things, so check there before assuming two copies are the same builder.
 
 ```python
 def test_pruned_node_is_labelled_pruned(...):


### PR DESCRIPTION
Closes #1541.

The `tests/service/` half of the fixture consolidation. #1459 shipped `tests/web/` only, and its
close left a pointer behind: `tests/service/test_data_helpers.py` said `_totals` was a duplicate
and that #1459 tracked consolidating it. That sentence went false on the close, which is why #1541
exists. It is fixed here, along with `test_node_route.py`'s claim that its `SAFE` mirrors
`test_egress.SAFE`.

Six builders move to `tests/service/conftest.py` as factory fixtures — the shape #1459 used, so
every call site reads exactly as it did before and only the signatures change. 94 test signatures
gained a parameter; 12 module-level definitions became 6.

| builder | was defined in | call sites |
|---|---|---|
| `_totals` | `test_data_helpers`, `test_data_service` | 9 + 2 |
| `_posture` | `test_egress`, `test_node_route` | 27 + 4 |
| `_topo` | `test_egress`, `test_node_route` | 19 + 5 |
| `_edge` | `test_egress`, `test_node_route` | 11 + 6 |
| `_on` | `test_alert_service`, `test_worker_presence` | 13 + 28 |
| `_down` | `test_alert_service`, `test_worker_presence` | 8 + 19 |

**Counted by an AST walk, never a regex.** A per-builder `grep -cE` scored `_on` at ZERO in
`test_alert_service.py`, where the AST finds 13 (`workers=_on("rig-1")`) — a builder that looked
dead and was not.

## Six, not the five routed — and why

`_down` was on the do-not-consolidate list because its two bodies "differ". They do, and only in
the docstring: both are `return [{"name": n, "status": "offline"} for n in names]`. The reason
given for excluding it does not hold, so it is included, and the conftest docstring keeps one
sentence covering both. `_monitor` stays excluded and for a reason that survives inspection — its
three definitions build `WorkerPresenceMonitor`, `NodeHealthMonitor` and `ContainerHealthMonitor`,
different classes with different signatures.

## `_SAFE` is a UNION, and that is a real change to what one module tracks

`test_egress.SAFE` carried three keys `test_node_route.SAFE` did not — `notify_sinks_enabled`,
`notify_tor`, `notify_sinks_private` — and no shared key disagreed. A differing binding is a
screen, not a verdict, so the effect was measured rather than assumed.

* **Measured.** For every override set `test_node_route` passes, plus a seven-case sweep over the
  knobs those sites touch: `compute_egress_posture` and `compute_topology` produce byte-identical
  output under either dict — 0 differing results over 10 cases × 2 functions. Two controls, both
  fired: seeding `notify_sinks_enabled=True` into the merged dict moved 19 results, `firewall=False`
  moved 15. The suite itself is the exhaustive version of the same check, since `test_node_route`
  now runs entirely through the merged dict.
* **Mechanism, re-derived at `mining_dashboard/service/egress.py`, not banked:** both signatures
  default those three to `False` / `True` / `False`, exactly the values the egress dict supplies, so
  passing them is a no-op by construction.
* **The cost, recorded in the conftest docstring:** the node-route tests now PIN those three rather
  than inheriting the defaults, so a change to those defaults no longer reaches them.

## The one caller that could not take a parameter

`TestRecoveryHysteresis._take_offline` is a helper method, not a test, so it is handed `_on` and
`_down` by its two callers. `test_egress`'s `route()` needed nothing at all: it is a closure inside
a test function and reads that test's parameter for free. Enumerated by AST — those were the only
two candidates, and only one was real.

## What was RUN

* **Suite, before and after at the same tip:** `2151 passed` both, rc 0. Nothing skipped.
* **`pytest --collect-only`, before vs after: identical on all 2151 test IDs**, the only diff being
  the timing line. No test moved, was renamed, or was dropped.
* **Mutation battery — the control that matters, because a consolidation can leave tests attached
  to nothing.** One seeded defect per fixture plus `_SAFE`: **7 of 7 KILLED**, each mutation proven
  applied on disk before the run, and the conftest verified byte-identical to clean afterwards. A
  pattern matching other than exactly once is refused rather than scored, so an unmatched `replace`
  cannot report a clean survival.
* **94 injected parameters, 0 declared-but-unreferenced** (AST check).
* **Dashboard coverage 97.03%** (bar 80%), 204 missed statements — inside this suite's measured
  ±1 run-to-run variance, and no production file is touched by this diff.
* **Lint:** `lint-py`, `lint-js`, `lint-yaml`, `lint-toml`, `lint-md`, `lint-docs-voice`,
  `lint-topology`, `lint-operator-strings`, `lint-file-budget` all pass.

## What was NOT run, and what proves nothing

* **`make test-patch-coverage` is VACUOUS on this change and its rc 0 is not evidence.** Against
  the real base it reports "No lines with coverage information in this diff" — the diff changes no
  production line, and `coverage.xml` carries no test files. The gate's own run reports
  `Coverage: 98%` over 1767 lines, which is the whole `develop-v2`-vs-`develop` delta and not this
  patch: `scripts/patch-coverage.sh` hardcodes `COMPARE=origin/develop` while this PR is based on
  `develop-v2`. That is #1537, open and unfixed. The mutation battery is the substitute evidence.
* **`make lint-sh` was skipped** — no shell file is in the diff, and it is the serialized path.
* **No `security-reviewer` pass.** This diff touches test builders and two docs; it reaches no
  control endpoint, no credential, and no outbound fetch.
* Docs: `docs/dev/testing-guide.md`'s dashboard recipe now names both conftests. `docs/` is shared,
  disclosed here per lane policy.

## From the over-engineering pass, recorded rather than hidden

**The repo did not get smaller — it got less duplicated.** Net **+46 lines** across
`tests/service/`: the six test modules shed 166 and gained 46, while `conftest.py` gained 131, of
which **44 are its module docstring**. The four shrinking budget rows are real but they are not the
whole picture, and reading them as "the change removes code" would be wrong. What is bought is one
definition per builder instead of two, and the disclosure the fixture ruling requires living where
a reader meets the code.

Two shapes I looked at and kept:

* **`_edge` is a stateless two-line lookup, and a fixture is a heavier wrapper than it needs.** The
  lighter alternative — define it once and import it from the sibling test module — is closed off
  by the `sys.path` decision recorded at `dashboard/pyproject.toml:49-51`, which is not something a
  refactor PR gets to reverse as a rider. A conftest fixture is the mechanism that exists.
* **The 44-line docstring.** It is longer than #1459's because of the `_SAFE` union disclosure,
  which is the one thing a later reader could get wrong. Kept for that reason, not for symmetry.

No new line over the 100-character wrap was introduced in any of the seven files (max width per
file is unchanged or lower against the base).

## Budget

Four rows shrank and were hand-lowered, never regenerated — `git diff` on the tsv shows exactly
four changed rows: `test_alert_service` 1102→1092, `test_data_helpers` 622→618, `test_data_service`
2542→2538, `test_egress` 480→451. `conftest.py` is 155 lines so it takes no row;
`test_node_route` (211) and `test_worker_presence` (175) stay rowless.
