### PR TITLE
fix(dashboard): stop keeping and serving the pool password in the worker change record (#1543)

### DIFF
--- a/dashboard/mining_dashboard/service/worker_config_store.py
+++ b/dashboard/mining_dashboard/service/worker_config_store.py
@@ -25,6 +25,15 @@ import sqlite3
 import time
 from typing import Any
 
+# The credential strip the rig-read path already uses on ``rig_config``
+# (``client/xmrig_client._rig_writable_config``), reused here rather than restated: a second copy
+# of the key list and the depth walk is a second place for them to drift, and this table feeds the
+# SAME editor prefill that one defends (#1543). The service -> client direction is the one
+# ``data_helpers``, ``worker_refresh`` and ``data_service`` already take; ``xmrig_client`` reaches
+# back only as far as ``control_service``, which imports ``config`` and nothing else, so this
+# closes no cycle.
+from mining_dashboard.client.xmrig_client import strip_credentials
+
 # The full terminal vocabulary the rig's control mirror can report (#1009) — applied/rejected/
 # rolled_back/failed from a control-apply, plus noop (already on target)/throttled (retry-later)
 # from a control-upgrade (rigforge#320). Mirrors xmrig_client._CONTROL_TERMINAL and pithead's own
@@ -41,13 +50,26 @@ _SELECT_CHANGE = "SELECT change_id, ts, status, changes, reason, type FROM worke
 
 def _shaped(row: sqlite3.Row) -> dict:
     """One ``worker_config`` row as the rest of the app reads it: ``changes`` parsed back to a
-    dict (unparseable JSON reads as ``{}`` rather than raising), and a row written before the
-    ``type`` column existed (#1014) reading back as ``"apply"``."""
+    dict (unparseable JSON reads as ``{}`` rather than raising), credentials stripped out of it,
+    and a row written before the ``type`` column existed (#1014) reading back as ``"apply"``.
+
+    The strip is HERE, and not at any of the three places that publish ``changes``, because this
+    is the one point both row-returning reads pass through — ``get_worker_config_history`` and
+    ``get_worker_config_change`` — and therefore the only single edit that covers every consumer
+    of them (#1543). The Inspect payload alone carries a row's ``changes`` in three separate
+    fields: ``last_applied`` (merged here), ``history``, and ``hashrate_history.markers[]``.
+    Stripping at ``get_last_applied_worker_config``, which is where the issue's own text points,
+    would have left the other two serving the credential, and nothing would have gone red.
+
+    It is also what makes an ALREADY-WRITTEN row safe: ``add_worker_config_version`` stops new
+    rows carrying a credential, but rows a previous build wrote still hold one, and this is what
+    keeps those from being served without needing a migration to rewrite them."""
     d = dict(row)
     try:
         d["changes"] = json.loads(d["changes"]) if d["changes"] else {}
     except (TypeError, ValueError):
         d["changes"] = {}
+    d["changes"] = strip_credentials(d["changes"])
     d["type"] = d.get("type") or "apply"
     return d
 
@@ -67,8 +89,23 @@ class WorkerConfigStoreMixin:
     ) -> None:
         """Record one applied/attempted worker change (#185): a config apply, or (``change_type=
         "upgrade"``, #1014) a one-click RigForge upgrade attempt — ``changes`` then carries
-        ``{"version": ...}`` instead of a writable-key diff. Stored as JSON — no secret ever lands
-        here. Forward-only."""
+        ``{"version": ...}`` instead of a writable-key diff. Forward-only.
+
+        Stored as JSON with the pool credentials stripped OUT of it first (#1543). That sentence
+        used to read "no secret ever lands here", which was not a property this method had: the
+        caller hands us the operator's own POSTed ``changes``, ``pools`` is on the writable
+        allowlist, and a pool entry carries ``pass``, so the credential landed here in plain text
+        and stayed — through a restart, and into any backup of the DB.
+
+        The strip is on the RECORD only. ``handle_worker_apply`` sends the operator's unmodified
+        ``changes`` to the rig before calling this, so the password still reaches the pool it is
+        for; what changes is what this dashboard keeps afterwards. ``strip_credentials`` builds
+        new containers rather than mutating, so the caller's dict is untouched either way.
+
+        One disclosed consequence: the strip stops walking past ``_MAX_CONFIG_DEPTH`` (6) and
+        returns ``None`` below it, so a ``changes`` nested deeper than that is recorded truncated.
+        A writable config is three deep at most (``pools`` -> a pool -> its fields), so nothing a
+        rig accepts reaches the bound — but the audit row, not the rig, is what would lose."""
         try:
             with self._db_lock:
                 if not self._conn:
@@ -81,7 +118,7 @@ class WorkerConfigStoreMixin:
                         change_id,
                         ts if ts is not None else time.time(),
                         status,
-                        json.dumps(changes),
+                        json.dumps(strip_credentials(changes)),
                         reason,
                         change_type,
                     ),

--- a/dashboard/tests/service/test_worker_config_credentials.py
+++ b/dashboard/tests/service/test_worker_config_credentials.py
@@ -1,0 +1,141 @@
+"""Pool credentials must not survive into the ``worker_config`` record, or out of any read of it
+(#1543).
+
+``pools`` is on the worker writable allowlist and a pool entry carries ``pass``, so the operator's
+own POSTed ``changes`` used to be stored verbatim and served back on every load of that rig's
+Inspect view. The defence is in two places and this module pins both, because they close different
+halves and only together close the issue:
+
+* ``add_worker_config_version`` strips before the INSERT, so a credential stops landing in the DB
+  (and therefore in any backup of it) at all. The raw-column assertions below are the only ones
+  that can see that half -- every reader would look clean under the read-side strip alone.
+* ``_shaped`` strips on the way back out, which is what covers a row an OLDER build already wrote.
+  Those rows are still in the table under any fix, so without this half the disclosure survives a
+  deploy. ``_seed_legacy_row`` writes that shape on purpose, by going around the store's own
+  writer, and ``test_the_legacy_seed_really_carries_the_credential`` is the control proving the
+  seed armed -- a strip test whose fixture never held a credential passes for the wrong reason.
+
+``strip_credentials``' own shape-agnosticism is NOT re-proved here: it is already covered at the
+function's own unit (``tests/client/test_rigforge_config.py``, dict-shaped ``pools``, a credential
+nested one level deeper, and a depth-bomb). Re-testing it through a DB round-trip would prove the
+same behaviour at a more expensive tier.
+
+The narrowness assertions (``url``/``user``/``keepalive`` still present) are load-bearing rather
+than decorative: a strip that returned ``{}`` would pass every "the password is gone" assertion in
+this file.
+"""
+
+import json
+
+_PASSWORD = "s3cret-pool-password"
+_FINGERPRINT = "aa:bb:cc:dd"
+
+
+def _pools_with_credentials():
+    """The writable-key diff an operator POSTs when they edit a pool -- credentials and all."""
+    return {
+        "pools": [
+            {
+                "url": "pool.example:3333",
+                "user": "wallet.rig1",
+                "pass": _PASSWORD,
+                "tls-fingerprint": _FINGERPRINT,
+                "keepalive": True,
+            }
+        ],
+        "DONATION": 1,
+    }
+
+
+def _seed_legacy_row(state_manager, worker="rig1", change_id="chg-legacy", status="applied"):
+    """A row exactly as a build BEFORE this fix wrote it: the credential in the stored JSON.
+
+    Deliberately bypasses ``add_worker_config_version`` -- that writer now strips, so using it
+    could not produce the row this half of the fix exists to defend against.
+    """
+    state_manager._conn.execute(
+        "INSERT INTO worker_config (worker, change_id, ts, status, changes, reason, type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (worker, change_id, 1000.0, status, json.dumps(_pools_with_credentials()), None, "apply"),
+    )
+    state_manager._conn.commit()
+
+
+def _raw_changes(state_manager, worker="rig1"):
+    """The ``changes`` column as bytes-on-disk, never through ``_shaped``."""
+    cur = state_manager._conn.execute(
+        "SELECT changes FROM worker_config WHERE worker = ? ORDER BY id DESC LIMIT 1", (worker,)
+    )
+    return cur.fetchone()[0]
+
+
+class TestNothingCredentialShapedIsStored:
+    """The write half: the credential never reaches the DB, so it is not in a backup either."""
+
+    def test_the_stored_json_has_no_password(self, state_manager):
+        state_manager.add_worker_config_version(
+            "rig1", "chg-1", "applied", _pools_with_credentials(), None
+        )
+        raw = _raw_changes(state_manager)
+        assert _PASSWORD not in raw
+        assert _FINGERPRINT not in raw
+        assert "pass" not in json.loads(raw)["pools"][0]
+        assert "tls-fingerprint" not in json.loads(raw)["pools"][0]
+
+    def test_the_stored_json_keeps_everything_else(self, state_manager):
+        # Narrowness. A writer that stored `{}` would pass the test above and lose the audit row.
+        state_manager.add_worker_config_version(
+            "rig1", "chg-1", "applied", _pools_with_credentials(), None
+        )
+        stored = json.loads(_raw_changes(state_manager))
+        assert stored["DONATION"] == 1
+        assert stored["pools"][0] == {
+            "url": "pool.example:3333",
+            "user": "wallet.rig1",
+            "keepalive": True,
+        }
+
+    def test_the_callers_own_dict_is_not_mutated(self, state_manager):
+        # handle_worker_apply sends `changes` to the rig and passes the SAME object here. If the
+        # strip mutated in place, the ordering of those two calls would decide whether the pool
+        # password ever reached the pool -- a coupling nothing in either function declares.
+        changes = _pools_with_credentials()
+        state_manager.add_worker_config_version("rig1", "chg-1", "applied", changes, None)
+        assert changes["pools"][0]["pass"] == _PASSWORD
+        assert changes["pools"][0]["tls-fingerprint"] == _FINGERPRINT
+
+
+class TestRowsAnOlderBuildWroteAreNotServed:
+    """The read half: rows already in the table are stripped on the way out, no migration needed."""
+
+    def test_the_legacy_seed_really_carries_the_credential(self, state_manager):
+        # THE CONTROL. Everything below asserts an absence; this is the one assertion that proves
+        # the absence is the strip working rather than the seed never having armed.
+        _seed_legacy_row(state_manager)
+        assert _PASSWORD in _raw_changes(state_manager)
+        assert _FINGERPRINT in _raw_changes(state_manager)
+
+    def test_history_read_is_stripped(self, state_manager):
+        _seed_legacy_row(state_manager)
+        pool = state_manager.get_worker_config_history("rig1")[0]["changes"]["pools"][0]
+        assert "pass" not in pool
+        assert "tls-fingerprint" not in pool
+        assert pool["url"] == "pool.example:3333"
+
+    def test_exact_id_read_is_stripped(self, state_manager):
+        # get_worker_config_change is the OTHER row-returning read (#1369). It has its own query,
+        # so a strip bolted onto get_worker_config_history alone would miss it.
+        _seed_legacy_row(state_manager)
+        pool = state_manager.get_worker_config_change("rig1", "chg-legacy")["changes"]["pools"][0]
+        assert "pass" not in pool
+        assert "tls-fingerprint" not in pool
+        assert pool["user"] == "wallet.rig1"
+
+    def test_last_applied_prefill_is_stripped(self, state_manager):
+        # The field the issue names. It reads through get_worker_config_history, so it is covered
+        # by the same edit rather than by a second one.
+        _seed_legacy_row(state_manager)
+        merged = state_manager.get_last_applied_worker_config("rig1")
+        assert "pass" not in merged["pools"][0]
+        assert "tls-fingerprint" not in merged["pools"][0]
+        assert merged["DONATION"] == 1

--- a/dashboard/tests/web/test_worker_detail_credentials.py
+++ b/dashboard/tests/web/test_worker_detail_credentials.py
@@ -1,0 +1,104 @@
+"""No pool credential leaves the Worker Inspect payload, in ANY of the fields that carry a
+``worker_config`` row's ``changes`` (#1543).
+
+The issue this closes named ``last_applied``, and that field really did serve the password. It was
+not the only one: ``build_worker_detail`` publishes the same rows' ``changes`` THREE times --
+``last_applied`` (the merge), ``history`` (the rendered table), and
+``hashrate_history.markers[]`` (the chart tooltips, #1015). A fix at
+``get_last_applied_worker_config`` would have cleaned the field the issue named and left the other
+two serving the credential, with nothing going red.
+
+So the load-bearing assertion here is deliberately NOT a per-field one:
+``test_no_credential_anywhere_in_the_serialized_payload`` scans the whole rendered payload, which
+is the only form of the check that does not depend on my having enumerated the fields correctly.
+The per-field tests are underneath it to say WHERE, so a future regression names itself.
+
+Every test seeds the row the way a build before the fix wrote it -- the credential in the stored
+JSON, inserted around the store's own writer, since that writer now strips.
+``test_the_seed_really_carries_the_credential`` is the control that the seed armed.
+"""
+
+import json
+import time
+
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.worker_detail import build_worker_detail
+
+_PASSWORD = "s3cret-pool-password"
+_FINGERPRINT = "aa:bb:cc:dd"
+
+
+def _seed_and_build(monkeypatch, *, ts=None):
+    """A rig whose one applied change carried a pool password, as an older build stored it."""
+    from mining_dashboard.web import views
+
+    monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "r1"}])
+    monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+    sm = StateManager(db_path=":memory:")
+    changes = {
+        "pools": [
+            {
+                "url": "pool.example:3333",
+                "user": "wallet.rig1",
+                "pass": _PASSWORD,
+                "tls-fingerprint": _FINGERPRINT,
+            }
+        ]
+    }
+    sm._conn.execute(
+        "INSERT INTO worker_config (worker, change_id, ts, status, changes, reason, type) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("rig1", "chg-1", ts or time.time(), "applied", json.dumps(changes), None, "apply"),
+    )
+    sm._conn.commit()
+    try:
+        detail = build_worker_detail(
+            "rig1", {"workers": [{"name": "rig1", "status": "online"}]}, sm
+        )
+        raw = sm._conn.execute("SELECT changes FROM worker_config").fetchone()[0]
+        return detail, raw
+    finally:
+        sm.close()
+
+
+class TestNoCredentialInTheInspectPayload:
+    def test_the_seed_really_carries_the_credential(self, monkeypatch):
+        # THE CONTROL. Every other assertion in this module is an absence; this is what separates
+        # "the strip works" from "the fixture never held a password in the first place".
+        _detail, raw = _seed_and_build(monkeypatch)
+        assert _PASSWORD in raw
+        assert _FINGERPRINT in raw
+
+    def test_no_credential_anywhere_in_the_serialized_payload(self, monkeypatch):
+        # The assertion that does not trust my own list of fields. If a future change publishes a
+        # row's `changes` through a FOURTH field, this fails and the per-field tests below do not.
+        detail, _raw = _seed_and_build(monkeypatch)
+        blob = json.dumps(detail, default=str)
+        assert _PASSWORD not in blob
+        assert _FINGERPRINT not in blob
+        # Narrowness: an empty payload would pass the two lines above.
+        assert "pool.example:3333" in blob
+
+    def test_last_applied_is_clean(self, monkeypatch):
+        detail, _raw = _seed_and_build(monkeypatch)
+        pool = detail["last_applied"]["pools"][0]
+        assert "pass" not in pool
+        assert "tls-fingerprint" not in pool
+        assert pool["user"] == "wallet.rig1"
+
+    def test_the_history_rows_are_clean(self, monkeypatch):
+        # The field the issue did not name. `history` is the rendered change table.
+        detail, _raw = _seed_and_build(monkeypatch)
+        pool = detail["history"][0]["changes"]["pools"][0]
+        assert "pass" not in pool
+        assert "tls-fingerprint" not in pool
+
+    def test_the_chart_markers_are_clean(self, monkeypatch):
+        # The other field the issue did not name. markerLabel only renders the KEY names, so
+        # nothing on screen ever showed this -- but the values still crossed the wire.
+        detail, _raw = _seed_and_build(monkeypatch)
+        markers = detail["hashrate_history"]["markers"]
+        assert markers, "the seeded row must reach the markers list, or this proves nothing"
+        pool = markers[0]["changes"]["pools"][0]
+        assert "pass" not in pool
+        assert "tls-fingerprint" not in pool

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -513,6 +513,12 @@ How it stays safe:
   editor renders it as a blank password field, never as JSON you could copy or mangle; leave it
   blank to keep it, type a value to replace it. the config tab's Advanced pane carries the sentinel
   through untouched unless you edit that key yourself.
+- **The pool password is not kept.** `pools` is editable and a pool entry carries the stratum
+  password, so the change record could hold one in plain text. It doesn't: the password and the TLS
+  fingerprint are stripped out of the record before it is written, and stripped again out of every
+  read of it — so a history written by an older build stops handing them back the moment you
+  upgrade, without anything having to rewrite the database. The password still reaches the rig; it
+  travels with the change itself. What the dashboard declines to do is keep its own copy.
 
 RigForge keeps no config history on the rig, so Pithead owns it: every change the dashboard applies is
 recorded with its keys, outcome, and time. Because the rig's enriched feed doesn't expose the writable


### PR DESCRIPTION
Closes #1543.

`pools` is on the worker writable allowlist and a pool entry carries `pass`, so an operator's POSTed `changes` was stored verbatim in `worker_config.changes` and served back on every load of that rig's Inspect view — through a restart, and into any backup of the DB.

## The remedy the issue names is a no-op, and the issue is mine

I wrote that body. It says `mask_secrets` "is not applied on this path", which is true, and invites a fix that changes nothing while looking correct. Measured with controls and posted as comment 5464995965: every `SECRET_PATHS` entry is rooted in the **host** config, a `last_applied` merge is `WORKER_WRITABLE_KEYS` only, and **the two root sets do not intersect at all**. A test asserting `mask_secrets` was called here goes green with the password still on the wire.

The instrument that works is `strip_credentials`, already used on the rig-read path. It drops `pass` and `tls-fingerprint` at any depth in any container shape, and **deletes** rather than substituting a sentinel — which is what a prefill that can be POSTed back needs, since an operator saving a sentinel-filled form would write the sentinel over the real password.

## Where the strip goes was the whole decision — and the issue points at the wrong place

**The Inspect payload carries a row's `changes` in THREE fields, not the one the issue names:** `last_applied` (the merge), `history` (the rendered change table), and `hashrate_history.markers[]` (the chart tooltips, #1015).

A fix at `get_last_applied_worker_config` — where the issue's own text points, and where my posted comment ranked it first — would have cleaned the named field and **left the other two serving the credential, with nothing going red.** That is why `_shaped` is the chokepoint rather than a stylistic preference: it is the one point both row-returning reads (`get_worker_config_history` and `get_worker_config_change`) pass through, so it is the single edit that covers every consumer, including ones nobody has written yet.

Two call sites, closing different halves:

- **`add_worker_config_version`** strips before the INSERT, so a credential stops landing in the DB. Its docstring claimed *"no secret ever lands here"* — a property it did not have, stated as if it did, which is part of why the gap survived being read. Corrected in place rather than deleted.
- **`_shaped`** strips on the way out. This is what makes a row an **older build already wrote** safe: those rows stay in the table under any fix, so without this half the disclosure survives a deploy. No migration needed.

The password still reaches the rig: `handle_worker_apply` sends the operator's unmodified `changes` before recording, and `strip_credentials` builds new containers rather than mutating, so the caller's dict is untouched. What changes is only what this dashboard keeps afterwards.

## ⛔ A disclosed conflict CI cannot see — read before merging

`tests/integration/rigforge-writable-keys.sh:176` restores a borrowed rig's pools from `.last_applied.pools`, and its own comment at line 182 says it does so **because that value still carries `pass`**. `tests/integration/selftest-rigforge-writable-keys.sh:307` asserts `"the restore uses last_applied, credential intact"`. This change removes that credential.

The failure mode is the worst one available. The leg's skip triggers on pools being **empty**; mine is non-empty and merely password-**less**, so it does not skip — it applies a password-less pools config to a real miner, which `docs/dev/integration-testing.md` says the proxy rejects a login without.

**CI cannot see this.** `selftest-rigforge-writable-keys.sh` overrides `_worker_detail` to echo a hardcoded `STUB_DETAIL` string, so it never reaches a real dashboard and stays green either way. Blast radius is narrow: the leg only runs when an operator sets `IT_RIG_POOLS_PROBE` against a real rig, so it is opt-in rather than every e2e run.

**The finding inside the finding, and the strongest argument for this fix:** the harness restores from `last_applied` *because the credential is stored there in plaintext*. The defect had become load-bearing for a test. That is what a plaintext credential does if it sits long enough, and it is a better justification than the hazard being unfired.

Routed to the controller, which is sequencing the harness change first: the leg's guard moves from "pools is empty" to "pools carries a usable credential" — testing `pass` explicitly. That predicate gap is a defect in the leg independent of this PR, and fixing it removes the ordering dependency entirely. `IT_RIG_POOLS_RESTORE`, symmetric with the probe the leg already requires, then follows as the real fix. `tests/integration/` is not this lane's path.

## Evidence

- **Full suite: 2201 passed, 0 failed.** No existing Python test depended on the credential being retained.
- **12 new tests**, service and web tier. The load-bearing web assertion scans the **whole serialized payload** rather than named fields, so it does not depend on my having enumerated the surfaces correctly — if a future change publishes `changes` through a fourth field, it fails and the per-field tests do not.
- **Both seeds are controlled.** Each module has a test proving the seeded row really carried the credential, because a strip test whose fixture never held one passes for the wrong reason. Narrowness assertions (`url`/`user`/`keepalive` survive) are load-bearing too: a strip returning `{}` would pass every "the password is gone" assertion.
- **Seeded-defect battery 2/2 KILLED** (`mutate-1543.py`): removing the read-side strip reds 7 tests, removing the write-side strip reds 2. Both halves are independently necessary and independently proven. The harness refuses a pattern that does not match exactly once, proves the mutation is on disk before running, and verifies the restore by sha256.
- **Coverage:** dashboard total 97% (bar 80%). All three added executable lines are outside the coverage-missing set, cross-checked mechanically against the diff rather than by eye. I did **not** run `make test-patch-coverage` — #1537 is open, so its rc is vacuous on a develop-v2 PR; saying which one I ran matters more than the rc.
- `ruff check` / `ruff format --check` clean, `make lint-docs-voice` clean, `make lint-file-budget` clean. All three touched files are under 400 lines and correctly take no budget row. `make lint-sh` skipped — no shell files in the diff.

## Disclosed consequence

The strip stops walking past `_MAX_CONFIG_DEPTH` (6) and returns `None` below it, so a `changes` nested deeper than that is **recorded** truncated. A writable config is three deep at most (`pools` → a pool → its fields), so nothing a rig accepts reaches the bound — but the audit row, not the rig, is what would lose.

Rows already written keep their plaintext at rest; the read-side strip stops them being served. The issue's own check of the one real database found zero instances, so a scrubbing migration would rewrite something demonstrably absent. Filing one is a reasonable follow-up if belt-and-braces is wanted.

## What the over-engineering pass changed

The PR-create gate asked for a review for over-engineering, so I ran one on my own diff rather than clearing it by pressing the button twice. It found one real thing and I cut it: a three-case parametrized class re-proving that `strip_credentials` is shape-agnostic (dict-shaped `pools`, a credential nested one level deeper, one under a different key). That behaviour is **already** covered at the function's own unit — `tests/client/test_rigforge_config.py:64` tests those exact shapes plus a depth-bomb — so re-testing it through a DB round-trip proved the same behaviour at a more expensive tier, against this repo's "test each behaviour once, at the lowest tier that proves it honestly" rule. Removing it took the battery's write-side row from 5 kills to 2, which is exactly the three tests removed and confirms they carried no independent signal. A pointer to where shape-agnosticism *is* proved now sits in the test module's docstring, so a reader does not conclude it went unproved.

I kept two things a stricter pass might also flag, with reasons. The **two** strip call sites are not redundant: read-side alone leaves plaintext at rest and in backups, write-side alone leaves rows an older build wrote — the battery kills each independently. The **per-field** web tests are partly redundant with the whole-payload scan, but they say *where*, so a future regression names itself instead of only failing a blanket assertion.

## Still owed

**An independent security pass.** This is the credential surface and I cannot self-serve it. A controller pass is explicitly not independent under DECISIONS item 14.
