### PR TITLE
fix(hugepages): bound the appliance's HugePages pool with a declared ceiling (#1103)

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -417,7 +417,8 @@ no LAN exposure, no firewall rule, no Tor hop.
 XMRig, so answering yes to "Mine on this machine too?" in the setup wizard is the whole job:
 pithead renders the miner's configuration (pool, stratum password, the stack's HugePages
 headroom, and a ceiling on how large the HugePages pool may grow), runs RigForge's setup in its
-appliance mode after the stack is up, and repeats that on every boot — the miner's service lives in `/run` and is re-created each time, like every other
+appliance mode after the stack is up, and repeats that on every boot — the miner's service lives
+in `/run` and is re-created each time, like every other
 derived thing on the appliance. The worker appears in the dashboard's Workers Alive table; toggle
 `local_miner.enabled` from the dashboard's configuration view to turn it off or on again. The
 rest of this section is the DIY flow.

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -415,9 +415,9 @@ no LAN exposure, no firewall rule, no Tor hop.
 
 **On the appliance, this is built in.** The image carries a pinned RigForge tree and a prebuilt
 XMRig, so answering yes to "Mine on this machine too?" in the setup wizard is the whole job:
-pithead renders the miner's configuration (pool, stratum password, and the stack's HugePages
-headroom), runs RigForge's setup in its appliance mode after the stack is up, and repeats that on
-every boot — the miner's service lives in `/run` and is re-created each time, like every other
+pithead renders the miner's configuration (pool, stratum password, the stack's HugePages
+headroom, and a ceiling on how large the HugePages pool may grow), runs RigForge's setup in its
+appliance mode after the stack is up, and repeats that on every boot — the miner's service lives in `/run` and is re-created each time, like every other
 derived thing on the appliance. The worker appears in the dashboard's Workers Alive table; toggle
 `local_miner.enabled` from the dashboard's configuration view to turn it off or on again. The
 rest of this section is the DIY flow.

--- a/lib/pithead/14-local-miner.sh
+++ b/lib/pithead/14-local-miner.sh
@@ -74,11 +74,18 @@ local_miner_hugepages_blocked() {
 #               the miner would get nothing beyond the boot pool — a cap that reads as a cap and
 #               silently switches the reservation off.
 #   >= 8592 MB  required on the supported machine is the fallback branch (the appliance reserves no
-#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2
-#               = 1168 + 6 + 50 + 3072 = 4296 pages. Below this the cap would bite on a HEALTHY box.
+#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2.
+#               ⛔ THAT BOUND IS NOT A CONSTANT — IT CARRIES A NODE COUNT, and 8592 is only its
+#               NUMA=1 evaluation (1168*1 + 6 + 50 + 3072 = 4296 pages). The node term is the only
+#               one that scales: EXTRA_2MB_PAGES does not (proposed-grub.sh L85-88). At NUMA=2 the
+#               requirement is 5464 pages = 10,928 MB and a 4608-page ceiling would cap a HEALTHY
+#               box 856 pages short; at NUMA=4, 7800 pages, short by 3192. RigForge caps and
+#               continues, so that under-reservation would be SILENT — the same failure direction
+#               the version gate below exists to avoid. This is why the value is gated on a
+#               detected single node (local_miner_numa_nodes) and not merely documented as one.
 #   <  11236 MB the contended landing measured above, 5618 pages. At or above it the ceiling would
 #               never bind and the over-reserve would survive the fix.
-# 4608 pages clears all three, with 312 pages of slack over required.
+# 4608 pages clears all three AT ONE NODE, with 312 pages of slack over required.
 #
 # NOT the guest's 4322: that reading is a KVM artifact (4 vCPUs presented as 4 sockets -> L3 64 MiB
 # -> THREADS 32). The same physical X5690 reports one 12 MiB L3 -> THREADS 6. Immaterial to the
@@ -98,6 +105,31 @@ readonly PITHEAD_HUGEPAGES_POOL_CEILING_MB=9216
 # is worse than one that plainly is not, so declare it only where it is honoured.
 readonly PITHEAD_RIGFORGE_POOL_CEILING_FLOOR=1.16.0
 
+# The node count the ceiling is valid for. MIRRORS RigForge's OWN precedence, step for step
+# (util/proposed-grub.sh L52-61 at the pinned ref), and that fidelity is the whole point: this
+# function exists to PREDICT the node count rigforge will size against, so any disagreement between
+# the two reintroduces the very defect the gate is here to stop — quietly, and in the silent
+# direction. Three steps, not two: lscpu's "NUMA node(s)", then the sysfs node count, then THE
+# SOCKET COUNT, then 1. The socket fallback is not hypothetical padding — the #1103 bench guest
+# reports Socket(s)=4 with NUMA node(s)=1, so a mirror that stopped at sysfs would read 1 where
+# rigforge read 4. rigforge's own L48-50 says the same thing from the other side: node count is not
+# socket count, and a single-socket EPYC can expose 2/4/8 nodes.
+# Prints its answer, so it must call nothing that writes to stdout.
+local_miner_numa_nodes() {
+    local n
+    n=$(lscpu 2>/dev/null | awk -F: '/^NUMA node\(s\):/ {gsub(/[^0-9]/, "", $2); print $2; exit}')
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=$(find "${PITHEAD_NODE_SYS:-/sys/devices/system/node}" -maxdepth 1 -name 'node[0-9]*' 2>/dev/null | wc -l | tr -d ' ')
+    fi
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=$(lscpu 2>/dev/null | awk '/Socket\(s\):/ {print $2; exit}')
+    fi
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=1
+    fi
+    echo "$n"
+}
+
 # The ceiling this machine may declare, in MB, or 0 for "declare nothing" — 0 is RigForge's own
 # documented default for "no ceiling", so an omitted key and a declared 0 mean the same to it.
 # Prints its answer, so it must never call log (stdout); warn goes to stderr and is safe here.
@@ -113,6 +145,20 @@ local_miner_pool_ceiling_mb() {
         echo 0
         return 0
     }
+    # ONE NODE ONLY — the regime 9216 was measured on. RigForge's requirement carries a 1168-page
+    # term PER NUMA NODE, so on a multi-node box this ceiling would sit BELOW a healthy requirement
+    # and rigforge would cap the write and carry on: a silent under-reservation, which is the same
+    # failure direction the version gate refuses. Left uncapped instead, which is exactly today's
+    # behaviour. Deliberately NOT a render-time recomputation of rigforge's formula: that would put
+    # a copy of their sizing inside pithead that must stay correct across their releases, and it
+    # needs THREADS (L3_MB/2, then THREADS_CAP) which pithead does not model at all.
+    local nodes
+    nodes=$(local_miner_numa_nodes)
+    if [ "$nodes" != 1 ]; then
+        warn "This machine reports $nodes NUMA nodes and the HugePages pool ceiling was measured on a single-node box — leaving the pool uncapped rather than capping it below a healthy requirement."
+        echo 0
+        return 0
+    fi
     # The tree that will actually RUN, not the image's stamp: pithead-sync copies /opt/rigforge to
     # /data/rigforge every boot, and it is the copy under $dir whose parse_config reads this key.
     ver=$(tr -d ' \t\r\n' <"$dir/VERSION" 2>/dev/null) || ver=""

--- a/lib/pithead/14-local-miner.sh
+++ b/lib/pithead/14-local-miner.sh
@@ -52,6 +52,88 @@ local_miner_hugepages_blocked() {
     [ "$pages" -gt 0 ] && [ "$pages" -lt "$PITHEAD_HUGEPAGES" ]
 }
 
+# --- #1103: the total-pool CEILING, the other half of the hand-off -----------------------------
+# hugepages_reserve_extra_mb tells RigForge what the stack HOLDS; this tells it how large the pool
+# may ever GET. Different levers, and only the second one bounds the measured defect. RigForge's
+# grow-only write is target = current + required - avail, and a co-resident holding pages at that
+# instant is subtracted from avail while the same pages already sit inside required — so they are
+# counted twice and the pool is inflated by exactly the amount held.
+#
+# MEASURED, not reasoned (~/appliance-suite-logs/1103/RESULTS.md, two KVM legs on a 16 GiB guest):
+# THE DOUBLE COUNT IS A RACE, NOT A CONSTANT. p2pool holds 1296 pages for ~6 s while it allocates
+# its RandomX dataset; the sync gate then stops it and it releases them. If RigForge's setup lands
+# inside that window the pool goes to 5618 pages and STAYS there until the next reboot; outside it,
+# 4322. Two consecutive boots of one image gave both numbers. That is why the fix is a ceiling and
+# not a re-ordering of the units: re-ordering would make the common case correct and leave the
+# failure intact under load, while a ceiling bounds the pool whoever wins the race.
+#
+# WHY 9216 MB (4608 pages) — the three bounds it has to sit between, each re-derived from rigforge's
+# own util/proposed-grub.sh at the pinned commit rather than taken from the issue text:
+#   > 6144 MB   _ensure_hugepages SKIPS THE WRITE ENTIRELY when ceiling_pages <= current, and the
+#               full tier's current is PITHEAD_HUGEPAGES = 3072 pages = 6144 MB. At or below that
+#               the miner would get nothing beyond the boot pool — a cap that reads as a cap and
+#               silently switches the reservation off.
+#   >= 8592 MB  required on the supported machine is the fallback branch (the appliance reserves no
+#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2
+#               = 1168 + 6 + 50 + 3072 = 4296 pages. Below this the cap would bite on a HEALTHY box.
+#   <  11236 MB the contended landing measured above, 5618 pages. At or above it the ceiling would
+#               never bind and the over-reserve would survive the fix.
+# 4608 pages clears all three, with 312 pages of slack over required.
+#
+# NOT the guest's 4322: that reading is a KVM artifact (4 vCPUs presented as 4 sockets -> L3 64 MiB
+# -> THREADS 32). The same physical X5690 reports one 12 MiB L3 -> THREADS 6. Immaterial to the
+# ceiling, wrong to quote as the requirement.
+#
+# THIS VALUE AND hugepages_reserve_extra_mb MOVE TOGETHER: extra_mb contributes (extra_mb+1)/2 =
+# 3072 of those 4296 required pages, so raising the declared headroom raises required toward the
+# ceiling and would eventually make the cap bite on a healthy box. Re-derive both if
+# PITHEAD_HUGEPAGES changes.
+readonly PITHEAD_HUGEPAGES_POOL_CEILING_MB=9216
+
+# The RigForge release that first honours the key. VERSION-GATED because the failure is SILENT in
+# the worse direction: rigforge's _warn_unknown_config_keys warns and never errors on a key it does
+# not know ("an unknown key is at worst a no-op, and erroring would brick fleet applies on any
+# future rename"), so declaring the ceiling into an older tree FAILS OPEN — the rendered config
+# would read as capped and behave exactly as it does today. A config that lies about being bounded
+# is worse than one that plainly is not, so declare it only where it is honoured.
+readonly PITHEAD_RIGFORGE_POOL_CEILING_FLOOR=1.16.0
+
+# The ceiling this machine may declare, in MB, or 0 for "declare nothing" — 0 is RigForge's own
+# documented default for "no ceiling", so an omitted key and a declared 0 mean the same to it.
+# Prints its answer, so it must never call log (stdout); warn goes to stderr and is safe here.
+local_miner_pool_ceiling_mb() {
+    local dir=$1 ver
+    # THE FULL TIER ONLY — the one tier the value was measured on. The reduced tier never reaches
+    # here (local_miner_hugepages_blocked refuses it outright, and leg B measured why: lifting that
+    # refusal asks for 12.0 GiB on a 7.76 GiB box, the kernel silently grants 5.7 GiB, MemAvailable
+    # falls to ~40 MB and RigForge still exits 0 saying "Deployment Complete"). The RELEASED tier
+    # declares zero headroom and holds no stack pages, so it has nothing to double-count and no
+    # measurement behind any value — it stays uncapped rather than guessing one.
+    [ "$(hugepages_decision_pages)" = "$PITHEAD_HUGEPAGES" ] || {
+        echo 0
+        return 0
+    }
+    # The tree that will actually RUN, not the image's stamp: pithead-sync copies /opt/rigforge to
+    # /data/rigforge every boot, and it is the copy under $dir whose parse_config reads this key.
+    ver=$(tr -d ' \t\r\n' <"$dir/VERSION" 2>/dev/null) || ver=""
+    # Fail CLOSED on anything not a plain dotted number. sort -V happily orders an unparseable
+    # string against a version and would answer "new enough" for a tree that is nothing of the kind.
+    case "$ver" in
+    '' | *[!0-9.]*)
+        warn "Could not read a RigForge version from $dir/VERSION — leaving the HugePages pool uncapped."
+        echo 0
+        return 0
+        ;;
+    esac
+    if [ "$(printf '%s\n%s\n' "$PITHEAD_RIGFORGE_POOL_CEILING_FLOOR" "$ver" | sort -V | head -n 1)" \
+        != "$PITHEAD_RIGFORGE_POOL_CEILING_FLOOR" ]; then
+        warn "RigForge $ver at $dir predates $PITHEAD_RIGFORGE_POOL_CEILING_FLOOR and ignores the HugePages pool ceiling — leaving the pool uncapped rather than writing a cap it would not honour."
+        echo 0
+        return 0
+    fi
+    echo "$PITHEAD_HUGEPAGES_POOL_CEILING_MB"
+}
+
 render_local_miner_config() {
     is_appliance || return 0
     # Not on a rig, ever. This function's "switched off" branch DELETES the miner's config, and
@@ -77,11 +159,14 @@ render_local_miner_config() {
         warn "Local mining is on, but there is no RigForge tree at $dir — this image does not carry the built-in miner."
         return 0
     fi
-    local port secret
+    local port secret ceiling
     port=$(stratum_port_effective)
     secret=$(env_get PROXY_STRATUM_PASSWORD 2>/dev/null || true)
+    ceiling=$(local_miner_pool_ceiling_mb "$dir")
     jq -n --arg url "127.0.0.1:$port" --arg pass "$secret" --argjson reserve "$(($(hugepages_decision_pages) * 2))" \
-        '{pools: [({url: $url} + (if $pass != "" then {pass: $pass} else {} end))], hugepages_reserve_extra_mb: $reserve}' \
+        --argjson ceiling "$ceiling" \
+        '{pools: [({url: $url} + (if $pass != "" then {pass: $pass} else {} end))], hugepages_reserve_extra_mb: $reserve}
+         + (if $ceiling > 0 then {hugepages_pool_ceiling_mb: $ceiling} else {} end)' \
         >"$dir/config.json"
     log "Local miner config rendered to $dir/config.json (pool 127.0.0.1:$port)."
 }

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -262,11 +262,21 @@ the tree it is handing the file to and declares nothing when it cannot confirm t
 
 It is declared only on the full tier, too. The reduced tier still refuses co-location outright, and
 the bench measured why that refusal should stay: lifting it by hand had RigForge ask for 6146 pages
-(12.0 GiB) on a 7.76 GiB box, the kernel granted 356 of them, available memory fell to about 40 MB,
+(12.0 GiB) on a 7.76 GiB box, the kernel grew the pool from 2560 pages to 2916 — 356 new pages of
+the 3586 it was asked to add — available memory fell to about 40 MB,
 and RigForge exited zero reporting a completed deployment. Nothing on the box named the shortfall.
 There is no ceiling value that helps on that tier — anything at or below 5120 MB is at or under the
 pool the boot already sized, so nothing is written at all, and anything above it is drawn from the
 roughly 700 MB the machine has spare.
+
+The ceiling is a single-node value, and the render checks for that too. RigForge sizes the
+fallback reservation as `1168 * nodes + threads + 50 + headroom`, where only the first term scales
+with the machine's NUMA node count. On a two-node box the requirement is 5464 pages — above the
+9216 MB ceiling — so declaring it there would cap a healthy machine short, and RigForge caps the
+write and carries on rather than failing, which would make the shortfall silent. The render reads
+the node count the same way RigForge does, preferring `lscpu`, then the kernel's own node entries,
+then the socket count, and declares nothing when it reads more than one node. Node count is not
+socket count in either direction: the bench guest reports four sockets and one node.
 
 **Still open on #1103:** whether a co-located miner on a reduced-RAM box mines usefully or thrashes
 is unanswered. Answering it needs synced chains rather than another KVM guest, because the sync gate

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -244,6 +244,34 @@ the `/run` marker records the chosen page count and both of them honour it — s
 kernel optimization caps its grow at the recorded pages, and the local-miner render
 hands RigForge the recorded reservation, never the baked 6 GiB, as its headroom.
 
+**Fixed — a boot-time race could reserve 11 GiB of HugePages on a 16 GiB machine (#1103).**
+The miner's config declares the stack's reservation as headroom, and RigForge sizes the pool as
+`current + required - available`. A co-resident holding pages at that instant is subtracted from
+available while the same pages already sit inside required, so they are counted twice. Measured on
+the bench: p2pool holds 1296 pages for about six seconds while it allocates its RandomX dataset,
+the sync gate then stops it and it releases them. Whether the box over-reserves depends on whether
+RigForge's setup lands inside that window — two consecutive boots of one image gave 5618 pages and
+4322 pages, each persisting until the next reboot. The render now declares a pool ceiling of
+9216 MB alongside the headroom, which bounds the pool whoever wins the race. Re-ordering the units
+was rejected: it would make the common case correct and leave the failure intact under load.
+
+The ceiling is declared only where it is honoured. RigForge ignores a config key it does not know,
+warning rather than failing, so declaring the ceiling into a tree older than v1.16.0 would leave a
+configuration that reads as bounded and behaves as it did before. The render reads the version of
+the tree it is handing the file to and declares nothing when it cannot confirm the floor.
+
+It is declared only on the full tier, too. The reduced tier still refuses co-location outright, and
+the bench measured why that refusal should stay: lifting it by hand had RigForge ask for 6146 pages
+(12.0 GiB) on a 7.76 GiB box, the kernel granted 356 of them, available memory fell to about 40 MB,
+and RigForge exited zero reporting a completed deployment. Nothing on the box named the shortfall.
+There is no ceiling value that helps on that tier — anything at or below 5120 MB is at or under the
+pool the boot already sized, so nothing is written at all, and anything above it is drawn from the
+roughly 700 MB the machine has spare.
+
+**Still open on #1103:** whether a co-located miner on a reduced-RAM box mines usefully or thrashes
+is unanswered. Answering it needs synced chains rather than another KVM guest, because the sync gate
+holds the stratum the miner dials.
+
 **Fixed — a restored coordinator strands dark instead of provisioning itself (#1239).**
 Live KVM guest evidence: `pithead-firstboot` lands a restored archive (`consume_preseed_restore`
 or the wizard's spool channel) and calls `setup()`, but the archive's `.env` is the SOURCE

--- a/pithead
+++ b/pithead
@@ -3206,11 +3206,18 @@ local_miner_hugepages_blocked() {
 #               the miner would get nothing beyond the boot pool — a cap that reads as a cap and
 #               silently switches the reservation off.
 #   >= 8592 MB  required on the supported machine is the fallback branch (the appliance reserves no
-#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2
-#               = 1168 + 6 + 50 + 3072 = 4296 pages. Below this the cap would bite on a HEALTHY box.
+#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2.
+#               ⛔ THAT BOUND IS NOT A CONSTANT — IT CARRIES A NODE COUNT, and 8592 is only its
+#               NUMA=1 evaluation (1168*1 + 6 + 50 + 3072 = 4296 pages). The node term is the only
+#               one that scales: EXTRA_2MB_PAGES does not (proposed-grub.sh L85-88). At NUMA=2 the
+#               requirement is 5464 pages = 10,928 MB and a 4608-page ceiling would cap a HEALTHY
+#               box 856 pages short; at NUMA=4, 7800 pages, short by 3192. RigForge caps and
+#               continues, so that under-reservation would be SILENT — the same failure direction
+#               the version gate below exists to avoid. This is why the value is gated on a
+#               detected single node (local_miner_numa_nodes) and not merely documented as one.
 #   <  11236 MB the contended landing measured above, 5618 pages. At or above it the ceiling would
 #               never bind and the over-reserve would survive the fix.
-# 4608 pages clears all three, with 312 pages of slack over required.
+# 4608 pages clears all three AT ONE NODE, with 312 pages of slack over required.
 #
 # NOT the guest's 4322: that reading is a KVM artifact (4 vCPUs presented as 4 sockets -> L3 64 MiB
 # -> THREADS 32). The same physical X5690 reports one 12 MiB L3 -> THREADS 6. Immaterial to the
@@ -3230,6 +3237,31 @@ readonly PITHEAD_HUGEPAGES_POOL_CEILING_MB=9216
 # is worse than one that plainly is not, so declare it only where it is honoured.
 readonly PITHEAD_RIGFORGE_POOL_CEILING_FLOOR=1.16.0
 
+# The node count the ceiling is valid for. MIRRORS RigForge's OWN precedence, step for step
+# (util/proposed-grub.sh L52-61 at the pinned ref), and that fidelity is the whole point: this
+# function exists to PREDICT the node count rigforge will size against, so any disagreement between
+# the two reintroduces the very defect the gate is here to stop — quietly, and in the silent
+# direction. Three steps, not two: lscpu's "NUMA node(s)", then the sysfs node count, then THE
+# SOCKET COUNT, then 1. The socket fallback is not hypothetical padding — the #1103 bench guest
+# reports Socket(s)=4 with NUMA node(s)=1, so a mirror that stopped at sysfs would read 1 where
+# rigforge read 4. rigforge's own L48-50 says the same thing from the other side: node count is not
+# socket count, and a single-socket EPYC can expose 2/4/8 nodes.
+# Prints its answer, so it must call nothing that writes to stdout.
+local_miner_numa_nodes() {
+    local n
+    n=$(lscpu 2>/dev/null | awk -F: '/^NUMA node\(s\):/ {gsub(/[^0-9]/, "", $2); print $2; exit}')
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=$(find "${PITHEAD_NODE_SYS:-/sys/devices/system/node}" -maxdepth 1 -name 'node[0-9]*' 2>/dev/null | wc -l | tr -d ' ')
+    fi
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=$(lscpu 2>/dev/null | awk '/Socket\(s\):/ {print $2; exit}')
+    fi
+    if ! { [ -n "$n" ] && [ "$n" -gt 0 ]; } 2>/dev/null; then
+        n=1
+    fi
+    echo "$n"
+}
+
 # The ceiling this machine may declare, in MB, or 0 for "declare nothing" — 0 is RigForge's own
 # documented default for "no ceiling", so an omitted key and a declared 0 mean the same to it.
 # Prints its answer, so it must never call log (stdout); warn goes to stderr and is safe here.
@@ -3245,6 +3277,20 @@ local_miner_pool_ceiling_mb() {
         echo 0
         return 0
     }
+    # ONE NODE ONLY — the regime 9216 was measured on. RigForge's requirement carries a 1168-page
+    # term PER NUMA NODE, so on a multi-node box this ceiling would sit BELOW a healthy requirement
+    # and rigforge would cap the write and carry on: a silent under-reservation, which is the same
+    # failure direction the version gate refuses. Left uncapped instead, which is exactly today's
+    # behaviour. Deliberately NOT a render-time recomputation of rigforge's formula: that would put
+    # a copy of their sizing inside pithead that must stay correct across their releases, and it
+    # needs THREADS (L3_MB/2, then THREADS_CAP) which pithead does not model at all.
+    local nodes
+    nodes=$(local_miner_numa_nodes)
+    if [ "$nodes" != 1 ]; then
+        warn "This machine reports $nodes NUMA nodes and the HugePages pool ceiling was measured on a single-node box — leaving the pool uncapped rather than capping it below a healthy requirement."
+        echo 0
+        return 0
+    fi
     # The tree that will actually RUN, not the image's stamp: pithead-sync copies /opt/rigforge to
     # /data/rigforge every boot, and it is the copy under $dir whose parse_config reads this key.
     ver=$(tr -d ' \t\r\n' <"$dir/VERSION" 2>/dev/null) || ver=""

--- a/pithead
+++ b/pithead
@@ -3184,6 +3184,88 @@ local_miner_hugepages_blocked() {
     [ "$pages" -gt 0 ] && [ "$pages" -lt "$PITHEAD_HUGEPAGES" ]
 }
 
+# --- #1103: the total-pool CEILING, the other half of the hand-off -----------------------------
+# hugepages_reserve_extra_mb tells RigForge what the stack HOLDS; this tells it how large the pool
+# may ever GET. Different levers, and only the second one bounds the measured defect. RigForge's
+# grow-only write is target = current + required - avail, and a co-resident holding pages at that
+# instant is subtracted from avail while the same pages already sit inside required — so they are
+# counted twice and the pool is inflated by exactly the amount held.
+#
+# MEASURED, not reasoned (~/appliance-suite-logs/1103/RESULTS.md, two KVM legs on a 16 GiB guest):
+# THE DOUBLE COUNT IS A RACE, NOT A CONSTANT. p2pool holds 1296 pages for ~6 s while it allocates
+# its RandomX dataset; the sync gate then stops it and it releases them. If RigForge's setup lands
+# inside that window the pool goes to 5618 pages and STAYS there until the next reboot; outside it,
+# 4322. Two consecutive boots of one image gave both numbers. That is why the fix is a ceiling and
+# not a re-ordering of the units: re-ordering would make the common case correct and leave the
+# failure intact under load, while a ceiling bounds the pool whoever wins the race.
+#
+# WHY 9216 MB (4608 pages) — the three bounds it has to sit between, each re-derived from rigforge's
+# own util/proposed-grub.sh at the pinned commit rather than taken from the issue text:
+#   > 6144 MB   _ensure_hugepages SKIPS THE WRITE ENTIRELY when ceiling_pages <= current, and the
+#               full tier's current is PITHEAD_HUGEPAGES = 3072 pages = 6144 MB. At or below that
+#               the miner would get nothing beyond the boot pool — a cap that reads as a cap and
+#               silently switches the reservation off.
+#   >= 8592 MB  required on the supported machine is the fallback branch (the appliance reserves no
+#               1G pages, so proposed-grub.sh takes it): 1168*NUMA + THREADS + 50 + (extra_mb+1)/2
+#               = 1168 + 6 + 50 + 3072 = 4296 pages. Below this the cap would bite on a HEALTHY box.
+#   <  11236 MB the contended landing measured above, 5618 pages. At or above it the ceiling would
+#               never bind and the over-reserve would survive the fix.
+# 4608 pages clears all three, with 312 pages of slack over required.
+#
+# NOT the guest's 4322: that reading is a KVM artifact (4 vCPUs presented as 4 sockets -> L3 64 MiB
+# -> THREADS 32). The same physical X5690 reports one 12 MiB L3 -> THREADS 6. Immaterial to the
+# ceiling, wrong to quote as the requirement.
+#
+# THIS VALUE AND hugepages_reserve_extra_mb MOVE TOGETHER: extra_mb contributes (extra_mb+1)/2 =
+# 3072 of those 4296 required pages, so raising the declared headroom raises required toward the
+# ceiling and would eventually make the cap bite on a healthy box. Re-derive both if
+# PITHEAD_HUGEPAGES changes.
+readonly PITHEAD_HUGEPAGES_POOL_CEILING_MB=9216
+
+# The RigForge release that first honours the key. VERSION-GATED because the failure is SILENT in
+# the worse direction: rigforge's _warn_unknown_config_keys warns and never errors on a key it does
+# not know ("an unknown key is at worst a no-op, and erroring would brick fleet applies on any
+# future rename"), so declaring the ceiling into an older tree FAILS OPEN — the rendered config
+# would read as capped and behave exactly as it does today. A config that lies about being bounded
+# is worse than one that plainly is not, so declare it only where it is honoured.
+readonly PITHEAD_RIGFORGE_POOL_CEILING_FLOOR=1.16.0
+
+# The ceiling this machine may declare, in MB, or 0 for "declare nothing" — 0 is RigForge's own
+# documented default for "no ceiling", so an omitted key and a declared 0 mean the same to it.
+# Prints its answer, so it must never call log (stdout); warn goes to stderr and is safe here.
+local_miner_pool_ceiling_mb() {
+    local dir=$1 ver
+    # THE FULL TIER ONLY — the one tier the value was measured on. The reduced tier never reaches
+    # here (local_miner_hugepages_blocked refuses it outright, and leg B measured why: lifting that
+    # refusal asks for 12.0 GiB on a 7.76 GiB box, the kernel silently grants 5.7 GiB, MemAvailable
+    # falls to ~40 MB and RigForge still exits 0 saying "Deployment Complete"). The RELEASED tier
+    # declares zero headroom and holds no stack pages, so it has nothing to double-count and no
+    # measurement behind any value — it stays uncapped rather than guessing one.
+    [ "$(hugepages_decision_pages)" = "$PITHEAD_HUGEPAGES" ] || {
+        echo 0
+        return 0
+    }
+    # The tree that will actually RUN, not the image's stamp: pithead-sync copies /opt/rigforge to
+    # /data/rigforge every boot, and it is the copy under $dir whose parse_config reads this key.
+    ver=$(tr -d ' \t\r\n' <"$dir/VERSION" 2>/dev/null) || ver=""
+    # Fail CLOSED on anything not a plain dotted number. sort -V happily orders an unparseable
+    # string against a version and would answer "new enough" for a tree that is nothing of the kind.
+    case "$ver" in
+    '' | *[!0-9.]*)
+        warn "Could not read a RigForge version from $dir/VERSION — leaving the HugePages pool uncapped."
+        echo 0
+        return 0
+        ;;
+    esac
+    if [ "$(printf '%s\n%s\n' "$PITHEAD_RIGFORGE_POOL_CEILING_FLOOR" "$ver" | sort -V | head -n 1)" \
+        != "$PITHEAD_RIGFORGE_POOL_CEILING_FLOOR" ]; then
+        warn "RigForge $ver at $dir predates $PITHEAD_RIGFORGE_POOL_CEILING_FLOOR and ignores the HugePages pool ceiling — leaving the pool uncapped rather than writing a cap it would not honour."
+        echo 0
+        return 0
+    fi
+    echo "$PITHEAD_HUGEPAGES_POOL_CEILING_MB"
+}
+
 render_local_miner_config() {
     is_appliance || return 0
     # Not on a rig, ever. This function's "switched off" branch DELETES the miner's config, and
@@ -3209,11 +3291,14 @@ render_local_miner_config() {
         warn "Local mining is on, but there is no RigForge tree at $dir — this image does not carry the built-in miner."
         return 0
     fi
-    local port secret
+    local port secret ceiling
     port=$(stratum_port_effective)
     secret=$(env_get PROXY_STRATUM_PASSWORD 2>/dev/null || true)
+    ceiling=$(local_miner_pool_ceiling_mb "$dir")
     jq -n --arg url "127.0.0.1:$port" --arg pass "$secret" --argjson reserve "$(($(hugepages_decision_pages) * 2))" \
-        '{pools: [({url: $url} + (if $pass != "" then {pass: $pass} else {} end))], hugepages_reserve_extra_mb: $reserve}' \
+        --argjson ceiling "$ceiling" \
+        '{pools: [({url: $url} + (if $pass != "" then {pass: $pass} else {} end))], hugepages_reserve_extra_mb: $reserve}
+         + (if $ceiling > 0 then {hugepages_pool_ceiling_mb: $ceiling} else {} end)' \
         >"$dir/config.json"
     log "Local miner config rendered to $dir/config.json (pool 127.0.0.1:$port)."
 }

--- a/tests/stack/test_appliance_hugepages.sh
+++ b/tests/stack/test_appliance_hugepages.sh
@@ -10,15 +10,26 @@
 # os/overlay/pithead-hugepages for where the marker this gate reads comes from — a real KVM
 # boot on reduced -m proves the marker itself; this proves what pithead does once it exists.
 #
-# The math this exists to stop (from the issue): RigForge's grow-only pool write is
-# required = 1168*numa + 128 + threads + 10 + (extra_mb+1)/2, and avail excludes pages the
-# stack already holds. On the REDUCED tier (2560 pages, sized for the stack's own two RandomX
-# datasets with no co-resident miner in the budget) any nonzero extra_mb the render declares is
-# added to required while the same pages are subtracted from avail — a real machine's numbers
-# put that at ~12 GiB requested on an 8 GiB box. No declared value bounds it, so the fix refuses
-# co-location on exactly that tier: the RELEASED tier (0 pages) already declares zero headroom
-# and has nothing to double-count, and the FULL tier is the measured, supported case — neither
-# changes.
+# The math this exists to stop. RigForge's grow-only write is target = current + required - avail,
+# and avail excludes pages the stack already holds. On the REDUCED tier (2560 pages, sized for the
+# stack's own two RandomX datasets with no co-resident miner in the budget) any nonzero extra_mb the
+# render declares is added to required while the same pages are subtracted from avail — counted
+# twice. No declared value bounds it, so the fix refuses co-location on exactly that tier: the
+# RELEASED tier (0 pages) already declares zero headroom and has nothing to double-count, and the
+# FULL tier is the measured, supported case — neither changes.
+#
+# CORRECTED (#1103 step 2): the formula this header used to quote —
+# `1168*numa + 128 + threads + 10 + (extra_mb+1)/2` — is not one of rigforge's, it MERGES two of
+# them. util/proposed-grub.sh at the pinned commit has a 1G-page branch
+# (`128 + THREADS + 10 + EXTRA`) and a pure-2MB FALLBACK (`1168*NUMA + THREADS + 50 + EXTRA`), and
+# the appliance always takes the FALLBACK because it reserves no 1G pages. The correct figure is
+# 1168 + 6 + 50 + 3072 = 4296 pages on the supported X5690; it reproduces both measured landings
+# exactly (the 16 GiB guest reads THREADS 32 rather than 6 and lands on 4322 — a KVM artifact).
+#
+# AND THE ~12 GiB ESTIMATE IS NO LONGER AN ESTIMATE: leg B measured the reduced tier with the
+# refusal lifted by hand. RigForge requested 6146 pages (12.0 GiB) on a 7.76 GiB box, the kernel
+# granted 2916, MemAvailable fell to ~40 MB, and RigForge exited 0 "Deployment Complete" — a 6.3 GiB
+# shortfall that nothing on the box reports. Evidence: ~/appliance-suite-logs/1103/RESULTS.md.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -43,6 +54,9 @@ assert_eq "marker present but at the full budget -> NOT blocked" \
 echo "== unit: render_local_miner_config refuses the reduced tier (#1103) =="
 LMH="$SANDBOX/lmh"
 mkdir -p "$LMH/rigforge"
+# The appliance always has a version-stamped tree here (pithead-sync copies the baked one every
+# boot). Without this the full-tier case below would quietly exercise the no-version path instead.
+printf '1.16.0\n' >"$LMH/rigforge/VERSION"
 printf '{"local_miner":{"enabled":true}}' >"$LMH/config.json"
 printf 'STRATUM_PORT=3333\n' >"$LMH/.env"
 export PITHEAD_RIGFORGE_DIR="$LMH/rigforge"
@@ -55,6 +69,8 @@ PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/reduced-marker" run_sourced "
 PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/no-marker" run_sourced "$LMH" render_local_miner_config >/dev/null 2>&1
 assert_eq "full tier -> headroom is UNCHANGED at 6144 MB (no regression on a normal box)" \
     "$(jq -r '.hugepages_reserve_extra_mb' "$LMH/rigforge/config.json")" "6144"
+assert_eq "full tier -> AND the #1103 pool ceiling is declared alongside it" \
+    "$(jq -r '.hugepages_pool_ceiling_mb' "$LMH/rigforge/config.json")" "9216"
 rm -f "$LMH/rigforge/config.json"
 # The released tier is untouched too: it already declares zero headroom, so there is nothing
 # for this gate to refuse.
@@ -62,6 +78,77 @@ printf 'released\npages=0\n' >"$LMH/released-marker"
 PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$LMH/released-marker" run_sourced "$LMH" render_local_miner_config >/dev/null 2>&1
 assert_eq "released tier -> still renders, zero headroom (unchanged)" \
     "$(jq -r '.hugepages_reserve_extra_mb' "$LMH/rigforge/config.json")" "0"
+# ABSENT, not present-and-zero: `has` is the assertion that discriminates the two, and only the
+# absent form leaves rigforge on its documented default.
+assert_eq "released tier -> no ceiling key at all (it was measured on the full tier only)" \
+    "$(jq -r 'has("hugepages_pool_ceiling_mb")' "$LMH/rigforge/config.json")" "false"
+unset PITHEAD_RIGFORGE_DIR
+
+echo "== unit: local_miner_pool_ceiling_mb — the #1103 ceiling and its version gate =="
+# WHY A VERSION GATE AT ALL: rigforge IGNORES a config key it does not know — its
+# _warn_unknown_config_keys warns and never errors, on the stated ground that "an unknown key is at
+# worst a no-op, and erroring would brick fleet applies on any future rename". So declaring the
+# ceiling into a tree older than the floor FAILS OPEN: the rendered config would READ as capped and
+# behave exactly as it does today. A config that lies about being bounded is worse than one that
+# plainly is not, which is what every case below pins.
+#
+# Each case is asserted on the VALUE (and, where it is the point, on the stated reason). None is
+# asserted on rc: this helper returns 0 on every path by construction, so an rc table would be
+# vacuous.
+CEI="$SANDBOX/cei"
+mkdir -p "$CEI/rigforge"
+printf '1.16.0\n' >"$CEI/rigforge/VERSION"
+assert_eq "full tier + the floor release -> the declared ceiling" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "9216"
+printf '1.17.2\n' >"$CEI/rigforge/VERSION"
+assert_eq "full tier + a NEWER release -> still declared (the gate is a floor, not an equality)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "9216"
+printf '1.15.1\n' >"$CEI/rigforge/VERSION"
+assert_eq "the release below the floor -> 0, because declaring it there would fail OPEN" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+assert_contains "below the floor -> says WHY, naming the floor" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>&1 >/dev/null)" "predates 1.16.0"
+# 1.9.0 is the case a LEXICAL compare gets backwards ("1.9.0" > "1.16.0" as strings). It is here to
+# prove the compare is version-ordered, not string-ordered.
+printf '1.9.0\n' >"$CEI/rigforge/VERSION"
+assert_eq "1.9.0 -> older than 1.16.0 (a lexical compare would call this NEWER)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+# The case sort -V alone gets WRONG, and the reason the numeric guard sits in front of the compare:
+# verified directly, `printf '1.16.0\ndev\n' | sort -V | head -1` is 1.16.0, so an unguarded
+# compare answers "new enough" for a tree that is nothing of the kind. That is a fail-OPEN.
+printf 'dev\n' >"$CEI/rigforge/VERSION"
+assert_eq "unparseable version -> 0 (fails CLOSED, where sort -V alone fails OPEN)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+rm -f "$CEI/rigforge/VERSION"
+assert_eq "no VERSION file at all -> 0" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+# Tier narrowness. The value was derived from full-tier measurements only; the released tier holds
+# no stack pages, so it has nothing to double-count and no measurement behind any number.
+printf '1.16.0\n' >"$CEI/rigforge/VERSION"
+printf 'released\npages=0\n' >"$CEI/released-marker"
+assert_eq "released tier + a new-enough tree -> still 0 (uncapped, never guessed)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/released-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+
+echo "== unit: render_local_miner_config declares the ceiling only where it is honoured (#1103) =="
+RCG="$SANDBOX/rcg"
+mkdir -p "$RCG/rigforge"
+printf '{"local_miner":{"enabled":true}}' >"$RCG/config.json"
+printf 'STRATUM_PORT=3333\n' >"$RCG/.env"
+export PITHEAD_RIGFORGE_DIR="$RCG/rigforge"
+printf '1.15.1\n' >"$RCG/rigforge/VERSION"
+PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$RCG/no-marker" run_sourced "$RCG" render_local_miner_config >/dev/null 2>&1
+assert_eq "old tree -> the key is ABSENT, not present-and-zero" \
+    "$(jq -r 'has("hugepages_pool_ceiling_mb")' "$RCG/rigforge/config.json")" "false"
+assert_eq "old tree -> the headroom hand-off is untouched" \
+    "$(jq -r '.hugepages_reserve_extra_mb' "$RCG/rigforge/config.json")" "6144"
+# The positive half of the same fixture: the ONLY variable changed is the version file, so this
+# pair shows the fixture can produce the key it just asserted absent.
+printf '1.16.0\n' >"$RCG/rigforge/VERSION"
+PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$RCG/no-marker" run_sourced "$RCG" render_local_miner_config >/dev/null 2>&1
+assert_eq "new-enough tree -> the key appears, same fixture, one variable moved" \
+    "$(jq -r '.hugepages_pool_ceiling_mb' "$RCG/rigforge/config.json")" "9216"
+assert_eq "new-enough tree -> and the pool URL is still derived as before" \
+    "$(jq -r '.pools[0].url' "$RCG/rigforge/config.json")" "127.0.0.1:3333"
 unset PITHEAD_RIGFORGE_DIR
 
 echo "== unit: provision_local_miner stops/refuses the miner on the reduced tier (#1103) =="

--- a/tests/stack/test_appliance_hugepages.sh
+++ b/tests/stack/test_appliance_hugepages.sh
@@ -98,6 +98,26 @@ echo "== unit: local_miner_pool_ceiling_mb — the #1103 ceiling and its version
 CEI="$SANDBOX/cei"
 mkdir -p "$CEI/rigforge"
 printf '1.16.0\n' >"$CEI/rigforge/VERSION"
+# ⛔ PIN THE NODE COUNT FOR EVERY CASE BELOW. local_miner_numa_nodes is a REAL detection against the
+# host, so without this the ceiling cases would assert 9216 on a single-node runner and 0 on a
+# multi-node one — passing or failing on the topology of whoever ran the suite rather than on the
+# code. `fake_lscpu` shadows lscpu on PATH; a stub that prints NOTHING stands in for "no lscpu",
+# since an absent binary and a silent one are indistinguishable to this function by construction.
+NUMABIN="$SANDBOX/numabin"
+mkdir -p "$NUMABIN"
+CEI_PATH_SAVED="$PATH"
+PATH="$NUMABIN:$PATH"
+fake_lscpu() { # <numa-nodes|-> <sockets|->   ('-' omits that line)
+    {
+        printf '#!/bin/sh\n'
+        [ "$2" = "-" ] || printf 'echo "Socket(s):             %s"\n' "$2"
+        [ "$1" = "-" ] || printf 'echo "NUMA node(s):          %s"\n' "$1"
+    } >"$NUMABIN/lscpu"
+    chmod +x "$NUMABIN/lscpu"
+}
+NONODES="$SANDBOX/nonodes"
+mkdir -p "$NONODES"
+fake_lscpu 1 1
 assert_eq "full tier + the floor release -> the declared ceiling" \
     "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "9216"
 printf '1.17.2\n' >"$CEI/rigforge/VERSION"
@@ -128,6 +148,72 @@ printf '1.16.0\n' >"$CEI/rigforge/VERSION"
 printf 'released\npages=0\n' >"$CEI/released-marker"
 assert_eq "released tier + a new-enough tree -> still 0 (uncapped, never guessed)" \
     "$(PITHEAD_HUGEPAGES_MARKER="$CEI/released-marker" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+
+echo "== unit: local_miner_numa_nodes mirrors RigForge's precedence, step for step (#1103) =="
+# WHY THIS EXISTS: the 9216 ceiling is a SINGLE-NODE value — rigforge's requirement carries a
+# 1168-page term per NUMA node (util/proposed-grub.sh L100-101 at the pinned ref 4ce29b3d), and
+# EXTRA_2MB_PAGES does not scale with nodes. At NUMA=2 the requirement is 5464 pages (10,928 MB), so
+# the ceiling would cap a HEALTHY box 856 pages short and rigforge would cap-and-continue: a SILENT
+# under-reservation. This function has to predict the count rigforge sizes against, so it mirrors
+# rigforge's precedence rather than picking a reasonable-looking source — a disagreement between the
+# two puts the defect straight back, quietly.
+fake_lscpu 1 1
+assert_eq "lscpu says one node -> 1" \
+    "$(PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_numa_nodes)" "1"
+fake_lscpu 2 1
+assert_eq "lscpu says two nodes -> 2 (lscpu wins, it is rigforge's first source)" \
+    "$(PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_numa_nodes)" "2"
+# Step 2: no lscpu answer, count sysfs nodes instead.
+NODESYS="$SANDBOX/nodesys"
+mkdir -p "$NODESYS/node0" "$NODESYS/node1"
+fake_lscpu - -
+assert_eq "no lscpu answer -> falls back to the sysfs node count" \
+    "$(PITHEAD_NODE_SYS="$NODESYS" run_sourced "$CEI" local_miner_numa_nodes)" "2"
+# Step 3 — THE QUIET-DEFECT PATH, and the reason the mirror has three steps and not two. A gate that
+# stopped at sysfs would read 1 here and declare the ceiling, while rigforge read the SOCKET count
+# and sized for four nodes. Not hypothetical: the #1103 bench guest reports Socket(s)=4 with
+# NUMA node(s)=1, so the two sources genuinely disagree on real hardware.
+fake_lscpu - 4
+assert_eq "no lscpu nodes and no sysfs nodes -> the SOCKET count, exactly as rigforge falls back" \
+    "$(PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_numa_nodes)" "4"
+fake_lscpu - -
+assert_eq "nothing readable anywhere -> 1, rigforge's own final default" \
+    "$(PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_numa_nodes)" "1"
+
+echo "== unit: the ceiling is declared ONLY on a single-node box (#1103) =="
+fake_lscpu 1 1
+# The NO-OP half: at one node the gate must not disturb what the C1/C2 bench pair measured. That
+# pair ran on a NUMA=1 guest, so this case is what carries its evidence across to the gated code.
+assert_eq "one node -> the measured ceiling, unchanged (the bench pair's regime)" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "9216"
+# The half that proves the gate EXISTS. Without this case the suite would be green on a gate that
+# did nothing, since the fixture is single-node everywhere else.
+fake_lscpu 2 2
+assert_eq "two nodes -> 0, uncapped rather than capped below a healthy requirement" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>/dev/null)" "0"
+assert_contains "two nodes -> says WHY, naming the count it read" \
+    "$(PITHEAD_HUGEPAGES_MARKER="$CEI/no-marker" PITHEAD_NODE_SYS="$NONODES" run_sourced "$CEI" local_miner_pool_ceiling_mb "$CEI/rigforge" 2>&1 >/dev/null)" "reports 2 NUMA nodes"
+# And through the render path, as a CONTROLLED PAIR: the node count is the ONLY variable moved
+# between these two renders. Without the positive leg, "the key is absent" cannot be told apart
+# from a fixture that never armed — which is how an assertion goes green off the wrong door.
+CNU="$SANDBOX/cnu"
+mkdir -p "$CNU/rigforge"
+printf '{"local_miner":{"enabled":true}}' >"$CNU/config.json"
+printf 'STRATUM_PORT=3333\n' >"$CNU/.env"
+printf '1.16.0\n' >"$CNU/rigforge/VERSION"
+fake_lscpu 1 1
+PITHEAD_APPLIANCE=1 PITHEAD_RIGFORGE_DIR="$CNU/rigforge" PITHEAD_HUGEPAGES_MARKER="$CNU/no-marker" \
+    PITHEAD_NODE_SYS="$NONODES" run_sourced "$CNU" render_local_miner_config >/dev/null 2>&1
+assert_eq "one node -> the key IS rendered (the fixture can arm)" \
+    "$(jq -r '.hugepages_pool_ceiling_mb' "$CNU/rigforge/config.json")" "9216"
+fake_lscpu 2 2
+PITHEAD_APPLIANCE=1 PITHEAD_RIGFORGE_DIR="$CNU/rigforge" PITHEAD_HUGEPAGES_MARKER="$CNU/no-marker" \
+    PITHEAD_NODE_SYS="$NONODES" run_sourced "$CNU" render_local_miner_config >/dev/null 2>&1
+assert_eq "two nodes -> the rendered config carries NO ceiling key at all" \
+    "$(jq -r 'has("hugepages_pool_ceiling_mb")' "$CNU/rigforge/config.json")" "false"
+assert_eq "two nodes -> the headroom hand-off is still untouched" \
+    "$(jq -r '.hugepages_reserve_extra_mb' "$CNU/rigforge/config.json")" "6144"
+fake_lscpu 1 1
 
 echo "== unit: render_local_miner_config declares the ceiling only where it is honoured (#1103) =="
 RCG="$SANDBOX/rcg"
@@ -204,6 +290,10 @@ assert_eq "enabled + full tier -> silent (nothing to warn about)" \
     "$(PITHEAD_APPLIANCE=1 PITHEAD_HUGEPAGES_MARKER="$DLB/no-marker" run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)" ""
 assert_eq "off the appliance -> silent regardless" \
     "$(PITHEAD_APPLIANCE=0 PITHEAD_HUGEPAGES_MARKER="$DLB/reduced-marker" run_sourced "$DLB" check_local_miner_hugepages_blocked 2>&1)" ""
+
+# Drop the lscpu shadow — nothing below depends on a pinned node count, and leaving a stub on
+# PATH would make any later case answer to it silently.
+PATH="$CEI_PATH_SAVED"
 
 echo ""
 printf 'appliance-hugepages tests: \033[1;32m%d passed\033[0m, ' "$PASS"


### PR DESCRIPTION
Bounds the appliance's HugePages pool with a declared ceiling, so a boot-time race cannot leave a
16 GiB machine holding 11 GiB of huge pages until the next reboot.

## The defect

The miner's config hands RigForge the stack's reservation as headroom, and RigForge sizes the pool
as `current + required - available`. A co-resident holding pages at that instant is subtracted from
`available` while the same pages already sit inside `required` — counted twice.

It is a **race, not a constant**. p2pool holds 1296 pages for about six seconds while allocating its
RandomX dataset; the #35 sync gate then stops it and it releases. Setup landing inside that window
takes the pool to 5618 pages and it stays there until reboot; outside it, 4322. Two consecutive
boots of one image gave both. A ceiling bounds it whoever wins; re-ordering the units would fix the
common case and leave the failure intact under load, so that was rejected.

## What ships

`render_local_miner_config` declares `hugepages_pool_ceiling_mb: 9216` behind **three** gates:

1. **Full tier only.** The reduced tier still refuses co-location (measured: lifting it asks 12.0 GiB
   on a 7.76 GiB box, the kernel grows the pool 2560 -> 2916, `MemAvailable` falls to ~40 MB, and
   RigForge exits 0 reporting "Deployment Complete"). Released tier holds no stack pages, so it has
   nothing to double-count and no measurement behind any value — it stays uncapped.
2. **RigForge >= 1.16.0.** rigforge warns and never errors on an unknown key, so declaring the
   ceiling into an older tree fails **open** — a config that reads as bounded and behaves as before.
   Verified in both directions at the pinned ref: 1.16.0 carries the key (`rigforge.sh:589` parse,
   `:691` known-keys, `:1520` the cap); 1.15.2 has zero occurrences.
3. **Detected NUMA nodes == 1.** See below — this one was a review finding.

## The NUMA gate (review finding, and the reason this PR is not the first draft)

The first draft froze 9216 with a comment deriving it as `1168*NUMA + THREADS + 50 + (extra+1)/2 =
1168 + 6 + 50 + 3072 = 4296`. **That substitutes `NUMA=1` away in the same sentence that writes the
term.** At the pinned ref `proposed-grub.sh:100-101` is
`TOTAL_2MB_FALLBACK=$(((BASE_2MB_PAGES * NUMA_NODES) + THREADS + 50 + EXTRA_2MB_PAGES))`, and
`EXTRA_2MB_PAGES` (L85-88) carries no node term — so the node term is the only one that scales:

| nodes | required | vs a 4608-page ceiling |
|---|---|---|
| 1 | 4296 pages (8,592 MB) | ceiling binds only under contention — correct |
| 2 | 5464 pages (10,928 MB) | caps a **healthy** box 856 pages short |
| 4 | 7800 pages (15,600 MB) | short by 3192 pages |

All three rows are the **supported X5690**, so they differ in the node term alone: `THREADS` is
`L3_MB/2` = 6 on its single 12 MiB L3, and `EXTRA_2MB_PAGES` is `(6144 + 1) / 2 = 3072`. Row 1's
8,592 MB is the `>= 8592` bound named in the shipped comment, which is the arithmetic's own check.

**An earlier cut of this table put the bench guest's measured 4322 in row 1** while rows 2 and 4
stayed on the X5690 — one table, two machines, and no tell, because every row supports the same
conclusion. 4322 is a **KVM artifact**: 4 vCPUs present as 4 sockets, L3 reads 64 MiB, THREADS
resolves 32. `lib/pithead/14-local-miner.sh` says so at the constant and calls it "wrong to quote
as the requirement" — the shipped files were right and the table was not.

RigForge caps the write and continues, so that under-reservation would be **silent** — the same
failure direction gate 2 exists to prevent. `local_miner_numa_nodes` therefore mirrors RigForge's own
precedence **step for step**: `lscpu` "NUMA node(s)", then sysfs `node[0-9]*`, then the **socket
count**, then 1. The socket step is load-bearing, not padding: the bench guest reports
**Socket(s)=4 with NUMA node(s)=1**, so a mirror stopping at sysfs would read 1 where RigForge read
4 — the defect back, quietly.

A render-time recomputation of RigForge's formula was considered and **rejected**: it puts a copy of
their sizing inside pithead that must stay correct across their releases, and it needs `THREADS`
(`L3_MB/2`, then `THREADS_CAP`) which pithead does not model. Freezing the value and documenting
"single node only" was also rejected — a constraint nothing enforces.

## Bench evidence — what was RUN

Full-tier 16 GiB KVM guest, `tests/os/run.sh --phase provision --keep`, **rc=0, 34 passed / 0 failed**.

**Treatment (ceiling present)** — produced by the boot path under a *real* race, not an armed hold:

```
Hardware-optimized HugePages: 4322 (2MB pages) calculated.
HugePages requirement (5618 pages) exceeds the declared pool ceiling —
  capping the write at 4608 pages (9216MB) instead of growing further (#398).
sysctl -w vm.nr_hugepages=4608   ->   HugePages_Total: 4608
```

`5618 - 4322 = 1296`, exactly p2pool's hold. RigForge quoting `9216MB` back is the second witness
that the key was **honoured**, not merely present.

**Control (key stripped, same boot, same 1296-page hold, one variable moved):** predicted 5618 in
advance, because RigForge had already printed it. Result `vm.nr_hugepages = 5618`, pool landed
**5618**.

Controls, all fired: hold delta asserted **exactly 1296** (`fallocate`, never `dd` — hugetlbfs has
no `write(2)`, and `dd` leaves a 0-byte file that `ls` shows as present); the independent variable
**read** (`ABSENT` vs `9216`), not assumed; the request taken from RigForge's own stdout, never a
readback — the kernel rewrites `vm.nr_hugepages` to what it achieved, so any post-hoc readback says
"granted in full" by construction.

### Disclosed: the legs ran OUT of my own protocol's order, and why that is harmless

My protocol required a reboot between legs ("a pool only grows"). In the event, the treatment landed
at boot with `current` = 3072 and the control ran afterwards with `current` already 4608. That is
the condition the reboot rule existed to prevent, so it needs stating rather than leaving for a
reviewer to find.

It does not bite, for a structural reason. With a hold of `H` and `_hugepages_avail` = free + pages
already held by the miner, `avail = current - H`, so:

```
target = current + required - avail = current + required - (current - H) = required + H
       = 4322 + 1296 = 5618        # current cancels
```

That identity is not a coincidence of one run — it holds **by construction**. At the pinned ref
`_miner_held_hugepages` (`rigforge.sh:1482`) reads `HugetlbPages` from `/proc/<MainPID>/status` of
the **miner service only**, and `_hugepages_avail` is `free + held`. So for any holder that is not
the miner service, `free = current - H - miner_held` and `avail = free + miner_held = current - H`
exactly, with nothing measured. The `fallocate` file qualifies, and so does p2pool in the field —
which is why the natural race and the manual hold land on the same 5618 by two different mechanisms.

**The premise this rests on, stated so it can be checked: the holder is not the miner service.**
When the holder *is* the miner, `avail = current`, `target = required`, and there is no over-reserve
to bound — coherent, since the defect is by definition a co-resident holder, but a real premise
rather than a technicality. **The run itself rules out the one way it could have failed:** had the
hold been counted as miner-held, `avail` would have been 3272 + 40 + 1296 = 4608 = `current` and the
target would have been 4322, not 5618. The measured 5618 is therefore a negative control on the
premise, obtained for free.

Verified against the logged numbers: `current` 4608, `free` 4568 -> 3272 after the hold, miner
holding 40, so `avail` = 3272 + 40 = 3312 = 4608 - 1296. **The delta-1296 assertion turns out to
license the analysis, not just the fixture** — it was armed against the `dd` trap and ended up
carrying an inference nobody had in mind when it was written. **The reboot rule was sufficient but
never necessary** — it guarded a dependence the arithmetic does not have.

### What this evidence does NOT cover

The guest is NUMA=1 by construction, so **the pair cannot exercise the NUMA axis at all**. That axis
is covered only by unit cases. The gate is a **no-op at one node**, which is what carries the pair's
evidence across to the gated code — and that is measured, not assumed: `local_miner_numa_nodes`
extracted verbatim from the built artifact and run on the live appliance beside RigForge's own
resolution agrees at 1.

Also still open on #1103 and **not** claimed here: whether a co-located miner on a reduced-RAM box
mines usefully or thrashes. It needs synced chains, not another guest — the sync gate holds the
stratum the miner dials, so xmrig takes ~40 pages and never allocates a dataset. A gated container's
absence is not memory pressure.

## Tests and gates

- `tests/stack/test_appliance_hugepages.sh`: **43 passed, 0 failed** (was 32). New: five detection
  cases including the socket fallback, the NUMA=2 refusal and its warn, and a render **controlled
  pair** (one node -> key present; two -> absent) — because "key absent" cannot otherwise be told
  from a fixture that never armed. The node count is **pinned** via a fake `lscpu` on PATH; without
  that, every ceiling case would answer to the runner's own topology.
- Mutation battery, each proven applied by byte-diff against a pristine copy and restored
  byte-identical: delete the node gate -> 3 kills; invert it -> 10; drop the socket fallback -> 1;
  break the sysfs glob -> 1. The two single kills are each on their own axis.
- Full `tests/stack/run.sh`: **3053 passed, 0 failed** (rc file read, `✗` count 0). That total is
  **unchanged** by this PR and should be: `test_appliance_hugepages.sh` sits in `tests/inventory.sh`'s
  UNSOURCED set — the underscore in its name marks exactly that — and is invoked standalone from
  `Makefile:21`, `Makefile:62` and `.github/workflows/ci.yml:461`, never from `run.sh`. So the 11 new
  cases are counted in the 43/0 above, not in the 3053.
- `make lint` rc=0; `lint-pithead-parity` OK (52 slices);
  budget gate OK (347 and 304 lines against target 400, **no new tsv row**); `tests/inventory.sh`
  lists the file with 9 sections.

## Over-engineering pass (by hand)

The ponytail gate keys off `git rev-parse --abbrev-ref HEAD` in the pinned shell cwd, which names a
different branch from this lane's worktree, so it cannot do this pass here — run manually and
disclosed. Both new helpers earn their place: `local_miner_pool_ceiling_mb` has four distinct exit
reasons that each need their own operator-facing message, and `local_miner_numa_nodes` exists to be
independently testable against a faked topology, which is the only way the NUMA=2 case can be
exercised at all. No adjacent helper could absorb either without making the render function's
branching untestable.

## Shared files

`docs/` is shared and no lane owns it — `docs/workers.md` and `os/KNOWN-ISSUES.md` are updated here,
disclosed per policy. `pithead` is regenerated by the build only, never hand-edited.

One correction to a figure already in this branch's `os/KNOWN-ISSUES.md`: it said the kernel "granted
356 of them" against a 6146-page request, which reads as 356 of 6146. The pool went 2560 -> 2916 —
356 **new** pages of the 3586 it was asked to add. Both figures were true in different senses and the
sentence blended them; the conclusion never moved, which is why nothing surfaced it.
