### PR TITLE
fix(integration): the pools restore tests the credential, not emptiness (#1546)

### DIFF
--- a/tests/integration/rigforge-writable-keys.sh
+++ b/tests/integration/rigforge-writable-keys.sh
@@ -176,15 +176,14 @@ run_rigforge_pools() { # <rig>
         return 0
     fi
     orig_pools="$(_worker_detail "$rig" | jq -c '.last_applied.pools // empty' 2>/dev/null)"
-    # #1546: test the CREDENTIAL, never emptiness as a proxy for it. A pools value being ON RECORD
-    # does not mean it can be written back: an array that is present but whose entries carry no
-    # usable `pass` restores the rig to a credential-less config and strands a borrowed miner —
-    # exactly the outcome the self-derived-pools refusal exists to prevent. Measured against this
-    # function before the guard existed: `[{"url":"real:1"}]` and `[{"url":"real:1","pass":""}]`
-    # both passed the old emptiness check and were POSTed; only an ABSENT key ever skipped.
-    # So the credential is tested FIRST and emptiness only picks the message. Refusing is the
-    # honest answer for the same reason #1236 refuses .rig_config.pools: the harness cannot tell
-    # "this rig has no pass" from "it was stripped", and must not guess on a real miner.
+    # #1546: test the CREDENTIAL, never emptiness as a proxy for it. Being ON RECORD does not mean a
+    # value can be written back — a pools array whose entries carry no usable `pass` restores the rig
+    # to a credential-less config, which is the outcome the self-derived-pools refusal exists to
+    # prevent. So the credential is tested FIRST and emptiness only picks the message. Refusing is
+    # the honest answer for the same reason #1236 refuses `.rig_config.pools`: the harness cannot
+    # tell "this rig has no pass" from "it was stripped", and must not guess against a real miner.
+    # The shapes that reach each branch are enumerated as executable cases in the self-test, which
+    # is where they cannot drift out of step with the code.
     if ! printf '%s' "$orig_pools" |
         jq -e 'type == "array" and length > 0 and all(.[]; (.pass? // "") != "")' >/dev/null 2>&1; then
         if [ -z "$orig_pools" ]; then

--- a/tests/integration/rigforge-writable-keys.sh
+++ b/tests/integration/rigforge-writable-keys.sh
@@ -161,8 +161,10 @@ run_rigforge_writable_keys() { # <rig>
 # could safely write back. pithead treats `pools` as opaque passthrough (WORKER_WRITABLE_KEYS checks
 # the key NAME, never the value shape), so a guessed value risks a real rejected/failed instead of
 # proving the round trip — the same reasoning IT_RIG_ROLLBACK_CHANGES applies to the #517 leg.
-# The restore target is `.last_applied.pools`: the dashboard's record of what IT pushed, which is
-# un-stripped, and the same source the real editor prefills from when the rig sends no config.
+# The restore target is `.last_applied.pools`: the dashboard's record of what IT pushed, and the
+# same source the real editor prefills from when the rig sends no config. It is the best available
+# restore value, but being on record is NOT a guarantee that it carries a credential — so the leg
+# checks, rather than assuming (#1546).
 run_rigforge_pools() { # <rig>
     local rig="$1" orig_pools res status ckeys
     if [ -z "${IT_RIG_POOLS_PROBE:-}" ]; then
@@ -174,13 +176,28 @@ run_rigforge_pools() { # <rig>
         return 0
     fi
     orig_pools="$(_worker_detail "$rig" | jq -c '.last_applied.pools // empty' 2>/dev/null)"
-    if [ -z "$orig_pools" ]; then
-        it_skip_leg "pools write (#1002b)" "rig '$rig' has no dashboard-applied pools on record (.last_applied.pools) — can't read a restorable original; the rig's own .rig_config.pools is credential-stripped and must not be written back"
+    # #1546: test the CREDENTIAL, never emptiness as a proxy for it. A pools value being ON RECORD
+    # does not mean it can be written back: an array that is present but whose entries carry no
+    # usable `pass` restores the rig to a credential-less config and strands a borrowed miner —
+    # exactly the outcome the self-derived-pools refusal exists to prevent. Measured against this
+    # function before the guard existed: `[{"url":"real:1"}]` and `[{"url":"real:1","pass":""}]`
+    # both passed the old emptiness check and were POSTed; only an ABSENT key ever skipped.
+    # So the credential is tested FIRST and emptiness only picks the message. Refusing is the
+    # honest answer for the same reason #1236 refuses .rig_config.pools: the harness cannot tell
+    # "this rig has no pass" from "it was stripped", and must not guess on a real miner.
+    if ! printf '%s' "$orig_pools" |
+        jq -e 'type == "array" and length > 0 and all(.[]; (.pass? // "") != "")' >/dev/null 2>&1; then
+        if [ -z "$orig_pools" ]; then
+            it_skip_leg "pools write (#1002b)" "rig '$rig' has no dashboard-applied pools on record (.last_applied.pools) — can't read a restorable original; the rig's own .rig_config.pools is credential-stripped and must not be written back"
+        else
+            it_skip_leg "pools write (#1002b)" "rig '$rig' has .last_applied.pools on record, but it carries no usable credential (a missing or empty \`pass\` on at least one entry) — restoring it would apply a credential-less pools config to a real miner, so this refuses rather than guesses (#1546)"
+        fi
         return 0
     fi
     it_step "Worker Inspect edit: pools -> the operator-supplied probe via /api/control/worker-apply…"
-    # The restore target is last_applied, which still carries `pass` — the same un-stripped value
-    # the revert below uses, and the only one safe to write back (#113). (#1379)
+    # The restore target is last_applied, and the guard above has PROVEN this value carries `pass`
+    # rather than assuming it — the same un-stripped value the revert below uses, and the only one
+    # safe to write back (#113). (#1379, #1546)
     rig_key_mark dash "$rig" pools "$orig_pools"
     res="$(_worker_apply "$rig" "{\"pools\":$IT_RIG_POOLS_PROBE}")"
     status="$(printf '%s' "$res" | jq -r '.status // empty' 2>/dev/null)"

--- a/tests/integration/selftest-rigforge-writable-keys.sh
+++ b/tests/integration/selftest-rigforge-writable-keys.sh
@@ -309,6 +309,36 @@ assert_eq "the restore uses last_applied, credential intact" \
 assert_eq "the restore is NOT the rig's credential-stripped self-read" \
     "$(applies | grep -c 'stripped:1')" "0"
 
+# #1546: the guard tests the CREDENTIAL, never emptiness as a proxy for it. These cases are the
+# reason this section could not be trusted before: the STUB_DETAIL above hardcodes `"pass":"secret"`,
+# so every assertion in this file stays green whether the guard tests `pass` or not — the coverage
+# was structurally blind, not merely thin. Measured against the pre-#1546 function, both shapes below
+# POSTed twice (the probe AND a credential-less restore, at a real miner); after it, zero. The
+# pass-present rows above are the positive control that the leg still runs and still POSTs.
+for _shape in '[{"url":"real:1"}]' '[{"url":"real:1","pass":""}]'; do
+    STUB_DETAIL="$(jq -cn --argjson p "$_shape" '{last_applied: {pools: $p}}')"
+    reset_applies
+    counts="$(quietly run_rigforge_pools rig1)"
+    assert_eq "a last_applied.pools with no usable pass POSTs nothing at the rig [$_shape]" \
+        "$(applies | grep -c .)" "0"
+    assert_eq "and self-skips rather than passing or failing [$_shape]" "$counts" "0,0"
+done
+# A skip that announces the wrong reason is its own small lie, and this leg now has two reasons to
+# skip. Assert each names itself, or a passless record would read as "nothing on record".
+STUB_DETAIL='{"last_applied":{"pools":[{"url":"real:1"}]}}'
+reset_applies
+err="$(drive_err run_rigforge_pools rig1)"
+assert_contains "the passless skip says the CREDENTIAL is what is missing" "$err" "no usable credential"
+STUB_DETAIL='{"last_applied":{}}'
+reset_applies
+err="$(drive_err run_rigforge_pools rig1)"
+assert_contains "the absent-record skip still says the RECORD is what is missing" \
+    "$err" "no dashboard-applied pools on record"
+assert_eq "and the absent-record skip does not claim a credential problem" \
+    "$(printf '%s' "$err" | grep -c 'no usable credential')" "0"
+
+STUB_DETAIL='{"rig_config":{"pools":[{"url":"stripped:1"}]},"last_applied":{"pools":[{"url":"real:1","pass":"secret"}]}}'
+
 export IT_RIG_POOLS_PROBE='not json'
 reset_applies
 counts="$(quietly run_rigforge_pools rig1)"


### PR DESCRIPTION
## What this changes

`run_rigforge_pools` restored a borrowed rig from `.last_applied.pools` and skipped only when that
value was **absent**, while the comment beside the write-back justified it by asserting the value
"still carries `pass`". Emptiness was standing in as a proxy for *carries a usable credential*, and
the two are not the same. A pools array that is **present but passless** cleared the guard and was
POSTed back to a real miner as a credential-less config.

The credential is now tested first; emptiness only picks which skip message prints.

## The measurement, on the unmodified function

Driven through the selftest's own stubs, four shapes of `.last_applied.pools`. The absent-key row is
the **positive control** — it proves the guard fires at all, so the other rows failing is a finding
about the guard rather than a broken probe.

| `.last_applied.pools` | before | after |
|---|---|---|
| `[{"url":"real:1","pass":"secret"}]` | POSTs 2, restores with credential | **unchanged** |
| `[{"url":"real:1"}]` | **POSTs 2, restores passless** | POSTs 0, skips |
| `[{"url":"real:1","pass":""}]` | **POSTs 2, restores passless** | POSTs 0, skips |
| key absent *(control)* | POSTs 0, skips | unchanged |

The first row is what keeps this from being a silencing: the leg still runs wherever it legitimately
can.

## Why the existing test could not have caught it

`selftest-rigforge-writable-keys.sh` stubs `_worker_detail` with a hardcoded
`"pass":"secret"`, so **every assertion in the file stays green whether the guard tests `pass` or
not**. The coverage was structurally blind, not merely thin — which is why a green selftest proves
nothing here by construction, and why the proof below is a controlled pair rather than a suite run.

**Seven cases added; five RED against the pre-fix function.** Verified by a cmp-gated swap (1309
differing bytes, so the swap is proven to have applied; file restored byte-identical afterwards and
the suite re-run green). All **52** pre-existing assertions pass on both sides — that is the point.
The two that pass on both sides are the absent-record message cases, which cover behaviour this
change deliberately leaves alone.

## A second way in, independent of #1546 — derived by reading, not executed

`get_last_applied_worker_config` merges the `changes` of applied history rows, last-write-wins per
key (`worker_config_store.py:213`, `storage_service.py:348`). So `.last_applied.pools` is literally
the last `pools` value the dashboard applied — **including this leg's own
`IT_RIG_POOLS_PROBE`**, which is typically passless.

If the probe apply lands and the revert does not — an aborted run (the #1401 class), a rejected
revert, a crash — then `.last_applied.pools` becomes the passless probe, and the *next* run reads it
as the original and restores it. Self-perpetuating, and the same shape as #1178's "previous run left
it borrowed". This fix breaks that loop as a side effect. **Stated as read from the dashboard source,
not run** — I did not execute it, and `dashboard/` is not this lane's path.

## Trade-off, stated rather than hidden

A pool that legitimately has no password now **skips forever** instead of round-tripping. That is
deliberate and it is the same refusal #1236 already makes about `.rig_config.pools`: the harness
cannot distinguish "this rig has no pass" from "it was stripped", so it must not guess against a
real miner. A skip announces itself; a credential-less config applied to a borrowed rig does not.
Both skip reasons name themselves, so a passless record cannot read as "nothing on record".

Also deliberate: a non-string `pass` (e.g. `5`) is accepted as a credential. It is a value, and
rejecting it would be the same proxy error in the other direction.

## Not done, and named rather than left implicit

- **`IT_RIG_POOLS_PROBE` is not itself required to carry a `pass`.** Requiring it would stop
  `last_applied` being poisoned in the first place, but it changes the contract of an
  operator-supplied input, so it is out of the scope I was given. Worth its own decision.
- **`IT_RIG_POOLS_RESTORE`** remains the right end state; this does not build it and does not block it.
- **No rig was touched.** This is a stubbed proof; the leg is opt-in (`IT_RIG_POOLS_PROBE` against a
  real rig) and no live run was needed to establish the defect.

## What was run

- `make test-integration-selftest` — **rc=0**, all 12 files, 0 failed (this file 50 -> 57).
- The pre-fix/post-fix controlled pair above, cmp-gated both directions.
- `shellcheck --severity=warning` (CI-pinned **0.11.0**) from the repo root over
  `tests/integration/*.sh tests/integration/mini-stack/*.sh` — rc=0, with a positive control on a
  deliberately broken file returning rc=1.
- `shfmt -i 4 -d` over both changed files — rc=0.
- `scripts/lint-file-budget.sh` — rc=0. Neither file is budgeted (213 and 351 lines, both under 400).
- `make lint-sh` deliberately **not** run: it is serialized and is this box's OOM path. The targeted
  shellcheck + shfmt pair above is the standing substitute.

## Ponytail pass (run on my own diff, findings and declines both stated)

The gate demands `/ponytail-review`, which is not declared by the plugin manifest and clears
unconditionally on the retry, so it verifies nothing — recorded in the fleet's tooling traps. The
practice instead: read the skill off disk, run the real review, publish it including what I declined.

**Taken:**

`rigforge-writable-keys.sh:L178-186: shrink:` the guard comment enumerated the two passless shapes
that are *already* asserted as executable cases. Cut to the rule plus a pointer at the self-test —
the repo's own #1489 lesson is that a claim restated in two places drifts. Applied as the second
commit here; net **-2 lines** and one fewer copy of a fact that can go stale.

**Declined, with the reason:**

- `L187-192: yagni:` two skip messages where one would do. **Declined.** The two branches are
  different diagnoses — "nothing on record" vs "on record but passless" — and this lane's whole
  brief is that a skip must announce itself honestly. Collapsing them would make a passless record
  report as an absent one, which is the same substitution-of-a-proxy the fix exists to remove. Both
  messages are asserted, including that the absent-record message does *not* claim a credential
  problem.
- `L193: shrink:` fold the `type == "array" and length > 0` prefix into `all(...)`. **Declined.**
  `all` over an empty array returns true, so dropping `length > 0` would let `[]` through — a
  shorter guard that reintroduces a variant of the bug. Verified across eleven input shapes,
  including `[]`, `["a"]`, `{"url":"a"}`, `null` and `[{"pass":null}]`.

`net: -2 lines possible` — taken.
