### PR TITLE
docs(dashboard): stop claiming the worker change record holds no secret (#1552)

### DIFF
--- a/dashboard/mining_dashboard/service/storage_service.py
+++ b/dashboard/mining_dashboard/service/storage_service.py
@@ -347,8 +347,8 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         # config history on the rig, so Pithead owns it: one row per change the dashboard applied,
         # with the writable-key `changes` we sent (each row IS a diff from the prior state, by
         # construction — we only ever record deltas we authored) and the rig's terminal outcome.
-        # `changes` holds only the writable allowlist keys; NO secret ever lands here (the rig token
-        # stays host-side, #440). change_id is the rig's 16-hex id, or NULL for a request that never
+        # `changes` holds writable allowlist keys only, but `pools` carries `pass`, so #1543 strips
+        # it on write and read. change_id is the rig's 16-hex id, or NULL for a request that never
         # reached a rig (rejected host-side). `type` distinguishes a config apply from a one-click
         # rig upgrade (#1014) — an upgrade's `changes` carries `{"version": ...}` instead of a
         # writable-key diff, and get_last_applied_worker_config must never merge that into the

--- a/dashboard/mining_dashboard/web/server.py
+++ b/dashboard/mining_dashboard/web/server.py
@@ -310,9 +310,9 @@ _RECORDABLE_WORKER_STATUSES = (
 
 def _record_worker_result(state_mgr, worker, changes, res, change_type="apply"):
     """Log a worker-apply or worker-upgrade outcome to the per-worker config history (#185/#1014).
-    Only terminal-ish statuses are kept; ``changes`` carries no secret (the rig token stays
-    host-side). ``worker``/``changes`` come from the caller's own request, never ``res`` — the
-    host runner omits ``worker`` from a pre-dial reject, so this stays correct either way."""
+    Only terminal-ish statuses are kept. ``changes`` is the operator's own POST, so a pool ``pass``
+    can be in it; ``add_worker_config_version`` strips it before the INSERT (#1543). ``worker``/
+    ``changes`` are the caller's own, never ``res``: a pre-dial reject omits ``worker`` there."""
     status = res.get("status", "unknown")
     if status in _RECORDABLE_WORKER_STATUSES:
         state_mgr.add_worker_config_version(

--- a/dashboard/tests/service/test_control_service.py
+++ b/dashboard/tests/service/test_control_service.py
@@ -454,7 +454,7 @@ class TestWorkerApply:
             "worker": "rig1",
             "changes": {"DONATION": 4},
         }
-        # No secret / addressing leaks into the container-writable spool.
+        # No rig token or addressing in the container-writable spool; a pool `pass` does land.
         assert "host" not in req and "port" not in req and "token" not in req
 
     def test_submit_worker_upgrade_spools_name_and_version_only(self, spool):


### PR DESCRIPTION
Closes #1552.

#1546 corrected the sentence *"no secret ever lands here"* in `add_worker_config_version`, calling it "not a property this method had". The same claim was still standing in **three** other places. Two came from a controller review of #1546; the third I found by widening the sweep, and it is the one in a test.

## The claim, re-derived rather than read

The sentence hangs on a guard that genuinely is enforced, which is why reading it does not settle anything. So I ran it:

```
>>> from mining_dashboard.service import control_service as cs
>>> cs.validate_worker_changes({"pools": [{"url": "...", "user": "wallet", "pass": "SUPER-SECRET"}]})
''
```

`''` is the accept. `pools` is on `WORKER_WRITABLE_KEYS`, and `validate_worker_changes` checks top-level key **names** only — it never inspects a value — so a `pass` nested in a pool entry passes validation untouched and reaches the recorder verbatim as the operator's own POSTed body.

"Holds only the writable allowlist keys" is true. "So no secret lands here" does not follow from it. **That non-sequitur is the defect**: the sentence states a real guard and then draws a conclusion the guard does not support, which is the shape most likely to stop the next reader from checking. It is also, per #1546, part of why the gap survived being read.

## Three sites, wrong in three different ways

A single copy-pasted correction would have been wrong at two of them, so each says what is true where it sits:

| site | what the claim was about | why it is false there |
|---|---|---|
| `web/server.py` — `_record_worker_result` | the `changes` **parameter** | it carries a credential and always did; #1546 changed nothing about that. What #1546 added is the strip one level down, in `add_worker_config_version`. |
| `service/storage_service.py` — the `worker_config` schema comment | the **table** | stated as a flat invariant. Since #1546 no *new* row carries a credential, but rows an older build wrote still do — which is exactly why #1546 put a second strip in `_shaped` on the read path. |
| `tests/service/test_control_service.py` — `test_submit_worker_apply_spools_tokenless_intent` | the **spool** | the comment said "no secret / addressing leaks into the container-writable spool" while the assertion checks only that `host`/`port`/`token` are absent. `submit_worker_apply` writes `changes` verbatim, so a pool `pass` does land there. |

On the third: **nothing is wrong with the test.** The assertion is right and matches the test's name; the comment generalised past it. The password has to transit the spool — it is on its way to the rig, and #1546 settled that the wire is not where to strip it. The comment is narrowed to what is tested and true rather than the test being changed.

The schema comment points at #1543 instead of restating its reasoning a third time. Duplicating the explanation is how this claim drifted out of sync in the first place; #1546's `add_worker_config_version` docstring is the one place that owns it.

## What I deliberately dropped

The rig-token parenthetical — *"(the rig token stays host-side, #440)"* — is removed, not corrected. It was **true**. But it is already stated accurately at the two functions that own it: `handle_worker_apply` ("this container never holds the rig's token") and `submit_worker_apply` ("never a host, port, or token: the host-side runner resolves the rig's real address and bearer from its own config.json"). Carrying a true clause alongside a false one is what lent the false one its authority, and a fact restated in four places is a fact that will go stale in three.

## What the sweep found and what it ruled out

Sweeping for the exact wording of #1546's sentence would **not** have found site 3 — `no secret` was the only overlap. That phrase is common enough here that most hits are true claims about other paths, and I checked rather than assumed:

- `service/data_helpers.py:320` and `service/control_service.py:58` — both about the #440 pre-masked **host config** copy, a different object on a different path. **Both hold.**
- `submit_worker_apply`'s own docstring — careful and correct: it claims no host, port or token, and claims nothing about `changes`. **Holds.**

The three that were false all describe the same object: the worker change record.

## Evidence

- **Full suite: 2201 passed, rc 0.** Identical to the base's count (#1546 reports the same 2201), which is the arithmetic that says nothing else moved.
- **`make lint` rc 0** — the whole surface, not a subset: `lint-py`, `lint-operator-strings`, `lint-topology`, `lint-file-budget`, `lint-docs-voice`, `lint-pithead-parity`, `lint-trivy-parity` and the rest, each with its self-tests green.
- **Comment-only.** `git diff --stat` is 6 insertions, 6 deletions across three files, and no line of the diff is executable. No new test: the behaviour is already covered by #1546's `tests/service/test_worker_config_credentials.py`, and re-testing it here would prove a behaviour twice.

## A constraint worth naming for the reviewer

All three files sat **exactly at their file-budget ceilings** — 645 / 1358 / 500, each equal to its `docs/dev/file-budget.tsv` row. Zero headroom, and ceilings only move down. So every edit is **line-neutral by construction**: the corrections were written to the character to fit the lines they replace, and `docs/dev/file-budget.tsv` is untouched. The 6-insertion/6-deletion stat is the proof of it, and `lint-file-budget` passes against the committed base.

That constraint shaped the prose: the schema comment points at #1543 rather than explaining, partly because that is the right structure and partly because there was no room to do otherwise. If a reviewer wants any of the three expanded, it needs a shrink elsewhere in the same file first — worth knowing before asking.
