### PR TITLE
docs(dashboard): say how to fix a red law 1 without shrinking the pinned set (#1487)

### DIFF
--- a/dashboard/tests/service/test_collapsed_return_channels.py
+++ b/dashboard/tests/service/test_collapsed_return_channels.py
@@ -93,10 +93,9 @@ _EMPTY = {"[]", "{}", "0"}
 _HANDLE = "_conn"
 
 # Measured, read at source, and cleared — the only set this file ratchets. Each declares `T | None`
-# and returns `None` from every failure path, which is the three-valued contract #1409 established.
-# `get_worker_config_change` documents it in its own docstring: "None means the read FAILED ...
-# {} means there is genuinely no such row". Listing them by name is what makes law 1 enforceable;
-# the vacuity guard below is what keeps the list from silently becoming a check against nothing.
+# and returns `None` from every failure path: the three-valued contract #1409 established,
+# documented in `get_worker_config_change`'s own docstring. Naming them is what makes law 1
+# enforceable; the vacuity guard below keeps the list from becoming a check against nothing.
 _SIGNED = {
     "service/storage_service.py:get_xvb_standby",
     "service/storage_service.py:get_kv",
@@ -320,9 +319,10 @@ class TestTheSignedContractHolds:
         assert "service/worker_config_store.py:get_worker_config_history" in package["signed"]
 
     def test_every_signed_function_still_declares_its_out_of_band_failure(self, package):
-        """LAW 1. These five were read at source and cleared. Dropping the `| None` from one would
-        move it back into the collapsed class with nothing to notice — #1409 undone by an edit that
-        looks like a simplification."""
+        """LAW 1. These five were read at source and cleared. Dropping the `| None` from one
+        would move it back into the collapsed class with nothing to notice — #1409 undone by an
+        edit that looks like a simplification. A rename UPDATES its entry; deleting it shrinks
+        the pinned set, and nothing IN THIS FILE goes red after that."""
         assert _SIGNED <= set(package["signed"])
 
     def test_no_signature_promises_an_out_of_band_failure_and_collapses_anyway(self, package):


### PR DESCRIPTION
Follow-up to #1550, which shipped the mechanism for #1487 without this sentence. Raised by the controller's review of that PR; the hazard is real and the file could not say so.

## What law 1 already does, and what it cannot

`test_every_signed_function_still_declares_its_out_of_band_failure` asserts `_SIGNED <= set(package["signed"])` — a **true subset check**, so a signed function that is renamed or removed goes RED. Fail-closed. That is the property that makes a name-pinned allowlist a ratchet toward correctness rather than the baseline this file's own ruling forbids, and it is worth being explicit that the subset assertion is what clears that ruling — not the intent behind the list.

**The residual is human, not mechanical.** When a legitimate refactor reds law 1, the tempting fix is *deleting* the name from `_SIGNED` rather than updating it. That passes: the subset check then holds against a smaller set, and nothing goes red afterwards to say the pin was lost.

**Nothing in this file goes red after that — measured, not reasoned.** Two mutations, each proven on disk by a moved sha256 and each restored to a byte-identical file:

| | mutation | result |
|---|---|---|
| **A** | delete `worker_config_store.py:get_worker_config_change` from `_SIGNED` — exactly what a tempted refactorer does | law 1 and its vacuity guard both **PASS, rc 0** |
| **B** | drop the `| None` from that function's signature — the case law 1 exists for | both **FAIL, rc 1** |

**B is the control that makes A worth reporting.** Without it, A's green is indistinguishable from a fixture that never armed — the instrument fires, so A's silence is the hazard itself.

The mechanism is visible in the two assertions once you look: the subset check holds against a **smaller** set, and the vacuity guard beside it is a **count** — `len(package["signed"]) >= len(_SIGNED)` — whose right-hand side the deletion lowers. A count also cannot tell "all five still signed" from "one renamed, a different function newly signed"; law 1's subset check covers that case, which is why the file is sound as it stands.

What is left is a person under time pressure choosing between two edits that look equally reasonable, with nothing in the file telling them which.

## Why law 1's own docstring, and not the `_SIGNED` header

The hazard bites at exactly one moment: a refactor has just turned law 1 red and someone is deciding what to do about it. The **failing test's docstring** is what gets read at that moment. The `_SIGNED` header is read by people who are not under that pressure and who are not about to make the mistake.

## What paid for it

The file sits at its budget ceiling — **563, equal to its `docs/dev/file-budget.tsv` row** — so the sentence had to be bought in the same file. I sold the `get_worker_config_change` docstring **quote** in the `_SIGNED` header, compressing it to a pointer at the docstring itself.

That is the right thing to sell twice over: the quote is illustrative rather than load-bearing, the docstring is one grep away in a function the comment names, and **duplicating text that lives elsewhere is precisely the drift mechanism #1553 exists to correct** — that PR removes three copies of a claim that went stale in exactly this way. Applying the finding to my own file rather than only to someone else's.

Net zero: **7 insertions, 7 deletions**, the file stays 563, and `docs/dev/file-budget.tsv` is untouched.

## Evidence

- **The file's own 18 tests pass, rc 0.** This is a test file, so its own suite is the first thing that would notice a docstring edit that broke a fixture or a raw-string boundary.
- **`make lint` rc 0** across the whole surface, `lint-file-budget` included — which is the one that would fail if the edit were not line-neutral.
- **Comment-only.** No line of the diff is executable; `_SIGNED`'s membership, both assertions, and the classifier are untouched.

## What this does NOT do

It does not make the deletion mechanically impossible. Mutation A above is the measurement of that: as this file stands, nothing in it reds. I am not claiming no gate COULD be written — only that none here does. It states the rule where the person about to break it will read it. If a mechanism is wanted later, it needs something that pins the *identity* of each signed function across a rename, which is a different and much larger change than #1487 asked for.