### PR TITLE
fix(installer): the remote-node preflight tests for a ZMQ publisher, not a port (#1497)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -317,17 +317,24 @@ and `--list` prints it).
 - `pithead status` exit code: `0` for a healthy config.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.
-- The Monero node publishes block notifications. A ZMTP handshake against the node's ZMQ port
-  succeeds and the peer advertises a publisher socket type ([#1497](https://github.com/p2pool-starter-stack/pithead/issues/1497)). This is a separate
+- The Monero node's ZMQ endpoint is a live ZMTP publisher. A ZMTP handshake against the node's ZMQ
+  port succeeds and the peer advertises a publisher socket type ([#1497](https://github.com/p2pool-starter-stack/pithead/issues/1497)). The row is
+  named for what the handshake proves, which is narrower than "publishes block notifications": a
+  node whose publisher is bound but permanently silent answers it exactly as a live one does. That
+  remaining gap is not left implicit — every run counts it as a missing leg, `monero ZMQ observed
+  block notification`, because a skip announces itself and a false green does not. Closing it needs
+  a moving chain tip, which a static or `--offline` node cannot supply. This is a separate
   assertion from "Monero is synced" because the sync check cannot fail for a node that can never
   publish: an `--offline` monerod reports `status: OK` with `target_height: 0`, which satisfies
   both halves of the caught-up predicate. Nothing downstream covered the gap either — p2pool's
   healthcheck is a TCP connect to its own stratum port — so a ZMQ-dead node brought the stack up
   green and starved p2pool with nothing able to notice. A bare TCP dial does not close it: a
   docker-published port with nothing behind it accepts the connection in `docker-proxy` itself and
-  answers a dial with rc 0. Measured on one host, three targets: the live node and the
+  answers a dial with rc 0. Measured on one host, four targets: the live node and the
   published-but-dead port were indistinguishable to a dial (both rc 0) and separated by the
-  handshake. Real nodes advertise `XPUB` rather than `PUB`; both are accepted.
+  handshake; the live node and a permanently silent publisher were indistinguishable to the
+  handshake as well, both answering `ok … XPUB`, which is what the declared skip above records.
+  Real nodes advertise `XPUB` rather than `PUB`; both are accepted.
   The probe bounds its own connect ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)). `timeout` cannot wrap a shell
   redirection, so the opening `exec` inherited only the kernel's SYN-retry deadline. A closed port
   answers with RST in about 2 ms, which is why this stayed hidden; a filtered or black-holed host

--- a/lib/pithead/10-installer-preseed.sh
+++ b/lib/pithead/10-installer-preseed.sh
@@ -231,16 +231,56 @@ prefill_from_previous_install() { # <spool-dir>
 # session read exactly that as a crash. TCP connect only (bash /dev/tcp): proves reachability,
 # not protocol health, which the stack's own healthchecks own. rc 0 = all reachable or none
 # remote; rc 1 = a named failure on stdout.
+# A TCP connect proves reachability and NOTHING ELSE, and on the ZMQ port that gap is
+# load-bearing rather than pedantic: docker's userland proxy binds a published host port and
+# accepts the connection ITSELF, so a containerised node whose publisher failed to bind answers
+# the dial rc 0 — and a remote node is a natural thing to run in a container. Measured: a dial
+# cannot separate that from a live node. One ZMTP greeting can, because an accept() cannot
+# produce one; a real publisher sends 64 bytes beginning ff … 7f as soon as it accepts.
+# Refusing here rather than warning is deliberate. A named setup error is recoverable in a
+# minute; the failure it replaces is p2pool starving for block notifications while every check
+# in the stack reports green, which nothing downstream can see.
+# The connect is bounded by wrapping the whole exchange in `timeout` — `timeout` cannot wrap a
+# bare redirection, so an unwrapped `exec` would inherit only the kernel's SYN-retry deadline
+# against a host that stops answering between the dial above and this call.
+# The release-gate harness carries the FULL probe (greeting, READY exchange, advertised socket
+# type). This is deliberately the greeting half alone, because the shipped CLI cannot depend on
+# the test harness and the greeting is the half that separates a publisher from an accept(). The
+# duplication is forced by that boundary, not chosen: if ZMTP's greeting shape ever moves, both
+# copies move together.
+# PURE, over the hex the peer sent, so every failure class is reachable from a fixture with no
+# socket: empty (the published-but-dead port), truncated, not-ZMTP, and ZMTP 2.
+# Length first — every slice below is read with `16#`, and `16#` on an empty string is a fatal
+# arithmetic error rather than a false verdict.
+zmq_greeting_ok() { # <hex>; rc 0 only for a well-formed ZMTP >=3 greeting
+    local g="${1,,}"
+    [ "${#g}" -ge 24 ] && [ "${g:0:2}" = "ff" ] && [ "${g:18:2}" = "7f" ] && [ "$((16#${g:20:2}))" -ge 3 ]
+}
+
+zmq_endpoint_greets() { # <host> <port>; rc 0 only for a ZMTP >=3 peer
+    local g
+    g=$(timeout 5 bash -c '
+        exec 3<>/dev/tcp/"$0"/"$1" 2>/dev/null || exit 1
+        { printf "\xff\x00\x00\x00\x00\x00\x00\x00\x00\x7f\x03\x01NULL"; head -c 48 /dev/zero; } >&3
+        head -c 64 <&3 | od -An -v -tx1 | tr -d " \n"' "$1" "$2" 2>/dev/null) || g=""
+    zmq_greeting_ok "$g"
+}
+
 preflight_remote_nodes() { # <config-file>
-    local cfg="$1" host port
+    local cfg="$1" host port zmq
     if [ "$(jq -r '.monero.mode // "local"' "$cfg")" = "remote" ]; then
         host=$(jq -r '.monero.remote.host // ""' "$cfg")
-        for port in $(jq -r '.monero.remote.rpc_port // 18081' "$cfg") $(jq -r '.monero.remote.zmq_port // 18083' "$cfg"); do
+        zmq=$(jq -r '.monero.remote.zmq_port // 18083' "$cfg")
+        for port in $(jq -r '.monero.remote.rpc_port // 18081' "$cfg") "$zmq"; do
             if ! timeout 5 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
                 printf 'cannot reach the remote Monero node at %s:%s — check the host, the port, and that the node allows LAN access (monero.rpc_lan_access / zmq_lan_access on a Pithead host)' "$host" "$port"
                 return 1
             fi
         done
+        if ! zmq_endpoint_greets "$host" "$zmq"; then
+            printf 'the remote Monero node at %s answers on ZMQ port %s but nothing there speaks ZMQ — a published container port with no publisher behind it answers a reachability check exactly like a live node does. Check that monerod is running with ZMQ enabled, and that zmq_lan_access is on if it is a Pithead host' "$host" "$zmq"
+            return 1
+        fi
     fi
     if [ "$(jq -r '.tari.mode // "local"' "$cfg")" = "remote" ]; then
         host=$(jq -r '.tari.remote.host // ""' "$cfg")

--- a/lib/pithead/10-installer-preseed.sh
+++ b/lib/pithead/10-installer-preseed.sh
@@ -243,11 +243,9 @@ prefill_from_previous_install() { # <spool-dir>
 # The connect is bounded by wrapping the whole exchange in `timeout` — `timeout` cannot wrap a
 # bare redirection, so an unwrapped `exec` would inherit only the kernel's SYN-retry deadline
 # against a host that stops answering between the dial above and this call.
-# The release-gate harness carries the FULL probe (greeting, READY exchange, advertised socket
-# type). This is deliberately the greeting half alone, because the shipped CLI cannot depend on
-# the test harness and the greeting is the half that separates a publisher from an accept(). The
-# duplication is forced by that boundary, not chosen: if ZMTP's greeting shape ever moves, both
-# copies move together.
+# The release-gate harness carries the full probe. This is the greeting half alone because the
+# shipped CLI cannot depend on the test harness: the duplication is forced by that boundary, not
+# chosen, so if ZMTP's greeting shape moves, both copies move with it.
 # PURE, over the hex the peer sent, so every failure class is reachable from a fixture with no
 # socket: empty (the published-but-dead port), truncated, not-ZMTP, and ZMTP 2.
 # Length first — every slice below is read with `16#`, and `16#` on an empty string is a fatal

--- a/pithead
+++ b/pithead
@@ -2369,11 +2369,9 @@ prefill_from_previous_install() { # <spool-dir>
 # The connect is bounded by wrapping the whole exchange in `timeout` — `timeout` cannot wrap a
 # bare redirection, so an unwrapped `exec` would inherit only the kernel's SYN-retry deadline
 # against a host that stops answering between the dial above and this call.
-# The release-gate harness carries the FULL probe (greeting, READY exchange, advertised socket
-# type). This is deliberately the greeting half alone, because the shipped CLI cannot depend on
-# the test harness and the greeting is the half that separates a publisher from an accept(). The
-# duplication is forced by that boundary, not chosen: if ZMTP's greeting shape ever moves, both
-# copies move together.
+# The release-gate harness carries the full probe. This is the greeting half alone because the
+# shipped CLI cannot depend on the test harness: the duplication is forced by that boundary, not
+# chosen, so if ZMTP's greeting shape moves, both copies move with it.
 # PURE, over the hex the peer sent, so every failure class is reachable from a fixture with no
 # socket: empty (the published-but-dead port), truncated, not-ZMTP, and ZMTP 2.
 # Length first — every slice below is read with `16#`, and `16#` on an empty string is a fatal

--- a/pithead
+++ b/pithead
@@ -2357,16 +2357,56 @@ prefill_from_previous_install() { # <spool-dir>
 # session read exactly that as a crash. TCP connect only (bash /dev/tcp): proves reachability,
 # not protocol health, which the stack's own healthchecks own. rc 0 = all reachable or none
 # remote; rc 1 = a named failure on stdout.
+# A TCP connect proves reachability and NOTHING ELSE, and on the ZMQ port that gap is
+# load-bearing rather than pedantic: docker's userland proxy binds a published host port and
+# accepts the connection ITSELF, so a containerised node whose publisher failed to bind answers
+# the dial rc 0 — and a remote node is a natural thing to run in a container. Measured: a dial
+# cannot separate that from a live node. One ZMTP greeting can, because an accept() cannot
+# produce one; a real publisher sends 64 bytes beginning ff … 7f as soon as it accepts.
+# Refusing here rather than warning is deliberate. A named setup error is recoverable in a
+# minute; the failure it replaces is p2pool starving for block notifications while every check
+# in the stack reports green, which nothing downstream can see.
+# The connect is bounded by wrapping the whole exchange in `timeout` — `timeout` cannot wrap a
+# bare redirection, so an unwrapped `exec` would inherit only the kernel's SYN-retry deadline
+# against a host that stops answering between the dial above and this call.
+# The release-gate harness carries the FULL probe (greeting, READY exchange, advertised socket
+# type). This is deliberately the greeting half alone, because the shipped CLI cannot depend on
+# the test harness and the greeting is the half that separates a publisher from an accept(). The
+# duplication is forced by that boundary, not chosen: if ZMTP's greeting shape ever moves, both
+# copies move together.
+# PURE, over the hex the peer sent, so every failure class is reachable from a fixture with no
+# socket: empty (the published-but-dead port), truncated, not-ZMTP, and ZMTP 2.
+# Length first — every slice below is read with `16#`, and `16#` on an empty string is a fatal
+# arithmetic error rather than a false verdict.
+zmq_greeting_ok() { # <hex>; rc 0 only for a well-formed ZMTP >=3 greeting
+    local g="${1,,}"
+    [ "${#g}" -ge 24 ] && [ "${g:0:2}" = "ff" ] && [ "${g:18:2}" = "7f" ] && [ "$((16#${g:20:2}))" -ge 3 ]
+}
+
+zmq_endpoint_greets() { # <host> <port>; rc 0 only for a ZMTP >=3 peer
+    local g
+    g=$(timeout 5 bash -c '
+        exec 3<>/dev/tcp/"$0"/"$1" 2>/dev/null || exit 1
+        { printf "\xff\x00\x00\x00\x00\x00\x00\x00\x00\x7f\x03\x01NULL"; head -c 48 /dev/zero; } >&3
+        head -c 64 <&3 | od -An -v -tx1 | tr -d " \n"' "$1" "$2" 2>/dev/null) || g=""
+    zmq_greeting_ok "$g"
+}
+
 preflight_remote_nodes() { # <config-file>
-    local cfg="$1" host port
+    local cfg="$1" host port zmq
     if [ "$(jq -r '.monero.mode // "local"' "$cfg")" = "remote" ]; then
         host=$(jq -r '.monero.remote.host // ""' "$cfg")
-        for port in $(jq -r '.monero.remote.rpc_port // 18081' "$cfg") $(jq -r '.monero.remote.zmq_port // 18083' "$cfg"); do
+        zmq=$(jq -r '.monero.remote.zmq_port // 18083' "$cfg")
+        for port in $(jq -r '.monero.remote.rpc_port // 18081' "$cfg") "$zmq"; do
             if ! timeout 5 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
                 printf 'cannot reach the remote Monero node at %s:%s — check the host, the port, and that the node allows LAN access (monero.rpc_lan_access / zmq_lan_access on a Pithead host)' "$host" "$port"
                 return 1
             fi
         done
+        if ! zmq_endpoint_greets "$host" "$zmq"; then
+            printf 'the remote Monero node at %s answers on ZMQ port %s but nothing there speaks ZMQ — a published container port with no publisher behind it answers a reachability check exactly like a live node does. Check that monerod is running with ZMQ enabled, and that zmq_lan_access is on if it is a Pithead host' "$host" "$zmq"
+            return 1
+        fi
     fi
     if [ "$(jq -r '.tari.mode // "local"' "$cfg")" = "remote" ]; then
         host=$(jq -r '.tari.remote.host // ""' "$cfg")

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -628,16 +628,18 @@ assert_running_state() {
 
     # 4. Monero caught up — per monerod's own get_info, not the dashboard UI field.
     if monero_caught_up; then it_pass "monerod reports synced (RPC)"; else it_fail "monerod reports synced (RPC)" "get_info not synchronized"; fi
-    # 4b. The node actually PUBLISHES block notifications (#1497). The check above is satisfied by
-    #     a node that can never publish one — an --offline monerod reports status OK with
-    #     target_height 0, so both disjuncts of monero_caught_up pass. Nothing downstream covers
-    #     the gap either: p2pool's healthcheck is a TCP connect to its OWN stratum port, so a
-    #     stack whose node is ZMQ-dead comes up green and starves p2pool silently. Neither does
-    #     the installer preflight, whose reachability dial is a bare TCP connect and therefore
-    #     passes on a docker-published port with nothing behind it (measured). This is a
-    #     protocol-level ZMTP handshake, which an accept() cannot satisfy.
-    #     Tier A only — asserting an OBSERVED notification needs a MOVING tip, and a height
-    #     comparison cannot discriminate against a STATIC node (#1497).
+    # 4b. The node's ZMQ endpoint is a live ZMTP PUBLISHER (#1497) — strictly less than "publishes
+    #     block notifications", and this row is named for what it proves, not for what the issue
+    #     wants. Step 4 is satisfied by a node that can never publish one: an --offline monerod
+    #     reports status OK with target_height 0, so both disjuncts of monero_caught_up pass.
+    #     Nothing downstream covers the gap either — p2pool's healthcheck is a TCP connect to its
+    #     OWN stratum port — and neither does the installer preflight, whose dial is a bare TCP
+    #     connect and so passes against a docker-published port with nothing behind it. A
+    #     protocol-level ZMTP handshake, which an accept() cannot satisfy, closes THAT case, and
+    #     only that case. MEASURED, four targets on one host: a permanently-silent XPUB and a live
+    #     monerod on a MOVING tip are INDISTINGUISHABLE here — both "ok ... XPUB". So the observed
+    #     notification is tier B, it is genuinely missing, and it is declared below as a COUNTED
+    #     SKIP rather than left in a comment: a skip announces itself, a false green does not.
     local zmq_host zmq_port zv
     if [ "$mode" = "remote" ]; then
         zmq_host="$REMOTE_MONERO_HOST"
@@ -646,7 +648,8 @@ assert_running_state() {
         zmq_host="127.0.0.1"
         zmq_port="18083"
     fi
-    if zv=$(zmq_pub_probe "$zmq_host" "$zmq_port" 8); then it_pass "monero ZMQ publishes block notifications (#1497)"; else it_fail "monero ZMQ publishes block notifications (#1497)" "$zv"; fi
+    if zv=$(zmq_pub_probe "$zmq_host" "$zmq_port" 8); then it_pass "monero ZMQ endpoint is a live ZMTP publisher (#1497)"; else it_fail "monero ZMQ endpoint is a live ZMTP publisher (#1497)" "$zv"; fi
+    it_skip_leg "monero ZMQ observed block notification" "tier B (#1497): needs a MOVING chain tip — the handshake above cannot separate a live publisher from a permanently silent one" missing
     # The dashboard's sync panel must also read "done" for a synced node — not stay stuck at
     # "loading". A synced monerod reports target_height 0, so the panel has to trust the caught-up
     # flag, not percent-vs-target; getting that wrong left a synced node "loading" forever (the real

--- a/tests/stack/test-appliance-defaults.sh
+++ b/tests/stack/test-appliance-defaults.sh
@@ -42,8 +42,57 @@ out=$(run_sourced "$PFSB" preflight_remote_nodes "$PFSB/bad.json" 2>/dev/null)
 assert_rc "unreachable remote Tari -> rc 1" "$?" "1"
 assert_contains "failure names host and port" "$out" "127.0.0.1:1"
 assert_contains "failure points at the LAN-access switch" "$out" "grpc_lan_access"
+
+# The ZMQ half. A TCP connect proves reachability and NOTHING else, and on the ZMQ port that gap
+# is load-bearing: docker's userland proxy binds a published host port and accepts the connection
+# itself, so a containerised node whose publisher failed to bind answers the dial rc 0. The
+# verdict is pure over the greeting the peer sent, so every failure class is a fixture here
+# rather than a socket. The first is CAPTURED from a live monerod; the rest are the shapes a
+# live node will not produce.
+PFZ_LIVE=ff00000000000000017f03014e554c4c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+PFZ_HTTP=485454502f312e312034303020426164205265717565737400000000000000000000000000000000000000000000000000000000000000000000000000000000
+PFZ_ZMTP2=ff00000000000000007f01004e554c4c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+run_sourced "$PFSB" zmq_greeting_ok "$PFZ_LIVE"
+assert_rc "a live monerod greeting is accepted" "$?" "0"
+# THE case the dial cannot see: an accept() with no greeting is a published-but-dead port.
+run_sourced "$PFSB" zmq_greeting_ok ""
+assert_rc "an accept() that sends no greeting is refused" "$?" "1"
+run_sourced "$PFSB" zmq_greeting_ok "ff0000"
+assert_rc "a truncated greeting is refused, not read past its end" "$?" "1"
+run_sourced "$PFSB" zmq_greeting_ok "$PFZ_HTTP"
+assert_rc "a listener that is not ZMQ at all is refused" "$?" "1"
+run_sourced "$PFSB" zmq_greeting_ok "$PFZ_ZMTP2"
+assert_rc "a ZMTP 2 peer is refused — the READY exchange needs 3.x" "$?" "1"
+
+# Wiring, both directions, with no socket: stub `timeout` so every dial answers rc 0 and the
+# greeting read returns whatever the case supplies. An empty return is exactly the
+# published-but-dead shape — reachable, and nothing behind it.
+printf '{"monero":{"mode":"remote","remote":{"host":"127.0.0.1","rpc_port":18081,"zmq_port":18083}},"tari":{"mode":"local"}}' >"$PFSB/zmq.json"
+out=$(
+    cd "$PFSB" || exit
+    source "$STACK"
+    set +e
+    timeout() { return 0; }
+    preflight_remote_nodes "$PFSB/zmq.json" 2>/dev/null
+)
+assert_rc "reachable but no ZMTP greeting -> rc 1" "$?" "1"
+assert_contains "the refusal says nothing there speaks ZMQ" "$out" "speaks ZMQ"
+assert_contains "the refusal names the ZMQ port" "$out" "18083"
+# The same run with a live greeting must PASS, or the case above would go green against a
+# preflight that refuses everything.
+out=$(
+    cd "$PFSB" || exit
+    source "$STACK"
+    set +e
+    timeout() {
+        case "$*" in *"od -An"*) printf '%s' "$PFZ_LIVE" ;; esac
+        return 0
+    }
+    preflight_remote_nodes "$PFSB/zmq.json" 2>/dev/null
+)
+assert_rc "reachable AND greeting -> rc 0" "$?" "0"
 rm -rf "$PFSB"
-unset PFSB out
+unset PFSB out PFZ_LIVE PFZ_HTTP PFZ_ZMTP2
 
 echo "== unit: appliance defaults (tor.auto_heal) =="
 # Applied only where ABSENT: an operator who wrote false meant it.

--- a/tests/stack/test-appliance-defaults.sh
+++ b/tests/stack/test-appliance-defaults.sh
@@ -70,6 +70,7 @@ assert_rc "a ZMTP 2 peer is refused — the READY exchange needs 3.x" "$?" "1"
 printf '{"monero":{"mode":"remote","remote":{"host":"127.0.0.1","rpc_port":18081,"zmq_port":18083}},"tari":{"mode":"local"}}' >"$PFSB/zmq.json"
 out=$(
     cd "$PFSB" || exit
+    # shellcheck disable=SC1090
     source "$STACK"
     set +e
     timeout() { return 0; }
@@ -82,6 +83,7 @@ assert_contains "the refusal names the ZMQ port" "$out" "18083"
 # preflight that refuses everything.
 out=$(
     cd "$PFSB" || exit
+    # shellcheck disable=SC1090
     source "$STACK"
     set +e
     timeout() {


### PR DESCRIPTION
Closes the two remaining halves of the remote-node ZMQ gap: the installer preflight, and a
correction to the harness row this lane shipped for it.

## 1. The row I shipped last week overclaimed, in the gate's own output

Reading step 4b before touching the preflight, the tier-A row printed:

```
PASS  monero ZMQ publishes block notifications
```

The probe proves no such thing. It proves a ZMTP peer behind the port advertises a publisher
socket type. Eleven lines above it, the comment already said "Tier A only — asserting an OBSERVED
notification needs a MOVING tip". **The honest limit and the output contradicted each other inside
one function, and the operator only ever reads the output.** The docs bullet led with the same
overclaim before walking it back.

Measured, four targets on one host, the preflight's dial beside the probe:

| target | preflight dial | tier-A probe |
|---|---|---|
| live monerod, moving tip | rc 0 | rc 0 `ok … XPUB` |
| **permanently silent XPUB** | rc 0 | **rc 0 `ok … XPUB`** |
| real docker published-but-dead port | rc 0 | rc 1 `no-greeting` |
| closed port, never published | rc 1 | rc 1 `connect-refused` |

Rows 1 and 2 are indistinguishable to the probe, and both printed that PASS line. So against the
exact hazard this issue was filed about, the release gate asserted a node publishes block
notifications when it never will.

**Keeping the halves apart, because they are not equally established.** That the probe cannot see
silence is *measured here*. That an `--offline` monerod *is* such a publisher is taken from the
measurement already recorded on the issue and is **not** re-derived in this PR.

Fixed by naming the row for what the handshake proves and moving the remainder out of the comment
and into the run summary as a counted skip (`it_skip_leg … missing`). A skip announces itself; a
false green does not. This is a correction to the earlier tier-A PR, disclosed rather than slipped
in as a drive-by.

## 2. The preflight tests for a ZMQ publisher, not for a port

`preflight_remote_nodes` dialled the ZMQ port with a bare TCP connect. Docker's userland proxy
binds a published host port and accepts the connection itself, so a containerised node whose
publisher failed to bind answers that dial rc 0 — and a remote node is a natural thing to
containerise.

One ZMTP greeting separates them, because an `accept()` cannot produce one:

```
live monerod, moving tip        dial PASS    greeting PASS
bound but silent publisher      dial PASS    greeting PASS   (correct: presence, not liveness)
REAL docker published-but-dead  dial PASS    greeting REFUSE  <- the finding
closed port, never published    dial refuse  (the dial catches it first)
```

**Risk posture, stated because this path can refuse a user's install.** The check is strictly
additive in severity: it can only red where the dial already succeeded *and* the peer then proved
it is not a ZMQ publisher. A bound-but-silent publisher still passes, which is right — the
preflight's subject is presence, and liveness is the declared tier-B gap above. Refusing rather
than warning is deliberate: a named setup error costs a minute, while the failure it replaces is
p2pool starving for block notifications with every check in the stack green.

The negative control uses a port that is **not published at all** — a published-but-dead port
answers the dial, so a control built that way comes back green and reads as a broken preflight.

## Proof

The verdict is split from the socket I/O, so its failure classes are fixtures with no socket.

**Controlled pair, both legs in one worktree**, the shipped artifact swapped and restored
byte-identically (`cmp`-gated — a restore that is not byte-identical invalidates the second leg).
Arming was checked before either leg ran, because a pair over two identical artifacts is a null
experiment: the two artifacts differ by 42 lines.

```
leg BASE (pre-fix artifact, new tests)   3054 passed, 8 FAILED   rc 1
restore                                  byte-identical OK
leg HEAD (this branch)                   3062 passed, 0 failed   rc 0
```

The 8 reds are exactly the 8 new assertions and nothing else:

```
✗ a live monerod greeting is accepted
✗ an accept() that sends no greeting is refused
✗ a truncated greeting is refused, not read past its end
✗ a listener that is not ZMQ at all is refused
✗ a ZMTP 2 peer is refused — the READY exchange needs 3.x
✗ reachable but no ZMTP greeting -> rc 1
✗ the refusal says nothing there speaks ZMQ
✗ the refusal names the ZMQ port
```

The ninth new case — `reachable AND greeting -> rc 0` — **passes against the base too**, on
purpose: it is the control proving the new cases are not going green against a preflight that
refuses everything.

13 integration self-tests green (604 assertions).

## Disclosures

- `docs/dev/integration-testing.md` — shared `docs/`, updated alongside the behaviour change.
- `pithead` — COMMON-serialized shared file. **Regenerated by `scripts/build-pithead.sh`, never
  hand-edited**, committed last, after a rebase. Proof it carries nothing else: the artifact's
  added and removed lines are identical, as a set and in order, to the fragment commit's diff.
- `lib/pithead/10-installer-preseed.sh` and `tests/stack/test-appliance-defaults.sh` are under a
  narrow controller grant scoped to this issue and expiring when this PR merges. The test case is
  appended **in place** inside the existing section; nothing relocated, per the prior ruling that
  moving it would break the order-preserving-concat proof.
- The ZMTP greeting logic is duplicated between the shipped CLI and the harness probe. That
  duplication is forced — the shipped CLI cannot depend on the test harness — and is named in a
  comment so the two move together.

## Not done

**Tier B — an *observed* block notification — is still not built, and this PR does not pretend
otherwise; that is the whole point of the counted skip.** It needs a moving chain tip. Recorded
for whoever takes it: p2pool logs `main chain height = N` and learns it only from monerod's ZMQ
notifications, so asserting that value advances is the end-to-end assertion, and it reds against a
static node. Honest cost: a mainnet block averages ~2.2 min but is exponentially distributed, so
p95 is ~6.6 min.

`#1083`'s remote-node row is **not** moved by this PR.

## Ponytail pass (over-engineering), run on this diff

Read off disk and applied to my own diff rather than treated as a checkbox.

- `lib/pithead/10-installer-preseed.sh: shrink:` the forced-duplication note ran to five comment
  lines. **Applied** — three carry it. (`net: -2 lines`.)
- `lib/pithead/10-installer-preseed.sh: yagni:` `zmq_greeting_ok` lowercases its input with
  `${1,,}`, and `od -tx1` only ever emits lowercase. **Declined**, and the reason is the fixtures:
  the harness's sibling verdict does the same, and a case written in uppercase hex would otherwise
  false-red against a function that is correct. Four characters buying parity with the sibling
  instrument.
- Comment-to-code ratio in the new preflight block is high (16:13). **Declined** — it matches the
  density of the function it sits in and of the harness probe, and every paragraph records a
  measurement or a refused alternative rather than restating the code.

`net: -2 lines possible` beyond what is applied.
