### PR TITLE
test(integration): the ZMQ row asserts the node PUBLISHES, not just a live socket (#1497)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -320,10 +320,19 @@ and `--list` prints it).
 - The Monero node's ZMQ endpoint is a live ZMTP publisher. A ZMTP handshake against the node's ZMQ
   port succeeds and the peer advertises a publisher socket type ([#1497](https://github.com/p2pool-starter-stack/pithead/issues/1497)). The row is
   named for what the handshake proves, which is narrower than "publishes block notifications": a
-  node whose publisher is bound but permanently silent answers it exactly as a live one does. That
-  remaining gap is not left implicit — every run counts it as a missing leg, `monero ZMQ observed
-  block notification`, because a skip announces itself and a false green does not. Closing it needs
-  a moving chain tip, which a static or `--offline` node cannot supply. This is a separate
+  node whose publisher is bound but permanently silent answers it exactly as a live one does. A
+  second row closes that case: it subscribes and waits for the peer to actually send something,
+  which a silent publisher never does. Measured on one host against both targets, the live node
+  passed in about 2 seconds and a permanently silent publisher red at its budget. The budget is
+  90 seconds, and the sample behind that figure is part of it — time-to-first-message against the
+  live node over eight samples ran 0.3, 1.5, 1.8, 3.3, 4.5, 5.6, 16.0 and 26.5 seconds, and the
+  first three would have justified a 30-second budget that the tail turns into a flaky red. It is
+  a ceiling rather than a cost: the read returns on the first byte. What remains unproven is
+  narrower than it was — that the frame carried a block notification rather than a transaction or
+  a miner update — and every run counts it as a missing leg, `monero ZMQ published frame is a
+  BLOCK notification`, because a skip announces itself and a false green does not. Closing that
+  needs a new block, a wait of minutes where any published frame arrives in seconds. This is a
+  separate
   assertion from "Monero is synced" because the sync check cannot fail for a node that can never
   publish: an `--offline` monerod reports `status: OK` with `target_height: 0`, which satisfies
   both halves of the caught-up predicate. Nothing downstream covered the gap either — p2pool's
@@ -333,7 +342,7 @@ and `--list` prints it).
   answers a dial with rc 0. Measured on one host, four targets: the live node and the
   published-but-dead port were indistinguishable to a dial (both rc 0) and separated by the
   handshake; the live node and a permanently silent publisher were indistinguishable to the
-  handshake as well, both answering `ok … XPUB`, which is what the declared skip above records.
+  handshake as well, both answering `ok … XPUB`, which is the pair the subscribe row separates.
   Real nodes advertise `XPUB` rather than `PUB`; both are accepted.
   The probe bounds its own connect ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)). `timeout` cannot wrap a shell
   redirection, so the opening `exec` inherited only the kernel's SYN-retry deadline. A closed port

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -637,9 +637,12 @@ assert_running_state() {
     #     connect and so passes against a docker-published port with nothing behind it. A
     #     protocol-level ZMTP handshake, which an accept() cannot satisfy, closes THAT case, and
     #     only that case. MEASURED, four targets on one host: a permanently-silent XPUB and a live
-    #     monerod on a MOVING tip are INDISTINGUISHABLE here — both "ok ... XPUB". So the observed
-    #     notification is tier B, it is genuinely missing, and it is declared below as a COUNTED
-    #     SKIP rather than left in a comment: a skip announces itself, a false green does not.
+    #     monerod on a MOVING tip are INDISTINGUISHABLE to the handshake — both "ok ... XPUB".
+    # 4c. So tier B SUBSCRIBES and waits for the peer to actually send something, which separates
+    #     those two by construction (measured both ways: live node passes in ~2s, silent XPUB reds
+    #     at the budget). What remains uncovered is narrower than it was — that the published frame
+    #     was a BLOCK notification rather than txpool or miner_data — and stays a COUNTED SKIP
+    #     below: a skip announces itself, a false green does not.
     local zmq_host zmq_port zv
     if [ "$mode" = "remote" ]; then
         zmq_host="$REMOTE_MONERO_HOST"
@@ -649,7 +652,8 @@ assert_running_state() {
         zmq_port="18083"
     fi
     if zv=$(zmq_pub_probe "$zmq_host" "$zmq_port" 8); then it_pass "monero ZMQ endpoint is a live ZMTP publisher (#1497)"; else it_fail "monero ZMQ endpoint is a live ZMTP publisher (#1497)" "$zv"; fi
-    it_skip_leg "monero ZMQ observed block notification" "tier B (#1497): needs a MOVING chain tip — the handshake above cannot separate a live publisher from a permanently silent one" missing
+    if zv=$(zmq_publishes_probe "$zmq_host" "$zmq_port" 8 90); then it_pass "monero ZMQ endpoint actually publishes, not merely a live socket (#1497)"; else it_fail "monero ZMQ endpoint actually publishes, not merely a live socket (#1497)" "$zv"; fi
+    it_skip_leg "monero ZMQ published frame is a BLOCK notification" "tier C (#1497): the row above proves the publisher is not silent, which is the starving-p2pool failure; proving the frame was chain_main rather than txpool_add needs a new block, a wait of minutes against seconds" missing
     # The dashboard's sync panel must also read "done" for a synced node — not stay stuck at
     # "loading". A synced monerod reports target_height 0, so the panel has to trust the caught-up
     # flag, not percent-vs-target; getting that wrong left a synced node "loading" forever (the real

--- a/tests/integration/selftest-zmq-probe.sh
+++ b/tests/integration/selftest-zmq-probe.sh
@@ -263,6 +263,15 @@ _mutated=$(
 )
 assert_eq "without the emptiness guard the SILENT node passes (mutation proof)" "$_mutated" "0"
 
+# A SHORT ZMTP message frame begins with a 0x00 flags byte, so the one byte tier B reads is very
+# often NUL. If the read pipeline collapsed that to the empty string, every publisher whose first
+# frame is short would be reported SILENT — the row would red on healthy nodes and, worse, its
+# passing cases would prove nothing. Assert both directions of the same pipeline the snippet runs.
+assert_eq "a NUL first byte is data, not silence" \
+    "$(printf '\x00\x01\x02' | head -c 1 | od -An -v -tx1 | tr -d ' \n')" "00"
+assert_eq "a genuinely empty stream still reads as silence" \
+    "$(printf '' | head -c 1 | od -An -v -tx1 | tr -d ' \n')" ""
+
 # Behavioural: a publish budget must not become the cost of an unreachable port. The connect
 # fails first, so the 90s wait is never entered — a regression here would add 90s per scenario
 # to a gate that is already failing.

--- a/tests/integration/selftest-zmq-probe.sh
+++ b/tests/integration/selftest-zmq-probe.sh
@@ -207,6 +207,75 @@ else
     it_fail "a closed port returns well inside the budget" "took ${elapsed}s of 9s"
 fi
 
+echo "== tier B: the peer must actually PUBLISH, not merely hold a socket open (#1497) =="
+
+# The live half of this pair cannot run here (no node, no socket), so it is recorded rather than
+# re-run. MEASURED on the bench 2026-08-30, one host, the SAME probe against both targets:
+#
+#   live monerod ZMQ 18083    tier A: ok … XPUB    tier B: ok, published in ~2s
+#   silent XPUB 28100         tier A: ok … XPUB    tier B: silent, red at the budget
+#
+# The first column is the defect: tier A cannot tell those two apart, and says PASS for both. The
+# silent XPUB is ~30 lines of python3 raw sockets — it completes the greeting and the READY
+# exchange advertising XPUB, then publishes nothing, forever.
+
+# Tier A must not have moved: it never subscribes, so its cost and its wire text are what shipped.
+tier_a_snippet=$(zmq_probe_snippet 127.0.0.1 18083 8)
+assert_eq "tier A sends no subscription" "$(printf '%s' "$tier_a_snippet" | grep -c 'x00.x01.x01')" "0"
+assert_eq "tier A reads no PUBLISH" "$(printf '%s' "$tier_a_snippet" | grep -c 'PUBLISH')" "0"
+# ...and asking for tier B must actually arm it. A budget that silently failed to appear would
+# make every tier-B row pass for the wrong reason — the arming check, not a text preference.
+tier_b_snippet=$(zmq_probe_snippet 127.0.0.1 18083 8 90)
+assert_eq "tier B sends a subscription frame" "$(printf '%s' "$tier_b_snippet" | grep -c 'x00.x01.x01')" "1"
+assert_contains "tier B bounds its wait at the budget it was given" "$tier_b_snippet" "timeout 90 head -c 1"
+
+PUB_LIVE="GREETING $LIVE_GREETING
+READY $LIVE_READY
+PUBLISH 04"
+PUB_SILENT="GREETING $LIVE_GREETING
+READY $LIVE_READY
+PUBLISH "
+PUB_UNASKED="GREETING $LIVE_GREETING
+READY $LIVE_READY"
+
+zmq_publish_verdict "$PUB_LIVE" 127.0.0.1 18083 >/dev/null
+assert_rc "a peer that sent a byte after subscribing is publishing" "$?" "0"
+v=$(zmq_publish_verdict "$PUB_SILENT" 127.0.0.1 18083)
+assert_rc "a peer that sent NOTHING is silent, not healthy" "$?" "1"
+assert_contains "the silent verdict names what it could not see" "$v" "published NOTHING within the budget"
+# Distinct from silence ON PURPOSE. A snippet run without a publish budget never asked the
+# question, and reporting that as a silent node would be a fabricated failure.
+v=$(zmq_publish_verdict "$PUB_UNASKED" 127.0.0.1 18083)
+assert_rc "an un-asked question is not a silent node" "$?" "1"
+assert_contains "the un-asked verdict says so" "$v" "not-probed"
+
+# MUTATION PROOF: the emptiness guard is the whole assertion. Remove it and the silent fixture —
+# the exact shape of an offline node — passes. Without this the cases above could all be green
+# against a verdict that can never fail.
+_mutated=$(
+    zmq_publish_verdict() {
+        local pub
+        pub=$(printf '%s\n' "$1" | sed -n 's/^PUBLISH //p') # the [ -z "$pub" ] test, deliberately gone
+        echo "ok published $pub"
+    }
+    zmq_publish_verdict "$PUB_SILENT" 127.0.0.1 18083 >/dev/null
+    echo "$?"
+)
+assert_eq "without the emptiness guard the SILENT node passes (mutation proof)" "$_mutated" "0"
+
+# Behavioural: a publish budget must not become the cost of an unreachable port. The connect
+# fails first, so the 90s wait is never entered — a regression here would add 90s per scenario
+# to a gate that is already failing.
+start=$SECONDS
+snippet_out=$(bash -c "$(zmq_probe_snippet 127.0.0.1 1 9 90)" 2>/dev/null)
+elapsed=$((SECONDS - start))
+assert_contains "a closed port still reports CONNECT-FAIL with tier B armed" "$snippet_out" "CONNECT-FAIL"
+if [ "$elapsed" -lt 3 ]; then
+    it_pass "a closed port with a 90s publish budget returns in ${elapsed}s"
+else
+    it_fail "a closed port does not pay the publish budget" "took ${elapsed}s"
+fi
+
 echo ""
 echo "selftest-zmq-probe: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/zmq-probe.sh
+++ b/tests/integration/zmq-probe.sh
@@ -15,10 +15,24 @@
 # An accept() cannot satisfy this probe: it speaks the ZMTP 3.x greeting and the NULL-mechanism
 # READY exchange, and it reads the peer's advertised Socket-Type.
 #
-# Deliberately stops at the handshake (tier A). Asserting an OBSERVED block notification needs a
-# MOVING chain tip, and a height comparison cannot discriminate against a STATIC node — a frozen
-# p2pool view and a frozen monerod agree forever. That tier is not buildable on a static node;
-# see #1497.
+# The handshake alone is tier A, and it is NOT enough: MEASURED on the bench 2026-08-30, a
+# permanently-silent XPUB (a peer that completes the greeting and the READY exchange, then
+# publishes nothing) and a live monerod are INDISTINGUISHABLE to it — both "ok ... XPUB". So this
+# file also carries tier B: SUBSCRIBE, then wait for the peer to actually send something. That
+# separates the two by construction, and the controlled pair is in selftest-zmq-probe.sh.
+#
+# Tier B asserts the publisher is not SILENT, which is the failure class #1497 is about (an
+# offline or ZMQ-dead node starving p2pool). It deliberately does NOT assert that the message was
+# a BLOCK notification — that needs a new block, whose wait is minutes and unbounded, where any
+# published frame arrives in seconds. The remainder stays a counted skip in run.sh, named for
+# what it is rather than left in a comment.
+#
+# THE BUDGET IS 90s, AND THE SAMPLE COUNT IS PART OF THAT FIGURE. Time-to-first-message against
+# the live node, 8 samples, sorted: 0.3 1.5 1.8 3.3 4.5 5.6 16.0 26.5 (seconds). The first three
+# samples all landed under 6s and a 30s budget looked like 5x headroom; the tail arrived only as
+# the sample grew, and 30s would have been a FLAKY RED in the release gate. 90s is ~3.4x the
+# observed max. It is a CEILING, not a cost: the read returns on the first byte, so the happy
+# path pays the median (~4s) and only a genuinely silent node pays the full budget.
 #
 # Split: the socket I/O runs ON THE TARGET through rx (the harness ships shell snippets, never
 # files), and returns hex. Every verdict below it is a PURE function of that hex, so the
@@ -154,7 +168,7 @@ zmq_ready_socket_type() {
 # attribution at all (#1500). A `timeout`-wrapped throwaway connect in a child shell is the one
 # shape that bounds it without re-quoting the whole snippet: the child cannot hand its fd back, so
 # the cost is a second connect on the reachable path, ~2ms against anything that answers.
-zmq_probe_snippet() { # <host> <port> <timeout_s>
+zmq_probe_snippet() { # <host> <port> <timeout_s> [publish_budget_s]
     cat <<EOF
 timeout $3 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null
 case \$? in
@@ -184,7 +198,28 @@ elif [ -n "\$hdr" ]; then
   body=\$(timeout $3 head -c 512 <&3 | od -An -v -tx1 | tr -d ' \n')
 fi
 echo "READY \$hdr\$body"
-exec 3<&-
+EOF
+    # Generated OUTSIDE the heredoc on purpose: an interpolated `$(...)` line leaves a blank line
+    # behind when it expands to nothing, so tier A's snippet text would no longer be what shipped.
+    zmq_subscribe_lines "${4:-}"
+    printf 'exec 3<&-\n'
+}
+
+# The tier-B half of the snippet, kept in its own generator so tier A's text is byte-identical
+# when no publish budget is asked for. Emits nothing at all in that case.
+#
+# The subscription is a ZMTP message frame whose body is 0x01 (subscribe) + topic; an EMPTY topic
+# subscribes to every topic the peer publishes, which is what makes the wait seconds rather than
+# minutes. We then read exactly ONE byte. That is deliberate and not laziness: `timeout` kills
+# `head` mid-buffer, so a larger read can DISCARD bytes that did arrive and report silence — a
+# false red in a release gate. One byte cannot be truncated, and one byte is the whole claim:
+# a peer that already passed the ZMTP handshake and advertised XPUB, and then sends data after a
+# subscription, is publishing. What it published is not asserted here.
+zmq_subscribe_lines() {
+    [ -n "$1" ] || return 0
+    cat <<EOF
+printf '\x00\x01\x01' >&3
+echo "PUBLISH \$(timeout $1 head -c 1 <&3 | od -An -v -tx1 | tr -d ' \n')"
 EOF
 }
 
@@ -237,4 +272,39 @@ zmq_pub_probe() {
     local host="$1" port="$2" to="${3:-5}" out
     out=$(rx "$(zmq_probe_snippet "$host" "$port" "$to")" 2>/dev/null)
     zmq_pub_verdict "$out" "$host" "$port"
+}
+
+# zmq_publish_verdict <target-output> <host> <port> — PURE, over the same text the snippet
+# printed. Tier B only: the caller runs the tier-A verdict first, so a handshake failure is
+# already reported by the time this is reached. Returns 0 only when the peer published.
+zmq_publish_verdict() {
+    local out="$1" host="$2" port="$3" pub
+    # A snippet run WITHOUT a publish budget prints no PUBLISH line at all. That is not silence,
+    # it is an un-asked question, and reporting it as silence would be a fabricated failure.
+    case "$out" in *PUBLISH*) ;;
+    *)
+        echo "not-probed no publish budget was given, so the peer was never asked to publish"
+        return 1
+        ;;
+    esac
+    pub=$(printf '%s\n' "$out" | sed -n 's/^PUBLISH //p')
+    if [ -z "$pub" ]; then
+        echo "silent $host:$port completed the ZMTP handshake and advertised a publisher socket, then published NOTHING within the budget — an offline or ZMQ-dead node looks exactly like this, and the handshake alone cannot see it"
+        return 1
+    fi
+    echo "ok $host:$port published within the budget — the publisher is live, not silent"
+    return 0
+}
+
+# zmq_publishes_probe <host> <port> [handshake_timeout_s] [publish_budget_s] — tier A THEN tier B
+# over ONE connection. Returns tier A's verdict unchanged when the handshake fails, so a dead port
+# is never reported as a silent publisher: those are different defects and want different fixes.
+zmq_publishes_probe() {
+    local host="$1" port="$2" to="${3:-5}" pub="${4:-90}" out v
+    out=$(rx "$(zmq_probe_snippet "$host" "$port" "$to" "$pub")" 2>/dev/null)
+    v=$(zmq_pub_verdict "$out" "$host" "$port") || {
+        printf '%s\n' "$v"
+        return 1
+    }
+    zmq_publish_verdict "$out" "$host" "$port"
 }


### PR DESCRIPTION
## What this closes

`#1497`'s residual. The shipped tier-A row completes a ZMTP handshake and reads the peer's
advertised socket type. That closes the published-but-dead-port case and **nothing more**: a
permanently-silent XPUB — a peer that finishes the greeting and the READY exchange, then publishes
nothing, forever — answers it exactly as a live node does.

## PROVEN BY ME, this session, on one host

Four cells, both instruments fired in both directions:

| Target | tier A (shipped) | tier B (this PR) |
|---|---|---|
| live monerod `18083` | `rc=0` ok … XPUB | `rc=0` published, ~2s |
| permanently-silent XPUB | `rc=0` ok … XPUB — **the false pass** | `rc=1` silent, red at budget |
| closed port | `rc=1` connect-refused | `rc=1` connect-refused (not "silent") |

That last row matters: a dead port is reported as a handshake failure, not as silence. Different
defects, different fixes.

The silent XPUB is ~30 lines of python3 raw sockets. It is a throwaway, and a previous cycle built
and discarded the same thing — the recipe is now recorded in `selftest-zmq-probe.sh` so a third
rebuild is not needed.

Controlled suite pair, both legs in one worktree, base extracted from git: **BASE 55 passed /
HEAD 69 passed**, +14 = exactly the 14 assertions added. Mutation proof included: with the
emptiness guard removed, the SILENT fixture passes — so the new cases are not green by construction.

## The budget, and why the sample size is part of the figure

Time-to-first-message against the live node, 8 samples: `0.3 1.5 1.8 3.3 4.5 5.6 16.0 26.5` seconds.
The first three all landed under 6s and made a 30s budget look like 5x headroom. The tail only
appeared as the sample grew, and 30s would have been a **flaky red in the release gate**. The budget
is 90s — a ceiling, not a cost: the read returns on the first byte, so the happy path pays the median
(~4s) and only a genuinely silent node pays the budget.

## What I did NOT do

- **Not proven: that the published frame was a BLOCK notification** rather than txpool or miner_data.
  That needs a new block — minutes, where any frame arrives in seconds. It stays a **counted skip**,
  renamed for what it actually is (`monero ZMQ published frame is a BLOCK notification`), not left in
  a comment.
- **Not settled: whether p2pool learns `main chain height` from ZMQ or from RPC polling.** An earlier
  plan for this work used that log value as the instrument, on the premise that it is ZMQ-only. I
  could not confirm that premise — the live p2pool log carries no ZMQ lines, and the value is printed
  on *sidechain* tip changes, not on monerod notifications. **This PR does not depend on it:** it
  subscribes to monerod directly, so the premise is now irrelevant rather than assumed.
- **Not measured: an `--offline` monerod as a silent publisher.** That claim is inherited from the
  issue and is still not re-derived. The synthetic silent XPUB is what was measured.
- **Residual false-red risk, stated rather than budgeted away:** a live node that publishes nothing
  for 90s reds. My samples show mainnet traffic every few seconds, but a genuinely quiet node is
  indistinguishable from a silent one — that is an irreducible limit of this instrument, not an
  oversight. Raising the budget hides it rather than removing it.

## Lints — with the file set each was measured over

Recording the set because a lint verdict without it is a scope claim, not a coverage claim.

- `shellcheck 0.11.0 --severity=warning` over `tests/integration/*.sh tests/integration/mini-stack/*.sh`
  — **rc 0**. Verified the set CONTAINS all three changed shell files. Positive control fired: an
  injected `SC2034` in `zmq-probe.sh` reddened it (`rc 1`), restore cmp-verified byte-identical.
- `shfmt -i 4 -d` over the Makefile's exact glob — **rc 0, zero diff lines**.
- `make lint-md`, `make lint-docs-voice`, `make lint-file-budget` — all green.
- `make test-integration-selftest` — all 12 self-test files ran, **0 failed**.
- `run.sh` is 2548 against its 2551 ceiling.

`make lint-sh` was NOT run as a whole: it is this box's OOM path and is serialized. The two halves
above are the documented substitute, and this time the changed files were confirmed inside the set.

## Shared-file disclosure

`docs/dev/integration-testing.md` is under `docs/`, which no role owns. Its ZMQ paragraph asserted
that the remaining gap "needs a moving chain tip, which a static or `--offline` node cannot supply" —
this change makes that false for the silence half, so the doc is corrected in the same commit rather
than left to rot.

## Over-engineering review (ran on my own diff; findings I DECLINED, with reasons)

- `yagni: zmq_subscribe_lines has one caller.` **Declined.** It is not decoration: interpolating it
  inside the heredoc leaves a blank line behind when it expands to nothing, which moves tier A's
  shipped snippet text. Measured — the first draft did exactly that, and a self-test now pins tier A
  byte-identical.
- `shrink: tier A and tier B open two connections and handshake twice.` **Declined**, but it is a
  real cost, not a non-finding. Collapsing them into one probe means returning two verdicts from one
  call, and `run.sh` has 3 lines of headroom. The price is one TCP connect on the happy path.
- `net: -8 lines possible` if both were taken. Neither is free.
