### PR TITLE
test(integration): the abort-trap guard WALKS the directory it claims to guard (#1515)

### DIFF
--- a/tests/integration/selftest-abort-traps.sh
+++ b/tests/integration/selftest-abort-traps.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 #
-# Self-test for the harness's ABORT TRAPS (#1401): checks exactly two named sites — e2e.sh's
-# `restore_all` trap and tor-client/probe.sh's `kill`-tor trap — and asserts each names `EXIT` and
-# nothing else. This is NOT a directory-wide sweep: it is two hardcoded (file, handler) pairs, not a
-# walk over tests/integration/, so a third file adding the same `EXIT INT TERM` idiom would pass this
-# file unnoticed (#1515, filed to widen this to a real walk). Standalone (not sourced by selftest.sh)
-# so it never touches that file's budget ceiling — the #1258/#1301 "moved into its own file"
-# precedent. Run directly, or via `make test-integration-selftest`. No server needed.
+# Self-test for the harness's ABORT TRAPS (#1401): WALKS every `*.sh` under tests/integration/ and
+# asserts that each `trap` statement names `EXIT` and nothing else. It checked two hardcoded (file,
+# handler) pairs until #1515, and the walk is the fix: measured, the two-site version stayed green
+# against all three shapes that reintroduce the defect — a signal added to a file the change never
+# touched, a brand-new selftest, and a second handler beside the guarded one inside e2e.sh itself.
+# The scan is `*.sh` only; verified at the time of writing that no shell file under this directory
+# lacks that extension, so nothing is currently out of reach, but one added later would be.
+# Standalone (not sourced by selftest.sh) so it never touches that file's budget ceiling — the
+# #1258/#1301 "moved into its own file" precedent. Run directly, or via
+# `make test-integration-selftest`. No server needed.
 #
 # WHAT THIS EXISTS TO STOP, and why a comment alone would not have. `trap handler EXIT INT TERM` is
 # the common idiom and it READS as more careful than bare `EXIT`, so it gets re-added by anyone who
@@ -79,16 +82,15 @@ abort_trial() { # <trap-spec, "" for none> <signal>
     TRIAL_CONTINUED="$(grep -c CONTINUED "$out")"
 }
 
-# The signal list of a `trap` line: everything after the handler argument.
-trap_signals() { # <file> <extended-regex matching the whole trap line>
-    local line
-    line="$(grep -hE "$2" "$1" | head -n1)"
-    [ -n "$line" ] || {
-        echo "__NO_TRAP_LINE_MATCHED__"
-        return
-    }
-    # Strip the leading `trap` and the handler (quoted or bare), leaving the signal names.
-    printf '%s\n' "$line" | sed -E "s/^trap[[:space:]]+('[^']*'|\"[^\"]*\"|[^[:space:]]+)[[:space:]]*//"
+# The signal list of one `trap` line: everything after the handler argument. The handler is stripped
+# FIRST, so a `#` inside a quoted handler can never be read as a comment; only then is a trailing
+# comment cut, which is safe because signal names contain no `#`. Leading indentation is allowed —
+# two of the shipped traps are installed inside functions, and anchoring on a bare `^trap` would
+# silently skip both, reporting a clean sweep over a population it never looked at.
+trap_line_signals() { # <the text of one trap line>
+    printf '%s\n' "$1" |
+        sed -E "s/^[[:space:]]*trap[[:space:]]+('[^']*'|\"[^\"]*\"|[^[:space:]]+)[[:space:]]*//" |
+        sed -E 's/#.*$//; s/[[:space:]]+$//'
 }
 
 echo "== CONTROLS: with no trap at all, the signal MUST kill the victim (#1401) =="
@@ -120,18 +122,39 @@ for sig in INT TERM; do
         "$TRIAL_FIRED" "2"
 done
 
-echo "== the shipped abort traps name EXIT and nothing else =="
-# e2e.sh: restore_all is the borrowed rig's only unwind. If this reds, read the block above before
-# "fixing" it by re-adding the signals — that is the change this file exists to refuse.
-sigs="$(trap_signals "$HERE/e2e.sh" '^trap[[:space:]]+restore_all[[:space:]]')"
-assert_ne "e2e.sh's restore_all trap line was found at all" "$sigs" "__NO_TRAP_LINE_MATCHED__"
-assert_eq "e2e.sh traps restore_all on EXIT alone (#1401)" "$sigs" "EXIT"
+echo "== every trap under tests/integration/ names EXIT and nothing else (#1401/#1515) =="
+# A WALK, not a list of known sites: #1401's second live instance was found by enumerating the class,
+# and a check wired to named sites cannot enumerate anything. If one of these reds, read the block at
+# the top of this file before "fixing" it by re-adding the signals — that is the change this file
+# exists to refuse.
+#
+# The scan reads the WORKING TREE, not `git ls-files`, so a file not yet `git add`ed is still swept;
+# #1486 is this same kind of check made blind in exactly that way.
+trap_scan="$(grep -rnE '^[[:space:]]*trap[[:space:]]' --include='*.sh' "$HERE")"
 
-# tor-client/probe.sh: same class, different consequence — naming the signals would kill tor and
-# then carry on into the bootstrap wait, spending BOOT_TIMEOUT to report a wrong diagnosis.
-sigs="$(trap_signals "$HERE/tor-client/probe.sh" "^trap[[:space:]]+'kill")"
-assert_ne "probe.sh's tor-kill trap line was found at all" "$sigs" "__NO_TRAP_LINE_MATCHED__"
-assert_eq "probe.sh traps the tor kill on EXIT alone (#1401)" "$sigs" "EXIT"
+# Fed by a heredoc rather than a pipe on purpose: `grep ... | while` runs the loop body in a
+# SUBSHELL, so every it_pass/it_fail it recorded would be discarded when the pipeline ended and the
+# summary below would count zero of them while printing green.
+while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    hit_file="${hit%%:*}"
+    hit_rest="${hit#*:}"
+    assert_eq "${hit_file#"$HERE"/}:${hit_rest%%:*} traps on EXIT alone (#1401)" \
+        "$(trap_line_signals "${hit_rest#*:}")" "EXIT"
+done <<EOF
+$trap_scan
+EOF
+
+# The walk alone is silently green over a tree whose traps were all DELETED, and green is the wrong
+# answer there: restore_all is the borrowed rig's only unwind, and probe.sh's kill is what stops a
+# leaked tor. So require the two load-bearing sites to still be present, read out of the same scan
+# rather than re-derived by a second mechanism that could drift from it.
+assert_num_ge "the walk found trap statements at all — a 0 here is a broken scan, not a clean tree" \
+    "$(printf '%s\n' "$trap_scan" | grep -c .)" "2"
+assert_contains "e2e.sh's restore_all trap is still installed — the borrowed rig's only unwind" \
+    "$trap_scan" "trap restore_all"
+assert_contains "probe.sh's tor-kill trap is still installed (#1401's second site)" \
+    "$trap_scan" "trap 'kill "
 
 echo ""
 echo "selftest-abort-traps: $IT_PASS passed, $IT_FAIL failed"


### PR DESCRIPTION
Closes #1515.

`tests/integration/selftest-abort-traps.sh` asserted that an abort trap names `EXIT` and nothing else — at two hardcoded `(file, anchored-regex)` pairs. No glob, no directory walk, no enumeration. The file's header described the directory; its mechanism covered two sites in it.

## The blindness, reproduced here rather than relayed

The issue lists three shapes that reintroduce #1401. I ran all three against the **pre-change guard** on this branch's base, so the claim is measured on this host and not carried across from the filing:

| shape | OLD guard | NEW guard |
|---|---|---|
| baseline, unmodified tree | 16 pass / 0 fail | 26 pass / 0 fail |
| `INT TERM` added to a file the change never touched (`selftest.sh:237`) | **16 / 0 — blind** | 25 / **1** |
| a brand-new `selftest-*.sh` with `trap cleanup EXIT INT TERM` | **16 / 0 — blind** | 26 / **1** |
| a second, differently-named handler beside the guarded one inside `e2e.sh` | **16 / 0 — blind** | 26 / **1** |

Every mutation was `cmp`-gated before it was allowed to count — a `sed` that silently matches nothing writes an unchanged file and the leg scores a false "blind" — and every restore was `cmp`-verified. The old guard was run from `git show`, placed at a path without a `.sh` extension so the new walk could not scan the very instrument it was being compared against.

The assertion count reconciles exactly: **16 → 26 = +11 walk rows, +3 new, −4 removed.**

## Two constraints the issue did not name

Both were found before the code was written, and either one would have made the widened guard worse than the narrow one:

1. **Two shipped traps are installed INSIDE functions** (`lib.sh:445`, `rig-key-ledger.sh:86`). The existing helper anchored on a bare `^trap`, which matches neither. A walk built on that anchor sweeps the directory, skips both, and prints a clean result — a sweep reporting green over a population it cannot express, which is the exact failure class this file exists to catch.
2. **One trap line carries a trailing comment** (`selftest-abort-traps.sh:46`, itself). It leaks into the signal list and the row reds on a correct file. Stripping the handler *first* fixes it and is also what stops a `#` inside a quoted handler being read as a comment; signal names contain no `#`, so the cut is safe only in that order.

## Two deliberate choices, stated rather than buried

- **The existence assertions are kept, not replaced.** The issue says "replace the two hardcoded call sites". A pure walk is silently green over a tree whose traps have all been *deleted*, and green is the wrong answer: `restore_all` is the borrowed rig's only unwind and `probe.sh`'s kill is what stops a leaked tor. Both are now read out of the same scan, so they cannot drift from it.
- **The scan reads the working tree, not `git ls-files`.** A file not yet `git add`ed is still swept. #1486 is this same kind of check made blind in exactly that way.

Two mechanics worth naming for whoever edits this next: the scan is fed to the loop by a heredoc rather than a pipe, because `grep ... | while` runs the body in a subshell and every `it_pass`/`it_fail` would be discarded at the end of the pipeline while the summary printed green; and the walk is `*.sh` only — verified at the time of writing that no shell file under this directory lacks that extension, so nothing is currently out of reach, but one added later would be. That limit is in the file header, not only here.

## Not done, and why

The guard is strict: any `trap` line whose signal list is not exactly `EXIT` reds, including forms that are not the #1401 defect at all (`trap - INT` to clear one, `trap '' PIPE` to ignore one). None exist in the tree today. A strict guard means a legitimate future use of those forms reds and has to be argued rather than waved through, which is the trade I took deliberately for a file whose whole subject is an idiom that reads as more careful than it is. It fails loudly and cheaply if I got that wrong.

## What was run

- shellcheck 0.11.0 over **the Makefile's first invocation verbatim**, rc 0 — not a partial glob, which invents SC2034s. The file set contains the changed file, and a positive control (an SC2034 injected into that file) reddened the run at 3 matches; restore `cmp`-verified.
- `shfmt -i 4 -d` over the Makefile's exact glob — rc 0, empty diff.
- `make test-integration-selftest` — rc 0 (the globbed runner, so this file is picked up with no registration).
- `make lint-md` — 48 files, 0 errors.
- `lane-guard.sh` fired both ways: rc 0 on the staged set (this file alone), rc 1 on a staged `tests/stack/` sibling. Entirely `tests/integration/`; no grant, no `.lane-override`, no shared file.
- No docs change: nothing in `docs/` describes this guard's scope, checked. No deployed twin of this file exists under the testbench directory, checked rather than assumed.

## Ponytail review (run on this diff, findings and what I declined)

Read off disk from `plugins/marketplaces/ponytail/skills/ponytail-review/SKILL.md` and applied to the diff. Two findings, both real, both declined — stated here rather than silently skipped:

- `selftest-abort-traps.sh:L152: yagni: the assert_num_ge non-vacuity row is subsumed by the two assert_contains rows below it — an empty scan already reds both. Delete it, net -3.`
  **Declined.** The two `assert_contains` rows assert about the *tree's content*; the `num_ge` row asserts about the *instrument*. This file's entire subject is a check that reported clean over a population it never looked at, and when a guard reds unattended the difference between "the scan broke" and "restore_all is missing" is the whole diagnosis. I am keeping the row that names the instrument.
- `selftest-abort-traps.sh:L91-93: shrink: two sed processes in a pipeline where one with two -e flags would do. net -1 line, -1 process.`
  **Declined.** Combining them means mixing single- and double-quoted expressions in one invocation, because the handler pattern contains `\"` and the trailing-comment cut contains `$`. The saving is one process in a test that already forks per trial; the cost is quoting subtlety inside the one function this guard's correctness rests on. Not a trade I will take in a file whose failure mode is a sweep that silently matches nothing.

`net: -4 lines possible, 0 taken.`
