### PR TITLE
fix(dashboard): the audit row's own id is the field the sanitizer skipped (#1561)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,10 +126,13 @@ The stack's defaults:
   large each one is, so the row's own identifier is bounded separately (#1561): every audit row id
   is length-capped and whitelisted at the writer, the one field the trail's sanitizer used to skip,
   and `rig-drift`'s revision is validated to a short opaque token at the point it is read as well.
-  A rig therefore cannot choose an audit row's identifier, and cannot make one arbitrarily large —
-  which is what the two bounds together have to say, because `audit_events` is never pruned and the
-  `rig-edit` id is built from a `change_id` the rig picks freely. The `host-edit` and mirrored
-  `control.log` rows are not attacker-controllable and are not capped.
+  A rig does still CHOOSE its own `rig-edit` row's identifier — that id is built from a `change_id`
+  it picks freely — but it can no longer make one arbitrarily large or carry markup into it, which
+  is what matters on a table that is never pruned. What it cannot do is forge a `host-edit` or
+  `control.log` identifier: those are built from hardcoded prefixes a `rig-edit` id can never equal.
+  Inside the `rig-edit-` prefix, though, the ids are a plain concatenation and do not separate one
+  worker from another (#1569), so read that namespace as one shared space rather than as per-worker.
+  The `host-edit` and mirrored `control.log` rows are not attacker-controllable and are not capped.
 
 ### Telegram control commands (#338)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,11 +121,15 @@ The stack's defaults:
   unauthenticated worker feed, so they SHARE one rate cap per worker (#724): a rig reporting
   distinct change_ids — or a fresh revision — on every poll can add at most a bounded number of
   rows per hour between them before the rest are dropped behind a single `rate-limited` marker that
-  names which of the two tipped it, so one LAN device can't grow the database without limit. One
-  budget rather than one each, because two would double what that device can make permanent. Values
-  from that feed are also validated to a short opaque token before they reach the store, so a rig
-  cannot choose an audit row's own identifier. The `host-edit` and mirrored `control.log` rows are
-  not attacker-controllable and are not capped.
+  names which of the two tipped it. One budget rather than one each, because two would double what
+  that device can make permanent. That cap bounds how many rows a LAN device can add and not how
+  large each one is, so the row's own identifier is bounded separately (#1561): every audit row id
+  is length-capped and whitelisted at the writer, the one field the trail's sanitizer used to skip,
+  and `rig-drift`'s revision is validated to a short opaque token at the point it is read as well.
+  A rig therefore cannot choose an audit row's identifier, and cannot make one arbitrarily large —
+  which is what the two bounds together have to say, because `audit_events` is never pruned and the
+  `rig-edit` id is built from a `change_id` the rig picks freely. The `host-edit` and mirrored
+  `control.log` rows are not attacker-controllable and are not capped.
 
 ### Telegram control commands (#338)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,8 +122,10 @@ The stack's defaults:
   distinct change_ids — or a fresh revision — on every poll can add at most a bounded number of
   rows per hour between them before the rest are dropped behind a single `rate-limited` marker that
   names which of the two tipped it. One budget rather than one each, because two would double what
-  that device can make permanent. That cap bounds how many rows a LAN device can add and not how
-  large each one is, so the row's own identifier is bounded separately (#1561): every audit row id
+  that device can make permanent. The cap is keyed on the worker name the device presents, which a
+  device chooses freely, so it bounds a NAME rather than a device: one rotating names draws a fresh
+  budget per name (#1566). And it bounds how many rows arrive, not how large each one is, so the
+  row's own identifier is bounded separately (#1561): every audit row id
   is length-capped and whitelisted at the writer, the one field the trail's sanitizer used to skip,
   and `rig-drift`'s revision is validated to a short opaque token at the point it is read as well.
   A rig does still CHOOSE its own `rig-edit` row's identifier — that id is built from a `change_id`
@@ -131,7 +133,7 @@ The stack's defaults:
   is what matters on a table that is never pruned. What it cannot do is forge a `host-edit` or
   `control.log` identifier: those are built from hardcoded prefixes a `rig-edit` id can never equal.
   Inside the `rig-edit-` prefix, though, the ids are a plain concatenation and do not separate one
-  worker from another (#1569), so read that namespace as one shared space rather than as per-worker.
+  worker from another (#1566), so read that namespace as one shared space rather than as per-worker.
   The `host-edit` and mirrored `control.log` rows are not attacker-controllable and are not capped.
 
 ### Telegram control commands (#338)

--- a/dashboard/mining_dashboard/service/audit_service.py
+++ b/dashboard/mining_dashboard/service/audit_service.py
@@ -15,6 +15,7 @@ unfiltered. Growth is bounded by the writers, not here: the audit log is trimmed
 """
 
 import calendar
+import hashlib
 import json
 import os
 import re
@@ -42,6 +43,42 @@ def _clean(value, max_len=200):
     if not isinstance(value, str):
         value = "" if value is None else str(value)
     return _SAFE_CHARS.sub("", value)[:max_len]
+
+
+# The audit row id is the ONE field the #530 writer does not put through ``_clean``, and it is the
+# ``audit_events`` PRIMARY KEY on a table with no retention prune (#1561) — so an oversized id is
+# permanent. Callers build it from their own inputs, and on the rig-edit path that input is an
+# unauthenticated worker's ``change_id``, validated upstream only as a non-empty ``str`` inside a
+# body capped at 1 MiB. The bound has to clear every id this repo legitimately constructs: the
+# longest is ``rig-drift-{worker}-{revision}`` at 10 + 128 (``_WORKER_NAME_RE``) + 1 + 64
+# (``parse_config_meta``) = 203 characters.
+MAX_EVENT_ID_LEN = 256
+
+# Enough digest that distinct inputs stay distinct in practice; a sha256 prefix, not a truncation.
+_EVENT_ID_DIGEST_LEN = 16
+
+
+def clean_event_id(event_id):
+    """``event_id`` as a bounded, charset-restricted, still-DETERMINISTIC audit row id (#1561).
+
+    An id that survives ``_clean`` unchanged is returned verbatim, so every id this repo builds
+    keeps the key it already has and no existing row is orphaned or duplicated. Anything the
+    whitelist or the length cap would alter is replaced by its safe prefix plus a sha256 digest of
+    the ORIGINAL, because bounding this field cannot be a plain truncation: two distinct long ids
+    sharing a prefix would collapse to one row under ``INSERT OR IGNORE`` and LOSE a detection.
+    The digest keeps the mapping one-way-collision-free while staying a pure function of the input,
+    so a rig re-reporting the same change every poll still dedupes to exactly one row.
+
+    Returns "" for a non-str or empty input, which is what the caller's ``or`` fallback to a random
+    id is written against."""
+    if not isinstance(event_id, str) or not event_id:
+        return ""
+    safe = _clean(event_id, MAX_EVENT_ID_LEN)
+    if safe == event_id:
+        return safe
+    digest = hashlib.sha256(event_id.encode("utf-8", "surrogatepass")).hexdigest()
+    keep = MAX_EVENT_ID_LEN - _EVENT_ID_DIGEST_LEN - 1
+    return f"{safe[:keep]}-{digest[:_EVENT_ID_DIGEST_LEN]}"
 
 
 def _tail_json_lines(path):

--- a/dashboard/mining_dashboard/service/data_service.py
+++ b/dashboard/mining_dashboard/service/data_service.py
@@ -707,15 +707,15 @@ class DataService:
         trail is served through (``audit_service._clean``) — defense in depth: ``actor``/``keys``
         here are already schema-shaped (a validated worker name, dotted config-key paths), but
         every field the Security panel serves gets the identical whitelist treatment regardless of
-        source, so a future caller can't accidentally skip it.
+        source — the row ``id`` included, since #1561.
 
         ``event_id`` lets a caller supply a DETERMINISTIC row id so ``INSERT OR IGNORE`` collapses
         repeat reports of the SAME event to one row (rig-edit: a rig re-reports its last change_id
-        every poll). A host-edit passes None — each detection is a genuinely distinct event, so a
-        random id is right there."""
+        every poll); ``clean_event_id`` bounds it HERE, at the sink, not at each caller. A host-edit
+        passes None — a distinct event each time, so the random id is right there."""
         await asyncio.to_thread(
             self.state_manager.add_audit_event,
-            id=event_id or f"{source}-{uuid.uuid4()}",
+            id=audit_service.clean_event_id(event_id) or f"{source}-{uuid.uuid4()}",
             ts=_iso_now(),
             source=audit_service._clean(source, 16),
             actor=audit_service._clean(actor, 64),

--- a/dashboard/tests/service/test_audit_event_id.py
+++ b/dashboard/tests/service/test_audit_event_id.py
@@ -67,6 +67,19 @@ class TestCleanEventIdContract:
         row only while the id is a pure function of the input."""
         assert audit_service.clean_event_id(HOSTILE) == audit_service.clean_event_id(HOSTILE)
 
+    def test_a_lone_surrogate_does_not_crash_the_poll_loop(self):
+        """A rig's JSON can carry ``\\ud800``, and ``json.loads`` hands it over as a lone
+        surrogate that plain ``str.encode("utf-8")`` refuses — which would raise inside the poll
+        loop rather than record a row. The digest encodes with ``surrogatepass`` for exactly this.
+        The first assertion is the control: it pins that the input really is un-encodable, so this
+        test cannot pass by accident on an ordinary string."""
+        lone = "rig-edit-miner1-" + "\ud800" + "x" * 300
+        with pytest.raises(UnicodeEncodeError):
+            lone.encode("utf-8")
+        out = audit_service.clean_event_id(lone)
+        assert len(out) <= audit_service.MAX_EVENT_ID_LEN
+        assert out == audit_service.clean_event_id(lone)
+
     @pytest.mark.parametrize("empty", [None, "", 42, b"bytes", {"a": 1}])
     def test_absent_or_non_str_is_falsy(self, empty):
         """The caller's ``or f"{source}-{uuid4()}"`` fallback is written against a falsy return —

--- a/dashboard/tests/service/test_audit_event_id.py
+++ b/dashboard/tests/service/test_audit_event_id.py
@@ -1,0 +1,130 @@
+"""The audit row id is sanitized like every other field the Security panel serves (#1561).
+
+``_record_audit_event`` cleans five fields through ``audit_service._clean`` and used to pass the
+sixth — ``id``, the ``audit_events`` PRIMARY KEY — through untouched. On the rig-edit path that id
+is built from an unauthenticated worker's ``change_id``, validated upstream only as a non-empty
+``str`` inside a body capped at 1 MiB, and ``audit_events`` has no retention prune, so an oversized
+id is permanent.
+
+Both halves are here because they are one behaviour and either alone is a false pass: the contract
+tests would stay green if ``_record_audit_event`` never called the helper, and the wiring test would
+stay green against a naive truncation that silently merges two detections.
+"""
+
+import types
+import uuid
+
+import pytest
+
+from mining_dashboard.service import audit_service
+from mining_dashboard.service.data_service import DataService
+
+# The longest id this repo legitimately constructs: "rig-drift-" + a worker name at the
+# _WORKER_NAME_RE bound (128) + "-" + a revision at the parse_config_meta bound (64) = 203.
+LONGEST_REAL_ID = f"rig-drift-{'w' * 128}-{'r' * 64}"
+
+HOSTILE = "rig-edit-miner1-" + "A" * 5000 + "\x00\n<script>"
+
+
+class TestCleanEventIdContract:
+    def test_real_ids_pass_through_verbatim(self):
+        """Every id the repo builds today keeps the key it already has — no row is orphaned by
+        this change, and ids stay readable in the table. A blanket digest would fail this."""
+        assert len(LONGEST_REAL_ID) == 203
+        for real in (
+            "11111111-1111-4111-8111-111111111111",
+            "host-edit-11111111-1111-4111-8111-111111111111",
+            "rig-edit-miner1-chg-2026-08-30T01:00:00Z",
+            "rig-edit-ratelimited-miner1-1756515600",
+            LONGEST_REAL_ID,
+        ):
+            assert audit_service.clean_event_id(real) == real
+
+    def test_oversized_is_bounded(self):
+        out = audit_service.clean_event_id(HOSTILE)
+        assert len(out) <= audit_service.MAX_EVENT_ID_LEN
+
+    def test_hostile_charset_is_stripped(self):
+        out = audit_service.clean_event_id(HOSTILE)
+        for bad in ("<", ">", "\x00", "\n", "script"):
+            assert bad not in out
+
+    def test_distinct_long_ids_sharing_a_prefix_stay_distinct(self):
+        """The anti-truncation control, and the reason this is a digest and not a slice.
+
+        Two rigs reporting different change_ids that agree on a long prefix must land on two rows.
+        Under a plain truncation both collapse to one id, ``INSERT OR IGNORE`` drops the second,
+        and a real detection is lost silently. This test goes RED against that fix."""
+        prefix = "rig-edit-miner1-" + "c" * 4000
+        a = audit_service.clean_event_id(prefix + "AAA")
+        b = audit_service.clean_event_id(prefix + "BBB")
+        assert a != b
+        assert len(a) <= audit_service.MAX_EVENT_ID_LEN
+        assert len(b) <= audit_service.MAX_EVENT_ID_LEN
+
+    def test_deterministic_so_repeat_reports_still_dedupe(self):
+        """A rig re-reports its last change_id every poll; INSERT OR IGNORE collapses those to one
+        row only while the id is a pure function of the input."""
+        assert audit_service.clean_event_id(HOSTILE) == audit_service.clean_event_id(HOSTILE)
+
+    @pytest.mark.parametrize("empty", [None, "", 42, b"bytes", {"a": 1}])
+    def test_absent_or_non_str_is_falsy(self, empty):
+        """The caller's ``or f"{source}-{uuid4()}"`` fallback is written against a falsy return —
+        a host-edit passes None and must still get a random id."""
+        assert audit_service.clean_event_id(empty) == ""
+
+
+class TestSinkActuallyUsesIt:
+    """Proves consumption, not just existence. Without these, every test above could pass while
+    ``_record_audit_event`` still wrote the raw value."""
+
+    @staticmethod
+    def _svc(recorded):
+        def add_audit_event(**kwargs):
+            recorded.append(kwargs)
+
+        return types.SimpleNamespace(
+            state_manager=types.SimpleNamespace(add_audit_event=add_audit_event)
+        )
+
+    async def test_hostile_event_id_reaches_the_writer_bounded_and_clean(self):
+        recorded = []
+        await DataService._record_audit_event(
+            self._svc(recorded),
+            "rig-edit",
+            "miner1",
+            "rig-edit",
+            "applied",
+            "change_id=x",
+            event_id=HOSTILE,
+        )
+        assert len(recorded) == 1
+        written = recorded[0]["id"]
+        assert len(written) <= audit_service.MAX_EVENT_ID_LEN
+        assert "<" not in written and "\x00" not in written and "\n" not in written
+        assert written == audit_service.clean_event_id(HOSTILE)
+
+    async def test_none_event_id_still_gets_a_random_id(self):
+        """The did-not-break-the-feature half: a host-edit is a genuinely distinct event each
+        time, so it must keep falling through to a uuid rather than to an empty primary key."""
+        recorded = []
+        svc = self._svc(recorded)
+        for _ in range(2):
+            await DataService._record_audit_event(
+                svc, "host-edit", "host", "host-edit", "detected", "keys=A", event_id=None
+            )
+        ids = [r["id"] for r in recorded]
+        assert len(set(ids)) == 2
+        for got in ids:
+            assert got.startswith("host-edit-")
+            uuid.UUID(got.removeprefix("host-edit-"))
+
+    async def test_a_real_rig_edit_id_is_unchanged_at_the_sink(self):
+        """Anti-false-pass for the pair above: the sink must not rewrite ordinary ids either, or
+        the dedup key for every already-stored rig-edit row would move."""
+        recorded = []
+        real = "rig-edit-miner1-chg-2026-08-30T01:00:00Z"
+        await DataService._record_audit_event(
+            self._svc(recorded), "rig-edit", "miner1", "rig-edit", "applied", "k", event_id=real
+        )
+        assert recorded[0]["id"] == real

--- a/dashboard/tests/service/test_audit_event_id.py
+++ b/dashboard/tests/service/test_audit_event_id.py
@@ -41,13 +41,24 @@ class TestCleanEventIdContract:
             assert audit_service.clean_event_id(real) == real
 
     def test_oversized_is_bounded(self):
+        """The literal 256 is deliberate. Asserting only against ``MAX_EVENT_ID_LEN`` would source
+        the assertion from the thing under test — widening the constant would widen the assertion
+        with it, and the test could never fail on a cap regression."""
         out = audit_service.clean_event_id(HOSTILE)
-        assert len(out) <= audit_service.MAX_EVENT_ID_LEN
+        assert len(HOSTILE) > 5000
+        assert len(out) <= 256
+        assert len(out) == audit_service.MAX_EVENT_ID_LEN
 
     def test_hostile_charset_is_stripped(self):
-        out = audit_service.clean_event_id(HOSTILE)
-        for bad in ("<", ">", "\x00", "\n", "script"):
+        """Only the charset is guaranteed here, so only the charset is asserted. An earlier draft
+        also asserted ``"script" not in out``, which passed because the cap cut before reaching it
+        rather than because anything strips it — a length accident wearing a charset claim. The
+        seeded id puts the hostile bytes FIRST so the assertion cannot pass by truncation."""
+        seeded = "<script>\x00\n" + "A" * 5000
+        out = audit_service.clean_event_id(seeded)
+        for bad in ("<", ">", "\x00", "\n"):
             assert bad not in out
+        assert "script" in out  # strip, don't blank — the same contract _clean holds to
 
     def test_distinct_long_ids_sharing_a_prefix_stay_distinct(self):
         """The anti-truncation control, and the reason this is a digest and not a slice.
@@ -131,13 +142,3 @@ class TestSinkActuallyUsesIt:
         for got in ids:
             assert got.startswith("host-edit-")
             uuid.UUID(got.removeprefix("host-edit-"))
-
-    async def test_a_real_rig_edit_id_is_unchanged_at_the_sink(self):
-        """Anti-false-pass for the pair above: the sink must not rewrite ordinary ids either, or
-        the dedup key for every already-stored rig-edit row would move."""
-        recorded = []
-        real = "rig-edit-miner1-chg-2026-08-30T01:00:00Z"
-        await DataService._record_audit_event(
-            self._svc(recorded), "rig-edit", "miner1", "rig-edit", "applied", "k", event_id=real
-        )
-        assert recorded[0]["id"] == real

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1055,7 +1055,10 @@ The last two read off the same unauthenticated worker feed, so they share ONE ra
 a bounded number of rows per hour between them before the rest are dropped behind a single
 `rate-limited` row that names which of the two tipped it. One budget rather than one each, because
 two would double what a single LAN device can make permanent. A real occasional rig change
-still records; only a flood is capped.
+still records; only a flood is capped. The cap bounds how many rows arrive rather than how big they
+are, so each row's identifier is separately length-capped and whitelisted where it is written
+([#1561](https://github.com/p2pool-starter-stack/pithead/issues/1561)): a `rig-edit` id is built from a change id the rig chooses, and `audit_events` is
+never pruned.
 
 Any of the three is worth treating like a rotate-now signal in the same spirit as
 [Operations › Watching for intruders](operations.md#watching-for-intruders): if you didn't make

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -319,8 +319,11 @@ them before the rest are dropped behind a single `rate-limited` marker. They sha
 rather than holding one each, since two would double what that device can make permanent. That cap
 bounds how many rows arrive and not how large each one is, so every audit row's own identifier is
 length-capped and whitelisted where it is written ([#1561](https://github.com/p2pool-starter-stack/pithead/issues/1561)) — the one field the trail's
-sanitizer used to skip, and the one a rig picks the input to. Between the two bounds, no LAN device
-can grow the database without limit. A genuine occasional rig change still records
+sanitizer used to skip, and the one a rig picks the input to. Between the two bounds, a rig holding
+one worker name is bounded in both how many rows it adds and how large each one is. The cap is
+keyed on the name the device presents and a device chooses that freely, so one that rotates names
+draws a fresh budget per name ([#1566](https://github.com/p2pool-starter-stack/pithead/issues/1566)):
+read the bound as per name, not per device. A genuine occasional rig change still records
 normally; only a flood is capped, and the cap is visible — the marker names which detection tipped
 it, and the dashboard logs a warning.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -315,9 +315,12 @@ kinds above — so the Security panel's range presets, date fields and search lo
 the log's own trimmed window. Because `rig-edit` and `rig-drift` both read off the unauthenticated
 worker feed, they share one rate cap per worker ([#724](https://github.com/p2pool-starter-stack/pithead/issues/724)): a rig reporting a fresh
 change_id, or a fresh revision, every poll can add only a bounded number of rows per hour between
-them before the rest are dropped behind a single `rate-limited` marker, so no one LAN device can
-grow the database without limit. They share one budget rather than holding one each, since two
-would double what that device can make permanent. A genuine occasional rig change still records
+them before the rest are dropped behind a single `rate-limited` marker. They share one budget
+rather than holding one each, since two would double what that device can make permanent. That cap
+bounds how many rows arrive and not how large each one is, so every audit row's own identifier is
+length-capped and whitelisted where it is written ([#1561](https://github.com/p2pool-starter-stack/pithead/issues/1561)) — the one field the trail's
+sanitizer used to skip, and the one a rig picks the input to. Between the two bounds, no LAN device
+can grow the database without limit. A genuine occasional rig change still records
 normally; only a flood is capped, and the cap is visible — the marker names which detection tipped
 it, and the dashboard logs a warning.
 


### PR DESCRIPTION
Closes #1561.

`_record_audit_event` cleans five fields through `audit_service._clean`, each with an explicit length cap, and passed the sixth through untouched. The sixth is `id` — the `audit_events` PRIMARY KEY — and on the `rig-edit` path it is built from an unauthenticated worker's `change_id`, which `parse_worker_control_status` validates only as a non-empty `str` inside a body capped at 1 MiB. `audit_events` has no retention prune, so an oversized id is permanent.

## What was RUN

Measured by driving the real sink, not argued from the source: reverting `data_service.py` to `ef94a4ea` and re-running the new wiring test writes a **5026-character permanent primary key carrying NUL, a newline and `<script>`**. That is the defect, reproduced.

**Suite: 2261 passed**, and the arithmetic reconciles across a base move that happened mid-cycle rather than being asserted: `c855ae3d` = 2234, `ef94a4ea` (= `c855ae3d` + #1562) = 2248, this branch = 2248 + 13 new tests = 2261. Both legs measured in this session, in the tree being shipped, after the rebase — a count taken before a base move is not evidence about the tree after it.

**Coverage: 97.1% total** (bar 80%). **Patch coverage 12/12 = 100%** (bar 90%), computed from `coverage.xml` rather than from `make test-patch-coverage`, because that target pins `COMPARE=origin/develop` (#1557) and its rc is no evidence on a develop-v2 PR. The path prefix was derived from the report's own `<source>` element (`dashboard/mining_dashboard`, not the repo root), and the run asserts **executable lines in patch > 0** before reporting a percentage — diff-cover exits 0 on "No lines with coverage information", so a percentage without that assertion is a vacuous pass.

One honest note on that number: `data_service.py` contributes **0 executable lines** to the patch. The sink change sits inside a multi-line call, so coverage attributes the statement to an unchanged line. The 100% is real but it is measuring the helper, not the wiring — which is why the wiring is proven by a control below rather than by the coverage figure.

Gates run: `ruff check` + `ruff format --check` (re-run here rather than carried from a handoff — the previous cycle certified a head as ruff-clean "PROVEN BY EXECUTION, do not re-run" and it was not), `lint-file-budget`, `lint-docs-voice`, `lint-md`, `lint-operator-strings`. `make lint-sh` was **not** run: no shell files in this diff, and it is the serialized OOM path.

## Three controls, each fired

A check that has not been shown able to fail is not evidence.

1. **Sink reverted to `ef94a4ea`** (helper present, unused) → `test_hostile_event_id_reaches_the_writer_bounded_and_clean` RED with the 5026-char id; the 12 contract tests stay green, correctly. This is what proves the helper is *consumed*, which the coverage number cannot say.
2. **Digest replaced by a plain truncation** → `test_distinct_long_ids_sharing_a_prefix_stay_distinct` RED. This is the constraint the issue turns on: two distinct long `change_id`s sharing a prefix truncate to one id, `INSERT OR IGNORE` drops the second, and a real detection is lost silently.
3. **`surrogatepass` removed from the digest encode** → the lone-surrogate test RED, and nothing else. That test carries its own inner control asserting the input really is un-encodable, so it cannot pass by accident on an ordinary string.

Each mutation asserted its pattern matched **exactly once** before writing, and refused otherwise — a `replace` that does not match writes the file back unchanged and scores a clean SURVIVED. Sources were restored from scratchpad copies and verified with `sha256sum -c`, not by "cp exited 0".

## The over-engineering pass found three defects in my own tests

The PR gate asks for this pass and clears after one blocked attempt, so it is satisfiable by pressing the button twice. Done on merits instead, by mutating the fix and reading which tests died — and it did not come back empty:

1. **`test_oversized_is_bounded` was self-referential.** It asserted only against `MAX_EVENT_ID_LEN`, sourcing its assertion from the thing under test. Widening the constant to 100000 widened the assertion with it and the test stayed **green** — it could never have failed on a cap regression. It now pins the literal 256 as well.
2. **`test_hostile_charset_is_stripped` passed by truncation luck.** It asserted `"script" not in out`; nothing strips `"script"`, only the charset is stripped, and it passed because the cap cut before reaching it — a length accident wearing a charset claim, exposed by the same cap-widening probe. The seeded id now puts the hostile bytes first so no truncation can satisfy it, and it asserts `"script" in out`: strip, don't blank.
3. **One test was a genuine duplicate and is deleted.** `test_a_real_rig_edit_id_is_unchanged_at_the_sink` died only alongside the helper-level test covering the same branch — no mutation killed it alone — and the hostile wiring test's exact-equality assertion already catches sink-side mangling of an ordinary id.

After the fixes, **five mutations kill exactly one test each**: revert the sink, truncate instead of digest, drop `surrogatepass`, drop the verbatim branch, widen the cap. Two tests dying to one mutation for the same reason is the duplicate signature, and there is none left.

## The fix, and why it is a digest

Bounded **at the sink**, not at each caller, so the docstring's existing guarantee — every field the Security panel serves gets the identical whitelist treatment, so a future caller can't accidentally skip it — becomes true for the field it already claimed to cover.

An id that survives `_clean` unchanged is returned **verbatim**, so every id this repo builds today keeps the key it already has and no stored row is orphaned or duplicated. Anything the whitelist or the cap would alter is replaced by its safe prefix plus a sha256 digest of the original: bounded, charset-restricted, deterministic (a rig re-reporting the same change every poll still dedupes to one row) and collision-free for distinct inputs.

`MAX_EVENT_ID_LEN` is 256 because the longest id this repo legitimately constructs is `rig-drift-{worker}-{revision}` at **203** characters — 10 + 128 (`_WORKER_NAME_RE`) + 1 + 64 (`parse_config_meta`). That is asserted in the test rather than left as a comment.

## Budgets

- `audit_service.py` 188 → 225 lines. Under the 400 target, so it takes **no** budget row — the gate fails on a needless entry as loudly as on a missing one.
- `data_service.py` is **NET ZERO at 1451** against its 1454 ceiling: one changed line at the sink, and the docstring amended within its existing line count. No ceiling was raised.

## Shared files touched, and the hatch

- **`SECURITY.md`** — repo root, **not** in `_shared.paths`. Committed alone, behind a one-shot `.lane-override` touched immediately before that commit; the guard listed that single file and consumed the marker. I attempted the commit **without** the override first to confirm the hatch was genuinely needed rather than assuming it — the guard refused, naming `SECURITY.md`. (That gap is DECISIONS item 15, filed by the controller, still open and still the operator's.)
- **`docs/operations.md`, `docs/dashboard.md`** — `docs/` is in `_shared.paths`, so no hatch was needed. Disclosed here per lane policy.

## The doc correction, and a disclosure about the intermediate head

The #724 cap bounds how **many** rows arrive; it never bounded how **large** each one is. Three files rested a growth guarantee on it:

- `SECURITY.md` and `docs/operations.md` said a LAN device "can't grow the database without limit" on the strength of the count cap alone.
- `SECURITY.md` also carried, as of #1562, *"Values from that feed are also validated to a short opaque token before they reach the store, so a rig cannot choose an audit row's own identifier."* The subject "that feed" is set two sentences earlier as the feed **both** `rig-edit` and `rig-drift` read off. The guarantee held for `rig-drift` (#1558's `parse_config_meta` fix, which is real) and did **not** hold for `rig-edit`. So the sentence was false for half of its own stated subject.

I found that while scoping this PR and reported it to the controller; it re-derived all four legs itself at the merged head and confirmed it — its correction is [issuecomment-5466111286](https://github.com/p2pool-starter-stack/pithead/pull/1562#issuecomment-5466111286) on #1562, posted 01:56:34Z, after the 01:52:47Z merge. **Stating it plainly, as the ruling requires: `SECURITY.md` was ahead of the code between #1562's merge and this PR.** The ruling was that the correction rides here rather than being scoped in a doc-only commit and re-widened two PRs later, because this change is what makes the broader statement true, and a doc-only commit would collide with exactly the paragraphs this PR must touch.

`docs/dashboard.md`'s cap paragraph was **not** false — it never claimed total growth was bounded — so it gains the size bound rather than a correction.

## What I did NOT do

- **`storage_service.py:999` was deliberately left alone.** It says a hostile feed "could otherwise grow this permanent table without limit", which the mechanical sweep flagged — but it is about `raffle_wins` and its `RAFFLE_WINS_MAX_ROWS` prune, an unrelated table where the claim is true. A blanket sweep for the phrase would have "fixed" a correct sentence into a wrong one. Classified per site.
- **No `security-reviewer` subagent.** This session runs under a standing no-subagent instruction, so the mandatory security pass was done **inline** and is disclosed here so it is not read as a subagent pass. That pass is what produced control 3: it asked what input reaches the digest and found the lone-surrogate path, which is reachable (`json.loads('{"change_id": "\ud800bad"}')` yields a lone surrogate that plain `str.encode("utf-8")` refuses, raising inside the poll loop).
- **`#1557` is not addressed** — `patch-coverage.sh` pinning `origin/develop` is the tests lane's, not mine. I worked around it here rather than fixing it.
- **No live-box or bench evidence.** Nothing in this diff needs it; there is no `os/` change and no shell file.


## The reviewer's finding, settled — and a BLOCKING fix to my own `SECURITY.md` sentence

`issuecomment-5466195297` asked me to do one thing: read `_normalize_proxy_workers` and either show the worker-name path is constrained, or widen the residual note. **It is not constrained, so the note is widened.** Two separate outcomes came out of that read.

### 1. The namespace claim was wrong — filed as #1569, NOT fixed here

`_normalize_proxy_workers` (`data_helpers.py:139`) applies no validation to the name: `w[_PX_NAME]` for the 6.x positional shape, `w.get("id", "Unknown")` for the legacy dict shape. `_WORKER_NAME_RE` is only in `config/worker_endpoints.py`, the operator-configured path. That a miner picks its own worker name is already this repo's stated position — the SSRF guard's own docstring says it (`xmrig_client.py:206`).

So `rig-edit-{worker}-{change_id}` is a plain concatenation of two attacker-chosen halves over a delimiter legal in both. **Measured by driving the real `_reconcile_worker_config`, not reasoned:**

```
LEG A  name='victim-chg1' change_id='extra'      -> rig-edit-victim-chg1-extra
       name='victim'      change_id='chg1-extra' -> rig-edit-victim-chg1-extra
       rows=2  distinct_ids=1   COLLIDES: True

LEG B  name='minerA'      change_id='chg1'       -> rig-edit-minerA-chg1     (control)
       name='minerB'      change_id='chg1'       -> rig-edit-minerB-chg1
       rows=2  distinct_ids=2   COLLIDES: False
```

Leg B is the control — without it, leg A is equally consistent with the harness collapsing everything.

**Scoped honestly:** this is a namespace-crossing *capability* with a guessing barrier, not turnkey suppression. Suppressing a specific victim row also needs the victim's `change_id`, or `int(window_start)` at one-second resolution for the cap-marker shape, and neither is readable off this feed. The reviewer's judgement that this is the one worth weighing is right, though: suppressing your own row is no new capability, suppressing another worker's flood marker is.

**Pre-existing, and deliberately left out of this PR.** `data_service.py:909` is untouched by this diff (`git diff ef94a4ea..HEAD` confirms), and these ids are short and all-safe so they take `clean_event_id`'s verbatim branch — behaviour is identical before and after. Filed as **#1569** with the repro, so the bound and the namespace stay separately reviewable.

### 2. ⛔ I shipped the same class of false sentence this PR exists to correct

This PR replaced #1562's false `SECURITY.md` claim. **My replacement repeated its shape and was also false:** *"A rig therefore cannot choose an audit row's identifier, and cannot make one arbitrarily large."* A rig **does** choose its `rig-edit` row's identifier — the id is built from a `change_id` it picks freely — and my own paragraph said exactly that two clauses later. It contradicted itself and I did not see it, because I adapted the predecessor's wording instead of deriving the sentence from what the fix actually does.

What #1561 buys is a **size and charset** bound, not choice. `b0587f2` rewrites the paragraph to say that, names what a rig genuinely cannot do (forge a `host-edit` or `control.log` id), and records the #1569 namespace caveat.

I checked `docs/dashboard.md` and `docs/operations.md` for the same claim and called them accurate as shipped. **That was wrong about `docs/operations.md`, and #1566 caught it — see the section below.** The narrower point still holds and is still the tell: on the *choice-vs-size* claim, only `SECURITY.md` went wrong, and it was the one file where I was editing someone else's sentence rather than writing a new one.


### 3. ⛔ A THIRD false sentence — mine, in `docs/operations.md`, caught by #1566

While I was fixing the above, the controller filed **#1566** independently, which duplicates my #1569 (closed; its one extra measurement carried over) and adds a shape I did not find: **`_rig_edit_within_cap` buckets on `worker`, which is the name the device presents on the proxy feed.** A rig that rotates names draws a fresh `_RIG_EDIT_CAP_PER_HOUR` budget per name, so the #724 cap has no per-device ceiling at all.

That falsifies a sentence **this PR added**: `docs/operations.md` said *"Between the two bounds, no LAN device can grow the database without limit."* It holds for a device reusing one name and not for one rotating them. The same overstatement was in the `SECURITY.md` paragraph (*"how many rows a LAN device can add"*).

Fixed in `136949d`: both now say the cap bounds a **name** rather than a device, and both point at #1566. Verified at source that the cap is keyed on `worker` with no global ceiling (`data_service.py:820-831`).

**Three false prose claims about one mechanism, in three commits, by two authors** — #1562's, mine replacing it, and now mine again on a different axis. Every one was an unqualified universal about what a rig "cannot" do, and each was written while fixing the previous one. The pattern is not carelessness about any single sentence; it is that **the sentence answering a finding gets written from the shape of the sentence it replaces, and the reviewer who asked for it is the worst-placed person to check it** — so the qualifier that the code actually supports never gets derived. `docs/operations.md`'s line was mine, written fresh, and it failed the same way: I stated a bound as absolute without asking what the cap is keyed on.

New head `136949d`. `SECURITY.md` + `docs/operations.md` only, +10/-5, still no code. Doc gates green.
### New head

`136949d` — `SECURITY.md` + `docs/operations.md`, no code at any point. `make lint-docs-voice`, `lint-md`, `lint-file-budget`, `lint-topology`, `lint-operator-strings` all green; `tests/service/test_audit_event_id.py` 13 passed. No code changed, so the suite and coverage figures above still stand at this head.

`SECURITY.md` needed no `.lane-override`: the controller's w55 grant in `roles/dashboard.paths` covers exactly this paragraph and expires on merge. My handoff said an override was required — that was stale, and I checked rather than assuming (the guard is armed here; `pre-commit -> lane-guard.sh`).

## One residual I want a reviewer's eye on

A rig can collide **two of its own** `rig-edit` rows: it knows both inputs, so it can compute a digest form and then send a second, clean `change_id` equal to it, suppressing one row under `INSERT OR IGNORE`. I judged this not worth further mechanism, because the rig already fully controls what it reports and can simply not report an edit — it is not a new capability. **CORRECTED at `b0587f2` — my original wording here said it "cannot reach outside its own namespace", and that was too broad.** What is true and structural: the id is `rig-edit-{worker}-…` before and after this change and the digest branch preserves that prefix, so no `host-edit` or mirrored `control.log` row can be suppressed this way — those prefixes are hardcoded literals a `rig-edit` id can never equal. What is NOT true is that the `rig-edit-` namespace confines a rig to its OWN rows. See the section below. Say so if you read the trade-off differently.

A second, smaller one: a rig that was **already** sending `change_id`s containing characters `_clean` strips will get a different id than before, so its next report writes one duplicate row. One-time, bounded by the #724 cap, and only for rigs already sending dirty ids.