### PR TITLE
fix(integration): compose a foreign EXIT trap instead of being displaced by it (#1404)

### DIFF
--- a/tests/integration/rig-key-ledger.sh
+++ b/tests/integration/rig-key-ledger.sh
@@ -40,6 +40,21 @@
 # at tier 1 by driving the real `rig_lock` against sandboxed paths, so if lib.sh's holder-path logic
 # ever changes, this copy reds rather than drifting quietly.
 #
+# THE SAME HAZARD RUNS THE OTHER WAY, AND THAT IS #1404. Folding lib.sh's trap into ours handles the
+# trap that is already installed when we arm. It does nothing about a trap installed AFTER — that one
+# replaces OURS, and every key outstanding at that moment is stranded silently. So `_rig_key_arm` is
+# not a once-only arm: it re-reads the live EXIT trap at every mark and CAPTURES any handler it is
+# about to displace, and `rig_key_atexit` runs the captured handlers. Composition in both directions,
+# which is the same choice lib.sh made, applied to the traps it could not see.
+#
+# WHAT THAT DOES NOT COVER, stated because a limit in a comment is the only honest place for one that
+# cannot be closed here: a foreign trap installed after the LAST mark. Nothing runs again to notice
+# it, so ours stays displaced and those keys are lost. Re-arming on every mark — the fix #1404
+# proposed — has exactly the same hole, measured, and pays for the part it does fix by stomping the
+# foreign trap instead of composing it. There is no bash hook on `trap`, so at this layer the case is
+# structurally unreachable rather than merely unimplemented. `selftest-rig-key-ledger.sh` pins it as
+# a known limit rather than leaving it to be rediscovered.
+#
 # WHY `EXIT` ALONE AND NOT `EXIT INT TERM`. Measured on this box rather than assumed: a bare EXIT
 # trap DOES run when the shell dies of SIGINT or SIGTERM, so naming the signals adds no coverage.
 # What it adds is worse than the second firing it is usually described as — a bash INT/TERM handler
@@ -65,24 +80,56 @@
 # next line starts with, as one credential, and reds the secret scan on this file. The finding
 # is anchored in the commit that introduces it, so renaming back cannot be undone at the tip.
 _RIG_LEDGER=""
-_RIG_KEY_TRAP_ARMED=0
+# Every EXIT handler this file has displaced, newline-separated, oldest first. Empty on the happy
+# path where nothing but ours was ever installed. The installed trap is its own "armed" flag now —
+# a separate boolean is what #1404 turned out to be.
+_RIG_KEY_FOREIGN=""
 
 # The EXIT handler: restore everything still outstanding, THEN do lib.sh's holder cleanup. Ordering
 # matters — the rig restore is the thing worth doing, so it goes first and the breadcrumb removal
 # cannot be skipped by it (no `set -e` here, and every step is best-effort).
 rig_key_atexit() {
     rig_key_unwind
+    # Whatever we displaced, in the order we displaced it (#1404). After the unwind, because the rig
+    # restore is the thing worth doing and a foreign handler is somebody else's best-effort cleanup;
+    # before the holder removal, so a foreign handler cannot skip it.
+    [ -z "$_RIG_KEY_FOREIGN" ] || eval "$_RIG_KEY_FOREIGN"
     # The fold lib.sh:rig_lock's comment prescribes. Re-derived from the durable env/default rather
     # than a local, exactly as the trap it replaces did, and best-effort in the same two steps: a
     # holder marker we cannot remove must never be fatal. (#244/#249)
+    #
+    # KEPT rather than left to the capture above, which looks redundant and is not: if a foreign trap
+    # displaced rig_lock's BEFORE our first mark, the capture replays that foreign handler and the
+    # breadcrumb strands. Measured — deleting this reds the NESTED case in
+    # selftest-rig-key-ledger.sh, which exists to hold it here, and reds nothing else. (#1404)
     local h="${RIG_LOCK_HOLDER:-${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}.holder}"
     rm -f "$h" 2>/dev/null || sudo -n rm -f "$h" 2>/dev/null || true
 }
 
-# Install the composed trap, once, at the FIRST mark. Lazy on purpose: see the no-op reasoning above.
+# Install the composed trap at every mark, capturing anything it displaces (#1404). Still lazy — it
+# runs only from `rig_key_mark`, so a run that writes nothing installs no trap at all, which is the
+# no-op reasoning above and is unchanged.
 _rig_key_arm() {
-    [ "$_RIG_KEY_TRAP_ARMED" = "1" ] && return 0
-    _RIG_KEY_TRAP_ARMED=1
+    local cur
+    cur="$(trap -p EXIT)"
+    case "$cur" in
+    # Already ours, and this branch is load-bearing rather than a shortcut: falling through would
+    # capture OUR OWN handler into the foreign list, and the next exit would run rig_key_atexit
+    # from inside rig_key_atexit.
+    *rig_key_atexit*) return 0 ;;
+    # `?*` is any NON-empty trap. An empty one — the first mark of an ordinary run — matches nothing
+    # here and falls straight to the install below.
+    ?*)
+        # `trap -p` prints `trap -- '<handler>' EXIT`, single-quoted by bash's own printer, so having
+        # bash re-parse that line is what unquotes a handler containing quotes or `$(…)` correctly.
+        # The handler is NOT run here: the quoting survives the round trip, which the self-test pins
+        # with a handler carrying both. Indexed array, not associative — bash 3.2, as everywhere here.
+        local -a _t
+        eval "_t=($cur)"
+        _RIG_KEY_FOREIGN="${_RIG_KEY_FOREIGN}${_t[2]}
+"
+        ;;
+    esac
     trap rig_key_atexit EXIT
     return 0
 }

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -157,6 +157,105 @@ assert_eq "and the writable key is restored in the same firing" \
     "$(restores)" 'dash|{"DONATION":5}'
 rm -f "$WORK/rig.lock" "$WORK/rig.holder"
 
+echo "== a trap installed AFTER a mark is COMPOSED, not silently displaced (#1404) =="
+# The case #1404 was filed on. `trap … EXIT` REPLACES, so before this the foreign handler took over
+# and every key outstanding at that moment was lost — with no output difference either way, in the
+# one run whose whole point is that it did not reach its own cleanup. Both halves are asserted
+# together on purpose: restoring the keys by stomping the foreign handler straight back satisfies
+# the first assertion while silently breaking somebody else's cleanup instead, and that trade is
+# the one this file exists to refuse.
+scenario 'rig_key_mark dash rig1 DONATION 5' \
+    "trap 'echo FOREIGN-FIRED' EXIT" \
+    'rig_key_mark dash rig1 max_temp_c 100' \
+    'exit 9' >/dev/null
+assert_eq "both keys outstanding across a foreign EXIT trap are still restored (#1404)" \
+    "$(n_restores)" "2"
+assert_eq "and the foreign handler still runs — composed, not stomped (#1404)" \
+    "$(grep -c FOREIGN-FIRED "$SCEN_OUT")" "1"
+
+echo "== repeated marks never capture OUR OWN handler (#1404) =="
+# The self-capture failure the arm's first case exists to stop. Composing at every mark means the
+# second mark reads a trap that is already ours, and capturing it would make rig_key_atexit eval
+# itself: the shell dies of stack exhaustion at exit — measured, rc 139 — AFTER the restores have
+# gone out. So every restore-counting assertion in this file still passes over it, and the child's
+# exit status is the only witness there is. It is asserted here because the multi-key case above
+# discards the rc, which is exactly how a suite goes green over a harness that crashes on the way
+# out. Needs two marks and NO foreign trap between them: with one interposed, the second mark
+# captures that instead and the fault never appears.
+rc="$(scenario 'rig_key_mark dash rig1 DONATION 5' \
+    'rig_key_mark dash rig1 max_temp_c 100' \
+    'exit 9')"
+assert_eq "two marks and no foreign trap leave the exit status intact, not a crash (#1404)" \
+    "$rc" "9"
+assert_eq "and both keys still came back exactly once" "$(n_restores)" "2"
+
+echo "== the captured handler survives quoting intact, and never runs at capture time =="
+# `trap -p` prints the handler single-quoted by bash's own printer, and the capture unquotes it by
+# letting bash re-parse that line. A handler carrying BOTH an apostrophe (which the printer has to
+# escape) and a `$( )` (which must survive to fire time, not expand at capture time) is what
+# separates a correct round trip from a mangled one. Counting the appends is what proves the capture
+# did not execute it: a body run at capture AND at exit appends twice, and the value would still
+# look right.
+: >"$WORK/foreign.log"
+# The HANDLER only; the `trap` line is composed below rather than written out. A literal `trap …`
+# at the start of a line is picked up by selftest-abort-traps.sh's directory walk even inside a
+# quoted heredoc, where it is test data and not an installed trap — and that walk's handler strip
+# cannot span the `'\''` idiom this very handler needs, so it reads the remainder as a signal list
+# and reds a compliant line. Both limits are filed; composing the line here keeps this file's
+# subject #1404 rather than that walk.
+awkward_body="$(
+    cat <<'AWK'
+printf "%s\n" "apostrophe: it'\''s here; substitution: $(echo SUBBED)" >>"$WORK/foreign.log"
+AWK
+)"
+scenario 'rig_key_mark dash rig1 DONATION 5' \
+    "trap '$awkward_body' EXIT" \
+    'rig_key_mark dash rig1 max_temp_c 100' \
+    'exit 9' >/dev/null
+assert_eq "a handler with an apostrophe and a \$( ) round-trips through the capture (#1404)" \
+    "$(cat "$WORK/foreign.log")" "apostrophe: it's here; substitution: SUBBED"
+assert_eq "and ran exactly once — the capture parses the handler, it does not execute it (#1404)" \
+    "$(grep -c . "$WORK/foreign.log")" "1"
+assert_eq "and the keys came back in the same firing" "$(n_restores)" "2"
+
+echo "== NESTED: a foreign trap displacing rig_lock's BEFORE our first mark =="
+# This is the case that keeps the hand-folded holder removal in `rig_key_atexit` honest, and it was
+# built because deleting that fold as redundant is the obvious follow-up to composing foreign traps.
+# In the plain rig_lock scenario above, the capture ALSO replays rig_lock's own handler, so the fold
+# and the capture each remove the breadcrumb and that assertion stays green with the fold deleted —
+# a guard that stops discriminating without ever failing. Here the captured handler is the FOREIGN
+# one, which does not touch the breadcrumb, so the fold is the only thing that can remove it.
+# Measured both ways: with the fold mutated out, this assertion reds and the one above does not.
+scenario 'export RIG_LOCK_FILE="$WORK/rig.lock" RIG_LOCK_HOLDER="$WORK/rig.holder"' \
+    'rig_lock selftest "rig-key-ledger #1404"' \
+    '[ -s "$RIG_LOCK_HOLDER" ] && echo HOLDER-WRITTEN' \
+    "trap 'echo FOREIGN-FIRED' EXIT" \
+    'rig_key_mark dash rig1 DONATION 5' \
+    'exit 9' >/dev/null
+assert_eq "rig_lock really wrote its breadcrumb (the control for the next assertion)" \
+    "$(grep -c HOLDER-WRITTEN "$SCEN_OUT")" "1"
+assert_eq "the breadcrumb is removed though the captured handler is not rig_lock's (#1404)" \
+    "$([ -e "$WORK/rig.holder" ] && echo STRANDED || echo gone)" "gone"
+assert_eq "the displaced foreign handler still ran" "$(grep -c FOREIGN-FIRED "$SCEN_OUT")" "1"
+assert_eq "and the outstanding key was restored" "$(restores)" 'dash|{"DONATION":5}'
+rm -f "$WORK/rig.lock" "$WORK/rig.holder"
+
+echo "== KNOWN LIMIT, pinned deliberately: a trap after the LAST mark still wins =="
+# NOT desired behaviour. A documented hole, asserted so that it is visible in this file's output
+# rather than rediscovered from a stranded rig. Composition happens at a mark, so a trap installed
+# after the last one is never seen — bash offers no hook on `trap`, which makes this structurally
+# unreachable at this layer rather than merely unimplemented. Re-arming at every mark, the fix
+# #1404 proposed, has the identical hole; measured, both restore zero keys here. If this assertion
+# ever reds, the hole has been CLOSED: rewrite the case as the guarantee, do not repair it. (#1404)
+scenario 'rig_key_mark dash rig1 DONATION 5' \
+    'rig_key_mark dash rig1 max_temp_c 100' \
+    "trap 'echo FOREIGN-FIRED' EXIT" \
+    'exit 9' >/dev/null
+assert_eq "KNOWN LIMIT: a trap installed after the last mark strands the ledger (#1404)" \
+    "$(n_restores)" "0"
+assert_eq "and it is the foreign handler that runs in our place (#1404)" \
+    "$(grep -c FOREIGN-FIRED "$SCEN_OUT")" "1"
+
 echo "== dying DURING the apply is covered — which is what mark-before-write buys =="
 # The window the ordering exists for, and the only thing that makes it falsifiable at this tier: a
 # stub that never returns, because the process dies inside the apply itself. Move the mark below


### PR DESCRIPTION
The writable-key ledger armed its `EXIT` trap once, behind a flag. Anything
installing an `EXIT` trap after the first `rig_key_mark` replaced ours, and every
key outstanding at that moment was stranded — silently, in the one run whose whole
point is that it did not reach its own cleanup. Latent, not live: nothing in the
harness installs a foreign trap after a mark today.

`_rig_key_arm` now re-reads the live `EXIT` trap at every mark, captures any handler
it is about to displace, and `rig_key_atexit` runs the captured handlers after the
unwind. That is the same choice lib.sh made when it prescribed folding its holder
`rm -f` into whatever trap came next, applied to the traps it could not see. The
`_RIG_KEY_TRAP_ARMED` flag is gone: the installed trap is its own armed state, and a
separate boolean is what this issue turned out to be.

NOT the fix the issue recommended, and the matrix is why. Four designs, four rows,
both controls firing (no-foreign-trap restores 2; foreign-trap-alone fires 1):

  row                                  shipped   re-arm    compose   compose+drop fold
  foreign trap BETWEEN two marks       k=0 f=1   k=2 f=0   k=2 f=1   k=2 f=1
  foreign trap AFTER the last mark     k=0 f=1   k=0 f=1   k=0 f=1   k=0 f=1
  (k = keys restored, f = foreign handler ran)

Re-arming on every mark, which the issue favoured, buys the first row by stomping
the foreign handler straight back — trading a silent loss of the rig's config for a
silent loss of somebody else's cleanup, which is the trade this file exists to
refuse. And the issue's table did not test the second row: a trap installed after
the LAST mark defeats re-arming exactly as it defeats arming once. Composition
happens at a mark and bash offers no hook on `trap`, so that case is structurally
unreachable here rather than merely unimplemented. It is pinned as a KNOWN LIMIT
case and named in the header, so it is visible in the output rather than
rediscovered from a stranded rig.

The hand-folded holder removal in `rig_key_atexit` is KEPT, and that is measured
rather than assumed. Deleting it as redundant is the obvious follow-up once foreign
traps are composed, and it passes the pre-existing `rig_lock` assertion — because
there the capture replays rig_lock's own handler, so both mechanisms remove the
breadcrumb and the guard stops discriminating without ever failing. Dropping the
fold reds only the new NESTED case, where the captured handler is a foreign one that
does not touch the breadcrumb. Without that case this change would have quietly
gutted an existing tier-1 guard.

Composing at every mark creates a self-capture hazard the first `case` branch
exists to stop, and that branch is load-bearing rather than a shortcut: without it
the second mark captures the trap we installed at the first, `rig_key_atexit` evals
itself, and the shell dies of stack exhaustion at exit — measured, rc 139. The
restores go out BEFORE the crash, so the suite was green over it: 44 of 44 passing
against a harness that segfaults on the way out. Found by reviewing this diff, not
by a test. The child's exit status is the only witness, and the multi-key case that
would have seen it discards the rc, so a case now asserts it.

13 new assertions, 31 -> 44. Mutation battery, every leg cmp-gated and refusing to
count on an unchanged file: restoring the arm-once flag reds 2 (the defect this
fixes); capturing nothing, never replaying, and executing the handler at capture
time each red 4; deleting the hand-fold reds exactly 1, the nested case; dropping
the already-ours branch reds exactly 1, the self-capture case. Of the 13, eight are
falsified by that battery, two are controls (rig_lock wrote its breadcrumb; the late
trap really fired), two are the pinned known limit and its control, and one — "the
outstanding key was restored" in the nested case — is a companion this battery does
not independently falsify.

The capture parses the handler, it does not run it. `trap -p` prints it single-quoted
by bash's own printer, so letting bash re-parse that line is what unquotes a handler
containing an apostrophe or a `$( )` correctly. Asserted with a handler carrying
both, and the append count is what proves capture-time execution did not happen — a
body run at capture and again at exit appends twice while still reading correct.

Scope of the checks run: shellcheck 0.11.0 over the Makefile's first invocation
verbatim, rc 0 — the file set contains both changed files, and the control that arms
in a sourced library is SC2046, not SC2034, which is suppressed there and did NOT
fire; restore cmp-verified. shfmt over the Makefile's exact glob, rc 0.
`make test-integration-selftest` rc 0, all 12 self-test files green.
`make lint-file-budget` rc 0 — both files are under the 400-line target, so neither
takes a tsv row. `make lint-md` 0 errors. No docs change: no prose in `docs/`
describes this trap's arming.

Two limits found in #1515's abort-trap walk while running it over this branch, filed
separately rather than fixed here: it scans a `trap …` literal inside a quoted
heredoc as though it were an installed trap, and its handler strip cannot span the
`'\''` idiom, so it reds a compliant line. Both fail loud rather than silent — the
mis-parse flags compliant and non-compliant shapes alike, so no bad trap slips
through. The new test composes its trap line instead of writing it literally, which
keeps this file's subject #1404.

Filed while here: **#1567** — the two `selftest-abort-traps.sh` parsing limits named above.

## Ponytail review (run on this diff, from the skill on disk)

`rig-key-ledger.sh:L86: shrink: a "") : ;; no-op branch beside *). ?*) matches non-empty, one branch fewer.` — **applied.**

Two things I checked for cuttability and kept, with the reason:

- `*rig_key_atexit*) return 0` is **not** a happy-path optimisation and cannot be cut. Falling through captures our own handler and `rig_key_atexit` evals itself; measured, the child segfaults at exit (rc 139). Reviewing this is what found the missing assertion — the suite was 44/44 green over that crash, because the restores go out before it.
- The KNOWN LIMIT case asserts current behaviour rather than desired behaviour, which reads like a candidate for deletion. Kept deliberately: it is the only place the uncovered case is visible in the output, and the header says to rewrite it as a guarantee rather than repair it if it ever reds.

`net: -1 line possible` — taken.

## What I did NOT do

- Did not close the after-the-last-mark hole. There is no bash hook on `trap`, so it is unreachable at this layer; it is pinned and named rather than hidden.
- Did not fix #1567 — a more permissive strip could start failing *silent* instead of loud, which would be worse than what is there.
- No bench, no rig, no docs change. Both files are in `tests/integration/`, this lane's exclusive paths: no grant, no `.lane-override`, no shared file.
- `IT_RIG_POOLS_PROBE`-gated behaviour untouched; #1236 stays parked.
