### PR TITLE
fix(integration): the abort-trap walk reads a shell WORD, not one quoted run (#1567)

### DIFF
--- a/tests/integration/selftest-abort-traps.sh
+++ b/tests/integration/selftest-abort-traps.sh
@@ -7,6 +7,11 @@
 # touched, a brand-new selftest, and a second handler beside the guarded one inside e2e.sh itself.
 # The scan is `*.sh` only; verified at the time of writing that no shell file under this directory
 # lacks that extension, so nothing is currently out of reach, but one added later would be.
+# The scan finds the population; a CLASSIFIER then reads each hit, and #1567 was two faults in
+# that half — a handler strip that could not span the `'\''` idiom, and a `trap …` literal held
+# as test data being asserted against as though this tree installed it. Both are fixed below, at
+# `trap_line_signals` and `trap_hit_is_data`, which carry the rules rather than have them
+# restated here — a recipe written in two places is one that drifts apart.
 # Standalone (not sourced by selftest.sh) so it never touches that file's budget ceiling — the
 # #1258/#1301 "moved into its own file" precedent. Run directly, or via
 # `make test-integration-selftest`. No server needed.
@@ -82,15 +87,55 @@ abort_trial() { # <trap-spec, "" for none> <signal>
     TRIAL_CONTINUED="$(grep -c CONTINUED "$out")"
 }
 
+# THE HANDLER IS ONE SHELL WORD, AND A SHELL WORD IS A RUN OF CONCATENATED PIECES (#1567). Reading
+# it as a single quoted run was the bug: `'echo it'\''s here'` is not one `'…'` but THREE pieces
+# glued together with no whitespace between them — a quoted run, a backslash escape, a quoted run —
+# because that escape is the only way bash lets an apostrophe inside single quotes. A one-alternative
+# strip stops at the first inner quote and reads the remainder as the signal list, which reds a
+# compliant line. The same fault hit `"echo \"hi\""`, a shape #1567 did not name.
+#
+# THE DIRECTION THAT MATTERS: this is more permissive than what it replaces, and a strip that goes
+# too far eats the signals and reports `EXIT` for a line naming three — the #1401 false green, from
+# inside the guard against it. It cannot: none of the four pieces matches whitespace outside quotes,
+# so the run always ends at the space before the signal list. The cases below pin that with a row for
+# every shape carrying BOTH an escaped quote and extra signals; each must still come back flagged.
+_TRAP_SQ="'[^']*'"             # a single-quoted run — bash allows no escapes at all inside one
+_TRAP_DQ='"([^"\]|\\.)*"'      # a double-quoted run, which may carry \" and \\
+_TRAP_ESC='\\.'                # a bare backslash escape, the glue in the `'\''` idiom
+_TRAP_BARE="[^[:space:]'\"\\]" # any other single character that is not whitespace or quoting
+_TRAP_WORD="($_TRAP_SQ|$_TRAP_DQ|$_TRAP_ESC|$_TRAP_BARE)+"
+
 # The signal list of one `trap` line: everything after the handler argument. The handler is stripped
 # FIRST, so a `#` inside a quoted handler can never be read as a comment; only then is a trailing
-# comment cut, which is safe because signal names contain no `#`. Leading indentation is allowed —
-# two of the shipped traps are installed inside functions, and anchoring on a bare `^trap` would
-# silently skip both, reporting a clean sweep over a population it never looked at.
+# comment cut, which is safe because signal names contain no `#`. An optional `--` is skipped: that
+# is the form `trap -p` itself prints, so it is what anyone round-tripping a captured handler writes.
+# Leading indentation is allowed — two of the shipped traps are installed inside functions, and
+# anchoring on a bare `^trap` would silently skip both, reporting a clean sweep over a population it
+# never looked at.
 trap_line_signals() { # <the text of one trap line>
     printf '%s\n' "$1" |
-        sed -E "s/^[[:space:]]*trap[[:space:]]+('[^']*'|\"[^\"]*\"|[^[:space:]]+)[[:space:]]*//" |
+        sed -E "s/^[[:space:]]*trap[[:space:]]+(--[[:space:]]+)?${_TRAP_WORD}[[:space:]]*//" |
         sed -E 's/#.*$//; s/[[:space:]]+$//'
+}
+
+# A `trap …` line that is DATA — a literal inside a quoted heredoc or a string, written for some
+# other process to execute — still sits at the start of a line, so the text scan finds it and the
+# walk asserts against a trap nothing in this tree installs (#1567). The exemption is EXPLICIT and
+# never inferred: the line immediately above must carry the marker. Inferring it instead — tracking
+# heredoc regions, say — is how a REAL trap escapes the walk with nothing printed, and a silent hole
+# in this guard is strictly worse than the false red it removes. Exempted lines are not asserted;
+# they are printed and counted into the summary, because a limit that lives only in a source comment
+# is invisible to whoever reads the output.
+TRAP_DATA_MARKER='# selftest-abort-traps: data'
+trap_hit_is_data() { # <file> <line number of the trap line>
+    local above
+    [ "$2" -gt 1 ] || return 1
+    above="$(sed -n "$(($2 - 1))p" "$1")"
+    # The marker must be the WHOLE line, indentation aside — never a substring. This file names the
+    # marker in its own header and in the assignment above, and under a substring match any trap line
+    # that came to follow one of those would be exempted: the guard reading its own documentation as
+    # permission to stop looking. Same family as the literal-scanned-as-installed fault it fixes.
+    [ "$(printf '%s' "$above" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')" = "$TRAP_DATA_MARKER" ]
 }
 
 echo "== CONTROLS: with no trap at all, the signal MUST kill the victim (#1401) =="
@@ -122,6 +167,73 @@ for sig in INT TERM; do
         "$TRIAL_FIRED" "2"
 done
 
+echo "== the classifier reads one trap line correctly, and stays FAIL-LOUD doing it (#1567) =="
+# Direct cases against trap_line_signals, because the walk can only ever exercise the shapes this
+# tree happens to contain and the shapes that broke it are the ones nobody had written here yet. The
+# expected value comes FIRST on each row so the row does not itself start with `trap` — otherwise the
+# walk below would scan its own fixtures. Every escaped-quote shape appears TWICE, once compliant and
+# once naming extra signals: the second row is the control, and it is the whole reason a more
+# permissive strip is safe here. If a shape ever parses to `EXIT` in BOTH rows the guard has been
+# switched off rather than fixed, which is the one outcome worse than the false red #1567 reports.
+while IFS='|' read -r want line; do
+    [ -n "$want" ] || continue
+    assert_eq "signals of [$line]" "$(trap_line_signals "$line")" "$want"
+done <<'CASES'
+EXIT|trap cleanup EXIT
+EXIT INT TERM|trap cleanup EXIT INT TERM
+EXIT|trap 'rm -f $f' EXIT
+EXIT|trap 'echo it'\''s here' EXIT
+EXIT INT TERM|trap 'echo it'\''s here' EXIT INT TERM
+EXIT|trap "echo \"hi\"" EXIT
+EXIT TERM|trap "echo \"hi\"" EXIT TERM
+EXIT|    trap rig_key_atexit EXIT
+EXIT|trap 'rm -rf "$D"' EXIT # a trailing comment, cut only after the handler
+EXIT|trap -- 'h' EXIT
+EXIT INT|trap -- 'h' EXIT INT
+CASES
+
+echo "== an exemption is DECLARED, never inferred — and it is not blanket (#1567) =="
+marker_fixture="$TRIAL_DIR/marker.sh"
+{
+    echo "$TRAP_DATA_MARKER"                                  # 1
+    echo 'trap h EXIT INT TERM'                               # 2 — marked
+    echo 'trap h EXIT INT TERM'                               # 3 — identical text, unmarked
+    echo "# prose that mentions $TRAP_DATA_MARKER in passing" # 4
+    echo 'trap h EXIT INT TERM'                               # 5 — under prose, not under a marker
+    echo "    $TRAP_DATA_MARKER"                              # 6 — indented, as in a heredoc
+    echo 'trap h EXIT INT TERM'                               # 7 — marked
+} >"$marker_fixture"
+assert_data() { # <description> <line number> <expected yes|no>
+    local got=no
+    trap_hit_is_data "$marker_fixture" "$2" && got=yes
+    assert_eq "$1" "$got" "$3"
+}
+assert_data "a trap line under the marker is classified DATA, so the walk leaves it alone" 2 yes
+# The negative control. Byte-identical text one line further down with no marker above it: were this
+# also DATA the exemption would be blanket, and the walk would be asserting over nothing at all.
+assert_data "control: the SAME line with no marker above it is NOT data" 3 no
+# And the control for a SUBSTRING match, which is what a marker check reaches for first. Line 4 only
+# mentions the marker — the shape this file's own header and assignment already have — so a
+# substring match would exempt line 5 and the walk would stop looking wherever it was documented.
+assert_data "control: a line that only MENTIONS the marker does not exempt the next line" 5 no
+# Indentation is allowed: a marker inside an indented heredoc is the ordinary case, not an exception.
+assert_data "an indented marker still declares the line under it data" 7 yes
+# A hit on line 1 has no line above it to read; without the guard this is `sed -n 0p`, which errors.
+assert_data "control: a trap on line 1 is not data, and asking does not error" 1 no
+
+# ONE REAL MARKED LINE IN THIS TREE, deliberately. Nothing else proves the walk below actually
+# CONSULTS trap_hit_is_data: a regression dropping that call stays green over a tree in which no line
+# is marked. Here it is load-bearing both ways — drop the call and the walk reds on this literal, and
+# the declared-data count asserted after it goes to zero.
+noncompliant_literal="$(
+    cat <<'LITERAL'
+# selftest-abort-traps: data
+trap h EXIT INT TERM
+LITERAL
+)"
+assert_eq "the literal below is genuinely non-compliant — an exemption over nothing proves nothing" \
+    "$(trap_line_signals "${noncompliant_literal##*$'\n'}")" "EXIT INT TERM"
+
 echo "== every trap under tests/integration/ names EXIT and nothing else (#1401/#1515) =="
 # A WALK, not a list of known sites: #1401's second live instance was found by enumerating the class,
 # and a check wired to named sites cannot enumerate anything. If one of these reds, read the block at
@@ -135,15 +247,28 @@ trap_scan="$(grep -rnE '^[[:space:]]*trap[[:space:]]' --include='*.sh' "$HERE")"
 # Fed by a heredoc rather than a pipe on purpose: `grep ... | while` runs the loop body in a
 # SUBSHELL, so every it_pass/it_fail it recorded would be discarded when the pipeline ended and the
 # summary below would count zero of them while printing green.
+TRAP_DATA_HITS=0
 while IFS= read -r hit; do
     [ -n "$hit" ] || continue
     hit_file="${hit%%:*}"
     hit_rest="${hit#*:}"
-    assert_eq "${hit_file#"$HERE"/}:${hit_rest%%:*} traps on EXIT alone (#1401)" \
+    hit_line="${hit_rest%%:*}"
+    if trap_hit_is_data "$hit_file" "$hit_line"; then
+        TRAP_DATA_HITS=$((TRAP_DATA_HITS + 1))
+        it_warn "declared DATA, NOT asserted (#1567): ${hit_file#"$HERE"/}:$hit_line"
+        continue
+    fi
+    assert_eq "${hit_file#"$HERE"/}:$hit_line traps on EXIT alone (#1401)" \
         "$(trap_line_signals "${hit_rest#*:}")" "EXIT"
 done <<EOF
 $trap_scan
 EOF
+
+# Pinned exactly, not `>= 0`: every declared-data line is a hole in this walk, so one appearing or
+# disappearing must red and be looked at rather than pass quietly. The one expected here is the
+# literal above. If you added a marked line legitimately, raise this by one and say so on the PR.
+assert_eq "exactly one line in this tree is declared data — a new one is a new hole in the walk" \
+    "$TRAP_DATA_HITS" "1"
 
 # The walk alone is silently green over a tree whose traps were all DELETED, and green is the wrong
 # answer there: restore_all is the borrowed rig's only unwind, and probe.sh's kill is what stops a
@@ -157,5 +282,7 @@ assert_contains "probe.sh's tor-kill trap is still installed (#1401's second sit
     "$trap_scan" "trap 'kill "
 
 echo ""
-echo "selftest-abort-traps: $IT_PASS passed, $IT_FAIL failed"
+# The declared-data count is in the SUMMARY, not just in a comment: it is the walk's own
+# admission of what it did not look at, and the summary line is the only part anyone reads.
+echo "selftest-abort-traps: $IT_PASS passed, $IT_FAIL failed, $TRAP_DATA_HITS declared data (not asserted)"
 [ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1567 (by hand — `Closes` never fires here, PRs merge to `develop-v2` while the default branch is `develop`).

`selftest-abort-traps.sh` has found its population correctly since #1515. The classifier that reads each hit was the imprecise half, and it red two shapes of *compliant* trap. Both fixes are in the classifier; the scan is untouched.

## 1. The handler is one shell WORD, and a word is a run of concatenated pieces

The strip modelled the handler as a single quoted run: `('[^']*'|"[^"]*"|[^[:space:]]+)`. But `'echo it'\''s here'` is three pieces glued together with no whitespace between them — a quoted run, a backslash escape, a quoted run — because that escape is the only way bash lets an apostrophe inside single quotes. The strip stopped at the first inner quote and read the remainder as the signal list.

**A third shape the issue did not name** turned up while building the cases: `"echo \"hi\""` failed the same way, on the double-quoted side. Same root cause, same fix.

| line | before | after |
|---|---|---|
| `trap 'echo it'\''s here' EXIT` | `\''s here' EXIT` | `EXIT` |
| `trap 'echo it'\''s here' EXIT INT TERM` | `\''s here' EXIT INT TERM` | `EXIT INT TERM` |
| `trap "echo \"hi\"" EXIT` | `hi\"" EXIT` | `EXIT` |
| `trap "echo \"hi\"" EXIT TERM` | `hi\"" EXIT TERM` | `EXIT TERM` |

An optional `--` is now skipped too — that is the form `trap -p` itself prints, so it is what anyone round-tripping a captured handler writes.

### The direction that matters, since this strip is MORE permissive

The issue asks for a case proving the new strip still catches `EXIT INT TERM` behind an escaped apostrophe, because a strip that goes too far would report `EXIT` for a line naming three signals — the #1401 false green, produced from inside the guard against it. Two answers, and the structural one is the stronger:

- **Structural.** The strip is prefix-anchored, and `EXIT` is the leftmost token of the signal list. An over-eager run therefore loses `EXIT` **first**; it can never leave `EXIT` behind. Measured on a deliberately permissive build (`_TRAP_BARE` widened to allow whitespace): `trap cleanup EXIT INT TERM` -> `[]`, `trap 'echo it'\''s here' EXIT INT TERM` -> `[]`, `trap cleanup EXIT` -> `[]`. Never `EXIT`. The failure mode of over-permissiveness here is a red, not a green.
- **Pinned anyway.** Every escaped-quote shape appears as a PAIR of cases — one compliant, one naming extra signals. If a shape ever parses to `EXIT` in both rows, the guard has been switched off rather than fixed, and the second row reds.

## 2. A `trap …` literal held as data

Exempted only when the line immediately above is **exactly** `# selftest-abort-traps: data`.

**Declared, never inferred.** Tracking heredoc regions instead was the obvious fix and is the wrong one: a mis-tracked region drops a REAL trap out of the walk with nothing printed, and a silent hole in this guard is strictly worse than the false red #1567 reports. An explicit marker's failure mode is an author writing one deliberately, which is the `# shellcheck disable` bargain.

**Whole-line, not substring** — found reviewing my own diff. This file names the marker in its own header and in the assignment that defines it. Under a substring match, any trap line that came to follow one of those would be exempted: the guard reading its own documentation as permission to stop looking. Same family as the fault it fixes. The fixture carries a prose-mention line with a trap under it as the control.

**The exemption is in the OUTPUT, not a comment.** Exempted lines print `declared DATA, NOT asserted (#1567): <file>:<line>` and the count lands in the summary — `44 passed, 0 failed, 1 declared data (not asserted)`. A limit that lives only in source is invisible to whoever reads a gate run. The count is pinned exactly, not `>= 0`: every marked line is a hole, so one appearing must red and be looked at.

**One real marked line is kept in the tree, deliberately.** Nothing else proves the walk actually consults the exemption — a regression dropping the call stays green over a tree where no line is marked. It is load-bearing both ways: legs 3 and 5 below.

## What was run

- `bash tests/integration/selftest-abort-traps.sh` — **44 passed, 0 failed, 1 declared data**. Was 26 passed on `develop-v2`.
- All 13 `tests/integration/selftest*.sh` — green (the `make test-integration-selftest` glob).
- `shellcheck --severity=warning` over `tests/integration/*.sh tests/integration/mini-stack/*.sh` — rc 0. It fired first on SC1087 (`$_TRAP_WORD[` read as an array subscript); fixed with braces.
- `shfmt -i 4 -d` over the Makefile's exact glob — rc 0. It fired first on comment alignment. Both halves run, per the rule that shfmt is the half that reds a PR after shellcheck passes.
- `make lint-file-budget` — OK. The file is 288 lines against a 400-line target, so it takes no `file-budget.tsv` row.
- `make lint-md` — 0 errors.

### Mutation battery — six legs, each `cmp`-gated and re-run against the FINAL file

A leg refuses to count on FILE UNCHANGED, and each reports its own changed-line count.

| leg | mutation | result |
|---|---|---|
| 1 | restore the old one-alternative strip | **6 red** — the two shapes #1567 names, the double-quote shape it does not, both `--` rows |
| 2 | widen the word to cross whitespace (the permissive direction) | **23 red** — every parse case and every real tree line; none returns `EXIT` |
| 3 | walk stops calling `trap_hit_is_data` | **2 red** — the literal, and the declared-data count |
| 4 | `trap_hit_is_data` always true (blanket exemption) | **4 red** — all three negative controls plus the count; 12 lines go "declared data" |
| 5 | delete the marker above the in-tree literal | **2 red** |
| 6 | marker matched as a SUBSTRING rather than whole-line | **1 red** — exactly the prose-mention control |

## What I did NOT do

- **No `docs/` change.** No file under `docs/` has ever described this walk or its classifier — checked `integration-testing.md`, `testing-guide.md`, and a repo-wide grep for `selftest-abort-traps`. This change adds no operator- or user-facing behaviour, and the marker is documented at its only point of use, in the header of the file whose red sends you there. Writing a new doc section for an internal instrument is a bigger scope decision than #1567 asks for; say the word and I will.
- **No heredoc-region tracking**, for the reason in §2. The cost is that a data literal needs a one-line marker rather than being recognised for free.
- **Nothing outside `tests/integration/`** — one file, in lane, no `.lane-override`, no shared file.

## Ponytail pass (skill read off disk, run on this diff)

```
L10-14:  shrink: the header restated the marker rule that `trap_hit_is_data` already
         carries. Point at the two functions instead. net -1.  ACCEPTED, applied.
L104:    yagni: `(--[[:space:]]+)?` plus two cases handle `trap -- 'h' EXIT`, a form no
         line in this tree writes. Delete the group and both rows. net -3.
L100-104: shrink: five `_TRAP_*` variables, one use each, one consumer. Inline them
         into the sed expression. net -5.
net: -8 lines possible (-1 taken).
```

**Declined, and why — veto either and I will cut it.**

- **The `--` group.** No site writes `trap --` today, so this is speculative by ponytail's test and the finding is fair. Kept because `trap -p` prints exactly that form and #1404 already round-trips `trap -p` output through this tree, so it is the next false red of the class #1567 reports, at a cost of twelve characters inside a regex being rewritten for that class anyway.
- **The five `_TRAP_*` pieces.** Inlined they are one ~110-character run of escaped quoting. Split, each piece carries the one-line comment saying which shell construct it models — which is the documentation for the whole fix, and the reason the original one-alternative version read as correct for as long as it did.
