### PR TITLE
fix(integration): run the holder removal AHEAD of a captured foreign handler (#1571)

### DIFF
--- a/tests/integration/rig-key-ledger.sh
+++ b/tests/integration/rig-key-ledger.sh
@@ -85,25 +85,29 @@ _RIG_LEDGER=""
 # a separate boolean is what #1404 turned out to be.
 _RIG_KEY_FOREIGN=""
 
-# The EXIT handler: restore everything still outstanding, THEN do lib.sh's holder cleanup. Ordering
-# matters — the rig restore is the thing worth doing, so it goes first and the breadcrumb removal
-# cannot be skipped by it (no `set -e` here, and every step is best-effort).
+# The EXIT handler: restore everything still outstanding, THEN lib.sh's holder cleanup, THEN
+# whatever we displaced. The order is the whole content of this function, and OUR OWN work is
+# sequenced ahead of anyone else's because only the last step can end the process (no `set -e` here,
+# and every step is best-effort).
 rig_key_atexit() {
     rig_key_unwind
-    # Whatever we displaced, in the order we displaced it (#1404). After the unwind, because the rig
-    # restore is the thing worth doing and a foreign handler is somebody else's best-effort cleanup;
-    # before the holder removal, so a foreign handler cannot skip it.
-    [ -z "$_RIG_KEY_FOREIGN" ] || eval "$_RIG_KEY_FOREIGN"
     # The fold lib.sh:rig_lock's comment prescribes. Re-derived from the durable env/default rather
     # than a local, exactly as the trap it replaces did, and best-effort in the same two steps: a
     # holder marker we cannot remove must never be fatal. (#244/#249)
     #
-    # KEPT rather than left to the capture above, which looks redundant and is not: if a foreign trap
+    # KEPT rather than left to the capture below, which looks redundant and is not: if a foreign trap
     # displaced rig_lock's BEFORE our first mark, the capture replays that foreign handler and the
     # breadcrumb strands. Measured — deleting this reds the NESTED case in
     # selftest-rig-key-ledger.sh, which exists to hold it here, and reds nothing else. (#1404)
     local h="${RIG_LOCK_HOLDER:-${RIG_LOCK_FILE:-/var/lock/rig-e2e.lock}.holder}"
     rm -f "$h" 2>/dev/null || sudo -n rm -f "$h" 2>/dev/null || true
+    # Whatever we displaced, in the order we displaced it (#1404) — and LAST (#1571). A captured
+    # handler that calls `exit` ends the shell from inside this trap, and bash does not re-enter an
+    # EXIT trap on an `exit` inside one, so anything sequenced after such a handler never runs at
+    # all. The first shape of this ran the capture first and asserted in a comment that the removal
+    # could not be skipped by it; it could, and that is #1571. Nothing wants the other order: the
+    # breadcrumb is display-only and no handler reads it.
+    [ -z "$_RIG_KEY_FOREIGN" ] || eval "$_RIG_KEY_FOREIGN"
 }
 
 # Install the composed trap at every mark, capturing anything it displaces (#1404). Still lazy — it

--- a/tests/integration/selftest-rig-key-ledger.sh
+++ b/tests/integration/selftest-rig-key-ledger.sh
@@ -240,6 +240,44 @@ assert_eq "the displaced foreign handler still ran" "$(grep -c FOREIGN-FIRED "$S
 assert_eq "and the outstanding key was restored" "$(restores)" 'dash|{"DONATION":5}'
 rm -f "$WORK/rig.lock" "$WORK/rig.holder"
 
+echo "== a captured handler that EXITS cannot skip the holder removal (#1571) =="
+# The removal is sequenced AHEAD of the capture for exactly this. A foreign handler that calls
+# `exit` ends the shell from inside the trap, and bash does not re-enter an EXIT trap on an `exit`
+# inside one, so anything after it never runs. The first shape of #1404 ran the capture first and
+# claimed in a comment that the removal could not be skipped by it — measured, it could.
+rc_exiting="$(scenario 'export RIG_LOCK_FILE="$WORK/rig.lock" RIG_LOCK_HOLDER="$WORK/rig.holder"' \
+    'rig_lock selftest "rig-key-ledger #1571"' \
+    '[ -s "$RIG_LOCK_HOLDER" ] && echo HOLDER-WRITTEN' \
+    "trap 'echo FOREIGN-FIRED; exit 3' EXIT" \
+    'rig_key_mark dash rig1 DONATION 5' \
+    'exit 9')"
+assert_eq "rig_lock really wrote its breadcrumb (the control for the assertions below)" \
+    "$(grep -c HOLDER-WRITTEN "$SCEN_OUT")" "1"
+assert_eq "the breadcrumb is removed though the captured handler EXITS (#1571)" \
+    "$([ -e "$WORK/rig.holder" ] && echo STRANDED || echo gone)" "gone"
+assert_eq "the handler really ran — a removal that happened because nothing ran proves nothing" \
+    "$(grep -c FOREIGN-FIRED "$SCEN_OUT")" "1"
+assert_eq "and the outstanding key was restored ahead of both" "$(restores)" 'dash|{"DONATION":5}'
+assert_eq "the exiting handler's own status wins, as it does for any handler that exits" \
+    "$rc_exiting" "3"
+rm -f "$WORK/rig.lock" "$WORK/rig.holder"
+
+# The paired control, differing in ONE character sequence — the `exit 3`. It duplicates the NESTED
+# case's shape on purpose: a pair that must be read as a pair is worth more adjacent than referenced
+# sixty lines away, and without it "the breadcrumb is gone" above is equally consistent with an
+# ordering that never mattered. Only the two discriminating facts are asserted here, so this stays a
+# control and does not become a second test of behaviour NESTED already covers.
+rc_plain="$(scenario 'export RIG_LOCK_FILE="$WORK/rig.lock" RIG_LOCK_HOLDER="$WORK/rig.holder"' \
+    'rig_lock selftest "rig-key-ledger #1571"' \
+    "trap 'echo FOREIGN-FIRED' EXIT" \
+    'rig_key_mark dash rig1 DONATION 5' \
+    'exit 9')"
+assert_eq "control: the same handler WITHOUT the exit also leaves no breadcrumb" \
+    "$([ -e "$WORK/rig.holder" ] && echo STRANDED || echo gone)" "gone"
+assert_eq "control: and there the script's own status survives, so the pair differs only in the exit" \
+    "$rc_plain" "9"
+rm -f "$WORK/rig.lock" "$WORK/rig.holder"
+
 echo "== KNOWN LIMIT, pinned deliberately: a trap after the LAST mark still wins =="
 # NOT desired behaviour. A documented hole, asserted so that it is visible in this file's output
 # rather than rediscovered from a stranded rig. Composition happens at a mark, so a trap installed


### PR DESCRIPTION
Closes #1571 (by hand — `Closes` never fires here, PRs merge to `develop-v2` while the default branch is `develop`).

`rig_key_atexit` ran the captured foreign handler first and then the holder removal, with a comment asserting the removal could not be skipped by it. It could. A captured handler that calls `exit` terminates the shell from inside the trap, and bash does not re-enter an `EXIT` trap on an `exit` inside one, so everything sequenced after such a handler never runs — the lock breadcrumb strands, which is exactly the outcome the #244/#249 fold exists to prevent.

**Introduced by #1568, not inherited**, as the issue says: before it nothing `eval`'d a foreign handler at all.

## Which of the two options, and why

#1571 offered narrowing the comment or making the removal robust, with no preference. **Robust** — it costs three moved lines and delivers the ordering the comment already claimed, rather than writing down a hole and leaving it. The new sequence is: our unwind, our holder removal, then whatever we displaced. The general form of the rule is worth more than this instance: **our own work goes ahead of anyone else's, because only the last step can end the process.**

Checked before moving it, since reordering a teardown is the kind of change that trades one bug for another:

- **The plain `rig_lock` case.** The captured handler IS `rig_lock`'s own removal, so the order is now our `rm -f` then theirs. Both are `rm -f` of the same path, both best-effort, idempotent either way.
- **The NESTED case** (a foreign trap displaced `rig_lock`'s before our first mark). The captured handler is the foreign one and never touches the breadcrumb, so the hand-folded removal is the only thing that can remove it — unchanged by the move, and its assertion stays green.
- **Nothing wants the other order.** The breadcrumb is display-only and no handler reads it, so there is no teardown step that needs it still present.
- **Exit status is unaffected.** Bash exits with the status the shell was dying of, not the trap's last command, unless a handler calls `exit` itself — and where one does, its status still wins. Both halves are asserted.

## Proof: a pair differing in one token

The same foreign handler with and without `exit 3`, adjacent, so it reads as a pair:

| leg | breadcrumb | handler ran | rc |
|---|---|---|---|
| handler calls `exit 3` | gone | yes | 3 |
| control: same handler, no `exit` | gone | yes | 9 (the script's own) |

**On the pre-fix ordering the exiting leg reds and the control does not** — `50 passed, 1 failed`, and the one red is `the breadcrumb is removed though the captured handler EXITS (#1571)`. Exactly one assertion moves, so the pair isolates the `exit` rather than the harness. Mutation applied by swapping the two blocks back, `cmp`-gated (6 changed lines), re-run against the final file after a late ponytail edit rather than quoted from an earlier measurement.

The control duplicates the NESTED case's shape deliberately. A pair that has to be read as a pair is worth more adjacent than referenced sixty lines away, and only the two discriminating facts are asserted on it, so it stays a control rather than becoming a second test of what NESTED already covers.

## What was run

- `bash tests/integration/selftest-rig-key-ledger.sh` — **51 passed, 0 failed**. Was 44 at `develop-v2` head.
- All 13 `tests/integration/selftest*.sh` — green.
- `shellcheck --severity=warning` over `tests/integration/*.sh tests/integration/mini-stack/*.sh` — rc 0.
- `shfmt -i 4 -d` over the Makefile's exact glob — rc 0. Both halves, as always here.
- `make lint-file-budget` — OK. 194 and 361 lines against a 400 target, so neither file takes a `file-budget.tsv` row.
- `make lint-md` — 0 errors.

## Ponytail pass (skill read off disk, run on this diff)

```
selftest-rig-key-ledger.sh:L256,L275: shrink: two scenario rcs written to temp files
   and read back with `cat`. `rc="$(scenario …)"` is the form the rest of this file
   uses. net -2, and two temp files.        ACCEPTED, applied.
selftest-rig-key-ledger.sh:L270-281: delete: the paired control duplicates the NESTED
   case, which is already a non-exiting foreign handler. net -8.
net: -10 lines possible (-2 taken).
```

**Declined, and why — veto it and I will cut it.** NESTED differs from the probe in more than the `exit`: different handler body, different assertions, sixty lines away. A pair whose legs differ in one token, sitting adjacent, is what makes "the breadcrumb is gone" mean the ordering rather than the scenario. That is the specific reading error this lane has been bitten by before.

## What I did NOT do

- **No `docs/` change** — and re-read to check, not assumed. `docs/dev/integration-testing.md`'s "The trap is composed, not stacked" bullet ends *"so arming it cannot silently strand the breadcrumb or silently skip the restore"*. It makes no claim about the ORDER of the fold against a captured handler, so it did not go false — but it was narrowly overclaiming for the exiting-handler case, and this change makes it true rather than needing a hedge. Which is the strongest argument for option 2 over option 1: the honest version of the source comment would have obliged a matching hedge in the doc.
- **Did not make the removal robust to anything else** a foreign handler could do — it can still `kill -9` its own shell, and no ordering survives that. Only the `exit` path is closed.
- **Nothing outside `tests/integration/`** — two files, in lane, no `.lane-override`, no shared file.
