### PR TITLE
fix(dashboard): #1556 slice 1 — annotate xvb_client's four blind failure returns

### DIFF
--- a/dashboard/mining_dashboard/client/xvb_client.py
+++ b/dashboard/mining_dashboard/client/xvb_client.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from datetime import UTC, datetime
+from typing import Any
 
 import requests
 
@@ -183,7 +184,7 @@ class XvbClient:
         self.REGEX_HR_1H = re.compile(r"1hr avg:\s*([\d\.]+)\s*([kKmMgG]?H/s)?", re.IGNORECASE)
         self.REGEX_HR_24H = re.compile(r"24hr avg:\s*([\d\.]+)\s*([kKmMgG]?H/s)?", re.IGNORECASE)
 
-    def get_stats(self):
+    def get_stats(self) -> dict[str, Any] | None:
         """
         Retrieves bonus history statistics from the XMRvsBeast service.
 
@@ -216,7 +217,7 @@ class XvbClient:
             self.logger.error(f"Unexpected error in XvB client: {e}")
             return None
 
-    def get_reward_estimates(self):
+    def get_reward_estimates(self) -> dict[str, float] | None:
         """Fetch XvB's published per-tier expected rewards (XMR/year) over Tor (#118).
 
         Returns ``{round_type: xmr_per_year}`` for the donor tiers on success, or ``None`` on a
@@ -246,7 +247,7 @@ class XvbClient:
             self.logger.error(f"Unexpected error fetching XvB reward estimates: {e}")
             return None
 
-    def get_recent_wins(self):
+    def get_recent_wins(self) -> dict[str, Any] | None:
         """Fetch XvB's public raffle-winners log over Tor — ONE request, both parses.
 
         Returns ``{"wins": [...], "round_stats": {...}}``: ``wins`` is THIS wallet's wins oldest
@@ -356,7 +357,7 @@ class XvbClient:
             self.logger.error(f"Unexpected error during XvB registration: {e}")
             return REG_ERROR
 
-    def _parse_html(self, html_text):
+    def _parse_html(self, html_text) -> dict[str, Any] | None:
         """
         Parses raw HTML content to extract mining statistics.
         """

--- a/dashboard/tests/service/test_collapsed_return_channels.py
+++ b/dashboard/tests/service/test_collapsed_return_channels.py
@@ -39,9 +39,9 @@ below pins the narrowness so it cannot drift.
 
 Two laws are HARD, and neither needs a baseline of existing instances:
 
-1. **The signed set stays signed** (`_SIGNED`). Five functions already express the three-valued
-   contract, #1409's own fix among them. Dropping the `| None` from one of them would return it to
-   the collapsed class silently — the regression this file exists to make impossible.
+1. **The signed set stays signed** (`_SIGNED`). Five functions are PINNED there, #1409's own fix
+   among them — not every function the classifier scores signed. Dropping the `| None` from a pinned
+   one would return it to the collapsed class silently: the regression this file exists to prevent.
 2. **A signature that promises an out-of-band failure must honour it.** If a function's annotation
    admits `None`, every failure return in it must BE `None`, not an empty container. This is a
    self-consistency law with no baseline at all: it is clean today, it stays clean forever, and it
@@ -60,14 +60,14 @@ about their number. This is deliberate and it is the whole ruling on this file:
 
 So the un-read instances get no row, no ratchet, and no green. They get a count and their names.
 
-## The residual, stated as a measurement
+## The residual, stated as a measurement AT A NAMED SHA
 
-At the tip this shipped against: **11 collapses** flagged (all in the DB read layer —
-`storage_service.py` and `telemetry_store.py`), **5 signed**, **0 half-fixes**, and **57 failure
-returns this gate CANNOT judge because their functions are unannotated.** That 57 is the honest
-limit, not an apology: the mechanism keys on the declared type, so a function that declares nothing
-declares no contract to check. Annotating that layer would bring it into scope and is the obvious
-next move; this file does not pretend to have made it.
+Every figure here is measured over live source, so it drifts under refactors unrelated to
+annotation, in both directions: quote one with the sha you took it at, and never hang an imperative
+on the number (#1556). At `b0a32bd`, the tip this shipped against — **11 collapses** flagged (all in
+the DB read layer), **5 signed**, **0 half-fixes**, **57 blind**. At `a0ddbec` plus this slice
+(`client/xvb_client.py`) — **11**, **10**, **0**, **52**. #1556 annotates the blind layer slice by
+slice; the flagged count is expected to RISE wherever a slice brings a genuine collapse into scope.
 
 `add_payouts` is worth naming out of the 11, because it shows the class is not academic here: a
 failed INSERT returns `[]`, indistinguishable from "every row was already stored", and that value


### PR DESCRIPTION
Closes nothing — first slice of #1556.

## What this does

`client/xvb_client.py`'s four functions carrying failure returns declared no return type, so
#1487's gate scored them `blind`: outside what the mechanism can judge either way. Each now
declares the signed three-valued contract the gate keys on.

| function | annotation | every failure return |
|---|---|---|
| `get_stats` | `dict[str, Any] \| None` | `None` |
| `get_reward_estimates` | `dict[str, float] \| None` | `None` |
| `get_recent_wins` | `dict[str, Any] \| None` | `None` |
| `_parse_html` | `dict[str, Any] \| None` | `None` |

Annotation only. No control flow, no network call, no parsing, no validation changed. Five added
lines: one `from typing import Any` and four signatures.

## What was RUN

**The controlled pair.** The gate's own `_classify`, over the whole package, twice in this
worktree — once with `client/xvb_client.py` replaced by its `origin/develop-v2` content, once as
shipped. Same process, same classifier, so the two are comparable:

```
BASE  (a0ddbec)      signed  6   half_fix 0   collapse 11   blind 56
HEAD  (this branch)  signed 10   half_fix 0   collapse 11   blind 52
delta signed +  client/xvb_client.py:{_parse_html, get_recent_wins, get_reward_estimates, get_stats}
delta blind  -  client/xvb_client.py:{_parse_html, get_recent_wins, get_reward_estimates, get_stats}
```

The two deltas are the same four names and nothing else, in both directions. `collapse` did not
move, which is the expected result here: none of the four returned an empty container, so
annotating them could not turn one into a flagged collapse.

**Every return re-derived by AST, not read.** All 17 return statements across the four functions
are either `None` or a `dict` expression — so each annotation is true of the function rather than
true of its docstring. `get_reward_estimates` is the narrow one: its success value comes from
`parse_reward_estimates`, which builds `{str: float}` via `float(value)`, and the `if not
estimates: return None` guard above means it never returns the empty dict.

**Suite:** 2261 passed (`uv run --locked --extra test python -m pytest`). Measured at this head
only — I did not measure the base's count, so this is not offered as a base-comparison.
**Coverage:** 97% total (bar 80%). **Patch coverage: 5/5 executable lines = 100%**, computed from
`coverage.xml` with the path prefix derived from its own `<source>` element and an
executable-total > 0 assertion (the first run of that check fired the assertion on a wrong prefix,
which is why the guard is there). `make test-patch-coverage` is NOT cited: it pins
`COMPARE=origin/develop` (#1557), so its rc says nothing on a develop-v2 PR.

**Ruff** clean (check + format), **file-budget gate** clean.

**The patch-coverage figure does not witness this change and should not be read as if it does.**
The five lines are an import and four `def` statements, which execute at import; 100% here proves
the module imports. What witnesses the change is the controlled classifier pair above.

## The docstring's stale figures, re-stated at a named sha

`test_collapsed_return_channels.py`'s residual paragraph said "57 failure returns" and "5 signed".
Both were correct when written at `b0a32bd` and both had drifted before this branch existed:

- **57 -> 56** because `storage_service.py:save_snapshot` left the blind set. Its signature is
  unchanged and still unannotated; a refactor DELETED its `if not self._conn: return` branch.
- **5 -> 6** because `worker_config_store.py:note_worker_revision` landed. It is ABSENT at
  `b0a32bd` (checked at source), declares `dict | None`, and returns `None` from every failure
  path including its handle guard.

So the paragraph now carries the sha each figure was taken at, and no imperative hangs on a number,
per this issue's own ruling. Swapping one number for another would have been the wrong fix: these
are live measurements over source and they move in both directions under refactors that have
nothing to do with annotation.

**Net zero lines.** That file is AT its recorded 563-line ceiling and `lint-file-budget.sh` rejects
any raise — ceilings only ever go down. The correction was fitted by deleting a sentence duplicated
verbatim in `_admits_none`'s own docstring, not by rewording around the bar.

## What I did NOT do, and one of them needs a decision before slice 2

- **The four are NOT added to `_SIGNED`, so law 1 does not pin them.** Dropping a `| None` from one
  of them would move it out of the signed class with nothing going red — which is exactly the
  silent reversion this issue's body warns against ("it must not be 'fixed' by reverting the
  annotation"). I did not add them because the fix does not scale and the budget gate is what
  proves it: `_SIGNED` lives in the file that is at a mechanically non-raisable ceiling, and
  #1556's remaining slices would need ~52 more entries there. Pinning this slice's four would work
  and leave the next slice with the same problem and less room.
- **`note_worker_revision` is the same gap, already live and not mine.** It is signed at the BASE
  and unpinned — found by the base leg of the measurement above, not by this change. So the hole in
  law 1 is not hypothetical and it predates this work.
- **The module's other functions are still unannotated** — `parse_reward_estimates`,
  `parse_winners`, `parse_round_stats`, `mask_wallet`. They carry no failure returns, so they are
  invisible to the gate and out of this issue's scope. `client/xvb_client.py` is left partly
  annotated as a result. Deliberate, and worth naming rather than discovering later.
- **`test_the_blind_spot_is_measured_rather_than_described` will go RED when #1556 finishes.** It
  asserts `package["blind"]` is non-empty, and blind reaches 0 when the last slice lands. Reading
  the test, that is by design — its docstring asks for "a deliberate look" at that moment rather
  than a silent change in what the green means. Flagging it now so the last slice is not surprised.
- **No security-reviewer subagent.** `xvb_client.py` is an outbound-fetch surface, so this lane's
  rule normally calls for one. This session's tool policy does not permit spawning it, so the pass
  was done in-session instead of delegated, and this is the disclosure. Its whole content: the diff
  adds one import and four return annotations, changes no control flow, no request, no proxy
  handling and no parsing, and Python does not evaluate these at call time — nothing in the diff
  can alter what the module does. Nothing in the tree reads `__annotations__` or `get_type_hints`
  (checked repo-wide).
- **No doc change.** `docs/dashboard.md` describes this gate qualitatively at :504-506 and carries
  none of these counts; a repo-wide grep found the figures only in the test file. `CHANGELOG.md` is
  the release lane's file.

## Over-engineering pass — one finding against this diff, declined with a reason

**Finding: the `from typing import Any` import is avoidable.** Three of the four could be
`dict | None`, which reaches the identical gate verdict in four lines instead of five and with no
new import. `Any` as a value type carries no information, so the import buys only "the keys are
strings".

**Declined.** The house is split and the split is principled, not arbitrary — the six functions
already in the signed class divide by what they return, not by taste:

```
dict[str, Any] | None   get_xvb_standby, load_snapshot          heterogeneous state blob
dict | None             get_worker_config_change, note_worker_revision   one audit row
list[dict] | None       get_worker_config_history
str | None              get_kv
```

`get_stats`, `get_recent_wins` and `_parse_html` return heterogeneous blobs — `{fail_count: int,
avg_1h: float, avg_24h: float}` and `{wins: list, round_stats: dict}` — so they take the blob
form. `get_reward_estimates` is the one that is genuinely homogeneous (`{str: float}` built by
`float(value)`), so it declares that instead of `Any`. The apparent inconsistency between the
three and the one is the point: precision where it is true, `Any` where it is not. Annotating
`_parse_html` matters for the same reason — `get_stats` returns its result verbatim, so the two
must carry the same type or one of them is lying.

Nothing else in the diff is machinery the job did not need: no helper, no constant, no test
scaffolding, and the docstring edit is a required correction fitted at net zero lines.
