### PR TITLE
fix(integration): the handler strip models shell words but not ANSI-C quoting (#1573)

### DIFF
--- a/tests/integration/selftest-abort-traps.sh
+++ b/tests/integration/selftest-abort-traps.sh
@@ -94,16 +94,25 @@ abort_trial() { # <trap-spec, "" for none> <signal>
 # strip stops at the first inner quote and reads the remainder as the signal list, which reds a
 # compliant line. The same fault hit `"echo \"hi\""`, a shape #1567 did not name.
 #
+# ANSI-C QUOTING IS ITS OWN PIECE (#1573). `$'a\'b'` is ONE word that bash reads as `a'b`, but
+# the single-quoted alternative stops at that escaped apostrophe: it takes `$` + `'a\'` + `b` and
+# reports the leftover quote as the signal list, redding a compliant line. Only `$'…'` needs an
+# alternative — `$"…"` is a `$` followed by an ordinary double-quoted run, which the pieces below
+# already read correctly.
+#
 # THE DIRECTION THAT MATTERS: this is more permissive than what it replaces, and a strip that goes
 # too far eats the signals and reports `EXIT` for a line naming three — the #1401 false green, from
-# inside the guard against it. It cannot: none of the four pieces matches whitespace outside quotes,
-# so the run always ends at the space before the signal list. The cases below pin that with a row for
-# every shape carrying BOTH an escaped quote and extra signals; each must still come back flagged.
-_TRAP_SQ="'[^']*'"             # a single-quoted run — bash allows no escapes at all inside one
-_TRAP_DQ='"([^"\]|\\.)*"'      # a double-quoted run, which may carry \" and \\
-_TRAP_ESC='\\.'                # a bare backslash escape, the glue in the `'\''` idiom
-_TRAP_BARE="[^[:space:]'\"\\]" # any other single character that is not whitespace or quoting
-_TRAP_WORD="($_TRAP_SQ|$_TRAP_DQ|$_TRAP_ESC|$_TRAP_BARE)+"
+# inside the guard against it. It cannot: none of the five pieces matches whitespace outside
+# QUOTING — the ANSI-C run swallows a space only inside its own `$'…'`, where bash agrees that space
+# belongs to the handler — so the run always ends at the space before the signal list. The cases
+# below pin that with a row for every shape carrying BOTH an escaped quote and extra signals; each
+# must still come back flagged.
+_TRAP_AQ="\\\$'([^'\\]|\\\\.)*'" # an ANSI-C run, `$'…'`, which may carry \' and \\
+_TRAP_SQ="'[^']*'"               # a single-quoted run — bash allows no escapes at all inside one
+_TRAP_DQ='"([^"\]|\\.)*"'        # a double-quoted run, which may carry \" and \\
+_TRAP_ESC='\\.'                  # a bare backslash escape, the glue in the `'\''` idiom
+_TRAP_BARE="[^[:space:]'\"\\]"   # any other single character that is not whitespace or quoting
+_TRAP_WORD="($_TRAP_AQ|$_TRAP_SQ|$_TRAP_DQ|$_TRAP_ESC|$_TRAP_BARE)+"
 
 # The signal list of one `trap` line: everything after the handler argument. The handler is stripped
 # FIRST, so a `#` inside a quoted handler can never be read as a comment; only then is a trailing
@@ -175,6 +184,15 @@ echo "== the classifier reads one trap line correctly, and stays FAIL-LOUD doing
 # once naming extra signals: the second row is the control, and it is the whole reason a more
 # permissive strip is safe here. If a shape ever parses to `EXIT` in BOTH rows the guard has been
 # switched off rather than fixed, which is the one outcome worse than the false red #1567 reports.
+#
+# THE LAST ROW IS A RECORDED LIMIT, NOT AN ENDORSEMENT (#1573). `trap - EXIT` RESETS the handler,
+# so bash installs nothing, yet the strip reads `-` as the handler word and the line parses to
+# `EXIT` and passes. It is not a hole in what this guard is for: #1401's hazard is a handler that
+# CATCHES INT/TERM and returns, and a line installing no handler catches nothing. `trap - INT` and
+# `trap - EXIT INT` both red correctly, and the two existence assertions at the end of this file
+# match the real handler text (`trap restore_all`, `trap 'kill `), so a reset cannot stand in for
+# either of the sites that matter. The row is here so that whoever next widens this classifier
+# trips over the limit instead of rediscovering it and assuming it was missed.
 while IFS='|' read -r want line; do
     [ -n "$want" ] || continue
     assert_eq "signals of [$line]" "$(trap_line_signals "$line")" "$want"
@@ -186,10 +204,15 @@ EXIT|trap 'echo it'\''s here' EXIT
 EXIT INT TERM|trap 'echo it'\''s here' EXIT INT TERM
 EXIT|trap "echo \"hi\"" EXIT
 EXIT TERM|trap "echo \"hi\"" EXIT TERM
+EXIT|trap $'a\'b' EXIT
+EXIT INT TERM|trap $'a\'b' EXIT INT TERM
+EXIT|trap $'a\'b c' EXIT
+EXIT INT|trap $'a\'b c' EXIT INT
 EXIT|    trap rig_key_atexit EXIT
 EXIT|trap 'rm -rf "$D"' EXIT # a trailing comment, cut only after the handler
 EXIT|trap -- 'h' EXIT
 EXIT INT|trap -- 'h' EXIT INT
+EXIT|trap - EXIT
 CASES
 
 echo "== an exemption is DECLARED, never inferred — and it is not blanket (#1567) =="


### PR DESCRIPTION
Closes #1573 (by hand — `Closes` never fires here, PRs merge to `develop-v2`).

## What was wrong

`$'a\'b'` is ONE shell word that bash reads as `a'b`. The handler strip does not model ANSI-C
quoting, so it takes `$` + `'a\'` + `b`, halts at the leftover apostrophe and reports it as the
signal list — redding a compliant line.

**This is a regression I introduced in #1570**, and an honest one: excluding `'` from the
bare-character piece is what removed four false reds, and the crude `[^[:space:]]+` it replaced got
this shape right by swallowing the whole word. It fails in the safe direction and no line under
`tests/integration/` uses the shape (grepped). Fixed anyway, because a guard that reds a compliant
line is this file's own subject one level up.

## The fix

A fifth piece, `_TRAP_AQ`, first in the word. **Only `$'…'` needs one:** `$"…"` is a `$` followed by
an ordinary double-quoted run that `_TRAP_DQ` already reads — the issue suggested a `$"…"`
alternative "would be the same shape"; it is not needed, and `trap $"x" EXIT` and `trap $"a\"b" EXIT`
both agree with bash at base *and* at head. Measured, not assumed.

## What was RUN

**The instrument.** Each shape executed in a clean `bash --norc`, then `trap -p <sig>` read back per
signal and compared to `trap_line_signals`. Bash is ground truth. Same rig, same 24 shapes, both
legs in this one worktree.

**My first rig was wrong and said so loudly.** `trap -p` on an *unset* signal prints nothing at all —
not even a newline — so my `SIG:` prefixes ran together and `^TERM:trap` could never match when INT
was unset. It reported bash installing only `EXIT` for `trap "echo \"hi\"" EXIT TERM`, a row this
file already asserts. Fixed (one probe, one line) before any row was believed. The extraction rig
also failed its own arm check when `_TRAP_AQ` was declared above the range it swept — caught as
`unbound variable`, not as a silent uniform result.

**Controlled pair (base = `origin/develop-v2`, head = this commit):**

| | agree | disagree |
|---|---|---|
| base | 18 | 6 |
| head | 20 | 4 |

The two `$'a\'b'` rows moved DISAGREE → agree. **Nothing else moved.** The 4 remaining are the three
`trap -` reset forms — **identical at base, so neither introduced nor widened here** — and
`trap $'oops EXIT INT TERM`, an unterminated quote that is a shell syntax error installing nothing;
it parses to garbage and reds loudly rather than to `EXIT`.

**Suite:** 44 passed at base → 49 at head, 0 failed both. The base copy was parked at a path with
**no `.sh` extension** so the walk could not scan the instrument it was being compared against.

**Mutation battery** — each leg `cmp`s before it counts, and refuses to count on FILE UNCHANGED:

| mutation | result |
|---|---|
| drop `$_TRAP_AQ` from the word | 45/4 — reds **exactly** the four ANSI-C rows, nothing else |
| let `_TRAP_BARE` match whitespace (over-eager) | 21/28 |
| drop `$_TRAP_SQ` from the word | 35/14 — the new piece did not make the old one redundant |

**The direction that matters, re-measured with five pieces rather than inherited from #1570:** under
the over-eager mutation every row parses to `[]`, never `EXIT`. Printed and read, not reasoned:
`expected [EXIT INT TERM], got []`. The run is prefix-anchored and `EXIT` is the leftmost signal, so
an over-eager strip loses `EXIT` first. That structural argument and the measurement both hold.

## `trap - EXIT` — the second half of the issue, deliberately NOT behaviour-changed

It parses to `EXIT` and passes though it installs nothing. Left standing, and now pinned as the last
`CASES` row with the reason beside it. I re-derived the issue's "not a hole" rather than relaying it:
#1401's hazard is a handler that CATCHES INT/TERM and returns, and a line installing no handler
catches nothing; `trap - INT` and `trap - EXIT INT` both red; and the two existence assertions
literal-match the real handler text (`trap restore_all`, `trap 'kill `), so a reset **cannot** stand
in for either site that matters. Making it red instead would be a false red on a harmless line.

## Ponytail review (run on this diff, findings and what I declined)

Read off disk and applied for real. It found something the tests did not:

- `L207-208: delete: two rows insensitive to the change they ship with.` **Accepted, then fixed
  rather than cut.** `$'a b'` passes identically with and without `_TRAP_AQ`, because the
  `$`+single-quote path already covers it — decoration. Replaced with `$'a\'b c'`, same line count,
  and the M1 mutation now reds **four** rows instead of two. Found by reviewing my own diff.
- `L97-101, L187-194: shrink: 14 lines of comment for 6 lines of code.` **Declined.** This file's
  design is that every limit lives in prose beside the row it constrains; the recorded-limit note is
  the whole deliverable of the issue's second half.

## What I did NOT do

- No `$"…"` alternative — shown unnecessary above, rather than added for symmetry.
- No behaviour change for `trap -` resets.
- **No docs change.** Grepped `docs/` for claims about the classifier's quoting shapes: none.
  `integration-testing.md` describes trap *semantics*, which this does not touch.
- No `make lint-md` — this diff changes no markdown.
- Unterminated `$'` left redding loudly; it is invalid shell, not a compliant line.

## Lint, with the file set each verdict was measured over

- `shellcheck --severity=warning tests/integration/*.sh tests/integration/mini-stack/*.sh` → rc=0.
  Set contains `tests/integration/selftest-abort-traps.sh` (confirmed by listing it).
- `shfmt -i 4 -d` over the Makefile's exact glob, 188 files → rc=0. Set contains the changed file.
- `make test-integration-selftest` → rc=0 (all self-tests, not just this one).
- `make lint-sh` NOT run whole: its second invocation is the ~3.8 GB `run.sh` root that has
  OOM-killed sessions on this box. The first invocation's glob, which is where this file sits, was
  run in full above.

Paths: `tests/integration/` only — in lane, no `.lane-override`. File is 311 lines, under the
400-line budget target, so no budget row.
