### PR TITLE
fix(integration): a throttle is transport wearing a status code, not a pin statement (#1576)

### DIFF
--- a/tests/integration/fakes/test_contract_freshness.py
+++ b/tests/integration/fakes/test_contract_freshness.py
@@ -57,22 +57,39 @@ def _get(url):
 def test_vendored_contract_bytes_match_the_producer_at_the_baked_ref():
     """Byte-compare tests/integration/fakes/contract/v1/ against RigForge at the baked pin (#1426).
 
-    A transport failure and a non-200 are different findings and are treated differently. A non-200
-    means the pin points somewhere these fixtures cannot be verified against at all — a real red,
-    everywhere. A transport failure is our own reachability, which offline development is allowed to
-    have and a release gate is NOT: in CI it fails, because a producer we could not reach must never
-    be read as a producer we agreed with. That distinction is the whole point of the leg — the
-    failure this file exists to prevent is a guard whose green means less than a reader thinks.
+    Failing to REACH the producer and the producer DISAGREEING with us are different findings and
+    are treated differently — that split is the whole point of the leg, and the failure this file
+    exists to prevent is a guard whose green means less than a reader thinks. Reachability is our
+    own, which offline development is allowed and a release gate is NOT: it skips locally and FAILS
+    in CI, because a producer we could not reach must never be read as one we agreed with. A pin
+    statement is a real red, everywhere.
+
+    THE STATUS CODE DOES NOT MAP ONTO THAT SPLIT BY ITSELF (#1576). A 429 is throttling and a 5xx is
+    the CDN having a bad minute: both are transport wearing a status code, both say nothing about
+    the ref, and filing them under the pin sends whoever reads the failure — at 3am — to check a pin
+    that never moved. A 404 is the one that really is a pin statement: that ref does not serve these
+    files. 403 is deliberately NOT reclassified, being ambiguous between throttling and the
+    repository becoming unreadable; the louder branch is the safer home for a status we have never
+    observed.
     """
     ref = _baked_ref()
     for name in _FILES:
         try:
             resp = _get(_RAW.format(ref=ref, name=name))
+            # Raised into the handler that already exists rather than given a branch of its own, so
+            # there is structurally ONE reachability policy here instead of two kept in step by
+            # hand. HTTPError is a RequestException, and `_get` has already returned, so this adds
+            # no retry.
+            if resp.status_code == 429 or resp.status_code >= 500:
+                raise requests.HTTPError(
+                    f"RigForge's raw host answered HTTP {resp.status_code} — throttled or "
+                    f"unavailable, which says nothing about the ref"
+                )
         except requests.RequestException as exc:
             unproven = (
-                f"could not reach RigForge to verify tests/integration/fakes/contract/v1/{name} "
-                f"against the baked pin {ref}: {exc}. The vendored fixtures are UNVERIFIED against "
-                f"their producer — this run proves nothing about their freshness (#1426)."
+                f"could not verify tests/integration/fakes/contract/v1/{name} against the baked "
+                f"pin {ref}: {exc}. The vendored fixtures are UNVERIFIED against their producer — "
+                f"this run proves nothing about their freshness (#1426)."
             )
             if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
                 pytest.fail(unproven)


### PR DESCRIPTION
Closes #1576 (by hand — `Closes` never fires here, PRs merge to `develop-v2`).

## What was wrong

The leg splits producer failures into two classes and the split is its whole design: **reachability**
(skip locally, FAIL in CI) versus **the pin** (a real red, everywhere). A `429` is transport wearing
a status code — it arrives as a non-200, takes the pin branch, and tells the maintainer to *"check
whether the pin moved to a ref predating the contract fixtures, or whether they were renamed
upstream"*. All of that is wrong for a throttle: the pin did not move, nothing was renamed, the
fixtures are fine. Same for a 5xx from the CDN. #1575's body disclosed the false *red*; it did not
name that the **message** misleads too, and the message is the part anyone acts on.

## The fix, which is smaller than the issue's suggested shape

429 and 5xx are raised as `requests.HTTPError` into the reachability handler that **already exists**,
rather than given a branch of their own. `HTTPError` is a `RequestException`, so there is
structurally **one** reachability policy instead of two that have to be kept in step by hand. `_get`
has already returned by then, so no retry is added.

I built the two-branch version first (a shared `_unverified()` helper). The ponytail pass killed it —
see below.

## What was RUN

Every leg drives the **real test function** in the real module with `requests.get` monkeypatched.
**The exception type is the instrument**: `Skipped`/`Failed` means the reachability branch fired,
`AssertionError` means the pin branch did — so each row reads *which branch ran*, not merely the
outcome.

**Controlled pair.** Base = `origin/develop-v2`, head = this commit, same harness, same ten legs.
The base copy was parked in-tree at the correct depth as `base_freshness_CONTROL.py` — `_REPO` is
derived from the file's own path depth, so a copy in `/tmp` silently resolves the wrong repo root
(it did, and errored loudly) — and under a name pytest cannot collect. Removed afterwards.

| leg | base | head |
|---|---|---|
| 429, CI unset | FAIL **[pin]** | **SKIP [reachability]** |
| 429, CI set | FAIL **[pin]** | **FAIL [reachability]** |
| 503, CI unset | FAIL **[pin]** | **SKIP [reachability]** |
| 503, CI set | FAIL **[pin]** | **FAIL [reachability]** |
| 404, CI unset | FAIL [pin] | FAIL [pin] |
| 404, CI set | FAIL [pin] | FAIL [pin] |
| transport exception, CI unset | SKIP [reachability] | SKIP [reachability] |
| transport exception, CI set | FAIL [reachability] | FAIL [reachability] |
| 200, matching bytes | PASS | PASS |
| 200, TAMPERED bytes | FAIL [pin/bytes] | FAIL [pin/bytes] |

**Four rows are controls and none of them moved:** 404 stays a pin statement, the transport
exception keeps its existing skip/fail policy, the happy path still passes, and the byte comparison
still bites when the fixture is tampered with. Only the four intended rows changed.

**The message, read as RENDERED output rather than grepped for source words** — the trap #1575 was
caught by:

> could not verify tests/integration/fakes/contract/v1/feed.json against the baked pin
> 4ce29b3daf063fd1b45e050649e93aa9592618e1: RigForge's raw host answered HTTP 429 — throttled or
> unavailable, which says nothing about the ref. The vendored fixtures are UNVERIFIED against their
> producer — this run proves nothing about their freshness (#1426).

Five probes, all correct: `check whether the pin moved` **absent**, `renamed upstream` **absent**,
`throttled or unavailable` present, `HTTP 429` present, `says nothing about the ref` present.

## Ponytail review (run on this diff; it changed the design)

- `L57-90: shrink: a shared _unverified() helper and a second policy branch.` **Accepted, and the
  helper deleted.** Raising `HTTPError` into the existing handler is ~14 lines shorter and makes
  policy drift structurally impossible instead of merely documented. It also disposes of a real
  hazard in the version I nearly shipped: the helper never returned, but if a later edit made it
  return, the caller fell through to the pin assertion and misfiled the throttle again — the exact
  defect this PR fixes, reintroduced by its own fix. Found reviewing my own diff.
- `L60-73: shrink: 14-line docstring for 6 lines of code.` **Declined.** This file's whole subject is
  what a green means; the classification rationale is the deliverable, and 403's exclusion has to be
  written down or it gets "fixed" later by reflex.

## What I did NOT do

- **403 is not reclassified.** Ambiguous between throttling and the repository becoming unreadable,
  and I have never observed one here — the louder branch is the safer home. Stated in the docstring
  so it is a decision, not an oversight.
- **No new test function.** `make test-fakes` staying at **31 passed** is the cheapest proof of that;
  the arming matrix above lives outside the tree.
- **No docs change.** `docs/dev/testing-strategy.md:156` says *"a producer the check cannot reach
  fails in CI rather than skipping (#1426)"* — still true, and now true of strictly more cases; it
  does not enumerate status codes, so it does not disagree with the code. Grepped `docs/` for the
  defect's own words: the `429` hits are hashrate figures in `docs/research/` data and unrelated
  dashboard rate-limiting prose.
- **No retry on 429.** Deliberate: `_get`'s one retry covers a transient transport blip; retrying a
  throttle immediately is what got us throttled.
- **The 429 path is still unobserved in the wild** — this reclassifies it correctly, it does not
  prove GitHub returns 429 rather than some other status when it throttles raw reads.

## Lint, with the file set each verdict was measured over

- `make test-fakes` → rc=0, **31 passed** (unchanged, as intended).
- `make lint-py` → rc=0: `ruff check .` all passed, `ruff format --check .` 207 files.
- No markdown or shell changed, so `lint-md` / `lint-sh` are not implicated by this diff.

Paths: `tests/integration/` only — in lane, no `.lane-override`.
