### PR TITLE
fix(dashboard): #1581 name the `-> None` verdict, and assert the six are exhaustive

### DIFF
--- a/dashboard/tests/service/annotation_gate.py
+++ b/dashboard/tests/service/annotation_gate.py
@@ -187,7 +187,7 @@ def _failure_returns(function: ast.AST) -> list[tuple[str, str, int]]:
 
 
 def classify(source: str, where: str) -> dict[str, list]:
-    """Sort every failure return in one module into the five verdicts.
+    """Sort every failure return in one module into the six verdicts, exhaustively.
 
     ``signed`` — declares an out-of-band marker and honours it.
     ``half_fix`` — declares one and returns an empty container anyway (law 2's quarry).
@@ -196,8 +196,16 @@ def classify(source: str, where: str) -> dict[str, list]:
     ``unjudged`` — annotated, declares NO out-of-band marker, and the failure value is outside
     `_EMPTY`. The gate takes no position on these, and the fifth list exists so that taking no
     position is a thing it SAYS rather than a thing it does silently.
+    ``procedure`` — declared `-> None`, so there is no success value for a failure to hide inside
+    and #1487's rule genuinely cannot apply. Out of scope, and SAID rather than skipped (#1581).
 
-    The fifth verdict was added by #1556 after a measured defect: without it these functions fell
+    Exhaustively is the load-bearing word, and the assertion at the end enforces it. Every law
+    built on this result is phrased as an absence — "nothing under this module is blind" — and an
+    absence is satisfied perfectly by its subject never being classified at all. That has happened
+    twice now, by two different exits, and neither looked wrong where it stood.
+
+    The fifth and sixth verdicts were both added after a measured defect of exactly this shape —
+    #1556 for `unjudged`, #1581 for `procedure`. Taking the fifth: without it these functions fell
     off the end of the branch chain and appeared in no list at all, so a pin asserting "nothing
     under this module is blind" was satisfied by a function VANISHING. Dropping `| None` from a
     signed function moves it here, not to `blind` — which is the one regression #1556's ratchet
@@ -213,7 +221,9 @@ def classify(source: str, where: str) -> dict[str, list]:
         "collapse": [],
         "blind": [],
         "unjudged": [],
+        "procedure": [],
     }
+    walked = 0
     for function in ast.walk(ast.parse(source)):
         if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -221,11 +231,16 @@ def classify(source: str, where: str) -> dict[str, list]:
         if not failures:
             continue
         name = f"{where}:{function.name}"
+        walked += 1
         # A `-> None` procedure is out of scope entirely, not "signed". It has no success value for
         # a failure to hide inside, so the defect this file describes cannot occur in one. Counting
         # its bare `return` as a signed contract would inflate the cleared set with functions that
-        # never made the promise — three of them here — and make the category mean two things.
+        # never made the promise, and make the category mean two things. Being out of scope is a
+        # VERDICT here rather than an exit, for the reason #1556 gave the residual one (#1581): a
+        # function that leaves the walk satisfies every law phrased as an absence, so the exclusion
+        # has to be something this gate SAYS.
         if _returns_nothing(function.returns):
+            verdicts["procedure"].append(name)
             continue
         admits = _admits_none(function.returns)
         values = {literal for _, literal, _ in failures}
@@ -248,6 +263,14 @@ def classify(source: str, where: str) -> dict[str, list]:
             # empty here by construction, so intersecting would record an empty tuple for every row
             # and throw away the only fact that distinguishes them.
             verdicts["unjudged"].append((name, sorted(values)))
+    # TOTALITY, and not a tidiness check — the reasoning is in the docstring above. What it buys
+    # that the six lists do not: a future `continue` added anywhere above trips this on the next
+    # run, instead of quietly shrinking the population every law is quantified over. That is the
+    # difference between a silent door being absent today and being inexpressible.
+    assert sum(len(rows) for rows in verdicts.values()) == walked, (
+        f"{where}: {walked} functions have a failure return but "
+        f"{sum(len(rows) for rows in verdicts.values())} rows were emitted — one left the walk"
+    )
     return verdicts
 
 
@@ -259,6 +282,7 @@ def classify_package() -> dict[str, list]:
         "collapse": [],
         "blind": [],
         "unjudged": [],
+        "procedure": [],
     }
     files = sorted(_PACKAGE.rglob("*.py"))
     # An empty scan is not a clean scan. Every law built on this result is a statement about a set,

--- a/dashboard/tests/service/annotation_gate.py
+++ b/dashboard/tests/service/annotation_gate.py
@@ -230,8 +230,11 @@ def classify(source: str, where: str) -> dict[str, list]:
         failures = _failure_returns(function)
         if not failures:
             continue
-        name = f"{where}:{function.name}"
+        # Counted HERE, immediately under the only other early exit, and not one statement lower:
+        # everything below this line is inside the invariant, so an exclusion added where a future
+        # author would naturally add one cannot open a window the assert is blind to.
         walked += 1
+        name = f"{where}:{function.name}"
         # A `-> None` procedure is out of scope entirely, not "signed". It has no success value for
         # a failure to hide inside, so the defect this file describes cannot occur in one. Counting
         # its bare `return` as a signed contract would inflate the cleared set with functions that

--- a/dashboard/tests/service/test_collapsed_return_channels.py
+++ b/dashboard/tests/service/test_collapsed_return_channels.py
@@ -66,8 +66,9 @@ Every figure here is measured over live source, so it drifts under refactors unr
 annotation, in both directions: quote one with the sha you took it at, and never hang an imperative
 on the number (#1556). At `b0a32bd`, the tip this shipped against — **11 collapses** flagged (all in
 the DB read layer), **5 signed**, **0 half-fixes**, **57 blind**. At `a0ddbec` plus this slice
-(`client/xvb_client.py`) — **11**, **10**, **0**, **52**. #1556 annotates the blind layer slice by
-slice; the flagged count is expected to RISE wherever a slice brings a genuine collapse into scope.
+(`client/xvb_client.py`) — **11**, **10**, **0**, **52**, since joined by `unjudged` **1** (#1556)
+and `procedure` **3** (#1581) at `17722da` — six, which `classify` asserts are exhaustive. #1556
+annotates the blind layer slice by slice; the flagged count RISES as slices bring collapses in.
 
 `add_payouts` is worth naming out of the 11, because it shows the class is not academic here: a
 failed INSERT returns `[]`, indistinguishable from "every row was already stored", and that value
@@ -152,6 +153,10 @@ class TestTheResidualIsReportedNotCertified:
             )
             for name, values in sorted(package["unjudged"]):
                 print(f"    {name} -> {','.join(values)}")
+            # NAMED, not counted — already non-empty, so an arrival moves no count anyone reads.
+            print(f"  and {len(package['procedure'])} `-> None` procedures — out of scope (#1581):")
+            for name in sorted(package["procedure"]):
+                print(f"    {name}")
 
     def test_the_blind_spot_is_measured_rather_than_described(self, package):
         """The unannotated layer is this gate's real limit, so it is asserted to be a known
@@ -260,6 +265,7 @@ class Store:
             "collapse": [],
             "blind": [],
             "unjudged": [],
+            "procedure": [],
         }
 
     def test_an_unannotated_function_is_blind_rather_than_clean(self):
@@ -332,11 +338,10 @@ class Store:
         assert classify(seeded, "m.py")["signed"] == ["m.py:get"]
 
     def test_a_procedure_returning_nothing_is_not_counted_as_a_signed_contract(self):
-        """NEGATIVE CONTROL. `reconcile_worker_config_status` and two siblings are `-> None`
-        procedures whose handle guard is a bare `return`. Once bare returns were read as `None`
-        they began scoring as signed — inflating the cleared set with three functions that never
-        made the promise, which is the same overstatement in miniature that this file refuses to
-        make about the eleven."""
+        """NEGATIVE CONTROL, sharpened by #1581. `reconcile_worker_config_status` and two
+        siblings are `-> None` procedures whose handle guard is a bare `return`; read as `None`
+        they scored as signed, inflating the cleared set with functions that never made the
+        promise. It now asserts the row is NAMED `procedure`, not merely absent from `signed`."""
         seeded = (
             "class C:\n    def do(self) -> None:\n"
             "        if not self._conn:\n            return\n"
@@ -348,6 +353,7 @@ class Store:
             "collapse": [],
             "blind": [],
             "unjudged": [],
+            "procedure": ["m.py:do"],
         }
 
     def test_an_annotated_function_whose_failure_value_is_untracked_is_unjudged(self):


### PR DESCRIPTION
Closes #1581.

`classify` called `continue` on `_returns_nothing` before assigning any verdict, so a function declared `-> None` emitted **no row at all**. The exclusion is right and I am not disputing it — a procedure has no success value for a failure to hide inside, so #1487's rule genuinely cannot apply. What was wrong is that it was **silent**, which is the same shape #1556 route 1 added the `unjudged` verdict to close.

## What changed

**`procedure` becomes the sixth verdict.** The `continue` becomes an append, and the residual report NAMES the rows rather than counting them — that population is already non-empty, so an arrival would not move a count anyone reads.

**`classify` asserts the six are exhaustive.** The walk counts the functions it admitted, and the assertion at the end requires every one of them to have produced a row. This is the part I would rather be reviewed hard: it makes a silent door *inexpressible* rather than merely absent today. Both laws in `test_annotation_coverage.py` are phrased as absences — "nothing under this module is blind" — and an absence is satisfied perfectly by its subject leaving the walk. That has now happened twice, by two different exits, and neither looked wrong where it stood.

## The three `procedure` functions are NOT defects

`service/storage_service.py:add_audit_event`, `service/worker_config_store.py:add_worker_config_version` and `service/worker_config_store.py:reconcile_worker_config_status` are legitimate procedures, correctly out of scope, and nothing in this diff says otherwise. The pin is not currently lying about them: it asserts no failure return in a pinned module is *unannotated*, and all three ARE annotated. The defect was the gate declining to rule without saying so — which made the edit INTO that state undetectable.

## Proven by me, this worktree, at `17722da`

- **The totality assert fires.** Seeded a `continue` before `verdicts["blind"].append` — the #1581 shape exactly — with an armed readback confirming the mutation was present. `AssertionError: client/docker/docker_control.py: 1 functions have a failure return but 0 rows were emitted — one left the walk`. Seeded a second at `collapse`: **the suite goes red, 4 failed / 16 errors**, so the invariant is held by the suite and not only by a hand-run script. Both restored by sha256 match against a pre-edit copy.
- **Full dashboard suite: 2276 passed**, identical to route 1's count — no test added, removed, or broken.
- **Coverage 97.17%** (6950 statements, 197 missed), against 97.14% (6950, 199) at route 1. Same statement total, and this diff is entirely under `dashboard/tests/`, which is outside the coverage source — so it cannot have moved `mining_dashboard` coverage. Treat the ±2 as this suite's known run-to-run variance, not as a result.
- `make lint-file-budget` rc 0; ruff check and ruff format clean.
- **File budget:** `test_collapsed_return_channels.py` 393 → **399**, still under the 400 target and still taking **no** budget row. The two whole-dict controls each needed the sixth key, and I paid for those two lines by tightening two docstrings rather than by adding a row — measured per edit, not as a running total. `annotation_gate.py` 273 → 299.
- **The verdict-enumeration sweep was run over the WHOLE repo, not `docs/`** — `git grep` for verdict-count prose returns exactly one site, the docstring updated here.

## Judgement calls a reviewer should check rather than take

- **No new test.** The two whole-dict controls already assert the classifier's entire output and both went red on this change — that is them working, and it is what caught the sibling docstring too. Adding a test for the sixth verdict beside them would be the duplicate signature this lane measures for.
- **Those controls stay literal dicts, not a shared constant.** Factoring them would have paid for the two lines and cost the alarm: a shared constant absorbs a seventh verdict silently.
- **No doc change.** Two files name the classifier — `docs/dashboard.md:512-516` and `docs/dev/repo-map.md:16`. Both describe its role and its import spelling, neither enumerates the verdicts, so neither is falsified. Named here so the call can be checked rather than trusted.

## The over-engineering pass found one thing, in my own diff

Done on merits before satisfying the gate, which is where this lane's useful findings come from. **The docstring paragraph and the assert's comment stated the same reasoning near-verbatim** — "every law built on this result is phrased as an absence" and "twice, by two different exits" appeared in both. Split by what each is FOR: the docstring carries the reasoning, because that is what a reader reads; the comment carries only what is local to the assert, namely why deleting it is not a tidy-up. `annotation_gate.py` 299 → 297 as a result.

I checked the assert itself for the same charge and kept it: ten lines for an invariant is the same trade this file already makes everywhere (`assert len(files) > 50` is the enumeration guard directly below it), and the class it closes has now bitten twice.

## Not done

Not rebased and not needed: branched off `17722da` directly. `#1556` slice 2 is deliberately behind this rather than stacked on it.
