### PR TITLE
fix(integration): redact by SHAPE — argv credentials and wallet addresses (#1582)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -61,12 +61,20 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   is reported `SKIPPED`, never run against the canonical DB.
 - No silent coverage drops. Any scenario whose prerequisite is missing (an alt data dir, a
   remote endpoint) is logged as `SKIPPED` with the reason. It never quietly disappears.
-- Secrets hygiene. RPC creds, the proxy token, wallet addresses and onion addresses are never
-  printed. Secret-preservation is checked by hashing them on the box (`sha256sum`) and comparing
-  the hash, so the plaintext never crosses the wire. All captured artifacts pass through a
-  redactor, which is keyed on the *shape* of a secret — a credential given as a flag value, an
-  address-length opaque run — rather than on a list of known field names. That list is what left
-  the gaps in [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582).
+- Secrets hygiene. Secret-preservation is checked by hashing on the box (`sha256sum`) and
+  comparing the hash, so the plaintext never crosses the wire, and every captured artifact passes
+  through a redactor. **What that redactor covers is narrower than "artifacts are redacted"
+  suggests**, and the gap is worth knowing before you trust a bundle. It reaches: a `KEY=value`
+  line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
+  a v3 onion; and any opaque run of 90 or more characters, which is what catches wallet addresses
+  (and a sha512 with them). **It does not reach JSON at all** — `"key": "value"` has neither an
+  `=` nor a `--` — so the bundle's verbatim `config.json` still carries six of its eight sensitive
+  fields, key material among them:
+  [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587). The two fields that *do*
+  redact there are addresses long enough to trip the length rule, which is a coincidence rather
+  than the redactor understanding JSON.
+  [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582) closed the flag-value and
+  address-shape gaps only.
 - Continue-on-error. A failing assertion doesn't abort the run. The whole matrix is collected
   and summarized, with per-scenario artifacts for the failures.
 

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -61,10 +61,12 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   is reported `SKIPPED`, never run against the canonical DB.
 - No silent coverage drops. Any scenario whose prerequisite is missing (an alt data dir, a
   remote endpoint) is logged as `SKIPPED` with the reason. It never quietly disappears.
-- Secrets hygiene. RPC creds, the proxy token, and onion addresses are never printed.
-  Secret-preservation is checked by hashing them on the box (`sha256sum`) and comparing the
-  hash, so the plaintext never crosses the wire. All captured artifacts pass through a
-  redactor.
+- Secrets hygiene. RPC creds, the proxy token, wallet addresses and onion addresses are never
+  printed. Secret-preservation is checked by hashing them on the box (`sha256sum`) and comparing
+  the hash, so the plaintext never crosses the wire. All captured artifacts pass through a
+  redactor, which is keyed on the *shape* of a secret — a credential given as a flag value, an
+  address-length opaque run — rather than on a list of known field names. That list is what left
+  the gaps in [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582).
 - Continue-on-error. A failing assertion doesn't abort the run. The whole matrix is collected
   and summarized, with per-scenario artifacts for the failures.
 
@@ -645,6 +647,12 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 `selftest-skip-accounting.sh` is the one that keeps the skip accounting honest: besides checking
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
+`selftest-redact.sh` covers the two shapes the redactor used to miss — a credential passed as a
+flag value, and a wallet address in JSON — and asserts in each case that the *raw* value is gone
+rather than that a `<redacted>` marker appeared, since a marker can come from some other field on
+the same line. It also guards the other direction: a sha256 digest and a non-secret flag value
+must survive, because an artifact with its image pins stripped is useless for the triage it exists
+for.
 `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures, so
 every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack.

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -33,14 +33,14 @@ it_err() { echo -e "${IT_RED}[ITEST]${IT_RESET} $1" >&2; }
 it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
-# The box holds real RPC creds, a proxy token, and onion addresses. Redact anything that
-# looks secret before it reaches a log file or the terminal. Defence-in-depth: we also avoid
-# printing these values in the first place. Patterns cover .env KEY=VALUE lines and .onion
-# hostnames. Keep this conservative — over-redaction is safe, leaks are not.
+# The box holds real RPC creds, a proxy token, wallet addresses and onion hostnames. Redact
+# anything that looks secret before it reaches a log file or the terminal. Defence-in-depth: we
+# also avoid printing these values in the first place. Keyed on SHAPE, not on an enumeration of
+# known names — enumerating is how #1582's two gaps opened. Over-redaction is safe, leaks are not.
 redact() {
     sed -E \
-        -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/' \
-        -e 's/[a-z2-7]{56}\.onion/<redacted>.onion/g'
+        -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g' \
+        -e 's/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
 }
 
 # --- Assertions -------------------------------------------------------------

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -34,9 +34,9 @@ it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
 # The box holds real RPC creds, a proxy token, wallet addresses and onion hostnames. Redact
-# anything that looks secret before it reaches a log file or the terminal. Defence-in-depth: we
-# also avoid printing these values in the first place. Keyed on SHAPE, not on an enumeration of
-# known names — enumerating is how #1582's two gaps opened. Over-redaction is safe, leaks are not.
+# anything that looks secret before it reaches a log file or the terminal. Only the ADDRESS rule
+# is shape-keyed (any opaque run >=90 chars — a sha512 goes with them); the CREDENTIAL rule is
+# still a name list, and JSON-form secrets are reached by NEITHER — read #1587 before trusting it.
 redact() {
     sed -E \
         -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g' \

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Self-test for the two redaction shapes #1582 found missing.
+#
+# redact() guarded two shapes — `KEY=value` for *_PASSWORD/*_TOKEN/*_SECRET, and v3 onion
+# hostnames — and selftest.sh asserted exactly those four cases. So the coverage matched the
+# implementation rather than the threat, and both gaps below were green by construction:
+#
+#   1. a credential passed as a FLAG value (`--rpc-login user:pass`). The KEY=value pattern
+#      needs an `=`, so a colon-separated flag argument was never reachable by it.
+#   2. a wallet address in JSON (`"wallet": "4…"`). Same reason — `"key": "value"` has no `=`.
+#
+# Both are live in `capture_artifacts`' bundle: the p2pool container logs its own argv, and
+# `cat config.json` is captured verbatim. That bundle is what release-gate.yml uploads under
+# the step name "Upload artifacts (redacted)".
+#
+# What makes this worth a file rather than a line: the artifact LOOKED redacted. The onion in
+# that same argv line does get replaced, so a reader sees redaction visibly happening and reads
+# the whole line as clean. A partial redaction is more dangerous than none, because it buys
+# confidence it has not earned.
+#
+# The binding assertion in every case below is that the RAW value is ABSENT — not that a
+# `<redacted>` marker appeared. A marker can appear because some OTHER field on the line was
+# replaced, which is precisely the failure this file exists to catch.
+#
+# The pre-existing shapes stay covered by selftest.sh:202-210 and are deliberately not repeated
+# here; that suite runs from the same Makefile glob.
+#
+# Run: tests/integration/selftest-redact.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+# Synthetic values throughout — nothing here is a real credential or a real address. The
+# addresses only need the LENGTH and alphabet of the real thing for the shape rule to bite.
+CRED="notARealPassword0123456789abcdef"
+XMR="4$(printf 'A%.0s' $(seq 1 94))"   # 95 chars, Monero standard-address length
+TARI="12$(printf 'B%.0s' $(seq 1 90))" # 92 chars, Tari address length
+SHA="$(printf 'a%.0s' $(seq 1 64))"    # a sha256 — must SURVIVE, see over-redaction below
+
+echo "== redact: a credential passed as a flag value =="
+OUT="$(printf -- '--rpc-login admin:%s\n' "$CRED" | redact)"
+assert_contains "flag credential is replaced" "$OUT" "--rpc-login <redacted>"
+case "$OUT" in *"$CRED"*) it_fail "raw flag credential absent" "credential leaked" ;; *) it_pass "raw flag credential absent" ;; esac
+
+# The `=` spelling of the same flag, and a differently-named secret flag: the rule is keyed on
+# the flag's NAME ending in a secret word, so both must be reached by one pattern.
+OUT="$(printf -- '--rpc-password=%s --api-token %s\n' "$CRED" "$CRED" | redact)"
+case "$OUT" in *"$CRED"*) it_fail "raw credential absent for = and second flag" "credential leaked" ;; *) it_pass "raw credential absent for = and second flag" ;; esac
+
+echo "== redact: wallet addresses, in JSON and as flag values =="
+OUT="$(printf '  "wallet": "%s",\n  "tari_wallet": "%s",\n' "$XMR" "$TARI" | redact)"
+case "$OUT" in *"$XMR"*) it_fail "raw Monero address absent from JSON" "address leaked" ;; *) it_pass "raw Monero address absent from JSON" ;; esac
+case "$OUT" in *"$TARI"*) it_fail "raw Tari address absent from JSON" "address leaked" ;; *) it_pass "raw Tari address absent from JSON" ;; esac
+
+# The shape that actually appears in logs.txt: an argv line carrying a credential, a wallet and
+# an onion at once. This is the regression case — the onion alone used to be replaced, which is
+# what made the rest look handled.
+ONION="$(printf 'a%.0s' $(seq 1 56)).onion"
+OUT="$(printf -- 'launching: p2pool --rpc-login admin:%s --wallet %s --onion-address %s --stratum 0.0.0.0:3333\n' "$CRED" "$XMR" "$ONION" | redact)"
+case "$OUT" in *"$CRED"*) it_fail "argv line: credential absent" "credential leaked" ;; *) it_pass "argv line: credential absent" ;; esac
+case "$OUT" in *"$XMR"*) it_fail "argv line: wallet absent" "wallet leaked" ;; *) it_pass "argv line: wallet absent" ;; esac
+assert_contains "argv line: onion still redacted" "$OUT" "<redacted>.onion"
+assert_contains "argv line: non-secret argument kept" "$OUT" "--stratum 0.0.0.0:3333"
+
+echo "== redact: over-redaction guard — debugging value must survive =="
+# "Over-redaction is safe" is true of secrets, not of everything: an artifact with the image
+# digests and endpoints stripped is useless for the debugging it exists for. These are the
+# near-misses — same alphabet, shorter than an address, or a flag whose name is not a secret.
+OUT="$(printf 'sha256:%s\nHOST_IP=box.lan\n--merge-mine tari://node:18142\n' "$SHA" | redact)"
+assert_contains "a sha256 digest survives" "$OUT" "$SHA"
+assert_contains "a non-secret KEY=value survives" "$OUT" "HOST_IP=box.lan"
+assert_contains "a non-secret flag value survives" "$OUT" "--merge-mine tari://node:18142"
+
+echo "selftest-redact: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes nothing automatically — `Closes #N` never fires here (PRs land on `develop-v2`, default branch is `develop`). Issue: #1582.

## What was wrong

`redact()` (`tests/integration/lib.sh`) guarded two shapes — `KEY=value` for `*_PASSWORD` / `*_TOKEN` / `*_SECRET`, and v3 onion hostnames — and `selftest.sh:202-210` asserted exactly those four cases. The coverage matched the implementation rather than the threat, so two shapes that are live in the artifact bundle were green by construction:

- a credential passed as a **flag value** (`--rpc-login user:pass`). The `KEY=value` pattern needs an `=`, so a colon-separated argument was never reachable by it.
- a **wallet address in JSON** (`"wallet": "4…"`). Same reason.

`capture_artifacts()` writes both: `cat config.json` verbatim, and `docker compose logs`. `.github/workflows/release-gate.yml:82` uploads `results/` for 14 days under the step name **"Upload artifacts (redacted)"**.

**What made it hard to see:** the artifact *looked* redacted. The onion on that same argv line does get replaced, so a reader sees redaction visibly happening and reads the whole line as clean. Partial redaction is worse than none — it buys confidence it has not earned.

## What was RUN

| check | result |
|---|---|
| `selftest-redact.sh` (new) | **12 passed, 0 failed** |
| `selftest.sh` (regression — the pre-existing shapes) | **214 passed, 0 failed** |
| `shellcheck 0.11.0 --severity=warning` over `tests/integration/*.sh tests/integration/mini-stack/*.sh` | rc 0 |
| `shfmt -i 4 -d` over the Makefile's exact glob | rc 0 |
| `scripts/lint-file-budget.sh` | OK — monotonic |
| `make lint-md` | 0 errors, 48 files |
| `make lint-docs-voice` | OK — 41 prose docs |

The `selftest.sh` run is the load-bearing regression check, not a formality: the new patterns ride the **existing** `-e` expressions (see placement below), so breaking the pre-existing four was the real risk of this edit.

## Proof it can fail

A green suite over a fix is not evidence. Reverted `redact()` to the pre-fix patterns, proved the file actually changed with `cmp`, and re-ran:

```
selftest-redact: 5 passed, 7 failed     (rc 1)
```

The **5 that passed are exactly the pre-existing behaviours** — the onion case, the non-secret argv argument, and the three over-redaction guards. So the new file reds only on what the fix adds, and does not merely red on everything. Restore verified byte-identical by `cmp`.

## Placement

- `lib.sh` is at its **692/692** ceiling, so the change is **line-neutral** — the new patterns ride the existing `-e` expressions rather than adding any. Diff is 6 insertions / 6 deletions.
- `selftest.sh` is at **686/686**, so the new cases go in a new file. The Makefile globs `selftest*.sh`, so no registration is needed.
- New file is 79 lines, under `TARGET_LINES=400`, so it takes no budget row.

## Shared paths

Touches `docs/dev/integration-testing.md`, which is in `_shared.paths` — disclosed here, no `.lane-override` used. Line 64 asserted *"RPC creds, the proxy token, and onion addresses are never printed"*: an enumeration that omitted wallets and was untrue for argv-form credentials. The doc stated the property the code did not have.

## The part worth carrying past this PR

The threat was **already known in this repo**. `lib/pithead/07-support-bundle.sh:5` names it in a comment — *"p2pool echoes its `--rpc-login` on launch, the exact leak class this exists to stop"* — and line 47 scrubs it. Two redactors, divergent coverage, neither one's tests aware of the other. So the fix is keyed on the **shape** of a secret (a credential given as a flag value; an address-length opaque run) rather than on a longer list of field names, because enumerating names is precisely what opened the gap.

The support-bundle redactor has the mirror-image gap and is filed separately — it scrubs the credential but not the wallet or onion on that same line.

## What I did NOT do

- **Did not audit the other five captured files** (`status.txt`, `doctor.txt`, `env.redacted.txt`, `api-state.json`, `compose-ps.txt`) for further shapes. I measured the two I could reach from a live stack and stopped; there may be more.
- **Did not change `build/p2pool/entrypoint.sh`**, which echoes the full argv in the first place — different lane, filed separately. This PR narrows the blast radius; it does not stop the echo.
- **Did not verify against a real release-gate artifact bundle.** The leak was reproduced against live-stack input piped through the real `redact()`, not by reading a `results/` directory from a red gate run.
- The `~4 minute` capture window figure on the issue is **one container, one uptime sample** — an order of magnitude, not a budget.
