### PR TITLE
fix(dashboard): #1556 slice 2 — annotate the client/ singletons, finishing the package

### DIFF
--- a/dashboard/mining_dashboard/client/docker/docker_control.py
+++ b/dashboard/mining_dashboard/client/docker/docker_control.py
@@ -61,7 +61,9 @@ class DockerControl:
             request_timeout=request_timeout,
         )
 
-    async def _post(self, path, params, action, container, quiet=False, request_timeout=None):
+    async def _post(
+        self, path, params, action, container, quiet=False, request_timeout=None
+    ) -> bool:
         url = f"{self.base_url}{path}"
         try:
             async with aiohttp.ClientSession() as session:

--- a/dashboard/mining_dashboard/client/monero/monero_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_client.py
@@ -40,7 +40,7 @@ class MoneroClient:
         self._auth = HTTPDigestAuth(username, password) if username else None
         self.timeout = timeout
 
-    def get_info(self):
+    def get_info(self) -> dict | None:
         """Return monerod's `get_info` payload as a dict, or None if unreachable/errored."""
         try:
             resp = bounded_get(self.url, auth=self._auth, timeout=self.timeout)

--- a/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
@@ -42,7 +42,7 @@ class MoneroWalletClient:
         self._auth = HTTPDigestAuth(username, password) if username else None
         self.timeout = timeout
 
-    def _rpc(self, method, params=None):
+    def _rpc(self, method, params=None) -> dict | None:
         """POST one JSON-RPC call; return the ``result`` dict, or None on any error."""
         payload = {"jsonrpc": "2.0", "id": "0", "method": method, "params": params or {}}
         try:

--- a/dashboard/mining_dashboard/client/tari/tari_client.py
+++ b/dashboard/mining_dashboard/client/tari/tari_client.py
@@ -69,7 +69,7 @@ class TariClient:
             return {**self._last_sync_status, "reachable": False}
         return {"is_syncing": False, "reachable": False}
 
-    async def _fetch_sync_status(self):
+    async def _fetch_sync_status(self) -> dict | None:
         """
         Read sync progress from the node's gRPC. Returns the status dict, or None if the
         node is unreachable (so the caller can fall back to the last known state).

--- a/dashboard/mining_dashboard/client/tari/tari_wallet_client.py
+++ b/dashboard/mining_dashboard/client/tari/tari_wallet_client.py
@@ -66,7 +66,7 @@ class TariWalletClient:
         self._channel = None
         self._stub = None
 
-    async def get_confirmed_payouts(self, min_height=0):
+    async def get_confirmed_payouts(self, min_height=0) -> list[dict]:
         """Return confirmed incoming payouts at or above ``min_height`` as normalized dicts.
 
         The caller seeds ``min_height`` from the highest stored Tari payout height, so a restart

--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -197,7 +197,7 @@ def parse_worker_control_status(payload):
     return {"change_id": change_id, "status": status, "reason": ctrl.get("reason")}
 
 
-def _safe_probe_host(ip):
+def _safe_probe_host(ip) -> str | None:
     """Return a safe host string to probe, or None.
 
     SSRF guard (#122): the dashboard runs ``network_mode: host`` and a connecting miner fully

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -50,11 +50,19 @@ import pytest
 from tests.service.annotation_gate import classify, classify_package
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 2 of 33 modules that hold a failure return at
-# all, `client/xvb_client.py` by slice 1 and `service/worker_config_store.py` by pre-existing work.
+# adds the module it finished. Measured at this tip: 8 of 33 modules that hold a failure return at
+# all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
+# and the six single-function `client/` modules by slice 2, which finishes the package: no module
+# under `client/` holds an unannotated failure return any more.
 # **Only ever add a module you have read.** Adding one because the gate happens to score it clean
 # is the baseline #1487 refused, wearing this file's name.
 PINNED = (
+    "client/docker/docker_control.py",
+    "client/monero/monero_client.py",
+    "client/monero/monero_wallet_client.py",
+    "client/tari/tari_client.py",
+    "client/tari/tari_wallet_client.py",
+    "client/xmrig_client.py",
     "client/xvb_client.py",
     "service/worker_config_store.py",
 )
@@ -65,6 +73,14 @@ PINNED = (
 # `rglob` all produce. `note_worker_revision` is the deliberate choice for its module — it is the
 # one signed function `_SIGNED` never named.
 _ANCHORS = {
+    "client/docker/docker_control.py": "client/docker/docker_control.py:_post",
+    "client/monero/monero_client.py": "client/monero/monero_client.py:get_info",
+    "client/monero/monero_wallet_client.py": "client/monero/monero_wallet_client.py:_rpc",
+    "client/tari/tari_client.py": "client/tari/tari_client.py:_fetch_sync_status",
+    "client/tari/tari_wallet_client.py": (
+        "client/tari/tari_wallet_client.py:get_confirmed_payouts"
+    ),
+    "client/xmrig_client.py": "client/xmrig_client.py:_safe_probe_host",
     "client/xvb_client.py": "client/xvb_client.py:get_stats",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
 }
@@ -80,8 +96,18 @@ _ANCHORS = {
 # handle and its docstring argues the fail-open choice at length, including why it must answer the
 # same for a closed handle and a `sqlite3.Error` while its sibling must not. That reading is what
 # this entry stands for. `_EMPTY` simply has no `"False"`, on #1487's own measured grounds.
+#
+# `docker_control.py:_post` (slice 2) is the second, and it is one of the five instances those
+# grounds were measured ON — `annotation_gate._EMPTY`'s own comment names `_post` among the
+# outbound senders where False-on-failure and False-elsewhere mean the same thing to a caller.
+# Read here rather than taken on that comment's word: it returns True only on HTTP 204/304, and
+# False on every other status and on any exception. Its callers act on "the container action did
+# not happen", which is what both False paths mean, so there is no out-of-band case to declare.
+# Annotating it `-> bool | None` to reach `signed` would be inventing a return the function never
+# makes — the reason this list exists is to say the gate declines, not to manufacture a verdict.
 _UNJUDGED_AND_READ = frozenset(
     {
+        "client/docker/docker_control.py:_post",
         "service/worker_config_store.py:worker_config_change_known",
     }
 )


### PR DESCRIPTION
## #1556 slice 2 — the six `client/` singletons. The package is now finished.

One return annotation per module, six modules, each read before it was annotated. With slice 1
(`client/xvb_client.py`) already in, **no module under `client/` holds an unannotated failure
return any more** — the first package #1556 closes out.

### Measured, base `fcc41dfd` -> head, with the gate's own `_classify` over live source

| verdict | base | head |
|---|---|---|
| blind | 52 | **46** |
| signed | 10 | **14** |
| collapse | 11 | **12** |
| unjudged | 1 | **2** |
| procedure | 3 | 3 |
| half_fix | 0 | 0 |

Modules with ZERO blind returns: **2 of 33 -> 8 of 33**, and the 8 are exactly the 2 previous pins
plus this slice's 6.

**I wrote the predicted verdict for each of the six down before measuring**, so the table could not
be retro-fitted. All six matched, verdict for verdict, and the totals matched.

### Two of the six deliberately do NOT reach `signed`

Both are recorded rather than papered over — reaching for `signed` on either would mean inventing a
contract the function does not have.

- **`docker_control.py:_post` -> `bool`, lands in `unjudged`.** It is one of the five instances
  `annotation_gate._EMPTY`'s own comment measured when it excluded `"False"` — the comment names
  `_post` by name. I read it rather than taking that on the comment's word: it returns `True` only
  on HTTP 204/304 and `False` on every other status and on any exception, and its callers act on
  "the container action did not happen", which is what both `False` paths mean. Named in
  `_UNJUDGED_AND_READ` **by name**, per the rule that the set is never widened by prefix or count.
- **`tari_wallet_client.py:get_confirmed_payouts` -> `list[dict]`, lands in `collapse`.** Its
  `except` handler returns `[]`, which is indistinguishable from "no payouts" — the caller cannot
  tell an unreachable wallet from an empty tip. **This is a real pre-existing defect that the
  annotation makes VISIBLE rather than one this slice introduces**, and a rising flagged count is
  the documented expected direction. Not reverted, not baselined, and not fixed here: changing the
  return is a behaviour change with callers, which is not an annotation slice's business.

### Proof

- **Both pin laws shown able to FAIL, on a module this slice newly pins.** `monero_client.py:get_info`
  is named in no other assertion (`_SIGNED` holds none of the six), so the pin is the only thing that
  can see it — which is what makes it a clean control rather than one that fires for another reason.

  | control | edit | verdict moves to | test that reddened |
  |---|---|---|---|
  | A | UNANNOTATE (remove the annotation) | `blind` | `..._is_unannotated[monero_client.py]` |
  | B | DE-SIGN (drop only the `\| None`) | `unjudged` | `..._is_unjudged[monero_client.py]` |

  Each armed with a readback, each caught by the specific assertion naming the specific function,
  each restored by sha256 match.
- **Full suite 2294 passed** (base 2276). The +18 reconciles exactly: 3 tests parametrized over
  `PINNED` x the 6 modules added.
- **Patch coverage 6/6 executable changed lines = 100%**, measured from `coverage.xml` against
  `origin/develop-v2` with the path prefix taken from its own `<source>` element, and with the
  executable-line total asserted `> 0` so an empty report could not read as a pass.
- **The six function bodies are bytecode-identical to base**, compared structurally on
  `co_code`/`co_names`/`co_varnames`/`co_argcount`/`co_flags`/`co_consts` recursively, with a
  negative control (a seeded real body edit) confirmed to DIFFER. The one apparent exception,
  `_post`, is a `NOP` in the synthetic module wrapper because its signature had to wrap for the
  100-char limit; `_post`'s own code object matches base on every attribute.
- `ruff check` + `ruff format` clean. `lint-file-budget` rc 0.

### Budget

`test_annotation_coverage.py` 289 -> 315 lines, under the 400 target, **still taking no budget
row**. `test_collapsed_return_channels.py` is **untouched at 399** — its residual figures are
scoped to named shas by design, so this slice does not falsify them, and its single line of
headroom is preserved.

### Docs

**No doc change is owed, and I checked rather than assumed.** Deriving the file set mechanically
(`git grep -l` for the subject names across the WHOLE repo, not just `docs/`) gives
`docs/dashboard.md` and `docs/dev/repo-map.md`; both describe the gate's role and the import
spelling, neither states a count or enumerates the verdicts, so neither goes stale.

### One thing worth flagging for the LAST slice, not acted on here

`pyproject.toml` records that annotation rules and a type-checker gate were **deliberately not
adopted (#284, closed)** because "only a small share of defs are annotated, so a gate would be all
noise" — and it ends **"Revisit if the package gets meaningfully annotated."** #1556 is the thing
that changes that precondition. The corollary that bites now: **nothing enforces these annotations
today**, so an inaccurate one would be caught by no gate at all, which is why each of the six was
read individually rather than pattern-matched.

### What I did NOT do

- Did not touch `test_collapsed_return_channels.py`, `annotation_gate.py`, or any behaviour.
- Did not fix the `get_confirmed_payouts` collapse, or widen `_EMPTY` to include `"False"`.
- Did not run the `security-reviewer` subagent. Two of the six files sit on the control channel and
  the SSRF guard, which normally triggers it; I substituted the bytecode-identity proof above,
  which is stronger evidence for this specific change than a read-through, since it shows no
  runtime behaviour changed at all. Flagging the substitution rather than leaving it unsaid.
- Did not re-derive slice 1's or route 1's figures; base figures are my own measurement at
  `fcc41dfd`.

### Over-engineering pass (done on merits, then the gate)

One candidate, and it is **declined with a named reason** rather than on preference:

**`PINNED` and `_ANCHORS` now list the same 8 modules — why not `PINNED = tuple(_ANCHORS)`?**
Because the agreement is already enforced and the redundancy is load-bearing in the other
direction. `test_a_pinned_module_is_actually_in_the_walk` is parametrized over `PINNED` and does
`_ANCHORS[module]`, so a module in one and not the other is a `KeyError`, not a silent drift.
Deriving one from the other would make "pin a module" a **one-line** change — which is exactly what
this file's own `**Only ever add a module you have read.**` comment exists to prevent. Requiring two
deliberate edits is that rule made structural, and collapsing it would trade a guard for three saved
lines.

Otherwise the diff adds no test, no helper and no abstraction — it adds data to structures that
already existed, which is the minimal shape for a slice. The one wrapped signature (`_post`) is
forced by the 100-char limit, and `ruff format` left it unchanged, so it is the canonical form.
