### PR TITLE
fix(integration): redact JSON secrets by FIELD NAME — the shape #1582 could not reach (#1587)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -67,14 +67,16 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   suggests**, and the gap is worth knowing before you trust a bundle. It reaches: a `KEY=value`
   line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
   a v3 onion; and any opaque run of 90 or more characters, which is what catches wallet addresses
-  (and a sha512 with them). **It does not reach JSON at all** — `"key": "value"` has neither an
-  `=` nor a `--` — so the bundle's verbatim `config.json` still carries six of its eight sensitive
-  fields, key material among them:
-  [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587). The two fields that *do*
-  redact there are addresses long enough to trip the length rule, which is a coincidence rather
-  than the redactor understanding JSON.
+  (and a sha512 with them); and a JSON `"key": "value"` whose key ends in one of a list of secret
+  words — `password`, `token`, `key`, `username`, `wallet` and the rest.
   [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582) closed the flag-value and
-  address-shape gaps only.
+  address-shape gaps; [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587) added
+  the JSON one. **That last rule is keyed on the field NAME, not the value, and that is forced**:
+  a view key and a container digest are both 64 hex characters, so nothing in the value separates
+  them. **The name list is open, and one field is still out of reach** — `notifications.ntfy.url`
+  is a capability URL whose key is the bare word `url`, which only its nesting separates from the
+  public `xvb.url`, and a line-wise filter cannot see nesting. The self-test states that gap
+  rather than hiding it.
 - Continue-on-error. A failing assertion doesn't abort the run. The whole matrix is collected
   and summarized, with per-scenario artifacts for the failures.
 
@@ -655,12 +657,14 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 `selftest-skip-accounting.sh` is the one that keeps the skip accounting honest: besides checking
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
-`selftest-redact.sh` covers the two shapes the redactor used to miss — a credential passed as a
-flag value, and a wallet address in JSON — and asserts in each case that the *raw* value is gone
-rather than that a `<redacted>` marker appeared, since a marker can come from some other field on
-the same line. It also guards the other direction: a sha256 digest and a non-secret flag value
-must survive, because an artifact with its image pins stripped is useless for the triage it exists
-for.
+`selftest-redact.sh` covers the shapes the redactor used to miss — a credential passed as a flag
+value, and secrets in JSON — and asserts in each case that the *raw* value is gone rather than
+that a `<redacted>` marker appeared, since a marker can come from some other field on the same
+line. Its JSON population is derived from `config.reference.json` rather than listed in the file,
+under a screen deliberately wider than the redactor's own list, so a sensitive field added to the
+schema fails the test by name until someone classifies it as redacted or as a stated survivor. It
+also guards the other direction: a sha256 digest and a non-secret flag value must survive, because
+an artifact with its image pins stripped is useless for the triage it exists for.
 `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures, so
 every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack.

--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -131,8 +131,9 @@ structurally cannot.
 - `make test-inventory` writes a generated (git-ignored) coverage list you can read locally — handy
   for seeing what already exists before you add a test.
 - Secrets: never print tokens, creds, or onions. The harness redacts artifacts and hashes secrets
-  on the box. If you add a secret-bearing field, confirm `redact()` covers it (there's a self-test
-  for the patterns).
+  on the box. If you add a secret-bearing field to `config.reference.json`,
+  `tests/integration/selftest-redact.sh` fails until you classify it — either `redact()` covers it,
+  or the file records why it is safe to keep.
 
 ## Gotchas learned on real hardware
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -33,14 +33,14 @@ it_err() { echo -e "${IT_RED}[ITEST]${IT_RESET} $1" >&2; }
 it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
-# The box holds real RPC creds, a proxy token, wallet addresses and onion hostnames. Redact
-# anything that looks secret before it reaches a log file or the terminal. Only the ADDRESS rule
-# is shape-keyed (any opaque run >=90 chars — a sha512 goes with them); the CREDENTIAL rule is
-# still a name list, and JSON-form secrets are reached by NEITHER — read #1587 before trusting it.
+# Redact before anything reaches a log or the terminal. Three shapes: KEY=value / --flag value by
+# NAME, an opaque run >=90 chars by SHAPE, and JSON "key": "value" by the key's SUFFIX (#1587).
+# THE SUFFIX LIST IS OPEN — add the spelling you meet; a closed enumeration is what opened #1582.
+# Nesting is invisible line-wise, so a bare "url" key is unreachable: ntfy's is secret, xvb's is not.
 redact() {
     sed -E \
         -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g' \
-        -e 's/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
+        -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/g; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
 }
 
 # --- Assertions -------------------------------------------------------------

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -75,5 +75,123 @@ assert_contains "a sha256 digest survives" "$OUT" "$SHA"
 assert_contains "a non-secret KEY=value survives" "$OUT" "HOST_IP=box.lan"
 assert_contains "a non-secret flag value survives" "$OUT" "--merge-mine tari://node:18142"
 
+echo "== redact: the JSON shape, keyed on the field name (#1587) =="
+# #1582 was the argv shape. This is the JSON one, and it could not be fixed the same way: a
+# view key and a container digest are both 64 hex characters, so nothing in the VALUE separates
+# them. The rule is therefore keyed on the field NAME's suffix — the opposite of the argv fix,
+# deliberately, because that case had a usable value shape and this one does not.
+#
+# The population below is DERIVED from config.reference.json rather than listed here, so a
+# sensitive field added to the schema later cannot quietly go uncovered. The screen that selects
+# it is deliberately BROADER than redact()'s own list: if the two lists were the same, this file
+# would be green by construction — the exact defect #1582 was found by.
+REF="$(cd "$HERE/../.." && pwd)/config.reference.json"
+
+# Hand-classified, and the classification is the judgement this test encodes. A field the screen
+# picks up that appears in NEITHER list fails below by name, so the schema cannot drift past it.
+MUST_REDACT="monero.wallet_address monero.node_username monero.node_password monero.view_key
+tari.wallet_address tari.view_key tari.spend_public_key p2pool.stratum_password xvb.donor_id
+xmrig_proxy.donor_id dashboard.auth.username dashboard.auth.password workers.api_token
+ssh.authorized_key healthchecks.ping_url telegram.bot_token notifications.ntfy.token"
+# Survivors, each for a stated reason — over-redaction is safe for secrets and not for anything
+# else: a bundle with its endpoints stripped is useless for the debugging it exists for.
+#   xvb.url / xmrig_proxy.url  public service endpoints
+#   workers.api_auth           an auth MODE string ("token"/"none"), not a credential
+#   telegram.chat_id           a routing id, not a secret
+MUST_SURVIVE="xvb.url xmrig_proxy.url workers.api_auth telegram.chat_id"
+# ⛔ NOT a survivor on merit. `notifications.ntfy.url` IS a capability URL and ought to be
+# redacted; a line-wise filter cannot reach it, because the key is the bare word "url" and only
+# its NESTING distinguishes it from xvb.url. Asserted at its CURRENT behaviour so the gap is
+# stated rather than hidden — when someone closes it, this line fails and moves to MUST_REDACT.
+KNOWN_GAP="notifications.ntfy.url"
+
+SENTINEL="S3nt1nelVALUE" # short, alphanumeric: reachable by the NAME rule and by no other
+SCREENED="$(
+    python3 - "$REF" <<'PY'
+import json, re, sys
+
+# INVARIANT: this screen must be a SUPERSET of redact()'s JSON name list, or a field carrying
+# that suffix is never classified and the drift alarm above cannot fire for it. `wallet` is here
+# for exactly that reason — it is in redact() and is reachable by no other alternative.
+SCREEN = re.compile(r"(password|passwd|secret|token|login|username|key|wallet|address|seed"
+                    r"|mnemonic|credential|url|auth|_id)$")
+
+
+def walk(node, path=""):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from walk(v, f"{path}.{k}" if path else k)
+    elif isinstance(node, list):
+        for v in node:
+            yield from walk(v, path + "[]")
+    else:
+        yield path, node
+
+
+for path, value in walk(json.load(open(sys.argv[1], encoding="utf-8"))):
+    if isinstance(value, str) and SCREEN.search(path.split(".")[-1]):
+        print(path)
+PY
+)"
+[ -n "$SCREENED" ] || it_fail "screen over config.reference.json returns fields" "empty population"
+
+# Word-splitting, not a `case` glob: the lists above wrap across lines, and a space-delimited
+# haystack silently misses every entry sitting next to a newline.
+in_list() { # <field> <list>
+    local needle="$1" item
+    for item in $2; do [ "$item" = "$needle" ] && return 0; done
+    return 1
+}
+
+for field in $SCREENED; do
+    key="${field##*.}"
+    out="$(printf '  "%s": "%s",\n' "$key" "$SENTINEL" | redact)"
+    if ! in_list "$field" "$MUST_REDACT $MUST_SURVIVE $KNOWN_GAP"; then
+        it_fail "config.reference.json field $field is classified" \
+            "new sensitive-looking field — add it to MUST_REDACT or MUST_SURVIVE with a reason"
+        continue
+    fi
+    if in_list "$field" "$MUST_REDACT"; then
+        case "$out" in
+        *"$SENTINEL"*) it_fail "$field redacted in JSON" "raw value survived: $out" ;;
+        *) it_pass "$field redacted in JSON" ;;
+        esac
+        continue
+    fi
+    # The gap gets a label that cannot be misread as approval. A green row saying a secret-bearing
+    # field "survives redaction" is exactly the confidence this file exists to refuse.
+    if in_list "$field" "$KNOWN_GAP"; then
+        assert_contains "KNOWN GAP (#1587) — $field is NOT redacted and should be" "$out" "$SENTINEL"
+        continue
+    fi
+    assert_contains "$field survives redaction" "$out" "$SENTINEL"
+done
+it_warn "KNOWN GAP (#1587): $KNOWN_GAP is a capability URL and is NOT redacted — nesting is invisible to a line-wise filter"
+
+# A value containing an escaped quote must be replaced WHOLE. A pattern stopping at the first
+# quote would leave the tail behind, which is the partial-redaction failure this file exists for.
+OUT="$(printf '  "node_password": "ab\\"%s",\n' "$SENTINEL" | redact)"
+case "$OUT" in *"$SENTINEL"*) it_fail "escaped quote inside a secret value" "tail survived: $OUT" ;; *) it_pass "escaped quote inside a secret value" ;; esac
+
+# Measured read-only against the live stack: `api-state.json` carries both wallet addresses, and
+# it carries them under the leaf key `wallet` — not under a secret-sounding name. Before the name
+# rule they were reached only by the >=90 length bar, which is the coincidence #1587 objects to.
+# A SHORT value under that key is what discriminates: no other rule in redact() can reach it.
+SHORTWALLET="4ShortNotAnAddress"
+OUT="$(printf '{"stratum":{"wallet":"%s"},"tari":{"wallet":"%s"}}\n' "$SHORTWALLET" "$SHORTWALLET" | redact)"
+case "$OUT" in *"$SHORTWALLET"*) it_fail "a short value under a \"wallet\" key is redacted by NAME" "value survived: $OUT" ;; *) it_pass "a short value under a \"wallet\" key is redacted by NAME" ;; esac
+
+# `passwd`, `secret` and `login` have no field in today's schema, so the derived population
+# above cannot exercise them. They are forward cover, mirroring the flag-value rule's word list —
+# and an unexercised pattern is one typo away from being dead, so they get an explicit case.
+OUT="$(printf '{"passwd":"%s","client_secret":"%s","rpc_login":"%s"}\n' "$SENTINEL" "$SENTINEL" "$SENTINEL" | redact)"
+case "$OUT" in *"$SENTINEL"*) it_fail "the spellings passwd/secret/login redact, though no schema field uses them" "value survived: $OUT" ;; *) it_pass "the spellings passwd/secret/login redact, though no schema field uses them" ;; esac
+
+# Compact JSON on one line — api-state.json is not pretty-printed, and a per-line filter has to
+# replace every occurrence on that line, not just the first.
+OUT="$(printf '{"username":"%s","mode":"local","view_key":"%s","port":18081}\n' "$SENTINEL" "$SENTINEL" | redact)"
+case "$OUT" in *"$SENTINEL"*) it_fail "compact JSON: both secrets on one line" "value survived: $OUT" ;; *) it_pass "compact JSON: both secrets on one line" ;; esac
+assert_contains "compact JSON: non-secret neighbours survive" "$OUT" '"mode":"local"'
+
 echo "selftest-redact: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1587 (by hand — `Closes` does not fire here, PRs merge to `develop-v2` while the default branch is `develop`).

## What was wrong

`redact()` recognised four things: `KEY=value` for a name list, a credential given as a `--flag` value, v3 onion hostnames, and any opaque run of 90 or more characters. `capture_artifacts` writes `config.json` **verbatim**, and `"key": "value"` has neither an `=` nor a `--` — so two of those three rules could not reach it **by construction**.

What was left was the length rule. A field was redacted **if and only if its value happened to be at least 90 characters long**. Six of the eight sensitive fields survived, `monero.view_key` among them; the two that did redact were addresses long enough to trip the bar. That is a length coincidence, not a security property.

## Why it could not be fixed the way #1582 was

#1582 keyed on the **shape of the value**, and that worked because a credential given as a flag has one. This case has none: **a view key and a container digest are both 64 hex characters.** No pattern can separate them by looking at the value, and a rule that tried would strip the image pins the artifacts exist to carry.

So this rule is keyed on the field **NAME's suffix** — deliberately the opposite approach, for a deliberately different reason.

`lib.sh` is **line-neutral, 692 → 692**: the new rule joins the existing `-e` chain rather than adding one.

## `api-state.json`, measured rather than assumed

#1587 names `api-state.json` as the obvious next file. I measured it read-only against the live stack rather than leaving it stated, and it changed the patch:

- It carries **no secret-named field at all** (16,053 leaves walked, 199 distinct key names, instrument proven by injecting a control field and re-walking).
- It carries **no credential and no key material** — `node_password`, `view_key`, `bot_token` and `auth.password` are all absent from the body.
- It **does** carry both wallet addresses, under the leaf key **`wallet`**. Those were reached only by the ≥90 length bar, so the same coincidence applied there too.

`wallet` is now in the name list. The assertion that discriminates is a **short** value under that key — no other rule in `redact()` can reach an 18-character string.

## The gap I did not close, and why you must not close it the obvious way

`notifications.ntfy.url` is a capability URL and is **not** redacted. It is asserted at its current behaviour under a row labelled `KNOWN GAP (#1587) — … is NOT redacted and should be`, so a green line cannot be misread as approval.

**The discriminator is NESTING, not the key.** The key is the bare word `url`, byte-identical to the public `xvb.url`; only the parent object separates them, and a line-wise filter cannot see a parent. **Do not close this by adding `url` to the list** — that redacts the public endpoints too, which is what the `M3` leg below measures.

## The test is written from the threat, not from the implementation

#1582's lesson was that `selftest.sh` asserted exactly the shapes `redact()` handled, so both gaps were green *by construction*. This file refuses that shape:

- The field population is **derived from `config.reference.json`**, not listed in the test.
- The screen that selects it is deliberately **wider** than `redact()`'s own list. If the two lists were the same, the file would be green by construction again.
- A screened field in **neither** the redact list nor the survivor list **fails by name**. A sensitive field added to the schema later cannot go quietly uncovered.
- Every survivor carries a stated reason. Over-redaction is safe for secrets and not for anything else: a bundle with its endpoints stripped is useless for the triage it exists for.

## Mutation battery — re-run AFTER the rebase

Every leg is `cmp`-guarded, so a mutation that fails to apply is **VOIDED** rather than counted as a pass. That guard earned its place: on the first run the delete-the-rule leg did not apply, and the guard voided it instead of reporting green. Baseline **39 passed, 0 failed**.

| leg | mutation | result |
|---|---|---|
| M1 | delete the JSON rule entirely | **21 fail** — 17 schema fields, escaped-quote, compact-JSON, short-wallet, forward-cover |
| M2 | drop only the `key` suffix | **5 fail** — the four key-material fields, plus the compact-JSON case, which carries a `view_key` |
| M3 | add `url` to the list | **3 fail** — both public endpoints, and the stated gap |
| M4 | drop only the `wallet` suffix | **1 fail** — the short-wallet case alone, so the address coverage is name-keyed and not length-keyed |
| M5 | add an unclassified field to the schema | **1 fail**, naming the field |

Two smaller controls, both fired: the escaped-quote fixture was confirmed armed with `od -c` (a literal backslash is present, not a printf artefact), and a companion fixture with a genuinely *closed* value leaves the tail outside the quotes — so the pattern is not simply eating to end of line.

## Rebase evidence

The base moved (#1584 merged as `7dda9ce`), so trees and shas are expected to differ and prove nothing. **Verified by PATCH**: the pre- and post-rebase `format-patch` bodies are identical at 264 normalised lines, and the comparison was shown able to detect a one-line tamper.

The first rebase attempt tried to replay #1584's two commits against their own squash-merged form and conflicted; `git rebase --onto origin/develop-v2 4305d70` replays only this commit.

## Gates run, at the rebased head

`shellcheck 0.11.0` rc 0 and `shfmt -i 4 -d` rc 0 (file list: `tests/integration/*.sh`, plus shfmt over the Makefile's exact glob); `make lint-md`, `make lint-docs-voice`, `make lint-file-budget` all rc 0; `make test-integration-selftest` rc 0 across 13 self-test files, **700 assertions, 0 failed**.

## Over-engineering pass

`/ponytail-review` is not invocable in this environment, so this was done by hand off the diff. Both findings are recorded with what I did about them, so a reviewer can overrule either.

**Found and fixed.** Four alternatives in the new pattern are unreachable against today's schema. One — `wallet` — is not dead at all: it is the rule that covers `api-state.json`, which the schema-derived population does not reach, and it has its own case and its own mutation leg (M4). The other three, `passwd`, `secret` and `login`, genuinely have no field today. They mirror the flag-value rule's word list and are deliberate forward cover, but an unexercised pattern is one typo away from being dead, so they now carry an explicit case.

**Considered and declined.** `jq` is the more idiomatic dependency for this harness — 12 files under `tests/integration/` use it, against 5 that use `python3` — and it could do the recursive walk and the regex screen. Declined: `python3` is already a dependency of this same directory, so nothing new is introduced, and the walk plus the injected-control check read more clearly in it. If a reviewer prefers `jq`, the swap is contained to one command substitution.

**Not a finding, recorded so it is not re-raised.** `wallet` and `wallet_address` are both in the list and neither is redundant: the alternation matches the key's tail, and `wallet_address` does not end in `wallet`. M4 drops only `wallet` and fails exactly one assertion, which is what shows both are load-bearing.

## Review fix (head `a38cdab`)

The reviewer found that the screen was **not** the superset this file's central claim depends on. Of the suffixes in `redact()`, `wallet_address`, `ping_url` and `donor_id` remain reachable through the screen's `address` / `url` / `_id` — but **`wallet`, the suffix the `api-state.json` measurement earned, matched no alternative at all.** A `wallet` field would never have been classified, so the drift alarm could not fire for it and it left no row.

**Not a leak** — `redact()` does cover `wallet`, so the value is redacted in a bundle either way. It is a **false guarantee**: `testing-guide.md` now promises the suite fails until a new secret-bearing field is classified, and for that one suffix it would not have.

`wallet` is added to the screen and the superset invariant is written down beside it, so the next person adding a `redact()` suffix is told the screen must move too. Verified both directions: the unmodified schema stays **39 passed / 0 failed**, and a seeded `monero.wallet` fails by name while `monero.wallet_address` keeps passing **in the same run** — so it discriminates rather than blanket-matching.

Worth recording how it was found: a **narrowness control with a near-miss sibling**, not a single seed. One seed that fails tells you the instrument saw something, not that it saw the thing.

## Known gaps in the new rule — follow-up, not this PR

Found by the reviewer running the rule rather than reading it. No claim is made that any of these leaks today; the shipped services' log output was not measured.

1. **Case.** The alternation is lowercase-only, so `{"apiKey":"…"}`, `{"authToken":"…"}` and `{"PASSWORD":"…"}` survive. `config.json` is snake_case so the bundle's config is unaffected; `docker compose logs` is the exposure. Note this is **not** fixable by the "add the spelling you meet" instruction in the `lib.sh` comment — the failure is case, not spelling.
2. **Escaped JSON inside a log string.** `{"msg":"{\"password\":\"X\"}"}` survives: the key is preceded by `\"`, so the literal quote the pattern anchors on never matches. A standard structured-logging shape.
3. **Non-string values.** `{"api_token":12345678}` survives; the rule requires the value's opening quote.

**Not a defect, recorded so a noisy bundle is not later filed as one:** over-redaction is broader than the docs imply — any key ending in `key` matches, so `cache_key`, `primary_key` and `monkey` all redact. That is consistent with the stated principle that over-redaction is the safe direction for secrets.

## Lane disclosure

`tests/integration/` is this lane's. `docs/dev/integration-testing.md` and `docs/dev/testing-guide.md` are `docs/`, shared via `_shared.paths` — disclosed here, no `.lane-override`. Both carried the old gap **as fact** and would have been false the moment this landed. `config.reference.json` is read by the self-test and **not modified**.

## What I did NOT do

- The other four captured files — `status.txt`, `doctor.txt`, `env.redacted.txt`, `compose-ps.txt`. Only `config.json` and `api-state.json` were measured.
- The `07-support-bundle.sh` redactor's own JSON coverage. That is #1585, a separate lane's file.
- Any check of artifact bundles already on disk. #1587 records that two exist carrying wallet addresses; the deletion call there is the operator's, not a lane's.
- Portability of the escaped-quote alternation `([^"\]|\\.)*` to BSD `sed`. POSIX says a backslash is literal inside a bracket expression, so it should hold, but it was measured on GNU `sed` only.
