### PR TITLE
fix(dashboard): #1556 slice 3 — annotate the web/ singletons, and scope slice 2's claim

### DIFF
--- a/dashboard/mining_dashboard/web/charts.py
+++ b/dashboard/mining_dashboard/web/charts.py
@@ -60,7 +60,7 @@ def _chart_tension(duration_s):
     return _MAX_TENSION
 
 
-def parse_window(from_arg, to_arg):
+def parse_window(from_arg, to_arg) -> tuple[float, float] | None:
     """Parse optional ``from``/``to`` query params (epoch seconds) into a ``(from, to)`` window,
     or ``None`` if absent or malformed. Defensive — any bad input falls back to ``None`` so the
     caller uses the preset ``range`` instead of erroring (Issue #47)."""

--- a/dashboard/mining_dashboard/web/infra_views.py
+++ b/dashboard/mining_dashboard/web/infra_views.py
@@ -451,7 +451,7 @@ def build_proxy_summary(data):
     }
 
 
-def _ip_to_sort_int(ip):
+def _ip_to_sort_int(ip) -> int:
     """Pack a dotted-quad IP into an int for client-side numeric sorting; 0 on malformed input."""
     try:
         a, b, c, d = (int(part) for part in ip.split("."))

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -245,7 +245,7 @@ def visible_update(update, running=None):
     return update
 
 
-def read_os_update_state():
+def read_os_update_state() -> dict | None:
     """The appliance OS-update state (step + post-reboot verdict), or ``None`` off an appliance.
 
     Host-written under a fixed name in the read-only results/ mount — only a Pithead OS

--- a/dashboard/mining_dashboard/web/xvb_views.py
+++ b/dashboard/mining_dashboard/web/xvb_views.py
@@ -67,7 +67,7 @@ _XVB_FAILING_TITLE = (
 WALLET_CHANGED_BADGE_SEC = 72 * 3600
 
 
-def recent_wallet_change(state_mgr, now=None):
+def recent_wallet_change(state_mgr, now=None) -> dict | None:
     """The payout-wallet tripwire's change record (#375) if one happened within the banner
     window: ``{"old8", "new8", "ts"}`` (addresses pre-truncated to 8 chars by the alerter),
     else ``None``. Reads the kv_store keys AlertService persists; any unreadable value reads

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -50,10 +50,21 @@ import pytest
 from tests.service.annotation_gate import classify, classify_package
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 8 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 12 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
-# and the six single-function `client/` modules by slice 2, which finishes the package: no module
-# under `client/` holds an unannotated failure return any more.
+# the six single-function `client/` modules by slice 2, and the four single-function `web/` modules
+# by slice 3.
+#
+# Slice 2 wrote here that "no module under `client/` holds an unannotated failure return any more".
+# That is TRUE under `_failure_returns`' definition and it READS as "`client/` is done, never look
+# here again". It is not. The gate sees exactly two doors — a `return` lexically inside an `except`
+# handler, and a return that is the whole body of a `self._conn` guard — and **14 unannotated
+# functions under `client/` hold collapse-shaped returns outside both of them**, measured.
+# `client/monero/monero_wallet_client.py:get_confirmed_payouts` is a genuine failure path among
+# them: it returns `[]` when `_rpc` returned `None`, which no caller can tell from "no payouts".
+# So the claim is scoped to the instrument that makes it — no unannotated failure return **that
+# this gate can see**. A pin is coverage of a mechanism, never a certificate about a package.
+#
 # **Only ever add a module you have read.** Adding one because the gate happens to score it clean
 # is the baseline #1487 refused, wearing this file's name.
 PINNED = (
@@ -65,6 +76,10 @@ PINNED = (
     "client/xmrig_client.py",
     "client/xvb_client.py",
     "service/worker_config_store.py",
+    "web/charts.py",
+    "web/infra_views.py",
+    "web/views.py",
+    "web/xvb_views.py",
 )
 
 # One function per pinned module, as the vacuity anchor. Law 1's own guard uses this shape: a
@@ -83,6 +98,10 @@ _ANCHORS = {
     "client/xmrig_client.py": "client/xmrig_client.py:_safe_probe_host",
     "client/xvb_client.py": "client/xvb_client.py:get_stats",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
+    "web/charts.py": "web/charts.py:parse_window",
+    "web/infra_views.py": "web/infra_views.py:_ip_to_sort_int",
+    "web/views.py": "web/views.py:read_os_update_state",
+    "web/xvb_views.py": "web/xvb_views.py:recent_wallet_change",
 }
 
 


### PR DESCRIPTION
Four single-function `web/` modules, one return annotation each — slice 3 of #1556.

`web/server.py` is deliberately **not** in this slice. It holds TWO blind returns
(`_finalize_worker_upgrade`, `_num`), so it belongs with the multi-blind group rather than the
singleton tail. Four modules, four functions.

## Measured, and predicted before measuring

Verdicts were written down per function **before** running the classifier, and all four matched.
Measured with the gate's own `classify_package()` over live source, base `8639f89` -> head:

| verdict | base | head |
|---|---|---|
| blind | 46 | **42** |
| signed | 14 | **17** |
| collapse | 12 | **13** |
| unjudged | 2 | 2 |
| procedure | 3 | 3 |
| half_fix | 0 | 0 |

**The arithmetic reconciles exactly: -4 blind == +3 signed +1 collapse.** That is the general
answer to "the flagged count went up" — it is arithmetic, not argument.

| function | annotation | verdict |
|---|---|---|
| `web/charts.py:parse_window` | `-> tuple[float, float] \| None` | signed |
| `web/views.py:read_os_update_state` | `-> dict \| None` | signed |
| `web/xvb_views.py:recent_wallet_change` | `-> dict \| None` | signed |
| `web/infra_views.py:_ip_to_sort_int` | `-> int` | **collapse** (`0`) |

## The one that does not reach `signed`, and its honest severity

`_ip_to_sort_int` returns `0` from its except handler, and `0` is also the correct packed value of
`0.0.0.0` — so no caller can tell malformed input from that address. It is a real instance of
#1487's rule, made VISIBLE by the annotation rather than introduced by it. Not reverted, not
baselined (#1487's ruling governs, and the flagged count is expected to rise as slices bring
genuine collapses into scope).

**Its practical consequence is a display-order tie, not a wrong decision** — the value is a
client-side sort key. I am stating that so "defect" is not read as carrying more weight than the
measurement supports. It is a defect by the rule; its blast radius is sorting.

## A clause owed on slice 2's own comment, discharged here

Slice 2 shipped `"no module under client/ holds an unannotated failure return any more."` That is
TRUE under `_failure_returns`' definition, and it **reads as "`client/` is done, never look here
again."** It is not. The gate sees exactly two doors — a `return` lexically inside an `except`
handler, and a return that is the whole body of a `self._conn` guard.

**Measured: 14 unannotated functions under `client/` hold collapse-shaped returns outside both
doors**, and `client/monero/monero_wallet_client.py:get_confirmed_payouts` is a genuine failure
path among them — it returns `[]` when `_rpc` returned `None`. That figure was reproduced
independently by a second seat at this tip.

The comment now scopes the claim to the instrument that makes it: *no unannotated failure return
**that this gate can see***, plus the general form — a pin is coverage of a mechanism, never a
certificate about a package.

**And the clause is load-bearing for the modules THIS slice pins, not only retrospectively.**
Measured on the four newly pinned `web/` modules with the same finder (positive control: it
reproduces the `client/` figure of 14 exactly): they hold **25 collapse-shaped returns outside the
gate's two doors, 22 of them in unannotated functions** — e.g. `web/views.py:host_display_addr`,
`web/xvb_views.py:xvb_realization`, `web/charts.py:_share_points`.

**What I did NOT do:** I have not classified which of those 25 are failure paths and which are
ordinary domain early-returns, and I am **not** claiming they are defects. Telling the two apart
needs reading each one — which is precisely why the gate's doors are narrow and why the pin is
worded as coverage. `parse_window`'s own two `None` returns are in that list and are plainly
legitimate answers, not failures.

## Both pin laws shown ABLE TO FAIL on a newly pinned module

`web/charts.py:parse_window` is not named by the sibling file's `_SIGNED` (which holds five
entries, none under `web/`), so **only the pin can see it**:

| leg | edit | expected | result |
|---|---|---|---|
| 1 | UNANNOTATE — remove the annotation | law 1 reds | `..._is_unannotated[web/charts.py]` FAILED, law 2 **green** |
| 2 | DE-SIGN — drop only the `\| None` | law 2 reds | `..._is_unjudged[web/charts.py]` FAILED, law 1 **green** |

Each leg was caught **by test node ID with the sibling law staying green** — the discriminating
result — rather than by reading a suite colour, which this lane has had read as an assert firing
when it was not. Both legs started from a verified green, were restored by sha256, and the
restore was verified **by content**.

## Behaviour

The four annotations are inert, proven by comparing the functions' code objects **recursively**
(`co_code`, `co_names`, `co_varnames`, `co_consts`) rather than a `dis` repr — a repr diff scored
this wrong in both directions on an earlier slice, because the delta was the object address.
Positive control first: the comparator fires on `return 1` vs `return 2`. All four bodies
byte-identical.

## Gates

- Suite **2294 -> 2306**, +12 reconciled as 3 `PINNED`-parametrized tests x 4 new modules. The
  2294 baseline was measured pre-merge at `58e99a2`; `git rev-parse <base>:dashboard` is
  **byte-identical** at `58e99a2` and `8639f89`, so it still describes the same program and the
  reconciliation survives the base move.
- Patch coverage **4/4** executable changed lines, measured from `coverage.xml` with the path
  prefix derived from its `<source>` element and the executable total asserted `> 0`.
  Package coverage 97%.
- `ruff check` / `ruff format --check` clean; `lint-file-budget`, `lint-docs-voice` and
  `lint-operator-strings` pass.
- `PINNED` and `_ANCHORS` go 8 -> 12 modules, both together.
- `test_annotation_coverage.py` 315 -> **334**, under the 400 target and still taking **no budget
  row** (a row for a file under target is itself a gate failure).
- `test_collapsed_return_channels.py` untouched — its residual figures are scoped to named shas by
  design; verified before deciding not to edit it, rather than assumed.
- `docs/dashboard.md` needed no change: it states the mechanism with no counts, and its "a pinned
  module may still hold a reported collapse" is now literally demonstrated by `_ip_to_sort_int`.
  Swept repo-wide for prose this slice falsifies; the other hits are different subjects.

No security-reviewer pass: this touches no control channel, no auth and no outbound fetch — four
return annotations with byte-identical function bodies.

## Over-engineering pass — findings, done on merits before the gate was pressed

The pass is what produced the `web/` residue measurement above; it was not a formality.

- **F1 (fixed).** The comment carried the phrase *"reproduced independently by a second seat at
  this tip"* — internal process vocabulary leaking into a repo source comment, meaningless to a
  reader of this file. Cut; the claim now rests on "measured", which is what a reader can check.
  334 lines, not 335, as a result.
- **F2 (fixed, in this body).** "Genuine pre-existing defect" for `_ip_to_sort_int` invited a
  severity read the measurement does not support. The blast radius is now stated: a sort-order
  tie, not a wrong decision.
- **F3 (considered, declined with a reason).** Compressing the 10-line clause down to the bare
  qualifier "that the gate can see". Declined: the bare qualifier softens the sentence without
  telling the reader *what* the gate can see, so the next author hits the same wall and is free to
  re-soften it. The two-door definition and the named counterexample are what make the qualifier
  actionable. There is no budget pressure forcing the cut — 66 lines of headroom under the 400
  target, and no budget row.
- **F4 (considered, declined).** Factoring the four new `_ANCHORS` entries behind a helper. They
  are data, and the file's own docstring argues for naming each anchor individually; a helper
  would make the vacuity guard's subject implicit, which is the property that guard exists to keep
  explicit.
