### PR TITLE
test(integration): assert p2pool actually REACHED the Tari node over gRPC (#1397)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -325,6 +325,31 @@ and `--list` prints it).
   That distinction is load-bearing: `tari` is a prefix of `tari-wallet`, so a substring match
   would report a stopped `tari` as running whenever the payout-confirm container is up.
 - `pithead status` exit code: `0` for a healthy config.
+- p2pool actually reached the Tari node over gRPC ([#1397](https://github.com/p2pool-starter-stack/pithead/issues/1397)). p2pool's merge-mining
+  client emits three lines at startup and only one of them says anything about Tari:
+  `MergeMiningClientTari tari://<host:port> uses chain_id <id>`, because p2pool cannot know the
+  chain id without a successful call to the node. The other two, `event loop started` and
+  `worker thread ready`, are local — they prove the object was constructed and its threads spun.
+  On the live stack they landed about 175 milliseconds before the chain-id read, so a row keyed on
+  either would pass with Tari unreachable. That case is its own verdict, `local-only`, and it
+  fails rather than passing quietly: it means the client is up and Tari is not answering. Nothing
+  else at any tier watches this leg — `fakes/test_contract.py` looks like it does and does not,
+  since it drives the dashboard's Tari client while merge-mining is a third-party binary's own
+  gRPC. Two properties of the signal shape the read. It is startup-only: the three lines landed
+  within about 17.5 seconds of the container starting, at positions 68, 69 and 71 of a log that
+  had reached 83,070 lines after 30 hours (one sample), so a `--tail` read cannot contain them.
+  The window is therefore a head read, bounded by the container's own start time so that an
+  earlier startup's line cannot satisfy the assertion after a restart. And the log is
+  ANSI-coloured with the escapes mid-line, between the client name and the endpoint, so a pattern
+  written against the rendered text matches nothing at all, silently — a probe that always reports
+  an absence looks exactly like a working one until the day it matters. The escapes are stripped
+  before matching, and the self-test carries that control fired in both directions: zero matches on
+  the captured bytes, one after stripping. When monerod is not caught up the leg skips rather than
+  fails, counted and classed `by-design`, because p2pool constructs the merge-mining client only
+  after its block-header download succeeds — so the signal cannot exist on an unsynced node, and no
+  input to this harness would create it. Only the matching lines cross the wire, which keeps the
+  container's argv line — carrying both wallet addresses, the RPC credential and the onion — out of
+  the capture.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.
 - The Monero node's ZMQ endpoint is a live ZMTP publisher. A ZMTP handshake against the node's ZMQ

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -139,6 +139,7 @@ The deploy-time axes — each changes a real runtime path. Full table and assert
 | Situation | Trigger | Tier |
 |---|---|---|
 | Real merge-mining share lands; real hashrate on dashboard | live mining | 4 ▶ |
+| p2pool actually reached the Tari node over gRPC (#1397): the merge-mining client's `uses chain_id` line, which p2pool cannot log without a successful call to the node. Its two sibling lines land ~175 ms earlier and are local, so a check keyed on them would pass with Tari unreachable — that case is a distinct `local-only` verdict and fails. Startup-only (three lines inside ~17.5 s of container start), and the log is ANSI-coloured mid-line, so the escapes are stripped before matching | live p2pool startup log, bounded by the container's own start time | 1 ✅ (verdicts, capture bounds and the ANSI control, `selftest-mergemine-probe.sh`) · 4 ✅ (the leg — run against the live stack read-only, not yet inside a full gate run) |
 | Caddy TLS scheme; Tor onion provisioning; HugePages/AVX2; real disk pressure; prune DB size | real host | 4 ▶ |
 
 ### I. RigForge worker ↔ Pithead contract (#209)

--- a/tests/integration/mergemine-probe.sh
+++ b/tests/integration/mergemine-probe.sh
@@ -1,0 +1,143 @@
+# shellcheck shell=bash
+#
+# The p2pool -> Tari merge-mining gRPC round-trip probe (#1397).
+#
+# WHY THIS EXISTS. Merge-mining is what makes Tari pay, and it is driven entirely by p2pool — a
+# third-party binary — not by any client we wrote. `fakes/test_contract.py` looks like it covers
+# this and does not: it drives the DASHBOARD's Tari client against `fake_tari.py`. Before this
+# file, nothing at any tier observed p2pool reaching the Tari node, so a gRPC method moving
+# behind an allow-list (the named risk on the Tari v5.6.0 bump, and the exact shape of #313)
+# would land with every gate green.
+#
+# WHY TIER 4 AND NOT A FAKE. #1397 offered "drive p2pool's merge-mining client against a
+# controllable fake" as the cheaper half that would also escape the sync problem. Measured at
+# p2pool v4.18's source (the pinned binary we ship): there is exactly ONE creation site for
+# merge-mining clients, `IMergeMiningClient::create`, and it sits inside the success callback of
+# `download_block_headers4` — after `BLOCK_HEADERS_REQUIRED = 720` headers parse. So a fake would
+# have to serve 720 consecutive, self-consistent Monero block headers and a live ZMQ publisher
+# before the Tari fake is reached at all. That is not the cheaper half; it re-implements a synced
+# monerod. Option 1 — a real box whose chain is already synced — is the one that works, and the
+# release gate already runs on one.
+#
+# WHAT PROVES A ROUND-TRIP, AND WHAT ONLY LOOKS LIKE ONE. p2pool emits three lines. Two are
+# LOCAL and prove only that the object was constructed and its threads spun:
+#
+#     MergeMiningClientTari event loop started
+#     MergeMiningClientTari worker thread ready
+#
+# The third is the only assertion worth building on:
+#
+#     MergeMiningClientTari tari://<host:port> uses chain_id <id>
+#
+# because p2pool cannot know the chain_id without a successful call to the Tari node. Measured on
+# the live stack, the two local lines land ~175 ms BEFORE the chain_id read, so asserting on
+# either would be satisfiable with Tari unreachable — the false green this harness exists to
+# kill. That is why `local-only` is its own verdict and a FAILURE, not a near-miss pass. It is
+# also the most informative failure here: it says the client is up and Tari is not answering.
+#
+# THE LOG IS ANSI-COLOURED AND THE ESCAPES SIT MID-LINE. Measured with `cat -v` on the live
+# stack, the chain_id line really reads:
+#
+#     ^[[0;90mMergeMiningClientTari ^[[0mtari://127.0.0.1:18142 uses chain_id ^[[0;96m01f0…
+#
+# `docker compose logs --no-color` suppresses DOCKER's colouring, not the application's own. A
+# pattern written against the rendered text — `MergeMiningClientTari tari://.* uses chain_id` —
+# therefore matches NOTHING, silently. That failure is invisible in the worst way: a probe that
+# always reports "absent" looks identical to a working one right up to the moment it matters.
+# Strip the escapes first, then match. The self-test carries the fired negative control.
+#
+# THE SIGNAL IS STARTUP-ONLY. The three lines land within ~17.5s of the container's start — at
+# positions 68/69/71 of a log that had reached 83,070 lines after 30h (ONE sample, live stack,
+# 2026-08-30). `--tail 200` cannot contain them on a container that has been up minutes, so this
+# read is bounded by the container's own StartedAt and a head window, never by a tail.
+
+# The startup window, in lines. The observed maximum position is 71 (one sample), so 2000 is
+# ~28x headroom while still being two orders below a day-old log — "startup" stays a real bound
+# rather than a name. It is a CEILING, not a cost: `head` closes the pipe, and only the matching
+# lines ever cross the wire.
+MM_WINDOW_LINES=2000
+
+# Strip SGR escape sequences. PURE.
+# The ESC byte is written with bash ANSI-C quoting rather than a `\x1b` inside the sed script,
+# because that spelling depends on the sed implementation and this box's text tools are shims.
+mm_strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
+
+# mm_roundtrip_verdict <log text> — prints exactly one of:
+#
+#   roundtrip <chain_id>  p2pool read a chain_id from the Tari node: the gRPC call SUCCEEDED
+#   local-only            the client was constructed, but no chain_id was ever read
+#   absent                p2pool never constructed a merge-mining client at all
+#
+# Returns 0 ONLY for roundtrip. PURE — a function of the text alone, so the self-test drives
+# every class from a fixture with no stack, no container and no network.
+mm_roundtrip_verdict() {
+    local plain id
+    plain="$(printf '%s\n' "$1" | mm_strip_ansi)"
+    # `tail -n 1` takes the newest epoch should more than one ever reach this function. The
+    # capture below already bounds the read to the current container run; this is the belt to
+    # that braces, and it costs nothing.
+    id="$(printf '%s\n' "$plain" |
+        grep -aoE 'MergeMiningClientTari tari://[^ ]+ uses chain_id [0-9a-f]{16,}' |
+        tail -n 1 | awk '{print $NF}')"
+    if [ -n "$id" ]; then
+        printf 'roundtrip %s\n' "$id"
+        return 0
+    fi
+    if printf '%s\n' "$plain" | grep -qa 'MergeMiningClientTari'; then
+        printf 'local-only\n'
+        return 1
+    fi
+    printf 'absent\n'
+    return 1
+}
+
+# Capture the CURRENT container run's merge-mining lines. Both bounds are load-bearing:
+#
+#   --since <StartedAt>  excludes any EARLIER startup epoch. Docker's restart policy can restart
+#                        p2pool in place, and the log then still carries the old startup's
+#                        chain_id line — which would satisfy this assertion while the live client
+#                        never reached Tari. StartedAt moves with the restart; the log does not.
+#   head -n <window>     keeps this a startup read rather than a whole-log scan.
+#
+# `docker inspect` is used with --format naming ONE field. Unformatted, it prints `.Args`, which
+# on this stack carries both wallet addresses, the RPC credential and the onion address; the same
+# is true of the p2pool log's own argv line. Only lines matching MergeMiningClientTari cross the
+# wire, so none of that is transferred here (#1582/#1585/#1586).
+mm_capture_startup() {
+    local started
+    started="$(rx "docker inspect p2pool --format '{{.State.StartedAt}}'" 2>/dev/null | tr -d '\r')"
+    [ -n "$started" ] || return 1
+    rx "docker compose logs --no-color --since $(quote_arg "$started") p2pool 2>&1 | head -n ${MM_WINDOW_LINES} | grep -a MergeMiningClientTari || true" 2>/dev/null
+}
+
+# The release-gate leg: PASS, FAIL, or an honest counted SKIP — never a silent green.
+#
+# The skip is classed `by-design` rather than `missing` on the skip-accounting test: no input,
+# flag or env var to THIS harness would make the signal exist on an unsynced node, because
+# p2pool does not construct the client at all until the header download completes (cycle 40
+# measured zero Tari gRPC calls across five legs against absent, synced-fake and partial-fake
+# monerods). Covering it means running against a synced chain, not supplying something.
+assert_mergemine_roundtrip() {
+    local lines verdict
+    if ! monero_caught_up; then
+        it_skip_leg "p2pool merge-mining gRPC round-trip (#1397)" \
+            "monerod is not caught up, and p2pool constructs its merge-mining client only after the block-header download succeeds — the signal cannot exist on this run" by-design
+        return 0
+    fi
+    if ! lines="$(mm_capture_startup)"; then
+        it_fail "p2pool merge-mining gRPC round-trip (#1397)" "could not read p2pool's container start time"
+        return 0
+    fi
+    verdict="$(mm_roundtrip_verdict "$lines")"
+    case "$verdict" in
+    roundtrip*) it_pass "p2pool reached the Tari node over gRPC — ${verdict} (#1397)" ;;
+    local-only)
+        it_fail "p2pool merge-mining gRPC round-trip (#1397)" \
+            "p2pool built its merge-mining client but never read a chain_id — the client is up and Tari is NOT answering"
+        ;;
+    *)
+        it_fail "p2pool merge-mining gRPC round-trip (#1397)" \
+            "no MergeMiningClientTari line in the first ${MM_WINDOW_LINES} lines after the container started — p2pool built no merge-mining client, or the log could not be read"
+        ;;
+    esac
+}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -33,6 +33,8 @@ source "$HERE/rigforge-writable-keys.sh"
 source "$HERE/rigforge-upgrade.sh"
 # shellcheck source=tests/integration/zmq-probe.sh
 source "$HERE/zmq-probe.sh"
+# shellcheck source=tests/integration/mergemine-probe.sh
+source "$HERE/mergemine-probe.sh"
 
 # --- Defaults / globals -----------------------------------------------------
 IT_MODE="ssh"
@@ -654,6 +656,7 @@ assert_running_state() {
     if zv=$(zmq_pub_probe "$zmq_host" "$zmq_port" 8); then it_pass "monero ZMQ endpoint is a live ZMTP publisher (#1497)"; else it_fail "monero ZMQ endpoint is a live ZMTP publisher (#1497)" "$zv"; fi
     if zv=$(zmq_publishes_probe "$zmq_host" "$zmq_port" 8 90); then it_pass "monero ZMQ endpoint actually publishes, not merely a live socket (#1497)"; else it_fail "monero ZMQ endpoint actually publishes, not merely a live socket (#1497)" "$zv"; fi
     it_skip_leg "monero ZMQ published frame is a BLOCK notification" "tier C (#1497): the row above proves the publisher is not silent, which is the starving-p2pool failure; proving the frame was chain_main rather than txpool_add needs a new block, a wait of minutes against seconds" missing
+    assert_mergemine_roundtrip
     # The dashboard's sync panel must also read "done" for a synced node — not stay stuck at
     # "loading". A synced monerod reports target_height 0, so the panel has to trust the caught-up
     # flag, not percent-vs-target; getting that wrong left a synced node "loading" forever (the real

--- a/tests/integration/selftest-mergemine-probe.sh
+++ b/tests/integration/selftest-mergemine-probe.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# Self-test for the p2pool -> Tari merge-mining round-trip probe (#1397) — the verdicts and the
+# leg's three outcomes, driven from CAPTURED log bytes with no stack, no container, no network.
+#
+# The fixtures below were captured on the live stack, 2026-08-30, through the probe's own
+# gesture (`docker compose logs --no-color --since <StartedAt> p2pool | head | grep`), escapes
+# and service prefix intact. They are captured rather than hand-built for the same reason
+# selftest-zmq-probe.sh captures its frames: a hand-built fixture agrees with whatever the
+# author believed, so it cannot fail when the real wire format moves.
+#
+# The case that matters most is the VACUITY control. p2pool's log is ANSI-coloured and the
+# escapes sit MID-LINE, between `MergeMiningClientTari ` and `tari://`. So the pattern anyone
+# would write from reading the rendered log matches nothing at all — silently, and a probe that
+# always says "absent" is indistinguishable from a working one until the day it matters. That
+# control is fired in BOTH directions here: zero matches on the raw bytes, one after stripping.
+#
+# Run: tests/integration/selftest-mergemine-probe.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+# shellcheck source=tests/integration/mergemine-probe.sh
+source "$HERE/mergemine-probe.sh"
+
+# --- CAPTURED fixtures ------------------------------------------------------
+# The chain_id is Tari's mainnet chain identifier, a public constant, and the address is the
+# loopback literal p2pool's entrypoint rewrites to under Tor (#278). Neither is a secret.
+MM_CHAIN_ID=01f0cf665bd4cd31cbb2b2470236389c483522b350335e10a4a5dca34cb85990
+MM_LOCAL_1=$(printf 'p2pool  | \x1b[0;36m2026-08-28 23:52:23.3889\x1b[0m \x1b[0;90mMergeMiningClientTari \x1b[0mevent loop started\x1b[0m')
+MM_LOCAL_2=$(printf 'p2pool  | \x1b[0;36m2026-08-28 23:52:23.3899\x1b[0m \x1b[0;90mMergeMiningClientTari \x1b[0mworker thread ready\x1b[0m')
+MM_ROUNDTRIP=$(printf 'p2pool  | \x1b[0;36m2026-08-28 23:52:23.5636\x1b[0m \x1b[0;90mMergeMiningClientTari \x1b[0mtari://127.0.0.1:18142 uses chain_id \x1b[0;96m%s\x1b[0m' "$MM_CHAIN_ID")
+
+MM_FULL="$MM_LOCAL_1
+$MM_LOCAL_2
+$MM_ROUNDTRIP"
+MM_LOCAL_ONLY="$MM_LOCAL_1
+$MM_LOCAL_2"
+
+echo "== the ANSI escapes are real, and stripping them is load-bearing (#1397) =="
+
+# NEGATIVE control. This is the pattern a reader of the rendered log writes, and on the real
+# bytes it matches NOTHING. If this case ever passes with a non-zero count, the log has stopped
+# being coloured and the strip has become optional — worth knowing, and not silently.
+assert_eq "the naive pattern matches ZERO on the raw captured line" \
+    "$(printf '%s\n' "$MM_ROUNDTRIP" | grep -ac 'MergeMiningClientTari tari://')" "0"
+# POSITIVE control on the same bytes: the only thing that changed is the strip.
+assert_eq "the same pattern matches ONCE after stripping" \
+    "$(printf '%s\n' "$MM_ROUNDTRIP" | mm_strip_ansi | grep -ac 'MergeMiningClientTari tari://')" "1"
+# The strip must not eat payload — the chain_id has to survive it intact.
+assert_contains "the chain_id survives the strip" \
+    "$(printf '%s\n' "$MM_ROUNDTRIP" | mm_strip_ansi)" "uses chain_id $MM_CHAIN_ID"
+assert_eq "the strip leaves no ESC byte behind" \
+    "$(printf '%s\n' "$MM_FULL" | mm_strip_ansi | grep -ac "$(printf '\033')")" "0"
+
+echo "== the verdict separates a gRPC round-trip from a client that merely started =="
+
+verdict="$(mm_roundtrip_verdict "$MM_FULL")"
+rc=$?
+assert_eq "a full startup capture reads roundtrip with the chain_id" "$verdict" "roundtrip $MM_CHAIN_ID"
+assert_rc "roundtrip returns 0" "$rc" "0"
+
+# THE NARROWNESS CONTROL, and the reason this file exists. The two local lines land ~175 ms
+# BEFORE the chain_id read, so they are present in every capture where Tari is unreachable. A
+# probe keyed on `MergeMiningClientTari` alone would pass here — green while merge-mining is
+# dead, which is the exact false green this harness exists to kill.
+verdict="$(mm_roundtrip_verdict "$MM_LOCAL_ONLY")"
+rc=$?
+assert_eq "the two LOCAL lines alone read local-only, not roundtrip" "$verdict" "local-only"
+assert_rc "local-only returns non-zero" "$rc" "1"
+
+verdict="$(mm_roundtrip_verdict "")"
+rc=$?
+assert_eq "an empty capture reads absent" "$verdict" "absent"
+assert_rc "absent returns non-zero" "$rc" "1"
+assert_eq "unrelated p2pool output reads absent" \
+    "$(mm_roundtrip_verdict 'p2pool  | 2026-08-28 23:52:23.0000 SideChain new chain tip')" "absent"
+
+echo "== near misses that must NOT be read as a round-trip =="
+
+# Each of these differs from the passing fixture in exactly ONE token. A boundary asserted only
+# by the case that passes is not asserted at all.
+mm_near() { mm_roundtrip_verdict "$(printf 'p2pool  | 2026-08-28 23:52:23.5636 MergeMiningClientTari %s\n' "$1")"; }
+assert_eq "a chain_id too short to be one is not a round-trip" \
+    "$(mm_near 'tari://127.0.0.1:18142 uses chain_id 01f0cf')" "local-only"
+assert_eq "a chain_id line with no tari:// endpoint is not a round-trip" \
+    "$(mm_near 'uses chain_id '"$MM_CHAIN_ID")" "local-only"
+assert_eq "a non-hex chain_id is not a round-trip" \
+    "$(mm_near 'tari://127.0.0.1:18142 uses chain_id ZZZZZZZZZZZZZZZZZZZZ')" "local-only"
+assert_eq "an endpoint with no chain_id at all is not a round-trip" \
+    "$(mm_near 'tari://127.0.0.1:18142 connecting')" "local-only"
+# Two startup epochs in one capture — what `docker compose logs` returns if the `--since` bound
+# below ever stops holding. The NEWEST chain_id must win: an old epoch's line standing in for a
+# live client that never reached Tari is the same false green, arriving by a different door.
+MM_OLD_ID=00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+assert_contains "with two startup epochs, the NEWEST chain_id wins" \
+    "$(mm_roundtrip_verdict "$(printf 'p2pool  | MergeMiningClientTari tari://127.0.0.1:18142 uses chain_id %s\n%s\n' "$MM_OLD_ID" "$MM_ROUNDTRIP")")" \
+    "roundtrip $MM_CHAIN_ID"
+
+# And the positive sibling of those four: the unprefixed form, as `docker logs` renders it,
+# must still pass. The probe must not be accidentally keyed on the compose service prefix.
+assert_contains "the unprefixed docker logs form still reads roundtrip" \
+    "$(mm_roundtrip_verdict "${MM_ROUNDTRIP#p2pool  | }")" "roundtrip $MM_CHAIN_ID"
+
+echo "== the capture is bounded to the current container run, and leaks nothing =="
+
+# Stubbing `rx` rather than `mm_capture_startup` is what reaches the two bounds inside it. Both
+# are invisible to a test that stubs the whole function: dropping `--since` or swapping the head
+# window for a tail leaves every other case in this file green, which is exactly how a bound
+# rots. Recording the composed command asserts WHICH command is sent to the target — a claim
+# about the gesture, not about docker's behaviour, and it is named that way below.
+# The recorder writes to a FILE, not a variable. `mm_capture_startup` is called through `$(...)`,
+# and a command substitution is a subshell: a variable assigned inside it is gone by the time the
+# assertion reads it. That is not hypothetical here — it was the first version of this block, and
+# it left the two negative checks below passing over an empty string, which is a vacuous green of
+# exactly the kind this file exists to refuse.
+MM_RX_LOG_FILE="$(mktemp)"
+trap 'rm -f "$MM_RX_LOG_FILE"' EXIT
+rx() {
+    printf '%s\n' "$*" >>"$MM_RX_LOG_FILE"
+    case "$*" in
+    *"docker inspect"*) printf '%s\n' "$MM_RX_STARTED" ;;
+    *) printf '%s\n' "$MM_RX_LOGS" ;;
+    esac
+}
+
+MM_RX_STARTED="2026-08-28T23:52:05.827654553Z"
+MM_RX_LOGS="$MM_FULL"
+: >"$MM_RX_LOG_FILE"
+cap="$(mm_capture_startup)"
+cap_rc=$?
+MM_RX_LOG="$(cat "$MM_RX_LOG_FILE")"
+
+assert_rc "a readable start time makes the capture succeed" "$cap_rc" "0"
+# ARM CHECK, before any assertion reads $MM_RX_LOG. Every check below it — including two phrased
+# as absences — is satisfiable by an empty recording, so an unarmed recorder would report a clean
+# sweep over nothing.
+assert_num_gt "the command recorder actually captured something" "$(printf '%s' "$MM_RX_LOG" | wc -c)" 0
+assert_contains "the log read is bounded by the container's OWN start time" "$MM_RX_LOG" "--since 2026-08-28T23:52:05.827654553Z"
+assert_contains "the window is a HEAD read — the signal is startup-only" "$MM_RX_LOG" "head -n 2000"
+# The negative sibling. A tail cannot contain a line that lands 17.5s into an hours-old log, and
+# the swap is silent: every fixture case above stays green through it.
+case "$MM_RX_LOG" in
+*--tail*) it_fail "the window is never a tail read" "the composed command asked for a tail" ;;
+*) it_pass "the window is never a tail read" ;;
+esac
+# Leak safety, as a checked claim rather than a comment: the filter runs ON THE TARGET, so the
+# argv line — which carries both wallets, the RPC credential and the onion (#1582/#1585/#1586) —
+# is never transferred. And `docker inspect` names ONE field, so it cannot print .Args.
+assert_contains "only merge-mining lines are asked to cross the wire" "$MM_RX_LOG" "grep -a MergeMiningClientTari"
+assert_contains "docker inspect names a single field, never the whole object" "$MM_RX_LOG" "--format '{{.State.StartedAt}}'"
+# End to end through the real capture: canned log bytes in, verdict out.
+assert_contains "a captured startup window reads roundtrip end to end" "$(mm_roundtrip_verdict "$cap")" "roundtrip $MM_CHAIN_ID"
+
+# An unreadable start time must refuse rather than read an unbounded log.
+MM_RX_STARTED=""
+: >"$MM_RX_LOG_FILE"
+mm_capture_startup >/dev/null 2>&1
+assert_rc "an unreadable start time refuses the capture" "$?" "1"
+MM_RX_LOG="$(cat "$MM_RX_LOG_FILE")"
+assert_num_gt "the recorder saw the inspect call it did make" "$(printf '%s' "$MM_RX_LOG" | wc -c)" 0
+case "$MM_RX_LOG" in
+*"compose logs"*) it_fail "no log is read when the start time is unknown" "it read the log anyway" ;;
+*) it_pass "no log is read when the start time is unknown" ;;
+esac
+unset -f rx
+
+echo "== the leg reports PASS, FAIL or a COUNTED skip — never a silent green =="
+
+# The leg is driven with its two collaborators stubbed, so all three outcomes are reachable
+# without a stack. Stubbing is what makes the skip path testable at all: on the boxes this
+# harness runs on monerod IS synced, so that branch would otherwise never be exercised here.
+monero_caught_up() { return "$MM_STUB_SYNCED"; }
+# The sentinel matters. `mm_capture_startup` has TWO distinct empty outcomes in production and
+# the leg treats them differently: it returns non-zero when the container's start time cannot be
+# read at all, and returns ZERO with empty output when the log simply held no MergeMiningClientTari
+# line (its `grep` is `|| true`). A stub keyed only on emptiness collapses them, and the case
+# named for the second silently exercises the first — which is how the `absent` branch survived a
+# mutation to `it_pass` here.
+mm_capture_startup() {
+    [ "$MM_STUB_CAPTURE" = "@FAIL" ] && return 1
+    printf '%s' "$MM_STUB_CAPTURE"
+}
+
+# Run the leg in a SUBSHELL with the harness counters zeroed, and report them as a line. Three
+# of the four cases below provoke a leg FAILURE on purpose; left in this file's own totals they
+# would make a working self-test report red, which is how a suite learns to be read past.
+mm_leg_outcome() { # <synced-rc> <capture> -> "<pass> <fail> <skipped-legs> <by-design> <names>"
+    (
+        MM_STUB_SYNCED="$1"
+        MM_STUB_CAPTURE="$2"
+        IT_PASS=0 IT_FAIL=0 IT_SKIPPED_LEGS=0 IT_SKIPPED_BY_DESIGN=0 IT_SKIPPED_MISSING=0 IT_SKIPPED_NAMES=""
+        assert_mergemine_roundtrip >/dev/null 2>&1
+        printf '%s %s %s %s %s\n' "$IT_PASS" "$IT_FAIL" "$IT_SKIPPED_LEGS" "$IT_SKIPPED_BY_DESIGN" "$IT_SKIPPED_NAMES"
+    )
+}
+
+out="$(mm_leg_outcome 1 "")"
+assert_eq "an unsynced monerod skips the leg — 0 pass, 0 fail, 1 counted skip" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 0 1"
+assert_eq "and the skip is classed by-design, not missing" "$(printf '%s' "$out" | cut -d' ' -f4)" "1"
+assert_contains "and the skip names itself and #1397" "$out" "#1397"
+
+out="$(mm_leg_outcome 0 "$MM_FULL")"
+assert_eq "a synced node with a chain_id line PASSES — 1 pass, 0 fail, 0 skips" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "1 0 0"
+
+out="$(mm_leg_outcome 0 "$MM_LOCAL_ONLY")"
+assert_eq "a client that never read a chain_id FAILS — 0 pass, 1 fail, 0 skips" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
+
+# The startup window read cleanly and held no merge-mining line at all: p2pool never built the
+# client. That is a FAILURE, never a skip — a skip would announce a hole that is really a dead
+# merge-mining leg.
+out="$(mm_leg_outcome 0 "")"
+assert_eq "no merge-mining client at all FAILS, and is never a skip — 0 pass, 1 fail, 0 skips" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
+
+# Its sibling, and the reason the two must not share a case: an unreadable container start time
+# is a different failure with a different cause, and it must not be able to stand in for the one
+# above.
+out="$(mm_leg_outcome 0 "@FAIL")"
+assert_eq "an unreadable container start time FAILS separately — 0 pass, 1 fail, 0 skips" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
+
+echo ""
+echo "selftest-mergemine-probe: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1397 by building its **option 1** — the release gate asserting p2pool's merge-mining gRPC
against the real synced box it already runs on.

## What was uncovered

The merge-mining leg is driven entirely by p2pool, a third-party binary, not by any client we
wrote. `fakes/test_contract.py` looks like it covers this and does not: it drives the *dashboard's*
Tari client. So a gRPC method moving behind an allow-list — the named risk on the Tari v5.6.0 bump,
and the shape of #313 — would have landed with every gate green.

## Why option 1 and not option 2

#1397 offered "drive p2pool's merge-mining client against a controllable fake" as the cheaper half.
Measured at p2pool v4.18's source (cycle 40, on the issue): there is exactly one creation site for
merge-mining clients, inside the success callback of `download_block_headers4`, after
`BLOCK_HEADERS_REQUIRED = 720` headers parse. A fake would have to serve 720 consecutive,
self-consistent Monero block headers plus a live ZMQ publisher before the Tari fake is reached at
all. That does not escape the sync problem; it re-implements a synced monerod.

## What proves a round-trip, and what only looks like one

p2pool emits three lines. Two are local and prove only that the object was constructed:

- `MergeMiningClientTari event loop started`
- `MergeMiningClientTari worker thread ready`

The third is the assertion, because p2pool cannot know the chain id without a successful call:

- `MergeMiningClientTari tari://<host:port> uses chain_id <id>`

Measured on the live stack, the two local lines land ~175 ms **before** the chain-id read — so a
check keyed on either would pass with Tari unreachable. That case is its own verdict, `local-only`,
and it **fails**: it means the client is up and Tari is not answering.

## Two measurements that changed the patch

**The log is ANSI-coloured and the escapes sit mid-line.** `cat -v` on the live stack shows an SGR
reset between `MergeMiningClientTari ` and `tari://`. `docker compose logs --no-color` suppresses
docker's colouring, not the application's, so the pattern anyone would write from reading the
rendered log matches **nothing** — silently. The self-test carries that control fired both ways:
0 matches on the captured bytes, 1 after stripping.

**The signal is startup-only.** The three lines landed within ~17.5 s of container start, at
positions 68/69/71 of a log that reached 83,070 lines in 30 h (one sample). A `--tail` read cannot
contain them, so the window is a head read bounded by the container's own `StartedAt` — which also
stops an earlier startup's line satisfying the assertion after a restart.

## Honest skip

When monerod is not caught up the leg **skips**, counted and classed `by-design`: p2pool constructs
the client only after the header download succeeds, so no input to this harness would create the
signal. Never a silent green.

## What was run

- `selftest-mergemine-probe.sh` — 35 assertions, green. Fixtures are **captured** from the live
  stack through the probe's own gesture, not hand-built.
- **Mutation battery, 13 legs, each `cmp`-proven to have changed the file and `bash -n`-checked so
  a red cannot come from a syntax error.** All 13 red, each naming the targeted assertion. Two
  earlier legs *survived* and are why the self-test stubs `rx` rather than the capture function;
  one more survivor exposed a case that was passing off a different branch than its name claimed.
- **Live, read-only, against the deployed stack:** the leg passes on real bytes, and a controlled
  pair over those same bytes drops to `local-only` when the chain-id line is removed.
- `make test-integration-selftest` (whole suite), `shellcheck 0.11.0` + `shfmt -i 4 -d` over
  `tests/integration/*.sh`, `lint-file-budget`, `tests/inventory.sh`, `lint-md`, `lint-docs-voice`
  — all green.

## Disclosures

- `docs/` is in `_shared.paths`: this PR touches `docs/dev/integration-testing.md` and
  `docs/dev/testing-strategy.md`. No `.lane-override`; every other file is `tests/integration/`.
- `run.sh` lands **exactly on** its recorded ceiling of 2551. The three lines are the source
  directive, the `source`, and the call — which is why the call site carries no comment and the
  rationale lives in the probe's header.
- The tier-4 row is marked "run against the live stack read-only, **not yet inside a full gate
  run**". The leg has not executed within `run.sh` end to end.
- `MM_WINDOW_LINES=2000` rests on **one sample** of the line positions. If p2pool ever logs more
  before constructing the client, this fails rather than skipping.
- Not fixed here, and filed separately: `tests/inventory.sh`'s source-agreement gate reads
  `tests/stack/run.sh` only, so `tests/integration/run.sh`'s six `source` lines — now seven — have
  no equivalent check.
