### PR TITLE
fix(dashboard): #1556 slice 4 — annotate the config/ singletons

### DIFF
--- a/dashboard/mining_dashboard/config/config.py
+++ b/dashboard/mining_dashboard/config/config.py
@@ -44,7 +44,7 @@ LOW_RAM_LOCAL_TARI_GB = 6
 LOW_RAM_LOCAL_MINER_GB = 3
 
 
-def local_miner_enabled(path=None):
+def local_miner_enabled(path=None) -> bool:
     """Whether this box runs the built-in RigForge miner (config.json: local_miner.enabled),
     read live off the same read-only masked-config mount as the worker descriptors below — no
     env plumb, and a dashboard toggle moves the floor without a container restart. A missing or

--- a/dashboard/mining_dashboard/config/worker_endpoints.py
+++ b/dashboard/mining_dashboard/config/worker_endpoints.py
@@ -42,7 +42,7 @@ def _valid_watts(v):
     return v if isinstance(v, (int, float)) and not isinstance(v, bool) and 0 < v < 1e6 else None
 
 
-def load_worker_endpoints(path):
+def load_worker_endpoints(path) -> list[dict]:
     """The validated workers.list[] entries (#506); invalid entries dropped, first name wins.
 
     dashboard.workers[] (#172) is read as a deprecated fallback when workers.list is unset or an

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -50,10 +50,15 @@ import pytest
 from tests.service.annotation_gate import classify, classify_package
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 12 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 14 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
-# the six single-function `client/` modules by slice 2, and the four single-function `web/` modules
-# by slice 3.
+# the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
+# slice 3, and the two single-function `config/` modules by slice 4.
+#
+# Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
+# written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
+# (`local_miner_enabled` returning `False`). A slice is coverage of the mechanism, so a slice whose
+# two functions both decline to be signable has done its whole job.
 #
 # Slice 2 wrote here that "no module under `client/` holds an unannotated failure return any more".
 # That is TRUE under `_failure_returns`' definition and it READS as "`client/` is done, never look
@@ -75,6 +80,8 @@ PINNED = (
     "client/tari/tari_wallet_client.py",
     "client/xmrig_client.py",
     "client/xvb_client.py",
+    "config/config.py",
+    "config/worker_endpoints.py",
     "service/worker_config_store.py",
     "web/charts.py",
     "web/infra_views.py",
@@ -97,6 +104,8 @@ _ANCHORS = {
     ),
     "client/xmrig_client.py": "client/xmrig_client.py:_safe_probe_host",
     "client/xvb_client.py": "client/xvb_client.py:get_stats",
+    "config/config.py": "config/config.py:local_miner_enabled",
+    "config/worker_endpoints.py": "config/worker_endpoints.py:load_worker_endpoints",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
     "web/charts.py": "web/charts.py:parse_window",
     "web/infra_views.py": "web/infra_views.py:_ip_to_sort_int",
@@ -124,9 +133,24 @@ _ANCHORS = {
 # not happen", which is what both False paths mean, so there is no out-of-band case to declare.
 # Annotating it `-> bool | None` to reach `signed` would be inventing a return the function never
 # makes — the reason this list exists is to say the gate declines, not to manufacture a verdict.
+#
+# `config/config.py:local_miner_enabled` (slice 4) is the third, and the first member that is NOT
+# an outbound sender — so it deliberately does not lean on the grounds `annotation_gate._EMPTY`
+# records. Those grounds name five senders, and it is worth knowing what they are a sample OF:
+# measured at `b0a32bd`, the tip that comment was written against, TWELVE functions already held a
+# `False` failure return and this was one of them, unannotated. The five were a subset somebody
+# read, never the whole population, so no later member may be waved through by that class — each
+# is read on its own terms, which is what this list is. It returns False when
+# the masked-config mount is missing or unreadable, and its docstring argues the choice outright:
+# DIY stacks without the mount never run the built-in miner. Its sole production caller is
+# arithmetic — `config.py:low_ram_floor_gb` does `+ (LOW_RAM_LOCAL_MINER_GB if
+# local_miner_enabled() else 0)` — so there is no third branch for an out-of-band answer to reach,
+# and False-on-failure and False-because-no-miner move the RAM floor by exactly the same amount.
+# `-> bool | None` would invent a return the function never makes.
 _UNJUDGED_AND_READ = frozenset(
     {
         "client/docker/docker_control.py:_post",
+        "config/config.py:local_miner_enabled",
         "service/worker_config_store.py:worker_config_change_known",
     }
 )


### PR DESCRIPTION
## What this is

Slice 4 of #1556 — the two `config/` modules that each hold exactly one unannotated failure
return. With this in, 14 of the 33 modules that hold a failure return at all are pinned.

| function | annotation | verdict | predicted before writing? |
|---|---|---|---|
| `config/config.py:local_miner_enabled` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `config/worker_endpoints.py:load_worker_endpoints` | `-> list[dict]` | `collapse` (`[]`) | yes — matched |

Both verdicts were written down before either annotation was applied, and both matched.

## ZERO signed is the CORRECT outcome here

Say it plainly so it does not read as a slice that underdelivered: `config/` adds **nothing** to
`signed`, and the tail recon predicted that before this branch existed. One of the two functions
is a genuine collapse the gate now flags by name; the other is a residual the gate declines to
rule on. A slice is coverage of the mechanism, never a verdict quota.

## The numbers, and the reconciliation

Measured at `0351ca2` before, and at this head after:

| verdict | before | after |
|---|---|---|
| signed | 17 | **17 (unchanged)** |
| half_fix | 0 | 0 |
| collapse | 13 | 14 |
| blind | 42 | 40 |
| unjudged | 2 | 3 |
| procedure | 3 | 3 |

`-2 blind == +1 collapse +1 unjudged` holds exactly. `PINNED` and `_ANCHORS` both go 12 -> 14.

## `_UNJUDGED_AND_READ` goes 2 -> 3, and the reading is written out

`local_miner_enabled` returns `False` when the read-only masked-config mount is missing or
unreadable, and its docstring argues that outright: DIY stacks without the mount never run the
built-in miner. Its sole production caller is arithmetic — `config.py:low_ram_floor_gb` does
`+ (LOW_RAM_LOCAL_MINER_GB if local_miner_enabled() else 0)` — so there is no third branch for an
out-of-band answer to reach, and both meanings of `False` move the RAM floor by the same amount.
`-> bool | None` would invent a return the function never makes.

**It is the first member of that set that is not an outbound sender**, so it deliberately does not
lean on the grounds `annotation_gate._EMPTY` records. Those grounds name five senders — and it is
worth knowing what they are a sample OF. Measured by me at `b0a32bd`, the tip that comment was
written against: **twelve** functions already held a `False` failure return there, and
`local_miner_enabled` was one of them, unannotated. So the five were a subset somebody read, never
the whole population, and no later member may be waved through by that class. That fact is now
recorded in the entry with its sha rather than left to be re-derived.

**This does not falsify anything already in the tree.** The population was 12 then and is 12 now,
so `_EMPTY`'s comment and `test_collapsed_return_channels.py`'s sibling docstring are both left
alone deliberately — they describe the five they selected, not the twelve they selected from.

## Controls — each caught BY NODE ID, with the sibling law GREEN

Never a suite colour. Each control was restored by sha256 and the restore verified by content.

| control | law that must RED | sibling law | result |
|---|---|---|---|
| UNANNOTATE `local_miner_enabled` | law 1 `[config/config.py]` | law 2 GREEN | fired |
| UNANNOTATE `load_worker_endpoints` | law 1 `[config/worker_endpoints.py]` | law 2 GREEN | fired |
| DROP the new `_UNJUDGED_AND_READ` entry | law 2 `[config/config.py]` | law 1 GREEN | fired |

The third control's first arming readback was **blind** and I am naming it: my grep for the entry
was unanchored, and the same string also sits in `_ANCHORS`, so it matched a different site and
proved nothing. Re-armed with a readback that discriminates — the `_UNJUDGED_AND_READ` site went
1 -> 0 while the `_ANCHORS` site held at 1 and the frozenset went 3 -> 2 — and only then was the
red trusted.

## The gate-invisible residue for `config/`, measured rather than assumed

Slice 3 proved the scoped clause generalises by measuring it, so this slice measured too rather
than inheriting the conclusion.

The finder is positive-controlled against **two** independently recorded figures before any new
number was read off it: it reproduces `client/`'s **14 unannotated functions** exactly, and slice
3's **25 returns / 22 in unannotated functions** over the four `web/` modules it pinned, exactly.

For `config/`: **1** collapse-shaped return outside the gate's two doors, in **0** unannotated
functions. It is `load_worker_endpoints:69` — `if not isinstance(raw, list): return []` — which
sits inside a function this slice annotated and read. So `config/` is the first slice whose prefix
carries no unannotated gate-invisible residue at all, against `client/`'s 14 and `web/`'s 16.

**Named, not fixed:** that line-69 return is arguably the same collapse as the one at line 57 — a
malformed `workers.list` yields `[]`, which no caller can tell from "no workers configured". It is
outside both doors, so the gate cannot see it. #1556 slices are annotation-only and fixing it would
change behaviour, so it is recorded here for a follow-up rather than touched.

## What I did NOT do

- I did not fix the line-69 return above, and I did not edit `_EMPTY` or its sibling docstring.
- I did not classify the 9 remaining unannotated `False`-returners across the package.
- No `security-reviewer` pass: both edits are return annotations proven byte-identical in the
  compiled function bodies (below), so there is no behaviour for a security lens to review.
- No doc change is owed — `docs/dashboard.md` describes this mechanism without enumerating the
  pinned modules, so nothing there went stale. Swept mechanically, whole repo, not just `docs/`.

## What was RUN

- Full dashboard suite: **2312 passed** (no `-q` on the command line, so the summary is real).
- `ruff check` + `ruff format --check`: clean.
- File-budget gate: OK. `config.py` stays at **exactly 717 lines against its 717 ceiling** — both
  annotations are in-place edits. `test_annotation_coverage.py` is 358, under the 400 target, so it
  takes **no** budget row. `test_collapsed_return_channels.py` was not touched.
- `make lint-docs-voice`: OK.
- Patch coverage read from `coverage.xml` (source `dashboard/mining_dashboard`), executable-line
  total asserted > 0 — **6950** lines, so not vacuous: **2 of 2** changed production lines covered,
  100%. Overall line-rate 97.15%.
- Behaviour-inertness: recursive `co_code`/`co_names`/`co_varnames`/`co_consts` compare of both
  function bodies, base vs head — **identical**. Never a repr, which carries the object address.
  The comparator was fired on a positive control FIRST: a seeded `return False` -> `return True`
  scored not-identical while its untouched sibling stayed identical, so it discriminates per
  function rather than per file.

Refs #1556.
