### PR TITLE
fix(integration): redact JSON secret keys in ANY case, and state the two shapes measured absent (#1590)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -68,7 +68,8 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
   a v3 onion; and any opaque run of 90 or more characters, which is what catches wallet addresses
   (and a sha512 with them); and a JSON `"key": "value"` whose key ends in one of a list of secret
-  words — `password`, `token`, `key`, `username`, `wallet` and the rest.
+  words — `password`, `token`, `key`, `username`, `wallet` and the rest, matched without regard to
+  case, so `apiKey` and `PASSWORD` are reached alongside `api_key`.
   [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582) closed the flag-value and
   address-shape gaps; [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587) added
   the JSON one. **That last rule is keyed on the field NAME, not the value, and that is forced**:
@@ -76,7 +77,14 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   them. **The name list is open, and one field is still out of reach** — `notifications.ntfy.url`
   is a capability URL whose key is the bare word `url`, which only its nesting separates from the
   public `xvb.url`, and a line-wise filter cannot see nesting. The self-test states that gap
-  rather than hiding it.
+  rather than hiding it. **Two further JSON shapes are stated rather than closed**
+  ([#1590](https://github.com/p2pool-starter-stack/pithead/issues/1590)): a JSON payload logged as
+  an escaped string inside another field (`"msg":"{\"password\":\"…\"}"`), and a secret whose
+  value is not a string (`"api_token":12345678`). Both were measured absent from every artifact
+  the harness captures — the container logs contribute JSON from one service only, Caddy, and not
+  one of its keys is secret-named in any case — and the one-character fix for the second replaces
+  the value's trailing delimiter along with the value, so it corrupts the JSON it is meant to
+  protect. The self-test pins both at today's behaviour, so a row fails if either shape arrives.
 - Continue-on-error. A failing assertion doesn't abort the run. The whole matrix is collected
   and summarized, with per-scenario artifacts for the failures.
 
@@ -683,7 +691,8 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
 `selftest-redact.sh` covers the shapes the redactor used to miss — a credential passed as a flag
-value, and secrets in JSON — and asserts in each case that the *raw* value is gone rather than
+value, and secrets in JSON under a key of any case — and asserts in each case that the *raw* value
+is gone rather than
 that a `<redacted>` marker appeared, since a marker can come from some other field on the same
 line. Its JSON population is derived from `config.reference.json` rather than listed in the file,
 under a screen deliberately wider than the redactor's own list, so a sensitive field added to the

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -34,13 +34,13 @@ it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
 # Redact before anything reaches a log or the terminal. Three shapes: KEY=value / --flag value by
-# NAME, an opaque run >=90 chars by SHAPE, and JSON "key": "value" by the key's SUFFIX (#1587).
-# THE SUFFIX LIST IS OPEN — add the spelling you meet; a closed enumeration is what opened #1582.
-# Nesting is invisible line-wise, so a bare "url" key is unreachable: ntfy's is secret, xvb's is not.
+# NAME, an opaque run >=90 chars by SHAPE, and JSON "key": "value" by the key's SUFFIX (#1587),
+# matched CASE-INSENSITIVELY (#1590) — add new SPELLINGS, never case variants. THE LIST IS OPEN;
+# a closed one opened #1582. Nesting is invisible line-wise: ntfy's bare "url" is secret, xvb's not.
 redact() {
     sed -E \
         -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g' \
-        -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/g; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
+        -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/gI; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
 }
 
 # --- Assertions -------------------------------------------------------------

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -193,5 +193,40 @@ OUT="$(printf '{"username":"%s","mode":"local","view_key":"%s","port":18081}\n' 
 case "$OUT" in *"$SENTINEL"*) it_fail "compact JSON: both secrets on one line" "value survived: $OUT" ;; *) it_pass "compact JSON: both secrets on one line" ;; esac
 assert_contains "compact JSON: non-secret neighbours survive" "$OUT" '"mode":"local"'
 
+echo "== redact: the JSON name rule is CASE-INSENSITIVE (#1590) =="
+# The suffix alternation shipped lowercase-only, so `apiKey`, `PASSWORD` and `Api_Token` were all
+# unreachable — and redact()'s own comment ("add the spelling you meet") could NOT fix it: the
+# failure is CASE, not spelling, so a contributor following that instruction adds more lowercase
+# entries and still misses every camelCase key. `config.reference.json` is snake_case throughout,
+# so the schema-derived population above cannot exercise this either. Hence explicit cases.
+OUT="$(printf '{"apiKey":"%s","authToken":"%s","viewKey":"%s","PASSWORD":"%s","Api_Token":"%s"}\n' \
+    "$SENTINEL" "$SENTINEL" "$SENTINEL" "$SENTINEL" "$SENTINEL" | redact)"
+case "$OUT" in *"$SENTINEL"*) it_fail "camelCase and UPPERCASE secret keys redact" "value survived: $OUT" ;; *) it_pass "camelCase and UPPERCASE secret keys redact" ;; esac
+
+# The other direction — the one the case widening could break. A non-secret key must not start
+# redacting merely because a service spelled it in a different case. These are the MUST_SURVIVE
+# fields above, in casings a service could plausibly emit; each would be a debugging value lost.
+OUT="$(printf '{"URL":"https://xvb.example","Api_Auth":"token","Chat_Id":"12345","Mode":"local"}\n' | redact)"
+assert_contains "case widening keeps a non-secret URL" "$OUT" '"URL":"https://xvb.example"'
+assert_contains "case widening keeps an auth MODE string" "$OUT" '"Api_Auth":"token"'
+assert_contains "case widening keeps a routing id" "$OUT" '"Chat_Id":"12345"'
+
+echo "== redact: the two JSON shapes #1590 MEASURED and did not close =="
+# Recorded at CURRENT behaviour with a label that cannot be misread as approval — the KNOWN_GAP
+# convention above. Both were measured absent from every artifact `capture_artifacts` puts through
+# redact() before the decision not to build them: ~48,400 JSON keys across the live container-log
+# corpus (48 distinct; a PER-CONTAINER partition puts every one in caddy, the only service here
+# that logs JSON — the other nine contribute exactly zero), 16,107 in a live `api-state.json`, 62
+# in a deployed `config.json`, and two archived bundles. The log corpus is live, so those two
+# counts are a snapshot and moved between captures; the distinct-key set did not. Not
+# one key in any of them carries a secret suffix in ANY casing, escaped or with a non-string value.
+# Fixing an unreachable shape that never occurs is cost with no benefit; if one ever occurs, these
+# two rows fail and say which shape arrived.
+OUT="$(printf '{"msg":"{\\"password\\":\\"%s\\"}"}\n' "$SENTINEL" | redact)"
+assert_contains "KNOWN GAP (#1590) — JSON escaped inside a log string is NOT reached" "$OUT" "$SENTINEL"
+OUT="$(printf '{"api_token":12345678,"password":null}\n' | redact)"
+assert_contains "KNOWN GAP (#1590) — a non-string secret value is NOT reached" "$OUT" "12345678"
+it_warn "KNOWN GAPS (#1590): escaped-JSON and non-string values are unreachable by the name rule — measured absent from every captured artifact, not fixed"
+
 echo "selftest-redact: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #1590 (by hand — `Closes` does not fire on this repo's `develop-v2` base).

#1590 named three JSON shapes `redact()`'s #1587 name rule cannot reach. Its own step 1 was a
**measurement**, so that came first: which of the three actually occur in the artifacts
`capture_artifacts` puts through `redact()`?

## What I measured (read-only, live stack plus two archived bundles)

| Population | JSON keys | distinct | shapes 1/2/3 found |
|---|---|---|---|
| container logs, `--tail 200`/service — the real capture window | 2,600 | 13 | 0 / 0 / 0 |
| container logs, `--tail 5000`/service | ~48,400 | 48 | 0 / 0 / 0 |
| live `api-state.json` | 16,107 | 243 | 0 / 0 / 0 |
| deployed `config.json` | 62 | 51 | 0 / 0 / 0 |
| two archived bundle `api-state.json` artifacts | 677 + 16,145 | 222 + 263 | 0 / 0 / 0 |

The scanner fired on all four buckets first, against the issue's own verbatim crafted inputs, and
a completeness control showed its key charset drops nothing: a deliberately loose
`"<anything>"\s*:` pattern returns byte-identical counts on every population.

**This corrects the issue's stated premise.** Container logs do not carry arbitrary
service-authored JSON here — a per-container partition puts every JSON key in the entire log
corpus in one service, Caddy (48,683 keys / 48 distinct), with the other nine contributing
**exactly zero**, and not one of Caddy's keys is secret-named in any casing. The log corpus is
live, so its totals are a snapshot and moved between captures; the distinct-key set did not. The name rule's real population is the two **pinned** artifacts, `config.json` and
`api-state.json`, whose shapes the schema and the dashboard API fix.

## What this ships

**Case** — the one shape whose argument does not rest on occurrence. The suffix alternation was
lowercase-only, and `redact()`'s own comment ("add the spelling you meet") **cannot** fix it: the
failure is case, not spelling, so a contributor following that instruction adds more lowercase
entries and still misses every `camelCase` key. `config.reference.json` is snake_case throughout,
so the schema-derived self-test population could not exercise it either. One `I` flag on one
existing `s///` — line-neutral against `lib.sh`'s 692/692 ceiling.

## What this does NOT ship, and why

Escaped-JSON (`"msg":"{\"password\":\"…\"}"`) and non-string values (`"api_token":12345678`).
Both are measured absent above, and the one-character fix for the non-string shape replaces the
value's trailing **delimiter** along with the value:

    {"api_token":<redacted>"mode":"local","port":18081}

— malformed JSON, in an artifact people read with `jq`. It corrupts what it is meant to protect.
Both shapes are pinned at today's behaviour under a `KNOWN GAP` label, so a row fails and names
the shape if either ever arrives.

## Proof the new rows can fail

Four mutations, each `cmp`-verified as landed before counting, each restored byte-identically:

| Mutation | Rows that red |
|---|---|
| drop the `I` | the case row |
| widen the suffixes with `url\|auth\|_id` | all three over-redaction rows (+5 pre-existing) |
| make all three quotes escape-tolerant | the escaped-JSON gap row |
| make the value's opening quote optional | the non-string gap row |

A first mutation attempt un-escaped only the *leading* quote and moved nothing — recorded here
because it landed cleanly and would have read as a vacuous row had I stopped there.

A **before/after pair**, both legs live against `origin/develop-v2`'s `lib.sh`, confirms the fix
moves only what it claims: shape 1 leaks before and is redacted after, while shapes 2 and 3 and
every must-survive field are byte-identical across both legs.

## Verification run

- `selftest-redact` 39 → 45 rows.
- `make test-integration-selftest`: 14 self-test files, all green, `selftest-redact: 45 passed, 0 failed`.
- `shellcheck --severity=warning` over `tests/integration/*.sh tests/integration/mini-stack/*.sh`
  (contains both changed shell files) — rc 0.
- `shfmt -i 4 -d` over the Makefile's exact glob — rc 0.
- `make lint-md` 0 errors; `make lint-docs-voice` OK; `make lint-file-budget` OK.
- Not run: the full `make lint-sh` (this box's OOM path, serialized) — substituted as above.
  No bench, no rig lock, no live-stack mutation; every measurement was read-only.

## Lane disclosure

`docs/dev/integration-testing.md` is a `docs/` change via `_shared.paths` — **no
`.lane-override`**. The redactor's coverage paragraph now states the case rule and both stated
gaps, so the doc cannot tell a reader the list is closed. That paragraph is the one #1584's
review blocked on, one revision earlier.

## An adjacent gap I checked and killed

The `KEY=value` rule is uppercase-only (`.*_PASSWORD` / `.*_TOKEN` / `.*_SECRET`), which is
shape 1's exact mirror in a different rule. It is **not** reachable: the deployed `.env` has 129
keys and none is anything but all-uppercase, and that file is *generated* by `pithead` from
`config.json`, so its casing is ours rather than a service's. Measured rather than filed.

## Over-engineering review, run off disk on this diff

**Acted on.** "Every JSON key comes from Caddy" was an **inference, not a measurement** — I had
concatenated all ten containers' logs into one file before scanning, so the partition was never
taken. Re-measured per container: Caddy 48,683 keys / 48 distinct, the other nine exactly zero.
The claim survived, and the test comment and this body now say it was measured that way.

**Declined — three survival rows could collapse into one.** `URL`, `Api_Auth` and `Chat_Id` could
be a single "the line is unchanged" assertion, which would be strictly stronger. Declined because
the file already keeps one named row per field (`xvb.url survives redaction`, and two more), and
a collapsed row fails without naming which field the widening ate.

**Declined — the measured figures in the test comment will go stale.** Kept, because they are
what justifies pinning the two shapes instead of fixing them, and the `KNOWN GAP` rows themselves
fail if the population ever changes, which is the corrective. Marked as a live snapshot.

**Considered, no change.** The new block runs about 20 comment lines to 12 of code, which is the
established ratio in this file rather than an excess.
