### PR TITLE
fix(dashboard): #1556 slice 5a — annotate the service/ outbound senders

### DIFF
--- a/dashboard/mining_dashboard/service/healthchecks.py
+++ b/dashboard/mining_dashboard/service/healthchecks.py
@@ -94,7 +94,7 @@ class HealthchecksClient:
             return True
         return (now - self._last_ping) >= self.interval
 
-    def ping(self):
+    def ping(self) -> bool:
         """Send one liveness heartbeat if due. Never raises.
 
         This is a pure dead-man's switch: it only reports that the stack (this dashboard loop) is

--- a/dashboard/mining_dashboard/service/notify_sinks.py
+++ b/dashboard/mining_dashboard/service/notify_sinks.py
@@ -46,7 +46,7 @@ class _HttpSink:
         """This sink pushes every event kind — enabled is the only gate."""
         return self.enabled
 
-    def _post(self, **kwargs):
+    def _post(self, **kwargs) -> bool:
         if not self.enabled:
             return False
         try:

--- a/dashboard/mining_dashboard/service/telegram_notifier.py
+++ b/dashboard/mining_dashboard/service/telegram_notifier.py
@@ -68,7 +68,7 @@ class TelegramNotifier:
         """True only when the notifier is usable *and* this event kind is toggled on."""
         return self.enabled and bool(self.events.get(event, False))
 
-    def send(self, text, event=""):
+    def send(self, text, event="") -> bool:
         """Push one message. Returns True on a successful 2xx send, False otherwise
         (including when disabled). Never raises. ``event`` is accepted for sink-interface
         parity (#380) and ignored — Telegram gates per-event upstream via event_enabled."""

--- a/dashboard/mining_dashboard/service/tor_heal.py
+++ b/dashboard/mining_dashboard/service/tor_heal.py
@@ -124,7 +124,7 @@ class TorEgressHealer:
             )
 
     @staticmethod
-    def _probe_egress():
+    def _probe_egress() -> bool:
         """One SOCKS request through the tor container; True iff a clearnet exit answered."""
         try:
             bounded_get(

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -50,10 +50,11 @@ import pytest
 from tests.service.annotation_gate import classify, classify_package
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 14 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 18 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
-# slice 3, and the two single-function `config/` modules by slice 4.
+# slice 3, the two single-function `config/` modules by slice 4, and the four outbound senders
+# under `service/` by slice 5a.
 #
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
@@ -82,6 +83,10 @@ PINNED = (
     "client/xvb_client.py",
     "config/config.py",
     "config/worker_endpoints.py",
+    "service/healthchecks.py",
+    "service/notify_sinks.py",
+    "service/telegram_notifier.py",
+    "service/tor_heal.py",
     "service/worker_config_store.py",
     "web/charts.py",
     "web/infra_views.py",
@@ -106,6 +111,10 @@ _ANCHORS = {
     "client/xvb_client.py": "client/xvb_client.py:get_stats",
     "config/config.py": "config/config.py:local_miner_enabled",
     "config/worker_endpoints.py": "config/worker_endpoints.py:load_worker_endpoints",
+    "service/healthchecks.py": "service/healthchecks.py:ping",
+    "service/notify_sinks.py": "service/notify_sinks.py:_post",
+    "service/telegram_notifier.py": "service/telegram_notifier.py:send",
+    "service/tor_heal.py": "service/tor_heal.py:_probe_egress",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
     "web/charts.py": "web/charts.py:parse_window",
     "web/infra_views.py": "web/infra_views.py:_ip_to_sort_int",
@@ -147,10 +156,26 @@ _ANCHORS = {
 # local_miner_enabled() else 0)` — so there is no third branch for an out-of-band answer to reach,
 # and False-on-failure and False-because-no-miner move the RAM floor by exactly the same amount.
 # `-> bool | None` would invent a return the function never makes.
+# Slice 5a adds the four OUTBOUND SENDERS as a group, and the shared argument is precisely why
+# they could be read as one: each returns True only when the send demonstrably landed, and False
+# for every other outcome — disabled, throttled, a non-2xx, or an exception. Every caller acts on
+# "the message did not go out", which is what all of those mean, so there is no out-of-band case
+# to declare and `-> bool | None` would invent a return none of them makes. The grouping has to be
+# EARNED, so each was confirmed to be that shape rather than admitted by it:
+#   `notify_sinks.py:_post`     — False when `not self.enabled`, and on `RequestException`.
+#   `telegram_notifier.py:send` — the same two, and its docstring states the contract outright.
+#   `tor_heal.py:_probe_egress` — True iff a clearnet exit answered, False on `RequestException`.
+#   `healthchecks.py:ping`      — a dead-man's switch, and the only one with TWO `except` handlers,
+#     both returning False. Its docstring already enumerates the False cases (not configured,
+#     throttled, request failed, endpoint rejected) as deliberately one answer.
 _UNJUDGED_AND_READ = frozenset(
     {
         "client/docker/docker_control.py:_post",
         "config/config.py:local_miner_enabled",
+        "service/healthchecks.py:ping",
+        "service/notify_sinks.py:_post",
+        "service/telegram_notifier.py:send",
+        "service/tor_heal.py:_probe_egress",
         "service/worker_config_store.py:worker_config_change_known",
     }
 )


### PR DESCRIPTION
## What this is

Slice 5a of #1556 — the four **outbound senders** under `service/`. Cut from slice 4 (#1598) and
rebased onto `develop-v2` after that merged, replaying only this slice's own commit.

| function | annotation | verdict | predicted before writing? |
|---|---|---|---|
| `service/notify_sinks.py:_post` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `service/telegram_notifier.py:send` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `service/tor_heal.py:_probe_egress` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `service/healthchecks.py:ping` | `-> bool` | `unjudged` (`False`) | yes — matched |

blind **40 -> 36**, unjudged **3 -> 7**, signed **17** and collapse **14** both UNCHANGED.
Reconciliation `-4 blind == +4 unjudged` holds. `PINNED`/`_ANCHORS` **14 -> 18**.

## Why this is a HALF of `service/`, and why the cut is here

`service/` has seven singletons left. Taking them in one slice would move `_UNJUDGED_AND_READ`
from 3 to 9 — the bulk-fill that file's own guard calls "how an exception list becomes a baseline".

Re-derived rather than relayed: the danger the file actually names is admitting entries **because
the gate scored them that way** — six admitted by SHAPE (`-> bool` returning `False`) instead of
six readings. **A split by COUNT would not touch that. A split by ARGUMENT does**, so that is the
cut:

- **5a (this PR) — the four senders.** They are exactly the class `annotation_gate._EMPTY`'s
  comment already argues for (`_post`/`ping`/`send`). Their readings legitimately share ONE
  argument: each returns True only when the send demonstrably landed, and False for every other
  outcome, so every caller acts on "the message did not go out". The grouping still has to be
  earned, so the comment confirms each function IS that shape rather than admitting it by shape.
- **5b (next) — the three that need bespoke arguments.** `egress.py:_sinks_all_private`,
  `steering_projection.py:won_round_live`, `update_checker.py:latest_release` (the one `signed`).

**The reason the cut is there and not elsewhere:** the two non-senders fail in OPPOSITE
directions. `_sinks_all_private` is fail-CLOSED (False = assume public, deny the LAN carve-out);
`won_round_live` is fail-OPEN (False = steer normally, the hold being a yield optimization and
never a safety path). Putting a fail-closed and a fail-open argument in one PR beside four senders
is how a reviewer rubber-stamps five of six.

## Controls — 8 of them, and THREE DID NOT ARM ON THE FIRST RUN

Each pin law shown able to fail on each of the four new modules, caught BY NODE ID with the
sibling law GREEN — never a suite colour. All restored by sha256, restores verified.

| control | law that must RED | sibling | result |
|---|---|---|---|
| UNANNOTATE each of the four | law 1 `[<module>]` | law 2 GREEN | fired, 4/4 |
| DROP each new `_UNJUDGED_AND_READ` entry | law 2 `[<module>]` | law 1 GREEN | fired, 4/4 |

**Naming the near-miss, because it is the whole reason the readbacks exist.** On the first run
three of the eight controls silently did not arm: `notify_sinks.py`'s `**kwargs` made the `sed`
pattern an invalid regex, and all four `_UNJUDGED_AND_READ` drops used `/` as the `sed` delimiter
against paths that contain `/`. Every one of those runs reported the law **passing** — which is
what an unarmed control looks like. They were caught because each readback counts the specific
SITE before and after (`_UNJUDGED_AND_READ` 1 -> 0 while `_ANCHORS` holds at 1), not merely that
the string is present somewhere: these entry names legitimately appear at two sites, so an
unanchored `grep -q` proves nothing about which one moved. Re-armed with `perl` and re-run; the
table above reports only the armed runs.

## Pinning `tor_heal.py` does NOT mean `tor_heal.py` is fully annotated

Measured, not assumed, with the finder positive-controlled against `client/`'s 14 and slice 3's
25/22 in the same run.

Across the four modules this slice pins: **11** collapse-shaped returns sit outside the gate's two
doors, in **5** functions — and **6 of those returns, in 2 functions, are UNANNOTATED**. Both are
in `tor_heal.py`: `decide` (four `None`s) and `check` (two bare `return`s). The gate cannot see
them, so law 1 is satisfied and correctly so, but the module is not "done".

This is the same scoping slice 2 had to write for `client/` and it is worth repeating: **a pin is
coverage of a mechanism, never a certificate about a file.** The three residue returns inside
`ping` itself (`not self.url`, `not self._due(now)`, and the non-2xx path) are exactly the cases
its docstring already enumerates as deliberately one answer, which is what makes its entry honest.

## On #1599 — this slice does NOT widen it

#1599 records that `annotation_gate._EMPTY`'s grounds for excluding `False` ("5 further instances,
all of them outbound senders") were derived from a population defined BY the property asserted
about it. The four functions this slice annotates are that very class, so it is worth being
explicit: **`_EMPTY` is untouched here.** What grows is `_UNJUDGED_AND_READ`, which records
readings and flags nothing.

It does move four functions across the boundary that makes the exclusion *matter*, though —
`False` is only flaggable once a function is ANNOTATED — so this slice enlarges the population
#1599 is about from one to five. That is an argument for fixing #1599 ONCE, deliberately, rather
than letting each slice re-litigate it, and it is why the readings above are per-function.

## What I did NOT do

- I did not annotate `tor_heal.py:decide` / `:check`, or any of the other gate-invisible residue.
- I did not touch the three functions 5b covers, and 5b is not written yet.
- No `security-reviewer` pass: all four edits are return annotations proven byte-identical in the
  compiled function bodies. `telegram_notifier.py` and `notify_sinks.py` both deliberately log the
  exception TYPE only because a `requests` message can embed a URL carrying a token — that
  behaviour is untouched and provably so.
- No doc change is owed; `docs/dashboard.md` describes this mechanism without enumerating pinned
  modules. Swept mechanically over the whole repo, not just `docs/`.

## What was RUN

- Full dashboard suite: **2324 passed** (no `-q` on the command line, so the summary is real).
  Measured before the rebase, and it still stands: `git rev-parse <base>:dashboard` is
  **byte-identical** at the old base and at `develop-v2`, so the program the suite ran did not
  change and no re-run is owed.
- Patch coverage from `coverage.xml`, executable total asserted > 0 (**6950**) AND the matched
  changed-line count asserted > 0: **4 of 4** covered. That second assertion is new — my first run
  of this measurement returned `0/0`, a vacuous pass wearing a green result.
- The two #1556 suites alone: **81 passed**, up 12 from 69 — four new modules x three
  parametrized laws, which is the arithmetic that says the pins are actually live for them.
- `ruff check` + `ruff format --check`: clean.
- File-budget gate: none of the four production files takes a budget row and all four edits are
  in-place, so every line count is unchanged. `test_annotation_coverage.py` is **383**, under the
  400 target, so it takes no row. `test_collapsed_return_channels.py` was not touched.
- Behaviour-inertness: recursive `co_code`/`co_names`/`co_varnames`/`co_consts` compare of all four
  bodies against slice 4's head — **identical**, never a repr. Comparator fired on a positive control
  first: a seeded `return False` -> `return True` in `_post` scored not-identical while its three
  siblings stayed identical, so it discriminates per function, not per file.

Refs #1556.
