### PR TITLE
fix(dashboard): #1556 slice 5b — the service/ singletons that need bespoke readings

### DIFF
--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -74,7 +74,7 @@ def _xvb_standby_route(source):
     return LOCAL if (ip.is_private or ip.is_loopback or ip.is_link_local) else TOR
 
 
-def _sinks_all_private(urls):
+def _sinks_all_private(urls) -> bool:
     """True when every configured sink URL targets a private/loopback IP literal — the LAN
     carve-out proof. A hostname can't be verified without a DNS lookup (which a pure config
     derivation must never do), so any hostname makes this False."""

--- a/dashboard/mining_dashboard/service/steering_projection.py
+++ b/dashboard/mining_dashboard/service/steering_projection.py
@@ -15,7 +15,7 @@ def reference_hr(target_hr, maint_margin_pct, maint_margin_abs_cap):
     return target_hr + min(target_hr * maint_margin_pct, maint_margin_abs_cap)
 
 
-def won_round_live(state_manager, hold_s, now=None, logger=None):
+def won_round_live(state_manager, hold_s, now=None, logger=None) -> bool:
     """Whether a won raffle round may still be running: any recorded win newer
     than ``hold_s``. Steering the donation down during a live won round can sag
     the credited 1h average through the round minimum and terminate the round

--- a/dashboard/mining_dashboard/service/update_checker.py
+++ b/dashboard/mining_dashboard/service/update_checker.py
@@ -51,7 +51,7 @@ class GitHubReleaseClient:
         self.api_url = api_url
         self.tor_proxy = tor_proxy
 
-    def latest_release(self):
+    def latest_release(self) -> dict | None:
         """Return ``{"tag": ..., "url": ...}`` for the latest published release, or ``None`` on any
         failure (network, non-200, malformed JSON). Routed through Tor when a proxy is set."""
         proxies = {"http": self.tor_proxy, "https": self.tor_proxy} if self.tor_proxy else None

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -53,8 +53,13 @@ from tests.service.annotation_gate import classify, classify_package
 # adds the module it finished. Measured at this tip: 18 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
-# slice 3, the two single-function `config/` modules by slice 4, and the four outbound senders
-# under `service/` by slice 5a.
+# slice 3, the two single-function `config/` modules by slice 4, the four outbound senders under
+# `service/` by slice 5a, and the last three `service/` singletons by slice 5b. That finishes the
+# SINGLETON tail, not #1556: **33 failure returns are still blind**, all in multi-function modules.
+#
+# The `client/` scoping below applies to `tor_heal.py` too, measured: `decide` holds four
+# unannotated `None` returns and `check` two bare ones, all six OUTSIDE the gate's two doors —
+# pinned, law 1 honestly green, and NOT "fully annotated".
 #
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
@@ -86,7 +91,10 @@ PINNED = (
     "service/healthchecks.py",
     "service/notify_sinks.py",
     "service/telegram_notifier.py",
+    "service/egress.py",
+    "service/steering_projection.py",
     "service/tor_heal.py",
+    "service/update_checker.py",
     "service/worker_config_store.py",
     "web/charts.py",
     "web/infra_views.py",
@@ -114,7 +122,10 @@ _ANCHORS = {
     "service/healthchecks.py": "service/healthchecks.py:ping",
     "service/notify_sinks.py": "service/notify_sinks.py:_post",
     "service/telegram_notifier.py": "service/telegram_notifier.py:send",
+    "service/egress.py": "service/egress.py:_sinks_all_private",
+    "service/steering_projection.py": "service/steering_projection.py:won_round_live",
     "service/tor_heal.py": "service/tor_heal.py:_probe_egress",
+    "service/update_checker.py": "service/update_checker.py:latest_release",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
     "web/charts.py": "web/charts.py:parse_window",
     "web/infra_views.py": "web/infra_views.py:_ip_to_sort_int",
@@ -131,25 +142,15 @@ _ANCHORS = {
 # here may be added because the gate happened to score it this way — that is the baseline #1487
 # refused, wearing this file's name. `worker_config_change_known` returns `False` on a closed
 # handle and its docstring argues the fail-open choice at length, including why it must answer the
-# same for a closed handle and a `sqlite3.Error` while its sibling must not. That reading is what
-# this entry stands for. `_EMPTY` simply has no `"False"`, on #1487's own measured grounds.
-#
-# `docker_control.py:_post` (slice 2) is the second, and it is one of the five instances those
-# grounds were measured ON — `annotation_gate._EMPTY`'s own comment names `_post` among the
-# outbound senders where False-on-failure and False-elsewhere mean the same thing to a caller.
-# Read here rather than taken on that comment's word: it returns True only on HTTP 204/304, and
-# False on every other status and on any exception. Its callers act on "the container action did
-# not happen", which is what both False paths mean, so there is no out-of-band case to declare.
-# Annotating it `-> bool | None` to reach `signed` would be inventing a return the function never
-# makes — the reason this list exists is to say the gate declines, not to manufacture a verdict.
+# same for a closed handle and a `sqlite3.Error` while its sibling must not. That reading, not the
+# gate's score, is what the entry stands for.
 #
 # `config/config.py:local_miner_enabled` (slice 4) is the third, and the first member that is NOT
 # an outbound sender — so it deliberately does not lean on the grounds `annotation_gate._EMPTY`
-# records. Those grounds name five senders, and it is worth knowing what they are a sample OF:
-# measured at `b0a32bd`, the tip that comment was written against, TWELVE functions already held a
-# `False` failure return and this was one of them, unannotated. The five were a subset somebody
-# read, never the whole population, so no later member may be waved through by that class — each
-# is read on its own terms, which is what this list is. It returns False when
+# records (see #1599: measured at `b0a32bd`, the tip that comment was written against, TWELVE
+# functions already held a `False` failure return and this was one of them, so its five senders
+# were a subset somebody read, never the whole population). No member is waved through by that
+# class; each is read on its own terms. It returns False when
 # the masked-config mount is missing or unreadable, and its docstring argues the choice outright:
 # DIY stacks without the mount never run the built-in miner. Its sole production caller is
 # arithmetic — `config.py:low_ram_floor_gb` does `+ (LOW_RAM_LOCAL_MINER_GB if
@@ -168,6 +169,20 @@ _ANCHORS = {
 #   `healthchecks.py:ping`      — a dead-man's switch, and the only one with TWO `except` handlers,
 #     both returning False. Its docstring already enumerates the False cases (not configured,
 #     throttled, request failed, endpoint rejected) as deliberately one answer.
+#   `docker/docker_control.py:_post` (slice 2) is the same class and is folded in here: True only
+#     on HTTP 204/304, False on every other status and any exception, and its callers act on "the
+#     container action did not happen", which is what both False paths mean.
+#
+# Slice 5b adds two MORE, listed separately rather than folded into the group above, because they
+# fail in OPPOSITE directions — which is why `service/` was split rather than taken whole:
+#   `egress.py:_sinks_all_private` is FAIL-CLOSED. False means "assume public", DENYING the LAN
+#     carve-out; its docstring gives the reason (a hostname cannot be verified without a DNS
+#     lookup, which a pure config derivation must never do), so False-on-ValueError and
+#     False-because-genuinely-public are one instruction: do not grant it.
+#   `steering_projection.py:won_round_live` is FAIL-OPEN by design. False means steer normally —
+#     the hold is a yield optimization, never a safety path, so a read error must not freeze
+#     steering. Collapsing these two readings into one would be the bulk-fill this list refuses:
+#     same shape, opposite safety argument. Neither reaches `signed` without inventing a return.
 _UNJUDGED_AND_READ = frozenset(
     {
         "client/docker/docker_control.py:_post",
@@ -175,6 +190,8 @@ _UNJUDGED_AND_READ = frozenset(
         "service/healthchecks.py:ping",
         "service/notify_sinks.py:_post",
         "service/telegram_notifier.py:send",
+        "service/egress.py:_sinks_all_private",
+        "service/steering_projection.py:won_round_live",
         "service/tor_heal.py:_probe_egress",
         "service/worker_config_store.py:worker_config_change_known",
     }


### PR DESCRIPTION
## What this is

Slice 5b of #1556 — the last three `service/` singletons, the ones that needed **bespoke**
arguments. Cut from 5a (#1601) and rebased onto `develop-v2` after that merged, replaying only
this slice's own commit; its parent is now `develop-v2`'s tip exactly.

| function | annotation | verdict | predicted before writing? |
|---|---|---|---|
| `service/egress.py:_sinks_all_private` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `service/steering_projection.py:won_round_live` | `-> bool` | `unjudged` (`False`) | yes — matched |
| `service/update_checker.py:latest_release` | `-> dict \| None` | **`signed`** | yes — matched |

blind **36 -> 33**, signed **17 -> 18**, unjudged **7 -> 9**, collapse **14** UNCHANGED.
Reconciliation `-3 blind == +1 signed +2 unjudged` holds. `PINNED`/`_ANCHORS` **18 -> 21**.
`latest_release` is the only `signed` in the entire singleton tail.

## ⚠️ This finishes the SINGLETON TAIL, not #1556 — and I am correcting my own handoff

My previous handoff said `test_the_blind_spot_is_measured_rather_than_described` "GOES RED when
#1556 finishes" and that **5b is that moment**. That is wrong, and it is wrong in the direction
that would have had a reviewer expecting a red.

The test asserts `package["blind"]` is **NON-EMPTY**. It reds only when blind reaches **zero**.
After this slice blind is **33** — every one of them in a multi-function module (`storage_service.py`
alone holds 10). So the test stays green, correctly, and #1556 still has 33 blind returns to go.
The file header now says this in place of the implication that the tail was the whole job.

## Why these two are listed separately instead of folded into 5a's group

5a's four are outbound senders sharing one argument. These two share a SHAPE (`-> bool` returning
`False`) and nothing else — they fail in **opposite directions**:

- **`_sinks_all_private` is FAIL-CLOSED.** False means "assume public", **denying** the LAN
  carve-out. Its docstring gives the reason: a hostname cannot be verified without a DNS lookup,
  which a pure config derivation must never do. False-on-`ValueError` and
  False-because-genuinely-public are one instruction to the caller — do not grant it.
- **`won_round_live` is FAIL-OPEN.** False means steer **normally**. Its docstring argues it
  outright: the hold is a yield optimization, never a safety path, so a read error must not be able
  to freeze steering.

Folding a fail-closed and a fail-open argument under one justification is exactly the bulk-fill
`_UNJUDGED_AND_READ` exists to refuse. Neither reaches `signed` without inventing a return it never
makes.

## Controls — 6, and ONE DID NOT ARM (again, same family)

Each law shown able to fail on each new module, BY NODE ID with the sibling law GREEN. Restored by
sha256, restores verified by content.

| control | law that must RED | sibling | result |
|---|---|---|---|
| UNANNOTATE each of the three | law 1 `[<module>]` | law 2 GREEN | fired, 3/3 |
| DROP each new `_UNJUDGED_AND_READ` entry | law 2 `[<module>]` | law 1 GREEN | fired, 2/2 |
| **DE-SIGN `latest_release`** (drop only ` \| None`) | law 2 | law 1 GREEN | fired |

That last one is the strongest control in this slice and the reason it is here: it runs the
de-sign regression against a **real** signed function rather than the synthetic snippet the
existing control uses, and law 1 stays green throughout — so law 2 is demonstrably the only thing
in the suite that sees it.

**Naming the unarmed one, because it is the third instance of one family across two slices.** The
`update_checker` control initially reported `0 -> 0` and its law PASSING: my loop used `|` as the
`IFS` delimiter and the pattern itself contains `dict | None`, so the pattern was split mid-way and
the edit never happened. Same shape as 5a's two (`**kwargs` breaking a regex; `/` as a `sed`
delimiter against paths containing `/`). **A delimiter that can occur in the payload is not a
delimiter**, and the arming readback is what catches it every time — the law's own result never
does, because an unarmed control returns the answer you were hoping for.

## The residue, measured — `update_checker.py` is pinned but NOT fully annotated

Finder positive-controlled against `client/`'s 14 in the same run. Across 5b's three modules: **10**
collapse-shaped returns outside the gate's two doors in **6** functions, of which **5 returns in 4
functions are UNANNOTATED** — all four in `update_checker.py` (`parse_semver`, `compute_update`,
`latest_release_cached`, `maybe_check`). Same scoping as `tor_heal.py` at 5a and `client/` at slice
2: **a pin is coverage of a mechanism, never a certificate about a file.**

Per #1601's pass, that measurement now lives **in the file** rather than only in a PR body — the
`tor_heal.py` one from 5a is written in there too, which was the nit that pass raised.

## Two changes to existing text, both deliberate

- **Slice 2's `docker_control.py:_post` entry is folded into 5a's sender group.** It is the same
  argument, and it was being stated twice; the group already confirms each member per function.
- **A trailing clause reading "`_EMPTY` simply has no `False`, on #1487's own measured grounds" is
  dropped.** #1599 records why those grounds cannot be leaned on — the population was defined by
  the property asserted about it. Leaving the clause while the slice-4 entry beside it explicitly
  refuses to lean on those grounds was an inconsistency. **`_EMPTY` itself is untouched.**

## What I did NOT do

- Did not annotate `update_checker.py`'s four remaining functions, or `tor_heal.py`'s two.
- Did not touch `_EMPTY`, and did not let this slice widen #1599.
- Did not take a budget row: `test_annotation_coverage.py` lands at **exactly 400**, at the target,
  paid for by compression rather than by a ceiling.
- No `security-reviewer` pass: all three edits are return annotations proven byte-identical in the
  compiled bodies. `_sinks_all_private` is security-adjacent (it gates the LAN carve-out), which is
  why its fail-CLOSED direction is argued explicitly above rather than assumed.
- No doc change owed; swept mechanically over the whole repo.

## What was RUN

- Full dashboard suite: **2333 passed** — 2324 + 9, which is the three new modules x three
  parametrized laws. No `-q` on the command line, so the summary is real; I read the whole output
  rather than a tail, because a missing summary means the run DIED, never that it was suppressed.
- Patch coverage from `coverage.xml`: **3 of 3** covered, with BOTH the report's executable total
  (**6950**) and the matched changed-line count asserted > 0 — a `0/0` here is a vacuous pass
  wearing a green result. Overall line-rate 97.15%.
- The two #1556 suites alone: **90 passed**, up 9 from 81 — three new modules x three parametrized
  laws, the arithmetic that says the pins are live for them.
- `ruff check` + `ruff format --check`: clean. File-budget gate: **OK**; all three production edits
  are in-place so no line count moved (`egress.py` stays 423 under its 424 ceiling).
- Behaviour-inertness: recursive `co_code`/`co_names`/`co_varnames`/`co_consts` compare of all three
  bodies against 5a's head — **identical**, never a repr. The rebase moved the base, and the
  `dashboard/` subtree hash is **byte-identical** across that move, so the 2333 result still
  describes the same program and no re-run is owed. Comparator fired on a positive control
  first: a seeded `return False` -> `return True` in `won_round_live` scored not-identical while
  its two siblings stayed identical.

Refs #1556.