### PR TITLE
fix(integration): the merge-mining leg books an unanswerable monerod RPC as an accepted hole (#1597)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -354,12 +354,21 @@ and `--list` prints it).
   written against the rendered text matches nothing at all, silently — a probe that always reports
   an absence looks exactly like a working one until the day it matters. The escapes are stripped
   before matching, and the self-test carries that control fired in both directions: zero matches on
-  the captured bytes, one after stripping. When monerod is not caught up the leg skips rather than
-  fails, counted and classed `by-design`, because p2pool constructs the merge-mining client only
-  after its block-header download succeeds — so the signal cannot exist on an unsynced node, and no
-  input to this harness would create it. Only the matching lines cross the wire, which keeps the
-  container's argv line — carrying both wallet addresses, the RPC credential and the onion — out of
-  the capture.
+  the captured bytes, one after stripping. The capture is read before the caught-up predicate, and
+  that order is itself an assertion ([#1597](https://github.com/p2pool-starter-stack/pithead/issues/1597)). `monero_caught_up` answers with one bit that cannot
+  separate a node that is behind from an RPC that could not be answered at all: its `curl`
+  discards stderr, so an unreachable host, a refused connection and a 401 alike leave the empty
+  body that `jq` reads as not caught up. Asked first, that bit decided the whole leg, and a stack
+  whose merge-mining client was up and reading chain_ids would have been booked as an accepted
+  hole for as long as a credential stayed broken — a state this repo has recorded lasting a day.
+  Any `MergeMiningClientTari` line is itself proof that monerod caught up, since p2pool builds no
+  client until the header download succeeds, so the log settles what the RPC could not. The leg
+  skips only when the window was read and held no such line: p2pool then built no client, the
+  download did not complete, and no input to this harness would create the signal, which is what
+  earns the counted `by-design` class rather than the predicate's bit. Every case the order moves,
+  it moves out of the skip ledger into a pass or a fail, never the other way. Only the matching
+  lines cross the wire, which keeps the container's argv line — carrying both wallet addresses,
+  the RPC credential and the onion — out of the capture.
 - Dashboard reads live state. `/api/state` is reachable; Monero is synced (`done`); pruned/full
   display matches `monero.prune` ([#32](https://github.com/p2pool-starter-stack/pithead/issues/32)); the sidechain `pool.type` matches `p2pool.pool`.
 - The Monero node's ZMQ endpoint is a live ZMTP publisher. A ZMTP handshake against the node's ZMQ
@@ -692,22 +701,21 @@ the counters and the real `summary()`, it censuses every harness file and fails 
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
 `selftest-redact.sh` covers the shapes the redactor used to miss — a credential passed as a flag
 value, and secrets in JSON under a key of any case — and asserts in each case that the *raw* value
-is gone rather than
-that a `<redacted>` marker appeared, since a marker can come from some other field on the same
-line. Its JSON population is derived from `config.reference.json` rather than listed in the file,
-under a screen deliberately wider than the redactor's own list, so a sensitive field added to the
-schema fails the test by name until someone classifies it as redacted or as a stated survivor. It
-also guards the other direction: a sha256 digest and a non-secret flag value must survive, because
-an artifact with its image pins stripped is useless for the triage it exists for.
-`selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures, so
-every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
-READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack.
-It also covers the truncated and hostile frames that used to end the parser rather than be named
-by it ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)): every length field is read with `16#`, which is fatal on an
-empty string, so a peer that stalled part-way through a header left an interpreter error on stderr
-and an empty verdict. Those cases assert the empty stderr alongside the reason, because the return
-code was already 1 while the bug was live and a case checking only the code would have passed
-against it.
+is gone rather than that a `<redacted>` marker appeared, since a marker can come from some other
+field on the same line. Its JSON population is derived from `config.reference.json` rather than
+listed in the file, under a screen deliberately wider than the redactor's own list, so a sensitive
+field added to the schema fails the test by name until someone classifies it as redacted or as a
+stated survivor. It also guards the other direction: a sha256 digest and a non-secret flag value
+must survive, because an artifact with its image pins stripped is useless for the triage it exists
+for. `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures,
+so every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
+READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack. It
+also covers the truncated and hostile frames that used to end the parser rather than be named by
+it ([#1500](https://github.com/p2pool-starter-stack/pithead/issues/1500)): every length field is
+read with `16#`, which is fatal on an empty string, so a peer that stalled part-way through a
+header left an interpreter error on stderr and an empty verdict. Those cases assert the empty
+stderr alongside the reason, because the return code was already 1 while the bug was live and a
+case checking only the code would have passed against it.
 
 ---
 

--- a/tests/integration/mergemine-probe.sh
+++ b/tests/integration/mergemine-probe.sh
@@ -112,20 +112,38 @@ mm_capture_startup() {
 
 # The release-gate leg: PASS, FAIL, or an honest counted SKIP — never a silent green.
 #
-# The skip is classed `by-design` rather than `missing` on the skip-accounting test: no input,
-# flag or env var to THIS harness would make the signal exist on an unsynced node, because
-# p2pool does not construct the client at all until the header download completes (cycle 40
-# measured zero Tari gRPC calls across five legs against absent, synced-fake and partial-fake
-# monerods). Covering it means running against a synced chain, not supplying something.
+# THE CAPTURE IS READ BEFORE THE PREDICATE, AND THAT ORDER IS ITSELF AN ASSERTION (#1597).
+# `monero_caught_up` reduces several independent conditions to one bit: its `curl -fsS` discards
+# stderr and leaves the body EMPTY on an unreachable RPC, a refused connection or a 401, and
+# `jq -e` over an empty body answers exactly as it does for a node that is genuinely behind.
+# Asked first, that one bit decided the whole leg — so a stack whose monerod was synced and whose
+# merge-mining client was up and reading chain_ids would have been booked as an ACCEPTED HOLE for
+# as long as the RPC stayed unanswerable. That state is not hypothetical here — `lib.sh`'s
+# env_bake_verdict comment records a day of it; read the incident there, not a second copy of it.
+# The capture answers the question the predicate was standing in for, and answers it from p2pool
+# rather than from the RPC we could not reach: p2pool constructs a MergeMiningClientTari only
+# after its block-header download succeeds, so ANY such line is proof that monerod caught up.
+#
+# The skip stays classed `by-design` rather than `missing` on the skip-accounting test, and
+# reading the capture first is what makes that class honest rather than merely conventional. It
+# is now reached only when the startup window WAS read and held no merge-mining line at all — so
+# p2pool built no client, so the header download did not complete, so no input, flag or env var
+# to THIS harness would make the signal exist (cycle 40 measured zero Tari gRPC calls across five
+# legs against absent, synced-fake and partial-fake monerods). Covering it means running against
+# a synced chain, not supplying something.
+#
+# Every case the reorder moves, it moves OUT of the skip ledger into a pass or a fail; no case
+# that previously passed or failed can become a skip. That direction is the safety argument, and
+# the self-test asserts all three moved cases rather than resting on it.
 assert_mergemine_roundtrip() {
     local lines verdict
-    if ! monero_caught_up; then
-        it_skip_leg "p2pool merge-mining gRPC round-trip (#1397)" \
-            "monerod is not caught up, and p2pool constructs its merge-mining client only after the block-header download succeeds — the signal cannot exist on this run" by-design
-        return 0
-    fi
     if ! lines="$(mm_capture_startup)"; then
         it_fail "p2pool merge-mining gRPC round-trip (#1397)" "could not read p2pool's container start time"
+        return 0
+    fi
+    if [ -z "$lines" ] && ! monero_caught_up; then
+        it_skip_leg "p2pool merge-mining gRPC round-trip (#1397)" \
+            "p2pool built no merge-mining client and monerod could not be confirmed caught up — p2pool constructs the client only after the block-header download succeeds, so the signal cannot exist on this run" by-design
         return 0
     fi
     verdict="$(mm_roundtrip_verdict "$lines")"

--- a/tests/integration/selftest-mergemine-probe.sh
+++ b/tests/integration/selftest-mergemine-probe.sh
@@ -196,11 +196,23 @@ mm_leg_outcome() { # <synced-rc> <capture> -> "<pass> <fail> <skipped-legs> <by-
     )
 }
 
+# The skip that REMAINS after #1597: the window was READ and held no merge-mining line, so
+# p2pool built no client, so the header download did not complete. That is what earns the
+# `by-design` class — not the predicate's bit, which on its own cannot tell "behind" from
+# "unanswerable". The reason string must therefore stop asserting monerod's state as known.
 out="$(mm_leg_outcome 1 "")"
-assert_eq "an unsynced monerod skips the leg — 0 pass, 0 fail, 1 counted skip" \
+assert_eq "no client AND no caught-up confirmation skips the leg — 0 pass, 0 fail, 1 counted skip" \
     "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 0 1"
 assert_eq "and the skip is classed by-design, not missing" "$(printf '%s' "$out" | cut -d' ' -f4)" "1"
 assert_contains "and the skip names itself and #1397" "$out" "#1397"
+assert_contains "and the reason hedges monerod's state rather than asserting it (#1597)" \
+    "$out" "could not be confirmed caught up"
+# The negative sibling of that assert_contains. A reason can carry the new hedge and the old
+# claim at once, which would read as fixed while still telling a reader the node is behind.
+case "$out" in
+*"monerod is not caught up"*) it_fail "the skip reason never states the unanswerable bit as fact (#1597)" "the reason still asserts monerod is not caught up" ;;
+*) it_pass "the skip reason never states the unanswerable bit as fact (#1597)" ;;
+esac
 
 out="$(mm_leg_outcome 0 "$MM_FULL")"
 assert_eq "a synced node with a chain_id line PASSES — 1 pass, 0 fail, 0 skips" \
@@ -222,6 +234,39 @@ assert_eq "no merge-mining client at all FAILS, and is never a skip — 0 pass, 
 # above.
 out="$(mm_leg_outcome 0 "@FAIL")"
 assert_eq "an unreadable container start time FAILS separately — 0 pass, 1 fail, 0 skips" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
+
+echo "== an unanswerable monerod RPC cannot book a covered leg as an accepted hole (#1597) =="
+
+# `monero_caught_up` reduces several independent conditions to ONE bit: its `curl -fsS` discards
+# stderr, so an unreachable host, a refused connection and a 401 all leave the body empty, and
+# `jq -e` over an empty body answers exactly as it does for a node that is genuinely behind. The
+# stub below returns that not-caught-up bit — which is what a perfectly synced monerod produces
+# behind a broken credential. `lib.sh`'s own env_bake_verdict comment records a day of that state.
+#
+# All three cases were a counted `by-design` skip before the capture was moved ahead of the
+# predicate. `by-design` on the skip ledger means an ACCEPTED HOLE, so each was an uncovered — or
+# in the first case a demonstrably WORKING — leg, filed as a hole the project had agreed to.
+# These assert the direction of the whole change: cases leave the skip ledger, never enter it.
+
+# The one that matters most. A chain_id line is proof monerod caught up, taken from p2pool rather
+# than from the RPC we could not reach: p2pool constructs no MergeMiningClientTari at all until
+# its block-header download succeeds. A working merge-mining round-trip must not be filed as a
+# hole because a credential broke.
+out="$(mm_leg_outcome 1 "$MM_FULL")"
+assert_eq "a chain_id line PASSES though the RPC says not-caught-up — the log outranks the predicate" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "1 0 0"
+
+# Its sharper sibling: here the leg is genuinely BROKEN — the client is up and Tari is not
+# answering — and the old order hid that red behind an accepted hole.
+out="$(mm_leg_outcome 1 "$MM_LOCAL_ONLY")"
+assert_eq "a client that never read a chain_id FAILS though the RPC says not-caught-up" \
+    "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
+
+# And the harness-fault case. p2pool is in EXPECTED_ALWAYS (lib.sh), so a container with no
+# readable start time is a broken measurement, not a hole in coverage.
+out="$(mm_leg_outcome 1 "@FAIL")"
+assert_eq "an unreadable container start time FAILS though the RPC says not-caught-up" \
     "$(printf '%s' "$out" | cut -d' ' -f1-3)" "0 1 0"
 
 echo ""


### PR DESCRIPTION
Closes #1597 — see "Scope" below for the half this deliberately does not take.

## The defect

`monero_caught_up` (`tests/integration/lib.sh`) reduces several independent conditions to one bit.
Its `curl -fsS ... 2>/dev/null` leaves the body empty on an unreachable host, on a refused
connection, and on a 401 — and `jq -e` over an empty body answers exactly as it does for a node
that is genuinely behind. Every caller gets one bit over several doors.

Three of the four callers turn that into a red, which is honest even when the message is imprecise.
The merge-mining leg turned it into a **counted skip classed `by-design`** — which on the skip
ledger means *an accepted hole*, the one class that says the project has agreed not to cover this.
Telling an accepted hole from an uncovered run is what #1083 and #1365 built that ledger for, so
this misfiled the second as the first.

The consequence is the shape this lane exists to kill: a stack whose monerod was synced, and whose
merge-mining client was up and reading chain_ids, would have been booked as an accepted hole for as
long as a credential stayed broken. Not hypothetical — `lib.sh`'s own `env_bake_verdict` comment
records a day of exactly that state.

## The fix is the order, not a new predicate

p2pool constructs a `MergeMiningClientTari` only after its block-header download succeeds, so any
such line is itself proof that monerod caught up — taken from p2pool rather than from the RPC we
could not reach. The capture is read first. The leg skips only when the window *was read* and held
no such line, and the skip's reason no longer asserts monerod's state as known.

Reading the capture first also **strengthens** the `by-design` class rather than merely preserving
it. The skip is now reached only where p2pool demonstrably built no client, so the header download
demonstrably did not complete, so no input, flag or env var to this harness would make the signal
exist. That is the actual `by-design` test, and it is now earned rather than assumed.

**Every case the reorder moves, it moves OUT of the skip ledger into a pass or a fail. No case that
previously passed or failed can become a skip.** That direction is the safety argument for the
change, and the self-test asserts the three moved cases rather than resting on it.

## Proven, not assumed

Three cases added to `selftest-mergemine-probe.sh`, each driven with the predicate answering
not-caught-up — which is what a 401 produces on a perfectly synced node — and each a counted
`by-design` skip before this change:

- a chain_id line now **PASSES** — the working leg that was being filed as a hole
- a client that never read a chain_id now **FAILS** — a real red that was hidden behind the skip
- an unreadable container start time now **FAILS** — a broken measurement, not a hole in coverage

### Mutation battery

Every arm was `cmp`-checked against the pristine file and `bash -n` parsed before its result was
counted; the file was restored and re-`cmp`'d afterwards. Run over the 40-case file:

| mutation | reds |
|---|---|
| restore the old order (predicate first) | exactly the 3 new cases |
| restore the old skip wording | exactly the 2 wording assertions |
| drop only the emptiness guard, keep capture-first | 2 of 3 — see below |
| keep the new hedge **and** re-add the old claim | only the negative control — see below |

The third arm's survivor is not a coverage gap: the start-time case is bought by the reorder alone,
and the first arm reds it. The fourth arm exists because the two wording assertions could have been
redundant — a reason string can carry the new hedge and the old claim at once, reading as fixed
while still telling a reader the node is behind. It reds only the `case` control, so the pair is
proven distinct rather than argued to be.

## What was run

- `tests/integration/selftest-mergemine-probe.sh` — 40 passed, 0 failed
- `make test-integration-selftest` — rc 0 over the whole `selftest*.sh` glob (214 in the last file)
- `shellcheck --severity=warning` 0.11.0, over the full `tests/integration/*.sh` +
  `tests/integration/mini-stack/*.sh` globs from the repo root — rc 0
- `shfmt -i 4 -d` on both changed shell files — clean
- `make lint-md` — 0 errors, 48 files
- `make lint-docs-voice` — OK, 41 prose docs
- `make lint-file-budget` — OK. Both changed shell files sit under the 400-line target, so neither
  carries a ceiling row: 161 and 274 lines.

## Over-engineering review

Run off disk against this diff. One finding **applied**: the comment restated `lib.sh`'s
`env_bake_verdict` incident in four lines, which is the duplicated-claim-that-drifts pattern this
repo has already paid for once — replaced with a one-line pointer to the single copy.

Findings **declined**, with reasons:

- *The comment block is long for a six-line change.* Declined. The order of two statements **is**
  the whole fix, and it is invisible in the code: a later contributor tidying by moving the cheap
  predicate check back to the front reintroduces the defect silently, with every test still green
  unless these cases exist. The comment is the extension point.
- *The `case` control duplicates the `assert_contains` beside it.* Declined, and then measured —
  the fourth mutation arm above shows it does not.
- *`mm_leg_outcome 1 "@FAIL"` duplicates the existing `mm_leg_outcome 0 "@FAIL"` case.* Declined.
  Before this change those two cases had different outcomes (skip vs fail); asserting only the
  synced one is what let the unsynced one be a skip.

## Scope, and what I did not do

- **I did not touch `monero_caught_up` itself.** #1597's structural option — give it three answers,
  caught-up / behind / unanswerable — touches every call site and is not taken here. The other
  three callers still receive the ambiguous bit, and by the issue's own table that is benign in all
  three: each converts it to a red, which is honest even when the reason text is imprecise. I judge
  the harmful half closed by this PR and say so on the issue rather than quietly leaving it open.
- **I did not run the live suite.** Every result above is from the pure-logic self-test with the
  two collaborators stubbed. The reorder is not proven against a running stack.
- **I did not resolve the issue's own open item** — whether `run.sh:632` always executes in the
  same run as the merge-mining leg. It no longer bears on this fix, which does not depend on
  another leg reddening.

## Paths

`tests/integration/` (this lane's) plus `docs/dev/integration-testing.md`. `docs/` is in
`_shared.paths`, so no `.lane-override` was used or needed. Disclosed here as required.

The doc hunk also carries the ruled reflow debt from #1600's insert — a 19-char orphan line — since
this change edits that file anyway. That part is a pure re-wrap, asserted content-identical before
it was written.
