### PR TITLE
fix(dashboard): #1604 — measure the residue the pin cannot rule on, in every pinned module

### DIFF
--- a/dashboard/tests/service/annotation_gate.py
+++ b/dashboard/tests/service/annotation_gate.py
@@ -277,6 +277,21 @@ def classify(source: str, where: str) -> dict[str, list]:
     return verdicts
 
 
+def _package_files() -> list[pathlib.Path]:
+    """Every module in `mining_dashboard`, with the enumeration guard both walks depend on.
+
+    An empty scan is not a clean scan. Every law and every count built on these files is a
+    statement about a set, and a set that is empty because the walk found no files satisfies all of
+    them for the wrong reason. The guard belongs here rather than in any caller, and the comment
+    that used to say so was advice a single caller could not enforce: a second caller inheriting
+    the walk without inheriting the guard is how an empty scan starts reading as a clean one. #1604
+    brought the second caller, so the advice became the shared function it was describing.
+    """
+    files = sorted(_PACKAGE.rglob("*.py"))
+    assert len(files) > 50, "enumeration guard: the package walk found almost nothing"
+    return files
+
+
 def classify_package() -> dict[str, list]:
     """Every failure return in `mining_dashboard`, classified, in one pass over the real package."""
     total: dict[str, list] = {
@@ -287,14 +302,78 @@ def classify_package() -> dict[str, list]:
         "unjudged": [],
         "procedure": [],
     }
-    files = sorted(_PACKAGE.rglob("*.py"))
-    # An empty scan is not a clean scan. Every law built on this result is a statement about a set,
-    # and a set that is empty because the walk found no files satisfies all of them for the wrong
-    # reason. The guard belongs here rather than in either caller: a second caller inheriting the
-    # walk without inheriting the guard is how an empty scan starts reading as a clean one.
-    assert len(files) > 50, "enumeration guard: the package walk found almost nothing"
-    for path in files:
+    for path in _package_files():
         where = str(path.relative_to(_PACKAGE))
         for verdict, rows in classify(path.read_text(), where).items():
             total[verdict].extend(rows)
     return total
+
+
+def _falsy_literal(value: ast.AST | None) -> str | None:
+    """The falsy value a ``return`` yields, or None if it is not one of them — the residue's set.
+
+    Built ON `_collapsed_literal` rather than beside it: every shape that one tracks is falsy, and
+    a second hand-written list of the same shapes is two definitions of one thing, free to drift
+    apart in a direction nobody is measuring. A bare `return` normalises to `None` here for the
+    reason `classify` gives where it does the same — the two spell a single value, and nothing this
+    count is used for can turn on the spelling.
+
+    `""` is the one addition, and it is added HERE rather than in `_collapsed_literal` because the
+    two sets answer opposite questions: that one is what a law FLAGS, kept narrow so every finding
+    is real and so the verdicts quoted with a sha stay put, while this is what a report DISCLOSES,
+    kept wide so the disclosure cannot flatter its own number.
+    """
+    literal = _collapsed_literal(value)
+    if literal is not None:
+        return "None" if literal == "<bare>" else literal
+    if isinstance(value, ast.Constant) and isinstance(value.value, str) and value.value == "":
+        return '""'
+    return None
+
+
+def unannotated_falsy_returns(source: str, where: str) -> list[tuple[str, str, int]]:
+    """``(function, literal, lineno)`` for every falsy return in a function that DECLARES NO TYPE.
+
+    This is not a seventh verdict and it is not `blind` widened. `blind` is a function this gate
+    REACHED — it has a failure return through one of the two doors — and then could not rule on for
+    want of an annotation. This walk asks a question the gate never asks: which functions return a
+    falsy value at all, having promised nothing about their return? Most of those returns come
+    through neither door, so `classify` emits no row for them and every law built on it is silent
+    about them, correctly. #1604 is that silence being read as a clean bill.
+
+    Annotated functions are excluded on the annotation alone: a function that declared a type is
+    this mechanism's subject, never its blind spot, however falsy the value it returns.
+    """
+    found: list[tuple[str, str, int]] = []
+    for function in ast.walk(ast.parse(source)):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if function.returns is not None:
+            continue
+        # `_own_nodes` for the same reason `_failure_returns` uses it, and it is the ONE choice
+        # here that a measured sweep already got wrong: `ast.walk(function)` descends into nested
+        # defs, so the enclosing function absorbs their returns AND they are counted again as
+        # themselves. #1604's table read `web/xvb_views.py` as 12 sites in 6 functions for exactly
+        # that reason — `build_xvb_calc` scored the returns at lines 731 and 767, which belong to
+        # the nested `_odds_day` and `_face_value` and to nothing of its own. The truth is 10 in 5.
+        for node in _own_nodes(function):
+            if not isinstance(node, ast.Return):
+                continue
+            if (literal := _falsy_literal(node.value)) is not None:
+                found.append((f"{where}:{function.name}", literal, node.lineno))
+    return found
+
+
+def unannotated_falsy_by_module() -> dict[str, list[tuple[str, str, int]]]:
+    """The residue in `mining_dashboard`, keyed by module path, over the real package.
+
+    A module holding none is present with an EMPTY LIST rather than absent. The caller's question
+    is "how much residue does this pinned module hold", and a dict that answers a clean module with
+    a `KeyError` gives the clean answer and the module-has-vanished answer the same shape — the
+    exact absence the pin's own vacuity guards exist to refuse.
+    """
+    residue: dict[str, list[tuple[str, str, int]]] = {}
+    for path in _package_files():
+        where = str(path.relative_to(_PACKAGE))
+        residue[where] = unannotated_falsy_returns(path.read_text(), where)
+    return residue

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -47,7 +47,12 @@ was not. That gap was in the tree at the base of this branch, not introduced by 
 
 import pytest
 
-from tests.service.annotation_gate import classify, classify_package
+from tests.service.annotation_gate import (
+    classify,
+    classify_package,
+    unannotated_falsy_by_module,
+    unannotated_falsy_returns,
+)
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
 # adds the module it finished. Measured at this tip: 18 of 33 modules that hold a failure return at
@@ -60,6 +65,14 @@ from tests.service.annotation_gate import classify, classify_package
 # The `client/` scoping below applies to `tor_heal.py` too, measured: `decide` holds four
 # unannotated `None` returns and `check` two bare ones, all six OUTSIDE the gate's two doors —
 # pinned, law 1 honestly green, and NOT "fully annotated".
+#
+# That sentence was true and, until #1604, it was the ONLY one of its kind here. Eight other pinned
+# modules hold the same residue and were named nowhere but inside the tuple below, so a reader who
+# found `tor_heal.py`'s disclosure could reasonably infer the rest were clean: an asymmetric
+# disclosure is worse than a uniform absence, because the silence beside the others reads as a
+# statement. The residue is now MEASURED for all twenty-one and printed by
+# `TestTheResidueThePinCannotRuleOn` below, which is the form of disclosure that cannot go
+# asymmetric again — a module joining `PINNED` gets a line whether anyone writes a sentence or not.
 #
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
@@ -242,6 +255,12 @@ def package() -> dict[str, list]:
     return classify_package()
 
 
+@pytest.fixture(scope="module")
+def residue() -> dict[str, list[tuple[str, str, int]]]:
+    """Every falsy return in an unannotated function, keyed by module, over the real package."""
+    return unannotated_falsy_by_module()
+
+
 class TestAnAnnotatedModuleStaysAnnotated:
     """The law. It ratchets coverage of the mechanism, never a verdict the mechanism returned."""
 
@@ -398,3 +417,163 @@ class Client:
         it cannot start to quietly."""
         assert _rows_under("client/xvb_client", package) == []
         assert _rows_under("service/worker_config_store", package) == []
+
+
+class TestTheResidueThePinCannotRuleOn:
+    """#1604 — what the pin has never said, said.
+
+    Law 1 says no FAILURE RETURN in a pinned module is unannotated. It has never said the module is
+    annotated, and the difference is not academic: nine of the twenty-one hold functions that
+    declare no return type and return a falsy value. Those returns come through neither of the
+    gate's two doors, so `classify` emits no row for them, and every law above is silent about them
+    — correctly, because the mechanism genuinely cannot reach them.
+
+    Nothing here rules on a single site. #1604 read none of them, and a count that grew a bound
+    would be the baseline #1487 refused, wearing a third file's name. What is asserted is that the
+    number exists and that the sweep producing it can tell one module from another."""
+
+    def test_the_residue_in_every_pinned_module_is_reported_without_being_ruled_on(
+        self, residue, capsys
+    ):
+        """Deliberately asserts NOTHING about the counts, for the reason the sibling file's
+        residual report gives at length: a bound over sites nobody has read certifies whatever they
+        contain, and this pass read none of them.
+
+        Every pinned module gets a line INCLUDING the twelve that score zero, and the zero lines
+        are the half that makes this a disclosure rather than a second asymmetry — an unmentioned
+        module and a measured-clean module are the same silence otherwise, which is the whole of
+        #1604."""
+        with capsys.disabled():
+            rows = {module: residue[module] for module in PINNED}
+            sites = sum(len(found) for found in rows.values())
+            functions = {name for found in rows.values() for name, _, _ in found}
+            holding = sum(1 for found in rows.values() if found)
+            print(
+                f"\n#1604 residue — {sites} falsy returns in {len(functions)} functions that "
+                f"declare no return type, across {holding} of the {len(PINNED)} pinned modules. "
+                "The gate reaches none of them:"
+            )
+            for module, found in sorted(rows.items(), key=lambda row: (-len(row[1]), row[0])):
+                names = {name for name, _, _ in found}
+                print(f"    {len(found):3d} sites {len(names):2d} fns  {module}")
+                for name, literal, lineno in sorted(found, key=lambda row: row[2]):
+                    print(f"        {name}:{lineno} -> {literal}")
+
+    def test_the_residue_sweep_tells_the_pinned_modules_apart(self, residue):
+        """VACUITY AND DISCRIMINATION guard, and it is here because the instrument arrived with
+        exactly this defect: #1604's first sweep keyed on a needle that also matched the `PINNED`
+        tuple itself, scored all twenty-one modules identically, and read as a clean bill. A sweep
+        that flags everything and a sweep that flags nothing are the same non-answer, so both ends
+        are asserted.
+
+        The membership check is the third failure this guards, and a different one: `residue` holds
+        every module the walk found, so a pinned module MISSING from it is a file that was deleted
+        or renamed while the rest of the package still walks — the absence that satisfies every law
+        phrased as one.
+
+        The lower bound reds the day the package becomes fully annotated. That is the same
+        deliberate choice the sibling file's blind-spot measurement makes, and for the same reason:
+        the pin would then cover something different from what it covers today, which is worth a
+        look rather than a silent green."""
+        missing = [module for module in PINNED if module not in residue]
+        assert missing == [], f"pinned modules that left the walk entirely: {missing}"
+        holding = [module for module in PINNED if residue[module]]
+        assert holding, "a residue of zero everywhere would change what this pin covers"
+        assert len(holding) < len(PINNED), "a sweep that flags every module discriminates nothing"
+
+
+class TestTheResidueSweepCanSeeWhatItIsCounting:
+    """The report above is a count, and a count nobody controlled is a number with no source. Each
+    control is seeded ACROSS the annotation boundary the sweep keys on, so a sweep that answered
+    "residue" to everything — or to nothing — fails them."""
+
+    _UNANNOTATED = """
+def read_window(request):
+    value = request.query.get("window")
+    if value not in _WINDOWS:
+        return None
+    return value
+"""
+
+    _ANNOTATED = """
+def read_window(request) -> str | None:
+    value = request.query.get("window")
+    if value not in _WINDOWS:
+        return None
+    return value
+"""
+
+    _TRUTHY = """
+def read_window(request):
+    value = request.query.get("window")
+    if value not in _WINDOWS:
+        return "1h"
+    return value
+"""
+
+    def test_it_counts_a_falsy_return_from_a_function_that_declared_nothing(self):
+        """POSITIVE CONTROL, and the second assertion is what makes this residue rather than
+        `blind` under another name: the SAME source through the gate produces no row in any of the
+        six verdicts, because the return is through neither door. That is why every law in this
+        file is silent about these sites, and why the count has to exist at all."""
+        assert "-> " not in self._UNANNOTATED  # arming readback: the annotation really is absent
+        found = unannotated_falsy_returns(self._UNANNOTATED, "web/charts.py")
+        assert [(name, literal) for name, literal, _ in found] == [
+            ("web/charts.py:read_window", "None")
+        ]
+        verdicts = classify(self._UNANNOTATED, "web/charts.py")
+        assert all(rows == [] for rows in verdicts.values()), verdicts
+
+    def test_it_drops_the_same_function_once_it_declares_a_return_type(self):
+        """NEGATIVE CONTROL, one annotation apart from the positive one — same body, same falsy
+        value, same call. A sweep keying on anything but the annotation could not tell these two
+        apart, and every annotated function it swept in would be a function the gate already
+        rules on, reported as a place the gate cannot reach."""
+        assert self._ANNOTATED == self._UNANNOTATED.replace("(request)", "(request) -> str | None")
+        assert unannotated_falsy_returns(self._ANNOTATED, "web/charts.py") == []
+
+    def test_it_does_not_count_a_truthy_return_from_an_unannotated_function(self):
+        """NARROWNESS CONTROL, and the near-miss that separates this count from "every return in an
+        unannotated function". The package is mostly unannotated (#284 is closed for that reason),
+        so a sweep that dropped the falsy half would report a number in the hundreds and mean
+        nothing by it."""
+        assert self._TRUTHY == self._UNANNOTATED.replace("return None", 'return "1h"')
+        assert unannotated_falsy_returns(self._TRUTHY, "web/charts.py") == []
+
+    def test_the_empty_string_is_counted_here_and_is_still_invisible_to_the_gate(self):
+        """`""` is the one shape this sweep adds to the set `_collapsed_literal` tracks, and the
+        two assertions are the two halves of that decision. It is counted here because a report
+        that leaves out a falsy shape flatters its own number; it stays out of the gate's set
+        because that set feeds verdicts quoted with a sha, and widening it would move them."""
+        unannotated = 'def render(rows):\n    if not rows:\n        return ""\n    return rows[0]\n'
+        found = unannotated_falsy_returns(unannotated, "web/charts.py")
+        assert [literal for _, literal, _ in found] == ['""']
+        collapsing = (
+            "class Store:\n"
+            "    def name(self) -> str:\n"
+            "        try:\n"
+            "            return self._conn.execute(SQL).fetchone()[0]\n"
+            "        except Exception:\n"
+            '            return ""\n'
+        )
+        verdicts = classify(collapsing, "service/storage_service.py")
+        assert all(rows == [] for rows in verdicts.values()), verdicts
+
+    def test_a_nested_def_is_counted_against_itself(self):
+        """A nested def is its own function with its own contract, so its returns are never the
+        parent's — and this is the control for a defect that HAS happened rather than a
+        hypothetical. `web/xvb_views.py` is the case: `build_xvb_calc` holds `_odds_day` and
+        `_face_value`, and a sweep using `ast.walk(function)` scored their returns at lines 731 and
+        767 against `build_xvb_calc`, which holds no residue return of its own, while still
+        counting them as themselves. That double count is the whole of #1604's 12-sites-in-6-
+        functions figure where the truth is 10 in 5."""
+        seeded = (
+            "def build(rows):\n"
+            "    def _odds(agg):\n"
+            "        if not agg:\n"
+            "            return None\n"
+            "        return agg['n']\n"
+            "    return _odds(rows)\n"
+        )
+        found = unannotated_falsy_returns(seeded, "web/xvb_views.py")
+        assert [name for name, _, _ in found] == ["web/xvb_views.py:_odds"]

--- a/dashboard/tests/service/test_collapsed_return_channels.py
+++ b/dashboard/tests/service/test_collapsed_return_channels.py
@@ -140,7 +140,8 @@ class TestTheResidualIsReportedNotCertified:
                 print(f"    {name} -> {','.join(values)}")
             print(
                 f"  and {len(package['blind'])} failure returns in UNANNOTATED functions, which "
-                "this mechanism cannot judge either way."
+                "this mechanism cannot judge. Falsy returns through NEITHER door fall outside "
+                "every count here; `test_annotation_coverage.py` measures those (#1604)."
             )
             # The `unjudged` rows are NAMED, not counted, and that is the difference between this
             # line and the one above it. There are few enough to name; the day there are not, the

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -512,8 +512,12 @@ the package does not. `dashboard/tests/service/test_annotation_coverage.py` hold
 (#1556): once a module's failure returns have been annotated and read, that file reds if any of
 them goes back to declaring nothing. It pins coverage of the rule rather than the rule's
 verdicts — a pinned module may still hold a reported collapse, and the report is where that
-belongs. The two files share one classifier, `dashboard/tests/service/annotation_gate.py`, which
-is a plain module and not a test.
+belongs. The pin also says less than its name suggests, and now says so: it covers the failure
+returns the rule can reach, never the whole module, and several pinned modules hold functions that
+declare no return type and hand back an empty answer from a path the rule cannot see. That file
+counts those per pinned module and prints them in its own output, so a module holding none reads as
+measured rather than merely unmentioned. The two files share one classifier,
+`dashboard/tests/service/annotation_gate.py`, which is a plain module and not a test.
 
 How it stays safe:
 

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -34,6 +34,7 @@ dashboard/tests/frontend/workerview.test.mjs	518
 dashboard/tests/frontend/xvbview.test.mjs	431
 dashboard/tests/service/test_alert_service.py	1092
 dashboard/tests/service/test_algo_service.py	822
+dashboard/tests/service/test_annotation_coverage.py	578
 dashboard/tests/service/test_control_service.py	500
 dashboard/tests/service/test_data_helpers.py	618
 dashboard/tests/service/test_data_service.py	2538

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -34,7 +34,7 @@ dashboard/tests/frontend/workerview.test.mjs	518
 dashboard/tests/frontend/xvbview.test.mjs	431
 dashboard/tests/service/test_alert_service.py	1092
 dashboard/tests/service/test_algo_service.py	822
-dashboard/tests/service/test_annotation_coverage.py	578
+dashboard/tests/service/test_annotation_coverage.py	579
 dashboard/tests/service/test_control_service.py	500
 dashboard/tests/service/test_data_helpers.py	618
 dashboard/tests/service/test_data_service.py	2538


### PR DESCRIPTION
Closes #1604.

## What the pin never said

Law 1 asserts that no **failure return** in a pinned module is unannotated. It has never asserted
that the module is annotated, and nine of the twenty-one hold functions that declare no return type
and return a falsy value through **neither** of the gate's two doors. `classify` emits no row for
them, so every law in the file is silent about them — correctly, because the mechanism genuinely
cannot reach them.

That silence was disclosed in prose for `tor_heal.py` alone. An asymmetric disclosure is worse than
a uniform absence: a reader who found that one could reasonably infer the other eight were clean.
This measures the residue for all twenty-one and prints it per module, **zeros included**, so a
module joining `PINNED` gets a line whether or not anybody writes a sentence about it.

## Measured

At `1e17293`, whose `dashboard/` tree is byte-identical to `71ad770` (the tip #1604 read):
**44 falsy returns in 29 unannotated functions, across 9 of the 21 pinned modules.**

| sites | fns | module |
|---:|---:|---|
| 10 | 5 | `web/xvb_views.py` |
| 9 | 8 | `client/xmrig_client.py` |
| 6 | 2 | `service/tor_heal.py` |
| 6 | 4 | `web/infra_views.py` |
| 5 | 4 | `service/update_checker.py` |
| 4 | 2 | `web/views.py` |
| 2 | 2 | `web/charts.py` |
| 1 | 1 | `client/monero/monero_client.py` |
| 1 | 1 | `client/monero/monero_wallet_client.py` |

**One correction to the issue.** Eight of the nine rows reproduce its table exactly.
`web/xvb_views.py` reads 10 sites in 5 functions here, not 12 in 6. The cause is **nested-function
absorption**: `ast.walk(function)` descends into nested defs, so `build_xvb_calc` absorbed the
returns at lines 731 and 767 — which belong to `_odds_day` and `_face_value` — while those two were
also counted as themselves. Seeding that mutation into this sweep reproduces the issue's per-site rows — the returns at 731
and 767 attributed to `build_xvb_calc` — which is what identifies the mechanism. Nothing else in the finding moves: the same nine modules hold residue, twelve
score zero, and `web/xvb_views.py` is still the largest.

> An earlier revision of this PR blamed `recent_wallet_change` (annotated `-> dict | None`, so
> excluded by both sweeps). That fits the totals arithmetically and is false — two mechanisms
> produce the same pair of numbers, and only the per-site line numbers tell them apart. The
> controller supplied those; the root cause here is theirs, and the mutation below is the guard
> they asked for.

Nothing here rules on a single site. #1604 read none of them, and a bound over unread sites is the
baseline #1487 refused.

## Evidence

**The gate's verdicts are unmoved**, measured either side of the change: blind 33, collapse 14,
unjudged 9, signed 18, procedure 3. The package walk was extracted to `_package_files()` so the
second caller inherits the enumeration guard the old comment could only recommend.

**Mutation battery** — four mutations, each proved to have changed the file:

| mutation | what reds |
|---|---|
| count every return, falsy or not | 4 controls, the truthy near-miss included |
| find nothing at all | discrimination guard + 3 controls |
| count ANNOTATED functions too | discrimination guard + the negative control |
| attribute a nested def's returns to its enclosing function | the nested-attribution control, alone |

The fourth is #1604's actual sweep bug, and it is caught by the per-site rows rather than by the
totals: under it `build_xvb_calc` swallows the returns at 731 and 767. **The 12-in-6 pair does NOT
discriminate** — counting annotated functions too lands on the identical pair by a different route
(`recent_wallet_change` at 78 and 80), so only the line numbers separate the two. The defect that
happened is a red test now. The
discrimination guard exists because #1604's first sweep matched the `PINNED` tuple itself and
scored all twenty-one modules identically; it asserts **both** ends, so a sweep that flags
everything and one that flags nothing both go red.

## Ponytail pass

* `annotation_gate.py`: `shrink:` a 7-line comment restated the `_falsy_literal` docstring below
  it. Folded in, **applied** — net −4 lines.
* `test_annotation_coverage.py`: `delete:` the empty-string control's second snippet asserts
  pre-existing gate behaviour. **Not applied** — it is the control for this diff's own claim that
  `""` is the one shape `_collapsed_literal` does not track, and it reds if someone widens that set.
* `test_annotation_coverage.py`: `shrink:` the missing-module assert overlaps the `KeyError` the
  report would raise anyway. **Not applied** — a named diagnostic beats a `KeyError` raised inside
  a print loop.

## Two things a reviewer should weigh

* **`test_annotation_coverage.py` takes a file-budget row at 578 lines.** Rule 2 of the gate
  sanctions it, and 578 is well under the 800 hard ceiling. The alternative — a third test file —
  needs `PINNED` moved into `annotation_gate.py`, because `--import-mode=importlib` means one test
  file cannot import another; that separates the pin's data from the argument that justifies it,
  which is a bigger change than a disclosure fix should make. The sibling was held at exactly 400
  by folding its pointer into the line above rather than adding one.
* **Patch coverage passes and proves nothing about this diff.** Every changed `.py` is under
  `dashboard/tests/`, which `[tool.coverage.run]` omits. The seven new tests do execute the new
  code — `make test-dashboard` is 2340 passed, 97.15% — and the mutation battery is what actually
  shows they bite.

`make lint-py`, `lint-docs-voice`, `lint-md`, `lint-file-budget` and `lint-operator-strings` are
green. `lint-sh` was not run locally (no shell changed, and shellcheck has OOMed this box before);
CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m8V8NiA14jgqSZsf2au6C