### PR TITLE
fix(integration): redact wallet addresses by POSITION — the argv shape no length bar reaches (#1596)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -66,13 +66,21 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   through a redactor. **What that redactor covers is narrower than "artifacts are redacted"
   suggests**, and the gap is worth knowing before you trust a bundle. It reaches: a `KEY=value`
   line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
-  a v3 onion; and any opaque run of 90 or more characters, which is what catches wallet addresses
-  (and a sha512 with them); and a JSON `"key": "value"` whose key ends in one of a list of secret
-  words — `password`, `token`, `key`, `username`, `wallet` and the rest, matched without regard to
-  case, so `apiKey` and `PASSWORD` are reached alongside `api_key`.
+  a v3 onion; any opaque run of 90 or more characters (and a sha512 with them); the token after
+  `--wallet` and the one after `--merge-mine`'s URI, by POSITION; and a JSON `"key": "value"` whose
+  key ends in one of a list of secret words — `password`, `token`, `key`, `username`, `wallet` and
+  the rest, matched without regard to case, so `apiKey` and `PASSWORD` are reached alongside
+  `api_key`.
   [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582) closed the flag-value and
   address-shape gaps; [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587) added
-  the JSON one. **That last rule is keyed on the field NAME, not the value, and that is forced**:
+  the JSON one; [#1596](https://github.com/p2pool-starter-stack/pithead/issues/1596) added the
+  positional one. **The length rule never covered wallet addresses as widely as it read**: a
+  positional argument has no name to key on, so that rule was the ONLY one reaching the Tari
+  address, and of the three Tari forms this repo accepts it reached only the base58 one — by a
+  single character.
+  Lowering the bound is not available: it starts matching ordinary log tokens well before it
+  reaches the 48-character form, and no bound reaches the emoji form at all.
+  **The JSON rule is keyed on the field NAME, not the value, and that is forced**:
   a view key and a container digest are both 64 hex characters, so nothing in the value separates
   them. **The name list is open, and one field is still out of reach** — `notifications.ntfy.url`
   is a capability URL whose key is the bare word `url`, which only its nesting separates from the
@@ -700,7 +708,8 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
 `selftest-redact.sh` covers the shapes the redactor used to miss — a credential passed as a flag
-value, and secrets in JSON under a key of any case — and asserts in each case that the *raw* value
+value, an address given by POSITION in an argv line, and secrets in JSON under a key of any case —
+and asserts in each case that the *raw* value
 is gone rather than that a `<redacted>` marker appeared, since a marker can come from some other
 field on the same line. Its JSON population is derived from `config.reference.json` rather than
 listed in the file, under a screen deliberately wider than the redactor's own list, so a sensitive

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -33,13 +33,13 @@ it_err() { echo -e "${IT_RED}[ITEST]${IT_RESET} $1" >&2; }
 it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
-# Redact before anything reaches a log or the terminal. Three shapes: KEY=value / --flag value by
-# NAME, an opaque run >=90 chars by SHAPE, and JSON "key": "value" by the key's SUFFIX (#1587),
-# matched CASE-INSENSITIVELY (#1590) — add new SPELLINGS, never case variants. THE LIST IS OPEN;
-# a closed one opened #1582. Nesting is invisible line-wise: ntfy's bare "url" is secret, xvb's not.
+# Redact before anything reaches a log or the terminal. FOUR shapes: KEY=value / --flag value by NAME;
+# an opaque run >=90 chars by SHAPE; the token after --wallet and after --merge-mine's URI by POSITION
+# (#1596: two of three Tari forms are too short for SHAPE); JSON "key": "value" by key SUFFIX (#1587)
+# CASE-INSENSITIVELY (#1590) — add SPELLINGS, never case. LIST IS OPEN (#1582); gaps: selftest-redact.sh
 redact() {
     sed -E \
-        -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g' \
+        -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g; s/(--wallet[ =])[^-[:space:]][^[:space:]]*/\1<redacted-address>/g; s/(--merge-mine[ =][^[:space:]]+[[:space:]]+)[^-[:space:]][^[:space:]]*/\1<redacted-address>/g' \
         -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/gI; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
 }
 

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Self-test for the two redaction shapes #1582 found missing.
+# Self-test for the redaction shapes successive issues found missing: #1582's two to begin with,
+# then #1587's JSON form, #1590's casing, and #1596's positional addresses. Sections are labelled.
 #
 # redact() guarded two shapes — `KEY=value` for *_PASSWORD/*_TOKEN/*_SECRET, and v3 onion
 # hostnames — and selftest.sh asserted exactly those four cases. So the coverage matched the
@@ -66,6 +67,68 @@ case "$OUT" in *"$XMR"*) it_fail "argv line: wallet absent" "wallet leaked" ;; *
 assert_contains "argv line: onion still redacted" "$OUT" "<redacted>.onion"
 assert_contains "argv line: non-secret argument kept" "$OUT" "--stratum 0.0.0.0:3333"
 
+echo "== redact: addresses by POSITION — the shape no length bar reaches (#1596) =="
+# The p2pool launch line (docker-compose.yml:416-421) names the Monero address as `--wallet <addr>`
+# and gives the Tari one as a BARE POSITIONAL after `--merge-mine tari://host:port`. A positional
+# has no name to key on, so the >=90-char SHAPE rule was carrying both — and it reaches only one of
+# the three Tari forms `28-parse-and-validate-config.sh` accepts: the base58 form clears 90 by a
+# SINGLE character, and the other two sit far below it. Lowering the bar is not the fix — it starts
+# matching ordinary log tokens, and no threshold reaches the emoji form at all. Hence POSITION.
+#
+# The cases below are written from the THREE FORMS the validator accepts, not from what the
+# expression happens to handle — the failure #1582 was found by. Which case proves which arm is
+# stated at ATTRIBUTION, because two of them are ALSO reachable by the length bar. The Monero
+# address is NOT re-asserted per form — the --wallet path is identical on all three lines, so
+# that would be one measurement printed three times; the two arms are proven to coexist on one
+# line by the quoted COMMAND column case below, which asserts both.
+TARI_B58="12$(printf 'B%.0s' $(seq 1 89))"                # 91 chars — cleared the old bar by ONE
+TARI_SINGLE="1224$(printf 'C%.0s' $(seq 1 44))"           # 48 chars — below any usable bar
+TARI_EMOJI="$(printf '\xf0\x9f\x90\xa2%.0s' $(seq 1 67))" # 67 glyphs, non-alphanumeric
+for _form in "base58:$TARI_B58" "single:$TARI_SINGLE" "emoji:$TARI_EMOJI"; do
+    _name="${_form%%:*}"
+    _addr="${_form#*:}"
+    OUT="$(printf -- 'p2pool --wallet %s --merge-mine tari://node:18142 %s --stratum 0.0.0.0:3333\n' \
+        "$XMR" "$_addr" | redact)"
+    case "$OUT" in
+    *"$_addr"*) it_fail "argv positional: Tari $_name address absent" "address survived: $OUT" ;;
+    *) it_pass "argv positional: Tari $_name address absent" ;;
+    esac
+done
+
+# ATTRIBUTION. `single` and `emoji` are the rows that discriminate for the --merge-mine arm; the
+# base58 row is 91 characters and the >=90 bar kills it either way. For the --wallet arm the
+# discriminating case is a SHORT value — below every length bar and under no JSON key, so the
+# POSITION rule is the only thing in redact() that can reach it. Without this row, deleting the
+# --wallet pattern leaves this whole file green, the 95-char Monero fixture being caught twice.
+SHORT_ARGV_WALLET="4ShortNotAnAddress"
+OUT="$(printf -- 'p2pool --wallet %s --stratum 0.0.0.0:3333\n' "$SHORT_ARGV_WALLET" | redact)"
+case "$OUT" in
+*"$SHORT_ARGV_WALLET"*) it_fail "argv positional: a SHORT value after --wallet is redacted" "value survived: $OUT" ;;
+*) it_pass "argv positional: a SHORT value after --wallet is redacted" ;;
+esac
+
+# The token match is GREEDY to the next space, deliberately, so it absorbs punctuation attached to
+# the address — `compose-ps.txt` quotes its COMMAND column and the closing quote goes with it. The
+# tidier alternative (stop the match at a quote) was MEASURED and refused: on `--wallet "<addr>"`
+# it declines the leading quote, matches nothing, and the address survives WHOLE. Absorbing a
+# quote is cosmetic; leaving one behind is the partial redaction this file exists to catch. Both
+# quotings are pinned here so the trade-off cannot be reversed for tidiness without a red row.
+OUT="$(printf -- 'itest-p2pool "/entrypoint.sh --wallet %s --merge-mine tari://n:1 %s" Up\n' \
+    "$XMR" "$TARI_SINGLE" | redact)"
+case "$OUT" in
+*"$XMR"*) it_fail "quoted COMMAND column: Monero address absent" "address survived: $OUT" ;;
+*) it_pass "quoted COMMAND column: Monero address absent" ;;
+esac
+case "$OUT" in
+*"$TARI_SINGLE"*) it_fail "quoted COMMAND column: Tari address absent" "address survived: $OUT" ;;
+*) it_pass "quoted COMMAND column: Tari address absent" ;;
+esac
+OUT="$(printf -- 'cmd --wallet "%s" --stratum 0.0.0.0:3333\n' "$TARI_SINGLE" | redact)"
+case "$OUT" in
+*"$TARI_SINGLE"*) it_fail "a QUOTED address after --wallet is redacted WHOLE" "address survived: $OUT" ;;
+*) it_pass "a QUOTED address after --wallet is redacted WHOLE" ;;
+esac
+
 echo "== redact: over-redaction guard — debugging value must survive =="
 # "Over-redaction is safe" is true of secrets, not of everything: an artifact with the image
 # digests and endpoints stripped is useless for the debugging it exists for. These are the
@@ -74,6 +137,12 @@ OUT="$(printf 'sha256:%s\nHOST_IP=box.lan\n--merge-mine tari://node:18142\n' "$S
 assert_contains "a sha256 digest survives" "$OUT" "$SHA"
 assert_contains "a non-secret KEY=value survives" "$OUT" "HOST_IP=box.lan"
 assert_contains "a non-secret flag value survives" "$OUT" "--merge-mine tari://node:18142"
+# The positional rule replaces the token AFTER the URI, never the URI itself, and refuses a token
+# beginning with `-`: a flag is never an address, so a change in argument order cannot silently
+# corrupt the line the endpoint explains. The assertion above is the same guard with the URI last.
+OUT="$(printf -- 'p2pool --merge-mine tari://node:18142 --local-api --stratum 0.0.0.0:3333\n' | redact)"
+assert_contains "the --merge-mine endpoint itself survives" "$OUT" "tari://node:18142"
+assert_contains "a FLAG after the endpoint is not taken for an address" "$OUT" "--local-api"
 
 echo "== redact: the JSON shape, keyed on the field name (#1587) =="
 # #1582 was the argv shape. This is the JSON one, and it could not be fixed the same way: a


### PR DESCRIPTION
## What this is

**#1596's site 2 only** — `tests/integration/lib.sh`'s `redact()`. Site 1
(`lib/pithead/07-support-bundle.sh`) is another lane's path and is the more serious half of that
issue: it is **untouched here and still open**, so #1596 must not be closed on this PR.

The p2pool launch line (`docker-compose.yml:416-421`) names the Monero address as `--wallet <addr>`
and gives the Tari one as a **bare positional** after `--merge-mine tari://host:port`. A positional
has no name to key on, so the `>=90`-character SHAPE rule was the only rule reaching it — and it
reaches one of the three Tari forms this repo accepts.

## Reproduced before fixing — PROVEN BY ME, not relayed from the issue

The real `redact()`, over a synthesised launch line. Synthetic values throughout: nothing here is a
real address, and the forms only need the length and alphabet of the real thing.

| form | length | before this PR |
|---|---|---|
| base58 | 91 | redacted — clears the 90 bar by ONE character |
| single | 48 | **survives verbatim** |
| emoji | 67 glyphs | **survives verbatim** |
| Monero | 95 | redacted — positive control, the expression ran |

## The change

Two positional patterns appended to `redact()`'s first `-e`: the token after `--wallet`, and the
token after `--merge-mine`'s URI. Both refuse a token beginning with `-`, so a flag in that
position is never taken for an address.

`lib.sh` sits at its **692-line ceiling**, so the change is **line-neutral**: the patterns append
inside existing single-line `-e` arguments, and the header comment was rewritten in place at the
same four lines. `file budget OK` confirms it.

**Broader than the issue asked, deliberately:** the `--merge-mine` pattern does not require the
`tari://` scheme, so p2pool's generic `--merge-mine IP:port ADDR` form is covered too.

## What was RUN

- `tests/integration/selftest-redact.sh` — **54 passed, 0 failed** — 45 before this PR, measured on both sides rather than counted from the diff.
- Whole glob, per file, unfiltered: all 15 `selftest*.sh` green, `make test-integration-selftest`
  exit 0.
- Re-ran under `LC_ALL=C` and `LC_ALL=C.UTF-8` as well as the default locale — the emoji case does
  not depend on a UTF-8 locale, and CI's is not guaranteed.
- `shellcheck --severity=warning tests/integration/*.sh` (0.11.0) → rc 0. Measured over the whole
  31-file directory glob, not a partial one; the list contains both changed files. **Positive
  control:** an injected unused assignment made the same command exit 1 (SC2034), then reverted.
- `shfmt -i 4 -d` on both changed files → rc 0. `make lint-md` → 0 errors, 48 files.
  `make lint-docs-voice` → OK, 41 prose docs. `make lint-file-budget` → OK, monotonic.

### The new cases can FAIL, and each is attributed to the arm that kills it

Mutation battery, each leg `cmp`-checked against the original before being counted:

| leg | result |
|---|---|
| drop the `--wallet` pattern | 2 red: the SHORT value after `--wallet`, and the QUOTED address |
| drop the `--merge-mine` pattern | 3 red: Tari single, Tari emoji, and the quoted COMMAND column |

`lib.sh` restored byte-identical afterwards, control re-run green. The `base58` row deliberately
does **not** red under either leg: at 91 characters the `>=90` bar covers it, so it cannot
attribute anything. That is stated in the test file so a later reader does not mistake it for
proof of the new rule.

## The over-engineering pass, run off disk on my own diff

One finding accepted, two declined:

- **Accepted, and cut:** the Monero address was re-asserted once per Tari form. The `--wallet` path
  is identical on all three lines, so that was one measurement printed three times. Removed; the
  two arms are still proven to coexist on one line by the quoted COMMAND column case, which asserts
  both. The comment now says so, so the rows are not quietly re-added.
- **Declined —** the comment-to-code ratio in the new section. It matches what every prior section
  of this file does, and each block records a decision that would otherwise be re-litigated.
- **Declined —** "do not lower the bound" appears both here and in the doc. Two audiences: the doc
  is read by someone deciding whether to trust a bundle, the comment by someone editing the
  expression. The file already carries #1587 and #1590 the same way.

## Trade-off pinned by a test, not left to taste

The token match is **greedy to the next space**, so it absorbs punctuation attached to the address
— `compose-ps.txt` quotes its COMMAND column and the closing quote goes with it. I measured the
tidier alternative (stop the match at a quote) and **refused it**: on `--wallet "<addr>"` it
declines the leading quote, matches nothing, and the address survives whole. Absorbing a quote is
cosmetic; leaving one behind is the partial redaction that self-test file exists to catch. Both
quotings are now pinned, so the trade-off cannot be reversed for tidiness without a red row.

## Docs

`docs/dev/integration-testing.md` is updated via `_shared.paths` — **disclosed here, no
`.lane-override`**. Two corrections beyond adding the new shape:

- The file stated the 90-character rule "is what catches wallet addresses". That is **the defect's
  own words carried as fact**, and it is the sentence that tells a reader they may stop checking.
- Adding the new rule to that list broke the referent of the sentence beginning "That last rule",
  which had pointed at the JSON rule. Named explicitly instead.

## What I did NOT do

- **Site 1 is untouched.** Not my path, and it is the half operators are actually asked to send us.
- **I did not measure a real bundle from a running stack.** Every figure comes from running the
  real expression over synthesised lines. That proves what the expression can and cannot reach; it
  does not prove any deployed stack emitted one.
- **A gap I found and did not fix here:** in `.env`, a `*_WALLET_ADDRESS` value shorter than 90
  characters survives — the `KEY=value` rule keys on `_PASSWORD` / `_TOKEN` / `_SECRET` only, and
  none of the new positional rules apply to a `KEY=value` line. `env.redacted.txt` is one of the
  five files **#1593** already names as never audited, so this belongs to that audit rather than to
  a new issue; I have recorded it there.
- **One sentence was dropped from `lib.sh`'s header comment** to stay line-neutral: the note that
  nesting is invisible to a line-wise filter (ntfy's bare `url`). It is replaced by a pointer to
  `selftest-redact.sh`, which carries that gap in full with its issue number, as does the doc.
  Nothing is lost repo-wide, but it is a deletion and not a reword.

Not closing #1596 — site 1 is still open, and `Closes` never fires here anyway: PRs target
`develop-v2` while the default branch is `develop`.
