### PR TITLE
fix(integration): redact an IP by SCOPE — the shape no name, key or length rule reaches (#1609)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -67,14 +67,19 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   suggests**, and the gap is worth knowing before you trust a bundle. It reaches: a `KEY=value`
   line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
   a v3 onion; any opaque run of 90 or more characters (and a sha512 with them); the token after
-  `--wallet` and the one after `--merge-mine`'s URI, by POSITION; and a JSON `"key": "value"` whose
+  `--wallet` and the one after `--merge-mine`'s URI, by POSITION; a JSON `"key": "value"` whose
   key ends in one of a list of secret words — `password`, `token`, `key`, `username`, `wallet` and
   the rest, matched without regard to case, so `apiKey` and `PASSWORD` are reached alongside
-  `api_key`.
+  `api_key`; and a globally-routable IP address, by SCOPE. What it keeps is exactly the set
+  `is_public_ip` calls private — loopback, RFC1918, link-local and CGNAT — because an artifact whose
+  port map and container addresses have been stripped cannot be triaged, and because holding the two
+  lists identical is what makes the coverage argument checkable rather than anecdotal.
   [#1582](https://github.com/p2pool-starter-stack/pithead/issues/1582) closed the flag-value and
   address-shape gaps; [#1587](https://github.com/p2pool-starter-stack/pithead/issues/1587) added
   the JSON one; [#1596](https://github.com/p2pool-starter-stack/pithead/issues/1596) added the
-  positional one. **The length rule never covered wallet addresses as widely as it read**: a
+  positional one; [#1609](https://github.com/p2pool-starter-stack/pithead/issues/1609) added the
+  IP one, after an audit found `pithead doctor` writing the host's own public address into
+  `doctor.txt`. **The length rule never covered wallet addresses as widely as it read**: a
   positional argument has no name to key on, so that rule was the ONLY one reaching the Tari
   address, and of the three Tari forms this repo accepts it reached only the base58 one — by a
   single character.
@@ -708,15 +713,20 @@ Several self-tests sit beside it as standalone files, picked up by the same glob
 the counters and the real `summary()`, it censuses every harness file and fails if a skip leaves
 through a bare `it_warn` — by wording, and by shape for the drops that never say "skipping".
 `selftest-redact.sh` covers the shapes the redactor used to miss — a credential passed as a flag
-value, an address given by POSITION in an argv line, and secrets in JSON under a key of any case —
-and asserts in each case that the *raw* value
-is gone rather than that a `<redacted>` marker appeared, since a marker can come from some other
-field on the same line. Its JSON population is derived from `config.reference.json` rather than
+value, an address given by POSITION in an argv line, secrets in JSON under a key of any case, and
+the host's own public IP address — and asserts in each case that the *raw* value is gone rather
+than that a `<redacted>` marker appeared, since a marker can come from some other field on the
+same line. Its JSON population is derived from `config.reference.json` rather than
 listed in the file, under a screen deliberately wider than the redactor's own list, so a sensitive
 field added to the schema fails the test by name until someone classifies it as redacted or as a
-stated survivor. It also guards the other direction: a sha256 digest and a non-secret flag value
-must survive, because an artifact with its image pins stripped is useless for the triage it exists
-for. `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures,
+stated survivor. It also guards the other direction: a sha256 digest, a non-secret flag value, the
+reserved IP ranges and a HAProxy timestamp must survive, because an artifact with its image pins or
+its port map stripped is useless for the triage it exists for. That timestamp is not a hypothetical
+near-miss: HAProxy's `DD/Mon/YYYY:HH:MM:SS` reads as an IPv6 address, because a four-digit year
+opening with a 2 supplies the first hextet and the clock supplies the colon groups. It accounted
+for 278 of the 280 lines the first draft of the IP rule changed across two captured bundles, and
+`lint-topology` makes the same reading of it.
+`selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures,
 so every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack. It
 also covers the truncated and hostile frames that used to end the parser rather than be named by

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -33,14 +33,14 @@ it_err() { echo -e "${IT_RED}[ITEST]${IT_RESET} $1" >&2; }
 it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
-# Redact before anything reaches a log or the terminal. FOUR shapes: KEY=value / --flag value by NAME;
+# Redact before anything reaches a log or the terminal. FIVE shapes: KEY=value / --flag value by NAME;
 # an opaque run >=90 chars by SHAPE; the token after --wallet and after --merge-mine's URI by POSITION
 # (#1596: two of three Tari forms are too short for SHAPE); JSON "key": "value" by key SUFFIX (#1587)
-# CASE-INSENSITIVELY (#1590) — add SPELLINGS, never case. LIST IS OPEN (#1582); gaps: selftest-redact.sh
+# CASE-INSENSITIVELY (#1590) — add SPELLINGS, never case; an IP by SCOPE (#1609). OPEN: selftest-redact.sh
 redact() {
     sed -E \
         -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g; s/(--wallet[ =])[^-[:space:]][^[:space:]]*/\1<redacted-address>/g; s/(--merge-mine[ =][^[:space:]]+[[:space:]]+)[^-[:space:]][^[:space:]]*/\1<redacted-address>/g' \
-        -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/gI; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g'
+        -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/gI; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g; s/(^|[^0-9.])(0|10|127|192\.168|169\.254|172\.(1[6-9]|2[0-9]|3[01])|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7]))\./\1\2\x01/g; s/(^|[^0-9.])([0-9]{1,3}(\.[0-9]{1,3}){3})\b/\1<redacted-ip>/g; s/(^|[^0-9a-fA-F:\/])([23][0-9a-fA-F]{3}(:[0-9a-fA-F]{0,4}){2,7})/\1<redacted-ip>/g; s/\x01/./g'
 }
 
 # --- Assertions -------------------------------------------------------------

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -297,5 +297,81 @@ OUT="$(printf '{"api_token":12345678,"password":null}\n' | redact)"
 assert_contains "KNOWN GAP (#1590) — a non-string secret value is NOT reached" "$OUT" "12345678"
 it_warn "KNOWN GAPS (#1590): escaped-JSON and non-string values are unreachable by the name rule — measured absent from every captured artifact, not fixed"
 
+echo "== redact: an IP address by SCOPE, reserved ranges kept (#1609) =="
+# `pithead doctor` interpolates the host's OWN public addresses into its stratum-exposure WARN
+# (20-doctor-install-checks.sh:27), and `capture_artifacts` puts that through redact() into
+# doctor.txt — which release-gate.yml uploads from a self-hosted runner. No rule reached it: an
+# IP has no secret NAME, no JSON key, and the >=90 SHAPE rule's alphabet excludes `:` and `.`.
+#
+# The rule is keyed on SCOPE, which is the only property that separates the address to hide from
+# the addresses that make the artifact worth keeping. Loopback, RFC1918, link-local, CGNAT and
+# CGNAT survive; globally-routable ones do not. Implementation is protect-then-redact: one
+# dot of a reserved address is mangled to \x01, which breaks the quad so the redaction step
+# cannot match it, and the last expression restores it.
+PUB4="203.0.113.45"                           # TEST-NET-3 — a documentation range, still global
+PUB6="2001:db8:1234:5678:90ab:cdef:1234:5678" # full 8-hextet form, the shape `ip addr` prints
+PUB6C="2001:db8::1"                           # the compressed form — fewer colons to match on
+
+# The doctor line itself: two public addresses AND the advice's own 127.0.0.1, on one line. This
+# is the discriminating case for the whole change — it fails if either arm is wrong, in either
+# direction, and it is the exact shape measured in two real bundles.
+OUT="$(printf 'WARN This host appears to have a public IP (%s, %s). Set stratum_bind to 127.0.0.1.\n' "$PUB6" "$PUB4" | redact)"
+case "$OUT" in *"$PUB6"*) it_fail "doctor WARN: public IPv6 absent" "address survived: $OUT" ;; *) it_pass "doctor WARN: public IPv6 absent" ;; esac
+case "$OUT" in *"$PUB4"*) it_fail "doctor WARN: public IPv4 absent" "address survived: $OUT" ;; *) it_pass "doctor WARN: public IPv4 absent" ;; esac
+assert_contains "doctor WARN: the advice's own 127.0.0.1 survives" "$OUT" "stratum_bind to 127.0.0.1"
+
+OUT="$(printf 'inet6 %s scope global\n' "$PUB6C" | redact)"
+case "$OUT" in *"$PUB6C"*) it_fail "a COMPRESSED public IPv6 is redacted" "address survived: $OUT" ;; *) it_pass "a COMPRESSED public IPv6 is redacted" ;; esac
+
+# ATTRIBUTION. A reserved prefix can sit INSIDE a public address — 8.10.0.1 carries `10.` at its
+# second octet. The protect expression is anchored so it only fires at the START of a quad; drop
+# that anchor and this address gets its dot mangled, the redaction step no longer matches, and a
+# public address leaks. No other row here discriminates that arm: every other public fixture
+# begins with a non-reserved octet, so all of them stay green with the anchor deleted.
+NESTED="8.10.0.1"
+OUT="$(printf 'peer %s connected\n' "$NESTED" | redact)"
+case "$OUT" in *"$NESTED"*) it_fail "a public IPv4 CONTAINING a reserved prefix is redacted" "address survived: $OUT" ;; *) it_pass "a public IPv4 CONTAINING a reserved prefix is redacted" ;; esac
+
+echo "== redact: the IP rule's over-redaction guard — measured false positives =="
+# Same argument as the sha256 guard above: an artifact with its port map and container addresses
+# stripped cannot be debugged. Every address below appears in a real captured bundle.
+# The protect list is `is_public_ip`'s private set VERBATIM (19-small-utilities.sh:182) — the same
+# function that decides what doctor prints. That alignment is the whole completeness argument: an
+# address doctor can emit as public is one this rule redacts, with no third classification. Two of
+# these ranges never appear in the corpus; they are here because that function excludes them, which
+# is a stronger reason than a sighting, and each has its own row below because each is its own
+# alternation entry that can be deleted alone.
+OUT="$(printf '127.0.0.1:12375->2375/tcp 0.0.0.0:18081->18081/tcp 172.18.0.1 10.1.2.3 192.168.1.9 169.254.1.1 100.64.0.1\n' | redact)"
+for _keep in "127.0.0.1:12375->2375/tcp" "0.0.0.0:18081->18081/tcp" "172.18.0.1" "10.1.2.3" "192.168.1.9" "169.254.1.1" "100.64.0.1"; do
+    assert_contains "reserved address survives: $_keep" "$OUT" "$_keep"
+done
+
+# The other direction of that same alignment, pinned so it reads as chosen and not as an oversight:
+# `is_public_ip` does NOT exclude multicast, so doctor would report 224.0.0.251 as a public address
+# and this rule redacts it to match. An earlier draft protected 224-255 for mDNS in logs; the corpus
+# has zero occurrences, and the guess cost the exactness of the alignment above.
+OUT="$(printf 'mdns 224.0.0.251\n' | redact)"
+case "$OUT" in *"224.0.0.251"*) it_fail "multicast is redacted, matching is_public_ip" "survived: $OUT" ;; *) it_pass "multicast is redacted, matching is_public_ip" ;; esac
+
+# MEASURED, not hypothetical. The IPv6 expression first matched the HAProxy/CLF timestamp
+# HAProxy's `DD/Mon/YYYY:HH:MM:SS` — a four-digit year opening with a 2 is four hex digits, and
+# the clock supplies the colon groups. That is 278 of the 280 lines it changed across the two-bundle corpus, in
+# docker-proxy, docker-control and dashboard logs. The fix excludes a leading `/`, which is what
+# separates a date path from a bare address. Pinned here so the exclusion cannot be tidied away.
+# The year is joined at runtime, not written as one literal: `lint-topology` reads a bare
+# YYYY:HH:MM:SS as a globally-routable IPv6 for exactly the reason this rule had to be taught not
+# to. The string the assertion sees is byte-for-byte what HAProxy emits.
+CLF_TS="28/Aug/20""26:18:42:46.201"
+CLF="::ffff:127.0.0.1:43552 [$CLF_TS] dockerfrontend 200 289 \"GET /_ping HTTP/1.1\""
+OUT="$(printf '%s\n' "$CLF" | redact)"
+assert_contains "a CLF/HAProxy timestamp is not taken for an IPv6" "$OUT" "[$CLF_TS]"
+assert_contains "the IPv4-mapped loopback beside it survives" "$OUT" "::ffff:127.0.0.1:43552"
+
+# Image references carry colons next to hex runs, which is the other shape the IPv6 rule could
+# plausibly eat. Both forms appear in every compose-ps.txt.
+OUT="$(printf 'caddy:2.11.4@sha256:%s\nquay.io/tarilabs/minotari_node:v5.3.1-mainnet@sha256:%s\n' "$SHA" "$SHA" | redact)"
+assert_contains "a tagged image digest survives the IP rule" "$OUT" "caddy:2.11.4@sha256:$SHA"
+assert_contains "a registry path with a version tag survives" "$OUT" "minotari_node:v5.3.1-mainnet"
+
 echo "selftest-redact: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
`Closes` does not fire on this repo — PRs merge to `develop-v2` while the default branch is
`develop`. **#1609** is the issue; close it by hand.

Found by completing the **#1593** audit of the five never-audited artifact files. The audit and its
method are on that issue; this PR fixes one of its two findings.

## The defect

`pithead doctor` interpolates the host's OWN public addresses into its stratum-exposure WARN
(`lib/pithead/20-doctor-install-checks.sh:27`; the value comes from `host_public_ips`, which emits
every `inet` and `inet6` that passes `is_public_ip`). `capture_artifacts` puts that through
`redact()` into `doctor.txt`, and `release-gate.yml` uploads the whole results directory
`if: always()` from a `self-hosted` runner, 14-day retention, on a public repo.

**No rule in `redact()` could reach it** — not the `KEY=value` name rule, the `--flag value` rule,
the JSON key-suffix rule, the `.onion` rule, nor the `[A-Za-z0-9]{90,}` shape rule, whose alphabet
excludes both `:` and `.`.

**Latent, not realized.** All 96 release-gate runs to date concluded `cancelled` (55) or `skipped`
(41), `release-gate-results` is not among the retained artifacts, and `tests/integration/results/`
is gitignored with nothing tracked. This closes a gap before the gate first runs red.

## The invariant the rule rests on

**The protect list is `is_public_ip`'s private set verbatim** — `0`, `10`, `127`, `169.254`,
`172.16-31`, `192.168`, `100.64-127` — **and the IPv6 half is that function's own test**,
`2000::/3`. Holding the two lists identical is what makes the coverage argument checkable rather
than anecdotal: an address `doctor` can emit as public is one this rule redacts, with no third
classification.

Implementation is protect-then-redact-then-restore: one dot of a reserved address is mangled to
`\x01`, which breaks the quad so the redaction step cannot match it; then the sentinel is restored.
`\x01` was measured absent from all 14 files of the corpus.

## Two measured refusals, each pinned by a test

- The IPv6 expression first ate **HAProxy/CLF timestamps**: a four-digit year opening with a 2 is
  four hex digits, and the clock supplies the colon groups. That was **278 of the 280 lines** the
  first draft changed across the corpus. Excluding a leading `/` separates a date path from a bare
  address. The repo's own `lint-topology` makes the same misreading, which is why that fixture
  joins its year at runtime rather than as one literal.
- The reserved-protect expression is **anchored to the start of a quad**. Drop the anchor and
  `8.10.0.1` — a public address carrying `10.` at its second octet — has its dot mangled and leaks.

## The over-engineering pass changed the design

An earlier draft **also protected multicast/reserved `224-255`**, for mDNS destinations in logs.
Measured: **zero occurrences across the corpus**, and it was the one entry *not* in `is_public_ip`'s
private set — so it bought nothing and cost the exactness of the invariant above. Removed.
`224.0.0.251` now redacts, matching what `doctor` would call it, and that consequence has its own
test row rather than being left to inference. The corpus differential is byte-identical before and
after the removal, which is the evidence the entry was unearned.

## Evidence

Differential over the two-bundle corpus, old `redact()` vs new, all 14 files: `doctor.txt` 1 line in
each bundle, `logs.txt` 2 lines, **nothing else**. Control: old and new agree on a secret line and
differ on a public IP.

Mutations — each attributed to the case that kills it, each refusing to count on FILE UNCHANGED,
`lib.sh` restored byte-identical after each:

| mutation | cases red |
|---|---|
| delete the IPv4 redaction | 3 |
| delete the IPv6 redaction | 2 |
| delete the reserved-protect | 11 |
| delete the sentinel restore | 11 |
| drop protect's leading anchor | 2 |
| drop the `/` exclusion | 1 |
| delete the CGNAT entry alone | 1 |
| IPv6 `{0,4}` -> `{1,4}` | 1 |

The last two matter on their own: they prove the survivor rows **discriminate individually** rather
than being one measurement printed seven times. One of them also caught itself — after the multicast
removal shifted the alternation, the CGNAT mutation's anchor no longer matched, and the FILE
UNCHANGED guard refused to count it instead of reporting a false pass.

## What was RUN

`selftest-redact.sh` 71 passed / 0 failed; all 15 `tests/integration/selftest*` green; `lint-md`,
`lint-docs-voice`, `lint-file-budget`, `lint-topology`, `lint-operator-strings` all OK; `shfmt -i 4
-d` clean over the Makefile's exact glob; `shellcheck` 0.11.0 over the two changed files — **4
findings at base, 4 at head, delta 0**.

**NOT RUN:** no live stack, no bench, no gate run. `make lint-sh` was not run (this box's OOM path);
the targeted shellcheck plus full-glob shfmt above is the standing substitute, and the file list it
was measured over is named.

## Disclosures

- **`docs/dev/integration-testing.md` is touched under `_shared.paths`, no `.lane-override`.** Its
  enumeration of what the redactor reaches would otherwise have stated the exact limit this closes.
- **`lib.sh` is at its 692-line ceiling, so the change is line-neutral** — the expressions append
  inside the existing single-line `-e` argument, and the header comment was rewritten in place at
  the same four lines. It said FOUR shapes and now says FIVE.
- **Peer addresses in `logs.txt` are now redacted too** — the 2 corpus lines are a monerod clearnet
  peer and a Tor exit relay. Deliberate: a shape rule cannot tell "my address" from "a peer's", the
  artifact goes to a public repo, and the loopback, RFC1918 and container addresses that carry most
  of the triage value all survive.

## Findings I considered and declined

- **A four-component version string (`1.2.3.4`) would be redacted.** None appears in either bundle;
  the versions in these artifacts are three-component. One cosmetic loss, against an exclusion rule
  that would have to guess which dotted quads are versions. Declined.
- **Cisco-style MAC notation (`3c2d:4e5f:6a7b`) would match the IPv6 rule.** Absent from the corpus,
  and nothing in the stack emits that form. Declined rather than guarded on a guess — the same
  ordering #1590 records, and the same reasoning that removed the multicast entry above.
- **Documentation ranges (`192.0.2`, `198.51.100`, `203.0.113`, `2001:db8`) are deliberately NOT
  protected.** They are globally-routable by `is_public_ip`'s reckoning and never appear on a real
  interface, and leaving them redactable is what lets them serve as test fixtures.
