### PR TITLE
fix(integration): key KEY=value on the JSON rule's vocabulary — one list, not two that drifted (#1611)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -65,12 +65,13 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   comparing the hash, so the plaintext never crosses the wire, and every captured artifact passes
   through a redactor. **What that redactor covers is narrower than "artifacts are redacted"
   suggests**, and the gap is worth knowing before you trust a bundle. It reaches: a `KEY=value`
-  line whose name ends in `_PASSWORD` / `_TOKEN` / `_SECRET`; a credential given as a flag value;
-  a v3 onion; any opaque run of 90 or more characters (and a sha512 with them); the token after
-  `--wallet` and the one after `--merge-mine`'s URI, by POSITION; a JSON `"key": "value"` whose
-  key ends in one of a list of secret words — `password`, `token`, `key`, `username`, `wallet` and
-  the rest, matched without regard to case, so `apiKey` and `PASSWORD` are reached alongside
-  `api_key`; and a globally-routable IP address, by SCOPE. What it keeps is exactly the set
+  line and a JSON `"key": "value"` whose key ends in one of a SINGLE shared list of secret words —
+  `password`, `token`, `key`, `username`, `wallet`, `ping_url` and the rest — the JSON side matched
+  without regard to case, so `apiKey` and `PASSWORD` are reached alongside `api_key`, the
+  `KEY=value` side uppercase-only because `.env` is generated uppercase throughout; a credential
+  given as a flag value; a v3 onion; any opaque run of 90 or more characters (and a sha512 with
+  them); the token after `--wallet` and the one after `--merge-mine`'s URI, by POSITION; and a
+  globally-routable IP address, by SCOPE. What it keeps is exactly the set
   `is_public_ip` calls private — loopback, RFC1918, link-local and CGNAT — because an artifact whose
   port map and container addresses have been stripped cannot be triaged, and because holding the two
   lists identical is what makes the coverage argument checkable rather than anecdotal.
@@ -79,7 +80,13 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   the JSON one; [#1596](https://github.com/p2pool-starter-stack/pithead/issues/1596) added the
   positional one; [#1609](https://github.com/p2pool-starter-stack/pithead/issues/1609) added the
   IP one, after an audit found `pithead doctor` writing the host's own public address into
-  `doctor.txt`. **The length rule never covered wallet addresses as widely as it read**: a
+  `doctor.txt`; and [#1611](https://github.com/p2pool-starter-stack/pithead/issues/1611) put the
+  `KEY=value` rule onto the JSON rule's vocabulary. Those two had DRIFTED, which is a sharper
+  failure than a missing spelling: the same field carrying the same value was classified two ways
+  depending only on the syntax it arrived in, so a wallet address below the length bar was
+  redacted in `config.json` and survived verbatim in `env.redacted.txt`. Keying one rule on the
+  other's list leaves one list to extend rather than two to drift apart, and the self-test asserts
+  mechanically that they still agree. **The length rule never covered wallet addresses as widely as it read**: a
   positional argument has no name to key on, so that rule was the ONLY one reaching the Tari
   address, and of the three Tari forms this repo accepts it reached only the base58 one — by a
   single character.
@@ -725,7 +732,14 @@ its port map stripped is useless for the triage it exists for. That timestamp is
 near-miss: HAProxy's `DD/Mon/YYYY:HH:MM:SS` reads as an IPv6 address, because a four-digit year
 opening with a 2 supplies the first hextet and the clock supplies the colon groups. It accounted
 for 278 of the 280 lines the first draft of the IP rule changed across two captured bundles, and
-`lint-topology` makes the same reading of it.
+`lint-topology` makes the same reading of it. That file also holds the vocabulary invariant: both
+of redact()'s suffix lists are read out of `lib.sh` and checked to agree with each other and to sit
+inside the screen, so the drift #1611 found cannot reopen quietly. `selftest-redact-env.sh` carries
+the `KEY=value` shape separately, including the three Tari address forms as `.env` renders them and
+the survivors that make a bundle worth keeping — a public endpoint, an auth mode string, a routing
+id. Its widening was measured before it shipped: across two archived bundles and the deployed
+`.env` it newly reaches ten keys, the same ten in all three populations, and changes nothing at all
+in the other six captured artifacts.
 `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures,
 so every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack. It

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -33,13 +33,13 @@ it_err() { echo -e "${IT_RED}[ITEST]${IT_RESET} $1" >&2; }
 it_step() { echo -e "${IT_DIM}  → $1${IT_RESET}"; }
 
 # --- Secrets hygiene --------------------------------------------------------
-# Redact before anything reaches a log or the terminal. FIVE shapes: KEY=value / --flag value by NAME;
-# an opaque run >=90 chars by SHAPE; the token after --wallet and after --merge-mine's URI by POSITION
-# (#1596: two of three Tari forms are too short for SHAPE); JSON "key": "value" by key SUFFIX (#1587)
-# CASE-INSENSITIVELY (#1590) — add SPELLINGS, never case; an IP by SCOPE (#1609). OPEN: selftest-redact.sh
+# Redact before anything reaches a log or the terminal. FIVE shapes: KEY=value and JSON "key": "value"
+# share ONE key-SUFFIX vocabulary (#1587; #1590 case-insensitive JSON-side; #1611 — they had drifted, so
+# one field was classified two ways); --flag value by NAME; >=90 chars by SHAPE; --wallet/--merge-mine's
+# next token by POSITION (#1596); an IP by SCOPE (#1609). SPELLINGS go in BOTH; selftest-redact*.sh.
 redact() {
     sed -E \
-        -e 's/(PROXY_AUTH_TOKEN|MONERO_NODE_PASSWORD|MONERO_NODE_USERNAME|.*_PASSWORD|.*_TOKEN|.*_SECRET)=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g; s/(--wallet[ =])[^-[:space:]][^[:space:]]*/\1<redacted-address>/g; s/(--merge-mine[ =][^[:space:]]+[[:space:]]+)[^-[:space:]][^[:space:]]*/\1<redacted-address>/g' \
+        -e 's/([A-Za-z0-9_]*(PASSWORD|PASSWD|SECRET|TOKEN|LOGIN|USERNAME|KEY|WALLET|WALLET_ADDRESS|PING_URL|DONOR_ID))=.*/\1=<redacted>/; s/(--[a-z-]*(login|password|passwd|secret|token|key))([ =])[^[:space:]]+/\1\3<redacted>/g; s/(--wallet[ =])[^-[:space:]][^[:space:]]*/\1<redacted-address>/g; s/(--merge-mine[ =][^[:space:]]+[[:space:]]+)[^-[:space:]][^[:space:]]*/\1<redacted-address>/g' \
         -e 's/("[A-Za-z0-9_]*(password|passwd|secret|token|login|username|key|wallet|wallet_address|ping_url|donor_id)"[[:space:]]*:[[:space:]]*")([^"\]|\\.)*/\1<redacted>/gI; s/[a-z2-7]{56}\.onion/<redacted>.onion/g; s/[A-Za-z0-9]{90,}/<redacted-address>/g; s/(^|[^0-9.])(0|10|127|192\.168|169\.254|172\.(1[6-9]|2[0-9]|3[01])|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7]))\./\1\2\x01/g; s/(^|[^0-9.])([0-9]{1,3}(\.[0-9]{1,3}){3})\b/\1<redacted-ip>/g; s/(^|[^0-9a-fA-F:\/])([23][0-9a-fA-F]{3}(:[0-9a-fA-F]{0,4}){2,7})/\1<redacted-ip>/g; s/\x01/./g'
 }
 

--- a/tests/integration/selftest-redact-env.sh
+++ b/tests/integration/selftest-redact-env.sh
@@ -42,10 +42,15 @@ SENTINEL="S3nt1nelVALUE" # short, alphanumeric: reachable by the NAME rule and b
 echo "== redact: KEY=value keyed on the JSON rule's vocabulary (#1611) =="
 # ATTRIBUTION. Every key below is BELOW the 90-character bar, carries no JSON quoting and no
 # `--flag`, so the name rule is the only thing in redact() that can reach it: delete the rule and
-# every row here reds. They are the six the two-bundle corpus showed still leaking, one per
-# vocabulary entry that `.env` actually exercises.
-for _key in MONERO_VIEW_KEY WALLET_RPC_USERNAME XVB_DONOR_ID HEALTHCHECKS_PING_URL \
-    TARI_SPEND_PUBLIC_KEY DASHBOARD_ONION_CLIENT_PRIVKEY; do
+# every row reds. ONE key per vocabulary entry that `.env` exercises, deliberately. The corpus
+# showed six keys still leaking, but `TARI_SPEND_PUBLIC_KEY` and `DASHBOARD_ONION_CLIENT_PRIVKEY`
+# both end in `KEY` like `MONERO_VIEW_KEY` — asserting all three is one measurement printed three
+# times, and a single mutation killed all three together. They are named here instead.
+# PASSWORD / TOKEN / SECRET stay covered by selftest.sh:202-210 and are not repeated. PASSWD,
+# LOGIN and the rest have no `.env` field and need no forward-cover row of their own: the
+# vocabulary invariant in selftest-redact.sh asserts this list IS the JSON one, so an entry cannot
+# quietly go missing here without that check failing.
+for _key in MONERO_VIEW_KEY WALLET_RPC_USERNAME XVB_DONOR_ID HEALTHCHECKS_PING_URL; do
     OUT="$(printf '%s=%s\n' "$_key" "$SENTINEL" | redact)"
     case "$OUT" in
     *"$SENTINEL"*) it_fail "$_key is redacted in a KEY=value line" "value survived: $OUT" ;;
@@ -103,7 +108,9 @@ assert_contains "an ordinary setting survives" "$OUT" "STACK_VERSION=v1.20.0"
 
 # Over-redaction that IS chosen, pinned so it cannot be filed later as a bug: any key ending in
 # `KEY` is replaced, `CACHE_KEY` included. That is the JSON rule's documented behaviour (#1590)
-# and narrowing it would mean guessing which `*_KEY` is a secret from its name.
+# and narrowing it would mean guessing which `*_KEY` is a secret from its name. This row shares
+# the `KEY` arm with the loop above and adds no coverage — it records the POLICY, so that a later
+# reader meeting a redacted `CACHE_KEY` finds it chosen rather than filing it.
 OUT="$(printf 'CACHE_KEY=%s\n' "$SENTINEL" | redact)"
 case "$OUT" in
 *"$SENTINEL"*) it_fail "an innocuous *_KEY is redacted too, as in JSON" "value survived: $OUT" ;;

--- a/tests/integration/selftest-redact-env.sh
+++ b/tests/integration/selftest-redact-env.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Self-test for the `KEY=value` shape (#1611). A separate file because selftest-redact.sh sits
+# just under lint-file-budget.sh's 400-line target; the runner globs `selftest*.sh`
+# (Makefile:29), so a new file needs no registration.
+#
+# The defect was a DISAGREEMENT, not a missing spelling. redact() already treated `wallet` as a
+# secret key name — in its JSON rule. On a `KEY=value` line only two rules could bite: a name
+# rule listing three uppercase spellings, and the >=90-character length rule. So the same field
+# carrying the same value was classified two ways depending only on the syntax it arrived in:
+#
+#     {"wallet":"4Short…"}           ->  {"wallet":"<redacted>"}
+#     MONERO_WALLET_ADDRESS=4Short…  ->  MONERO_WALLET_ADDRESS=4Short…   (before this change)
+#
+# The fix keys the `KEY=value` rule on the JSON rule's own suffix vocabulary rather than adding
+# one more spelling to a second list. selftest-redact.sh asserts mechanically that the two lists
+# still agree, so this cannot drift back apart silently.
+#
+# MEASURED before it shipped, over `env.redacted.txt` in two archived bundles and the deployed
+# `.env` (129 / 127 / 129 keys): the widening newly reaches exactly TEN keys, the same ten in all
+# three populations, and changes NOTHING in the other six captured artifacts — zero lines across
+# 307 KB of logs.txt, status.txt, doctor.txt, config.json, api-state.json and compose-ps.txt.
+# That is the answer to the risk this change had to clear: the replacement takes the whole rest
+# of the line, so a widened match could have stripped a debugging value. It reaches none.
+# Six of the ten still carried a raw value under the redactor as it stood, a 64-hex Monero view
+# key among them.
+#
+# Every fixture here is synthetic. The binding assertion in each case is that the RAW value is
+# ABSENT — never that a `<redacted>` marker appeared, since a marker can come from another field
+# on the same line.
+#
+# Run: tests/integration/selftest-redact-env.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+SENTINEL="S3nt1nelVALUE" # short, alphanumeric: reachable by the NAME rule and by no other
+
+echo "== redact: KEY=value keyed on the JSON rule's vocabulary (#1611) =="
+# ATTRIBUTION. Every key below is BELOW the 90-character bar, carries no JSON quoting and no
+# `--flag`, so the name rule is the only thing in redact() that can reach it: delete the rule and
+# every row here reds. They are the six the two-bundle corpus showed still leaking, one per
+# vocabulary entry that `.env` actually exercises.
+for _key in MONERO_VIEW_KEY WALLET_RPC_USERNAME XVB_DONOR_ID HEALTHCHECKS_PING_URL \
+    TARI_SPEND_PUBLIC_KEY DASHBOARD_ONION_CLIENT_PRIVKEY; do
+    OUT="$(printf '%s=%s\n' "$_key" "$SENTINEL" | redact)"
+    case "$OUT" in
+    *"$SENTINEL"*) it_fail "$_key is redacted in a KEY=value line" "value survived: $OUT" ;;
+    *) it_pass "$_key is redacted in a KEY=value line" ;;
+    esac
+done
+
+# The three Tari forms `28-parse-and-validate-config.sh` accepts, as `.env` renders them. The
+# base58 form is the one the old length bar reached, by a single character; the other two sat
+# below it, and the emoji form is unreachable by any bound because the bar's alphabet is
+# alphanumeric. Only the short and emoji rows discriminate — stated, so the base58 row is not
+# read as proof of anything the length rule was not already doing.
+TARI_B58="12$(printf 'B%.0s' $(seq 1 89))"                # 91 chars — cleared the old bar by ONE
+TARI_SINGLE="1224$(printf 'C%.0s' $(seq 1 44))"           # 48 chars — below any usable bar
+TARI_EMOJI="$(printf '\xf0\x9f\x90\xa2%.0s' $(seq 1 67))" # 67 glyphs, non-alphanumeric
+for _form in "base58:$TARI_B58" "single:$TARI_SINGLE" "emoji:$TARI_EMOJI"; do
+    _name="${_form%%:*}"
+    _addr="${_form#*:}"
+    OUT="$(printf 'TARI_WALLET_ADDRESS=%s\n' "$_addr" | redact)"
+    case "$OUT" in
+    *"$_addr"*) it_fail "TARI_WALLET_ADDRESS: the $_name form is redacted" "address survived: $OUT" ;;
+    *) it_pass "TARI_WALLET_ADDRESS: the $_name form is redacted" ;;
+    esac
+done
+
+# The name rule runs before the length rule, so a wallet line that both reach now reports
+# `<redacted>` where it used to report `<redacted-address>`. Pinned because it is a deliberate
+# trade and not an oversight: one vocabulary across both syntaxes is worth more than the hint
+# that the value happened to be an address, and the JSON rule already emitted the plain marker.
+XMR="4$(printf 'A%.0s' $(seq 1 94))" # 95 chars, Monero standard-address length
+OUT="$(printf 'MONERO_WALLET_ADDRESS=%s\n' "$XMR" | redact)"
+assert_contains "a wallet KEY=value reports the plain marker, as JSON does" "$OUT" "=<redacted>"
+
+# The old rule's prefix was `.*`, which is GREEDY: on a line carrying two secret keys it matched
+# the LAST one and left the first value in place. This is a real shape — `docker inspect` and
+# `pithead status` print several assignments on one line. The vocabulary prefix is
+# `[A-Za-z0-9_]*`, which cannot cross the space, so the match starts at the FIRST key and the
+# replacement takes the rest of the line with it. Restore the `.*` prefix and this row reds.
+OUT="$(printf 'A_TOKEN=%s B_TOKEN=%s\n' "$SENTINEL" "$SENTINEL" | redact)"
+case "$OUT" in
+*"$SENTINEL"*) it_fail "two secret keys on ONE line: neither value survives" "value survived: $OUT" ;;
+*) it_pass "two secret keys on ONE line: neither value survives" ;;
+esac
+
+echo "== redact: the KEY=value over-redaction guard — debugging value must survive =="
+# The same four fields selftest-redact.sh pins as JSON survivors, in the spelling `.env` uses.
+# Holding the two syntaxes to one vocabulary means holding them to the same survivors too: a
+# bundle with its endpoints and routing ids stripped is useless for the triage it exists for.
+# `XVB_URL` is the sharp one — only `PING_URL` is in the vocabulary, so a bare `_URL` survives.
+OUT="$(printf 'XVB_URL=https://xvb.example\nWORKERS_API_AUTH=token\nTELEGRAM_CHAT_ID=12345\nSTACK_VERSION=v1.20.0\n' | redact)"
+assert_contains "a public endpoint survives" "$OUT" "XVB_URL=https://xvb.example"
+assert_contains "an auth MODE string survives" "$OUT" "WORKERS_API_AUTH=token"
+assert_contains "a routing id survives" "$OUT" "TELEGRAM_CHAT_ID=12345"
+assert_contains "an ordinary setting survives" "$OUT" "STACK_VERSION=v1.20.0"
+
+# Over-redaction that IS chosen, pinned so it cannot be filed later as a bug: any key ending in
+# `KEY` is replaced, `CACHE_KEY` included. That is the JSON rule's documented behaviour (#1590)
+# and narrowing it would mean guessing which `*_KEY` is a secret from its name.
+OUT="$(printf 'CACHE_KEY=%s\n' "$SENTINEL" | redact)"
+case "$OUT" in
+*"$SENTINEL"*) it_fail "an innocuous *_KEY is redacted too, as in JSON" "value survived: $OUT" ;;
+*) it_pass "an innocuous *_KEY is redacted too, as in JSON" ;;
+esac
+
+# ⛔ STATED, not approved. Unlike the JSON rule this one is CASE-SENSITIVE, so a lowercase
+# assignment is not reached. `.env` is generated by `pithead` from config.json and is uppercase
+# throughout — #1590 measured all 129 keys — so nothing in the captured population needs it, and
+# a case-insensitive `key=.*` would eat the rest of any log line containing `key=`. If a
+# lowercase secret assignment ever needs covering, this row fails and names the shape.
+OUT="$(printf 'monero_view_key=%s\n' "$SENTINEL" | redact)"
+assert_contains "KNOWN GAP (#1611) — a lowercase KEY=value is NOT reached" "$OUT" "$SENTINEL"
+it_warn "KNOWN GAP (#1611): the KEY=value rule is uppercase-only — .env is generated uppercase, and a case-insensitive rule would eat log lines"
+
+echo "selftest-redact-env: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -176,7 +176,7 @@ KNOWN_GAP="notifications.ntfy.url"
 
 SENTINEL="S3nt1nelVALUE" # short, alphanumeric: reachable by the NAME rule and by no other
 SCREENED="$(
-    python3 - "$REF" <<'PY'
+    python3 - "$REF" "$HERE/lib.sh" <<'PY'
 import json, re, sys
 
 # INVARIANT: this screen must be a SUPERSET of redact()'s JSON name list, or a field carrying
@@ -200,9 +200,31 @@ def walk(node, path=""):
 for path, value in walk(json.load(open(sys.argv[1], encoding="utf-8"))):
     if isinstance(value, str) and SCREEN.search(path.split(".")[-1]):
         print(path)
+# The invariant above, MECHANICALLY (#1590): it shipped as a comment and was already false once,
+# at `wallet`. Both lists are READ OUT of lib.sh — a list restated here is the drift this asserts.
+lib = open(sys.argv[2], encoding="utf-8").read()
+j = re.search(r"\[A-Za-z0-9_\]\*\(([a-z_|]+)\)", lib)
+e = re.search(r"\[A-Za-z0-9_\]\*\(([A-Z_|]+)\)", lib)
+if not j or not e or len(j.group(1).split("|")) < 8:
+    print("!!could not read redact()'s two suffix vocabularies out of lib.sh")
+else:
+    for entry in j.group(1).split("|"):
+        if not SCREEN.search(entry):
+            print("!!the screen does not reach redact()'s JSON suffix: " + entry)
+    d = set(j.group(1).split("|")) ^ {x.lower() for x in e.group(1).split("|")}
+    if d:
+        print("!!KEY=value and JSON vocabularies disagree (#1611): " + " ".join(sorted(d)))
 PY
 )"
+# Violations are prefixed, so one python run reports both the population and the invariant.
+VOCAB_BAD="$(printf '%s\n' "$SCREENED" | sed -n 's/^!!//p')"
+SCREENED="$(printf '%s\n' "$SCREENED" | grep -v '^!!')"
 [ -n "$SCREENED" ] || it_fail "screen over config.reference.json returns fields" "empty population"
+if [ -n "$VOCAB_BAD" ]; then
+    it_fail "redact()'s two suffix vocabularies agree, and the screen covers them" "$VOCAB_BAD"
+else
+    it_pass "redact()'s two suffix vocabularies agree, and the screen covers them"
+fi
 
 # Word-splitting, not a `case` glob: the lists above wrap across lines, and a space-delimited
 # haystack silently misses every entry sitting next to a newline.


### PR DESCRIPTION
## What this fixes

`redact()` already treated `wallet` as a secret key name — **in its other rule**. On a `KEY=value`
line only two rules could bite: a name rule listing three uppercase spellings
(`.*_PASSWORD` / `.*_TOKEN` / `.*_SECRET`), and the `>=90`-character length rule. So the same field,
carrying the same value, was classified two ways depending only on the syntax it arrived in:

    {"wallet":"4Short…"}           ->  {"wallet":"<redacted>"}
    MONERO_WALLET_ADDRESS=4Short…  ->  MONERO_WALLET_ADDRESS=4Short…

That is the defect #1611 names: not a missing spelling, but two guards that drifted apart. So the fix
is not another spelling. The `KEY=value` rule is now keyed on the JSON rule's own suffix vocabulary —
one list to extend, rather than two to drift apart — and the self-test asserts mechanically that they
still agree.

## The risk this had to clear first, and the measurement

The `KEY=value` replacement takes the **whole rest of the line**, so widening what it matches could
strip a debugging value. Measured before writing the patch, then re-derived with the real shipped
function at base and at head over all 14 captured artifacts in two archived bundles:

| artifact | lines changed |
|---|---|
| `env.redacted.txt` | 10 per bundle |
| `logs.txt`, `status.txt`, `doctor.txt`, `config.json`, `api-state.json`, `compose-ps.txt` | **0** |

Zero, across ~307 KB of logs. The widening newly reaches exactly ten keys — the **same ten** in all
three populations checked (two bundles' `env.redacted.txt` plus the deployed `.env`, 129/127/129
keys). Every one of the ten is a field the same function already classifies as secret in JSON syntax,
so this applies the existing policy rather than inventing one.

Six of the ten still carried a raw value under the redactor as it stood — `MONERO_VIEW_KEY` (64 hex),
`HEALTHCHECKS_PING_URL`, `XVB_DONOR_ID`, `WALLET_RPC_USERNAME` and the two `DASHBOARD_ONION_CLIENT_*`
keys. The two wallet addresses in these bundles were already covered by the length rule, at 95 and 91
characters — the under-90 forms the issue names are real but do not occur in this corpus.

**A correction to my own first reading:** I nearly reported the two `DASHBOARD_ONION_CLIENT_*` values
as a leaking key pair. They are 11 characters, all-lowercase, and byte-identical to each other in both
bundles — a placeholder, not a key. Checked before claiming it.

## A second defect found on the way

The old prefix was `.*`, which is **greedy**: on a line carrying two secret keys it matched the *last*
one and left the first value in place.

    A_TOKEN=one B_TOKEN=two   ->   A_TOKEN=one B_TOKEN=<redacted>   (the first value survived)

The vocabulary prefix is `[A-Za-z0-9_]*`, which cannot cross a space, so the match starts at the first
key and the replacement takes the rest of the line with it. Pinned by its own case.

## More than the issue asked for, stated

Also shipped: #1590's suggestion 3, the **mechanical** version of an invariant that had been a comment
in `selftest-redact.sh`. Both of `redact()`'s suffix lists are now read out of `lib.sh` — never
restated in the test — and asserted to agree with each other and to sit inside the screen. It is here
rather than in a follow-up because this fix creates the second copy of the vocabulary; shipping the
copy without the guard would rebuild the drift the issue is about. That comment's superset claim was
already false once, at `wallet`, and was caught by review — which is what a check does not need.

## Proof the new rows can fail

Mutation battery, each leg `cmp`-checked to prove the file actually changed before any count was
trusted; restored byte-identical afterwards.

| mutation | result |
|---|---|
| revert the rule to its pre-#1611 form | 11 rows red |
| restore the greedy `.*` prefix | exactly the two-keys-on-one-line row reds |
| drop `WALLET`/`WALLET_ADDRESS` | the short and emoji Tari rows red — **the 91-char base58 row stays green**, which is the attribution stated in the file: the length rule carries that one, so it proves nothing about this rule |
| drop `PING_URL` | the ping-URL row reds |
| widen `PING_URL` to a bare `URL` | the over-redaction guard reds on a surviving public endpoint |
| drop `KEY` / `USERNAME` / `DONOR_ID` / `PING_URL` individually | exactly one row reds each (`KEY` reds two: its coverage row and the policy pin that shares the arm, labelled as such in the file) |
| make the two vocabularies disagree | the invariant reds, naming the differing entries |
| add a JSON suffix the screen cannot reach | the invariant reds, naming it |
| break the extraction itself | the invariant reds loudly rather than passing vacuously |

## What the over-engineering pass changed

It found a real fault in my own first draft, and the fix is in this PR rather than noted in it. The
`KEY=value` coverage loop asserted six keys — but `MONERO_VIEW_KEY`, `TARI_SPEND_PUBLIC_KEY` and
`DASHBOARD_ONION_CLIENT_PRIVKEY` all end in `KEY`, so all three exercise **one** alternation entry.
A single mutation (drop `KEY`) killed all three together, which is the tell: one measurement printed
three times, the same failure this lane recorded at cycle 46. The loop is now one row per vocabulary
entry `.env` actually exercises — four — and the other two corpus keys are named in the comment,
where a fact belongs that is not a discriminating assertion.

The pass also removed a row I had been about to add. `PASSWD` and `LOGIN` have no `.env` field, and
the sibling JSON file gives such entries a forward-cover case on the argument that an unexercised
pattern is one typo away from being dead. That argument no longer holds here: the vocabulary
invariant asserts this list *is* the JSON one, so a missing entry fails mechanically. The invariant
paid for itself by making three rows unnecessary.

Net: 15 rows, not 17, and every one attributable to the arm that kills it.

## Findings I considered and declined, with reasons

- **Preserving `<redacted-address>` for wallet keys.** The name rule runs first, so those lines now
  report the plain `<redacted>`. Nothing anywhere parses the address marker (grepped `.sh`/`.py`/`.md`/`.yml`);
  one vocabulary across both syntaxes is worth more than the hint that a value was an address. Pinned
  by a case so it reads as chosen.
- **Making the rule case-insensitive, matching the JSON side.** Declined: `.env` is generated by
  `pithead` and is uppercase throughout — #1590 measured all 129 keys — so it is load-bearing for
  nothing here, while a case-insensitive `key=.*` would eat the rest of any log line containing
  `key=`. Recorded as a labelled KNOWN GAP that fails and names the shape if a lowercase assignment
  ever arrives.
- **Adding a bare `URL` to the vocabulary.** The mutation above shows it strips a public endpoint.

## What I did NOT do

- No live capture. The corpus is two archived bundles plus the deployed `.env`, read-only.
- The under-90 Tari forms are covered by construction and by the self-test, not by a sighting in a
  bundle — they do not occur in this corpus.
- `selftest-redact.sh` now sits at **399 lines against the 400-line budget target**. One line of
  headroom; the next addition to it needs a budget row or a new file. That is why the `KEY=value`
  cases went into `selftest-redact-env.sh` rather than into it.

## Verification run

`shellcheck --severity=warning` over the whole `tests/integration` glob from the repo root, rc=0.
`shfmt -i 4 -d` over the Makefile's exact glob (191 files, list confirmed to contain both changed
shell files — the new file is only in it once staged), rc=0. `make lint-file-budget` **locally**,
which is the only run that exercises the monotonic ratchet (#1608): OK, with `lib.sh` at 692 against
its 692 ceiling — **line-neutral, the comment rewritten to the same four lines**. `make lint-md`
(0 errors), `make lint-docs-voice`, `make lint-topology`: all OK. All **16** files in the
`selftest*.sh` glob pass, the new one at 15 rows. `make lint-sh` was NOT run as a whole — it is this
box's OOM path and is serialized; the targeted substitute above is what ran.

## Shared files

`docs/dev/integration-testing.md` only (`docs/` is shared, no lane owns it). Its redactor-coverage
paragraph described the `KEY=value` rule by its three old suffixes, so it went stale with this change.
