### PR TITLE
fix(dashboard): #1556 slice 7 — the ten handle-guard procedures in storage_service.py

### DIFF
--- a/dashboard/mining_dashboard/service/storage_service.py
+++ b/dashboard/mining_dashboard/service/storage_service.py
@@ -275,7 +275,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
             self.db_unrecoverable = True
             self._db_error("DB Recovery Error", e)
 
-    def _prune_quarantined(self):
+    def _prune_quarantined(self) -> None:
         """Keep only the newest ``_CORRUPT_KEEP`` ``<db>.corrupt-*`` files; delete older ones."""
         directory = os.path.dirname(self.db_path) or "."
         base = os.path.basename(self.db_path) + ".corrupt-"
@@ -493,7 +493,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
             self.logger.info("Migrating DB: Adding type column to worker_config")
             self._conn.execute("ALTER TABLE worker_config ADD COLUMN type TEXT DEFAULT 'apply'")
 
-    def load(self):
+    def load(self) -> None:
         """
         Loads state from SQLite into memory on startup.
         """
@@ -593,7 +593,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
 
     def update_history(
         self, hashrate: float, p2pool_hr: float = 0, xvb_hr: float = 0, windows=None
-    ):
+    ) -> None:
         """Appends a new hashrate data point to the history buffer.
 
         ``windows`` (Issue #168) is an optional ``{window: (p2pool_hr, xvb_hr)}`` mapping of the
@@ -677,7 +677,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         except sqlite3.Error as e:
             self._db_error("History Update Error", e)
 
-    def add_share(self, ts: float, difficulty: float):
+    def add_share(self, ts: float, difficulty: float) -> None:
         """Appends a new share to history and persists it to the DB."""
         with self._lock:
             # Check if share already exists to prevent duplicate in-memory appends
@@ -724,7 +724,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         with self._lock:
             return list(self.state.get("shares", []))
 
-    def add_event(self, ts: float, event_type: str, detail: str = ""):
+    def add_event(self, ts: float, event_type: str, detail: str = "") -> None:
         """Record a chart event marker (#99) — a degradation/recovery point the chart draws and the
         history window prunes, mirroring shares. Persisted so it survives a dashboard restart."""
         with self._lock:
@@ -757,7 +757,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
 
     def add_share_stats(
         self, ts: float, accepted: int = 0, rejected: int = 0, invalid: int = 0, expired: int = 0
-    ):
+    ) -> None:
         """Record one poll's pool-wide share-health DELTAS (#116) — how much each cumulative
         proxy counter advanced since the previous poll — in memory and in the DB. Mirrors
         add_event: retention-pruned in memory, probabilistically pruned on disk."""
@@ -928,7 +928,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         the data-service poll loop is one big try/except, so nothing else would surface that."""
         return {k: dict(v) for k, v in self.table_health.items()}
 
-    def add_block(self, ts: float, height: int, difficulty: float):
+    def add_block(self, ts: float, height: int, difficulty: float) -> None:
         """Record one pool block-found event (#196): permanent (no retention prune — a handful of
         rows/week, like payouts). The caller (DataService) reuses `_shares_to_record` on p2pool's
         cumulative blocks_found counter so this fires exactly once per genuinely NEW block; a
@@ -1029,7 +1029,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
             self.logger.error(f"Raffle Win Read Error: {e}")
             return []
 
-    def add_worker_history(self, rows: list[dict[str, Any]]):
+    def add_worker_history(self, rows: list[dict[str, Any]]) -> None:
         """Record one poll's per-worker hashrate/share-count samples (#196) in a SINGLE
         executemany call — the caller batches every online worker for one wall-clock tick rather
         than issuing N inserts per cycle. 30-day retention. Each row needs ts/name/h15/accepted/
@@ -1199,7 +1199,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         avg_1h: float | None = None,
         fail_count: int | None = None,
         **kwargs,
-    ):
+    ) -> None:
         """
         Updates specific fields within the XvB statistics state.
 
@@ -1293,7 +1293,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
             self.logger.error(f"KV Read Error: {e}")
             return None
 
-    def set_kv(self, key: str, value):
+    def set_kv(self, key: str, value) -> None:
         """Insert-or-replace one kv_store value (#375). Values are stored as strings, mirroring
         the XvB stats writes above."""
         try:

--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -41,30 +41,61 @@ moved the data, which is the failure the pin comment below records happening twi
 """
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 25 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 26 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
 # slice 3, the two single-function `config/` modules by slice 4, the four outbound senders under
 # `service/` by slice 5a, and the last three `service/` singletons by slice 5b. Slice 6 is the first
 # MULTI-function slice — the four parse-or-read pairs under `service/`, each pinned only once BOTH of
-# its failure returns were annotated and read. **25 failure returns are still blind.**
+# its failure returns were annotated and read, and the ten handle-guard procedures in
+# `service/storage_service.py` by slice 7. **15 failure returns are still blind**, in seven modules.
 #
-# That "25 of 33" read 18 until this slice measured it: 5b moved this tuple from 18 to 21 and left
-# the sentence beside it saying 18. A slice adds rows to a tuple and the counting prose next to it is
-# falsified in the same commit, silently — re-derive it here rather than carrying it.
+# Every figure above is re-derived at the head being shipped, never carried across a slice: 5b moved
+# this tuple from 18 to 21 and left the sentence beside it saying 18. A slice adds rows to a tuple
+# and the counting prose next to it is falsified in the same commit, silently, and no gate in this
+# repo can see it — re-derive it here rather than carrying it. Slice 7 found two more of exactly
+# that kind already standing below, one of them spelled in WORDS, where a digit-keyed sweep misses.
 #
 # The `client/` scoping below applies to `tor_heal.py` too, measured: `decide` holds four
 # unannotated `None` returns and `check` two bare ones, all six OUTSIDE the gate's two doors —
 # pinned, law 1 honestly green, and NOT "fully annotated".
 #
-# That sentence was true and, until #1604, it was the ONLY one of its kind here. Eight other pinned
-# modules hold the same residue and were named nowhere but inside the tuple below, so a reader who
-# found `tor_heal.py`'s disclosure could reasonably infer the rest were clean: an asymmetric
-# disclosure is worse than a uniform absence, because the silence beside the others reads as a
-# statement. The residue is now MEASURED for all twenty-one and printed by
-# `TestTheResidueThePinCannotRuleOn` in `test_annotation_coverage.py`, which is the form of
-# disclosure that cannot go
-# asymmetric again — a module joining `PINNED` gets a line whether anyone writes a sentence or not.
+# That sentence was true and, until #1604, it was the ONLY one of its kind here. At #1604 eight
+# other pinned modules held the same residue and were named nowhere but inside the tuple below, so
+# a reader who found `tor_heal.py`'s disclosure could reasonably infer the rest were clean: an
+# asymmetric disclosure is worse than a uniform absence, because the silence beside the others
+# reads as a statement. That count is written in the past tense on purpose — it was `Eight other
+# pinned modules hold`, present tense, and two slices had made it false. The residue is now
+# MEASURED for every pinned module and printed by `TestTheResidueThePinCannotRuleOn` in
+# `test_annotation_coverage.py`, which is the form of disclosure that cannot go asymmetric again —
+# a module joining `PINNED` gets a line whether anyone writes a sentence or not.
+#
+# Slice 7 is `service/storage_service.py`, the first slice carried by the HANDLE GUARD rather than
+# the `except` door: nine of its ten come through the guard, and `_prune_quarantined` is the one
+# handler. Ten, not the nine a guard-door count gives — that miscount was in the handoff this
+# slice started from, and pinning the module needs all ten. All ten are the same shape and were
+# read as one only after each was confirmed to BE that shape: the guard's whole body is a bare
+# `return`, and the function returns no value on any path. That was measured, not eyeballed —
+# zero valued returns and zero yields across all ten, with
+# a positive control (`get_kv`, which has three valued returns) to show the walk could see one.
+#
+# So every one is a genuine `-> None` procedure, and the slice adds ZERO to `signed` and ten to
+# `procedure`. That is the whole outcome and it is stated plainly rather than dressed up: what this
+# module's pin asserts is that #1487's rule structurally CANNOT apply to these ten — a procedure has
+# no success value for a failure to hide inside — and that this is now SAID rather than silent,
+# which is exactly what #1581 added the sixth verdict for. Law 2 is NOT vacuous here despite the
+# module holding no `unjudged` row: re-signing one of them `-> bool` sends its bare `return` to
+# `unjudged`, and law 2 reds. That was seeded and confirmed, because a law nobody fired is a law
+# nobody has evidence for.
+#
+# The module's EIGHT `collapse` rows are untouched by this slice and stay flagged, as does the
+# residue below. A pin is coverage of the mechanism; it clears nothing.
+#
+# The reading is also what found **#1615**: `add_block` and `add_worker_history` stamp the per-table
+# write-health signal, and the guard returns BEFORE either stamp — so after a failed corruption
+# recovery every telemetry table reports `healthy: True` while its writes are dropped. Filed rather
+# than fixed here: this slice is annotation-only and proven bytecode-identical, and that fix is a
+# behaviour change to five write paths.
 #
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
@@ -101,6 +132,7 @@ PINNED = (
     "service/egress.py",
     "service/price_feed.py",
     "service/steering_projection.py",
+    "service/storage_service.py",
     "service/tor_heal.py",
     "service/update_checker.py",
     "service/worker_config_store.py",
@@ -115,7 +147,10 @@ PINNED = (
 # statement about "no blind names under this prefix" is satisfied perfectly by a module that has
 # vanished from the walk, and that is the reading a deleted file, a moved package root or a broken
 # `rglob` all produce. `note_worker_revision` is the deliberate choice for its module — it is the
-# one signed function `_SIGNED` never named.
+# one signed function `_SIGNED` never named. `add_block` is the choice for
+# `storage_service.py` — of that module's eleven procedures it is one of the two carrying the
+# per-table health channel #1615 is about, so it is the one whose silent exit from the walk would
+# cost most.
 _ANCHORS = {
     "client/docker/docker_control.py": "client/docker/docker_control.py:_post",
     "client/monero/monero_client.py": "client/monero/monero_client.py:get_info",
@@ -137,6 +172,7 @@ _ANCHORS = {
     "service/price_feed.py": "service/price_feed.py:parse_prices",
     "service/xvb_standby.py": "service/xvb_standby.py:parse_standby",
     "service/steering_projection.py": "service/steering_projection.py:won_round_live",
+    "service/storage_service.py": "service/storage_service.py:add_block",
     "service/tor_heal.py": "service/tor_heal.py:_probe_egress",
     "service/update_checker.py": "service/update_checker.py:latest_release",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -278,7 +278,7 @@ class TestTheResidueThePinCannotRuleOn:
     """#1604 — what the pin has never said, said.
 
     Law 1 says no FAILURE RETURN in a pinned module is unannotated. It has never said the module is
-    annotated, and the difference is not academic: thirteen of the twenty-five hold functions that
+    annotated, and the difference is not academic: fourteen of the twenty-six hold functions that
     declare no return type and return a falsy value. Those returns come through neither of the
     gate's two doors, so `classify` emits no row for them, and every law above is silent about them
     — correctly, because the mechanism genuinely cannot reach them.


### PR DESCRIPTION
#1556 slice 7: `service/storage_service.py`. Ten unannotated failure returns become `-> None`, and
the module joins `PINNED` and `_ANCHORS`. Stacked on #1612, rebased onto `develop-v2` after it
merged.

## The population, re-derived rather than carried

My handoff said nine. Nine is the HANDLE-GUARD count; the module holds **ten** blind functions —
`_prune_quarantined` comes through the `except` door — and pinning it needs all ten. That is the
figure the slice was built on, measured at this head.

| door | functions |
|---|---|
| handle guard | `load`, `update_history`, `add_share`, `add_event`, `add_share_stats`, `add_block`, `add_worker_history`, `update_xvb_stats`, `set_kv` |
| `except` | `_prune_quarantined` |

Package-wide, blind goes **25 -> 15** functions across **7** modules; `PINNED` goes 25 -> 26 of the
33 modules that hold a failure return at all.

## What the slice actually achieves — stated plainly

All ten are genuine procedures, so the slice adds **ZERO to `signed` and ten to `procedure`.** It
fixes nothing. What the pin asserts for this module is that #1487's rule structurally cannot apply
to these ten — a procedure has no success value for a failure to hide inside — and that this is now
SAID rather than silent, which is what #1581 added the sixth verdict for. Same shape as slice 4,
which added zero to `signed` and was the correct outcome.

The module's **eight `collapse` rows are untouched and stay flagged**, as does its residue.

## PROVEN BY ME

**They really are procedures.** Zero valued returns and zero yields across all ten, walked with the
gate's own `_own_nodes` rather than a re-spelled predicate. Positive control: `get_kv`, which the
same walk reports with three valued returns. `add_worker_history` has two `return`s — the guard and
an `if not rows` early exit — both valueless.

**Annotation-only.** All ten code objects compare identical base-vs-head on `co_code`, `co_names`,
`co_varnames`, `co_freevars`, `co_cellvars`, `co_argcount`, `co_flags` and `co_consts`, recursively.
Never a repr — a `dis.dis()` output diff scored 4-of-6 differing on this lane's annotation-only edits
once, and the whole delta was the object address. The comparator's core is lifted byte-identically
from slice 5a's, not retyped. **Positive control:** seeding one real behaviour change
(`str(value)` -> `str(value).strip()` in `set_kv`) flips exactly that function to False and leaves
the other nine True — so it fires *and* discriminates.

**Three controls, each fired for its own law and scoped to this module alone.** Each armed with an
exact-match applier that refuses unless the target site matches exactly once, with a before/after
site count as the readback, and each restored by `cmp` against a sha256'd copy — never
`git checkout`, which has silently eaten uncommitted work in this lane.

| control | seeded | fired |
|---|---|---|
| A | UNANNOTATE `add_block` (undo the slice) | law 1, `[service/storage_service.py]`, alone |
| B | re-sign it `-> bool` (bare `return` now collapses) | law 2, same scope, alone |
| C | point its `_ANCHORS` value at a missing function | the vacuity guard, same scope, alone |

Control B matters beyond ceremony: the module holds no `unjudged` row, so law 2 looks vacuous here.
It is not — the reachable regression is someone making a writer report success, and law 2 reds on it.

**No caller consumes a value from any of the ten.** Every grep hit was `json.load(f)` or a JS
`this.load()` — a different subject per site, classified individually rather than counted.

**Ran:** `test_annotation_coverage.py` + `test_collapsed_return_channels.py` (112 pass);
`make test-dashboard` (**2355 passed**, coverage 97.17%); `lint-py`, `lint-file-budget`,
`lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-md` — all green, re-run at the
rebased head rather than reported from before the base move.

**Patch coverage:** 0 of 10 changed lines uncovered, measured from `coverage.xml` directly (its
`<source>` is `dashboard/mining_dashboard`), not from the gate's rc. Three of the ten are
continuation lines of multi-line signatures, which coverage attributes to the `def` — so diff-cover
measures seven and all seven are hit.

**The base move did not move the program:** `git rev-parse <ref>:dashboard` is
`6b2271de4fb8d83418ddef2ba8096f24f4109f64` at the old base, the squash, and the `develop-v2` tip.

## Counting prose — three sentences were already stale, and two were spelled in words

Re-derived every count in the files I edited instead of carrying it, which is how these surfaced.
No gate in this repo sees this class.

- `25 of 33` -> **26 of 33**.
- `**25 failure returns are still blind**` -> **15**, in seven modules.
- `Eight other pinned modules hold the same residue` — **present tense, false for two slices**. Now
  past tense and scoped to #1604, with a note saying why it is written that way.
- `The residue is now MEASURED for all twenty-one` -> "for every pinned module", phrased so no slice
  can leave it stale again.
- `test_annotation_coverage.py`: `thirteen of the twenty-five` -> **fourteen of the twenty-six**.

**Classified and deliberately LEFT:** `test_annotation_coverage.py:320`'s "scored all twenty-one
modules identically" is a true statement about what #1604's first sweep did when `PINNED` held 21.
A count word can belong to a different subject; this one does.

## The finding — #1615

`add_block` and `add_worker_history` stamp the per-table write-health signal, and the handle guard
returns **before** either stamp. After a failed corruption recovery `_conn` stays `None` for good,
so every telemetry write is dropped while `get_table_health()` still reports `healthy: True` — the
exact case its own docstring says it exists to surface. Reproduced by driving that path, not
inferred from the shape of the code.

Bounded honestly on the issue: `db_healthy`/`db_unrecoverable` are correctly False/True, so the
global badge is right, and `get_table_health()` has no production caller today. Latent, not live.

## What I did NOT do

- **Did not fix #1615.** It is a behaviour change to five write paths across two modules and wants
  its own review; fixing it here would also cost this slice its bytecode-identity proof.
- **Did not hedge the two source comments that state that guarantee** (`storage_service.py:161-166`
  and `:926-929`). Named on #1615 with line numbers so the fix cannot leave them standing — this
  lane has shipped a doc arguing FOR a defect before. The module is also at **zero budget headroom**
  (1358 against a 1358 ceiling), so any rewrite there has to be line-for-line.
- **Did not touch `telemetry_store.py`** — its three handle-guard blind returns are slice 8.
- **No security-reviewer pass.** The change touches no control channel, auth, credential or
  outbound fetch; it is ten signatures, proven bytecode-identical.
- **Nothing asserts `PINNED`'s size** — pre-existing, and now filed by the controller as #1614.

## Over-engineering pass (done on merits, then the gate satisfied)

The gate blocked once and cleared on the retry, so it verifies nothing — the pass is reported here
because it was run, not because the gate says it was.

It found one real defect, in my own new prose: the slice-7 comment opened "the first slice whose
whole population came through the HANDLE GUARD" and then said "nine of its ten" in the same
sentence. Self-contradicting, and the kind of sentence that reads as authoritative. Rewritten to
say what is true — nine through the guard, one handler, ten in total — and to name the guard-door
miscount explicitly, since that is the trap the next slice inherits.

Also checked and deliberately kept: the 25-line reading is in this file's established register
(the argument travels with the entry, and `_UNJUDGED_AND_READ`'s existing comments carry method at
the same length). The one clause that looked redundant against the past-tense note below it —
"one of them spelled in WORDS, where a digit-keyed sweep misses" — carries the actionable half that
the instance site does not, so it stays.
