### PR TITLE
fix(dashboard): #1556 slice 8 — the three telemetry_store writers, closing the handle-guard population

### DIFF
--- a/dashboard/mining_dashboard/service/telemetry_store.py
+++ b/dashboard/mining_dashboard/service/telemetry_store.py
@@ -43,7 +43,7 @@ class TelemetryStoreMixin:
         fail_count: int = 0,
         donation_fraction: float = 0.0,
         mode: str = "",
-    ):
+    ) -> None:
         """Record one XvB-scalars sample (#196), 30-day retention. The caller wall-clock-gates
         this to ~5 min (DataService._sync_xvb_stats) so the cadence survives an UPDATE_INTERVAL
         change, and only calls it on a genuine XvB fetch (never on a failed one)."""
@@ -91,7 +91,7 @@ class TelemetryStoreMixin:
         height: int = 0,
         reward: float = 0.0,
         pool_hashrate: float = 0.0,
-    ):
+    ) -> None:
         """Record one hourly network-stats sample (#196): Monero difficulty/height/reward plus the
         pool's own hashrate. 90-day retention. DB-only (nothing reads this per-cycle)."""
         try:
@@ -136,7 +136,7 @@ class TelemetryStoreMixin:
         monero_db_bytes: int = 0,
         disk_used_gb: float = 0.0,
         disk_total_gb: float = 0.0,
-    ):
+    ) -> None:
         """Record one hourly disk-growth sample (#196): monerod's DB size plus host disk usage.
         Permanent (no retention prune — tiny, ~24 rows/day; it's a capacity trend line)."""
         try:

--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -41,14 +41,16 @@ moved the data, which is the failure the pin comment below records happening twi
 """
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 26 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 27 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
 # slice 3, the two single-function `config/` modules by slice 4, the four outbound senders under
 # `service/` by slice 5a, and the last three `service/` singletons by slice 5b. Slice 6 is the first
 # MULTI-function slice — the four parse-or-read pairs under `service/`, each pinned only once BOTH of
 # its failure returns were annotated and read, and the ten handle-guard procedures in
-# `service/storage_service.py` by slice 7. **15 failure returns are still blind**, in seven modules.
+# `service/storage_service.py` by slice 7, and its three siblings in `service/telemetry_store.py` by
+# slice 8. **12 failure returns are still blind**, in six modules — every one through the `except`
+# door, because slice 8 closed the handle-guard population entirely.
 #
 # Every figure above is re-derived at the head being shipped, never carried across a slice: 5b moved
 # this tuple from 18 to 21 and left the sentence beside it saying 18. A slice adds rows to a tuple
@@ -97,6 +99,27 @@ moved the data, which is the failure the pin comment below records happening twi
 # than fixed here: this slice is annotation-only and proven bytecode-identical, and that fix is a
 # behaviour change to five write paths.
 #
+# Slice 8 is `service/telemetry_store.py`, and it is slice 7's shape with nothing new to argue: its
+# three writers are the same closed-handle guard whose whole body is a bare `return`, measured the
+# same way (zero valued returns, zero yields, with `get_xvb_history`'s three valued returns as the
+# control that the walk can see one). Three more `procedure` rows, ZERO to `signed`. It closes the
+# HANDLE-GUARD population — every one of the twelve failure returns still blind now comes through
+# the `except` door.
+#
+# One thing here is worth carrying: this module's residue and its blind set were the SAME THREE
+# SITES. The gate saw them through the guard door, and #1604's sweep saw them as falsy returns from
+# functions declaring nothing — two instruments answering different questions about one site. So
+# annotating cleared both at once, and the module now reports **0 residue sites**. That zero is a
+# disclosure, not an absence: it is printed because the module is pinned, which is the whole of why
+# #1604 prints the clean modules too.
+#
+# That overlap is NOT unique and the first draft of this comment said it was, unmeasured. Measured
+# at this tip: `helper/utils.py` has the same shape — 2 residue functions and the same 2 blind — and
+# it is not pinned yet, so the slice that takes it should expect its residue to go to zero too. In
+# every other module the two sets are DISJOINT (`storage_service.py`'s residue is `add_shares` and
+# `save_snapshot`, neither of them among the ten slice 7 annotated). **Do not infer one set from the
+# other; they answer different questions and only sometimes coincide.**
+#
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
 # (`local_miner_enabled` returning `False`). A slice is coverage of the mechanism, so a slice whose
@@ -133,6 +156,7 @@ PINNED = (
     "service/price_feed.py",
     "service/steering_projection.py",
     "service/storage_service.py",
+    "service/telemetry_store.py",
     "service/tor_heal.py",
     "service/update_checker.py",
     "service/worker_config_store.py",
@@ -150,7 +174,8 @@ PINNED = (
 # one signed function `_SIGNED` never named. `add_block` is the choice for
 # `storage_service.py` — of that module's eleven procedures it is one of the two carrying the
 # per-table health channel #1615 is about, so it is the one whose silent exit from the walk would
-# cost most.
+# cost most. For `telemetry_store.py` all three writers are equivalent for this purpose and
+# `add_xvb_history` is simply the first declared — recorded so nobody hunts for a reason.
 _ANCHORS = {
     "client/docker/docker_control.py": "client/docker/docker_control.py:_post",
     "client/monero/monero_client.py": "client/monero/monero_client.py:get_info",
@@ -173,6 +198,7 @@ _ANCHORS = {
     "service/xvb_standby.py": "service/xvb_standby.py:parse_standby",
     "service/steering_projection.py": "service/steering_projection.py:won_round_live",
     "service/storage_service.py": "service/storage_service.py:add_block",
+    "service/telemetry_store.py": "service/telemetry_store.py:add_xvb_history",
     "service/tor_heal.py": "service/tor_heal.py:_probe_egress",
     "service/update_checker.py": "service/update_checker.py:latest_release",
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -278,7 +278,7 @@ class TestTheResidueThePinCannotRuleOn:
     """#1604 — what the pin has never said, said.
 
     Law 1 says no FAILURE RETURN in a pinned module is unannotated. It has never said the module is
-    annotated, and the difference is not academic: fourteen of the twenty-six hold functions that
+    annotated, and the difference is not academic: fourteen of the twenty-seven hold functions that
     declare no return type and return a falsy value. Those returns come through neither of the
     gate's two doors, so `classify` emits no row for them, and every law above is silent about them
     — correctly, because the mechanism genuinely cannot reach them.


### PR DESCRIPTION
#1556 slice 8: `service/telemetry_store.py`. Three unannotated failure returns become `-> None`, and
the module joins `PINNED` and `_ANCHORS`. **Stacked on #1617** (slice 7) — based on that branch, so
GitHub retargets this to `develop-v2` when #1617 merges. Review #1617 first.

**This closes the handle-guard population.** All twelve failure returns still blind come through the
`except` door, in six modules holding **exactly two each**: `helper/utils.py`, `alert_service`,
`clearnet_sync`, `control_service`, `telegram_commands`, `web/server`.

## What it does

Slice 7's shape with nothing new to argue: `add_xvb_history`, `add_network_history` and
`add_disk_growth` are the same closed-handle guard whose whole body is a bare `return`. Three more
`procedure` rows, **ZERO to `signed`**. The module's three `collapse` rows are untouched and stay
flagged. `PINNED` 26 -> 27 of the 33 modules that hold a failure return at all; blind 15 -> 12.

## PROVEN BY ME

**They really are procedures** — measured, not assumed off slice 7's result: zero valued returns and
zero yields across all three, walked with the gate's own `_own_nodes`. Positive control:
`get_xvb_history`, which the same walk reports with three valued returns.

**Annotation-only.** All three code objects compare identical base-vs-head on `co_code`, `co_names`,
`co_varnames`, `co_freevars`, `co_cellvars`, `co_argcount`, `co_flags` and `co_consts`, recursively —
never a repr. **Positive control:** seeding one real behaviour change (`INSERT` -> `INSERT OR IGNORE`
in `add_disk_growth`) flips exactly that function to False and leaves the other two True.

**Three controls**, each armed with an exact-match applier that refuses unless the target site
matches exactly once, readback by before/after site count, each restored by `cmp` against a sha256'd
copy — never `git checkout`.

| control | seeded | fired |
|---|---|---|
| A | UNANNOTATE `add_xvb_history` | law 1, `[service/telemetry_store.py]`, alone |
| B | re-sign it `-> bool` | law 2, same scope, alone |
| C | point its `_ANCHORS` value at a missing function | the vacuity guard, same scope, alone |

**Ran:** `make test-dashboard` — **2358 passed**, coverage 97.14%. The +3 over #1617's 2355 is fully
attributed: the three laws are parametrized over `PINNED`, so one added module adds exactly three
tests, and no test was written. `lint-py`, `lint-file-budget`, `lint-md`, `lint-docs-voice` green.
Pins module 273 lines, under the 400 target with **no budget row** — correct, since under 400 *with*
a row is a gate failure.

## The one case worth reading

This module's residue and its blind set were the **same three sites**. The gate saw them through the
guard door; #1604's sweep saw them as falsy returns from functions declaring nothing — two
instruments answering different questions about one site. Annotating cleared both at once, so the
module now reports **0 residue sites**. That zero is printed *because* the module is pinned, which
is the whole of why #1604 prints the clean modules too: an unmentioned module and a measured-clean
module are otherwise the same silence.

## Over-engineering pass (done on merits, then the gate satisfied)

The gate blocked once and cleared on the retry, so it verifies nothing. The pass is reported because
it was run — and it caught a real defect in my own new prose, the second cycle running it has paid.

I had written that the overlap above was "its own case" — an **unqualified uniqueness claim I never
measured**, the defect this lane keeps shipping. Measured: it is **not** unique. `helper/utils.py`
has the same shape (2 residue functions, the same 2 blind) and is not pinned yet, so the slice that
takes it should expect the same. Everywhere else the two sets are disjoint — `storage_service.py`'s
residue is `add_shares` and `save_snapshot`, neither among the ten slice 7 annotated. The comment
now says that, and says not to infer one set from the other.

Nothing else was cut: the reading is the length this file's convention asks for (the argument travels
with the entry), and the anchor note records that all three writers are equivalent and
`add_xvb_history` is simply the first declared — written down so nobody hunts for a reason.

## What I did NOT do

- **Did not fix #1615**, of which these three writers are half — the guard returns before the
  per-table health stamp here exactly as it does in `storage_service.py`. The reading says so; the
  fix is a behaviour change across two modules and would cost this slice its bytecode-identity proof.
- **Did not update docs.** `docs/dashboard.md` describes the mechanism and states no count this slice
  moves; swept mechanically across the whole repo, not just `docs/`.
- **No security-reviewer pass** — three signatures, no control channel, auth, credential or outbound
  fetch, proven bytecode-identical.
