### PR TITLE
fix(dashboard): #1556 slice 9 — helper/utils.py's two valued except returns, one signed and one read

### DIFF
--- a/dashboard/mining_dashboard/helper/utils.py
+++ b/dashboard/mining_dashboard/helper/utils.py
@@ -299,7 +299,7 @@ def resolve_target_threshold(tiers, stable_hr, donation_level, max_fraction):
     return target, sustainable
 
 
-def is_ip_address(value):
+def is_ip_address(value) -> bool:
     """True if ``value`` is a literal IP address (IPv4 or IPv6), False for a hostname.
 
     Used to decide whether the configured ``dashboard.host`` already *is* an address, in
@@ -312,7 +312,7 @@ def is_ip_address(value):
         return False
 
 
-def detect_host_ipv4():
+def detect_host_ipv4() -> str | None:
     """Best-effort primary LAN IPv4 of the host this dashboard runs on.
 
     Opens a UDP socket toward an off-link sentinel address so the kernel selects the source

--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -41,7 +41,7 @@ moved the data, which is the failure the pin comment below records happening twi
 """
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 27 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 28 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
 # slice 3, the two single-function `config/` modules by slice 4, the four outbound senders under
@@ -49,8 +49,9 @@ moved the data, which is the failure the pin comment below records happening twi
 # MULTI-function slice — the four parse-or-read pairs under `service/`, each pinned only once BOTH of
 # its failure returns were annotated and read, and the ten handle-guard procedures in
 # `service/storage_service.py` by slice 7, and its three siblings in `service/telemetry_store.py` by
-# slice 8. **12 failure returns are still blind**, in six modules — every one through the `except`
-# door, because slice 8 closed the handle-guard population entirely.
+# slice 8, and the two `except`-door functions in `helper/utils.py` by slice 9. **10 failure
+# returns are still blind**, in five modules — every one through the `except` door, because slice 8
+# closed the handle-guard population entirely.
 #
 # Every figure above is re-derived at the head being shipped, never carried across a slice: 5b moved
 # this tuple from 18 to 21 and left the sentence beside it saying 18. A slice adds rows to a tuple
@@ -103,8 +104,13 @@ moved the data, which is the failure the pin comment below records happening twi
 # three writers are the same closed-handle guard whose whole body is a bare `return`, measured the
 # same way (zero valued returns, zero yields, with `get_xvb_history`'s three valued returns as the
 # control that the walk can see one). Three more `procedure` rows, ZERO to `signed`. It closes the
-# HANDLE-GUARD population — every one of the twelve failure returns still blind now comes through
-# the `except` door.
+# HANDLE-GUARD population — at slice 8's own head every one of the twelve failure returns still
+# blind came through the `except` door. That figure is deliberately left scoped to that head rather
+# than updated in place: slice 9 took two of them and the live count is in the header above. A
+# past-tense sentence about a shipped slice cannot be falsified by a LATER slice — but it can still
+# be wrong at the head it describes, and slice 9 found exactly that in the sibling test file, where
+# "the twelve that score zero" had drifted to thirteen before any slice noticed. Scoping a figure
+# to its head protects it from the future, not from the measurement.
 #
 # One thing here is worth carrying: this module's residue and its blind set were the SAME THREE
 # SITES. The gate saw them through the guard door, and #1604's sweep saw them as falsy returns from
@@ -114,11 +120,49 @@ moved the data, which is the failure the pin comment below records happening twi
 # #1604 prints the clean modules too.
 #
 # That overlap is NOT unique and the first draft of this comment said it was, unmeasured. Measured
-# at this tip: `helper/utils.py` has the same shape — 2 residue functions and the same 2 blind — and
-# it is not pinned yet, so the slice that takes it should expect its residue to go to zero too. In
-# every other module the two sets are DISJOINT (`storage_service.py`'s residue is `add_shares` and
-# `save_snapshot`, neither of them among the ten slice 7 annotated). **Do not infer one set from the
-# other; they answer different questions and only sometimes coincide.**
+# at this tip: `helper/utils.py` had the same shape — 2 residue functions and the same 2 blind —
+# and slice 9 took it, so that prediction is DISCHARGED rather than left standing: re-measured at
+# slice 9's head, the module reports 0 residue sites.
+#
+# The sentence that stood here — "in every other module the two sets are DISJOINT", carrying
+# `storage_service.py`'s `add_shares`/`save_snapshot` as its evidence — is RETRACTED. It was true
+# of the module it named and false as the generalisation it read as, because the two halves were
+# measured over DIFFERENT POPULATIONS: in a PINNED module `blind` is empty by construction, so
+# "disjoint" is vacuous there rather than a finding, and every module it implicitly quantified over
+# was pinned. Re-measured at slice 9's head over the five modules that still hold a blind return,
+# the sets are disjoint in NOT ONE of them — `blind` is a SUBSET of the residue in all five, and in
+# `web/server.py` they are the SAME SET (`_finalize_worker_upgrade` and `_num`), a THIRD module of
+# the shape this paragraph first called unique and then called doubled. The mechanism is that a
+# blind function is unannotated by definition, so a falsy failure return lands it in both
+# instruments at once; only a blind function returning a NON-falsy value can separate them, which
+# is why the coincidence is the common case and not the exception. **Do not infer one set from the
+# other — but do not infer independence either: they answer different questions, they coincide far
+# more often than this file used to say, and which way they fall depends on whether the module has
+# been pinned yet.**
+#
+# Slice 9 is `helper/utils.py`, and slices 7 and 8 transfer NOTHING to it beyond the method. The
+# discriminator is NOT the door — slice 7's `_prune_quarantined` came through the `except` door
+# too — it is that those thirteen were all bare-`return` procedures, measured at zero valued
+# returns and zero yields, where `-> None` is simply honest. BOTH of these return a VALUE, so
+# each had to be read on its own terms and they landed in DIFFERENT verdicts. That split is the point of the slice: one `signed`, one `unjudged`, ZERO
+# `procedure`. `helper/utils.py` is the SECOND module to hold both verdicts at once, not the first
+# — `service/worker_config_store.py` already did. That was measured here rather than asserted,
+# because the first draft of this sentence said "first" and the measurement refuted it.
+#
+#   `detect_host_ipv4` -> `str | None` is a true `signed`, and the annotation invents nothing: the
+#     docstring ALREADY declared the contract in prose — "Returns ``None`` when it can't be
+#     determined (e.g. no default route), so callers fall back to showing the hostname alone" — and
+#     its sole production caller, `web/views.py:host_display_addr`, acts on exactly that. `None` is
+#     the out-of-band answer, distinguishable from every success value, which is what `signed`
+#     means. The annotation moves a promise the code already kept into the signature.
+#
+# `is_ip_address` is the `unjudged` one and its reading is filed with its entry below rather than
+# here, so that the argument travels WITH the value the way every other entry in this file does.
+#
+# Both functions were proven bytecode-identical base-vs-head, with a seeded `return True` ->
+# `return False` inside `is_ip_address` as the positive control: it flipped that function and ONLY
+# that function, which is what makes the clean reading on the other two evidence rather than an
+# empty result.
 #
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
@@ -147,6 +191,7 @@ PINNED = (
     "client/xvb_client.py",
     "config/config.py",
     "config/worker_endpoints.py",
+    "helper/utils.py",
     "service/healthchecks.py",
     "service/notify_sinks.py",
     "service/telegram_notifier.py",
@@ -176,6 +221,12 @@ PINNED = (
 # per-table health channel #1615 is about, so it is the one whose silent exit from the walk would
 # cost most. For `telemetry_store.py` all three writers are equivalent for this purpose and
 # `add_xvb_history` is simply the first declared — recorded so nobody hunts for a reason.
+# `helper/utils.py` names `detect_host_ipv4` on a stronger ground than "either would do": that
+# module's other candidate, `is_ip_address`, is ALREADY held alive by the separate vacuity guard on
+# `_UNJUDGED_AND_READ`, which requires every entry to still exist and still score `unjudged`.
+# Anchoring here on `is_ip_address` would guard one function twice and leave the `signed` one
+# guarded by nothing but law 1's aggregate — which a vanished module satisfies perfectly. The
+# anchor goes where the other guard is not.
 _ANCHORS = {
     "client/docker/docker_control.py": "client/docker/docker_control.py:_post",
     "client/monero/monero_client.py": "client/monero/monero_client.py:get_info",
@@ -188,6 +239,7 @@ _ANCHORS = {
     "client/xvb_client.py": "client/xvb_client.py:get_stats",
     "config/config.py": "config/config.py:local_miner_enabled",
     "config/worker_endpoints.py": "config/worker_endpoints.py:load_worker_endpoints",
+    "helper/utils.py": "helper/utils.py:detect_host_ipv4",
     "service/healthchecks.py": "service/healthchecks.py:ping",
     "service/notify_sinks.py": "service/notify_sinks.py:_post",
     "service/telegram_notifier.py": "service/telegram_notifier.py:send",
@@ -258,6 +310,25 @@ _ANCHORS = {
 #     the hold is a yield optimization, never a safety path, so a read error must not freeze
 #     steering. Collapsing these two readings into one would be the bulk-fill this list refuses:
 #     same shape, opposite safety argument. Neither reaches `signed` without inventing a return.
+#
+# Slice 9 adds `helper/utils.py:is_ip_address`, and it is the first member whose `except` handler
+# is not an ERROR PATH at all — which is the whole reason it is readable rather than a collapse.
+# `ipaddress.ip_address` communicates "this is not an address" by RAISING `ValueError`, so the
+# handler is where the function's negative answer is computed, not where a failure is absorbed.
+# `AttributeError` is the same answer arriving by a second route: `value.strip()` raises it when
+# `value` is not a string, and a non-string is not an IP address either. So both handled cases and
+# the `False` they return mean one thing — "not a literal IP" — and there is no third outcome for
+# an out-of-band value to carry. `-> bool | None` would invent a return the function never makes.
+#
+# The sole production caller agrees, and was read rather than assumed: `web/views.py`'s
+# `host_display_addr` does `if is_ip_address(host): return None`, i.e. "the configured host is
+# already an address, so show it alone". On False it falls through and tries `detect_host_ipv4()`.
+# A malformed or `None` host takes the False branch, which is correct there for the same reason —
+# it is not an address, so there is something worth trying to add beside it. No caller branch
+# exists that a third answer could reach.
+#
+# What this entry does NOT claim: that `False` is the right answer for every future caller. It is
+# a reading of the two paths that exist at this head, which is all any entry in this list is.
 _UNJUDGED_AND_READ = frozenset(
     {
         "client/docker/docker_control.py:_post",
@@ -265,6 +336,7 @@ _UNJUDGED_AND_READ = frozenset(
         "service/healthchecks.py:ping",
         "service/notify_sinks.py:_post",
         "service/telegram_notifier.py:send",
+        "helper/utils.py:is_ip_address",
         "service/egress.py:_sinks_all_private",
         "service/steering_projection.py:won_round_live",
         "service/tor_heal.py:_probe_egress",

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -278,7 +278,7 @@ class TestTheResidueThePinCannotRuleOn:
     """#1604 — what the pin has never said, said.
 
     Law 1 says no FAILURE RETURN in a pinned module is unannotated. It has never said the module is
-    annotated, and the difference is not academic: fourteen of the twenty-seven hold functions that
+    annotated, and the difference is not academic: fourteen of the twenty-eight hold functions that
     declare no return type and return a falsy value. Those returns come through neither of the
     gate's two doors, so `classify` emits no row for them, and every law above is silent about them
     — correctly, because the mechanism genuinely cannot reach them.
@@ -294,7 +294,7 @@ class TestTheResidueThePinCannotRuleOn:
         residual report gives at length: a bound over sites nobody has read certifies whatever they
         contain, and this pass read none of them.
 
-        Every pinned module gets a line INCLUDING the twelve that score zero, and the zero lines
+        Every pinned module gets a line INCLUDING the fourteen that score zero, and the zero lines
         are the half that makes this a disclosure rather than a second asymmetry — an unmentioned
         module and a measured-clean module are the same silence otherwise, which is the whole of
         #1604."""


### PR DESCRIPTION
Slice 9 of #1556: `helper/utils.py`. Two failure returns, both through the `except` door.
The production diff is **two signature lines** — everything else is pin data and the arguments
that travel with it.

```
-def is_ip_address(value):            +def is_ip_address(value) -> bool:
-def detect_host_ipv4():              +def detect_host_ipv4() -> str | None:
```

## Why slices 7 and 8 transfer nothing here

The discriminator is NOT the door — slice 7's `_prune_quarantined` came through the `except` door
too. It is that those thirteen were all bare-`return` procedures, measured at zero valued returns
and zero yields, where `-> None` is simply honest. BOTH of these return a VALUE, so each had to be
read on its own terms — and the two landed in DIFFERENT verdicts. One `signed`, one `unjudged`,
ZERO `procedure`.

- **`detect_host_ipv4` -> `str | None` is a true `signed`.** The docstring already declared the
  contract in prose ("Returns `None` when it can't be determined (e.g. no default route)"), and
  its sole production caller `web/views.py:host_display_addr` acts on exactly that. The annotation
  moves a promise the code already kept into the signature; it invents nothing.
- **`is_ip_address` -> `bool` is `unjudged`, and is added to `_UNJUDGED_AND_READ` with its
  reading.** Its `except` handler is not an error path at all: `ipaddress.ip_address` says "not an
  address" by RAISING, so the handler is where the negative answer is COMPUTED. `AttributeError`
  is the same answer by a second route (a non-string is not an address either). Both handled cases
  mean one thing, so `-> bool | None` would invent a return the function never makes.

## PROVEN BY ME, at the head being shipped

- **Verdicts MEASURED, not predicted from the decision chain.** After annotation `classify` reports
  `signed: 1`, `unjudged: 1` (`['False']`), `blind: 0`, `procedure: 0` for this module.
- **Bytecode-identical base-vs-head** for `is_ip_address`, `detect_host_ipv4` and a bystander
  (`format_hashrate`), comparing `co_code`/`co_names`/`co_varnames`/`co_consts` recursively — never
  a `dis` repr. **Positive control fired:** a seeded `return True` -> `return False` inside
  `is_ip_address` flipped that function and ONLY that function.
- **Three controls, one per structure touched, each armed at a verified single site and restored by
  `cmp` against a sha256'd copy** — never `git checkout`:
  | control | seeded | reddened |
  |---|---|---|
  | A | UNANNOTATE the anchor | law 1 `..._is_unannotated[helper/utils.py]`, alone |
  | B | DE-SIGN it to `-> str` | law 2 `..._is_unjudged[helper/utils.py]`, alone |
  | C | corrupt its `_ANCHORS` value | vacuity guard `..._is_actually_in_the_walk[helper/utils.py]`, alone |
  Each fired for its OWN law and only for the module seeded. B is the one that looks vacuous in a
  module with no `unjudged` row and is not; here the module HAS one, and B still discriminates.
- **Residue went to 0 sites**, as the pins file predicted before this slice existed. That
  prediction is now discharged in the file rather than left standing as a prediction.
- **The `-> bool` contract was attacked, not assumed.** `'3232235876'`, `'123'`, `'0x7f000001'`,
  `''`, `None`, `42`, `b'1.2.3.4'` — none slips through as `True`, none escapes as an exception.

## Two figures this slice found stale, one of them NOT its own fault

The repo-wide counting-prose sweep (needles derived mechanically from the changed names, digits
AND words, with a firing control on the pattern) found three falsified sentences:

1. `annotation_pins.py` — "every one of the **twelve** failure returns still blind" (spelled in
   WORDS). Rewritten to be scoped to slice 8's own head in the past tense, so a later slice cannot
   falsify it again; the live figure lives in the header.
2. `test_annotation_coverage.py` — "fourteen of the **twenty-seven** hold". The *fourteen* is still
   correct; only the denominator moved. Changed the denominator alone.
3. `test_annotation_coverage.py` — "INCLUDING the **twelve** that score zero". **This one was
   already stale before this slice.** Measured at the pre-slice state by restoring the PRE copies
   and re-running: 27 pinned = 14 holding + **13** zero. So it was off by one at the head I started
   from and is now fourteen. Reported rather than quietly corrected, because it means the figure
   drifted without any slice noticing.

## A generalisation in the pins file is RETRACTED, with the measurement

The file said "in every other module the two sets are DISJOINT" — blind vs #1604 residue — citing
`storage_service.py`. That was true of the module it named and **false as the generalisation it
read as**, because the two halves were measured over different populations: in a PINNED module
`blind` is empty by construction, so "disjoint" there is vacuous rather than a finding.

Re-measured over the five modules that still hold a blind return: **the sets are disjoint in not
one of them.** `blind` is a SUBSET of the residue in all five, and in `web/server.py` they are the
SAME SET (`_finalize_worker_upgrade`, `_num`) — a third module of the shape that paragraph called
unique and then called doubled. Mechanism: a blind function is unannotated by definition, so a
falsy failure return lands it in both instruments at once; only a blind function returning a
NON-falsy value can separate them. The retraction is in the file, in place, not deleted.

## Counts, re-derived here and not carried

| | pre-slice | shipped |
|---|---|---|
| pinned modules (of 33 holding a failure return) | 27 | **28** |
| blind failure returns | 12 | **10** |
| modules holding a blind return | 6 | **5** |
| pinned modules holding residue / scoring zero | 14 / 13 | **14 / 14** |

## What I did NOT do

- **No security-reviewer pass.** `detect_host_ipv4` opens a UDP socket, which normally triggers
  this lane's mandatory security lens — but the change is provably behaviour-free (bytecode
  identity above, positive control fired), so there is no new surface to review. Stated rather
  than skipped silently; say so if you want it run anyway.
- **No doc change.** `docs/dashboard.md`'s account of the pin is deliberately count-free ("several
  pinned modules"), so this slice falsifies nothing in it. Checked, not assumed.
- **No new test.** The three laws are parametrized over `PINNED`, so pinning the module adds three
  test instances by construction. That is the established design; a bespoke test would duplicate
  it. This is the whole of the suite delta — 2358 -> 2361 reconciles as one module x three laws.
- **The `b'\x01\x02\x03\x04'` packed-bytes case** would return `True` from `is_ip_address`, but
  `dashboard.host` comes from JSON and is never bytes, so it is unreachable. Not recorded in the
  pin, because the entry is scoped to the paths that exist at this head.
