### PR TITLE
fix(dashboard): #1556 slice 10 — web/server.py's procedure/signed pair, and the first nested annotation

### DIFF
--- a/dashboard/mining_dashboard/web/server.py
+++ b/dashboard/mining_dashboard/web/server.py
@@ -385,7 +385,7 @@ async def handle_worker_apply(request):
     return web.json_response({"id": rid, **res})
 
 
-async def _finalize_worker_upgrade(state_mgr, worker, version, rid, latest_data=None):
+async def _finalize_worker_upgrade(state_mgr, worker, version, rid, latest_data=None) -> None:
     """The server-side half of recording a worker-upgrade attempt (#1014): ``handle_worker_upgrade``
     returns 202 before any result exists (a rig rebuild can take minutes, so it never waits inline
     like ``handle_worker_apply`` does), so this runs as its own background task and records the
@@ -493,7 +493,7 @@ def _log_filters(request):
     non-numeric reads as absent — a malformed bound must never 500 a log view) and ``q`` trimmed
     and length-capped (it's compared, never stored or echoed unsanitized)."""
 
-    def _num(name):
+    def _num(name) -> float | None:
         v = request.query.get(name)
         if v in (None, ""):
             return None

--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -41,7 +41,7 @@ moved the data, which is the failure the pin comment below records happening twi
 """
 
 # The modules with ZERO unannotated failure returns, measured over live source. Each slice of #1556
-# adds the module it finished. Measured at this tip: 28 of 33 modules that hold a failure return at
+# adds the module it finished. Measured at this tip: 29 of 33 modules that hold a failure return at
 # all — `client/xvb_client.py` by slice 1, `service/worker_config_store.py` by pre-existing work,
 # the six single-function `client/` modules by slice 2, the four single-function `web/` modules by
 # slice 3, the two single-function `config/` modules by slice 4, the four outbound senders under
@@ -49,9 +49,11 @@ moved the data, which is the failure the pin comment below records happening twi
 # MULTI-function slice — the four parse-or-read pairs under `service/`, each pinned only once BOTH of
 # its failure returns were annotated and read, and the ten handle-guard procedures in
 # `service/storage_service.py` by slice 7, and its three siblings in `service/telemetry_store.py` by
-# slice 8, and the two `except`-door functions in `helper/utils.py` by slice 9. **10 failure
-# returns are still blind**, in five modules — every one through the `except` door, because slice 8
-# closed the handle-guard population entirely.
+# slice 8, and the two `except`-door functions in `helper/utils.py` by slice 9, and the two in
+# `web/server.py` by slice 10. **8 failure returns are still blind**, in four modules — every one
+# through the `except` door, because slice 8 closed the handle-guard population entirely. That
+# last clause is a measurement and not a reading the walk could not contradict: `guard` is a door
+# the same walk still reports 31 times package-wide.
 #
 # Every figure above is re-derived at the head being shipped, never carried across a slice: 5b moved
 # this tuple from 18 to 21 and left the sentence beside it saying 18. A slice adds rows to a tuple
@@ -164,6 +166,50 @@ moved the data, which is the failure the pin comment below records happening twi
 # that function, which is what makes the clean reading on the other two evidence rather than an
 # empty result.
 #
+# Slice 10 is `web/server.py`, and it repeats slice 9's lesson rather than slice 7/8's: two blind
+# functions, both through the `except` door, landing in DIFFERENT verdicts again — one `procedure`,
+# one `signed`, ZERO `unjudged`, so no `_UNJUDGED_AND_READ` entry is owed. Two slices running now, a
+# module's blind pair has not shared a verdict; do not expect the next one to.
+#
+#   `_finalize_worker_upgrade` -> `-> None` is a genuine procedure, measured the way slices 7 and 8
+#     measured theirs: ONE return, ZERO valued, ZERO yields, with `handle_control_preview`'s three
+#     valued returns as the control that the walk can see one. It is #1014's background half — it
+#     records the terminal outcome of a worker upgrade and answers nobody — so its `except` return
+#     is a bare `return` after `logger.exception`, with no success value to hide inside.
+#
+#   `_num` -> `-> float | None` is a true `signed`, and like `detect_host_ipv4` the annotation moves
+#     a promise the code already kept into the signature. All three returns are valued and every one
+#     is a float or `None`: an absent/empty param, the `ValueError` from `float()`, and
+#     `f if math.isfinite(f) else None` because `float()` parses "inf"/"nan". Its docstring already
+#     said so in prose — "anything non-numeric reads as absent" — and the consumer agrees, read
+#     rather than assumed: `_log_filters`' two callers hand the pair straight to
+#     `audit_service.filter_log_entries`, whose docstring says `None` means "don't filter on this
+#     axis". `None` is out-of-band there, distinguishable from every float bound.
+#
+# The anchor is `_finalize_worker_upgrade`: declared first, and top-level where `_num` is a nested
+# closure — lifting or inlining it would drop its row for a reason that is not a walk failure. What
+# is NOT a reason, measured before choosing rather than argued after: the nested-def regression
+# (`_own_nodes` degraded to `ast.walk`) ADDS a `_log_filters` row rather than removing one, so
+# NEITHER candidate fires on it. Neither is double-guarded either, this module contributing no
+# `_UNJUDGED_AND_READ` entry, so law 1's aggregate and this anchor are the whole of its cover.
+#
+# One thing slice 10 has that slices 1-9 did not, and it narrows what the proof claims. Annotating
+# a NESTED def is not free at the bytecode level: both annotated functions ARE bytecode-identical
+# base-vs-head, but the enclosing `_log_filters` is NOT, and that is correct rather than a defect.
+# Its delta was read instruction by instruction and is exactly the annotation built at def time —
+# a `'return'`/`float`/`None`/`BINARY_OP |`/`BUILD_TUPLE` prologue, `MAKE_FUNCTION closure` becoming
+# `MAKE_FUNCTION annotations, closure`, and the two jump offsets that prologue shifts. Nothing else
+# moved, and the package already carries the shape (`wizard.py:build_config`). Measured for what is
+# left, keyed by NODE rather than by name and with a control that the walk can report a nested def
+# at all: of the EIGHT blind functions remaining, SIX are class methods and TWO are module-level.
+# None is nested inside a FUNCTION, which is the only scope that rebuilds the annotation per call —
+# a method's is built once in the class body at import. So no remaining slice of #1556 inherits
+# this. Nothing is claimed about a nested def some future slice might introduce.
+#
+# The module's residue went 3 sites in 2 functions to ZERO, DISCHARGING the prediction slice 9's
+# retraction left standing above: it named `web/server.py` as the module where `blind` and the
+# residue are the SAME SET, and annotating the pair cleared both instruments at once.
+#
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
 # (`local_miner_enabled` returning `False`). A slice is coverage of the mechanism, so a slice whose
@@ -208,6 +254,7 @@ PINNED = (
     "service/xvb_standby.py",
     "web/charts.py",
     "web/infra_views.py",
+    "web/server.py",
     "web/views.py",
     "web/xvb_views.py",
 )
@@ -256,6 +303,7 @@ _ANCHORS = {
     "service/worker_config_store.py": "service/worker_config_store.py:note_worker_revision",
     "web/charts.py": "web/charts.py:parse_window",
     "web/infra_views.py": "web/infra_views.py:_ip_to_sort_int",
+    "web/server.py": "web/server.py:_finalize_worker_upgrade",
     "web/views.py": "web/views.py:read_os_update_state",
     "web/xvb_views.py": "web/xvb_views.py:recent_wallet_change",
 }

--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -278,7 +278,7 @@ class TestTheResidueThePinCannotRuleOn:
     """#1604 — what the pin has never said, said.
 
     Law 1 says no FAILURE RETURN in a pinned module is unannotated. It has never said the module is
-    annotated, and the difference is not academic: fourteen of the twenty-eight hold functions that
+    annotated, and the difference is not academic: fourteen of the twenty-nine hold functions that
     declare no return type and return a falsy value. Those returns come through neither of the
     gate's two doors, so `classify` emits no row for them, and every law above is silent about them
     — correctly, because the mechanism genuinely cannot reach them.
@@ -294,7 +294,7 @@ class TestTheResidueThePinCannotRuleOn:
         residual report gives at length: a bound over sites nobody has read certifies whatever they
         contain, and this pass read none of them.
 
-        Every pinned module gets a line INCLUDING the fourteen that score zero, and the zero lines
+        Every pinned module gets a line INCLUDING the fifteen that score zero, and the zero lines
         are the half that makes this a disclosure rather than a second asymmetry — an unmentioned
         module and a measured-clean module are the same silence otherwise, which is the whole of
         #1604."""


### PR DESCRIPTION
#1556 slice 10 — `web/server.py`. Two failure returns, both through the `except` door, and the
production diff is **two signature lines**: `_finalize_worker_upgrade(...) -> None` and
`_num(name) -> float | None`.

## The two readings

They land in **different verdicts**, as slice 9's pair did: one `procedure`, one `signed`, **zero
`unjudged`**, so no `_UNJUDGED_AND_READ` entry is owed.

- **`_finalize_worker_upgrade` → `-> None`** is a genuine procedure: ONE return, ZERO valued, ZERO
  yields, measured — with `handle_control_preview`'s three valued returns as the positive control
  that the walk can see a valued return. It is #1014's background half; it records the terminal
  outcome of a worker upgrade and answers nobody, so its `except` return is a bare `return` after
  `logger.exception` and there is no success value for a failure to hide inside.
- **`_num` → `-> float | None`** is a true `signed`. All three returns are valued and every one is a
  float or `None`. Its docstring already said so in prose ("anything non-numeric reads as absent"),
  and the consumer was **read rather than assumed**: `audit_service.filter_log_entries` documents
  `None` as "don't filter on this axis", so `None` is out-of-band there, distinguishable from every
  float bound. The annotation moves a promise the code already kept into the signature.

## The finding: this slice's proof claim is NARROWER than slices 1-9's

`_num` is a **nested closure**, the first #1556 has annotated, and annotating a nested def is not
free at the bytecode level. Both annotated functions **are** bytecode-identical base-vs-head, but
the enclosing `_log_filters` is **not**, and that is correct rather than a defect. Its delta was
read instruction by instruction and is exactly the annotation being built at def time — a prologue
building `float | None`, `MAKE_FUNCTION closure` becoming `MAKE_FUNCTION annotations, closure`, and
the two jump offsets that prologue shifts. Nothing else moved. The package already carries the
shape (`wizard.py:build_config` annotates two nested defs). Of the **eight blind functions left,
six are class methods and two are module-level; none is nested inside a FUNCTION**, which is the
only scope that rebuilds the annotation per call — a method's is built once in the class body at
import. So no remaining slice of #1556 inherits it, and nothing is claimed about a nested def some
future slice might introduce.

That enumeration is keyed by NODE rather than by name and carries a control that the walk can report
a nested def at all (`_num`, `wizard.py:s_`, `_odds_day` all fire), plus a negative-direction control
that a known method reports `class`. **The first pass had neither**, and reported all eight as
"top-level" by collapsing the six methods into the same bucket. The verdict did not move; the
characterisation did. Re-derived after `lane-controller-e2` flagged it as a disjointness claim worth
re-enumerating — a right conclusion under a wrong characterisation has no tell of its own.

## Counts, measured at this head rather than carried

29 of 33 modules pinned; **8 failure returns still blind in 4 modules**, every one through the
`except` door — and that last clause is a measurement, not a reading the walk could not contradict:
`guard` is a door the same walk still reports 31 times package-wide. 14 pinned modules hold residue,
15 score zero. This module's residue went **3 sites in 2 functions to zero**, which discharges the
prediction slice 9's retraction left standing: it named `web/server.py` as the module where `blind`
and the residue are the same set.

Four counting sentences were falsified and are corrected here: the pins header's "28 of 33" and "10
failure returns … in five modules", and the sibling test file's "fourteen of the twenty-eight" and
"the fourteen that score zero". The last had drifted for the same reason "the twelve that score
zero" did at slice 9.

## The anchor, and a reason that turned out not to be one

The anchor is `_finalize_worker_upgrade`: declared first, and top-level where `_num` is a closure a
refactor could drop for a reason that is not a walk failure. What is **not** a reason — measured
before choosing rather than argued after — is the nested-def regression: degrading `_own_nodes` to
`ast.walk` **adds** a `_log_filters` row rather than removing one, so neither candidate fires on it.

## What was RUN

- **Verdicts measured** from `classify` at this head, never predicted from the decision chain.
- **Bytecode identity** base-vs-head for both annotated functions plus `handle_audit_log` as a
  bystander, comparing `co_code`/`co_names`/`co_varnames`/`co_consts` recursively (never a `dis`
  repr). Positive control: a seeded `else None` → `else 0.0` inside `_num` flipped that function and
  only that function.
- **Three controls**, each armed by an exact-match applier that refuses a site not matching exactly
  once, each restored by `cmp` against a hashed copy: (A) unannotate the anchor → law 1 only;
  (B) re-sign it `-> bool` → law 2 only; (C) corrupt its `_ANCHORS` value → the vacuity guard only.
  Each reddened its **own** law and only the `[web/server.py]` parameter, against a control-0 run
  with zero failures.
- **Full suite 2364 passed** — the +3 over slice 9 is one module times three parametrized laws.
- **Patch coverage read from `coverage.xml`, not from a gate's rc** (#1557): both changed production
  lines covered, hits=1 each. Module line-rate 0.981; overall 97%.
- **Twelve lint targets run individually**, all rc 0 — run one at a time because `make` stops at the
  first failure and would hide the rest.
- **Base moved during this slice** and the proof was taken accordingly: `742ef689` landed between my
  slice-9 copy and its squash, so the parents differ and a tree check is the wrong instrument —
  the **patches** were compared and are identical, with slice 8's patch as a control that two
  genuinely different patches do report as differing. `git rev-parse <base>:dashboard` is identical
  at both bases, so the program the suite ran did not change and the counts above stand.

## What was NOT done

- **`make lint-sh` was not run.** It is the serialized OOM path and this diff touches zero shell
  files; CI runs it here.
- **No `security-reviewer` subagent was spawned**, which this lane's standing rule asks for on
  anything touching the control channel — `_finalize_worker_upgrade` sits on `control_service`'s
  wait path. The session's harness bars unrequested subagents, so the pass was done in-line instead.
  The basis for calling it safe is narrow and stated so it can be checked: the diff is two type
  annotations, both annotated functions are proven bytecode-identical, and the only bytecode delta
  anywhere in the diff is `_log_filters` constructing `_num`'s annotation. No control-channel
  behaviour, payload, or trust boundary is touched.
- **Nobody classified the residue.** A pin is coverage of the mechanism; it clears nothing.