### PR TITLE
fix(integration): lift the two facts the deployed twin still held, and guard the copy that would delete them (#1506)

### DIFF
--- a/docs/dev/test-server-architecture.md
+++ b/docs/dev/test-server-architecture.md
@@ -152,6 +152,11 @@ cp ~/pithead/tests/integration/testbench-README.md ~/pithead-testbench/README.md
 ~/pithead-testbench/system-info.sh > ~/pithead-testbench/system-info.md
 ```
 
+These copies seed a **fresh** box. On a box that already has them they overwrite whatever the
+operator annotated locally, and both halves have held such detail (#1506): the README names hosts,
+users and paths the repo twin deliberately does not carry, and a deployed script has outlived the
+tracked one on a safety warning. Diff before you copy, and reconcile by hand rather than overwrite.
+
 **6. Validate it's release-fit:**
 
 ```bash

--- a/tests/integration/compact-chain.sh
+++ b/tests/integration/compact-chain.sh
@@ -13,11 +13,19 @@
 #   ~2.5 hours reclaiming nothing. Read `mdb_stat -ef` on an IDLE copy first. (An earlier header
 #   here promised "~95 GiB of live data" — a retired expectation, never a measurement.)
 #
+# THE COST IS SET BY THE SOURCE CHAIN, NOT BY WHAT THE RUN RECLAIMS.
+#   The figure above is this bench's, and it is the case that reclaims nothing — so budget hours
+#   for any mainnet source regardless of how much you expect back. The box's own operational copy
+#   of this script records the reason as a block-by-block rather than page-level copy; that
+#   mechanism is carried here as recorded, not measured. [TODO: verify upstream — read the copy
+#   loop in monero's blockchain_prune before restating it as fact.]
+#
 # THE TOOL IS COPY-THEN-SWAP — IT DOES NOT ONLY READ THE SOURCE (#1489).
 #   After building <data-dir>/lmdb-pruned it renames <data-dir>/lmdb to <data-dir>/lmdb-old and
 #   moves the pruned DB into its place. The binary carries the strings "Swapping databases,
-#   pre-pruning blockchain will be left in", "-old and can be removed if desired" and
-#   "Blockchain pruned OK, but renaming failed". `--copy-pruned-database` does not change that:
+#   pre-pruning blockchain will be left in", "-old and can be removed if desired",
+#   "Blockchain pruned OK, but renaming failed" and "Error renaming" — all four read out of the
+#   binary itself, not out of either header. `--copy-pruned-database` does not change that:
 #   its help text is "Copy database anyway if already pruned", so it lifts an early-exit guard on
 #   an already-pruned source rather than selecting a copy-only mode.
 #

--- a/tests/integration/testbench-README.md
+++ b/tests/integration/testbench-README.md
@@ -9,6 +9,12 @@ over SSH as `$BENCH_HOST`.
 See `docs/dev/test-server-architecture.md` for the full architecture and how to stand a box up from
 scratch.
 
+**This file is the generic twin, and it is meant to differ from the copy on a running box.** A real
+bench keeps its own README naming that box's hosts, users and paths — the detail an operator needs
+and the detail this repo must not carry. Neither copy can be synced onto the other: syncing this way
+would publish a topology, and syncing the other way would delete what the box runs on. Reconcile the
+two by hand, fact by fact, or leave them alone (#1506).
+
 ## ⚠️ Golden rules
 
 This is a test bench, not a production miner — downtime and teardown/redeploy are fine. The


### PR DESCRIPTION
`Closes` cannot fire here — PRs merge to `develop-v2` while the default branch is `develop` — and
this closes only part of #1506 anyway. What remains is named at the bottom.

## The change

#1506 classified four deployed twins and asked for two things in tracked files. Both are here.

**Class C — lift what only the box's copy held.** The issue named two facts missing from tracked
`compact-chain.sh`. **Re-measured before building: one of them had since landed**, so only these two
are lifted, and I am saying which rather than restating the issue's pair:

| fact | state when re-measured |
|---|---|
| the cost warning | already in the tracked copy — **not** lifted |
| `"Error renaming"`, the fourth copy-then-swap string | still missing — lifted |
| the cost *mechanism* (why the run is expensive at all) | still missing — lifted, with its provenance |

The tracked header listed **three** binary strings; the deployed one listed four.

**Class D — say that the README pair is meant to differ.** The issue's words: *"Say so in the tracked
copy, so the next reader does not try."* Neither direction of a sync is available — one way publishes
a topology, the other deletes what the box runs on.

## The strings were read out of the binary, not out of either header

My own lane's rule is that when two files in the lane disagree about a tool, the finding is at the
**tool**. So all four were checked against `monero-blockchain-prune` directly, each with a negative
control proving the check can return zero:

| string | in binary |
|---|---|
| `"Swapping databases, pre-pruning blockchain will be left in"` | 1 |
| `"-old and can be removed if desired"` | 1 |
| `"Blockchain pruned OK, but renaming failed"` | 1 |
| `"Error renaming"` | **1 — the one the tracked header lacked** |
| `"Copy database anyway if already pruned"` | 1 |
| *negative control* `"Error renumbering"` | **0** |

The `-old...` row needed `grep -F -e`: this box's `grep` is a ugrep shim and ate the leading dash as
a flag, scoring it absent on the first pass. Recorded because a silent zero there would have read as
a missing string and put a wrong claim in a safety header.

## ⛔ The finding this PR did not set out to make

Grepping `docs/` for the defect's own words — the step my lane keeps paying for skipping — turned up
`docs/dev/test-server-architecture.md` step 5:

    cp ~/pithead/tests/integration/testbench-README.md ~/pithead-testbench/README.md

**On a fresh box that is correct**: it seeds the README, which is what step 5 is for. The hazard is
**re-running** the block, which is the natural way to pick up a script fix later — it silently
overwrites whatever the operator annotated. Both halves have held such detail: the README by design,
and a deployed script outlived the tracked one on a safety warning, which is #1506's own Class B.
**Guarded at the point of risk rather than removed** — the guard living only in file-header prose is
what #1330 filed.

I first read this as flat contradiction of the note I had just written. It is not; it is a re-run
hazard on one block, and the PR says the narrower thing.

## What was RUN

- `shellcheck --severity=warning` (0.11.0) over the **full** `tests/integration/*.sh` +
  `mini-stack/*.sh` glob, not a partial one — rc 0, and the measured file list confirmed to contain
  `compact-chain.sh`.
- `shfmt -i 4 -d` over the Makefile's exact glob — rc 0. Not skipped; skipping it has reddened a PR
  here before.
- `make test-integration-selftest` — **214 passed, 0 failed.**
- `make lint-md` (0 errors), `make lint-docs-voice` (41 prose docs clean), `make lint-file-budget`
  with the files `git add`ed. That target is also the only place the **monotonic ratchet** actually
  runs (#1608 — CI skips it), and it passed.
- `detect-topology.py` on both changed docs — clean, each with a positive control that fired.
- `git merge-tree --write-tree` against `develop-v2` — rc 0, a real merge rather than the
  `MERGEABLE` field, with the control returning rc 1 against frozen `develop`.

## Findings I declined, and why

- **The block-by-block mechanism is carried as recorded, not measured, with a `[TODO: verify
  upstream]`.** I could not verify the copy loop from here, and the house rule is to mark rather
  than invent. I weighed dropping it: the *consequence* is measured and is the actionable half, so
  the mechanism earns little on its own. **Kept anyway**, because leaving it only on the box is the
  exact condition #1506 exists to end. Named here so a reviewer can overrule that call cheaply.
- **The two notes overlap** — one in the README, one at the `cp` in the architecture doc. Deliberate,
  and not the recipe duplication my lane warns about: they address different readers at different
  moments, and the point-of-risk one is the one #1330 says is missing when a guard lives only in a
  header.
- **`system-info.sh` (Class A) and the deployed-side patches (Class B, Class C's other direction) are
  not here.** They are box operations, not tracked-file changes, and Class B's safety half is already
  done on the box.

## Shared paths

`docs/dev/test-server-architecture.md` is under `docs/`, which is in `_shared.paths` — disclosed
rather than taken with `.lane-override`. Everything else is `tests/integration/`, this lane's own.

## What I did NOT do

No bench time and no live run: this is header and prose work, and the binary strings are readable
without executing the tool. **I did not run `monero-blockchain-prune`** — the lane's standing rule is
not to re-derive this bench's chain or re-run the ~2.5h build. I did not reconcile the remaining 73
differing lines between the two `compact-chain.sh` copies; only the two facts #1506 named were in
scope, and the rest has not been classified.
