### PR TITLE
fix(integration): give monero_caught_up three answers, with the top end left open (#1605)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -379,10 +379,16 @@ and `--list` prints it).
   an absence looks exactly like a working one until the day it matters. The escapes are stripped
   before matching, and the self-test carries that control fired in both directions: zero matches on
   the captured bytes, one after stripping. The capture is read before the caught-up predicate, and
-  that order is itself an assertion ([#1597](https://github.com/p2pool-starter-stack/pithead/issues/1597)). `monero_caught_up` answers with one bit that cannot
-  separate a node that is behind from an RPC that could not be answered at all: its `curl`
+  that order is itself an assertion ([#1597](https://github.com/p2pool-starter-stack/pithead/issues/1597)). `monero_caught_up` answered, at the time, with one bit that could
+  not separate a node that is behind from an RPC that could not be answered at all: its `curl`
   discards stderr, so an unreachable host, a refused connection and a 401 alike leave the empty
-  body that `jq` reads as not caught up. Asked first, that bit decided the whole leg, and a stack
+  body that `jq` reads as not caught up.
+  ([#1605](https://github.com/p2pool-starter-stack/pithead/issues/1605) has since given the
+  predicate three answers — `0` caught up, `1` answered and behind, any other rc could-not-ask,
+  the open top end so that `rx`'s own ssh failure at `255` cannot be reported as a node that is
+  behind. The merge-mining leg still treats both nonzero doors alike, deliberately, and the
+  ordering below is what makes that honest rather than the predicate's precision.)
+  Asked first, that bit decided the whole leg, and a stack
   whose merge-mining client was up and reading chain_ids would have been booked as an accepted
   hole for as long as a credential stayed broken — a state this repo has recorded lasting a day.
   Any `MergeMiningClientTari` line is itself proof that monerod caught up, since p2pool builds no

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -377,14 +377,14 @@ control_units_verdict() { # <doctor-output>
 # and trust its `synchronized` flag / target_height 0, exactly like the sync gate. "Its own"
 # follows the mode: in monero.mode=remote nothing listens on the box's loopback (the render
 # emits no MONERO_RPC_URL; the in-stack relay is container-local), so the endpoint derives from
-# config.json — found by #1083's first live remote run. Returns 0 when synced.
-monero_caught_up() {
+# config.json — found by #1083's first live remote run. Read the rc with `= 1`, never `!= 0` (#1605).
+monero_caught_up() { # 0 caught up / 1 answered, behind / ANY other could-not-ask: 2 no usable body, 255 ssh
     rx 'u=$(grep -E "^MONERO_NODE_USERNAME=" .env 2>/dev/null | cut -d= -f2-);
         p=$(grep -E "^MONERO_NODE_PASSWORD=" .env 2>/dev/null | cut -d= -f2-);
         url=$(grep -E "^MONERO_RPC_URL=" .env 2>/dev/null | cut -d= -f2-); [ -n "$url" ] || url=$(jq -r "if (.monero.mode // \"local\") == \"remote\" and .monero.remote.host then \"http://\" + .monero.remote.host + \":\" + ((.monero.remote.rpc_port // 18081) | tostring) else \"http://127.0.0.1:18081\" end" config.json 2>/dev/null); [ -n "$url" ] || url="http://127.0.0.1:18081";
         if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null);
         else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi;
-        printf "%s" "$body" | jq -e "(.status==\"OK\") and ((.synchronized==true) or (.target_height==0))" >/dev/null 2>&1'
+        [ -n "$body" ] || exit 2; printf "%s" "$body" | jq -e "(.status==\"OK\") and ((.synchronized==true) or (.target_height==0))" >/dev/null 2>&1; case $? in 0) exit 0 ;; 1) exit 1 ;; *) exit 2 ;; esac'
 }
 
 # --- Shared-bench rig lock (#430; canonical helper from rigforge#183) --------

--- a/tests/integration/mergemine-probe.sh
+++ b/tests/integration/mergemine-probe.sh
@@ -113,9 +113,15 @@ mm_capture_startup() {
 # The release-gate leg: PASS, FAIL, or an honest counted SKIP — never a silent green.
 #
 # THE CAPTURE IS READ BEFORE THE PREDICATE, AND THAT ORDER IS ITSELF AN ASSERTION (#1597).
-# `monero_caught_up` reduces several independent conditions to one bit: its `curl -fsS` discards
+# `monero_caught_up` REDUCED several independent conditions to one bit: its `curl -fsS` discards
 # stderr and leaves the body EMPTY on an unreachable RPC, a refused connection or a 401, and
-# `jq -e` over an empty body answers exactly as it does for a node that is genuinely behind.
+# `jq -e` over an empty body answered exactly as it does for a node that is genuinely behind.
+# #1605 has since split that bit three ways — 0 caught up, 1 answered-and-behind, any other rc
+# could-not-ask — but THIS SITE DELIBERATELY TAKES BOTH NONZERO DOORS: `! monero_caught_up` below
+# is true for each, and the skip's own text says "could not be confirmed caught up", which is a
+# true statement about both. The capture-first order, not the predicate's precision, is what keeps
+# this skip honest; narrowing the test to `= 1` here would make the leg red on an unreachable RPC
+# in the one case p2pool has already proved the signal cannot exist.
 # Asked first, that one bit decided the whole leg — so a stack whose monerod was synced and whose
 # merge-mining client was up and reading chain_ids would have been booked as an ACCEPTED HOLE for
 # as long as the RPC stayed unanswerable. That state is not hypothetical here — `lib.sh`'s

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -629,7 +629,7 @@ assert_running_state() {
     it_pass "dashboard /api/state reachable"
 
     # 4. Monero caught up — per monerod's own get_info, not the dashboard UI field.
-    if monero_caught_up; then it_pass "monerod reports synced (RPC)"; else it_fail "monerod reports synced (RPC)" "get_info not synchronized"; fi
+    if monero_caught_up; then it_pass "monerod reports synced (RPC)"; elif [ $? = 1 ]; then it_fail "monerod reports synced (RPC)" "get_info answered: not synchronized"; else it_fail "monerod reports synced (RPC)" "get_info could not be asked — unreachable, refused, timed out or rejected"; fi
     # 4b. The node's ZMQ endpoint is a live ZMTP PUBLISHER (#1497) — strictly less than "publishes
     #     block notifications", and this row is named for what it proves, not for what the issue
     #     wants. Step 4 is satisfied by a node that can never publish one: an --offline monerod
@@ -1057,7 +1057,7 @@ assert_release_readiness() {
     it_log "── release-server readiness ────────────────────────"
 
     # 1. The whole point of a release server: chains already synced, reused in minutes.
-    if monero_caught_up; then it_pass "Monero is synced (chain reusable by the matrix)"; else it_fail "Monero is synced" "monerod not caught up — the matrix would have to re-sync"; fi
+    if monero_caught_up; then it_pass "Monero is synced (chain reusable by the matrix)"; elif [ $? = 1 ]; then it_fail "Monero is synced" "monerod answered: not caught up — the matrix would have to re-sync"; else it_fail "Monero is synced" "monerod could not be asked — unreachable, refused, timed out or rejected; sync state unknown"; fi
     pithead status >/dev/null 2>&1
     assert_rc "stack is healthy (pithead status)" "$?" "0"
 

--- a/tests/integration/selftest-mergemine-probe.sh
+++ b/tests/integration/selftest-mergemine-probe.sh
@@ -238,9 +238,12 @@ assert_eq "an unreadable container start time FAILS separately — 0 pass, 1 fai
 
 echo "== an unanswerable monerod RPC cannot book a covered leg as an accepted hole (#1597) =="
 
-# `monero_caught_up` reduces several independent conditions to ONE bit: its `curl -fsS` discards
+# `monero_caught_up` REDUCED several independent conditions to ONE bit: its `curl -fsS` discards
 # stderr, so an unreachable host, a refused connection and a 401 all leave the body empty, and
-# `jq -e` over an empty body answers exactly as it does for a node that is genuinely behind. The
+# `jq -e` over an empty body answered exactly as it does for a node that is genuinely behind.
+# #1605 split that bit three ways (0 / 1 / any other rc); the stub below still returns a single
+# not-caught-up bit because this leg deliberately treats both nonzero doors alike — see the note
+# above `assert_mergemine_roundtrip`. Its three answers are covered in selftest-monero-caught-up.sh. The
 # stub below returns that not-caught-up bit — which is what a perfectly synced monerod produces
 # behind a broken credential. `lib.sh`'s own env_bake_verdict comment records a day of that state.
 #

--- a/tests/integration/selftest-monero-caught-up.sh
+++ b/tests/integration/selftest-monero-caught-up.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Self-test for `monero_caught_up`'s THREE answers (#1605, successor to #1597/#1603).
+#
+# THE DEFECT WAS ONE BIT OVER SEVERAL DOORS. `monero_caught_up` dials monerod's get_info with
+# `curl -fsS … 2>/dev/null` and pipes the body into `jq -e`. Stderr was discarded and the body is
+# EMPTY on an unreachable host, a refused connection, a timeout and a 401 alike — so `jq -e` over
+# that empty body answered exactly as it does for a node that is genuinely behind. A caller could
+# not tell "monerod says it is behind" from "monerod could not be asked", and #1597 established
+# that this is most expensive where the bit feeds a SKIP CLASS, because a skip is an accepted hole.
+#
+# THE FIX IS AN rc, NOT A STRING, and it is deliberately open at the top end:
+#
+#     0        caught up
+#     1        monerod ANSWERED and is not caught up
+#     anything else   could not ask
+#
+# THE `[ -n "$body" ]` GUARD IS REDUNDANT WITH THE `case`, DELIBERATELY, and this is the note that
+# stops a later reader deleting it as dead code or trusting it as the only mechanism. Measured:
+# `jq -e` over EMPTY input exits 4, which the `case`'s `*)` arm already maps to 2 — so removing the
+# guard changes no observable behaviour today. It stays because it states OUR protocol ("no body
+# means we were not answered") rather than resting the classification on an entry in jq's exit
+# table. The guard acts first, so the mutation that reds the empty-body rows is a mutation of the
+# GUARD; the `case` is what would act if it were removed outright.
+#
+# The open top end is the whole safety argument. An empty body exits 2, but `rx` reaches the box
+# over ssh and **ssh exits 255 when the connection itself fails** — so a mapping written as
+# `!= 0 -> behind` would have booked an unreachable BOX as a node that is behind, re-creating the
+# defect one layer up. Callers therefore test `= 1` for behind and let every other nonzero fall to
+# could-not-ask. Part B below asserts that on the SHIPPED call-site lines, rc 255 included.
+#
+# HOW THIS FILE MEASURES. Part A runs the REAL snippet — `rx` in `IT_MODE=local` against a fake box
+# directory, with a fake `curl` on PATH and the REAL `jq`. Nothing about `monero_caught_up` is
+# stubbed, so the rows exercise the shipped text rather than a paraphrase of it. Part B lifts the
+# two shipped classification lines OUT of run.sh by `grep` and `eval`s them against a stubbed
+# predicate; it therefore cannot pass against a run.sh that has been rewritten back to two-valued.
+#
+# PROVEN ABLE TO FAIL — five mutations, each RE-RUN against the text that actually shipped, and
+# each `cmp`-checked against an untouched copy first so a mutation that failed to apply cannot be
+# counted as a leg. Measured, not predicted; the row counts are what the runs printed:
+#   * lib.sh, revert to the old `printf … | jq -e …` (drop both the empty-body guard and the
+#     explicit case)                                 -> 5 rows red, all in Part A (22/5).
+#   * lib.sh, `|| exit 2` -> `|| exit 1`             -> 4 rows: the EMPTY-BODY arm only (23/4).
+#     STATED, not hidden: those four are one code path behind four outside doors — ONE arm, not
+#     four. The non-JSON row survives this leg, which is what proves the two arms are separate.
+#   * lib.sh, `*) exit 2` -> `*) exit 1` (route jq's non-1 rcs to behind)
+#                                                    -> the non-JSON row, and ONLY it (26/1).
+#   * either call site -> `if …; then … else <one reason>; fi`  (re-run after the anchor change)
+#                                                    -> that site's "behind and could-not-ask give
+#     DIFFERENT reasons" row, and only it (25/1).
+#   * site A's `elif [ $? = 1 ]` -> `elif [ $? != 2 ]`, routing 255 to the BEHIND arm and leaving
+#     rc 2 alone                                     -> that site's ssh-255 row, and ONLY it (25/1).
+#     That leg is what ATTRIBUTES the 255 row to its own arm rather than to the rc-2 row.
+#
+# The lift anchor is deliberately loose for the same reason — see the note at the grep below.
+#
+# A separate file because lib.sh and run.sh both sit ON their lint-file-budget ceilings (692 and
+# 2551) and this change had to be line-neutral in both; the runner globs `selftest*.sh`
+# (Makefile:29), so a new file needs no registration.
+#
+# Run: tests/integration/selftest-monero-caught-up.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+# ARMING. `lib.sh` refuses to define anything unless its siblings are present, and a `source` whose
+# stderr is hidden leaves every function undefined while an absence-based sweep reads CLEAN. Assert
+# the subjects EXIST before asserting anything about their behaviour.
+for _fn in monero_caught_up rx; do
+    if declare -F "$_fn" >/dev/null; then it_pass "armed: $_fn is defined"; else
+        it_fail "armed: $_fn is defined" "lib.sh did not define it — every row below would be vacuous"
+        echo "selftest-monero-caught-up: ABORTED unarmed"
+        exit 1
+    fi
+done
+
+# --- The fake box -----------------------------------------------------------------------------
+# `rx` in local mode is `(cd "$IT_REMOTE_DIR" && bash -c "$snippet")`, so a directory holding a
+# .env and a config.json IS a box as far as this function is concerned. `curl` is faked because the
+# doors under test are curl's failure modes; `jq` is the REAL one, because the parse is the part we
+# are trusting to tell "answered" from "answered false".
+BOX="$(mktemp -d)"
+FAKEBIN="$BOX/bin"
+mkdir -p "$FAKEBIN"
+trap 'rm -rf "$BOX"' EXIT
+
+cat >"$FAKEBIN/curl" <<'CURL_EOF'
+#!/bin/sh
+# Stands in for the dial only. FAKE_CURL_BODY empty + a nonzero rc is what a refused connection, a
+# timeout, a 401 under -f and any non-2xx all look like to the caller: no body on stdout.
+[ -n "${FAKE_CURL_BODY:-}" ] && printf '%s' "$FAKE_CURL_BODY"
+exit "${FAKE_CURL_RC:-0}"
+CURL_EOF
+chmod +x "$FAKEBIN/curl"
+
+printf 'STACK_VERSION=v1.20.0\n' >"$BOX/.env"
+printf '{"monero":{"mode":"local"}}\n' >"$BOX/config.json"
+
+export PATH="$FAKEBIN:$PATH"
+export IT_MODE=local
+export IT_REMOTE_DIR="$BOX"
+
+# CONTROL ON THE FAKE ITSELF. A fake that is not on PATH, or not executable, would make every
+# could-not-ask row pass for the wrong reason — the real curl would dial 127.0.0.1:18081, find
+# nothing, and return an empty body too. Prove the fake is the thing answering.
+if [ "$(FAKE_CURL_BODY=probe-fake FAKE_CURL_RC=0 curl -fsS http://127.0.0.1:1/x 2>/dev/null)" = "probe-fake" ]; then
+    it_pass "control: the fake curl is the one on PATH"
+else
+    it_fail "control: the fake curl is the one on PATH" "rows below would pass off the real curl's failure"
+fi
+
+# `monero_caught_up` with a chosen body/rc from the dial. Prints the rc.
+_mcu_rc() { # <curl body> <curl rc>
+    FAKE_CURL_BODY="$1" FAKE_CURL_RC="$2" monero_caught_up
+    printf '%s' "$?"
+}
+
+echo "== monero_caught_up: three answers over the doors that produce them (#1605) =="
+
+# --- Part A: the predicate ----------------------------------------------------------------------
+# ATTRIBUTION. Rows 1-3 are the ANSWERED arm and are reached through `jq -e` exactly as before this
+# change; they are here so a mutation that makes everything unanswerable cannot read as a pass.
+# Rows 4-6 are the arm this issue exists for: all three carry an EMPTY body and differ only in the
+# curl rc, which the function never reads — they are one door each on the outside, one code path
+# inside, and they are listed separately because the ISSUE names them separately.
+assert_rc "synchronized:true is caught up" "$(_mcu_rc '{"status":"OK","synchronized":true,"target_height":800000}' 0)" "0"
+assert_rc "target_height 0 is caught up (the --offline disjunct)" "$(_mcu_rc '{"status":"OK","synchronized":false,"target_height":0}' 0)" "0"
+assert_rc "answered and behind is 1, not 2" "$(_mcu_rc '{"status":"OK","synchronized":false,"target_height":800000}' 0)" "1"
+
+# The one row that separates "monerod is not there" from "monerod is not OK": a body arrived, so we
+# were answered, and the answer is not a synced verdict. It must NOT be filed as could-not-ask.
+assert_rc "answered with status != OK is 1 (we were answered)" "$(_mcu_rc '{"status":"BUSY","synchronized":false,"target_height":800000}' 0)" "1"
+
+for _door in "refused:7" "timeout:28" "401 under -f:22"; do
+    assert_rc "could not ask (${_door%%:*}) is NOT 1" "$(_mcu_rc '' "${_door##*:}")" "2"
+done
+
+# A body that arrived but is not monerod's JSON. MEASURED, not assumed: `jq -e` answers 0 for true,
+# 1 for false, 5 for a parse error and 127 when jq is absent — so a mapping of "anything not 0 is
+# behind" reports a confident "not synchronized" for a box whose jq is broken or whose endpoint is
+# something else entirely. Only 1 means answered-and-behind; every other jq rc is could-not-ask.
+# This row shares the `*)` arm with the jq-absent case, which is why that case has no row of its own.
+assert_rc "a non-JSON body is could-not-ask, not behind" "$(_mcu_rc 'not json at all' 0)" "2"
+
+# The digest branch is a SECOND copy of the dial (lib.sh:385 vs :386) and the classification sits
+# after both, but a future edit could easily fix one and not the other — so exercise it. This needs
+# MONERO_NODE_USERNAME present in the box's .env, which is what selects that branch.
+printf 'MONERO_NODE_USERNAME=rpcuser\nMONERO_NODE_PASSWORD=rpcpass\n' >>"$BOX/.env"
+assert_rc "the authenticated dial classifies could-not-ask too" "$(_mcu_rc '' 7)" "2"
+assert_rc "the authenticated dial still answers caught-up" "$(_mcu_rc '{"status":"OK","synchronized":true,"target_height":800000}' 0)" "0"
+
+# --- Part B: the SHIPPED classification lines ---------------------------------------------------
+# Lifted out of run.sh by grep rather than restated here. A copy of the mapping written into this
+# file would be an assertion sourced from the thing it tests; lifting the real line means a run.sh
+# rewritten back to two answers reds these rows instead of silently keeping them green.
+_classify() { # <shipped line> <rc monero_caught_up returns>
+    MC_RC="$2"
+    # shellcheck disable=SC2329  # all three stubs are reached indirectly, by the `eval` below
+    (
+        monero_caught_up() { return "$MC_RC"; }
+        it_pass() { printf 'PASS|%s|\n' "$1"; }
+        it_fail() { printf 'FAIL|%s|%s\n' "$1" "${2:-}"; }
+        eval "$1"
+    )
+}
+
+echo "== the shipped call sites, lifted from run.sh and driven over all four rcs =="
+for _site in "assert_running_state:monerod reports synced (RPC)" "readiness:Monero is synced (chain reusable by the matrix)"; do
+    _name="${_site%%:*}"
+    _anchor="${_site#*:}"
+    # DELIBERATELY LOOSE: anchored on the call and the row's own label, NEVER on the comparison
+    # under test. An anchor carrying `elif [ $? = 1 ]` would make every mutation of the mapping red
+    # this presence row instead of the classification rows below — the guard would mask the
+    # measurement, and a battery would read as firing while proving nothing about the mapping.
+    _line="$(grep -F 'monero_caught_up' "$HERE/run.sh" | grep -F "it_pass \"$_anchor\"")"
+    if [ -z "$_line" ]; then
+        it_fail "$_name: the call site is present in run.sh" "no monero_caught_up line carrying: $_anchor"
+        continue
+    fi
+    it_pass "$_name: the call site is present in run.sh"
+
+    case "$(_classify "$_line" 0)" in
+    PASS*) it_pass "$_name: rc 0 passes the row" ;;
+    *) it_fail "$_name: rc 0 passes the row" "got: $(_classify "$_line" 0)" ;;
+    esac
+
+    # The DISCRIMINATING pair. Both fail the row — that was already true and is not what is being
+    # measured. What is measured is that they fail it for DIFFERENT, TRUE reasons: the old code
+    # gave both the "not synchronized" text, which is a false statement about an unreachable node.
+    _behind="$(_classify "$_line" 1)"
+    _unans2="$(_classify "$_line" 2)"
+    _unans255="$(_classify "$_line" 255)"
+    for _r in "behind:$_behind" "empty body:$_unans2" "ssh failure:$_unans255"; do
+        case "${_r#*:}" in
+        FAIL*) it_pass "$_name: ${_r%%:*} fails the row" ;;
+        *) it_fail "$_name: ${_r%%:*} fails the row" "got: ${_r#*:}" ;;
+        esac
+    done
+    assert_ne "$_name: behind and could-not-ask give DIFFERENT reasons" "$_behind" "$_unans2"
+
+    # ⛔ THE ROW THIS FILE EXISTS FOR. `rx` returns ssh's own 255 when the BOX is unreachable. Under
+    # a `!= 0 -> behind` mapping that is reported as "monerod is not caught up" — a confident false
+    # statement about a node nobody managed to contact. It must classify with the empty body.
+    assert_eq "$_name: an ssh failure (255) is could-not-ask, NOT behind" "$_unans255" "$_unans2"
+done
+
+echo "selftest-monero-caught-up: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
#1605 is #1597's structural half: #1603 fixed the consequence (the merge-mining
leg no longer converts an unanswerable RPC into a counted `by-design` skip) and
deliberately left the predicate alone. This is the predicate.

`monero_caught_up` dialled with `curl -fsS … 2>/dev/null` and piped the body into
`jq -e`. An unreachable host, a refused connection, a timeout and a 401 all leave
the body EMPTY, and `jq -e` over an empty body answers exactly as it does for a
node that is genuinely behind. Now:

    0              caught up
    1              monerod ANSWERED and is not caught up
    anything else  could not ask

THE OPEN TOP END IS THE POINT, and it is the one design decision here worth
disagreeing with. `rx` reaches the box over ssh, and ssh exits 255 when the
connection itself fails — MEASURED, not assumed, against an unreachable host —
so the obvious mapping, `!= 0 -> behind`, would have reported an unreachable BOX
as a node that is behind, re-creating the defect one layer up. Callers test `= 1`
for behind and let every other nonzero fall to could-not-ask.

The `= 1` test is load-bearing in a second place found only by attacking the
first draft, which had `… | jq -e … && exit 0; exit 1`. jq's rcs are 0 true,
1 false, 5 parse error, 127 absent — all measured — so that draft answered a
confident "not synchronized" for a box whose jq is broken or whose endpoint is
not monerod at all. Only 1 is answered-and-behind; every other jq rc now exits 2.

Both call sites in run.sh name the true reason instead of asserting "not
synchronized" about a node nobody managed to contact. Neither verdict changes:
both were, and remain, a red.

LINE-NEUTRAL IN BOTH BUDGETED FILES, deliberately — lib.sh sits on 692/692 and
run.sh on 2551/2551, zero headroom either side. The contract rides on the
signature line, which had 20 characters spare; the classification stays a single
`if/elif` statement because `cmd; case $? in` is two statements and shfmt splits
it, which would have cost a line run.sh does not have.

COVERAGE. New tests/integration/selftest-monero-caught-up.sh (203 lines, under
the 400 target, so no budget row; the runner globs selftest*.sh). It drives the
REAL snippet through `rx` in local mode against a fake box, and lifts the two
shipped call-site lines out of run.sh by grep rather than restating them, so a
revert to two-valued reds it. Six mutations, each `cmp`-checked and each re-run
against the text that shipped: reverting the snippet reds 5 rows; the empty-body
arm and the jq arm each red ONLY their own rows (4 and 1), which is what
attributes them separately; reverting either call site reds that site's
"different reasons" row; and routing 255 to the behind arm reds that site's
ssh-255 row and only it.

WHAT IS NOT CHANGED, and why:

  * `_pred_monero_synced` -> `wait_monero_synced` propagates the new rc, and
    `wait_for` treats every nonzero as "not yet" — verified at source, it is
    `if "$@"; then return 0; fi`. Both callers are `wait_monero_synced 120 ||
    true`, so nothing reads the bit. The cost this issue named — a 120s wait
    then a warning saying "sync" when the cause was reachability — survives.
    Fixing it means changing `wait_for`, which six other predicates share.

  * `mergemine-probe.sh:144` deliberately keeps taking BOTH nonzero doors.
    `! monero_caught_up` is true for each, and the skip's own text says "could
    not be confirmed caught up", which is true of both. Narrowing it to `= 1`
    would red the leg on an unreachable RPC in the one case p2pool has already
    proved the signal cannot exist. Comment updated to say so at the site.

AN ENUMERATION GAP IN THE ISSUE, filed rather than fixed: #1605's consumer table
is described on the issue as "closed rather than sampled" and it is not — it
misses `mergemine-probe.sh:144`, a fifth live consumer. That site is honest, so
this is a gap in the enumeration, not a defect. The walk that found it was given
a control that CAN produce the other answer (a consumer seeded outside
tests/ and docs/ was found, then removed), and the same walk at the merge base
returns the identical file set, so no site named here is an artifact of this diff.

Prose that this change falsified, in two files the code diff would not have
touched: mergemine-probe.sh's and selftest-mergemine-probe.sh's header comments
both stated the one-bit behaviour in the present tense.

docs/ is in _shared.paths; disclosed rather than taken with .lane-override.


---

### What I ran

| check | result |
|---|---|
| `tests/integration/selftest*.sh` (all 19 files) | 0 failures; the new file is 27 passed / 0 failed |
| six mutations, each `cmp`-verified and re-run against the shipped text | each reds its own arm and only its own arm |
| `shfmt -i 4 -d` over the Makefile's exact glob | clean |
| `shellcheck -x` over the five changed shell files | 0 findings in the SC2181/SC2329 classes; no new findings |
| `make lint-file-budget` (locally — CI skips the ratchet, #1608) | OK; `lib.sh` 692/692 and `run.sh` 2551/2551 unchanged |
| `make lint-md`, `make lint-docs-voice` | 0 errors; long-line count in the touched doc equals base (39 = 39) |

`make lint-sh` was NOT run whole — it is this box's OOM path and is serialized. The substitute is
the targeted `shellcheck` plus `shfmt` over the Makefile's own glob, as this lane's contract
prescribes; CI runs the real target.

### What I did NOT do

- No live run against a real monerod. Every rc above is measured through `rx` in local mode against
  a fake box, plus a real ssh hop to localhost to confirm `exit 2` survives the remote path and an
  unreachable host to confirm ssh's 255. The one thing not reproduced is a live 401 — which is the
  gap #1605 itself declares, and it is unchanged by this PR.
- The `wait_for` timeout message still says "sync" when the cause was reachability. Named above,
  not fixed; it is the remaining item on #1605 and it is diagnosis, not a verdict.

### The over-engineering pass (the ponytail gate's own question)

**One finding, kept rather than removed, and disclosed so it is not later filed as dead code.**
`[ -n "$body" ] || exit 2` is redundant with the `case` that follows it: measured, `jq -e` over
empty input exits 4, which the `*)` arm already maps to 2, so deleting the guard changes no
observable behaviour today. It stays because it states this harness's own protocol — "no body means
we were not answered" — instead of resting that classification on an entry in jq's exit table,
which is a detail of jq's implementation and not a contract. The guard acts first, so the mutation
that reds the empty-body rows is a mutation of the guard, not of the `case`; that asymmetry is
recorded at the site.

**Checked and judged NOT over-engineered:** the grep-lift in Part B (a restated mapping would be an
assertion sourced from the thing it tests, and run.sh cannot be sourced — it is a runner with side
effects); the file's size relative to a six-line production change (the header carries the contract
and the measured mutation evidence, which is this directory's existing house style — compare
`selftest-redact-env.sh`); and the three-valued rc itself, which is the change #1605 asked for and
the controller's ruling on that issue commissioned.
