### PR TITLE
fix(integration): mask the captured config BY PATH, using the box's own walk (#1630)

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -98,10 +98,13 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   reaches the 48-character form, and no bound reaches the emoji form at all.
   **The JSON rule is keyed on the field NAME, not the value, and that is forced**:
   a view key and a container digest are both 64 hex characters, so nothing in the value separates
-  them. **The name list is open, and one field is still out of reach** — `notifications.ntfy.url`
+  them. **The name list is open, and one field is out of the FILTER's reach** — `notifications.ntfy.url`
   is a capability URL whose key is the bare word `url`, which only its nesting separates from the
-  public `xvb.url`, and a line-wise filter cannot see nesting. The self-test states that gap
-  rather than hiding it. **Two further JSON shapes are stated rather than closed**
+  public `xvb.url`, and a line-wise filter cannot see nesting. That is a limit of the filter, not
+  of the bundle: since [#1630](https://github.com/p2pool-starter-stack/pithead/issues/1630) the
+  `config.json` artifact is masked BY PATH before it reaches the filter (*Artifacts & triage*
+  below), so the topic does not survive a capture. The self-test states the filter's gap rather
+  than hiding it, and deliberately does not assert a redaction the filter cannot deliver. **Two further JSON shapes are stated rather than closed**
   ([#1590](https://github.com/p2pool-starter-stack/pithead/issues/1590)): a JSON payload logged as
   an escaped string inside another field (`"msg":"{\"password\":\"…\"}"`), and a secret whose
   value is not a string (`"api_token":12345678`). Both were measured absent from every artifact
@@ -655,6 +658,22 @@ On a scenario failure, the harness captures (redacted) to `results/<scenario>/`:
 `compose-ps.txt`, `status.txt`, `doctor.txt`, `config.json`, `env.redacted.txt`,
 `api-state.json`, and `logs.txt` (last 200 lines per service). The end-of-run summary lists
 each failed assertion and points at these.
+
+`config.json` is the one artifact that is not streamed straight through the redactor. A config is a
+document with an enumerable shape, and the stack already classifies it by PATH:
+`render_masked_config` walks `CONTROL_SECRET_PATHS` plus the three variable-length array cases a
+fixed-path walk cannot reach (`workers.list[].token`, the deprecated `dashboard.workers[].token`,
+and `notifications.webhooks[]`, where the whole URL is the bearer secret). The capture SOURCES the
+box's own `./pithead` and calls that function rather than restating the list or the jq program
+here: sourcing is the shipped contract, since the prelude sets `_STACK_SOURCED` and skips the `cd`,
+the traps and `main`. One classification, one place to change it. The masked document then passes
+through the redactor as before, so the shape, position and IP rules keep their reach over
+everything the path list does not name — the pass is additive and cannot narrow coverage. It
+renders from the LIVE config at capture time rather than copying the box's pre-rendered
+`$CONTROL_DIR/masked/config.json`, which is refreshed only on setup/apply/upgrade and is documented
+as degrading to a stale copy on a render hiccup: an artifact presenting stale state as the state
+under test is the failure this harness exists to catch. If the program cannot be sourced the
+capture writes no config rather than falling back to the raw file, and says so in the artifact.
 
 ### Reading the verdict — what did not run
 

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -684,9 +684,9 @@ capture_artifacts() {
     rx "docker compose ps" 2>&1 | redact >"${dir}/compose-ps.txt" || true
     rx "$IT_PITHEAD status" 2>&1 | redact >"${dir}/status.txt" || true
     rx "$IT_PITHEAD doctor" 2>&1 | redact >"${dir}/doctor.txt" || true
-    rx "cat config.json" 2>&1 | redact >"${dir}/config.json" || true
+    # config.json is masked BY PATH first (#1630) — redact() is line-wise and cannot see nesting.
+    rx '. ./pithead >/dev/null 2>&1; d=$(mktemp -d); render_masked_config "$d"; cat "$d/masked/config.json" 2>/dev/null; rm -rf "$d"' 2>&1 | redact >"${dir}/config.json" || true
     rx "cat .env" 2>&1 | redact >"${dir}/env.redacted.txt" || true
     api_state | redact >"${dir}/api-state.json" || true
-    # Last 200 lines of each service's logs, redacted.
     rx "docker compose logs --tail=200 --no-color" 2>&1 | redact >"${dir}/logs.txt" || true
 }

--- a/tests/integration/selftest-capture-config.sh
+++ b/tests/integration/selftest-capture-config.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Self-test for the config.json artifact capture (#1630).
+#
+# THE DEFECT. `capture_artifacts` wrote the live config.json through `redact()`, which is a
+# LINE-WISE stream filter keyed on field NAMES. `notifications.ntfy.url` is the bare word `url`
+# and only its NESTING separates it from `xvb.url` and the other public endpoints — so no name
+# rule can reach it without also eating those. The ntfy topic in that path IS the capability:
+# whoever holds a captured bundle can publish to, and subscribe to, the operator's channel.
+# Measured on the shipped filter before this change, `notifications.webhooks[]` survived too —
+# one value more than the issue names, and the whole URL there is the bearer secret (#848).
+#
+# THE FIX IS ROUTING, NOT NEW MACHINERY. The stack already classifies this document by PATH:
+# `render_masked_config` (lib/pithead/30-release-fetch-and-masked-config.sh) walks
+# CONTROL_SECRET_PATHS *plus* three variable-length array cases the fixed-path walk cannot reach
+# (workers.list[].token, the deprecated dashboard.workers[].token, and notifications.webhooks[]).
+# The capture now SOURCES the box's own `./pithead` and calls that function, so there is ONE
+# classification source and this harness restates neither the list nor the jq program. Sourcing is
+# the shipped contract, not a trick: 00-prelude.sh sets `_STACK_SOURCED=1` when BASH_SOURCE[0]
+# differs from $0 and skips every side effect — the cd, the traps, and `main`.
+#
+# WHY THE LIVE CONFIG AND NOT THE BOX'S PRE-RENDERED COPY. `$CONTROL_DIR/masked/config.json`
+# already exists and would have cost nothing to `cat`, but it is re-rendered on setup/apply/upgrade
+# and is documented as degrading to a STALE copy on a render hiccup. A debugging artifact that
+# presents stale state as the state under test is this lane's founding defect class, so the capture
+# renders from the live config at capture time instead.
+#
+# THE PASS IS ADDITIVE. The masked document still goes through `redact()` afterwards, so the shape
+# and vocabulary rules keep their reach over anything the path list does not name; row 4 pins that.
+#
+# WHY THE SHIPPED LINE CARRIES ONLY ONE COMMENT LINE. tests/integration/lib.sh sits at its recorded
+# 692-line ceiling with zero headroom, so the reasoning lives here and in
+# docs/dev/integration-testing.md. The one comment line it does carry was paid for by deleting a
+# comment that restated its own code.
+#
+# HOW THIS FILE MEASURES. It runs the REAL `capture_artifacts` from lib.sh against a fake box
+# directory in IT_MODE=local, with the REAL built `pithead` and the REAL `jq`. Nothing about the
+# masking is stubbed, so the rows exercise the text that ships rather than a paraphrase of it.
+#
+# PROVEN ABLE TO FAIL — the mutations and their row counts are recorded in the PR body; each was
+# `cmp`-checked against an untouched copy first, so a mutation that failed to apply cannot be
+# counted as a leg.
+
+set -uo pipefail
+
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+REPO="$(cd -P "$HERE/../.." && pwd -P)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+BOX="$TMP/box"
+OUT="$TMP/out"
+FAKEBIN="$TMP/bin"
+mkdir -p "$BOX" "$OUT" "$FAKEBIN"
+
+# The box runs the REAL program — the point of the fix is that nothing here restates it.
+ln -s "$REPO/pithead" "$BOX/pithead"
+
+# Sentinels are SHORT on purpose. A value of 90+ alnum characters is reached by redact()'s shape
+# rule, which would make the rows below pass off the stream filter rather than off the document
+# pass they exist to measure.
+NTFY_TOPIC="NTFYTOPICSENTINEL"
+WEBHOOK="WEBHOOKSENTINEL"
+VIEWKEY="VIEWKEYSENTINEL"
+# 95 alnum characters under a benign key no path rule and no name rule reaches: only redact()'s
+# shape rule can remove it, so it measures whether the stream pass still runs after the document.
+LONGVAL="$(printf 'A%.0s' $(seq 1 95))"
+
+cat >"$BOX/config.json" <<CONFIG_EOF
+{
+  "monero": { "mode": "local", "view_key": "$VIEWKEY" },
+  "xvb": { "url": "https://xmrvsbeast.com/p2pool/XvB" },
+  "notifications": {
+    "ntfy": { "url": "https://ntfy.sh/$NTFY_TOPIC" },
+    "webhooks": ["https://hooks.example.com/$WEBHOOK"]
+  },
+  "workers": { "list": [ { "name": "rig1", "note": "$LONGVAL" } ] }
+}
+CONFIG_EOF
+
+# capture_artifacts also shells out to docker and the dashboard API; stub them so this file tests
+# the config route and nothing else. IT_PITHEAD is `true` so the status/doctor captures cannot
+# EXECUTE the real pithead sitting in the fake box.
+printf '#!/bin/sh\nexit 0\n' >"$FAKEBIN/docker"
+printf '#!/bin/sh\nexit 1\n' >"$FAKEBIN/curl"
+chmod +x "$FAKEBIN/docker" "$FAKEBIN/curl"
+
+export PATH="$FAKEBIN:$PATH"
+export IT_MODE=local
+export IT_REMOTE_DIR="$BOX"
+export IT_PITHEAD=true
+
+echo "== capture_artifacts: config.json is masked BY PATH before the stream filter (#1630) =="
+
+# ATTRIBUTION. Before anything else, prove the stream filter ALONE leaves the ntfy topic standing.
+# Without this row, a green "the topic is absent" below could be redact()'s doing and the document
+# pass would be untested — the borrowed green this lane has shipped before.
+RAW_THROUGH_REDACT="$(redact <"$BOX/config.json")"
+assert_contains "attribution: redact() ALONE leaves the ntfy topic — the gap is real and unfixed in the stream filter" \
+    "$RAW_THROUGH_REDACT" "$NTFY_TOPIC"
+assert_contains "attribution: redact() ALONE leaves the webhook URL too — one value more than the issue names" \
+    "$RAW_THROUGH_REDACT" "$WEBHOOK"
+
+capture_artifacts "cfg" "$OUT" >/dev/null 2>&1
+ART="$(cat "$OUT/cfg/config.json" 2>/dev/null)"
+
+# ARMING. Every row below is an ABSENCE, and an empty or missing artifact makes all of them pass.
+# This row is what makes those absences mean anything: the capture produced a real document that
+# still carries its non-secret content.
+assert_contains "control: the capture produced a config-shaped document (absences below are earned)" \
+    "$ART" '"mode"'
+assert_contains "control: a public endpoint is NOT masked — the path walk is selective, not a blanket" \
+    "$ART" "xmrvsbeast.com"
+
+# THE ROW THIS FILE EXISTS FOR. Assert the RAW value is ABSENT — never that a marker appeared. A
+# marker can arrive from another field on the same line, and partial redaction is worse than none.
+case "$ART" in
+*"$NTFY_TOPIC"*) it_fail "the ntfy topic is absent from the captured config" "raw capability value survived the capture" ;;
+*) it_pass "the ntfy topic is absent from the captured config" ;;
+esac
+case "$ART" in
+*"$WEBHOOK"*) it_fail "the webhook URL is absent from the captured config" "raw bearer value survived the capture" ;;
+*) it_pass "the webhook URL is absent from the captured config" ;;
+esac
+case "$ART" in
+*"$VIEWKEY"*) it_fail "a fixed-path secret leaf is absent from the captured config" "raw value survived the capture" ;;
+*) it_pass "a fixed-path secret leaf is absent from the captured config" ;;
+esac
+
+# ADDITIVE, not a replacement. `workers.list[].note` is in no path rule and no name vocabulary, so
+# only redact()'s >=90-character shape rule can reach it. If this reds, the document pass has
+# REPLACED the stream pass instead of preceding it, which would be a coverage regression.
+case "$ART" in
+*"$LONGVAL"*) it_fail "the stream rules still run over the masked document" "a shape-reached value survived — the document pass replaced redact() instead of preceding it" ;;
+*) it_pass "the stream rules still run over the masked document" ;;
+esac
+
+# FAIL CLOSED. If the box's program cannot be reached the capture must produce NO config rather
+# than fall back to the raw file. The snippet never `cat`s config.json, so this holds by
+# construction — and a later edit that adds a convenience fallback reds here.
+rm -f "$BOX/pithead"
+capture_artifacts "closed" "$OUT" >/dev/null 2>&1
+ART_CLOSED="$(cat "$OUT/closed/config.json" 2>/dev/null)"
+case "$ART_CLOSED" in
+*"$NTFY_TOPIC"*) it_fail "an unreachable masking program captures no config, not the raw one" "raw capability value was captured when the program was gone" ;;
+*) it_pass "an unreachable masking program captures no config, not the raw one" ;;
+esac
+
+echo "selftest-capture-config: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/integration/selftest-capture-config.sh
+++ b/tests/integration/selftest-capture-config.sh
@@ -19,11 +19,8 @@
 # the shipped contract, not a trick: 00-prelude.sh sets `_STACK_SOURCED=1` when BASH_SOURCE[0]
 # differs from $0 and skips every side effect — the cd, the traps, and `main`.
 #
-# WHY THE LIVE CONFIG AND NOT THE BOX'S PRE-RENDERED COPY. `$CONTROL_DIR/masked/config.json`
-# already exists and would have cost nothing to `cat`, but it is re-rendered on setup/apply/upgrade
-# and is documented as degrading to a STALE copy on a render hiccup. A debugging artifact that
-# presents stale state as the state under test is this lane's founding defect class, so the capture
-# renders from the live config at capture time instead.
+# WHY THE LIVE CONFIG AND NOT THE BOX'S PRE-RENDERED COPY: docs/dev/integration-testing.md, under
+# *Artifacts & triage*. Stated once, there, rather than restated here.
 #
 # THE PASS IS ADDITIVE. The masked document still goes through `redact()` afterwards, so the shape
 # and vocabulary rules keep their reach over anything the path list does not name; row 4 pins that.
@@ -63,14 +60,13 @@ ln -s "$REPO/pithead" "$BOX/pithead"
 # pass they exist to measure.
 NTFY_TOPIC="NTFYTOPICSENTINEL"
 WEBHOOK="WEBHOOKSENTINEL"
-VIEWKEY="VIEWKEYSENTINEL"
 # 95 alnum characters under a benign key no path rule and no name rule reaches: only redact()'s
 # shape rule can remove it, so it measures whether the stream pass still runs after the document.
 LONGVAL="$(printf 'A%.0s' $(seq 1 95))"
 
 cat >"$BOX/config.json" <<CONFIG_EOF
 {
-  "monero": { "mode": "local", "view_key": "$VIEWKEY" },
+  "monero": { "mode": "local" },
   "xvb": { "url": "https://xmrvsbeast.com/p2pool/XvB" },
   "notifications": {
     "ntfy": { "url": "https://ntfy.sh/$NTFY_TOPIC" },
@@ -124,11 +120,6 @@ case "$ART" in
 *"$WEBHOOK"*) it_fail "the webhook URL is absent from the captured config" "raw bearer value survived the capture" ;;
 *) it_pass "the webhook URL is absent from the captured config" ;;
 esac
-case "$ART" in
-*"$VIEWKEY"*) it_fail "a fixed-path secret leaf is absent from the captured config" "raw value survived the capture" ;;
-*) it_pass "a fixed-path secret leaf is absent from the captured config" ;;
-esac
-
 # ADDITIVE, not a replacement. `workers.list[].note` is in no path rule and no name vocabulary, so
 # only redact()'s >=90-character shape rule can reach it. If this reds, the document pass has
 # REPLACED the stream pass instead of preceding it, which would be a coverage regression.

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -171,7 +171,14 @@ MUST_SURVIVE="xvb.url xmrig_proxy.url workers.api_auth telegram.chat_id"
 # ⛔ NOT a survivor on merit. `notifications.ntfy.url` IS a capability URL and ought to be
 # redacted; a line-wise filter cannot reach it, because the key is the bare word "url" and only
 # its NESTING distinguishes it from xvb.url. Asserted at its CURRENT behaviour so the gap is
-# stated rather than hidden — when someone closes it, this line fails and moves to MUST_REDACT.
+# stated rather than hidden.
+# ⛔ THE ARTIFACT EXPOSURE IS CLOSED (#1630); THIS ROW IS STILL TRUE, AND THAT IS NOT A
+# CONTRADICTION. `capture_artifacts` no longer pipes the config document through redact() alone —
+# it masks BY PATH first, using the box's own `render_masked_config`, so the topic never reaches a
+# captured bundle. redact() ITSELF is unchanged and still cannot see nesting, which is what this
+# row measures. So the pin does NOT move to MUST_REDACT: asserting redaction here would assert
+# something false about the stream filter. The rows that measure the closed exposure live in
+# selftest-capture-config.sh. Anyone closing the gap INSIDE redact() reds this line, as before.
 # ⛔ THE .env HALF OF THIS VALUE WAS CLOSED (#1626); THIS ONE IS STILL OPEN. `NTFY_URL` fell to a
 # specific suffix catching exactly itself. That does not transfer, because this key is the bare
 # word `url` and only its nesting separates it from `xvb.url`. `ntfy_url` IS carried in both of
@@ -259,12 +266,12 @@ for field in $SCREENED; do
     # The gap gets a label that cannot be misread as approval. A green row saying a secret-bearing
     # field "survives redaction" is exactly the confidence this file exists to refuse.
     if in_list "$field" "$KNOWN_GAP"; then
-        assert_contains "KNOWN GAP (#1587) — $field is NOT redacted and should be" "$out" "$SENTINEL"
+        assert_contains "KNOWN GAP (#1630) — $field is NOT redacted by the STREAM filter" "$out" "$SENTINEL"
         continue
     fi
     assert_contains "$field survives redaction" "$out" "$SENTINEL"
 done
-it_warn "KNOWN GAP (#1587): $KNOWN_GAP is a capability URL and is NOT redacted — nesting is invisible to a line-wise filter"
+it_warn "KNOWN GAP (#1630): $KNOWN_GAP is a capability URL that redact() cannot reach — nesting is invisible to a line-wise filter. Captured bundles are covered by the path-keyed pass in capture_artifacts, not by this filter."
 
 # A value containing an escaped quote must be replaced WHOLE. A pattern stopping at the first
 # quote would leave the tail behind, which is the partial-redaction failure this file exists for.


### PR DESCRIPTION
Closes the JSON half of #1630, routed to this lane by the redaction-policy ruling on that issue.

## The defect, and one value more than the issue names

`capture_artifacts` wrote the live `config.json` through `redact()` — a LINE-WISE stream filter
keyed on field NAMES. `notifications.ntfy.url` is the bare word `url`, and only its NESTING
separates it from `xvb.url` and the other public endpoints, so no name rule reaches it without
eating those too. The topic in that path IS the capability: whoever holds a captured bundle can
publish to and subscribe to the operator's channel.

Measured against the shipped filter before the change, `notifications.webhooks[]` survived as
well — not named in the issue, and there the whole URL is the bearer secret (#848). Both are
pinned as attribution rows in the new self-test, so the green below is not borrowed from
`redact()` doing the work.

## The route I took, and why — the open (i)/(ii) choice the issue banked

**Route (ii): mask the LIVE config at capture time by executing the box's own program.**

The capture now sources the box's `./pithead` and calls `render_masked_config`. Sourcing is the
shipped contract, not a trick: `00-prelude.sh:98-101` sets `_STACK_SOURCED=1` when `BASH_SOURCE[0]`
differs from `$0`, and the guarded block below it skips the `cd`, the traps and `main`. Verified
two ways — by reading the guard, and by executing it (`_STACK_SOURCED=1`, `main` defined and not
run). That check mattered: a bare `./pithead` is a full-deploy trap on at least one checkout here.

**Against (i), capturing `$CONTROL_DIR/masked/config.json`.** It would have cost one `cat` and the
box already renders it. But it is re-rendered only on setup/apply/upgrade and is documented as
degrading to a STALE copy on a render hiccup — best-effort by design. A debugging artifact that
presents stale state as the state under test is this lane's founding defect class, so the
truthfulness cost outweighed the convenience. The shape cost the issue raised (secrets become
`{"__secret__": true}` objects rather than strings) applies to both routes and is not what decided
it; nothing in the repo reads this artifact by shape, and the sentinel additionally distinguishes
"set" from "not set", which `<redacted>` cannot.

**Constraint 1 — ONE classification source.** Nothing here restates the list or the jq program.
The harness executes the shipped function, so the fixed-path walk over `CONTROL_SECRET_PATHS` AND
the three variable-length array cases (`workers.list[].token`, the deprecated
`dashboard.workers[].token`, `notifications.webhooks[]`) all come along. That was the concrete risk
the recon flagged: restating only `CONTROL_SECRET_PATHS` would have dropped the array cases, and
the tell would have been a bundle that looks masked.

**Constraint 2 — ADDITIVE.** The masked document still goes through `redact()`. Pinned by a row
that puts a 95-character value under `workers.list[].note`, which no path rule and no name rule
reaches — only the shape rule can remove it. If the document pass ever REPLACES the stream pass,
that row reds.

**Fail-closed.** The snippet never `cat`s `config.json`, so an unreachable or missing program
captures nothing rather than the raw file. Measured: the artifact then contains
`render_masked_config: command not found` — it says why rather than going silently empty.

## Where the reasoning lives, and the one comment line

`tests/integration/lib.sh` is at its recorded **692-line ceiling with zero headroom**, so the
change is line-neutral: one code line replaced in place, one comment line added, paid for by
deleting a comment that restated its own code (`# Last 200 lines of each service's logs,
redacted.` above a `--tail=200 | redact` line). The reasoning is in
`selftest-capture-config.sh`'s header and in `docs/dev/integration-testing.md`. Calling that out
rather than leaving a reviewer to wonder why a security change carries one line of comment.

## The pins — I did NOT do what the ruling anticipated, and here is why

The ruling said the known-gap pins "move to MUST_REDACT with it". They do not, and I think moving
them would be wrong. That instruction assumed a fix INSIDE `redact()`. This fix routes the
document around `redact()`'s blind spot; the filter itself is unchanged and still cannot see
nesting. Asserting `MUST_REDACT` would assert something false about the stream filter and would
red immediately.

What I did instead: the two live pins move off **closed #1587** to **#1630** and are reworded so a
reader cannot read "still a gap" as "bundles still leak" — the row now says the value is not
redacted *by the stream filter*, and points at the file that measures the closed exposure. The
three remaining `#1587` mentions in that file, and the one at `lib.sh:37`, are provenance for when
the JSON rule landed, not live gap-pins, so they stay. **Flagging this as a deliberate divergence
from the ruling for the non-author pass to judge.**

## Proven able to fail

Five mutations against the text that shipped, each `cmp`-checked against an untouched copy first,
so a mutation that failed to apply cannot be counted. Two legs (M2, M3) hit a quoting bug in the
harness on the first run and the `cmp` guard **discarded them rather than counting them** — they
were re-run cleanly. Row counts are what the runs printed:

| Mutation | Predicted | Printed |
|---|---|---|
| M1 revert to the pre-fix line (`cat config.json \| redact`) | the absence rows red | **5 passed, 3 failed** — ntfy, webhook, fail-closed |
| M2 drop the stream pass (`\| redact` → `\| cat`) | additivity row only | **7 passed, 1 failed** — the shape-reached value survived |
| M3 add a convenience raw fallback when the program is gone | fail-closed row only | **7 passed, 1 failed** |
| M4 capture nothing at all | do the ARMING rows catch it? | **6 passed, 2 failed** — both control rows red, every absence row still GREEN |
| M5 disable the array arm in a COPY of `pithead` (read-only) | webhook only | ntfy=masked, webhook=**SURVIVED** |

**M4 is the one worth reading.** With the capture producing nothing, every absence row passes — so
without the two arming rows this file would have scored a clean green on a fix that captures
nothing. That is why the "config-shaped document" and "a public endpoint is NOT masked" rows are
there. **M5** answers the redundancy question M1 raises: the ntfy row and the webhook row are
reached by different arms of the shipped classification (fixed-path walk vs array map), so the
three rows M1 reds are not one arm wearing three labels.

## What was run

- All 20 `tests/integration/selftest*.sh`, each rc=0 — the new file is discovered by the
  `Makefile:29` glob (no registration needed) and reports **8 passed, 0 failed**.
- `shellcheck --severity=warning tests/integration/*.sh` → rc=0, **with a positive control**: my
  first control used SC2086, which `--severity=warning` filters out and which returned a
  misleading rc=0; re-run with SC2164 on a copy of the new file it fires rc=1, so the clean result
  is evidence.
- `shfmt -i 4 -d` over the Makefile's exact glob → rc=0.
- `make lint-md`, `make lint-docs-voice`, `make lint-file-budget` (staged first — the gate is blind
  to an untracked file) → all pass. `lib.sh` holds at exactly 692.
- **Remote-mode quoting**, which the self-test does not reach: the snippet was lifted OUT of
  `lib.sh` by `grep` (so it cannot drift from what ships), rebuilt into the exact command string
  `rx` hands to `ssh`, and run the way the remote shell parses it — masked document produced, raw
  topic absent.
- The captured artifact is still valid JSON after `redact()`, and private IPs survive for triage.

## The over-engineering pass, and what it changed

This lane's standing note is that the ponytail gate clears unconditionally on the retry and
verifies nothing, so the review was run for real off disk against this diff. It produced two
findings and both were acted on in the second commit rather than waved through:

1. **A row that could not discriminate.** The `view_key` absence row was removed. `redact()`'s
   name rule already deletes that value, so no mutation of the document pass could red it, and the
   ntfy row already covers the fixed-path arm. A row that has not been shown able to fail is
   decoration — and this file exists to argue the opposite.
2. **Duplicated rationale.** The staleness argument for rendering from the live config was written
   out in both the test header and the doc. Two copies of one recipe is the duplication that has
   drifted in this lane before; the header now points at the doc.

Declined, with reasons: the 40-line test header stays — `lib.sh` has zero line headroom, so the
reasoning has to live somewhere, and the half a reader needs is in the doc. Both attribution rows
stay: they are paired one-to-one with the two absence rows they license, and M5 shows the two
values travel through different arms of the classification.

Because the second commit edits a test the battery names, **the whole battery was re-run against
the edited file** and the table above carries the re-run's numbers, not the first pass's.

## What I did NOT do

- **No live-box run.** This is proven at self-test level plus the lifted-snippet remote-mode
  simulation. A full gate run replaces the deployed stack, and nothing about this change earned
  that cost. If the non-author pass wants a live leg, say so and I will take the rig lock.
- I did not measure against the #1593 bundle corpus. The corpus was captured by older redactors
  and is a stream-filter corpus; this change alters the *document* route, so the corpus cannot
  discriminate. Saying so rather than running it for the look of it.
- I did not touch `redact()`, and I did not touch `lib/pithead/` — the classification is another
  lane's file and the point of the design is that this harness does not restate it.
- An older `pithead` on the box masks by ITS classification, not today's. That is the correct
  semantics for a release-gate artifact (masked by the code under test) but it is a property worth
  knowing, so it is stated here rather than discovered later.
- `mktemp -d` on the box leaks one empty directory if the connection dies mid-snippet.
