### PR TITLE
fix(dashboard): #1615 the per-table health channel now answers for the handle, not just the last write

### DIFF
--- a/dashboard/mining_dashboard/service/storage_service.py
+++ b/dashboard/mining_dashboard/service/storage_service.py
@@ -69,7 +69,7 @@ WORKER_HISTORY_RETENTION_SEC = HISTORY_RETENTION_SEC  # 30 days
 # unbounded: keep the newest N. Decades of legit wins fit; a hostile feed cannot grow it past this.
 RAFFLE_WINS_MAX_ROWS = 5000
 
-# Table names carrying a per-table write-health signal (see __init__ / _table_write_ok below).
+# Table names carrying a per-table write-health signal (see get_table_health / _table_write_ok).
 # It stays HERE and stays a plain name list: __init__ is its only reader, it seeds a dict of
 # health entries from it, and it never dispatches into a method — so the three tables whose
 # writers moved to telemetry_store.py (#1369) need no indirection back out of this module.
@@ -158,15 +158,11 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         # on the next recovery attempt that succeeds.
         self.db_unrecoverable = False
 
-        # Per-table "last successful write" health signal for the v1.7 telemetry backbone (#196
-        # Wave-0), mirroring db_healthy above but per table: DataService's whole poll loop is one
-        # big try/except, so a capture hook that starts silently raising would otherwise stop
-        # writing forever with no visible symptom. `healthy` flips False on a write failure
-        # (routed through _db_error, so it also trips the global #131 badge); `last_write` is the
-        # wall-clock of the last successful write, None until the first one lands.
-        self.table_health = {
-            name: {"healthy": True, "last_write": None} for name in _TELEMETRY_TABLES
-        }
+        # Per-table write health for the v1.7 telemetry backbone (#196 Wave-0), mirroring
+        # db_healthy above but per table. RAW: these entries record write ATTEMPTS only and know
+        # nothing about the handle, so a closed one leaves them all reading healthy — read through
+        # get_table_health, which folds that in (#1615), never this dict directly.
+        self.table_health = {n: {"healthy": True, "last_write": None} for n in _TELEMETRY_TABLES}
 
         self._conn = sqlite3.connect(self.db_path, timeout=30.0, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
@@ -925,8 +921,11 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
     def get_table_health(self) -> dict[str, dict[str, Any]]:
         """Per-table write health for the v1.7 telemetry backbone (#196): ``{table: {"healthy",
         "last_write"}}``. Lets a caller notice a capture hook that has silently stopped writing —
-        the data-service poll loop is one big try/except, so nothing else would surface that."""
-        return {k: dict(v) for k, v in self.table_health.items()}
+        the data-service poll loop is one big try/except, so nothing else would surface that. A
+        closed handle drops every write at the guard before either stamp runs, so ``healthy`` is
+        derived here (#1615) — no table reads healthy while there is no handle to write through."""
+        live = bool(self._conn)  # the very test each writer's guard makes, not a re-spelling of it
+        return {k: {**v, "healthy": v["healthy"] and live} for k, v in self.table_health.items()}
 
     def add_block(self, ts: float, height: int, difficulty: float) -> None:
         """Record one pool block-found event (#196): permanent (no retention prune — a handful of

--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -103,9 +103,10 @@ moved the data, which is the failure the pin comment below records happening twi
 #
 # The reading is also what found **#1615**: `add_block` and `add_worker_history` stamp the per-table
 # write-health signal, and the guard returns BEFORE either stamp — so after a failed corruption
-# recovery every telemetry table reports `healthy: True` while its writes are dropped. Filed rather
-# than fixed here: this slice is annotation-only and proven bytecode-identical, and that fix is a
-# behaviour change to five write paths.
+# recovery every telemetry table REPORTED `healthy: True` while its writes were dropped. Filed
+# rather than fixed here: this slice is annotation-only and proven bytecode-identical. #1615 then
+# fixed it at the READ rather than by stamping the five guards — `get_table_health` derives
+# `healthy` from the handle — so every guard below is untouched and that proof still stands.
 #
 # Slice 8 is `service/telemetry_store.py`, and it is slice 7's shape with nothing new to argue: its
 # three writers are the same closed-handle guard whose whole body is a bare `return`, measured the

--- a/dashboard/tests/service/test_storage_telemetry.py
+++ b/dashboard/tests/service/test_storage_telemetry.py
@@ -338,6 +338,37 @@ class TestTelemetryTableHealth:
         health["blocks"]["healthy"] = False
         assert state_manager.get_table_health()["blocks"]["healthy"] is True
 
+    def test_a_closed_handle_reads_unhealthy_for_every_table(self, state_manager):
+        # #1615: the closed-handle guard returns before either stamp, so the RAW entries stay
+        # healthy while every write is dropped -- get_table_health folds the handle in instead.
+        state_manager.add_block(time.time(), height=1, difficulty=1.0)
+        # Control against a derivation that is wrong in the other direction: a write that DID
+        # land, on a live handle, still reads healthy.
+        assert state_manager.get_table_health()["blocks"]["healthy"] is True
+        state_manager.close()
+        assert [t for t, row in state_manager.get_table_health().items() if row["healthy"]] == []
+        # ...and the raw dict is untouched, so the fix is at the read and not a fifth stamp.
+        assert state_manager.table_health["blocks"]["healthy"] is True
+
+    def test_last_write_survives_a_closed_handle(self, state_manager):
+        # `last_write` is a historical fact about a write that landed; only `healthy` is derived.
+        t0 = time.time()
+        state_manager.add_block(t0, height=1, difficulty=1.0)
+        state_manager.close()
+        assert state_manager.get_table_health()["blocks"] == {"healthy": False, "last_write": t0}
+
+    def test_a_failed_recovery_reads_unhealthy(self, state_manager, monkeypatch):
+        # The production path #1615 reports, rather than close(): _recover_corrupt_db's reconnect
+        # raises, `_conn` stays None for good, and every telemetry write is dropped from then on.
+        def boom(*_a, **_kw):
+            raise sqlite3.OperationalError("unable to open database file")
+
+        monkeypatch.setattr("mining_dashboard.service.storage_service.sqlite3.connect", boom)
+        state_manager._recover_corrupt_db("test: forced reconnect failure")
+        assert state_manager.is_db_unrecoverable() is True
+        state_manager.add_block(time.time(), height=1, difficulty=1.0)
+        assert state_manager.get_table_health()["blocks"]["healthy"] is False
+
 
 class TestTelemetryTablesAfterClose:
     """After close() the connection is None — every v1.7 telemetry-table accessor must no-op /


### PR DESCRIPTION
Fixes #1615.

## What was wrong

`get_table_health()` reported every telemetry table `healthy: True` in the one state where every
telemetry write is silently dropped for good: `_recover_corrupt_db`'s reconnect fails, it sets
`db_unrecoverable` and leaves `_conn` at `None`, the process carries on, and all five writers
return at their closed-handle guard *before* either health stamp runs. The tables keep whatever
`__init__` seeded.

## The fix, and the option it was chosen over

Derived at the READ, not stamped at the five guards. `get_table_health` folds in `bool(self._conn)`
— the very test each writer's guard makes, not a re-spelling of it — so no table reads healthy
while there is no handle to write through.

The issue named guard-stamping as one option and deleting the channel as another. Deriving was
chosen because the defect *is* "a guard was written and its stamp forgotten": a sixth telemetry
writer added later gets this right with nothing to remember, where five stamps reproduce the
hazard five times. **What that trades away, stated so it is not over-read:** after a LATER
successful recovery every table reads healthy again, where five stamps would have held `False`
until a real write landed. `last_write` still dates the last write that actually landed, and a
successful recovery already announces itself through `db_reset_count` / `last_db_reset`.

The derivation is monotone in the safe direction — `v["healthy"] and live` can only turn `True`
into `False`, never `False` into `True` — so a genuine per-table write failure is unchanged.

## The two comment sites the issue required

Both corrected here, and a third the sweep found:

- the `__init__` comment now says the entries are RAW (write ATTEMPTS only, blind to the handle)
  and must be read through the accessor;
- `get_table_health`'s docstring states what `healthy` now covers;
- `annotation_pins.py`'s slice-7 note recorded the defect in the present tense. Scoped to past
  tense, and it now records that no guard was touched — so slice 7's bytecode-identity proof
  still stands.

## Measured, not predicted

- **Controlled pair on this base (`56cec225`), both legs in one worktree:** 2377 -> 2380, +3
  exactly, zero failures on either leg.
- **The three new tests RED against the base module and GREEN against this one**, run both ways.
  A test that only passes at head proves nothing.
- **The issue's own repro driven directly:** at base all five tables report `healthy: True` after
  a forced recovery failure; at head all five report `False`. The same probe carries a positive
  control — a write that DID land on a live handle still reads healthy — which passes at BOTH
  heads, so it is not merely reading the change. This is the control the issue asked for against
  a derivation that is wrong in the other direction.
- **Patch coverage 3/3** on the changed executable production lines (165, 927, 928), `hits=1`
  each, read from a `coverage.xml` regenerated on this tree and mtime-checked.
- **Budget:** `storage_service.py` 1358 -> 1357 against its 1358 ceiling. It pays for itself by
  consolidating the `__init__` comment, whose content duplicated `_table_write_failed`'s
  docstring; **no budget row raised.** `annotation_pins.py` 367 and `test_storage_telemetry.py`
  390, both under the rowless 400.
- `make lint` rc 0, ruff check and formatter clean.

## Over-engineering pass, done on merits

`/ponytail-review` is not installed in this session, so this was done by hand. It found one thing,
in my own change: the derivation first read `self._conn is not None` while the guards read
`if not self._conn` — two spellings of one condition, the shape that rots. Changed to
`bool(self._conn)` so the accessor and the guards make the same test. Nothing else was found; the
`{**v, ...}` copy, the unlocked read of `_conn` and the no-production-caller surface are all
addressed below.

## What I did NOT do

- **No docs change.** A repo-wide sweep (not scoped to `docs/`) for this channel's prose found it
  in no doc. `CHANGELOG.md` is only written at release cuts here.
- **No security review.** The channel has no production caller — only tests — and the change
  touches no auth, control-channel or outbound-fetch path.
- **No lock, bench claim or shared file touched.** All three files are in this lane's paths, so
  no `.lane-override`.

## One thing a reviewer should push on

`get_table_health` reads `self._conn` without `_db_lock`. It already read `table_health` unlocked,
so this adds no new locking requirement, and the only window is mid-`_recover_corrupt_db`, where
`_conn` is transiently `None` and the read reports unhealthy for that instant — the cautious
direction, and consistent with `db_healthy`, which is `False` through that whole window. I judged
that acceptable rather than taking the lock in a read accessor; say so if you disagree.
