### PR TITLE
docs(integration): say what the mini-stack's Tari fake does NOT cover (#1397)

### DIFF
--- a/tests/integration/mini-stack/docker-compose.fake.yml
+++ b/tests/integration/mini-stack/docker-compose.fake.yml
@@ -90,6 +90,13 @@ services:
     ports: ["28081:18081"]   # 28081 on the host (avoids a real monerod's 18081), → 18081 inside
     volumes: ["../fakes:/fakes:ro"]
 
+  # Read by the DASHBOARD's Tari client and nothing else here (TARI_GRPC_ADDRESS above; the runner
+  # flips this fake's mode over the control port to drive the sync gate). p2pool's OWN merge-mining
+  # gRPC — the leg that makes Tari pay — is NOT exercised in this stack and cannot be: the p2pool
+  # below is a busybox stand-in, and the real p2pool builds no merge-mining client until its Monero
+  # block-header download completes, so a fake would have to re-implement a synced monerod to be
+  # reached at all (#1397, measured at p2pool v4.18's source). That leg lives at tier 4 only —
+  # `assert_mergemine_roundtrip` in mergemine-probe.sh, which carries the measurement.
   fake-tari:
     image: *fake_image
     container_name: itest-fake-tari


### PR DESCRIPTION
Comment-only. The mini-stack wires a full `fake-tari` service and a `TARI_GRPC_ADDRESS` next to a container named `itest-p2pool`, and `run-mini-stack.sh` narrates p2pool's relationship to Tari — scenario 4 is literally "p2pool keeps mining Monero through a Tari-only outage". Nothing on the service said which of those is actually exercised.

It is not, and it cannot be here. This adds seven comment lines to `fake-tari` saying so, and saying why.

## What the comment claims, and how each half was checked

| Claim | How it was checked |
|---|---|
| `fake-tari` is read by the **dashboard's** Tari client and nothing else in this stack | Parsed the compose file and enumerated every service's env and command: only `dashboard` carries `TARI_*` (`TARI_GRPC_ADDRESS`, `TARI_REQUIRED`); `p2pool` and `xmrig-proxy` carry none and run `sh -c 'while true; do sleep 30; done'` |
| the runner drives the fake over its control port, not its gRPC | `run-mini-stack.sh:83` `set_tari()` POSTs to the control side-channel; the compose file publishes `28152:18152` for exactly that |
| the real p2pool builds no merge-mining client until its block-header download completes | Measured at p2pool v4.18's source in cycle 40 and posted on #1397: one creation site, `IMergeMiningClient::create`, inside `download_block_headers4`'s success callback |
| that leg is covered at tier 4 | `tests/integration/run.sh:659` calls `assert_mergemine_roundtrip` (`mergemine-probe.sh`), which carries the measurement |

## What was run

- `make lint-yaml` — green. Its file list names `tests/integration/mini-stack/docker-compose.fake.yml`, so the verdict was measured over the changed file rather than merely over the repo.
- `make lint-file-budget` (staged first, #1486), `make lint-topology`, `make lint-operator-strings` — all green, each printing its own self-test fired.
- `tests/integration/selftest-mergemine-probe.sh` — 40 passed, 0 failed, rc 0. Not touched by this diff; run to confirm the tier-4 leg the comment points at is real and green before pointing at it.
- **Inertness proven directly**: parsed the file at `origin/develop-v2` and at this head and compared the loaded structures — identical. The comparison was fired on a deliberately mutated image value to show it can say no, so the `True` is a measurement rather than a vacuous pass.

`make lint-sh` was NOT run: no shell changed, and it is this box's OOM path.

## What I did NOT do

- No behaviour change, no test added. This is a disclosure, and it should be judged as prose.
- I did not annotate the `p2pool` stand-in block fifty lines below to point back here. Declined deliberately: its comment already says the miner containers idle, and restating the same fact in two places in this file is the duplication that drifts.
- I did not quote the block-header count in the comment, though the probe header carries it. A bare figure in a second place is the thing that goes stale; the comment points at `mergemine-probe.sh`, which owns the number and its provenance.
- No bench time, no rig lock, no deployed stack touched.

Groundwork for closing #1397, which is separately verified as already shipped by #1594 and hardened by #1603 and #1632. Not using a closing keyword — `Closes` cannot fire on a PR merging to `develop-v2` while the default branch is `develop`.
