### PR TITLE
fix(dashboard): #1592 the monero clients answer for the body's SHAPE, not just its syntax

### DIFF
--- a/dashboard/mining_dashboard/client/monero/monero_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_client.py
@@ -58,6 +58,14 @@ class MoneroClient:
             logger.error("monerod get_info returned a non-JSON body")
             return None
 
+        # A JSON body is not necessarily a JSON OBJECT. An array, string, number or null parses
+        # cleanly and then dies at the first `.get` below — a raise, where the signature and the
+        # docstring above both promise None (#1592). Route it to the unreachable channel, which is
+        # what `get_sync_status` already degrades on.
+        if not isinstance(data, dict):
+            logger.error(f"monerod get_info returned a JSON {type(data).__name__}, not an object")
+            return None
+
         # get_info embeds its own status string; anything other than OK (e.g. "BUSY")
         # means the heights aren't trustworthy yet.
         status = data.get("status")

--- a/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
+++ b/dashboard/mining_dashboard/client/monero/monero_wallet_client.py
@@ -60,11 +60,30 @@ class MoneroWalletClient:
         except ValueError:
             logger.error(f"wallet-rpc {method} returned a non-JSON body")
             return None
+        # A JSON body is not necessarily a JSON OBJECT. An array, string, number or null parses
+        # cleanly and then dies below — at the membership test for a number or null, at the `.get`
+        # for an array or string — a raise, where the docstring above promises None (#1592).
+        if not isinstance(data, dict):
+            logger.error(
+                f"wallet-rpc {method} returned a JSON {type(data).__name__}, not an object"
+            )
+            return None
         # monero-wallet-rpc reports errors as a top-level "error" object, not an HTTP status.
         if "error" in data and data["error"]:
             logger.warning(f"wallet-rpc {method} error: {data['error']}")
             return None
-        return data.get("result") or {}
+        result = data.get("result")
+        if result is None:
+            return {}  # the call succeeded and carried no result — an empty answer, not an error.
+        if not isinstance(result, dict):
+            # A truthy non-dict `result` used to be handed straight back, escaping the annotation
+            # above as a returned VALUE rather than as an exception — and then raising one level up
+            # in `get_confirmed_payouts`, whose own docstring says it never raises (#1592).
+            logger.warning(
+                f"wallet-rpc {method} returned a {type(result).__name__} result, not an object"
+            )
+            return None
+        return result
 
     def get_confirmed_payouts(self, min_height=0):
         """Return confirmed incoming transfers at or above ``min_height`` as normalized dicts.
@@ -92,7 +111,20 @@ class MoneroWalletClient:
         if result is None:
             return []
         payouts = []
-        for t in result.get("in", []) or []:
+        # `in` is the wallet's word for its own payload shape, and the same "never raises" promise
+        # covers it. A non-list `in` was iterated anyway — a dict yields its KEYS, a string its
+        # CHARACTERS, and both then died at `.get` below; a number raised on the `for` itself
+        # (#1592). Refuse the payload rather than the poll: `[]` is what every other failure here
+        # returns, and the caller cannot distinguish it from "no payouts" in any case.
+        rows = result.get("in") or []
+        if not isinstance(rows, list):
+            logger.warning(
+                f"wallet-rpc get_transfers sent a {type(rows).__name__} 'in', not a list"
+            )
+            return []
+        for t in rows:
+            if not isinstance(t, dict):
+                continue  # a non-object transfer is unusable — the same skip as the two below
             txid = t.get("txid")
             amount = t.get("amount")
             if not txid or amount is None:

--- a/dashboard/tests/client/test_monero_client.py
+++ b/dashboard/tests/client/test_monero_client.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 import mining_dashboard.client.monero.monero_client as monero_mod
@@ -92,6 +93,37 @@ class TestGetInfo:
             monero_mod.requests, "get", return_value=_resp(json_data={"status": "BUSY"})
         ):
             assert client.get_info() is None
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("array", b"[1, 2, 3]"),
+            ("number", b"7"),
+            ("string", b'"hello"'),
+            ("null", b"null"),
+        ],
+    )
+    def test_a_json_body_that_is_not_an_object_returns_none(self, label, body):
+        """#1592: valid JSON is not necessarily a JSON OBJECT, and the signature says dict | None.
+
+        Each of these parses cleanly and used to reach ``data.get("status")``, which RAISED —
+        `AttributeError` for an array, string or null, `TypeError` for a number — past a contract
+        that promises None. The bytes go through the real bounded read, so nothing here is
+        satisfied by the size cap: they are four bytes' worth of body, not a megabyte.
+        """
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get", return_value=_resp(body=body)):
+            assert client.get_info() is None, label
+
+    def test_a_json_object_body_is_still_returned(self):
+        """The control for the guard above: it must refuse non-objects WITHOUT refusing objects.
+
+        Without this, deleting `get_info`'s body and returning None unconditionally would keep
+        every assertion in the parametrized test green.
+        """
+        client = MoneroClient(username="u", password="p")
+        with patch.object(monero_mod.requests, "get", return_value=_resp(body=b'{"height": 5}')):
+            assert client.get_info() == {"height": 5}
 
 
 class TestGetSyncStatus:

--- a/dashboard/tests/client/test_monero_wallet_client.py
+++ b/dashboard/tests/client/test_monero_wallet_client.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 import mining_dashboard.client.monero.monero_wallet_client as wallet_mod
@@ -147,3 +148,117 @@ class TestGetConfirmedPayouts:
         err = {"error": {"code": -1, "message": "no wallet file"}}
         with patch.object(wallet_mod.requests, "post", return_value=_resp(json_data=err)):
             assert self._client().get_confirmed_payouts() == []
+
+
+# The bodies #1592 is about: each is valid JSON that `_rpc` handled past its own contract.
+# `result` cases escaped as a returned VALUE; the top-level cases raised. Kept as one table so the
+# two claims below — the annotation's, and the docstring's — are graded over the same population.
+_NOT_AN_OBJECT = [
+    ("result is an array", b'{"result": [1, 2, 3]}'),
+    ("result is a string", b'{"result": "wat"}'),
+    ("result is a number", b'{"result": 7}'),
+    ("body is an array", b"[1, 2, 3]"),
+    ("body is a number", b"7"),
+    ("body is a string", b'"hello"'),
+    ("body is null", b"null"),
+]
+
+
+class TestRpcReturnShape:
+    """#1592: `_rpc` is annotated ``dict | None`` and its docstring promises None on any error."""
+
+    def _rpc(self, body):
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(wallet_mod.requests, "post", return_value=_resp(body=body)):
+            return client._rpc("get_transfers")
+
+    @pytest.mark.parametrize(("label", "body"), _NOT_AN_OBJECT)
+    def test_a_non_object_never_escapes_the_annotation(self, label, body):
+        """A truthy non-dict ``result`` was returned STRAIGHT BACK — the one way this annotation
+        could be falsified without anything raising. The top-level cases raised instead, at the
+        membership test for a number or null and at ``.get`` for an array or string.
+
+        The bodies are a handful of bytes, so no assertion here can be satisfied by the size cap.
+        """
+        assert self._rpc(body) is None, label
+
+    def test_an_object_result_is_still_returned(self):
+        """The control: the guard must refuse non-objects WITHOUT refusing objects. Without it, a
+        `_rpc` rewritten to ``return None`` would pass every row of the parametrized test."""
+        assert self._rpc(b'{"result": {"in": [{"txid": "aa"}]}}') == {"in": [{"txid": "aa"}]}
+
+    def test_a_missing_or_null_result_is_still_an_empty_dict(self):
+        """Unchanged by #1592, and asserted because the fix rewrote the line that decided it: a
+        call that succeeded and carried no ``result`` is an empty answer, not an error."""
+        assert self._rpc(b'{"id": "0"}') == {}
+        assert self._rpc(b'{"result": null}') == {}
+
+
+class TestGetConfirmedPayoutsNeverRaises:
+    """#1592's blast radius: ``get_confirmed_payouts``' docstring says *never raises*, and a
+    truthy non-dict ``result`` reached its ``result.get("in", [])`` and raised there."""
+
+    @pytest.mark.parametrize(("label", "body"), _NOT_AN_OBJECT)
+    def test_a_non_object_body_degrades_to_an_empty_list(self, label, body):
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(wallet_mod.requests, "post", return_value=_resp(body=body)):
+            assert client.get_confirmed_payouts() == [], label
+
+    def test_a_well_formed_body_still_yields_its_payouts(self):
+        """The control for the row above: degrading to ``[]`` must not be how this reads EVERY
+        body. Same call, same path, a real transfer — and it still comes back."""
+        row = {"txid": "aa", "amount": 250_000_000_000, "height": 100, "timestamp": 1000}
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(
+            wallet_mod.requests, "post", return_value=_resp(json_data=_transfers([row]))
+        ):
+            assert [p["txid"] for p in client.get_confirmed_payouts()] == ["aa"]
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("in is a string", b'{"result": {"in": "abc"}}'),
+            ("in is an object", b'{"result": {"in": {"a": 1}}}'),
+            ("in is a number", b'{"result": {"in": 7}}'),
+            ("in holds numbers", b'{"result": {"in": [1, 2, 3]}}'),
+            ("in holds strings", b'{"result": {"in": ["a", "b"]}}'),
+            ("in holds nulls", b'{"result": {"in": [null]}}'),
+            ("in holds arrays", b'{"result": {"in": [[1]]}}'),
+        ],
+    )
+    def test_a_malformed_in_payload_degrades_rather_than_raising(self, label, body):
+        """The SECOND layer, past what #1592 filed: a well-formed ``result`` whose ``in`` is not a
+        list of objects. Fixing ``_rpc`` alone does not reach here — iterating an object yields its
+        KEYS and a string its CHARACTERS, so both still died at ``t.get``, and a number raised on
+        the ``for`` itself. The docstring's *never raises* covers this payload too, so the guard
+        belongs here rather than in a narrowed docstring.
+        """
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(wallet_mod.requests, "post", return_value=_resp(body=body)):
+            assert client.get_confirmed_payouts() == [], label
+
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("in absent", b'{"result": {}}'),
+            ("in null", b'{"result": {"in": null}}'),
+            ("in empty", b'{"result": {"in": []}}'),
+        ],
+    )
+    def test_an_empty_in_payload_is_still_no_payouts_not_an_error(self, label, body):
+        """Unchanged by the guard above, and pinned because the guard rewrote the line that read
+        ``in``: a wallet with nothing to report is an empty answer on the normal path."""
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(wallet_mod.requests, "post", return_value=_resp(body=body)):
+            assert client.get_confirmed_payouts() == [], label
+
+    def test_one_bad_transfer_does_not_discard_its_good_siblings(self):
+        """The narrowness control: a non-object transfer must SKIP, exactly as a transfer missing
+        its txid already does — not abort the scan. Without this, a guard that returned ``[]`` on
+        the first bad row would pass every assertion in the malformed test above."""
+        rows = [{"txid": "aa", "amount": 1, "height": 1, "timestamp": 1}, "junk", None]
+        client = MoneroWalletClient(username="wallet", password="p")
+        with patch.object(
+            wallet_mod.requests, "post", return_value=_resp(json_data=_transfers(rows))
+        ):
+            assert [p["txid"] for p in client.get_confirmed_payouts()] == ["aa"]


### PR DESCRIPTION
Fixes #1592.

## The defect

Both monero clients validated that the body **parsed**, never that it was a JSON **object**.

`client/monero/monero_wallet_client.py:_rpc` is annotated `-> dict | None` and its docstring says
*"return the `result` dict, or None on any error"*. `client/monero/monero_client.py:get_info` says
*"or None if unreachable/errored"*. Neither held:

- A **truthy non-dict `result`** — array, string, number — was handed straight back by
  `return data.get("result") or {}`. This is the one way that annotation could be falsified as a
  **returned value** rather than as an exception.
- A **non-object body** parsed cleanly and then died below: at `data.get` for an array or string,
  at the `"error" in data` membership test for a number or null. A raise, where both contracts
  promise `None`.

## What changed

Three guards, each routing to the failure channel the callers already degrade on — `get_sync_status`
returns `None`, `get_confirmed_payouts` returns `[]`:

1. `get_info`: refuse a non-object body.
2. `_rpc`: refuse a non-object body, and refuse a non-object `result`.
3. `get_confirmed_payouts`: refuse a non-list `in`, and skip a non-object transfer.

A **missing or null `result` still returns `{}`**, unchanged — a call that succeeded and carried no
result is an empty answer, not an error, and collapsing it into the error channel would log a
warning on a normal event. Pinned by a test, because the fix rewrote the line that decided it.

The `logger.error` / `logger.warning` split follows the convention already in `_rpc`: a
body-level malformation is an error, an RPC-level answer problem is a warning.

## Two findings past what #1592 filed — re-derived by me, not read

**The population is wider than the issue names.** #1592 says an array body raises `AttributeError`
and a number `TypeError`. True, and incomplete: a top-level **string** and a top-level **null** raise
too, at *both* clients. The real population is any non-JSON-object body. Found by driving the real
clients through the real `bounded_*` path over eight bodies, not by reading.

**Fixing `_rpc` alone does NOT make `get_confirmed_payouts`' "never raises" docstring true.** That
docstring is the strongest claim in the file and it survived the `_rpc` fix as an overclaim, at a
second layer the issue never reaches: a well-formed `result` whose `in` is an **object** yields its
KEYS when iterated and a **string** yields its CHARACTERS, so both still died at `t.get`; a number
raised on the `for` itself; and a list of non-objects died the same way. Seven further raise paths,
measured. Rather than narrow the docstring, the guard is here — a non-list `in` refuses the payload,
a non-object row skips exactly as the two existing malformed-row skips do. **The docstring is now
true rather than narrowed.** I would rather this were reviewed as scope than shipped as a known-false
sentence in a file I was already editing.

## What I did NOT fix, and why

The **poll-loop amplification** #1592 describes. Confirmed at source by AST at `c437f7fa`: the `try`
at `service/data_service.py:940` has its body spanning 942..1448, the last statement of that body is
`iteration_count += 1` at 1448, the handler is `except Exception` at 1449, and step 7d is at 1420
gated on `iteration_count % 10 == 0`. A raise there freezes the counter on a multiple of ten and
turns a one-in-ten step into every poll.

**The specific trigger is gone** — these clients no longer raise — but the placement is the general
case, fires on any exception in that body, and has its own blast radius. Filed as **#1637** rather
than fixed in passing. Neither change depends on the other.

## A checked negative: the sibling clients do not have this

Derived mechanically (every `.json()` parse under `client/` and `collector/`), not sampled:

- **`xmrig_proxy_client`** — its four `response.json()` returns are **unannotated** and deliberately
  raise on transport failure for the caller to handle. No falsifiable contract, so not this defect.
- **`tari_wallet_client`** — gRPC behind a blanket `except Exception`; a non-object body is not
  expressible on that wire.

This is a checked negative with the ground named, not an assumption that the problem is local.

## Evidence

All measured in this worktree, on base `c437f7fa` (`origin/develop-v2`).

- **Controlled suite pair: 2380 → 2413, +33 exactly, zero failures either leg.** Both legs run here,
  after the base move.
- **The new assertions discriminate, run both ways.** Against the base modules: **26 failed, 33
  passed**. Against mine: **all 33 pass**. The 7 that stay green at base are exactly the controls
  (`26 + 7 = 33` reconciles) — they assert *preserved* behaviour, so they must be green both ways.
  That is what makes them controls rather than filler.
- **Controls that can produce the other answer.** A guard that refused *everything* would satisfy
  every hostile-body assertion here, so each class carries its opposite: an object body is still
  returned, an object `result` is still returned, a well-formed transfer still comes back, and a
  bad row **skips** without discarding its good siblings. That last one is the narrowness control —
  it fails a guard that returns `[]` on the first bad row.
- **No assertion here can be satisfied by the size cap.** The hostile bodies are a handful of bytes,
  deliberately, because an absence assertion satisfied by truncation is a false pass.
- **Patch coverage 20/20 = 100%** (bar: ≥90%), computed from the diff hunks mechanically against a
  `coverage.xml` regenerated on this tree and read 1 second old.
- **`make lint` rc 0**, captured directly rather than through a pipeline — a `tail` in the way
  reports its own rc, and did on my first run, hiding a real format failure.
- **No budget row needed or taken.** All four files are rowless and well under 400: 120 / 138 / 195 /
  215 lines.
- **No counting prose falsified.** Swept the edited files for digits and count-words; the only
  numbers are timeouts, heights and issue refs. The pin comment at `annotation_pins.py:241` about
  `get_confirmed_payouts` returning `[]` invisibly stays true — this change makes it return `[]` in
  strictly more cases, never fewer.

## Review notes

**The over-engineering pass was done by hand, on merits** — `/ponytail-review` is not installed in
this session, and the gate it belongs to verifies nothing. What the pass changed or settled:

- **Declined** extracting the shared `if not isinstance(data, dict)` into a helper. The honest place
  would be `BoundedResponse.json()`, but that seam is shared with `xmrig_proxy_client`, which
  deliberately raises — so a helper there would change a caller this issue is not about. Two lines in
  two files, with module-specific log wording that is what makes the log actionable, is the cheaper
  and more honest form.
- **Disclosed overlap, deliberately kept.** `TestRpcReturnShape` and `TestGetConfirmedPayoutsNeverRaises`
  parametrize over the same seven bodies. They are not independent under every mutation. They are kept
  because they grade different contracts — the annotation on `_rpc`, and the caller-facing docstring
  that #1592's whole severity argument rests on — and pre-fix they failed for *different* reasons on
  the same input: the `result` cases passed `_rpc` and raised one level up.

**Assumed, not proven:** that no caller wants to distinguish "the daemon sent garbage" from "the
daemon is unreachable". Both now return `None`/`[]`. The two existing callers cannot tell the
difference today either, so this preserves their world rather than changing it — but it does mean a
future caller wanting that distinction needs a different signal, and the log line is currently the
only place it survives.

**Not verified:** none of this is reproduced against a live monerod or wallet. It is driven through
the real `bounded_request`/`bounded_get` path with the response faked at the `requests` boundary,
which is the tier this behaviour is honestly testable at.
