### PR TITLE
test(dashboard): #1614 record a floor under each pin structure, so the gate cannot narrow in silence

### DIFF
--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -55,6 +55,8 @@ it, and deliberately carry them ONLY there: a budget argument copied into anothe
 numbers to keep true, which is the failure this file's own header records twice.
 """
 
+from collections.abc import Collection
+
 import pytest
 
 from tests.service.annotation_gate import (
@@ -103,6 +105,35 @@ def _rows_under(module: str, verdicts: dict[str, list]) -> list[str]:
             if name.startswith(f"{module}:"):
                 found.append(name)
     return sorted(found)
+
+
+def _shortfall(structure: Collection[str], floor: int) -> int:
+    """How far a pin structure has fallen below its recorded floor. Zero means it held, or grew.
+
+    Named here rather than spelled in the law for the reason `_unsigned_unjudged_under` above is:
+    a control that re-spells its subject's predicate is mutated in lockstep with it and witnesses
+    nothing. The law and both controls below call THIS function."""
+    return max(0, floor - len(structure))
+
+
+# #1614's recorded floors. **Each is a FLOOR, not a count.** A slice that ADDS a module satisfies
+# the law untouched, so nothing here is ever edited to make the suite go green; only a DELETION
+# reds it, and the way back to green is to lower a number HERE, in the diff that removed the entry.
+# That records a judgement and is NOT a gate — drop an entry and lower the floor together and it
+# passes, exactly as `docs/dev/file-budget.tsv` does when somebody lowers a ceiling. What it buys
+# is that the narrowing is WRITTEN DOWN where a reviewer reads it instead of happening silently in
+# a module that reads as "just data". The argument for the shape, and what each structure was
+# measured to be exposed to, is in `TestThePinSetOnlyGrows`.
+#
+# The figures are NOT copies of the counting prose in the data modules: that prose says what the
+# population IS and a slice falsifies it in the same commit; these say what it may never fall
+# BELOW and a slice leaves them true. Keeping them tight as the population grows is a convention
+# and not a law — the reporting test below prints the slack so it cannot drift unseen.
+_FLOORS: dict[str, tuple[Collection[str], int]] = {
+    "PINNED": (PINNED, 33),
+    "_ANCHORS": (_ANCHORS, 33),
+    "_UNJUDGED_AND_READ": (_UNJUDGED_AND_READ, 12),
+}
 
 
 @pytest.fixture(scope="module")
@@ -273,6 +304,98 @@ class Client:
         it cannot start to quietly."""
         assert _rows_under("client/xvb_client", package) == []
         assert _rows_under("service/worker_config_store", package) == []
+
+
+class TestThePinSetOnlyGrows:
+    """#1614 — the population the three laws quantify over may not shrink.
+
+    Every law above is a statement ABOUT a set, so each is satisfied by that set getting SMALLER.
+    Laws 1 and 2 and the walk guard are parametrized over `PINNED`, so dropping a module does not
+    fail their cases, it DELETES them; the vacuity guard on `_UNJUDGED_AND_READ` asks only that the
+    entries still THERE are real, and an entry that left is not there.
+
+    **The three are not equally exposed, and #1614 over-generalises from `PINNED`.** Measured, one
+    removal per structure, against a control-0 of 124 passed:
+
+    - `PINNED` — dropping `web/xvb_views.py` reds THIS LAW AND NOTHING ELSE (1 failed, 120 passed;
+      the missing three are that module's own law-1, law-2 and walk-guard cases, which vanished
+      with it rather than failing). This is the hole the issue describes, and it was real.
+    - `_ANCHORS` — dropping the same module's entry ALSO reds
+      `test_a_pinned_module_is_actually_in_the_walk[web/xvb_views.py]`, which subscripts `_ANCHORS`
+      by a module still in `PINNED` and raises `KeyError` (2 failed, 122 passed).
+    - `_UNJUDGED_AND_READ` — dropping `service/clearnet_sync.py:_write_marker` ALSO reds law 2 for
+      that module, which stops excusing a function still scoring `unjudged` (2 failed, 122 passed).
+
+    So on the two sibling structures this is defence in depth and not the sole catcher. It is kept
+    because an incidental `KeyError` is a crash rather than a stated law and moves with any
+    refactor of the guard raising it, and because law 2's catch is a side effect of what the entry
+    MEANS rather than of the set having a size. Neither survives being relied on silently.
+
+    **One honest cost, on `_UNJUDGED_AND_READ` alone.** An entry whose function was properly
+    annotated is a stale exception the vacuity guard already demands be removed, so that set has a
+    LEGITIMATE way to shrink and this law reds on it. That is intended rather than a false pass:
+    the exception surface genuinely narrowed, and lowering the floor in the same diff is the
+    recording the ratchet exists to force. `PINNED` and `_ANCHORS` have no such case."""
+
+    @pytest.mark.parametrize("name", sorted(_FLOORS))
+    def test_the_structure_has_not_fallen_below_its_recorded_floor(self, name):
+        """THE LAW. The parametrization over all three structures is load-bearing, not tidiness.
+        `_UNJUDGED_AND_READ` moved to `annotation_readings.py` at slice 12, so a guard written over
+        `PINNED` and `_ANCHORS` alone would cover one file and read as covering the pin — and
+        seeding ONE structure would have passed while proving nothing about the other two, which is
+        why the class docstring above records a separate removal against each."""
+        structure, floor = _FLOORS[name]
+        assert _shortfall(structure, floor) == 0, (
+            f"{name} holds {len(structure)} entries against a recorded floor of {floor}. "
+            "An entry was removed, which narrows what the #1487 gate covers. Restore it, or lower "
+            "the floor in the same diff and say in the PR body what the gate stopped covering."
+        )
+
+
+class TestTheFloorCanSeeAShrinkingPinSet:
+    """A green floor names nothing on its own: a comparison that answered "fine" to every input
+    would pass the law above against all three structures. Both controls run the REAL structures
+    through the SAME function the law calls, seeded across the boundary the law decides on."""
+
+    @pytest.mark.parametrize("name", sorted(_FLOORS))
+    def test_a_structure_one_entry_short_of_its_floor_is_caught(self, name):
+        """POSITIVE CONTROL. One short of the floor is the smallest edit the defect can arrive as,
+        and it is what a careless deletion in a data module looks like. Built from the REAL
+        structure, because a hand-made stub would prove only that a short list is short.
+
+        Truncating to `floor - 1` rather than dropping ONE element is what keeps this a control
+        instead of a second exact count: once a slice grows a population past its floor, "the real
+        set minus one" is still ABOVE the floor and this test would red on a legitimate addition —
+        the bump-to-pass failure #1614 refused. The floors are tight today, so the two are the same
+        edit; the truncation is what survives the slack."""
+        structure, floor = _FLOORS[name]
+        shrunk = sorted(structure)[: floor - 1]
+        assert len(shrunk) == floor - 1, f"{name} is already below its own floor of {floor}"
+        assert _shortfall(shrunk, floor) == 1
+
+    @pytest.mark.parametrize("name", sorted(_FLOORS))
+    def test_a_structure_that_grew_does_not_disturb_the_floor(self, name):
+        """NEGATIVE CONTROL, and the one that separates a floor from the exact count #1614 refused.
+        A structure with an entry ADDED must still satisfy the law with this table untouched. If
+        this ever reds, the guard has become a number every slice has to bump, which is the failure
+        mode the issue named and the reason shape B was taken over a hardcoded size."""
+        structure, floor = _FLOORS[name]
+        grown = [*sorted(structure), "service/some_new_module.py:some_new_function"]
+        assert len(grown) == len(structure) + 1
+        assert _shortfall(grown, floor) == 0
+
+    def test_the_slack_between_each_population_and_its_floor_is_reported(self, capsys):
+        """Deliberately asserts NOTHING, in the idiom `TestTheResidueThePinCannotRuleOn` below uses
+        and for the same reason: a floor ratchets only as tightly as it is kept, and keeping it
+        tight is a convention no assertion can enforce without becoming the exact count #1614
+        refused. So the slack is PRINTED — the entries in that gap are the ones a deletion could
+        take without reddening anything, and they should not be able to accumulate unseen."""
+        with capsys.disabled():
+            print("\n#1614 pin-set floors — a population may never fall below its recorded floor:")
+            for name, (structure, floor) in sorted(_FLOORS.items()):
+                slack = len(structure) - floor
+                note = "tight" if slack == 0 else f"{slack} entries a deletion could take unseen"
+                print(f"    {name:22s} {len(structure):3d} against floor {floor:3d}  ({note})")
 
 
 class TestTheResidueThePinCannotRuleOn:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -523,7 +523,12 @@ the modules pinned and the anchor function each one is checked through, and
 `dashboard/tests/service/annotation_readings.py` holds the exceptions somebody read and signed,
 each with its reading. They are separate because they are the part that grows: a slice adds rows to
 them, while the file holding the laws records a ceiling in `docs/dev/file-budget.tsv` that only
-ever goes down.
+ever goes down. Being the part that grows, they are also the part that can quietly shrink, and
+every law above is a statement about a set that a smaller set satisfies. So the laws record a floor
+under each of the three: adding a row passes untouched, removing one reds, and the way back to
+green is to lower the recorded number in the same change. That does not stop anyone from narrowing
+what the pin covers — it makes the narrowing something a reviewer reads rather than something that
+happens in a data file in silence.
 
 How it stays safe:
 


### PR DESCRIPTION
Closes #1614.

`PINNED`, `_ANCHORS` and `_UNJUDGED_AND_READ` are the populations the #1487 annotation gate's three
laws quantify over, and every one of those laws is a statement ABOUT a set — so every one is
satisfied by that set getting smaller. Laws 1 and 2 and the walk guard are parametrized over
`PINNED`: dropping a module does not fail their cases, it deletes them. Nothing measured the size.

This takes **shape B** of the two the issue offers (monotonicity, in the ratchet's own idiom), on
the controller's w73 ruling.

## What it does

Each structure gets a recorded **FLOOR, not a count**. An addition satisfies the law untouched, so
the table is never edited to make the suite pass; only a deletion reds it. The issue refused an
exact count and the reasoning stands — every slice would have to bump it, and it cannot tell a
deliberate addition from a silent deletion.

**It records a judgement and it is NOT a gate.** A diff that drops an entry and lowers the floor in
the same commit passes, exactly as the file-budget ratchet passes when somebody lowers a ceiling.
What it buys is that the narrowing has to be written down where a reviewer reads it, instead of
happening in a data module that reads as "just data". Nothing here prevents anything, and the code
says so in those words.

The law is parametrized across **both** data files. `_UNJUDGED_AND_READ` moved to
`annotation_readings.py` at slice 12, so a guard over `annotation_pins.py` alone would cover one
file while reading as covering the pin.

## Shown able to fail — one removal per structure, on the shipped head

Run at `bedc661f`, against a control-0 of **124 passed**. Each seed anchored on the AST node rather
than a string (the module path spelled in `PINNED` also appears as an `_ANCHORS` key and in prose),
with a parsed before/after readback, and restored by `sha256sum -c` afterwards — never
`git checkout`.

| seed | removed | result |
|---|---|---|
| `PINNED` | `web/xvb_views.py` | **this law and nothing else** — 1 failed, 120 passed |
| `_ANCHORS` | the same module's entry | this law **and** the walk guard — 2 failed, 122 passed |
| `_UNJUDGED_AND_READ` | `service/clearnet_sync.py:_write_marker` | this law **and** law 2 — 2 failed, 122 passed |

The `PINNED` row reconciles: 124 - 121 = 3, which is exactly that module's own law-1, law-2 and
walk-guard cases, deleted with it rather than failed.

## It corrects the issue's framing, and this is the finding

**The three structures are not equally exposed, and #1614 over-generalises from `PINNED`.** Only
`PINNED` was genuinely unguarded. On the other two a removal already reddens an existing assertion:
`_ANCHORS` via `_ANCHORS[module]` raising `KeyError` on a module still in `PINNED`, and
`_UNJUDGED_AND_READ` via law 2 for that module, which stops excusing a function still scoring
`unjudged`.

Kept on both anyway, and the class docstring says why rather than implying three holes were closed:
an incidental `KeyError` is a crash rather than a stated law and moves with any refactor of the
guard that raises it, and law 2's catch is a side effect of what the entry MEANS, not of the set
having a size. Neither survives being relied on silently.

## Disclosed cost, on `_UNJUDGED_AND_READ` alone

An entry whose function was properly annotated is a stale exception the vacuity guard **already
demands** be removed — so that set has a legitimate way to shrink, and this law reds on it. That is
intended rather than a false pass: the exception surface genuinely narrowed, and lowering the floor
in the same diff is the recording the ratchet exists to force. `PINNED` and `_ANCHORS` have no such
case.

## Controls that ship with it

- **Positive** — truncate to `floor - 1` rather than dropping one element. That is what keeps it a
  control instead of a second exact count: once a slice grows a population past its floor, "the
  real set minus one" is still above the floor and the test would red on a legitimate addition,
  which is the bump-to-pass failure the issue refused. The floors are tight today, so the two are
  the same edit; the truncation is what survives the slack.
- **Negative** — a grown structure must not disturb the floor. This is the assertion that separates
  a floor from an exact count, and it reds the day the guard becomes a number every slice bumps.
- **Non-asserting report** — the slack between each population and its floor is printed at every
  run, in the idiom `TestTheResidueThePinCannotRuleOn` already uses. A floor ratchets only as
  tightly as it is kept, and keeping it tight is a convention no assertion can enforce without
  becoming the refused exact count, so the entries a deletion could take unseen are printed instead
  of accumulating unseen.

Law and both controls call the same `_shortfall`, for the reason `_unsigned_unjudged_under` is
factored out above it: a control that re-spells its subject's predicate is mutated in lockstep with
it and witnesses nothing.

## Over-engineering pass, done on merits — it found something

Filed separately as **#1639**, a different defect class, not folded in: **`_ANCHORS` may hold a key for a
module that is not in `PINNED`, and nothing looks.** The enforcement is one-directional — a pinned
module missing an anchor reds by `KeyError`, a phantom anchor key is read by no test. Measured on
this head: inserting `"service/no_such_module.py"` gives **124 passed, zero failures**, with the
population parsed as 34 against `PINNED` 33 as the arming readback. The floors here are blind to it
by construction, since a phantom key moves the count the safe way. `set(_ANCHORS) == set(PINNED)`
holds today, measured both directions.

## What was run

- `pytest tests/service/test_annotation_coverage.py` — 124 passed; full dashboard suite **2423
  passed**, which reconciles against the 2413 base by exactly the 10 cases added here.
- `lint-py`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`,
  `lint-file-budget`, `lint-yaml`, `lint-toml` — each run **individually**, all PASS. That CI job
  runs six targets past the five in its name and `make` stops at the first failure, so a single
  `make lint` would have hidden any target after the first red.
- `ruff check` and `ruff format --check` on the changed file — clean.

## What was NOT run, and what is not claimed

- **Patch coverage is vacuous here and is not quoted as a number.** The diff touches no file under
  `dashboard/mining_dashboard`, which is what `coverage.xml` scopes to, so diff-cover has no lines
  to score. What is true instead: all 10 added cases executed and passed, and the report test's
  output appeared in the run.
- One branch is unexercised: the slack report's `else` arm, which only renders when a
  population has drifted above its floor. All three floors are tight today, so slack is zero. Left untested rather than padded
  — it is a print, and the residue printer above it has the same property.
- No shell target was run. The diff touches no shell.

## Budget and lane notes

`test_annotation_coverage.py` goes 436 → 559 against its recorded ceiling of **579**, leaving 20
lines of headroom (counted by record, the way the gate counts, not `wc -l`). The first draft landed
at 578 — one line — and was compressed rather than given a raised ceiling; raising a ceiling to fit
prose is what that gate exists to refuse. No row added or changed. `annotation_pins.py` and
`annotation_readings.py` are untouched by the shipped diff.

`docs/dashboard.md` gains one paragraph, in the section that already describes this mechanism.
`docs/` is in `_shared.paths`, disclosed here per lane policy.
