### PR TITLE
docs(dashboard): #1628 confirm the weak-`signed` population by binding, and answer its first question

### DIFF
--- a/dashboard/tests/service/annotation_pins.py
+++ b/dashboard/tests/service/annotation_pins.py
@@ -228,6 +228,27 @@ moved the data, which is the failure the pin comment below records happening twi
 # the quiet success is NOT claimed — seeing that needs the callee's returns, a whole-package
 # inference this walk deliberately does not make.
 #
+# #1628 RE-DERIVED that population and CONFIRMED it at three, by a different route rather than by
+# re-reading this paragraph. The figures above resolved the callee BY NAME across the package,
+# which #1628 says is approximate in both directions and had already produced one false positive
+# removed by hand (`control_service.py:result` calling stdlib `json.load`, matched against
+# `storage_service.py:load`). The re-derivation binds instead — `self.X` to the enclosing class,
+# a bare name to module defs then that module's imports, a dotted name to an in-package module —
+# and reports anything it cannot bind rather than scoring it clean. Same three rows, same counts,
+# and `result` falls out MECHANICALLY into the unresolved bucket, which holds five rows in all —
+# `result`'s `json.load`, `float` twice, `json.loads`, and a chained `datetime` call. Shown able to answer
+# otherwise, both ways, against the real package: de-noning `parse_prices` drops `fetch` to two
+# rows, and giving `mask_secrets` one `None` return moves `_read_host_config` from clean to flagged
+# at four. The instrument is NOT shipped — resolving callees is the inference #1487's ruling
+# governs, and #1628's own ruling was to leave `classify` alone.
+#
+# `_safe_reply_for`'s collapse is DELIBERATE, which is #1628's first question answered: its caller
+# does `if reply:` and sends nothing either way, so a handler that raised and a message that was
+# not a command are the same event downstream, and the docstring's "a broken command just goes
+# quiet" is the intent rather than an oversight. That sentence belongs beside the code and is here
+# instead: `telegram_commands.py` stands at 1023 lines against a recorded ceiling of 1023, and
+# paying for a comment by compressing production code is worse than the gap it documents.
+#
 # Slice 4 added ZERO to `signed`, which is the CORRECT outcome and was predicted before it was
 # written: `config/` holds one collapse (`load_worker_endpoints` returning `[]`) and one residual
 # (`local_miner_enabled` returning `False`). A slice is coverage of the mechanism, so a slice whose


### PR DESCRIPTION
Closes #1628.

#1628 records that three of `classify`'s 31 `signed` rows are weaker than the word: the verdict
reads the FAILURE returns alone, so it cannot see a SUCCESS return that is a call producing the
same marker. Slice 11 already disclosed all three together in `annotation_pins.py` — deliberately
all three rather than only the new one, because an asymmetric disclosure is what #1604 was.

So this is not the disclosure. What was still owed is the issue's own first separation — **is it a
defect in the code or in the verdict?** — and the issue's own caveat that three may not be the
whole population.

Per the controller's ruling: **the three annotations STAY and `classify` is NOT widened.** Each
declared type is the true one.

## The population was re-derived, and it is confirmed at three

The issue resolved the callee **by name** across the package, and says so — that route had already
produced one false positive which had to be removed **by reading each site**
(`control_service.py:result` calling stdlib `json.load`, matched against
`storage_service.py:load`). The issue's own words: *"A resolution keyed to the actual binding could
find more."*

So it was re-derived by binding rather than by name: `self.X` against the enclosing class (walking a
parent map, so nested `def`s resolve), a bare name against module-level defs and then that module's
own imports, a dotted name against an in-package imported module. **Anything it cannot bind is
reported UNRESOLVED rather than scored clean**, so the unknown bucket is visible instead of being
counted as absence of a defect. It calls the gate's own `_failure_returns`, `_own_nodes` and
`_admits_none` rather than re-spelling them.

Result: **the same three rows, with the same counts** — `reply_for` 3 of 15, `_parse_html` 2 of 3,
`parse_prices` 2 of 3. And `result` falls into the unresolved bucket **mechanically**, which is the
false positive the issue had to catch by hand. The unresolved bucket holds five rows in all:
`result`'s `json.load`, `float` twice, `json.loads`, and a chained `datetime` call — every one an
out-of-package binding.

**#1628's "3 of 31" is therefore confirmed by an independent route, not corrected.**

## Shown able to answer otherwise — both directions, on the real package

An instrument that agrees with the issue is not evidence until it has been shown able to disagree.
Both controls seeded against the real package, with armed readbacks and `sha256sum -c` restores:

| control | seed | result |
|---|---|---|
| negative | de-none `parse_prices` (annotation and both `return None`) | `fetch` **leaves** the set, 3 → 2 |
| positive | give `mask_secrets` one `None` return | `_read_host_config` crosses **clean → flagged**, 3 → 4 |

The positive control moves a row **across** the boundary rather than adding an unrelated one, which
is what makes the three mean something.

One arming assert fired and refused a seed rather than producing a false control: bounding the
negative seed with `str.partition` matched **6** `return None` across the file tail instead of the 2
inside `parse_prices`, so the readback rejected it and nothing was written. Redone bounded to the
function's own AST line span. The refused run's output was shaped exactly like a passing baseline,
which is why the count is asserted rather than eyeballed.

## The instrument is NOT shipped

Resolving callees is the whole-package inference #1487's ruling governs, and #1628's ruling was to
leave `classify` alone. **A pin of the three was considered and declined for that reason** — it
would need the inference into the test tree to assert it. It is reference only, and that is the
controller's call to reverse, not mine.

## `_safe_reply_for`'s collapse is deliberate — the issue's first question, answered

Its caller does `if reply:` and sends nothing either way, so a handler that raised and a message
that was not a command are the same event downstream. The existing docstring's *"a broken command
just goes quiet"* is the intent, not an oversight. It is a gap in what the verdict CLAIMS, not a
defect in the code, and no return is changed.

## What is NOT done, and the reason

**That sentence belongs beside the code and it is not there.** `telegram_commands.py` stands at
**1023 lines against a recorded ceiling of 1023 — zero headroom**, so not one line fits, and paying
for a comment by compressing production code is worse than the gap it documents. Raising the row to
fit a comment is what that gate exists to refuse.

It is said in the pin data instead, where the other two rows are already disclosed, and named here
as a gap rather than left silent. If the site comment is wanted, it needs a compression pass on
`telegram_commands.py` on its own merits first, which is its own change.

## What was run

- `pytest tests/service/test_annotation_coverage.py` — **114 passed**, which reconciles: this
  branch is off `develop-v2` without #1640's 10 new cases (124 − 10).
- `lint-py`, `lint-file-budget`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology` — each
  run individually, all PASS.
- `ruff check` and `ruff format --check` — clean. Longest added line 106 against the 110 bar.
- No shell target: the diff touches no shell. No behaviour changed, so there is nothing to cover at
  a lower tier — the diff is comment text in a data module.

## Budget

`annotation_pins.py` 367 → **388**, still under the 400 at which a budget row becomes owed. No row
added or changed. Independent of #1640, which does not touch this file.
