### PR TITLE
test(dashboard): #1639 assert the anchor set and the pin set name the same modules

### DIFF
--- a/dashboard/tests/service/test_annotation_coverage.py
+++ b/dashboard/tests/service/test_annotation_coverage.py
@@ -121,14 +121,12 @@ def _shortfall(structure: Collection[str], floor: int) -> int:
 # reds it, and the way back to green is to lower a number HERE, in the diff that removed the entry.
 # That records a judgement and is NOT a gate — drop an entry and lower the floor together and it
 # passes, exactly as `docs/dev/file-budget.tsv` does when somebody lowers a ceiling. What it buys
-# is that the narrowing is WRITTEN DOWN where a reviewer reads it instead of happening silently in
-# a module that reads as "just data". The argument for the shape, and what each structure was
-# measured to be exposed to, is in `TestThePinSetOnlyGrows`.
-#
-# The figures are NOT copies of the counting prose in the data modules: that prose says what the
-# population IS and a slice falsifies it in the same commit; these say what it may never fall
-# BELOW and a slice leaves them true. Keeping them tight as the population grows is a convention
-# and not a law — the reporting test below prints the slack so it cannot drift unseen.
+# is that the narrowing is WRITTEN DOWN where a reviewer reads it instead of happening silently in a
+# module that reads as "just data". The argument for the shape, and each structure's exposure, is in
+# `TestThePinSetOnlyGrows`. The figures are NOT copies of the counting prose in the data modules:
+# that prose says what the population IS and a slice falsifies it in the same commit; these say what
+# it may never fall BELOW and a slice leaves them true. Keeping them tight as the population grows
+# is a convention and not a law — the reporting test prints the slack so it cannot drift unseen.
 _FLOORS: dict[str, tuple[Collection[str], int]] = {
     "PINNED": (PINNED, 33),
     "_ANCHORS": (_ANCHORS, 33),
@@ -198,6 +196,24 @@ class TestAnAnnotatedModuleStaysAnnotated:
         law's job hides the law's absence, because the suite goes red either way."""
         assert _rows_under(module, package), f"the walk found nothing at all in {module}"
         assert _ANCHORS[module] in _rows_under(module, package)
+
+    def test_every_anchored_module_is_also_a_pinned_one(self):
+        """VACUITY GUARD, in the direction the walk guard cannot see (#1639). That guard subscripts
+        `_ANCHORS[module]` over `PINNED`, so a MISSING anchor raises `KeyError`; an anchor for a
+        module nobody pins is read by NOTHING, because every law here parametrizes over `PINNED`.
+        Such a key is dead data that reads as a live pin — someone scanning `_ANCHORS` finds the
+        module and concludes it is covered when no law mentions it.
+
+        Its own test rather than a second assertion in the walk guard, which runs per module: a
+        whole-set statement placed there is one measurement run 33 times behind two failure doors.
+
+        **It does not make the `_ANCHORS` floor redundant, and the cleanup that says so reopens
+        #1614.** Retiring a module drops its `PINNED` and `_ANCHORS` rows together — both sets
+        shrink, this holds at 32 == 32, and the floors are again the ONLY catchers."""
+        assert set(_ANCHORS) == set(PINNED), (
+            f"anchored but not pinned: {sorted(set(_ANCHORS) - set(PINNED))}; "
+            f"pinned but not anchored: {sorted(set(PINNED) - set(_ANCHORS))}"
+        )
 
 
 class TestThePinCanSeeWhatItIsPinning:
@@ -315,21 +331,25 @@ class TestThePinSetOnlyGrows:
     entries still THERE are real, and an entry that left is not there.
 
     **The three are not equally exposed, and #1614 over-generalises from `PINNED`.** Measured, one
-    removal per structure, against a control-0 of 124 passed:
+    removal per structure, against a control-0 of 125 passed:
 
-    - `PINNED` — dropping `web/xvb_views.py` reds THIS LAW AND NOTHING ELSE (1 failed, 120 passed;
-      the missing three are that module's own law-1, law-2 and walk-guard cases, which vanished
-      with it rather than failing). This is the hole the issue describes, and it was real.
+    - `PINNED` — dropping `web/xvb_views.py` reds this law and #1639's equality guard (2 failed,
+      120 passed; the missing three are that module's own law-1, law-2 and walk-guard cases, which
+      vanished with it rather than failing). This is the hole the issue describes, and it was real.
     - `_ANCHORS` — dropping the same module's entry ALSO reds
       `test_a_pinned_module_is_actually_in_the_walk[web/xvb_views.py]`, which subscripts `_ANCHORS`
-      by a module still in `PINNED` and raises `KeyError` (2 failed, 122 passed).
+      by a module still in `PINNED` and raises `KeyError` (3 failed, 122 passed).
     - `_UNJUDGED_AND_READ` — dropping `service/clearnet_sync.py:_write_marker` ALSO reds law 2 for
-      that module, which stops excusing a function still scoring `unjudged` (2 failed, 122 passed).
+      that module, which stops excusing a function still scoring `unjudged` (2 failed, 123 passed).
 
-    So on the two sibling structures this is defence in depth and not the sole catcher. It is kept
-    because an incidental `KeyError` is a crash rather than a stated law and moves with any
-    refactor of the guard raising it, and because law 2's catch is a side effect of what the entry
-    MEANS rather than of the set having a size. Neither survives being relied on silently.
+    So on the two sibling structures this is defence in depth and not the sole catcher — **for the
+    one-structure removal seeded above, and only there.** Retiring a module drops its `PINNED` and
+    `_ANCHORS` rows TOGETHER: both sibling catches need the module still in `PINNED`, so their
+    cases are DELETED rather than failed, `set(_ANCHORS) == set(PINNED)` still holds at 32 == 32,
+    and these floors are the only assertions left. Measured on that seed: **2 failed, 120 passed,
+    and both are floors.** They are kept for the sibling case too, because an incidental `KeyError`
+    is a crash rather than a stated law and moves with any refactor of the guard raising it, and
+    because law 2's catch is a side effect of what the entry MEANS, not of the set having a size.
 
     **One honest cost, on `_UNJUDGED_AND_READ` alone.** An entry whose function was properly
     annotated is a stale exception the vacuity guard already demands be removed, so that set has a


### PR DESCRIPTION
Closes #1639. Based on `develop-v2` @ `8f8de10d` (rebased after #1641 landed; every figure below
was re-measured on that base, not carried over).

## What was wrong

`_ANCHORS` held one entry per pinned module by convention only, and the convention was enforced in
one direction. `test_a_pinned_module_is_actually_in_the_walk` subscripts `_ANCHORS[module]` over
`PINNED`, so a **missing** anchor raises `KeyError`. An anchor for a module nobody pins was read by
nothing — every law in the file parametrizes over `PINNED`. A stale key is dead data that reads as
a live pin: someone scanning `_ANCHORS` finds the module and concludes it is covered when no law
mentions it.

## The fix, and why it is its own test

`assert set(_ANCHORS) == set(PINNED)`, as its **own** test rather than a second assertion inside
the walk guard. That guard is parametrized per module, so a whole-set statement placed there is one
measurement run 33 times behind two independent failure doors. The failure message prints the
symmetric difference **both ways**.

## Measured, not reasoned

Every figure below is from one battery in one worktree on `8f8de10d`, seeding each edit into the
real data modules and restoring by checksum afterwards (restore verified clean).

| seed | result |
|---|---|
| control-0, no seed | **125 passed** |
| phantom `_ANCHORS` key for an unpinned module | **1 failed, 124 passed** — the only failure is the new test |
| `PINNED` row removed alone | 2 failed, 120 passed |
| `_ANCHORS` row removed alone | 3 failed, 122 passed |
| `_UNJUDGED_AND_READ` row removed alone | 2 failed, 123 passed |
| **full module retirement** (`PINNED` + `_ANCHORS` together) | **2 failed, 120 passed — both are floors** |

The phantom-key row is the positive control: it is seeded across the boundary the new test decides
on, and nothing else in the file reddens on it.

## The floor is NOT made redundant by this

Stated next to the assertion, because it is the tempting cleanup that would reopen #1614: retiring
a module drops its `PINNED` and `_ANCHORS` rows **together**, both sets shrink, the equality still
holds at 32 == 32, and the recorded floors are again the only catchers. That is the last row of the
table, measured.

## A correction this carries (discharge, not a force-push)

`TestThePinSetOnlyGrows` said "on the two sibling structures this is defence in depth and not the
sole catcher". That is true of the one-structure removal it seeds and **false of a full module
retirement**, where both sibling catches need the module still in `PINNED` and their cases are
deleted rather than failed. Corrected in place.

Separately, **all four figures in that class docstring were quoted against a control-0 that this
test moves by one**, so they are re-derived here rather than left stale. Per controller ruling 2
this is a discharge commit against the merged #1640, not a force-push of it.

## Budget

`test_annotation_coverage.py` lands at **579 against its ceiling of 579**. Paid for by compressing
this lane's own w65 prose in the `_FLOORS` comment block (two paragraphs merged, no claim dropped)
and reflowing one orphaned word. **The tsv row is untouched and nothing predating this lane was
trimmed**; no control or assertion was shaved to make room.

## Gates

`make lint` rc=0 · full dashboard suite **2424 passed** · `make test-patch-coverage` rc=0. The diff
is test-only, so it adds no production lines for patch coverage to judge.
