### PR TITLE
fix(os): #1649 raise x/crypto and grpc so the appliance rootfs scan is green again

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -48,13 +48,27 @@ ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
 #   golang.org/x/mod       v0.40.0   CVE-2026-56864 / CVE-2026-56865. Indirect in both: cosign
 #                                    v3.1.3 pins v0.37.0; compose v5.4.0 and v5.5.0 both pin
 #                                    v0.38.0; cosign's own main is still v0.38.0.
-#   google.golang.org/grpc v1.82.1   GHSA-hrxh-6v49-42gf. cosign v3.1.3 pins v1.82.0 — v1.82.1 is
-#                                    where cosign's own main has already moved.
+#   golang.org/x/crypto    v0.55.0   CVE-2026-56854 (CRITICAL), x/crypto/ssh source-address
+#                                    restrictions unenforced. COMPOSE ONLY: compose reaches
+#                                    v0.54.0 indirectly (x/mod -> x/tools -> x/net -> x/crypto),
+#                                    below the fix. cosign deliberately gets NO entry — the x/mod
+#                                    raise alone already seats it at v0.55.0 there, measured by
+#                                    reading the built binary rather than assumed (#1649).
+#   google.golang.org/grpc v1.83.1   CVE-2026-84304 (HIGH), in BOTH binaries. Held v1.82.1 here
+#                                    for GHSA-hrxh-6v49-42gf (#1153) until that raise aged into a
+#                                    finding of its own. THE GENERAL PROPERTY, not a mistake in
+#                                    that entry: an exact-version raise IS a pin, and a pin goes
+#                                    stale — and nothing watches these, because
+#                                    scripts/trivyignore-watch.sh watches the .trivyignore MUTES
+#                                    and a raise by design leaves no mute to watch (#1649).
 #
 # WHAT A RAISE ACTUALLY MOVES: `go get X@v Y@v` upgrades the whole closure minimum-version
-# selection needs to satisfy X and Y, not just X and Y. Measured on these exact entries: compose
-# moves 1 module, cosign moves 9 — x/mod pulls x/tools, which pulls x/net, x/sync and x/sys, and
-# x/net pulls x/crypto, x/term and x/text. No formulation avoids that; it is what raising a module
+# selection needs to satisfy X and Y, not just X and Y. Measured on these exact entries, from Go's
+# own upgrade list: compose moves 4 (x/crypto, x/mod, x/text, grpc), cosign 9 (x/crypto, x/mod,
+# x/net, x/sync, x/sys, x/term, x/text, x/tools, grpc) — x/mod pulls x/tools, which pulls x/net,
+# x/sync and x/sys, and x/net pulls x/crypto, x/term and x/text. compose read 1 before #1649 added
+# two entries: the count MOVES when the entries do, so re-measure it rather than quoting this line.
+# No formulation avoids that; it is what raising a module
 # in a Go build means. So read a line here as "this module and whatever MVS needs to seat it", and
 # when you add one, run the command and read Go's own upgrade list rather than assuming it is one.
 #

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -48,29 +48,15 @@ ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
 #   golang.org/x/mod       v0.40.0   CVE-2026-56864 / CVE-2026-56865. Indirect in both: cosign
 #                                    v3.1.3 pins v0.37.0; compose v5.4.0 and v5.5.0 both pin
 #                                    v0.38.0; cosign's own main is still v0.38.0.
-#   golang.org/x/crypto    v0.55.0   CVE-2026-56854 (CRITICAL), x/crypto/ssh source-address
-#                                    restrictions unenforced. COMPOSE ONLY: compose reaches
-#                                    v0.54.0 indirectly (x/mod -> x/tools -> x/net -> x/crypto),
-#                                    below the fix. cosign deliberately gets NO entry — the x/mod
-#                                    raise alone already seats it at v0.55.0 there, measured by
-#                                    reading the built binary rather than assumed (#1649).
-#   google.golang.org/grpc v1.83.1   CVE-2026-84304 (HIGH), in BOTH binaries. Held v1.82.1 here
-#                                    for GHSA-hrxh-6v49-42gf (#1153) until that raise aged into a
-#                                    finding of its own. THE GENERAL PROPERTY, not a mistake in
-#                                    that entry: an exact-version raise IS a pin, and a pin goes
-#                                    stale — and nothing watches these, because
-#                                    scripts/trivyignore-watch.sh watches the .trivyignore MUTES
-#                                    and a raise by design leaves no mute to watch (#1649).
+#   golang.org/x/crypto    v0.55.0   CVE-2026-56854 (CRITICAL). COMPOSE ONLY: compose reaches v0.54.0
+#                                    indirectly; cosign's x/mod raise already seats v0.55.0 (#1649).
+#   google.golang.org/grpc v1.83.1   CVE-2026-84304 (HIGH), both binaries. The #1153 raise to
+#                                    v1.82.1 (GHSA-hrxh-6v49-42gf) aged into it: a raise is an
+#                                    unwatched pin — #1655.
 #
 # WHAT A RAISE ACTUALLY MOVES: `go get X@v Y@v` upgrades the whole closure minimum-version
-# selection needs to satisfy X and Y, not just X and Y. Measured on these exact entries, from Go's
-# own upgrade list: compose moves 4 (x/crypto, x/mod, x/text, grpc), cosign 9 (x/crypto, x/mod,
-# x/net, x/sync, x/sys, x/term, x/text, x/tools, grpc) — x/mod pulls x/tools, which pulls x/net,
-# x/sync and x/sys, and x/net pulls x/crypto, x/term and x/text. compose read 1 before #1649 added
-# two entries: the count MOVES when the entries do, so re-measure it rather than quoting this line.
-# No formulation avoids that; it is what raising a module
-# in a Go build means. So read a line here as "this module and whatever MVS needs to seat it", and
-# when you add one, run the command and read Go's own upgrade list rather than assuming it is one.
+# selection needs to satisfy X and Y, not just X and Y — here compose moves 4 modules and cosign 9
+# (x/mod pulls x/tools, x/net, x/crypto...). When you add one, read Go's own upgrade list, not this.
 #
 # Every entry here is debt, not a feature: drop it the moment an upstream release makes it a no-op,
 # and delete its .trivyignore mute in the SAME change — a mute left over a finding you have just

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -64,8 +64,8 @@ ARG COSIGN_COMMIT=11926fa5bbbbde47e88fc006b625a17769b743b2
 # survived in that file until #1153. Verify by re-running the scan against the built binaries with
 # NO ignore file, never by reading release notes: the first version of this change fixed x/mod and
 # left two other HIGH findings standing.
-ARG COMPOSE_GO_RAISES="golang.org/x/mod@v0.40.0"
-ARG COSIGN_GO_RAISES="golang.org/x/mod@v0.40.0 google.golang.org/grpc@v1.82.1"
+ARG COMPOSE_GO_RAISES="golang.org/x/mod@v0.40.0 golang.org/x/crypto@v0.55.0 google.golang.org/grpc@v1.83.1"
+ARG COSIGN_GO_RAISES="golang.org/x/mod@v0.40.0 google.golang.org/grpc@v1.83.1"
 ENV CGO_ENABLED=0
 
 # Blobless clone then detach to the commit: the tag is only a convenience for the version string.


### PR DESCRIPTION
Closes #1649 — though closing keywords are inert on `develop-v2`; the controller closes by hand.

Two entries in `os/rootfs/Dockerfile`, plus the doc block that entry mechanism asks a change like this to update.

```
ARG COMPOSE_GO_RAISES="golang.org/x/mod@v0.40.0 golang.org/x/crypto@v0.55.0 google.golang.org/grpc@v1.83.1"
ARG COSIGN_GO_RAISES="golang.org/x/mod@v0.40.0 google.golang.org/grpc@v1.83.1"
```

## The proof: a controlled pair, not a clean scan

A scan that comes back empty has not been shown able to say anything else, so this does not rest on one. Both legs are `docker build --target gobuild` off **this branch's Dockerfile**, in one worktree, differing only in the two ARG values; both scanned with the digest-pinned scanner `lint-trivy-parity` holds CI to (`aquasec/trivy@sha256:62b1e65e…`, v0.74.0) under the gate's own flags — `--scanners vuln --severity HIGH,CRITICAL --ignore-unfixed` — and **with no ignore file**.

| leg | findings |
|---|---|
| **base** (previous ARG values) | `CVE-2026-56854` CRITICAL, compose `x/crypto` v0.54.0 → 0.55.0<br>`CVE-2026-84304` HIGH, compose `grpc` v1.83.0 → 1.83.1<br>`CVE-2026-84304` HIGH, cosign `grpc` v1.82.1 → 1.83.1 |
| **fix** (as committed) | **0** |

The base leg reproduces all three findings the issue reported, so the instrument is shown firing on exactly these CVEs, on exactly these binaries, under exactly the gate's configuration.

**The control was verified armed** rather than assumed: all four binaries differ by `sha256sum`, and `go version -m` read out of each one shows compose at x/crypto v0.54.0 / grpc v1.83.0 on the base leg against v0.55.0 / v1.83.1 on the fix leg.

Full cold `--no-cache` build of the whole rootfs also passes (rc 0), and its scan is clean under the gate config.

## What the raises actually moved — Go's own upgrade list

- **compose moves 4**: `x/crypto` v0.54.0→v0.55.0, `x/mod` v0.38.0→v0.40.0, `x/text` v0.40.0→v0.41.0, `grpc` v1.83.0→v1.83.1
- **cosign moves 9**: `x/crypto` v0.53.0→v0.55.0, `x/mod` v0.37.0→v0.40.0, `x/net` v0.56.0→v0.58.0, `x/sync` v0.21.0→v0.22.0, `x/sys` v0.46.0→v0.47.0, `x/term` v0.44.0→v0.45.0, `x/text` v0.38.0→v0.41.0, `x/tools` v0.46.0→v0.49.0, `grpc` v1.82.0→v1.83.1

The block recorded compose at 1; that was true of the single `x/mod` entry. `x/text` moved on compose without being asked for, which is the block's own "this module and whatever MVS needs to seat it" — so the doc commit corrects the figure and says the count moves when the entries do.

**No `downgraded` lines on either binary.** The block warns `go get` will happily downgrade a module already newer, and compose's grpc was v1.83.0 — above cosign's. Checked, not assumed.

## What I deliberately did NOT do

- **No `x/crypto` entry for cosign.** On the base leg cosign's x/crypto is *already* v0.55.0 — the `x/mod` raise alone seats it, read out of the built binary. An entry would be a no-op today, and this block's rule is that every entry is debt to be dropped the moment it becomes one. This is why the issue's scan showed no x/crypto finding on cosign.
- **No `.trivyignore` change.** That file is the currency lane's path. See below — it needs one, and it is not mine to make.

## A finding this turned up, outside this PR's scope

**`CVE-2026-34040`'s mute in `.trivyignore` is now obsolete.** Scanning this image at *all* severities, fixed and unfixed, returns zero occurrences of that ID — Trivy's DB no longer carries it. `github.com/docker/docker` v28.5.2+incompatible now reports a different set (`CVE-2026-41567`, `CVE-2026-42306` HIGH, both `fixed=NONE`; `CVE-2026-33997`, `CVE-2026-41568` MEDIUM).

That matters because it is exactly the state `.trivyignore` warns about in its own words — a mute standing over a finding that is no longer there means the scan can no longer tell "fixed" from "hidden". It also means **the single documented compose finding this change was supposed to be verified against no longer exists**, which is why the no-ignore-file scan reads 0 rather than 1. Flagging for the currency lane; not fixed here.

## Build note for anyone reproducing this locally

The first build failed rc 1 on an apt 404 for `linux-cpupower`. Cause is the local layer cache, not this diff: `stage-1 2/51` is the only step that runs `apt-get update`, and when it is served CACHED its stale index advertises a package debian-security has rotated out of the pool, which the bare `apt-get install` at `Dockerfile:204` then 404s on. CI has no layer cache and never sees it. **Build `os/rootfs` with `--no-cache`** — the cold build then passes rc 0, which is how this was settled rather than argued.

## Over-engineering pass, by hand

The ponytail gate reads `git rev-parse --abbrev-ref HEAD` from this lane's pinned shell cwd, which is a different worktree on a dead branch, so it cannot see this diff — **disclosed rather than relied on**, and the pass below was done by hand against the right diff.

The change is two ARG values and the comment block that documents them. There is no smaller form: the mechanism is one string per binary, and both binaries carry the grpc finding. The alternative considered and rejected was muting both CVEs in `.trivyignore`, which the Dockerfile's own doctrine refuses in as many words ("raising the module beats muting the scanner") and which would have left the CRITICAL standing in the shipped artifact. A third option — adding `x/crypto` to `COSIGN_GO_RAISES` for symmetry — was available and is rejected above with the measurement that makes it a no-op.

## Blocks

#1648 was held on this. Once this lands its checks want a re-run; its own diff was always innocent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EkURJXJ5SmHjF9Ld9aNFn
