### PR TITLE
fix(p2pool): #1586 mask the secret VALUES on the entrypoint audit line, keep every flag NAME

### DIFF
--- a/build/p2pool/entrypoint.sh
+++ b/build/p2pool/entrypoint.sh
@@ -85,10 +85,60 @@ if printf '%s' "${P2POOL_FLAGS:-}" | grep -q -- '--socks5'; then
     esac
 fi
 
+# Mask the secret VALUES on the launch line while keeping every flag NAME (#1586). #273 needs the
+# applied flags to be VISIBLE — notably the #165 `--socks5` — and never needed their values, but the
+# line printed both: the RPC login, both wallet addresses and the service onion. Two redactors
+# downstream grew up cleaning after it (#1582 in the test harness, #1585 in `support-bundle`), which
+# is the shape worth fixing at the source rather than a third time.
+#
+# Positional, and it has to be: the Tari address is a BARE argument after `--merge-mine <url>` (in
+# EITHER spelling), so a name-keyed scrubber misses it by construction — how #1585 happened. Here the
+# entrypoint knows which argument is which, so nothing has to guess. A token starting with `-` is
+# passed through even in a value position: on a malformed argv that would otherwise swallow the next
+# flag NAME, and a flag silently missing from this line is the one failure it exists to prevent.
+_redact_argv() {
+    local a out="" next=none
+    for a in "$@"; do
+        case "$next" in
+        mask)
+            next=none
+            case "$a" in -*) : ;; *)
+                out="$out [redacted]"
+                continue
+                ;;
+            esac
+            ;;
+        mmurl) # the tari://host:port URL is routing, not a secret; the address AFTER it is
+            out="$out $a"
+            next=mask
+            continue
+            ;;
+        esac
+        case "$a" in
+        --rpc-login | --wallet | --onion-address | --merge-mine=*)
+            out="$out $a"
+            next=mask
+            ;;
+        --rpc-login=* | --wallet=* | --onion-address=*) out="$out ${a%%=*}=[redacted]" ;;
+        --merge-mine)
+            out="$out $a"
+            next=mmurl
+            ;;
+        *) out="$out $a" ;;
+        esac
+    done
+    printf '%s' "${out# }"
+}
+
 # Log the FINAL launch command (#273): makes the applied flags — notably the #165 `--socks5` Tor
-# routing — auditable in `docker logs p2pool`, so a stale image silently dropping P2POOL_FLAGS shows
-# up here (and `pithead doctor` fails on it) rather than leaking quietly. After the #278 block above so
-# it reflects the rewritten --host.
-echo "[p2pool-entrypoint] launching: p2pool $* ${P2POOL_FLAGS:-}"
+# routing — auditable in `docker logs p2pool`, so a stale image silently dropping P2POOL_FLAGS is
+# visible here rather than leaking quietly. (`pithead doctor` catches the same staleness on its own,
+# by reading the container's /proc/1/cmdline — `06-doctor.sh`; this line is the human-readable trail,
+# not doctor's input.) After the #278 block above so it reflects the rewritten --host.
+#
+# Fold P2POOL_FLAGS in BEFORE both, so the line printed is provably the argv exec'd — one word-split,
+# read twice — instead of a space-joined `$*` that only resembles it.
 # shellcheck disable=SC2086  # intentional word-splitting of the space-separated flag string
-exec p2pool "$@" ${P2POOL_FLAGS:-}
+set -- "$@" ${P2POOL_FLAGS:-}
+echo "[p2pool-entrypoint] launching: p2pool $(_redact_argv "$@")"
+exec p2pool "$@"

--- a/tests/stack/test-monero-tari.sh
+++ b/tests/stack/test-monero-tari.sh
@@ -32,7 +32,6 @@ build_val_sandbox
 DOCKER_LOG="$V/docker.log"
 
 echo "== unit: p2pool_outbound_flags — Tor-by-default for outbound P2P (#165) =="
-# Default (clearnet absent/false) routes outbound sidechain dials through the bundled Tor SOCKS proxy.
 assert_eq "default → Tor SOCKS flags" "$(run_sourced "$SANDBOX" p2pool_outbound_flags false 172.28.0)" "--socks5 172.28.0.25:9050 --socks5-proxy-type tor"
 assert_eq "empty arg → Tor (default off)" "$(run_sourced "$SANDBOX" p2pool_outbound_flags '' 172.28.0)" "--socks5 172.28.0.25:9050 --socks5-proxy-type tor"
 # clearnet opt-out → no SOCKS flags (p2pool dials peers directly, IP exposed).
@@ -84,6 +83,14 @@ mm_clear=$(PATH="$PE:$SE:$PATH" P2POOL_FLAGS="--mini" \
     bash "$ROOT/build/p2pool/entrypoint.sh" --merge-mine tari://172.28.0.27:18142 WALLET --stratum 0.0.0.0:3333 2>&1)
 assert_contains "no --socks5 → merge-mine URL untouched" "$mm_clear" "ARG=[tari://172.28.0.27:18142]"
 assert_eq "no --socks5 → no Tari bridge spawned" "$(cat "$SANDBOX/socat.log")" ""
+
+echo "== p2pool entrypoint masks secret VALUES on the #273 launch line, keeps every flag NAME (#1586) =="
+# `docker logs p2pool` keeps this line for the container's life, so its VALUES are the leak (#1582
+# and #1585 both grew up cleaning after it). Masked values and kept flag names are ONE property.
+ml_out=$(PATH="$PE:$SE:$PATH" P2POOL_FLAGS="--mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor" bash "$ROOT/build/p2pool/entrypoint.sh" --host 172.28.0.26 --rpc-login nodeuser:nodepass --wallet 4MoneroPayout --merge-mine tari://172.28.0.27:18142 12TariPayout --onion-address examplep2pool.onion --stratum 0.0.0.0:3333 2>&1)
+assert_eq "launch line masks all four secrets, keeps every flag name and --socks5" "$(printf '%s\n' "$ml_out" | sed -n 's/^\[p2pool-entrypoint\] launching: //p')" "p2pool --host 127.0.0.1 --rpc-login [redacted] --wallet [redacted] --merge-mine tari://127.0.0.1:18142 [redacted] --onion-address [redacted] --stratum 0.0.0.0:3333 --mini --socks5 172.28.0.25:9050 --socks5-proxy-type tor"
+assert_contains "p2pool is still exec'd with the RAW bare tari address" "$ml_out" "ARG=[12TariPayout]"
+assert_eq "--flag=VALUE masked, and --merge-mine= still masks the address AFTER it" "$(PATH="$PE:$PATH" bash "$ROOT/build/p2pool/entrypoint.sh" --wallet=4MoneroPayout --merge-mine=tari://172.28.0.27:18142 12TariPayout 2>&1 | sed -n 's/^\[p2pool-entrypoint\] launching: //p')" "p2pool --wallet=[redacted] --merge-mine=tari://172.28.0.27:18142 [redacted]"
 
 echo "== unit: monero_prune_flag maps prune bool -> 1/0, honouring explicit false (#294) =="
 # render_env + preflight both size disk off this flag; an explicit prune:false must yield 0, not the
@@ -157,7 +164,6 @@ assert_eq "healthcheck: RPC down after scan done -> unhealthy (#718)" "$(run_hc)
 assert_contains "wallet-entrypoint touches the scan marker on create (#718)" "$(cat "$ROOT/build/monero/wallet-entrypoint.sh")" 'touch "$SCAN_MARKER"'
 
 echo "== unit: monero_address_type — p2pool needs a PRIMARY address, and a REAL one (#250, #829) =="
-_a94="$(printf 'a%.0s' $(seq 94))"
 _a93="$(printf 'a%.0s' $(seq 93))"
 assert_eq "monero_address_type: real 4…/95  => primary" "$(run_sourced "$SANDBOX" monero_address_type "$VALID_PRIMARY")" "primary"
 assert_eq "monero_address_type: real 8…/95  => subaddress" "$(run_sourced "$SANDBOX" monero_address_type "$VALID_SUBADDR")" "subaddress"
@@ -187,7 +193,6 @@ echo "== unit: tari_address_type — DammSum over both address forms (#845) =="
 assert_eq "tari_address_type: reference dual base58 => ok" "$(run_sourced "$SANDBOX" tari_address_type "$VALID_TARI")" "ok"
 assert_eq "tari_address_type: same address, emoji form => ok" "$(run_sourced "$SANDBOX" tari_address_type "$VALID_TARI_EMOJI")" "ok"
 assert_eq "tari_address_type: single form => ok" "$(run_sourced "$SANDBOX" tari_address_type "$VALID_TARI_SINGLE")" "ok"
-# One flipped character in each form must fail as "checksum", not pass — the whole point.
 assert_eq "tari_address_type: one flipped base58 char => checksum" "$(run_sourced "$SANDBOX" tari_address_type "${VALID_TARI:0:90}B")" "checksum"
 _TARI_66="🍗🌊🦂🍎🐛🔱🍟🚦🦆👃🐛🎼🛵🔮💋👙💦🍷👠🦀🐺🍪🚀🎮🎩👅🐔🐉🍍🥑💔📌🚧🐊💄🎥🎓🚗🎳🐛🚿💉🌴🧢🐵🎩👾👽🎃🤡👍🔮👒👽🎵👀🚨😷🎒👂👶🍄🏰🚑🌸🍁"
 assert_eq "tari_address_type: tari's invalid-checksum emoji vector => checksum" "$(run_sourced "$SANDBOX" tari_address_type "${_TARI_66}🎒")" "checksum"
@@ -245,7 +250,6 @@ case "$out" in
 *"$VIEWKEY"*) bad "view key never printed by apply" "the view key leaked into apply stdout" ;;
 *) ok "view key never printed by apply" ;;
 esac
-# The wallet-rpc password stays off the .env command line too — it's in .env but never on stdout.
 case "$out" in
 *"$(run_sourced "$V" env_get_file "$V/.env" WALLET_RPC_PASSWORD)"*) bad "wallet-rpc password not printed" "leaked into apply stdout" ;;
 *) ok "wallet-rpc password not printed" ;;
@@ -427,7 +431,6 @@ out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_rc "tari.remote.host with a comma rejected" "$?" "1"
 assert_contains "comma-host message names the field" "$out" "tari.remote.host"
 
-# (6c) A non-numeric tari.remote.grpc_port is rejected.
 seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"'"$VALID_TARI"'","mode":"remote","remote":{"host":"tari.example.com","grpc_port":"18142; rm -rf"}}, "p2pool":{"pool":"main"}, "dashboard":{"secure":true,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
 out="$(cd "$V" && PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
@@ -551,7 +554,6 @@ assert_eq "blank username -> admin in .env" "$(run_sourced "$V" env_get_file "$V
 assert_eq "generated password is 32 chars" "${#env_pass}" "32"
 assert_eq "username persisted to config.json" "$(jq -r '.monero.node_username' "$V/config.json")" "admin"
 assert_eq "password persisted to config.json" "$(jq -r '.monero.node_password' "$V/config.json")" "$env_pass"
-# Second apply must not rotate the now-populated creds.
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_eq "password stable across apply" "$(jq -r '.monero.node_password' "$V/config.json")" "$env_pass"
 
@@ -569,13 +571,11 @@ printf '{ "monero": {"mode":"remote","wallet_address":"%s","node_username":"","n
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_eq "remote rpc_port propagated" "$(run_sourced "$V" env_get_file "$V/.env" MONERO_RPC_PORT)" "28081"
 assert_eq "remote zmq_port propagated" "$(run_sourced "$V" env_get_file "$V/.env" MONERO_ZMQ_PORT)" "28083"
-# And the defaults apply when omitted (local node).
 seed_env
 printf '{ "monero": {"mode":"local","wallet_address":"%s","node_username":"u","node_password":"p"}, "tari":{"wallet_address":"'"$VALID_TARI"'"}, "p2pool":{"pool":"mini"}, "dashboard":{"secure":false,"host":"box.lan"} }\n' "$WALLET" >"$V/config.json"
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead apply -y 2>&1)"
 assert_eq "zmq_port defaults to 18083" "$(run_sourced "$V" env_get_file "$V/.env" MONERO_ZMQ_PORT)" "18083"
 
-# `logs` forwards its service argument to `docker compose logs -f` (read-only follow).
 seed_env
 : >"$DOCKER_LOG"
 out="$(cd "$V" && DOCKER_LOG="$DOCKER_LOG" PATH="$V/bin:$PATH" ./pithead logs monerod 2>&1)"


### PR DESCRIPTION
**#1586 is closed by hand with a comment naming this PR** — `Closes` cannot fire here, because PRs
merge to `develop-v2` while the default branch is `develop`.

## What this changes

`build/p2pool/entrypoint.sh` echoed the full argv, so the #273 audit line printed the RPC login, both
wallet addresses and the service onion — into `docker logs p2pool`, where it stays for the
container's life. It is the upstream **source** of #1582 and #1585: two redactors that grew up
cleaning after this one line.

The fix masks the **values** and keeps every flag **name**, so #273's audit requirement survives
intact — `--socks5` and its target stay legible, and so does the `tari://` routing URL.

`_redact_argv` is **positional, and it has to be**: the Tari address is a bare argument after
`--merge-mine <url>`, so a name-keyed scrubber misses it by construction — which is exactly how
#1585 happened. The entrypoint is the one place that knows which argument is which. A token starting
with `-` is passed through even in a value position, so a malformed argv cannot swallow the next flag
**name**; a flag silently missing from this line is the one failure the line exists to prevent.

`P2POOL_FLAGS` is now folded in with `set -- "$@" ${P2POOL_FLAGS:-}` **before** both the echo and the
`exec`, so the line printed is provably the argv exec'd — one word-split, read twice — instead of a
space-joined `$*` that only resembles it.

`pithead doctor` does **not** parse this line — `06-doctor.sh:178` reads `/proc/1/cmdline` via
`docker exec` — which was #1586's one named risk, re-derived at source rather than assumed.

## The over-engineering pass changed the patch

Reviewing my own diff for over-engineering turned up the opposite: an **under**-covered arm, and a
real one. The equals spellings were handled for `--rpc-login=`, `--wallet=` and `--onion-address=`
but **not** for `--merge-mine=`, and merge-mine is the one flag whose secret is the *next* token.
Measured before touching anything:  (the stack's own compose-default private IPs are
elided as `<tari-ip>` / `<tor-ip>` throughout this body, per the topology rule — nothing else in
any quoted output is altered.)

```
$ ... entrypoint.sh --wallet=4MoneroPayout --merge-mine=tari://<tari-ip>:18142 12TariPayout
p2pool --wallet=[redacted] --merge-mine=tari://<tari-ip>:18142 12TariPayout
                                                               ^^^^^^^^^^^^ the bare address, raw
```

This is the adjacent-pair test: both spellings can hold the same thing, so the asymmetry was a
defect, not a deliberate split. The fix is **line-neutral** — `--merge-mine=*` joins the existing
"mask the next token" arm, whose semantics it already wanted — and the equals-form test row was
widened to cover it rather than a new row added. Not reachable from our own
`docker-compose.yml` (which uses the separated spelling), and shipped anyway because the cost was one
pattern token.

Declined, and why: **"print flag names only, drop every value"** would be simpler machinery, but it
also drops `--stratum 0.0.0.0:3333`, the `--socks5` target and the `tari://` URL — the non-secret
values that make the line worth auditing at all. The masking keeps #273's line useful.

## What was RUN

**Full `tests/stack/run.sh`, clean tree:** `3065 passed, 0 failed` (rc 0, zero `✗` marks in the log)

**Red-proof.** The real text of `tests/stack/test-monero-tari.sh:43-93` was run on top of the real
`tests/stack/lib.sh` — first unmutated (control: the driver can say PASS), then with
`build/p2pool/entrypoint.sh` reverted to `origin/develop-v2`. Every leg `cmp`-checked the file
actually changed before being counted.

```
LEG 1 — head entrypoint:      PASS=14 FAIL=0
LEG 2 — pre-fix entrypoint:   PASS=12 FAIL=2

  ✗ launch line masks all four secrets, keeps every flag name and --socks5
      got [p2pool --host 127.0.0.1 --rpc-login nodeuser:nodepass --wallet 4MoneroPayout
           --merge-mine tari://127.0.0.1:18142 12TariPayout --onion-address examplep2pool.onion
           --stratum 0.0.0.0:3333 --mini --socks5 <tor-ip>:9050 --socks5-proxy-type tor]
  ✗ --flag=VALUE masked, and --merge-mine= still masks the address AFTER it
      got [p2pool --wallet=4MoneroPayout --merge-mine=tari://<tari-ip>:18142 12TariPayout ]
```

That `got` line **is** the defect, printed.

**Per-arm attribution — each masked arm killed ALONE reds the row, so the green is not borrowed:**

```
BASELINE (no mutation)         PASS=14 FAIL=0
kill --rpc-login arm           PASS=13 FAIL=1
kill --wallet arm              PASS=13 FAIL=1
kill --onion-address arm       PASS=13 FAIL=1
kill --merge-mine position     PASS=13 FAIL=1   (next=mmurl -> next=none)
kill --merge-mine= arm         PASS=13 FAIL=1
```

One of these legs first ran with a malformed `sed` that matched nothing; the `cmp`-before-count guard
refused to score it, and it was re-run with a working mutation. Reported rather than quietly fixed.

The third row — `p2pool is still exec'd with the RAW bare tari address` — is **green on both legs by
design**: it is the control that the fix did not change what p2pool actually receives, so a mutation
of the *log line* must leave it alone.

**Gates:** `make lint-file-budget` green (**582/582** at head, see below); `shfmt -i 4 -d` clean on
both changed files; `shellcheck --severity=warning` rc 0 over
`build/*/*.sh tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_*.sh os/overlay/pithead-boot`
plus `tests/stack/run.sh`, with a positive control (an injected `cd` with no `|| exit`) confirmed
firing SC2164 first. `pithead-boot` is paired in deliberately: without it the partial glob invents
three SC2034s in `test-appliance-boot.sh`, a file this diff never touches — the pairing the Makefile
already documents.

## The line budget — pay-for-lines, as ruled

`tests/stack/test-monero-tari.sh` was at **582/582 with zero headroom**. Per the controller's ruling
the block pays for itself: **8 lines added, 8 lines deleted**, every deletion a comment that restates
the code beneath it (or dead code), **no assertion touched**, and the file back at exactly 582. This
is the file's first shave.

Deleted, verbatim:

```
_a94="$(printf 'a%.0s' $(seq 94))"
# Default (clearnet absent/false) routes outbound sidechain dials through the bundled Tor SOCKS proxy.
# One flipped character in each form must fail as "checksum", not pass — the whole point.
# The wallet-rpc password stays off the .env command line too — it's in .env but never on stdout.
# (6c) A non-numeric tari.remote.grpc_port is rejected.
# Second apply must not rotate the now-populated creds.
# And the defaults apply when omitted (local node).
# `logs` forwards its service argument to `docker compose logs -f` (read-only follow).
```

`_a94` is not a comment: it is **dead code** — defined and never referenced anywhere in the file
(`_a93` and `_h94` beside it are both used). `(6c)` is the last label in its `6a/6b/6c` group, so
removing it leaves no gap in the surviving numbering.

`build/p2pool/entrypoint.sh` is 144 lines with no budget row (under `TARGET_LINES=400`), so it needed
no payment.

## Lane and grants

- `build/p2pool/entrypoint.sh` — **GRANT 2** (`roles/e2e.paths`, #1586 only).
- `tests/stack/test-monero-tari.sh` — **GRANT 2b**, armed by the controller at w79 on this lane's
  ask: one additive `echo "== ... =="` block beside the stub p2pool/socat harness already at
  `:44-86`, no edit to existing rows, no `tests/stack/run.sh` stanza (the file is already
  registered). Tier 1 is the right home per `docs/dev/testing-strategy.md` — a `selftest-*.sh` under
  `tests/integration/` is harness self-test and is not one of the four tiers.
- Both grants expire when this PR merges. No shared file touched, no `.lane-override` used.

## What I did NOT do

- **No doc change, and I checked rather than assumed.** Grepped `docs/` for the defect's own words:
  nothing documents the launch line or #273. The two nearest claims both survive unchanged —
  `docs/operations.md:28` describes what `support-bundle` scrubs (still true; this makes that
  scrubbing redundant for *future* logs, not wrong), and `:657` points at the merge-mine **bridge**
  line, which this does not touch.
- **Old logs are not retroactively cleaned.** Containers running from before this ships keep the
  unmasked line for their life; `support-bundle`'s redactor (#1585) is what covers those, and stays.
- **The masked set is `--rpc-login`, `--wallet`, `--onion-address` and the `--merge-mine` positional,
  in both spellings.** Any future secret-bearing flag needs a line here — the comment above
  `_redact_argv` says so, rather than implying the list is closed.
- **Filed while here:** #1661 — `tests/stack/lib.sh:81` falls back to the caller's cwd when
  `mktemp -d` fails, and line 82 then arms `rm -rf` on it. Static reading plus three isolated legs;
  the defect path was never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PaSXfW6JRNQzKgm7xMyJc
