### PR TITLE
tests(os): #1664 KVM pre-flight refuses the 16 GiB guest when the host cannot back it

### DIFF
--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -14,6 +14,10 @@ os/rauc/mkimage.sh --dev                      # bootable image -> os/rauc/build/
 sudo tests/os/run.sh --image os/rauc/build/system.img
 ```
 
+Every guest boot is preceded by a host pre-flight (`tests/os/kvm-preflight.sh`): under 20 GiB of
+`MemAvailable` the battery refuses to boot the 16 GiB guest rather than risk hanging the host that
+runs it (`PITHEAD_KVM_MIN_AVAIL_MB` sets the bar; the reading is printed at every boot either way).
+
 The harness builds its own update bundles from the same tarball (`os/rauc/mkbundle.sh --dev`),
 signed with a throwaway development key. A release build names its key instead — see the custody
 runbook in [`docs/dev/release-server.md`](../../docs/dev/release-server.md).

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -565,19 +565,3 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ] && [ "${1:-}" = "--self-test" ]; then
     _fe_self_test
     exit $?
 fi
-
-# kvm_preflight — refuse to boot the 16 GiB guest when the host cannot back it (#1059, the 02:56Z
-# hang). The KVM host also hosts the fleet: a memory hang there takes every lane down and needs
-# the operator's hands to recover, so a refused boot is a finding and a hang is a lost box. The bar
-# is the guest plus a 4 GiB margin; MemAvailable already counts reclaimable cache, so it is the
-# honest "what the guest can take without swapping" figure. The reading is printed either way, so
-# every boot leaves the number the next reader will want.
-kvm_preflight() {
-    local need avail
-    need=${PITHEAD_KVM_MIN_AVAIL_MB:-20480}
-    avail=$(awk '/^MemAvailable:/{printf "%d", $2 / 1024}' /proc/meminfo)
-    printf '     · host MemAvailable=%s MiB before the guest boots (bar %s MiB)\n' "$avail" "$need"
-    [ "$avail" -ge "$need" ] && return 0
-    bad "KVM PRE-FLIGHT REFUSED: host MemAvailable ${avail} MiB is under the ${need} MiB bar — not booting the 16 GiB guest (#1059: the condition that hung the host)"
-    return 1
-}

--- a/tests/os/failure-evidence.sh
+++ b/tests/os/failure-evidence.sh
@@ -565,3 +565,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ] && [ "${1:-}" = "--self-test" ]; then
     _fe_self_test
     exit $?
 fi
+
+# kvm_preflight — refuse to boot the 16 GiB guest when the host cannot back it (#1059, the 02:56Z
+# hang). The KVM host also hosts the fleet: a memory hang there takes every lane down and needs
+# the operator's hands to recover, so a refused boot is a finding and a hang is a lost box. The bar
+# is the guest plus a 4 GiB margin; MemAvailable already counts reclaimable cache, so it is the
+# honest "what the guest can take without swapping" figure. The reading is printed either way, so
+# every boot leaves the number the next reader will want.
+kvm_preflight() {
+    local need avail
+    need=${PITHEAD_KVM_MIN_AVAIL_MB:-20480}
+    avail=$(awk '/^MemAvailable:/{printf "%d", $2 / 1024}' /proc/meminfo)
+    printf '     · host MemAvailable=%s MiB before the guest boots (bar %s MiB)\n' "$avail" "$need"
+    [ "$avail" -ge "$need" ] && return 0
+    bad "KVM PRE-FLIGHT REFUSED: host MemAvailable ${avail} MiB is under the ${need} MiB bar — not booting the 16 GiB guest (#1059: the condition that hung the host)"
+    return 1
+}

--- a/tests/os/kvm-preflight.sh
+++ b/tests/os/kvm-preflight.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+#
+# KVM pre-flight for the battery (#1059, #1664): refuse to boot the 16 GiB guest when the host
+# cannot back it. Sourced by tests/os/run.sh, which defines bad() and calls this immediately
+# before every virt-install. The KVM host also hosts the fleet: a memory hang there takes every
+# lane down and needs the operator's hands to recover, so a refused boot is a finding and a hang
+# is a lost box (two host hangs on 2026-09-02/03; the second with the guest up). The bar is the
+# guest plus a 4 GiB margin; MemAvailable already counts reclaimable cache, so it is the honest
+# "what the guest can take without swapping" figure. The reading is printed either way, so every
+# boot leaves the number the next reader will want. PITHEAD_KVM_MIN_AVAIL_MB raises or lowers
+# the bar; PITHEAD_KVM_MEMINFO points the read at a fixture so both branches are provable
+# without a guest.
+kvm_preflight() {
+    local need avail
+    need=${PITHEAD_KVM_MIN_AVAIL_MB:-20480}
+    avail=$(awk '/^MemAvailable:/{printf "%d", $2 / 1024}' "${PITHEAD_KVM_MEMINFO:-/proc/meminfo}")
+    printf '     · host MemAvailable=%s MiB before the guest boots (bar %s MiB)\n' "$avail" "$need"
+    [ "$avail" -ge "$need" ] && return 0
+    bad "KVM PRE-FLIGHT REFUSED: host MemAvailable ${avail} MiB is under the ${need} MiB bar — not booting the 16 GiB guest (#1059: the condition that hung the host)"
+    return 1
+}

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -47,6 +47,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 . "$SCRIPT_DIR/hugepages-boot-verdict.sh"
 # shellcheck source=tests/os/failure-evidence.sh
 . "$SCRIPT_DIR/failure-evidence.sh"
+# shellcheck source=tests/os/kvm-preflight.sh
+. "$SCRIPT_DIR/kvm-preflight.sh"
 # shellcheck source=tests/os/restore-live-state-verdict.sh
 . "$SCRIPT_DIR/restore-live-state-verdict.sh"
 # shellcheck source=tests/os/reinstall-prefill-verdict.sh
@@ -327,7 +329,6 @@ require_host() {
         echo "/dev/kvm absent — this harness needs hardware virtualization" >&2
         exit 2
     }
-    # --image is the boot phase's input; the update phase builds its own v1/v2 images.
     # --image is the boot phase's input; update and fault build their own v1/v2 images.
     if [ "$PHASE" = "boot" ] || [ "$PHASE" = "all" ]; then
         [ -n "$IMAGE" ] && [ -f "$IMAGE" ] || {
@@ -479,13 +480,8 @@ phase_boot() {
     }
     ok "wizard serves the token gate ($ip)"
 
-    # SSH is a host service that finishes starting after the wizard container's HTTP gate answers,
-    # so the first _ssh here must wait it out — a single-shot probe raced ssh.service and misread a
-    # healthy boot as "SSH unreachable". The budget is the update phase's own first-boot figure
-    # (_vm_boot_disk + _wait_ssh 240): this is the VERY FIRST cold-host VM of the run — 6 GiB of
-    # hugepages reserved, systemd-repart growing /data to ~24 GiB, the wizard image loading, the
-    # host key generating — and 120 s clipped it (SSH came up just after, per the failed-run
-    # forensics). An equally unprovisioned update-phase guest reaches SSH within 240 s.
+    # SSH is a host service that starts after the wizard's HTTP gate answers, so the first _ssh here
+    # must wait it out — a single-shot probe raced ssh.service and misread a healthy boot as dead.
     # 900, not the update phase's 240: this is the run's very FIRST cold boot — 6 GiB of
     # hugepages, systemd-repart growing /data, the wizard image unpacking, host-key generation —
     # and it starts while the image build's export I/O is still settling. 420 s passed idle but
@@ -551,11 +547,6 @@ phase_boot() {
 _vm_boot_disk() {
     vm_destroy
     cp "$1" "$DISK"
-    # 16 GiB guest: the appliance reserves 6 GiB of hugepages at boot (RandomX), so a smaller VM
-    # leaves too little for the stack — and the plan sizes appliance RAM to the compose caps anyway.
-    # Grow the scratch disk before first boot: the image ships only the ESP and slot A, and
-    # systemd-repart creates slot B and /data on whatever disk it finds. A 40 GiB disk leaves
-    # /data around 24 GiB, which the update phase asserts.
     qemu-img resize "$DISK" 40G >/dev/null 2>&1 || true
     : >"$SERIAL"
     kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -434,6 +434,7 @@ phase_boot() {
     qemu-img resize "$DISK" 40G >/dev/null 2>&1 || true
     : >"$SERIAL"
     # UEFI (OVMF), serial to a file we tail, import the raw appliance disk as-is.
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -557,6 +558,7 @@ _vm_boot_disk() {
     # /data around 24 GiB, which the update phase asserts.
     qemu-img resize "$DISK" 40G >/dev/null 2>&1 || true
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1190,6 +1192,7 @@ phase_install() {
     # The image rides a USB bus with removable=on — that is what makes the guest a faithful
     # analog of a user's stick: the host-side gate (installer_mode_available) keys on
     # /sys/block/*/removable, which virtio never sets.
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1299,6 +1302,7 @@ phase_install() {
     vm_destroy
     # Boot from the TARGET alone — the stick is gone, exactly as the instructions tell the user.
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1383,6 +1387,7 @@ phase_install() {
     sleep 8
     vm_destroy
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1531,6 +1536,7 @@ phase_install() {
     cp "$img" "$DISK"
     qemu-img resize "$DISK" 16G >/dev/null 2>&1 || true
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1606,6 +1612,7 @@ phase_install() {
     fi
     vm_destroy
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1769,6 +1776,7 @@ phase_install() {
     cp "$img" "$DISK"
     qemu-img resize "$DISK" 16G >/dev/null 2>&1 || true
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
@@ -1863,6 +1871,7 @@ phase_install() {
     fi
     vm_destroy
     : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
     virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
         --osinfo debian12 \
         --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \


### PR DESCRIPTION
Closes #1664 — closing keywords are inert on `develop-v2`; the controller closes by hand.

Ships the KVM pre-flight the #1059 re-proof ran with: `kvm_preflight` reads `MemAvailable`, prints it before every guest boot, and refuses to boot the 16 GiB guest under a 20,480 MiB bar (`PITHEAD_KVM_MIN_AVAIL_MB` overrides). Called at all nine `virt-install` sites in `tests/os/run.sh`.

## Shape, per the #1059 close ruling: no ceiling moves

The two bench commits are cherry-picked as-is for provenance; the third commit moves the function out of `tests/os/failure-evidence.sh` (at its 567 ceiling, and its header scopes that file to the os-update leg's failure evidence) into **`tests/os/kvm-preflight.sh`** — 21 lines, under target, no tsv row — sourced by `run.sh` beside the verdict files. `failure-evidence.sh` lands byte-identical to the tip (`git diff --quiet` against the base: yes).

**Shave count: ONE file, `tests/os/run.sh`, 11 lines** (+9 call sites, +2 source lines; 3437 → 3437). The second file needed none. The deletions, verbatim:

1. One line of a duplicated pair (the line kept under it says the same and adds `fault`):
   `# --image is the boot phase's input; the update phase builds its own v1/v2 images.`
2. Five lines in `_vm_boot_disk`, a verbatim copy of the paragraph in `phase_boot` 125 lines above it (kept there):
   `# 16 GiB guest: the appliance reserves 6 GiB of hugepages at boot (RandomX), so a smaller VM`
   `# leaves too little for the stack — and the plan sizes appliance RAM to the compose caps anyway.`
   `# Grow the scratch disk before first boot: the image ships only the ESP and slot A, and`
   `# systemd-repart creates slot B and /data on whatever disk it finds. A 40 GiB disk leaves`
   `# /data around 24 GiB, which the update phase asserts.`
3. Five lines' worth of the SSH-wait paragraph in `phase_boot`, restated — and superseded, 240 s → 900 s — by the paragraph directly under it, which is kept whole:
   `The budget is the update phase's own first-boot figure (_vm_boot_disk + _wait_ssh 240): this is the VERY FIRST cold-host VM of the run — 6 GiB of hugepages reserved, systemd-repart growing /data to ~24 GiB, the wizard image loading, the host key generating — and 120 s clipped it (SSH came up just after, per the failed-run forensics). An equally unprovisioned update-phase guest reaches SSH within 240 s.`
   The two surviving sentences reflowed from three lines to two: `SSH is a host service that starts after the wizard's HTTP gate answers, so the first _ssh here must wait it out — a single-shot probe raced ssh.service and misread a healthy boot as dead.` Max comment-line width in the file is 107 before and after.

One change to the proven function, one token: the meminfo path is `"${PITHEAD_KVM_MEMINFO:-/proc/meminfo}"`, so both branches are provable without a guest (`diff` of the function body against the bench commit shows exactly that line).

## What was RUN here

| check | result |
|---|---|
| fixture 12,402 MiB (the 02:56Z hang's own `MemAvailable`) | **refused**, rc 1, ✗ line printed |
| fixture 20,479 MiB (one under the bar) | **refused**, rc 1 |
| fixture 20,480 MiB (at the bar) | passes, rc 0 |
| fixture 23,437 MiB | passes, rc 0 |
| override control: same 12,402 fixture, `PITHEAD_KVM_MIN_AVAIL_MB=12000` | passes, rc 0 — the bar variable is live |
| live `/proc/meminfo` on the KVM host, dev stack running | 21,583 MiB, passes |
| `shellcheck --severity=warning` on `run.sh` + the new file | rc 0 |
| `shfmt -i 4 -d` on both | rc 0 |
| `scripts/lint-file-budget.sh` at the branch head, **with the new file staged** (the gate enumerates `git ls-files`; a first run before staging is not counted) | rc 0, tsv monotonic |
| `bash -n` both | ok |

**Relayed, not re-run here:** the bench proof — refused under the bar and passed above it on the same day, and printed at all seven boots of run 2 (23.6–23.9 GB) — is the #1059 re-proof's evidence on the KVM host. The ruling puts this PR before the next guest boot, so no guest was booted for it.

## Not done, named

- No tier-1 case in `tests/stack/` (not this lane's path; needs a grant). With the fixture override it is a six-line addition whenever the tests lane wants it.
- The 20,480 MiB bar is a floor, not a measured threshold — two hangs do not settle it. The issue says the operator can raise it; nothing here claims it is right.
- `docs/dev/testing-strategy.md` untouched: the pre-flight is not a test of the image, it guards the host. `tests/os/README.md` carries the two-line note instead.

## Over-engineering pass, by hand

The ponytail gate reads the branch from this lane's pinned shell cwd (a different worktree on a dead branch) — disclosed; the pass was done against this diff.

- **Keep the function in `failure-evidence.sh` and shave both files** (16 + 9): available, rejected — two shaves where the ruling prefers one, and that file's header scopes it to os-update failure evidence, which a pre-flight is not.
- **Put it in `hugepages-boot-verdict.sh`**, already sourced and under target: rejected — that file is pure over its arguments and fixture-tested at tier 1; a `/proc` reader that calls `bad()` breaks its contract.
- **A `_virt_install` wrapper collapsing the nine sites** so the guard is one line: available, rejected — it rewrites nine ten-line blocks in a ship-the-proven-commits PR; the nine one-liners are the shape that was proven on the bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkgFiBFkN16zgVjvKRH8Kw
