### PR TITLE
fix(gates): #1557 grade patch coverage against the PR's own base, not frozen develop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      (`lychee`) runs on a weekly schedule, not per-PR.
    - **test-dashboard** — the dashboard `pytest` suite (must stay ≥ the **80% total coverage gate**).
      CI also runs **`make test-patch-coverage`** (`diff-cover`): new/changed lines must be **≥ 90%**
-     covered vs `origin/develop`, the ratchet that stops coverage rotting at the margin. The gate
+     covered against the PR's own base branch, the ratchet that stops coverage rotting at the margin. The gate
      says so explicitly when a diff has nothing it measures (shell/docs-only PRs pass loudly), and
      fails if a changed dashboard Python file is missing from `coverage.xml` entirely — the
      silent no-op it used to be. Run it right after `make test-dashboard`, so `coverage.xml`

--- a/scripts/patch-coverage.sh
+++ b/scripts/patch-coverage.sh
@@ -8,7 +8,31 @@
 # loudly and says so. Run `--self-test` to check the overlap logic against fixtures.
 set -euo pipefail
 
-COMPARE=origin/develop
+# The base the gate grades against, and #1557: this was a bare `COMPARE=origin/develop` with no
+# override. `develop` is FROZEN and all work lands on `develop-v2`, so every lane branch was graded
+# over the whole twin divergence instead of its own patch — on one branch, 572 files instead of 2
+# and 87 measured dashboard files instead of 0. Green over the wrong set is the same word as green
+# over the right one, and there is no rc, no warning and no empty output to notice it.
+#
+# On a pull_request run GITHUB_BASE_REF is the PR's own base and ci.yml already fetches it; reading
+# it here is the whole of #1557's other half, so that shared file needs no change. Off a PR it is
+# unset (a local run, or a push build — `push:` only fires on main/develop): prefer develop-v2,
+# where work lands, and fall back to develop when develop-v2 was never fetched, which is the push
+# case. `COMPARE` in the environment still wins, so a caller can grade against anything.
+pick_compare() { # <github-base-ref> <preferred-exists: yes|no> <preferred> <fallback> -> the ref
+    [ -n "$1" ] && {
+        echo "origin/$1"
+        return 0
+    }
+    [ "$2" = yes ] && {
+        echo "origin/$3"
+        return 0
+    }
+    echo "origin/$4"
+}
+_pref=develop-v2
+if git rev-parse --verify --quiet "origin/$_pref" >/dev/null; then _has=yes; else _has=no; fi
+COMPARE="${COMPARE:-$(pick_compare "${GITHUB_BASE_REF:-}" "$_has" "$_pref" develop)}"
 # The tree the dashboard coverage run measures (pytest --cov=mining_dashboard). Python outside
 # it (tests, integration fakes) is never in coverage.xml, so it can't make the gate applicable.
 MEASURED='dashboard/mining_dashboard/*.py'
@@ -88,6 +112,23 @@ if [ "${1:-}" = "--self-test" ]; then
     check_overlap "$tmp/coverage.xml" dashboard/mining_dashboard/client/tari/generated/foo_pb2.py >"$tmp/out" || rc=$?
     expect_rc "generated stub absent from coverage.xml -> still pass (coverage-omitted by design)" 0 "$rc"
 
+    # #1557: the base is a decision, so it gets fixtures too — a run graded against the wrong
+    # branch must be distinguishable from one graded right, or the self-test certifies a behaviour
+    # it cannot see. pick_compare is pure for exactly this reason; the git lookup that feeds its
+    # second argument stays at the top, where the self-test is not the thing under test.
+    expect_eq() { # <desc> <expected> <actual>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (expected '$2', got '$3')"
+            st_fail=1
+        fi
+    }
+    expect_eq "on a PR, GITHUB_BASE_REF is the base" origin/develop-v2 "$(pick_compare develop-v2 no develop-v2 develop)"
+    expect_eq "GITHUB_BASE_REF outranks the preference, even naming the frozen branch" origin/develop "$(pick_compare develop yes develop-v2 develop)"
+    expect_eq "off a PR, develop-v2 when it is fetched" origin/develop-v2 "$(pick_compare "" yes develop-v2 develop)"
+    expect_eq "off a PR, fall back to develop when develop-v2 is absent" origin/develop "$(pick_compare "" no develop-v2 develop)"
+
     [ "$st_fail" -eq 0 ] && {
         echo "patch-coverage self-test OK"
         exit 0
@@ -97,6 +138,9 @@ if [ "${1:-}" = "--self-test" ]; then
 fi
 
 # --- main: diff-cover as before, then the overlap check on its green paths ----------------------
+# Say which base the number is about, BEFORE diff-cover runs (#1557). Changing the default alone
+# leaves the next base change as silent as this one was; the count is carried by check_overlap.
+echo "patch coverage: grading changed lines against $COMPARE."
 rc=0
 (cd dashboard && uv run --locked --extra test \
     diff-cover coverage.xml --compare-branch="$COMPARE" --fail-under=90) || rc=$?


### PR DESCRIPTION
**#1557 is closed by hand with a comment naming this PR, at merge** — `Closes` cannot fire here,
because PRs merge to `develop-v2` while the default branch is `develop`.

## What this changes

`scripts/patch-coverage.sh:11` pinned the gate's comparison base as a bare `COMPARE=origin/develop`
with no environment override. `develop` is frozen and all work lands on `develop-v2`, so every lane
branch was graded over the whole twin divergence instead of its own patch.

Measured on a live branch before touching anything — the issue's own example was smaller:

```
vs origin/develop:     572 files changed,  87 under the measured tree (dashboard/mining_dashboard/*.py)
vs origin/develop-v2:    2 files changed,   0 under the measured tree
```

That branch touched no dashboard Python at all, so its correct verdict was the loud not-applicable
pass. Instead the gate scored 87 files it never wrote. Both directions are live: a good patch can
fail on uncovered lines in unrelated files, and a bad patch can pass, diluted by a large
well-covered unrelated diff. The existing #1000 vacuity guard cannot see either — the run is not
vacuous, it is simply about another set, so there is no rc, no warning and no empty output to notice.

The base is now resolved rather than pinned: `GITHUB_BASE_REF` on a pull_request run, else
`develop-v2`, falling back to `develop` when `develop-v2` was never fetched. `COMPARE` in the
environment still wins. The gate prints the base it resolved, before diff-cover runs — changing the
default alone would leave the next base change as silent as this one was.

## The ci.yml half of #1557 needs no ci.yml change — a finding, not a shortcut

The issue scopes a second half to `.github/workflows/ci.yml`: it "fetches `GITHUB_BASE_REF` and
nothing in `scripts/` or `Makefile` reads it". Both halves of that sentence are true. The conclusion
does not follow, and it is worth stating because it is the reason a shared serialized file was left
alone rather than edited under a carve-out.

`ci.yml:67` already runs `git fetch --no-tags origin develop "${GITHUB_BASE_REF:-develop}"`, and
`:63-65` already documents the intent in a comment — naming this exact symptom, a bash-only PR into
the appliance branch failing on `wizard.py` lines it never touched. CI did its half completely. The
only missing piece was a **reader**, and the reader belongs in the script, which is in lane. So
GRANT 3's explicit ci.yml carve-out was never exercised and the file is untouched.

## What was RUN

**Self-test: 8/8**, up from 4 — `bash scripts/patch-coverage.sh --self-test`, rc 0.

**Per-arm attribution.** Each leg reverted the file and re-mutated from a pristine copy, and each
`cmp`-checked that the file actually changed before being allowed to score:

```
BASELINE (no mutation)              red_rows=0
kill the GITHUB_BASE_REF arm        red_rows=2
flip the preferred-exists arm       red_rows=2
fallback returns preferred          red_rows=1
arm1 hardcodes develop-v2           red_rows=1   catches ONLY the precedence row
arm1 hardcodes develop              red_rows=1   catches ONLY the plain row
```

The last two legs exist because the two `GITHUB_BASE_REF` rows both red under one mutation, which is
the redundancy tell. They settle it in both directions: each row catches a mutation the other misses,
so neither row's green is borrowed from the other.

**A defect in my own battery, reported rather than quietly fixed:** the first run counted with
`grep -c 'self-test FAIL'`, which also matches the summary line `self-test FAILED`, so every count
came back one high. The per-row lists were correct throughout; the counts above are from the re-run
with an anchored `'^  self-test FAIL: '`.

**End-to-end on a live branch:** the base resolves to `origin/develop-v2` and the graded set is 0
measured files, down from 87.

**Gates, each with the set it was measured over** (a lint verdict without its file list is not a
verdict):

- `shellcheck --severity=warning` rc 0 over all 15 `scripts/*.sh`, which contains the changed file.
  **Not** the Makefile's full glob: that is this box's OOM path and it exceeded the timeout, so what
  is reported here is the targeted run, which is what I actually measured.
- **The first positive control was dead and I nearly counted it.** The usual recipe — an injected
  `cd` with no `|| exit`, expecting SC2164 — returned **rc 0**, because shellcheck suppresses SC2164
  when `set -e` is active, and this file sets `set -euo pipefail`. Re-armed with SC2154 (an
  unassigned variable reference, warning-level and not suppressed), confirmed it fires rc 1, and only
  then trusted the clean run.
- `shfmt -i 4 -d` rc 0 over the same set.
- `make lint-file-budget` green, `git add` first (#1486). The file is 157 lines, under
  `TARGET_LINES=400`, so it has no budget row and needed none.
- `make lint-md` 0 errors over 48 files; `make lint-docs-voice` clean over 41 prose docs, and a
  seeded banned word in `CONTRIBUTING.md` made it fail naming `CONTRIBUTING.md:164` — so that green
  comes from an instrument shown able to see the file it cleared.

## The over-engineering pass

- **I tried the simpler `pick_compare` and it is worse.** With two arguments the branch names live
  only inside the function, but the caller still needs the literal `develop-v2` for its `git
  rev-parse` existence check — so the name is duplicated either way, in two places that can drift
  into checking one ref and returning another. The four-argument form names it once, in `_pref`, and
  feeds both the lookup and the result. Kept for that reason rather than by default.
- **The `set -e` interaction was checked, not assumed.** `[ -n "$1" ] && { …; return 0; }` looks like
  it should abort under `set -euo pipefail` when the test fails. It does not — the failing command is
  not the one following the final `&&`, so it is exempt — and self-test legs 3 and 4 pass only
  because execution continues past it. It also matches pre-existing code in the same file (`:91`).
- **Declined:** a pre-check that the resolved base ref exists before invoking diff-cover. It would
  only produce a nicer message than git's own, for a case ci.yml structurally prevents by fetching
  whatever `GITHUB_BASE_REF` names.

## Lane and grants

- `scripts/patch-coverage.sh` — **GRANT 3** (`roles/e2e.paths`, #1557 only). Its ci.yml carve-out
  was **not** exercised; see above for why it turned out not to be needed.
- `CONTRIBUTING.md` — **GRANT 3b**, asked for and armed by the controller before the edit, #1557
  only, that one clause, expiring on merge. It is not this lane's file. No `.lane-override` was
  used, which would have been the wrong instrument for a file another role owns.
- The doc edit replaces "covered vs `origin/develop`" with "covered against the PR's own base
  branch". Nothing else in that bullet moves: the >=90% figure, the loud not-applicable pass and the
  missing-from-`coverage.xml` failure all stay true as written. The line is 110 chars, exactly the
  file's existing maximum, and MD013 is disabled, so no reflow was needed either.

## What I did NOT do

- **Rebased across a squash, and proved it by patch identity rather than by trees or shas.** This
  branch was cut on top of the #1586 branch, which has since squash-merged, so `git rebase <base>`
  would have replayed a merged commit against its own squash. Used `rebase --onto`; `git diff
  <old-base> <old-head>` and `git diff <new-base> <new-head>` are byte-identical at 4095 bytes, and
  the comparator was shown able to say DIFFERS.
- **I did not verify diff-cover's own output format**, so the claim above is only that the gate now
  prints its resolved base and that `check_overlap` prints the measured-file count. Whether
  diff-cover separately reports a line total is untested here.
- **No behaviour change for CI push builds.** `push:` fires only on `main` and `develop`, where the
  fallback resolves exactly as before.
