### PR TITLE
tests(os): #1652 the soak's daily probe — one fixed read-only SSH read, one line a day, scored against the ruled pass condition

### DIFF
--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -84,3 +84,13 @@ that the boot path's files sit where the firmware and GRUB will look.
 sudo tests/os/verify-image.sh os/rauc/build/system.img          # release: test artifacts REFUSED
 sudo tests/os/verify-image.sh os/rauc/build/system.img --test   # harness build: SSH key expected
 ```
+
+## Soak probe
+
+`tests/os/soak-probe.sh HOST LOGDIR [--start]` is the 7-day unattended soak's daily reader
+(#1652): one non-interactive, read-only SSH session whose remote command is fixed in the script,
+one line per day appended to `LOGDIR/soak.log`, scored against the pass condition ruled on the
+issue (one boot, restart counts and start times flat, every container running and — except
+`xmrig-proxy`, #1098 — healthy, at most the probe's own login). `--start` writes the day-0
+baseline; `--self-test` proves the verdict over canned readings without a box. Run it from a
+cron line on the build host, never from a resident session.

--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -91,6 +91,10 @@ sudo tests/os/verify-image.sh os/rauc/build/system.img --test   # harness build:
 (#1652): one non-interactive, read-only SSH session whose remote command is fixed in the script,
 one line per day appended to `LOGDIR/soak.log`, scored against the pass condition ruled on the
 issue (one boot, restart counts and start times flat, every container running and — except
-`xmrig-proxy`, #1098 — healthy, at most the probe's own login). `--start` writes the day-0
-baseline; `--self-test` proves the verdict over canned readings without a box. Run it from a
-cron line on the build host, never from a resident session.
+`xmrig-proxy`, #1098 — healthy, exactly the probe's own login since the previous read). Each
+read records the journal cursor it reached in `LOGDIR/ssh.cursor`, and the next read counts logins
+from there, so nothing falls between two days and nothing is counted twice; a count of 0 fails
+naming the instrument, since the probe's own login must be there. `--start` writes the day-0
+baseline — its own line reads `window=25h` and carries a rule-4 FAIL from the setup logins, so day
+0 is the baseline, not a soak day. `--self-test` proves the verdict over canned readings without a
+box. Run it from a cron line on the build host, never from a resident session.

--- a/tests/os/README.md
+++ b/tests/os/README.md
@@ -96,5 +96,10 @@ read records the journal cursor it reached in `LOGDIR/ssh.cursor`, and the next 
 from there, so nothing falls between two days and nothing is counted twice; a count of 0 fails
 naming the instrument, since the probe's own login must be there. `--start` writes the day-0
 baseline — its own line reads `window=25h` and carries a rule-4 FAIL from the setup logins, so day
-0 is the baseline, not a soak day. `--self-test` proves the verdict over canned readings without a
-box. Run it from a cron line on the build host, never from a resident session.
+0 is the baseline, not a soak day. Only `--start` writes `day0.env`; a cron read never does, so a
+restart in the window's first hours can never be absorbed into the baseline it is scored against.
+Every line carries `read=N`, its `soak.log` line number, because the first cron read lands under
+24 h after `--start` and shares `day=0` with the baseline line; each run's raw readings are kept as
+`LOGDIR/readN.env`. `--self-test` proves the verdict over canned readings, then drives the script
+three times through a stubbed `ssh` to prove the baseline survives a cron read, without a box. Run
+it from a cron line on the build host, never from a resident session.

--- a/tests/os/soak-probe.sh
+++ b/tests/os/soak-probe.sh
@@ -20,16 +20,41 @@
 #                       moves only the second.
 #   3 all running     — every day-0 container is `running`; health asserted for all EXCEPT
 #                       xmrig-proxy, whose healthcheck is the product defect #1098 (excluded BY
-#                       NAME; it must still be running with rules 1-2 holding).
-#   4 no intervention — `journalctl -m -u ssh` counts at most ONE `Accepted` in the last 25 h
-#                       (this probe's own login) and `last` shows no interactive session; rule 2's
-#                       StartedAt covers hand-run container verbs. `last` is recorded because the
-#                       ruling names it, and it is a NULL instrument on the bench (no wtmp: it read
-#                       0 with 22 logins in the journal) — the journal count is the one that fires.
+#                       NAME; it must still be running with rules 1-2 holding). The set is DAY 0's:
+#                       a container that appears later is outside rule 3 by decision — rule 4
+#                       covers the only route by which one could be started.
+#   4 no intervention — `journalctl -m -u ssh` counts EXACTLY ONE `Accepted` since the previous
+#                       probe's read: this probe's own login. The count starts at the journal
+#                       CURSOR the previous read recorded (LOGDIR/ssh.cursor, passed to the remote
+#                       command as its one named input), so there is no window edge to straddle
+#                       and no clock on either side to trust. With no cursor (day 0, or the file
+#                       missing) it falls back to the last 25 h and the line says `window=25h`, so
+#                       day 0's line carries a rule-4 FAIL from the setup logins: it is the
+#                       baseline, not a soak day. A count of 0 FAILS naming the instrument
+#                       (`ssh-journal-blind`): the probe's own login is a positive control the
+#                       reading must hold, so 0 means the journal could not be read (cursor
+#                       journal split, journald down) — never a quiet day. A cursor names one
+#                       entry in one journal file, and a cursor that no longer resolves (journal
+#                       vacuumed or reset, box re-flashed) is loud either way, measured both ways
+#                       on 2026-09-03: the build host's journalctl refuses the seek (count 0,
+#                       `ssh-journal-blind`), the box's seeks to the START and counts every login
+#                       on record (457) — a day that fails rule 1 as well, which is the right
+#                       answer for it. The read then records a fresh cursor, so the next day
+#                       scores normally. journald
+#                       writes asynchronously, so a 0 or a 2 on a live box is a rare LOUD flake
+#                       to look at, not a silent pass. `last` shows no interactive session; rule
+#                       2's StartedAt covers hand-run container verbs. `last` is recorded because
+#                       the ruling names it, and it is a NULL instrument on the bench (no wtmp: it
+#                       read 0 with 22 logins in the journal) — the journal count is the one that
+#                       fires.
 #   5 chain recorded  — monerod height / synchronized / peers are RECORDED (a stall is visible)
 #                       and never gate. Tari is recorded by container state only: the box has no
 #                       gRPC client, so its height is not read — stated, not skipped silently.
-# A day whose line is missing, or whose SSH read failed, is a FAIL by the ruling's own terms.
+# A day whose line is missing, or whose SSH read failed, is a FAIL by the ruling's own terms; a
+# failed read keeps the previous cursor, so the next good day also counts the failed day's login.
+# The session skips host-key checking on purpose: the box regenerates its host key on every
+# provisioning (#1659's churn) and the probe is read-only on a bench LAN, so a pinned key would
+# only turn each re-flash into a READ-FAILED day.
 set -uo pipefail
 
 KEY="${PITHEAD_SOAK_KEY:-$HOME/.ssh/pithead-os-test}"
@@ -37,9 +62,9 @@ EXCLUDED_HEALTH="xmrig-proxy"
 
 # The one remote command. Read-only by construction: every line is a read, and the .env is
 # consulted for monerod's RPC credentials without ever printing them.
-read_box() { # $1 = host; prints key=value lines
+read_box() { # $1 = host, $2 = previous read's journal cursor or empty; prints key=value lines
     timeout 120 ssh -i "$KEY" -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "root@$1" 'bash -s' <<'REMOTE'
+        -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "root@$1" "SOAK_CURSOR='$2' bash -s" <<'REMOTE'
 set -u
 printf 'btime=%s\n' "$(awk '/^btime/{print $2}' /proc/stat)"
 printf 'jdirs=%s\n' "$(ls /var/log/journal 2>/dev/null | wc -l)"
@@ -50,7 +75,14 @@ printf 'rauc=%s\n' "$(rauc status --output-format=shell 2>/dev/null | awk -F= '/
 for c in $(podman ps -aq 2>/dev/null); do
     podman inspect -f 'container={{.Name}}|{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.State.StartedAt}}' "$c" 2>/dev/null
 done
-printf 'ssh_accepted_25h=%s\n' "$(journalctl -m -u ssh --since '-25h' --no-pager -q 2>/dev/null | grep -c 'Accepted ')"
+if [ -n "${SOAK_CURSOR:-}" ]; then
+    printf 'ssh_window=cursor\n'
+    printf 'ssh_accepted=%s\n' "$(journalctl -m -u ssh --after-cursor="$SOAK_CURSOR" --no-pager -q 2>/dev/null | grep -c 'Accepted ')"
+else
+    printf 'ssh_window=25h\n'
+    printf 'ssh_accepted=%s\n' "$(journalctl -m -u ssh --since '-25h' --no-pager -q 2>/dev/null | grep -c 'Accepted ')"
+fi
+printf 'ssh_cursor=%s\n' "$(journalctl -m -u ssh -n1 --no-pager -q -o cat --show-cursor 2>/dev/null | sed -n 's/^-- cursor: //p')"
 printf 'last_sessions=%s\n' "$(last -F 2>/dev/null | grep -v -c -E '^(reboot|wtmp|$)')"
 env_get() { sed -n "s/^$1=//p" /data/pithead/.env 2>/dev/null | head -1 | tr -d '"'; }
 mu=$(env_get MONERO_NODE_USERNAME); mp=$(env_get MONERO_NODE_PASSWORD); murl=$(env_get MONERO_RPC_URL); [ -n "$murl" ] || murl=http://127.0.0.1:18081
@@ -64,12 +96,12 @@ REMOTE
 # measured today FAILS, so an empty reading can never pass.
 soak_day_verdict() {
     local base="$1" today="$2" fails="" b t
-    kv() { printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1; }
-    b=$(kv "$base" btime)
-    t=$(kv "$today" btime)
+    rd() { printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1; } # a reading, not the top-level kv
+    b=$(rd "$base" btime)
+    t=$(rd "$today" btime)
     { [ -n "$b" ] && [ "$b" = "$t" ]; } || fails="$fails 1:boot(btime $b->${t:-?})"
-    b=$(kv "$base" jdirs)
-    t=$(kv "$today" jdirs)
+    b=$(rd "$base" jdirs)
+    t=$(rd "$today" jdirs)
     { [ -n "$t" ] && [ "${t:-0}" -le "${b:-0}" ]; } 2>/dev/null || fails="$fails 1:journal-dirs($b->${t:-?})"
     local name brc bstarted tstate trc thealth tstarted tline
     while IFS='|' read -r name _ brc _ bstarted; do
@@ -85,9 +117,14 @@ soak_day_verdict() {
         [ "$tstarted" = "$bstarted" ] || fails="$fails 2:$name-started-anew"
         if [ "$name" != "$EXCLUDED_HEALTH" ] && [ "$thealth" != none ] && [ "$thealth" != healthy ]; then fails="$fails 3:$name-$thealth"; fi
     done < <(printf '%s\n' "$base" | sed -n 's/^container=//p')
-    t=$(kv "$today" ssh_accepted_25h)
-    { [ -n "$t" ] && [ "$t" -le 1 ]; } 2>/dev/null || fails="$fails 4:ssh-accepted(${t:-?})"
-    t=$(kv "$today" last_sessions)
+    t=$(rd "$today" ssh_accepted)
+    case "$t" in
+    '' | *[!0-9]*) fails="$fails 4:ssh-accepted(${t:-?})" ;;
+    0) fails="$fails 4:ssh-journal-blind(0)" ;; # the probe's own login is missing: the instrument, not the day
+    1) ;;
+    *) fails="$fails 4:ssh-accepted($t)" ;;
+    esac
+    t=$(rd "$today" last_sessions)
     { [ -n "$t" ] && [ "$t" -eq 0 ]; } 2>/dev/null || fails="$fails 4:last-sessions(${t:-?})"
     if [ -z "$fails" ]; then
         echo "VERDICT=PASS"
@@ -99,7 +136,7 @@ soak_day_verdict() {
 
 self_test() {
     local base today out
-    base=$'btime=100\njdirs=1\ncontainer=monerod|running|0|healthy|2026-09-03T06:00:00Z\ncontainer=xmrig-proxy|running|0|unhealthy|2026-09-03T06:00:00Z\nssh_accepted_25h=1\nlast_sessions=0'
+    base=$'btime=100\njdirs=1\ncontainer=monerod|running|0|healthy|2026-09-03T06:00:00Z\ncontainer=xmrig-proxy|running|0|unhealthy|2026-09-03T06:00:00Z\nssh_window=cursor\nssh_accepted=1\nlast_sessions=0\nmonero=h:100 sync:true peers:1/2'
     n=0
     f=0
     chk() { if [ "$2" = "$3" ]; then n=$((n + 1)); else
@@ -134,9 +171,21 @@ self_test() {
     today=$(printf '%s\n' "$base" | grep -v '^container=monerod')
     out=$(soak_day_verdict "$base" "$today")
     chk "a day-0 container missing from today fails rule 3" "$?" 1
-    today=${base/ssh_accepted_25h=1/ssh_accepted_25h=2}
+    today=${base/ssh_accepted=1/ssh_accepted=2}
     out=$(soak_day_verdict "$base" "$today")
     chk "a second SSH login fails rule 4" "$?" 1
+    chk "  …named" "${out#*fails=}" "4:ssh-accepted(2)"
+    today=${base/ssh_accepted=1/ssh_accepted=0}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "zero logins fails rule 4 naming the instrument (the probe's own login is the positive control)" "$?" 1
+    chk "  …named" "${out#*fails=}" "4:ssh-journal-blind(0)"
+    today=$(printf '%s\n' "$base" | grep -v '^ssh_accepted=')
+    out=$(soak_day_verdict "$base" "$today")
+    chk "no ssh reading at all fails rule 4" "$?" 1
+    chk "  …named" "${out#*fails=}" "4:ssh-accepted(?)"
+    today=${base/monero=h:100 sync:true peers:1\/2/monero=h:50 sync:false peers:0\/0}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a changed chain reading still passes (rule 5 records, never gates)" "$?" 0
     today=${base/last_sessions=0/last_sessions=1}
     out=$(soak_day_verdict "$base" "$today")
     chk "an interactive session fails rule 4" "$?" 1
@@ -152,17 +201,28 @@ case "${1:-}" in
     exit $?
     ;;
 '' | -h | --help)
-    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+    awk 'NR > 1 && /^set -/ { exit } NR > 1 { sub(/^# ?/, ""); print }' "$0"
     exit 2
     ;;
 esac
+if [ -z "${2:-}" ]; then # HOST without LOGDIR would mkdir "" and write day0.env at /
+    echo "usage: $0 HOST LOGDIR [--start] | --self-test" >&2
+    exit 2
+fi
 HOST="$1"
 LOGDIR="$2"
 MODE="${3:-}"
 mkdir -p "$LOGDIR"
 chmod 700 "$LOGDIR"
 now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-today=$(read_box "$HOST")
+# The previous read's journal cursor is the one input the fixed remote command takes. --start
+# opens a new window and ignores any cursor a previous window left behind.
+cursor=""
+if [ "$MODE" != "--start" ] && [ -s "$LOGDIR/ssh.cursor" ]; then
+    cursor=$(head -1 "$LOGDIR/ssh.cursor")
+    case "$cursor" in *[!A-Za-z0-9\;=]*) cursor="" ;; esac # anything else never came from journalctl
+fi
+today=$(read_box "$HOST" "$cursor")
 rc=$?
 if [ "$rc" -ne 0 ] || [ -z "$today" ]; then
     printf '%s day=? READ-FAILED ssh rc=%s VERDICT=FAIL fails=read\n' "$now" "$rc" | tee -a "$LOGDIR/soak.log"
@@ -182,8 +242,9 @@ running=$(printf '%s\n' "$today" | grep -c '^container=.*|running|')
 total=$(printf '%s\n' "$today" | grep -c '^container=')
 unhealthy=$(printf '%s\n' "$today" | sed -n 's/^container=\([^|]*\)|[^|]*|[^|]*|unhealthy|.*/\1/p' | tr '\n' ',' | sed 's/,$//')
 verdict=$(soak_day_verdict "$(cat "$LOGDIR/day0.env")" "$today")
-printf '%s day=%s btime=%s jdirs=%s up=%ss running=%s/%s unhealthy=%s ssh_accepted_25h=%s last=%s monero=%s rauc=%s data_free_mb=%s load=%s %s\n' \
-    "$now" "$day" "$(kv btime)" "$(kv jdirs)" "$(kv uptime_s)" "$running" "$total" "${unhealthy:-none}" "$(kv ssh_accepted_25h)" "$(kv last_sessions)" "$(kv monero)" "$(kv rauc)" "$(kv data_free_mb)" "$(kv load)" "$verdict" |
+printf '%s day=%s btime=%s jdirs=%s up=%ss running=%s/%s unhealthy=%s ssh_accepted=%s window=%s last=%s monero=%s rauc=%s data_free_mb=%s load=%s %s\n' \
+    "$now" "$day" "$(kv btime)" "$(kv jdirs)" "$(kv uptime_s)" "$running" "$total" "${unhealthy:-none}" "$(kv ssh_accepted)" "$(kv ssh_window)" "$(kv last_sessions)" "$(kv monero)" "$(kv rauc)" "$(kv data_free_mb)" "$(kv load)" "$verdict" |
     tee -a "$LOGDIR/soak.log"
 printf '%s\n' "$today" >"$LOGDIR/day$day.env"
+[ -n "$(kv ssh_cursor)" ] && printf '%s\n' "$(kv ssh_cursor)" >"$LOGDIR/ssh.cursor"
 case "$verdict" in VERDICT=PASS*) exit 0 ;; *) exit 1 ;; esac

--- a/tests/os/soak-probe.sh
+++ b/tests/os/soak-probe.sh
@@ -48,8 +48,13 @@
 #                       read 0 with 22 logins in the journal) — the journal count is the one that
 #                       fires.
 #   5 chain recorded  — monerod height / synchronized / peers are RECORDED (a stall is visible)
-#                       and never gate. Tari is recorded by container state only: the box has no
-#                       gRPC client, so its height is not read — stated, not skipped silently.
+#                       and never gate. The appliance's monerod RPC is RESTRICTED (measured
+#                       2026-09-03: `get_info` answers `restricted:true`, `get_connections` is
+#                       "Method not found"), and a restricted `get_info` zeroes the peer counts
+#                       and peer lists by design — so peers reads `restricted` there rather than
+#                       a 0/0 that is the instrument, not the node; height moving between days is
+#                       the stall signal. Tari is recorded by container state only: the box has
+#                       no gRPC client, so its height is not read — stated, not skipped silently.
 # A day whose line is missing, or whose SSH read failed, is a FAIL by the ruling's own terms; a
 # failed read keeps the previous cursor, so the next good day also counts the failed day's login.
 # The session skips host-key checking on purpose: the box regenerates its host key on every
@@ -87,7 +92,7 @@ printf 'last_sessions=%s\n' "$(last -F 2>/dev/null | grep -v -c -E '^(reboot|wtm
 env_get() { sed -n "s/^$1=//p" /data/pithead/.env 2>/dev/null | head -1 | tr -d '"'; }
 mu=$(env_get MONERO_NODE_USERNAME); mp=$(env_get MONERO_NODE_PASSWORD); murl=$(env_get MONERO_RPC_URL); [ -n "$murl" ] || murl=http://127.0.0.1:18081
 if [ -n "$mu" ]; then body=$(curl -fsS --max-time 8 --digest -u "$mu:$mp" "$murl/get_info" 2>/dev/null); else body=$(curl -fsS --max-time 8 "$murl/get_info" 2>/dev/null); fi
-printf 'monero=%s\n' "$(printf '%s' "${body:-null}" | jq -r '"h:\(.height // "?") sync:\(.synchronized // "?") peers:\(.incoming_connections_count // "?")/\(.outgoing_connections_count // "?")"' 2>/dev/null || echo 'h:? sync:? peers:?/?')"
+printf 'monero=%s\n' "$(printf '%s' "${body:-null}" | jq -r '"h:\(.height // "?") sync:\(.synchronized // "?") peers:\(if .restricted == true then "restricted" else "\(.incoming_connections_count // "?")/\(.outgoing_connections_count // "?")" end)"' 2>/dev/null || echo 'h:? sync:? peers:?/?')"
 REMOTE
 }
 

--- a/tests/os/soak-probe.sh
+++ b/tests/os/soak-probe.sh
@@ -2,8 +2,13 @@
 # The 7-day unattended soak's daily probe (#1652). Runs on the build host, never on the box, and
 # reads the box over ONE non-interactive SSH session whose remote command is fixed below, so a
 # reader can audit exactly what the only permitted login did. It appends one line per run to
-# LOGDIR/soak.log, keeps the day-0 baseline in LOGDIR/day0.env, and scores the day against the
-# pass condition ruled on #1652 — a missing measurement is a FAIL, never a skip.
+# LOGDIR/soak.log, labelled `read=N` by the line number it lands on (the one label no two reads
+# can share; `day=` is information, and the first cron read lands under 24 h after --start, so it
+# shares day=0 with the baseline line), keeps each run's raw readings in LOGDIR/readN.env, and
+# scores the run against the day-0 baseline in LOGDIR/day0.env, which ONLY --start writes: a
+# cron read never touches it, so a restart in the window's first hours can never be absorbed
+# into the baseline it is scored against. The pass condition is the one ruled on #1652 — a
+# missing measurement is a FAIL, never a skip.
 #
 #   tests/os/soak-probe.sh HOST LOGDIR --start     # day 0: write the baseline, open the window
 #   tests/os/soak-probe.sh HOST LOGDIR             # every later day (a cron line on the build host)
@@ -196,8 +201,40 @@ self_test() {
     chk "an interactive session fails rule 4" "$?" 1
     out=$(soak_day_verdict "$base" "")
     chk "an empty reading FAILS every rule, never passes" "$?" 1
+    self_test_driver "$base"
     echo "soak-probe self-test: $n ok, $f failed"
     [ "$f" -eq 0 ]
+}
+
+# The driver, through a stubbed `ssh` that prints a canned reading: the pure verdict above cannot
+# see what the driver does with LOGDIR, and that is where the first cron read used to overwrite
+# day0.env and every later day passed against the moved baseline (#1667 F1). Three runs land in
+# the same day=0, which is the shape the label and the write-once baseline exist for.
+self_test_driver() { # $1 = a canned reading that passes against itself
+    local tmp out
+    tmp=$(mktemp -d) || return 1
+    mkdir -p "$tmp/bin"
+    printf '%s\n' '#!/usr/bin/env bash' 'cat >/dev/null' 'printf "%s\n" "${@: -1}" >>"$SOAK_STUB_ARGS"' 'cat "$SOAK_STUB_READING"' >"$tmp/bin/ssh"
+    chmod +x "$tmp/bin/ssh"
+    printf '%s\nssh_cursor=s=1;i=1\n' "$1" >"$tmp/a"
+    printf '%s\nssh_cursor=s=2;i=2\n' "${1/monerod|running|0|healthy/monerod|running|1|healthy}" >"$tmp/b"
+    drv() { PATH="$tmp/bin:$PATH" SOAK_STUB_READING="$tmp/$1" SOAK_STUB_ARGS="$tmp/args" bash "$0" stub-host "$tmp/log" ${2:-}; }
+    drv a --start >/dev/null
+    chk "driver: --start passes against its own reading" "$?" 0
+    cmp -s "$tmp/a" "$tmp/log/day0.env"
+    chk "driver: day0.env is the --start reading" "$?" 0
+    drv b >/dev/null
+    chk "driver: a restart on the first cron read (still day=0) fails rule 2" "$?" 1
+    cmp -s "$tmp/a" "$tmp/log/day0.env"
+    chk "driver: day0.env is byte-identical after that read (write-once)" "$?" 0
+    out=$(drv b)
+    chk "driver: the same reading again STILL fails — the baseline never absorbed the restart" "$?" 1
+    chk "  …named" "${out##*fails=}" "2:monerod-restarts(0->1)"
+    chk "driver: three lines, three distinct read= labels" "$(sed -n 's/^[^ ]* read=\([0-9]*\) .*/\1/p' "$tmp/log/soak.log" | sort -u | tr '\n' ' ')" "1 2 3 "
+    cmp -s "$tmp/b" "$tmp/log/read3.env"
+    chk "driver: read3.env holds the third read's raw readings" "$?" 0
+    chk "driver: the second read was handed the first read's cursor" "$(sed -n 2p "$tmp/args")" "SOAK_CURSOR='s=1;i=1' bash -s"
+    rm -rf "$tmp"
 }
 
 case "${1:-}" in
@@ -220,6 +257,8 @@ MODE="${3:-}"
 mkdir -p "$LOGDIR"
 chmod 700 "$LOGDIR"
 now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+# This run's label is the soak.log line number it lands on — day= is information, not identity.
+line=$(($([ -f "$LOGDIR/soak.log" ] && wc -l <"$LOGDIR/soak.log" || echo 0) + 1))
 # The previous read's journal cursor is the one input the fixed remote command takes. --start
 # opens a new window and ignores any cursor a previous window left behind.
 cursor=""
@@ -230,15 +269,15 @@ fi
 today=$(read_box "$HOST" "$cursor")
 rc=$?
 if [ "$rc" -ne 0 ] || [ -z "$today" ]; then
-    printf '%s day=? READ-FAILED ssh rc=%s VERDICT=FAIL fails=read\n' "$now" "$rc" | tee -a "$LOGDIR/soak.log"
+    printf '%s read=%s day=? READ-FAILED ssh rc=%s VERDICT=FAIL fails=read\n' "$now" "$line" "$rc" | tee -a "$LOGDIR/soak.log"
     exit 1
 fi
-if [ "$MODE" = "--start" ]; then
+if [ "$MODE" = "--start" ]; then # the ONLY writer of day0.env
     printf '%s\n' "$today" >"$LOGDIR/day0.env"
     printf '%s\n' "$now" >"$LOGDIR/started"
 fi
 [ -s "$LOGDIR/day0.env" ] || {
-    printf '%s day=? NO-BASELINE VERDICT=FAIL fails=baseline (run with --start first)\n' "$now" | tee -a "$LOGDIR/soak.log"
+    printf '%s read=%s day=? NO-BASELINE VERDICT=FAIL fails=baseline (run with --start first)\n' "$now" "$line" | tee -a "$LOGDIR/soak.log"
     exit 1
 }
 day=$((($(date -u +%s) - $(date -u -d "$(cat "$LOGDIR/started")" +%s)) / 86400))
@@ -247,9 +286,9 @@ running=$(printf '%s\n' "$today" | grep -c '^container=.*|running|')
 total=$(printf '%s\n' "$today" | grep -c '^container=')
 unhealthy=$(printf '%s\n' "$today" | sed -n 's/^container=\([^|]*\)|[^|]*|[^|]*|unhealthy|.*/\1/p' | tr '\n' ',' | sed 's/,$//')
 verdict=$(soak_day_verdict "$(cat "$LOGDIR/day0.env")" "$today")
-printf '%s day=%s btime=%s jdirs=%s up=%ss running=%s/%s unhealthy=%s ssh_accepted=%s window=%s last=%s monero=%s rauc=%s data_free_mb=%s load=%s %s\n' \
-    "$now" "$day" "$(kv btime)" "$(kv jdirs)" "$(kv uptime_s)" "$running" "$total" "${unhealthy:-none}" "$(kv ssh_accepted)" "$(kv ssh_window)" "$(kv last_sessions)" "$(kv monero)" "$(kv rauc)" "$(kv data_free_mb)" "$(kv load)" "$verdict" |
+printf '%s read=%s day=%s btime=%s jdirs=%s up=%ss running=%s/%s unhealthy=%s ssh_accepted=%s window=%s last=%s monero=%s rauc=%s data_free_mb=%s load=%s %s\n' \
+    "$now" "$line" "$day" "$(kv btime)" "$(kv jdirs)" "$(kv uptime_s)" "$running" "$total" "${unhealthy:-none}" "$(kv ssh_accepted)" "$(kv ssh_window)" "$(kv last_sessions)" "$(kv monero)" "$(kv rauc)" "$(kv data_free_mb)" "$(kv load)" "$verdict" |
     tee -a "$LOGDIR/soak.log"
-printf '%s\n' "$today" >"$LOGDIR/day$day.env"
+printf '%s\n' "$today" >"$LOGDIR/read$line.env"
 [ -n "$(kv ssh_cursor)" ] && printf '%s\n' "$(kv ssh_cursor)" >"$LOGDIR/ssh.cursor"
 case "$verdict" in VERDICT=PASS*) exit 0 ;; *) exit 1 ;; esac

--- a/tests/os/soak-probe.sh
+++ b/tests/os/soak-probe.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# The 7-day unattended soak's daily probe (#1652). Runs on the build host, never on the box, and
+# reads the box over ONE non-interactive SSH session whose remote command is fixed below, so a
+# reader can audit exactly what the only permitted login did. It appends one line per run to
+# LOGDIR/soak.log, keeps the day-0 baseline in LOGDIR/day0.env, and scores the day against the
+# pass condition ruled on #1652 — a missing measurement is a FAIL, never a skip.
+#
+#   tests/os/soak-probe.sh HOST LOGDIR --start     # day 0: write the baseline, open the window
+#   tests/os/soak-probe.sh HOST LOGDIR             # every later day (a cron line on the build host)
+#   tests/os/soak-probe.sh --self-test             # the verdict over canned readings, no box
+#
+#   0 6 * * *  $HOME/dev/<worktree>/tests/os/soak-probe.sh <ipv4> $HOME/soak-1652 >>$HOME/soak-1652/cron.log 2>&1
+#
+# The rules, and the instrument each one reads (#1659 made plain `journalctl -b` unusable on the
+# bench for the whole boot, so nothing here depends on it):
+#   1 one boot        — /proc/stat btime equals day 0's; the journal-directory count is the
+#                       secondary counter (one directory per boot until #1659 lands).
+#   2 restarts flat   — every container's RestartCount equals day 0's, AND its StartedAt is day
+#                       0's: a supervisor restart moves the first, a hand `podman stop/start`
+#                       moves only the second.
+#   3 all running     — every day-0 container is `running`; health asserted for all EXCEPT
+#                       xmrig-proxy, whose healthcheck is the product defect #1098 (excluded BY
+#                       NAME; it must still be running with rules 1-2 holding).
+#   4 no intervention — `journalctl -m -u ssh` counts at most ONE `Accepted` in the last 25 h
+#                       (this probe's own login) and `last` shows no interactive session; rule 2's
+#                       StartedAt covers hand-run container verbs. `last` is recorded because the
+#                       ruling names it, and it is a NULL instrument on the bench (no wtmp: it read
+#                       0 with 22 logins in the journal) — the journal count is the one that fires.
+#   5 chain recorded  — monerod height / synchronized / peers are RECORDED (a stall is visible)
+#                       and never gate. Tari is recorded by container state only: the box has no
+#                       gRPC client, so its height is not read — stated, not skipped silently.
+# A day whose line is missing, or whose SSH read failed, is a FAIL by the ruling's own terms.
+set -uo pipefail
+
+KEY="${PITHEAD_SOAK_KEY:-$HOME/.ssh/pithead-os-test}"
+EXCLUDED_HEALTH="xmrig-proxy"
+
+# The one remote command. Read-only by construction: every line is a read, and the .env is
+# consulted for monerod's RPC credentials without ever printing them.
+read_box() { # $1 = host; prints key=value lines
+    timeout 120 ssh -i "$KEY" -o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR "root@$1" 'bash -s' <<'REMOTE'
+set -u
+printf 'btime=%s\n' "$(awk '/^btime/{print $2}' /proc/stat)"
+printf 'jdirs=%s\n' "$(ls /var/log/journal 2>/dev/null | wc -l)"
+printf 'uptime_s=%s\n' "$(awk '{print int($1)}' /proc/uptime)"
+printf 'load=%s\n' "$(cut -d' ' -f1-3 /proc/loadavg | tr ' ' ',')"
+printf 'data_free_mb=%s\n' "$(df -Pk /data 2>/dev/null | awk 'NR==2{print int($4/1024)}')"
+printf 'rauc=%s\n' "$(rauc status --output-format=shell 2>/dev/null | awk -F= '/^RAUC_SYSTEM_BOOTED_BOOTNAME=/{b=$2} /^RAUC_BOOT_PRIMARY=/{p=$2} END{gsub(/\x27/,"",b); gsub(/\x27/,"",p); printf "%s/%s", b, p}')"
+for c in $(podman ps -aq 2>/dev/null); do
+    podman inspect -f 'container={{.Name}}|{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}|{{.State.StartedAt}}' "$c" 2>/dev/null
+done
+printf 'ssh_accepted_25h=%s\n' "$(journalctl -m -u ssh --since '-25h' --no-pager -q 2>/dev/null | grep -c 'Accepted ')"
+printf 'last_sessions=%s\n' "$(last -F 2>/dev/null | grep -v -c -E '^(reboot|wtmp|$)')"
+env_get() { sed -n "s/^$1=//p" /data/pithead/.env 2>/dev/null | head -1 | tr -d '"'; }
+mu=$(env_get MONERO_NODE_USERNAME); mp=$(env_get MONERO_NODE_PASSWORD); murl=$(env_get MONERO_RPC_URL); [ -n "$murl" ] || murl=http://127.0.0.1:18081
+if [ -n "$mu" ]; then body=$(curl -fsS --max-time 8 --digest -u "$mu:$mp" "$murl/get_info" 2>/dev/null); else body=$(curl -fsS --max-time 8 "$murl/get_info" 2>/dev/null); fi
+printf 'monero=%s\n' "$(printf '%s' "${body:-null}" | jq -r '"h:\(.height // "?") sync:\(.synchronized // "?") peers:\(.incoming_connections_count // "?")/\(.outgoing_connections_count // "?")"' 2>/dev/null || echo 'h:? sync:? peers:?/?')"
+REMOTE
+}
+
+# Pure over the readings: $1 = day-0 baseline (key=value lines), $2 = today's readings. Prints
+# `VERDICT=PASS|FAIL fails=<rule list>` on stdout; exit 0 on PASS. Every rule that cannot be
+# measured today FAILS, so an empty reading can never pass.
+soak_day_verdict() {
+    local base="$1" today="$2" fails="" b t
+    kv() { printf '%s\n' "$1" | sed -n "s/^$2=//p" | head -1; }
+    b=$(kv "$base" btime)
+    t=$(kv "$today" btime)
+    { [ -n "$b" ] && [ "$b" = "$t" ]; } || fails="$fails 1:boot(btime $b->${t:-?})"
+    b=$(kv "$base" jdirs)
+    t=$(kv "$today" jdirs)
+    { [ -n "$t" ] && [ "${t:-0}" -le "${b:-0}" ]; } 2>/dev/null || fails="$fails 1:journal-dirs($b->${t:-?})"
+    local name brc bstarted tstate trc thealth tstarted tline
+    while IFS='|' read -r name _ brc _ bstarted; do
+        [ -n "$name" ] || continue
+        tline=$(printf '%s\n' "$today" | sed -n "s/^container=$name|//p" | head -1)
+        if [ -z "$tline" ]; then
+            fails="$fails 3:$name-missing"
+            continue
+        fi
+        IFS='|' read -r tstate trc thealth tstarted <<<"$tline"
+        [ "$tstate" = running ] || fails="$fails 3:$name-$tstate"
+        [ "$trc" = "$brc" ] || fails="$fails 2:$name-restarts($brc->$trc)"
+        [ "$tstarted" = "$bstarted" ] || fails="$fails 2:$name-started-anew"
+        if [ "$name" != "$EXCLUDED_HEALTH" ] && [ "$thealth" != none ] && [ "$thealth" != healthy ]; then fails="$fails 3:$name-$thealth"; fi
+    done < <(printf '%s\n' "$base" | sed -n 's/^container=//p')
+    t=$(kv "$today" ssh_accepted_25h)
+    { [ -n "$t" ] && [ "$t" -le 1 ]; } 2>/dev/null || fails="$fails 4:ssh-accepted(${t:-?})"
+    t=$(kv "$today" last_sessions)
+    { [ -n "$t" ] && [ "$t" -eq 0 ]; } 2>/dev/null || fails="$fails 4:last-sessions(${t:-?})"
+    if [ -z "$fails" ]; then
+        echo "VERDICT=PASS"
+        return 0
+    fi
+    echo "VERDICT=FAIL fails=${fails# }"
+    return 1
+}
+
+self_test() {
+    local base today out
+    base=$'btime=100\njdirs=1\ncontainer=monerod|running|0|healthy|2026-09-03T06:00:00Z\ncontainer=xmrig-proxy|running|0|unhealthy|2026-09-03T06:00:00Z\nssh_accepted_25h=1\nlast_sessions=0'
+    n=0
+    f=0
+    chk() { if [ "$2" = "$3" ]; then n=$((n + 1)); else
+        f=$((f + 1))
+        echo "  ✗ $1: [$2] wanted [$3]"
+    fi; }
+    out=$(soak_day_verdict "$base" "$base")
+    chk "identical day passes (xmrig-proxy unhealthy is excluded by name)" "$?" 0
+    today=${base/btime=100/btime=200}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a new btime fails rule 1" "$?" 1
+    chk "  …named" "${out#*fails=}" "1:boot(btime 100->200)"
+    today=${base/jdirs=1/jdirs=2}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a new journal directory fails rule 1" "$?" 1
+    today=${base/monerod|running|0|healthy/monerod|running|1|healthy}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a supervisor restart fails rule 2" "$?" 1
+    chk "  …named" "${out#*fails=}" "2:monerod-restarts(0->1)"
+    today=${base/monerod|running|0|healthy|2026-09-03T06:00:00Z/monerod|running|0|healthy|2026-09-04T06:00:00Z}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a hand stop/start (StartedAt moved, RestartCount not) fails rule 2" "$?" 1
+    today=${base/monerod|running|0|healthy/monerod|exited|0|none}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a container not running fails rule 3" "$?" 1
+    today=${base/monerod|running|0|healthy/monerod|running|0|unhealthy}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "monerod unhealthy fails rule 3 (only xmrig-proxy is excluded)" "$?" 1
+    today=${base/xmrig-proxy|running|0|unhealthy/xmrig-proxy|exited|0|unhealthy}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "xmrig-proxy NOT running still fails rule 3 (the exclusion is health only)" "$?" 1
+    today=$(printf '%s\n' "$base" | grep -v '^container=monerod')
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a day-0 container missing from today fails rule 3" "$?" 1
+    today=${base/ssh_accepted_25h=1/ssh_accepted_25h=2}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "a second SSH login fails rule 4" "$?" 1
+    today=${base/last_sessions=0/last_sessions=1}
+    out=$(soak_day_verdict "$base" "$today")
+    chk "an interactive session fails rule 4" "$?" 1
+    out=$(soak_day_verdict "$base" "")
+    chk "an empty reading FAILS every rule, never passes" "$?" 1
+    echo "soak-probe self-test: $n ok, $f failed"
+    [ "$f" -eq 0 ]
+}
+
+case "${1:-}" in
+--self-test)
+    self_test
+    exit $?
+    ;;
+'' | -h | --help)
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+    exit 2
+    ;;
+esac
+HOST="$1"
+LOGDIR="$2"
+MODE="${3:-}"
+mkdir -p "$LOGDIR"
+chmod 700 "$LOGDIR"
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+today=$(read_box "$HOST")
+rc=$?
+if [ "$rc" -ne 0 ] || [ -z "$today" ]; then
+    printf '%s day=? READ-FAILED ssh rc=%s VERDICT=FAIL fails=read\n' "$now" "$rc" | tee -a "$LOGDIR/soak.log"
+    exit 1
+fi
+if [ "$MODE" = "--start" ]; then
+    printf '%s\n' "$today" >"$LOGDIR/day0.env"
+    printf '%s\n' "$now" >"$LOGDIR/started"
+fi
+[ -s "$LOGDIR/day0.env" ] || {
+    printf '%s day=? NO-BASELINE VERDICT=FAIL fails=baseline (run with --start first)\n' "$now" | tee -a "$LOGDIR/soak.log"
+    exit 1
+}
+day=$((($(date -u +%s) - $(date -u -d "$(cat "$LOGDIR/started")" +%s)) / 86400))
+kv() { printf '%s\n' "$today" | sed -n "s/^$1=//p" | head -1; }
+running=$(printf '%s\n' "$today" | grep -c '^container=.*|running|')
+total=$(printf '%s\n' "$today" | grep -c '^container=')
+unhealthy=$(printf '%s\n' "$today" | sed -n 's/^container=\([^|]*\)|[^|]*|[^|]*|unhealthy|.*/\1/p' | tr '\n' ',' | sed 's/,$//')
+verdict=$(soak_day_verdict "$(cat "$LOGDIR/day0.env")" "$today")
+printf '%s day=%s btime=%s jdirs=%s up=%ss running=%s/%s unhealthy=%s ssh_accepted_25h=%s last=%s monero=%s rauc=%s data_free_mb=%s load=%s %s\n' \
+    "$now" "$day" "$(kv btime)" "$(kv jdirs)" "$(kv uptime_s)" "$running" "$total" "${unhealthy:-none}" "$(kv ssh_accepted_25h)" "$(kv last_sessions)" "$(kv monero)" "$(kv rauc)" "$(kv data_free_mb)" "$(kv load)" "$verdict" |
+    tee -a "$LOGDIR/soak.log"
+printf '%s\n' "$today" >"$LOGDIR/day$day.env"
+case "$verdict" in VERDICT=PASS*) exit 0 ;; *) exit 1 ;; esac


### PR DESCRIPTION
Part of #1652 (the instrument; the window itself opens when the operator's item 20 decision lands). Closing keywords are inert on `develop-v2`.

## What this is

The 7-day unattended soak had no instrument: nothing on or near the bench records a day, and the ruling on #1652 requires the pass condition to be *measured*, written before the run, with a missing measurement scored as a FAIL. `tests/os/soak-probe.sh HOST LOGDIR [--start]` is that instrument, and it deliberately lives in the tree so the one login the window permits is auditable line by line.

- **One non-interactive, read-only SSH session per day**, whose remote command is fixed in the script. It reads `.env` for monerod's RPC credentials and never prints them.
- **One line per day** appended to `LOGDIR/soak.log`, plus `day0.env` (the baseline — written by `--start` and by NOTHING else) and `readN.env` (each read's raw readings, N its `soak.log` line number; every line carries `read=N`, since the first cron read lands under 24 h after `--start` and shares `day=0` with the baseline line), all outside git.
- **Scored against the ruled rules**, each with its instrument named in the header:
  1. one boot — `/proc/stat` btime equals day 0's; journal-directory count as the secondary counter;
  2. restarts flat — every container's `RestartCount` **and** `StartedAt` equal day 0's (a supervisor restart moves the first; a hand `podman stop/start` moves only the second);
  3. all running — every day-0 container `running`; health asserted for all **except `xmrig-proxy`, excluded by name** (#1098), which must still be running with rules 1–2 holding;
  4. no intervention — EXACTLY one `Accepted` in `journalctl -m -u ssh` since the journal cursor the previous read recorded (the probe's own; 0 fails naming the instrument, `ssh-journal-blind`; no cursor falls back to the last 25 h and says `window=25h`), and `last` empty;
  5. chain recorded, never gating — monerod height / `synchronized` / peers on every line.
- **The verdict is a pure function over the readings** (`soak_day_verdict`), with a `--self-test` of 29 rows — 20 over the pure verdict and 9 over the DRIVER through a stubbed `ssh` (added for F1 of the second pass: the pure rows cannot see what the driver does with `LOGDIR`): an identical day passes; each rule fails on its own perturbation; a hand stop/start is caught by `StartedAt` alone; xmrig-proxy exited still fails; a day-0 container missing from today fails; **an empty reading fails every rule** rather than passing vacuously.

## What was RUN

| check | result |
|---|---|
| `--self-test` | 29 ok, 0 failed |
| **F1 (second pass) mutation controls** — restore the `day$day.env` write in a scratch copy; drop the `read=` label in another | 4 driver rows red (the third run prints `VERDICT=PASS`, the reported defect verbatim); 1 row red |
| `shellcheck --severity=warning`, `shfmt -i 4 -d`, budget gate, docs voice | rc 0 |
| **dry run against the bench, read-only, three times** (`--start` into a scratch dir, then a day-N read) | 8/8 running, `xmrig-proxy` unhealthy exactly as #1098 says, `RestartCount` 0 across the board, RAUC slot B, monerod synchronized at a live height |
| **rule 4 fired on the live box**: 22, then 23, then 24 `Accepted` in the last 25 h — the pre-flight reads of the last day, mine included | `VERDICT=FAIL fails=4:ssh-accepted(24)` — the instrument shown able to fail before the window opens |
| stderr carries no address (ssh's known-hosts warning suppressed with `LogLevel=ERROR`) | verified by substitution over stdout+stderr |

## Review record

- **First pass F1/F2** (cursor pass-through, rule-4 four-way case) — fixed at `3b45ab37`.
- **Second pass F1, blocking** — the first cron read computed `day=0` and overwrote `day0.env`, so a restart in the window's first hours showed on one discounted line and every later day passed against the moved baseline. Fixed at the current head: `day0.env` is written by `--start` only, raw readings go to `readN.env`, every line carries `read=N`, and the self-test drives the script three times through a stubbed `ssh` (all landing in `day=0`) asserting the baseline is byte-identical after a cron read and that the same restarted reading still fails on the third run.

## Two things the dry run found, stated rather than smoothed

- **`last` is a null instrument on this box.** It read 0 through all 24 logins (no wtmp). It is recorded because the ruling names it and the header says it cannot fire; the journal count is the rule-4 gate.
- **Rule 2's `StartedAt` already tells a story on the bench today**: six containers started 02:13Z (the pre-flash `pithead backup` cycles the stack) and `tor`+`monerod` at 03:16Z with `RestartCount` still 0 — a hand restart, not a supervisor one, which is exactly the case `RestartCount` alone would miss. Whatever it was, the window's day-0 baseline is taken *after* the flash, so it does not bleed in. Also on that line: monerod `peers:0/0` while `synchronized:true` — recorded, not judged; the probe never gates on the chain.

## Not done, named

- **Tari's height is not read** — the box has no gRPC client; its container state and health are. Said in the header.
- **No tier-1 case in `tests/stack/`** — the verdict's fixture proof is the script's own `--self-test` (the `failure-evidence.sh --self-test` shape), which needs no grant and runs anywhere.
- **The window is not open.** Nothing on the bench was written; the two scratch `--start` runs went to a temporary directory on the build host. Day 0 is the first run after the flashed image is up, from a cron line, never from a resident session.

## Over-engineering pass, by hand

The ponytail gate reads the branch from this lane's pinned shell cwd (a different worktree on a dead branch) — disclosed; the pass was done against this diff.

- **A systemd timer on the box** instead of a cron line on the build host: rejected — it would put a writer on the box inside the window and make the probe part of the artifact under test.
- **`pithead doctor --json` as the daily read**: rejected — it is a verb on the box and takes tens of seconds of probes; `podman inspect` and one `get_info` answer the ruled rules directly and are cheaper to audit.
- **Dropping `last`**: available, rejected — the ruling names it; keeping a null instrument *labelled* null is better than a reader wondering why rule 4 has one leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkgFiBFkN16zgVjvKRH8Kw

