### PR TITLE
fix(os): #1414 verify-image compares the baked RigForge ref to the pin, not just its existence

### DIFF
--- a/tests/integration/selftest-verify-image-ref.sh
+++ b/tests/integration/selftest-verify-image-ref.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Self-test for verify-image.sh's baked-RigForge-ref check (#1414).
+#
+# The check it covers asserted only that a `ref=` line EXISTED, so it was green for the whole
+# time the appliance shipped a pin two rigforge releases stale. These cases drive the real
+# comparison over a synthetic root tree — no image, no loop mount, no root, no bench.
+#
+# It lives here rather than beside verify-image.sh because that file is 398 lines against the
+# 400-line target, and crossing it would force a docs/dev/file-budget.tsv entry.
+#
+# Run: tests/integration/selftest-verify-image-ref.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+# Sourcing verify-image.sh defines rigforge_ref_matches and runs nothing (its sourced-guard).
+# Driving the SHIPPED function is the point: a copy of the comparison here could only prove the
+# test agrees with itself.
+# shellcheck source=tests/os/verify-image.sh
+source "$HERE/../os/verify-image.sh"
+
+echo "== verify-image: the baked rigforge ref must EQUAL the pin, not merely exist (#1414) =="
+
+# The instrument has to be alive before any of its verdicts mean anything: if the source above
+# silently failed, every case below would call a missing function and report the same rc.
+if declare -F rigforge_ref_matches >/dev/null; then
+    it_pass "rigforge_ref_matches is defined (verify-image.sh sourced without running)"
+else
+    it_fail "rigforge_ref_matches is defined" "not defined — the sourced-guard or the source path moved"
+    echo "selftest-verify-image-ref: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+PIN=4ce29b3daf063fd1b45e050649e93aa9592618e1
+OLD=1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d
+
+# The fixture Dockerfile carries the same shape as the real one: prose lines that MENTION
+# RIGFORGE_REF sit above the single `ARG RIGFORGE_REF=` that actually pins it. os/rootfs/Dockerfile
+# has four such mentions, so an unanchored read would take a comment for the pin.
+mkdockerfile() { # <path> <pinned-ref>
+    {
+        echo "# RIGFORGE_REF below pins a commit, not a tag."
+        echo "ARG RIGFORGE_REF=$2"
+        echo '        "https://example.invalid/${RIGFORGE_REF}.tar.gz" \'
+    } >"$1"
+}
+
+mkroot() { # <dir> <recorded-ref>  — omit the ref to leave the record file out entirely
+    mkdir -p "$1/opt/rigforge"
+    [ "$#" -ge 2 ] && printf 'ref=%s version=v1.16.0\n' "$2" >"$1/opt/rigforge/RIGFORGE_REF"
+}
+
+check() { # <name> <root> <dockerfile> <want-rc>
+    local name="$1" root="$2" df="$3" want="$4" got
+    rigforge_ref_matches "$root" "$df"
+    got=$?
+    if [ "$got" = "$want" ]; then it_pass "$name"; else it_fail "$name" "want rc=$want, got rc=$got"; fi
+}
+
+mkdockerfile "$TMP/Dockerfile" "$PIN"
+mkroot "$TMP/match" "$PIN"
+mkroot "$TMP/stale" "$OLD"
+mkroot "$TMP/empty" ""
+mkroot "$TMP/norecord"
+
+check "the recorded ref IS the pin -> pass" "$TMP/match" "$TMP/Dockerfile" 0
+# The case the old assertion could not see, and the reason this issue exists.
+check "a stale recorded ref -> FAIL" "$TMP/stale" "$TMP/Dockerfile" 1
+check "a present but empty ref -> FAIL" "$TMP/empty" "$TMP/Dockerfile" 1
+check "no record file at all -> FAIL" "$TMP/norecord" "$TMP/Dockerfile" 1
+# The call site SKIPS on an unreadable Dockerfile and exit refuses a skip (#1064). The function
+# must still refuse to say "match" — an absent pin is never equal to a present ref.
+check "an unreadable Dockerfile -> FAIL, never a silent pass" "$TMP/match" "$TMP/nope" 1
+# The only case where the -n guard is the mechanism that acts: with no record AND no Dockerfile
+# both sides read empty, and a bare equality calls that a MATCH — a clean verdict on an image
+# carrying no record at all. Every other row here survives the guard's deletion.
+check "no record AND no Dockerfile -> FAIL (the -n guard's only case)" "$TMP/norecord" "$TMP/nope" 1
+# Narrowness: the pin is read from `^ARG RIGFORGE_REF=` alone. Seeded here because a prose line
+# is the near-miss that an unanchored read would take, and the real Dockerfile has four of them.
+mkdockerfile "$TMP/Dockerfile.prose" "$PIN"
+sed -i '1s/.*/# RIGFORGE_REF=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef is NOT the pin/' "$TMP/Dockerfile.prose"
+check "a commented RIGFORGE_REF= is not read as the pin" "$TMP/match" "$TMP/Dockerfile.prose" 0
+
+# THE DIFFERENTIAL, and the only thing here that proves the defect is closed rather than restated:
+# on the SAME fixtures the assertion this replaced is green and the new comparison is red. Without
+# it, every row above is consistent with a check that was never weak in the first place.
+#
+# BOTH fixtures are needed, and that is what earns the empty-ref row its place: `grep -q "^ref="`
+# matches a `ref=` carrying NO VALUE just as happily as a stale one, so the empty case is a second
+# thing the old check waved through, not a restatement of the missing-file case. No mutation of the
+# comparison reds those two rows — this is the arm they are attributable to.
+for fx in stale empty; do
+    if grep -q "^ref=" "$TMP/$fx/opt/rigforge/RIGFORGE_REF"; then
+        it_pass "the OLD 'grep -q ^ref=' assertion passes on the $fx fixture (the defect, reproduced)"
+    else
+        it_fail "the OLD assertion passes on the $fx fixture" "it did not — that fixture is not the defect's shape"
+    fi
+done
+
+echo ""
+echo "selftest-verify-image-ref: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -19,6 +19,21 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=os/rauc/loop-wait.sh
 . "$SCRIPT_DIR/../../os/rauc/loop-wait.sh"
 
+# #1414: the baked ref must EQUAL the pin, not merely exist. `grep -q "^ref="` passed for any
+# value — including one two rigforge releases stale, which is the state this gate shipped in.
+# Two values from two places, the shape the prebuilt-commit check below already uses. The
+# Dockerfile is READ, never written, and resolved from SCRIPT_DIR rather than cwd; an unreadable
+# one SKIPS, and exit refuses a skip (#1064), so this cannot go quiet the way its predecessor did.
+DOCKERFILE="$SCRIPT_DIR/../../os/rootfs/Dockerfile"
+rigforge_ref_matches() { # <image-root> <dockerfile> — 0 iff the recorded ref IS the pinned one
+    local rec pin
+    rec=$(sed -n 's/^ref=\([^ ]*\).*/\1/p' "$1/opt/rigforge/RIGFORGE_REF" 2>/dev/null)
+    pin=$(sed -n 's/^ARG RIGFORGE_REF=\([^ ]*\).*/\1/p' "$2" 2>/dev/null)
+    [ -n "$rec" ] && [ "$rec" = "$pin" ]
+}
+# Sourcing defines the helper and runs nothing, so the self-test drives the REAL comparison.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then return 0; fi
+
 IMAGE="${1:-}"
 MODE="${2:-}"
 [ -f "$IMAGE" ] || {
@@ -186,7 +201,11 @@ echo "==> the built-in miner (local_miner on the appliance)"
 # The whole point of baking: nothing here can be installed after the image ships. A missing
 # piece surfaces as a miner that silently never starts — on a machine with no shell.
 chk "rigforge tree baked" '[ -x "$ROOT/opt/rigforge/rigforge.sh" ]'
-chk "rigforge ref recorded" 'grep -q "^ref=" "$ROOT/opt/rigforge/RIGFORGE_REF"'
+if [ -r "$DOCKERFILE" ]; then
+    chk "rigforge ref recorded AND equal to the pin" 'rigforge_ref_matches "$ROOT" "$DOCKERFILE"'
+else
+    skip "rigforge ref recorded AND equal to the pin" "os/rootfs/Dockerfile not readable"
+fi
 chk "prebuilt xmrig baked (Tor-only box cannot clone)" '[ -x "$ROOT/opt/rigforge/prebuilt/xmrig/build/xmrig" ]'
 chk "prebuilt commit marker matches rigforge's pin" '[ "$(cat "$ROOT/opt/rigforge/prebuilt/xmrig/.rigforge-commit")" = "$(sed -n "s/^XMRIG_COMMIT=\"\${XMRIG_COMMIT:-\(.*\)}\"$/\1/p" "$ROOT/opt/rigforge/rigforge.sh")" ]'
 chk "prebuilt sha record present (integrity check input)" '[ -s "$ROOT/opt/rigforge/prebuilt/xmrig/.rigforge-sha256" ]'


### PR DESCRIPTION
Closes nothing automatically — #1414 is closed BY HAND on merge (`Closes` cannot fire here: PRs
merge to `develop-v2` while the default branch is `develop`).

## What was wrong

`tests/os/verify-image.sh:189` asserted that a line beginning `ref=` **existed**:

```sh
chk "rigforge ref recorded" 'grep -q "^ref=" "$ROOT/opt/rigforge/RIGFORGE_REF"'
```

It never compared that ref to anything, so it was green for the whole time the appliance shipped a
pin two rigforge releases behind, and it is green now the pin has moved — **it cannot distinguish
those two states.** The only input that could ever fail it was an empty or malformed file.

## What it does now

Two values from two places, the shape the prebuilt-commit check beside it already uses: the `ref=`
recorded in the image, against `^ARG RIGFORGE_REF=` in `os/rootfs/Dockerfile`.

The Dockerfile is **read, never written**, and resolved from `SCRIPT_DIR` rather than cwd — the
script's header only promises `cwd == repo root`, and `SCRIPT_DIR` is already how it resolves
`loop-wait.sh`. An unreadable Dockerfile **SKIPS** rather than passing, and `exit` refuses any skip
(#1064), so this cannot go quiet the way its predecessor did.

## Placement, and why the self-test is not in the same file

`verify-image.sh` is **398 lines against `TARGET_LINES=400`**. Crossing it forces a
`docs/dev/file-budget.tsv` entry — a shared, per-lane-regenerated file, and not in grant. So the
self-test is `tests/integration/selftest-verify-image-ref.sh`: this lane's outright, and
`Makefile:29` globs `selftest*.sh`, so it needs no registration.

It **sources `verify-image.sh`** through a new sourced-guard and drives the shipped function. A
copy of the comparison in the test could only prove the test agrees with itself.

## Proven able to fail

Five mutations, each `cmp`-proved to have actually changed the file, each row attributed to the arm
that kills it:

| mutation | rows it reds |
|---|---|
| revert to existence-only | `a stale recorded ref` + `an unreadable Dockerfile` |
| drop the `-n` guard | `no record AND no Dockerfile` — **alone** |
| unanchor the pin regex | both rc-0 rows |
| let the ref capture run past the space | both rc-0 rows |
| match a commented pin, line-start kept | `a commented RIGFORGE_REF=` — **alone** |

Mutations 3 and 4 red the **same pair**, so the narrowness row's green would have been borrowed
from the general positive path. The fifth was written to isolate it, and does. The `no record AND
no Dockerfile` case exists for the same reason: it is the only one where the `-n` guard is the
mechanism that acts, and without it a bare equality calls two empty reads a MATCH.

The self-test also carries **the differential the issue turns on**: over the stale *and* the
empty-ref fixtures, the old `grep -q "^ref="` is GREEN while the new comparison is RED. Without
that pair, every other row is consistent with a check that was never weak in the first place. The
differential is itself **proven able to fail** — pointed at a fixture the old check does not pass
on, it reds.

## One figure in the issue is wrong; its conclusion survives

The issue says `RIGFORGE_REF` appears in **7 places repo-wide**. The token is in five files — the
Dockerfile, this script, `scripts/pin-watch.sh`, `fakes/test_contract.py`,
`fakes/test_contract_freshness.py` — plus `docs/dev/testing-strategy.md`. But every one of those
reads `ARG RIGFORGE_REF` **from the Dockerfile** and none reads the baked **record**, so *"this
check is the sole consumer of the record"* is correct. Re-derived here with a fired positive
control, because a wrong figure under a right conclusion has no tell.

## Self-review — what I found on my own diff, and what I declined

- **Fixed (the ponytail pass's own finding):** `a present but empty ref` was killed by **no**
  mutation and read as a duplicate of `no record file at all` — the code cannot tell those two
  apart. Before cutting it I measured whether the OLD check passes on that fixture: `grep -q
  "^ref="` matches a `ref=` carrying no value, so it does, and the row is a **second differential
  case** rather than a duplicate. The fix was to widen the differential to both fixtures, which
  *attributes* the row instead of leaving it looking redundant. Cutting it would have removed real
  coverage; leaving it unattributed would have left borrowed green.
- **Fixed:** the `chk` and `skip` labels disagreed. The file's convention (`:257`/`:260`,
  `:291`/`:295`) is that a skip carries its check's label, so a reader greping the output finds the
  same string either way.
- **Declined — two `^ARG RIGFORGE_REF=` lines would make the pin multiline and FAIL.** There is
  exactly one today, and failing loudly on a Dockerfile carrying two competing pins is the right
  outcome. A `q` after the first match would silently pick one.
- **Declined — verifying a deliberately OLD image against a moved tree now reds.** That red is
  correct information for a gate whose stated job is catching a stale artifact, and it is not a new
  failure mode: `:295` already skips "not run from the repo root" and any skip already exits 1, so
  a run outside a repo could never pass before this change either. Verified at source, not assumed.
- **Declined, stated so the gap is a decision:** the `version=` half of the record is still unread.
  The issue calls it "a second, independent route", but the Dockerfile writes both fields in one
  command, reading `version=` from the same `/opt/rigforge/VERSION` the image ships — so the two are
  self-consistent by construction and could only disagree after post-build tampering. Weak, not
  zero; not taken here.
- **Checked and clean:** nothing else in the repo parses the old label `rigforge ref recorded`
  (grep with a positive control showing `verify-image` references *are* found where they exist), and
  `DOCKERFILE` shadows nothing in the script.

## What was run

- `shellcheck --severity=warning` — CI's own threshold — **rc 0** on both files.
- `shfmt -i 4 -d` over the Makefile's exact glob — **rc 0**.
- All 22 `tests/integration/selftest*.sh` — **rc 0**, mine 10/10.
- `make lint-file-budget` with both files staged (#1486) — **OK**.

No bench, no image, no root, no KVM. **Not run:** the KVM battery and any real image build — this
change is the static half #1651 names, and nothing here needs a mounted image to exercise.

## Lane discipline

`tests/os/` is the appliance lane's. **GRANT 4** in `roles/e2e.paths` covers this **one file** for
#1414 only, expiring on merge. Arming proven by me rather than relayed: my staged set ACCEPTED, and
an ungranted `tests/os/` sibling REFUSED — so "accepted" cannot be a widened `tests/os/` prefix.
No `.lane-override` was used.

Rebased across the moved base and **proven by patch identity**, not by tree: `git diff <old-base>
<old-head>` and `git diff <new-base> <new-head>` are byte-identical at 7891 B, with a control
confirming `cmp` reports a difference when there is one. Appliance's PR #1668 touches this file at
`:309`, which does not overlap my region at `:189`; it had not merged when this was rebased.

Docs: nothing in `docs/` stated the old behaviour, so no doc goes false.
