### PR TITLE
fix(tests/os): #1670 soak-probe --self-test counts a failed mktemp -d as a failed row, not a skipped set

### DIFF
--- a/tests/os/soak-probe.sh
+++ b/tests/os/soak-probe.sh
@@ -212,7 +212,12 @@ self_test() {
 # the same day=0, which is the shape the label and the write-once baseline exist for.
 self_test_driver() { # $1 = a canned reading that passes against itself
     local tmp out
-    tmp=$(mktemp -d) || return 1
+    # A scratch dir that cannot be made is a FAILED row, never a skipped set: bare `return` here
+    # dropped the nine driver rows and the summary still read `0 failed`, rc 0 (#1670).
+    tmp=$(mktemp -d) || {
+        chk "driver: mktemp -d" 1 0
+        return
+    }
     mkdir -p "$tmp/bin"
     printf '%s\n' '#!/usr/bin/env bash' 'cat >/dev/null' 'printf "%s\n" "${@: -1}" >>"$SOAK_STUB_ARGS"' 'cat "$SOAK_STUB_READING"' >"$tmp/bin/ssh"
     chmod +x "$tmp/bin/ssh"


### PR DESCRIPTION
## What

`self_test_driver()` opened with `tmp=$(mktemp -d) || return 1` and `self_test` called it bare, so when `mktemp -d` failed the nine driver rows never ran and the summary still ended `0 failed` with rc 0: a shorter run that read as green. The soak's own rule is that a missing measurement is a FAIL, never a skip. The self-test now holds itself to it: the failure is counted as a row (`driver: mktemp -d`), the summary reads `1 failed`, and the exit code is 1. One statement changed plus a two-line comment; the file has no budget row (296 lines).

## What was RUN

Positive control on the UNFIXED file, `mktemp` forced to fail with `TMPDIR=/nonexistent`:

```
soak-probe self-test: 20 ok, 0 failed      rc=0
```

The same input on the fixed file:

```
  ✗ driver: mktemp -d: [1] wanted [0]
soak-probe self-test: 20 ok, 1 failed      rc=1
```

The normal run on the fixed file: `29 ok, 0 failed`, rc 0, unchanged from the base. So the nine driver rows are the 29 minus 20, as the issue said.

`shellcheck --severity=warning` rc 0, `shfmt -i 4 -d` clean, `bash -n` clean, `make lint-file-budget` OK.

## What was NOT run

No bench, no live soak: the change is inside `--self-test` only, and the probe's live path is untouched. No doc names the self-test's row count, so no doc changed.

## Over-engineering pass (by hand; the PR-gate hook keys off a different branch from this lane's cwd)

The issue's one-line shape was taken as written. The alternative of having `self_test` check `self_test_driver`'s return value would leave the driver's own contract ("return 1 = skipped") in place and add a second site to keep honest; counting the failure where it happens removes the skip path instead of wrapping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016im4L55nBZr9JTYGQTzeu9
