### PR TITLE
fix(dashboard): #1265 the rollback banner names the check that held the boot gate

### DIFF
--- a/dashboard/mining_dashboard/web/static/osupdate.mjs
+++ b/dashboard/mining_dashboard/web/static/osupdate.mjs
@@ -12,6 +12,7 @@
 // dashboard answers again; the post-reboot verdict (updated / rolled back) arrives via the
 // host-persisted state in state.os_update and renders as a banner.
 
+import { verdictText } from "./osverdict.mjs";
 import { Component, html } from "./preact.mjs";
 
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
@@ -89,15 +90,6 @@ export async function runOsDownload(
 // Pin it client-side: only the public GitHub release page ever renders as a link.
 export const releaseNotesHref = (u) =>
   typeof u === "string" && u.startsWith("https://github.com/") ? u : null;
-
-// One verdict line for the banner. Pure — the render just wraps it.
-export function verdictText(verdict) {
-  if (!verdict || !verdict.outcome) return null;
-  if (verdict.outcome === "updated") return `System updated to v${verdict.to}.`;
-  if (verdict.outcome === "rolled_back")
-    return `The update to v${verdict.to} failed its health checks and was rolled back automatically — still on v${verdict.from}.`;
-  return null;
-}
 
 // Post-reboot verdict banner, rendered by App beside the disconnected banner. Dismiss hides it
 // for this browser session (keyed on the verdict's timestamp); the host clears the verdict

--- a/dashboard/mining_dashboard/web/static/osverdict.mjs
+++ b/dashboard/mining_dashboard/web/static/osverdict.mjs
@@ -1,0 +1,41 @@
+// The post-reboot OS-update verdict, turned into one sentence for the banner (#1051, #1265).
+//
+// Its own module rather than more of osupdate.mjs: that file is at its recorded budget ceiling
+// with no headroom, and this is a self-contained concern — host verdict in, display text out,
+// with no fetching, sequencing or state of its own.
+//
+// The rollback sentence used to say only that health checks failed, which reads as "bad release"
+// and is usually wrong. The boot gate rolls a GOOD update back when doctor fails a check the
+// update did not cause — #1265's cert-coverage race is exactly that shape: an address arrives
+// between render's mint and doctor's check, and the box reverts a healthy payload. pithead-boot
+// (#1671) now copies doctor's failing messages into the verdict as `blocking`, so the banner can
+// name what actually held the gate instead of implying the release was at fault.
+
+// One doctor message is a sentence, not a paragraph. The host writes them, but they reach an
+// operator through this page, so bound them: a runaway message must not become the whole banner.
+// Display-only — the full list stays in the state file for anyone reading the host.
+export const MAX_BLOCKING_LEN = 120;
+
+// The checks that held the gate, as a trailing clause, or "" when the host named none. An OS
+// image older than #1671 omits `blocking` altogether, so the caller's sentence has to read
+// correctly without it — absence here is "we were not told", never "nothing was wrong".
+export function blockingCause(verdict) {
+  const held = (verdict && Array.isArray(verdict.blocking) ? verdict.blocking : [])
+    .filter((m) => typeof m === "string" && m.trim())
+    .map((m) => m.trim().replace(/\.+$/, "").slice(0, MAX_BLOCKING_LEN));
+  if (!held.length) return "";
+  // Name the first and count the rest: the gate stops at the first failing check, and one named
+  // cause an operator can act on beats a wall of them.
+  return ` Blocked by: ${held[0]}${held.length > 1 ? ` (+${held.length - 1} more)` : ""}.`;
+}
+
+// One verdict line for the banner. Pure — the render just wraps it.
+export function verdictText(verdict) {
+  if (!verdict || !verdict.outcome) return null;
+  if (verdict.outcome === "updated") return `System updated to v${verdict.to}.`;
+  if (verdict.outcome !== "rolled_back") return null;
+  return (
+    `The update to v${verdict.to} failed its health checks and was rolled back automatically` +
+    ` — still on v${verdict.from}.${blockingCause(verdict)}`
+  );
+}

--- a/dashboard/mining_dashboard/web/static/osverdict.mjs
+++ b/dashboard/mining_dashboard/web/static/osverdict.mjs
@@ -20,9 +20,13 @@ export const MAX_BLOCKING_LEN = 120;
 // image older than #1671 omits `blocking` altogether, so the caller's sentence has to read
 // correctly without it — absence here is "we were not told", never "nothing was wrong".
 export function blockingCause(verdict) {
+  // Judge emptiness AFTER normalising, not before: a punctuation-only message like "..." is
+  // truthy on the way in and empty on the way out, and filtering first let it take the named
+  // slot and hide the real cause behind " Blocked by:  (+1 more).".
   const held = (verdict && Array.isArray(verdict.blocking) ? verdict.blocking : [])
-    .filter((m) => typeof m === "string" && m.trim())
-    .map((m) => m.trim().replace(/\.+$/, "").slice(0, MAX_BLOCKING_LEN));
+    .filter((m) => typeof m === "string")
+    .map((m) => m.trim().replace(/\.+$/, "").slice(0, MAX_BLOCKING_LEN))
+    .filter((m) => m);
   if (!held.length) return "";
   // Name the first and count the rest: the gate stops at the first failing check, and one named
   // cause an operator can act on beats a wall of them.

--- a/dashboard/tests/frontend/osupdate.test.mjs
+++ b/dashboard/tests/frontend/osupdate.test.mjs
@@ -15,7 +15,6 @@ import {
   pollOsResult,
   releaseNotesHref,
   runOsDownload,
-  verdictText,
 } from "../../mining_dashboard/web/static/osupdate.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
@@ -132,16 +131,6 @@ test("runOsDownload passes a rejection through as the outcome", async () => {
   );
   assert.equal(out.status, "rejected");
   assert.match(out.error, /free space/);
-});
-
-test("verdictText covers both outcomes and stays quiet otherwise", () => {
-  assert.equal(verdictText({ outcome: "updated", to: "1.19.0" }), "System updated to v1.19.0.");
-  assert.match(
-    verdictText({ outcome: "rolled_back", from: "1.18.1", to: "1.19.0" }),
-    /v1\.19\.0 failed .* rolled back automatically — still on v1\.18\.1/,
-  );
-  assert.equal(verdictText(null), null);
-  assert.equal(verdictText({ outcome: "weird" }), null);
 });
 
 test("fmtMiB rounds to MiB and stays empty for the unknowable", () => {
@@ -374,4 +363,21 @@ test("OsVerdictBanner renders the outcome and nothing without one", () => {
   );
   assert.match(out, /rolled back automatically/);
   assert.match(out, /Dismiss/);
+  // #1265: when the host names what held the boot gate, the banner says so rather than leaving
+  // "failed its health checks" to read as a bad release.
+  const named = renderToString(
+    OsVerdictBanner({
+      os: {
+        step: "idle",
+        verdict: {
+          outcome: "rolled_back",
+          from: "1.18.1",
+          to: "1.19.0",
+          ts: 5,
+          blocking: ["the dashboard certificate does not cover an IPv6 address of the box"],
+        },
+      },
+    }),
+  );
+  assert.match(named, /Blocked by: the dashboard certificate does not cover an IPv6 address/);
 });

--- a/dashboard/tests/frontend/osverdict.test.mjs
+++ b/dashboard/tests/frontend/osverdict.test.mjs
@@ -1,0 +1,79 @@
+// The post-reboot OS-update verdict sentence (#1051) and the blocking-cause clause #1265 adds.
+//
+// The host makes every judgment; these tests only check that its verdict becomes honest display
+// text. The case that matters most is the one with nothing to render: an appliance on an OS image
+// older than #1671 sends no `blocking` at all, and the sentence must read exactly as it always
+// did rather than growing a dangling clause or implying a cause nobody reported.
+//
+// Escaping is deliberately NOT asserted here. Preact escapes text interpolations in the browser,
+// but tests/frontend/helpers/render.mjs is a render probe that does not escape, so an assertion
+// made through it would pass or fail for a reason unrelated to the thing it names. What this file
+// does hold is the sanitizer's own contract: shape, type, and a bounded length.
+//
+// Run with Node's built-in test runner:
+//     node --test dashboard/tests/frontend/*.test.mjs
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  blockingCause,
+  MAX_BLOCKING_LEN,
+  verdictText,
+} from "../../mining_dashboard/web/static/osverdict.mjs";
+
+// #1265's own observed failing check, verbatim from the bench run in the issue.
+const CERT = "the dashboard certificate does not cover an IPv6 address of the box (a ULA)";
+
+test("verdictText covers both outcomes and stays quiet otherwise", () => {
+  assert.equal(verdictText({ outcome: "updated", to: "1.19.0" }), "System updated to v1.19.0.");
+  assert.match(
+    verdictText({ outcome: "rolled_back", from: "1.18.1", to: "1.19.0" }),
+    /v1\.19\.0 failed .* rolled back automatically — still on v1\.18\.1/,
+  );
+  assert.equal(verdictText(null), null);
+  assert.equal(verdictText({ outcome: "weird" }), null);
+});
+
+test("a host that names no blocking check reads exactly as it did before #1265", () => {
+  assert.equal(
+    verdictText({ outcome: "rolled_back", from: "1.18.1", to: "1.19.0" }),
+    "The update to v1.19.0 failed its health checks and was rolled back automatically" +
+      " — still on v1.18.1.",
+  );
+  assert.equal(blockingCause({ outcome: "rolled_back" }), "");
+  assert.equal(blockingCause({ blocking: [] }), "");
+  assert.equal(blockingCause(null), "");
+});
+
+test("the named check reaches the sentence and the rest are counted", () => {
+  assert.equal(blockingCause({ blocking: [CERT] }), ` Blocked by: ${CERT}.`);
+  assert.match(
+    verdictText({ outcome: "rolled_back", from: "1.18.1", to: "1.19.0", blocking: [CERT] }),
+    /still on v1\.18\.1\. Blocked by: the dashboard certificate does not cover/,
+  );
+  assert.equal(blockingCause({ blocking: [CERT, "b", "c"] }), ` Blocked by: ${CERT} (+2 more).`);
+});
+
+test("blocking is host JSON, so every garbled shape degrades to no clause", () => {
+  for (const bad of ["a bare string", 7, {}, true]) {
+    assert.equal(blockingCause({ blocking: bad }), "");
+  }
+  assert.equal(blockingCause({ blocking: [null, 3, "", "   "] }), "");
+  // A usable message beside the junk still gets named — degrading is not the same as giving up.
+  assert.equal(blockingCause({ blocking: [null, CERT] }), ` Blocked by: ${CERT}.`);
+});
+
+test("one long message cannot become the whole banner", () => {
+  // The literal is pinned alongside the constant on purpose: a bound test that reads its bound
+  // from the module under test can never fail when someone moves the bound.
+  assert.equal(MAX_BLOCKING_LEN, 120);
+  const out = blockingCause({ blocking: ["x".repeat(500)] });
+  assert.equal(out, ` Blocked by: ${"x".repeat(120)}.`);
+});
+
+test("a message that already ends in a period does not get a second one", () => {
+  assert.equal(
+    blockingCause({ blocking: ["cert coverage failed."] }),
+    " Blocked by: cert coverage failed.",
+  );
+});

--- a/dashboard/tests/frontend/osverdict.test.mjs
+++ b/dashboard/tests/frontend/osverdict.test.mjs
@@ -59,8 +59,12 @@ test("blocking is host JSON, so every garbled shape degrades to no clause", () =
     assert.equal(blockingCause({ blocking: bad }), "");
   }
   assert.equal(blockingCause({ blocking: [null, 3, "", "   "] }), "");
+  // Punctuation-only is junk too: it survives a raw truthiness check but names nothing once the
+  // trailing period is stripped, so it must not reach the sentence as an empty cause.
+  assert.equal(blockingCause({ blocking: ["..."] }), "");
   // A usable message beside the junk still gets named — degrading is not the same as giving up.
   assert.equal(blockingCause({ blocking: [null, CERT] }), ` Blocked by: ${CERT}.`);
+  assert.equal(blockingCause({ blocking: ["...", CERT] }), ` Blocked by: ${CERT}.`);
 });
 
 test("one long message cannot become the whole banner", () => {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1218,9 +1218,12 @@ re-derives and re-verifies every step itself.
 
 After the reboot the machine health-checks itself before committing the new version — the same
 gate every appliance boot runs. A banner reports the outcome: updated to the new version, or
-rolled back to the previous one automatically because the new version failed its checks. Either
-way the machine ends on a working system; wallets, settings, and chain data live on the data
-partition and are never part of an update.
+rolled back to the previous one automatically because a check did not pass inside the window.
+When the host records which check held the gate, the banner names it. A rollback on its own is
+not evidence that the release was faulty: a check can fail for a reason the update did not cause,
+and the named cause is what tells the two apart before you retry. Either way the machine ends on
+a working system; wallets, settings, and chain data live on the data partition and are never part
+of an update.
 
 ## Tips
 


### PR DESCRIPTION
Closes #1265 (the dashboard half — see "Not done" below for what stays open).

## The defect

A good OS update can roll back. The boot gate mints the dashboard certificate at render, **before** `up`; doctor re-checks coverage inside the gate loop, **after** `up`. An address that arrives in between — a SLAAC/ULA prefix is exactly this shape — makes the settled name list a superset of the minted one, doctor fails coverage on every round, and the box reverts a healthy payload.

#1671 fixed the boot half and began recording doctor's failing messages in the verdict as `blocking`. The dashboard was still rendering only *"failed its health checks"*, which reads as a bad release and for this defect is simply wrong: retrying reproduces the same race, so the operator has no way to tell a bad release from an environmental check failure.

## What this does

The rollback banner names the cause — the first blocking check, plus a count of the rest. `pithead-boot` names the first on the console too (`jq -r '.blocking[0]'`), so the console and the dashboard agree rather than telling two stories.

`blocking` is host JSON and is **absent on any OS image older than #1671**, so the clause is strictly additive: with nothing named, the sentence is byte-for-byte what it was. That is the case most likely to regress, so a test pins it as an exact string rather than a regex.

Hardening on the sanitizer, since these strings are host-written and reach an operator through this page: non-list shapes, non-string entries, blank entries and punctuation-only entries all degrade to no clause; a usable message beside junk is still named; one message is bounded at `MAX_BLOCKING_LEN` (120) so a runaway string cannot become the whole banner.

## Shape, and why it is a new module

`osupdate.mjs` sits at its recorded ceiling of **415 with zero headroom**, and the change does not fit inline. Moving the verdict-text concern into a new `web/static/osverdict.mjs` takes that file to **407**; the new module is **45** lines, under the 400 target, so it carries no `file-budget.tsv` row. `verdictText` was imported only by its own test, so the move is contained — `components.mjs` imports `OsVerdictBanner`, which stays put, and `wizard.mjs`'s same-named `verdictText` is an unrelated local `const`, checked rather than assumed.

## What was RUN

- `node --test dashboard/tests/frontend/*.test.mjs` — **502 pass / 0 fail**, twice (once after the import reorder below).
- **Test-name set diff, before vs after:** 273 -> 278. Exactly one name left `osupdate.test.mjs` and the *identical* name appears in `osverdict.test.mjs` — a move, not a deletion — plus 5 new rows. The instrument was given a seeded removal first and reported it, so the clean reading is not an unfired one.
- `make lint-js` rc 0, `lint-md` rc 0, `lint-docs-voice` rc 0, `lint-operator-strings` rc 0, `lint-topology` rc 0, `lint-file-budget` rc 0 — run individually, because that CI job runs six targets past the five in its name and `make` stops at the first failure.
- `lint-js` **failed first** on an unsorted import block and was fixed; recording it because a stale green here would have reddened CI.
- Line counts re-measured at the pushed head with the gate's own `awk 'END{print NR}'`: 45 / 407 / 383 / 83 against the 415 ceiling. (41 / 79 at the first push; the review fix below moved both.)
- `add_static("/static", ...)` serves the whole directory, so the new module is served — checked, because an allowlist would have 404'd it in a browser with every test still green.

**Patch coverage:** `MEASURED` in `patch-coverage.sh` is `dashboard/mining_dashboard/*.py`, and this diff changes no Python, so the gate takes its loud not-applicable pass. No Python changed, so `read_os_update_state` needed no edit — it already returns the host dict whole, with no key allowlist to widen.

## Fixed in review (F1)

`blockingCause` judged emptiness on the raw entry and normalised afterwards, so an entry that is
truthy going in and empty coming out — `"..."` is the whole class, since the map strips trailing
periods — passed the filter and then took the named slot. Measured at the previous head:
`["..."]` gave `" Blocked by: ."` and `["...", CERT]` gave `" Blocked by:  (+1 more)."`, the junk
hiding the real cause. Map first, then drop the empties; the change is one-directional, since an
entry with an empty `trim()` also normalises empty, so nothing previously dropped is now kept.
Both shapes are rows in that test now, shown **red at the previous head** before green — and
because Node's assert short-circuits, the `["...", CERT]` row was measured directly against the
unfixed module rather than assumed. Suite still **502 / 0** (assertions inside an existing test,
not new tests).

## The over-engineering pass, done on merits

Four things considered and rejected, with the reason:

1. **Compressing `osupdate.mjs` by ~9 lines to fit inline.** Rejected: the only lines available are house-voice comments carrying the reasoning for the control flow. Paying a budget line by gutting an explanation is the trade this lane is told not to make.
2. **Rendering the full blocking list.** Rejected: one named cause an operator can act on beats a wall of them, and naming the first is what the host's own console line does.
3. **Asserting escaping through `renderToString`.** Rejected and named as a gap instead — `tests/frontend/helpers/render.mjs` says outright that it does not escape, so the assertion would have passed for a reason unrelated to the thing it names. Preact escapes text interpolations in the browser; this harness cannot witness it.
4. **Keeping `blockingCause` private.** Rejected: it is half the module's contract, not an internal, and its degradation behaviour is the part worth pinning directly.

## Not done, deliberately

- The issue's **candidate 2** (doctor counting cert drift as `warn` for the commit decision) and **candidate 3** (`pithead apply` reaching the mint on an unchanged config) live in `lib/pithead/` — not this lane's paths.
- The **cosmetic post-commit operator-rollback verdict** still reads "updated" while the box runs the old version. Host-side, untouched.
- **Nothing here is proven on hardware.** The KVM battery still does not stage a late-arriving address, so #1671's strategy row stays "added — unverified" and this half inherits that.
- `docs/` is in `_shared.paths` and is disclosed here rather than reached for silently; no other lane's path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKUzVaEQWQSeUUgLB9vFFJ

