### PR TITLE
chore(trivyignore): #1656 drop the obsolete CVE-2026-34040 mute, and record why nothing replaces it

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,32 +9,40 @@
 CVE-2026-23949
 CVE-2026-24049
 
-# Appliance rootfs Go binaries. This block used to hold three findings on the grounds that the
-# modules were VENDORED inside downloaded release binaries, so "no pin bump can clear them until
-# upstream cuts releases on the fixed modules". That premise is gone: the rootfs COMPILES
-# docker-compose and cosign itself, so the module graph is ours and a finding in it is fixable
-# whether or not upstream has moved. Two of the three are now fixed at the source by the
-# COMPOSE_GO_RAISES / COSIGN_GO_RAISES entries in os/rootfs/Dockerfile and have been deleted from
-# here — golang.org/x/text (CVE-2026-56852) and google.golang.org/grpc (GHSA-hrxh-6v49-42gf).
-# Deleting them is not cosmetic: while a mute is present the scan cannot tell "fixed" from
-# "hidden", so leaving one for a finding you have just fixed destroys the only evidence that the
-# fix landed. Scanned with no ignore file at all after the raises: cosign 0 findings, compose 1.
+# Appliance rootfs Go binaries. THIS BLOCK IS DELIBERATELY EMPTY — it stays here so that nobody
+# re-adds a line to it without reading why the last one went. It used to hold three findings on
+# the grounds that the modules were VENDORED inside downloaded release binaries, so "no pin bump
+# can clear them until upstream cuts releases on the fixed modules". That premise is gone: the
+# rootfs COMPILES docker-compose and cosign itself, so the module graph is ours and a finding in it
+# is fixable whether or not upstream has moved. Two of the three were fixed at the source by the
+# COMPOSE_GO_RAISES / COSIGN_GO_RAISES entries in os/rootfs/Dockerfile — golang.org/x/text
+# (CVE-2026-56852) and google.golang.org/grpc (GHSA-hrxh-6v49-42gf). Deleting a mute is not
+# cosmetic: while a mute is present the scan cannot tell "fixed" from "hidden", so leaving one for
+# a finding you have just fixed destroys the only evidence that the fix landed.
 #
-# github.com/docker/docker, reached as an indirect dependency of the compiled docker-compose. This
-# one stays, and unlike the other two it genuinely cannot be raised. Trivy names the fix as 29.3.1,
-# but that is a Moby release, not a version of this MODULE — `go list -m -versions` tops out at
-# v28.5.2+incompatible for both github.com/docker/docker and github.com/moby/moby, and the attempt
-# fails the build with "invalid version: unknown revision v29.3.1". Docker 29 lives at a module
-# path compose does not import, so no compose release can carry it either: v5.4.0, v5.5.0 and main
-# all pin v28.5.2+incompatible. The advisory is also a daemon-side authz bypass — compose links the
-# client half, and the appliance talks to podman's compat socket, not dockerd.
-# Clears when compose moves to the docker 29 module path; `go list -m -versions github.com/docker/docker`
-# is the one-line check. Nothing re-surfaces this on its own: the weekly CVE sweep (#833) scans WITH
-# this file applied, so a muted finding never reaches it (#1174). scripts/trivyignore-watch.sh
-# checks whether this ID still shows up in any image the file covers — weekly now, via
-# .github/workflows/trivyignore-watch.yml on the default branch, which checks this lane out to
-# run it (#1174). Same cadence as the clearing check above.
-CVE-2026-34040
+# The third was CVE-2026-34040 on github.com/docker/docker, reached as an indirect dependency of
+# the compiled docker-compose. It is now gone and has been dropped (#1656). Two routes agree:
+# scripts/trivyignore-watch.sh's scheduled run of 2026-08-31 reported it OBSOLETE — no covered
+# image reports it — and an isolated probe on the pinned engine (a go.mod requiring
+# github.com/docker/docker v28.5.2+incompatible) does not match the ID at all. The advisory now
+# names github.com/moby/moby rather than github.com/docker/docker; that is the likely mechanism,
+# but it is inferred from the advisory's affected-package list and was not proven against trivy's
+# own matcher.
+#
+# NOTHING REPLACES IT, and that is a decision rather than an oversight (#1656). The same module
+# today reports CVE-2026-41567 and CVE-2026-42306 (HIGH, both fixed=NONE), CVE-2026-33997 (fixable
+# at 29.3.1 but MEDIUM) and CVE-2026-41568 (MEDIUM, unfixed). At the gate's own scope — --severity
+# HIGH,CRITICAL --ignore-unfixed, which ci.yml, os-rootfs.yml and scripts/trivyignore-watch.sh all
+# share — that module yields ZERO findings: both HIGHs are unfixed, and the one fixable finding is
+# below the severity floor. Measured as a controlled pair on the pinned engine, same probe with one
+# variable changed: wide scope 4 findings, gate scope 0.
+#
+# So there is nothing here to mute, and an entry would be worse than absent. It would suppress
+# nothing the gate ever reports, and because trivyignore-watch.sh scans with --ignore-unfixed too,
+# it would be flagged OBSOLETE on the very next weekly run — a mute that exists only to be
+# reported as dead. What would change this: compose moving to the docker 29 module path, which is
+# what makes a finding here fixable and therefore gating. `go list -m -versions
+# github.com/docker/docker` is the one-line check.
 # NOTE ON GO STDLIB FINDINGS — there are none listed here on purpose. The appliance rootfs used
 # to download upstream release binaries and inherit whichever Go toolchain built them, so every Go
 # stdlib CVE became an accepted finding we could not clear (nine of them by 2026-08). It now

--- a/.trivyignore
+++ b/.trivyignore
@@ -9,40 +9,29 @@
 CVE-2026-23949
 CVE-2026-24049
 
-# Appliance rootfs Go binaries. THIS BLOCK IS DELIBERATELY EMPTY — it stays here so that nobody
-# re-adds a line to it without reading why the last one went. It used to hold three findings on
-# the grounds that the modules were VENDORED inside downloaded release binaries, so "no pin bump
-# can clear them until upstream cuts releases on the fixed modules". That premise is gone: the
-# rootfs COMPILES docker-compose and cosign itself, so the module graph is ours and a finding in it
-# is fixable whether or not upstream has moved. Two of the three were fixed at the source by the
-# COMPOSE_GO_RAISES / COSIGN_GO_RAISES entries in os/rootfs/Dockerfile — golang.org/x/text
-# (CVE-2026-56852) and google.golang.org/grpc (GHSA-hrxh-6v49-42gf). Deleting a mute is not
-# cosmetic: while a mute is present the scan cannot tell "fixed" from "hidden", so leaving one for
-# a finding you have just fixed destroys the only evidence that the fix landed.
+# Appliance rootfs Go binaries. THIS BLOCK IS DELIBERATELY EMPTY — it stays so nobody re-adds a
+# line to it without reading why the last one went. It once held three findings on the grounds that
+# the modules were VENDORED inside downloaded release binaries, so no pin bump could clear them.
+# That premise is gone: the rootfs COMPILES docker-compose and cosign itself, so the module graph is
+# ours and a finding in it is fixable whether or not upstream has moved. Two were then fixed at the
+# source by the COMPOSE_GO_RAISES / COSIGN_GO_RAISES entries in os/rootfs/Dockerfile —
+# golang.org/x/text (CVE-2026-56852) and google.golang.org/grpc (GHSA-hrxh-6v49-42gf). Deleting a
+# mute is not cosmetic: while one is present the scan cannot tell "fixed" from "hidden", so leaving
+# one for a finding you have just fixed destroys the only evidence that the fix landed.
 #
-# The third was CVE-2026-34040 on github.com/docker/docker, reached as an indirect dependency of
-# the compiled docker-compose. It is now gone and has been dropped (#1656). Two routes agree:
-# scripts/trivyignore-watch.sh's scheduled run of 2026-08-31 reported it OBSOLETE — no covered
-# image reports it — and an isolated probe on the pinned engine (a go.mod requiring
-# github.com/docker/docker v28.5.2+incompatible) does not match the ID at all. The advisory now
-# names github.com/moby/moby rather than github.com/docker/docker; that is the likely mechanism,
-# but it is inferred from the advisory's affected-package list and was not proven against trivy's
-# own matcher.
+# The third was CVE-2026-34040 on github.com/docker/docker, an indirect dependency of the compiled
+# docker-compose. Dropped as obsolete (#1656): trivyignore-watch.sh's scheduled run of 2026-08-31
+# reported it seen in no covered image, and on the pinned engine the ID no longer matches
+# github.com/docker/docker v28.5.2+incompatible at all.
 #
-# NOTHING REPLACES IT, and that is a decision rather than an oversight (#1656). The same module
-# today reports CVE-2026-41567 and CVE-2026-42306 (HIGH, both fixed=NONE), CVE-2026-33997 (fixable
-# at 29.3.1 but MEDIUM) and CVE-2026-41568 (MEDIUM, unfixed). At the gate's own scope — --severity
-# HIGH,CRITICAL --ignore-unfixed, which ci.yml, os-rootfs.yml and scripts/trivyignore-watch.sh all
-# share — that module yields ZERO findings: both HIGHs are unfixed, and the one fixable finding is
-# below the severity floor. Measured as a controlled pair on the pinned engine, same probe with one
-# variable changed: wide scope 4 findings, gate scope 0.
-#
-# So there is nothing here to mute, and an entry would be worse than absent. It would suppress
-# nothing the gate ever reports, and because trivyignore-watch.sh scans with --ignore-unfixed too,
-# it would be flagged OBSOLETE on the very next weekly run — a mute that exists only to be
-# reported as dead. What would change this: compose moving to the docker 29 module path, which is
-# what makes a finding here fixable and therefore gating. `go list -m -versions
-# github.com/docker/docker` is the one-line check.
+# NOTHING REPLACES IT, and that is a decision (#1656). That module still reports CVE-2026-41567 and
+# CVE-2026-42306, both HIGH — but both are fixed=NONE, and the only fixable finding on it is MEDIUM.
+# At the scope this file is written for, and which ci.yml, os-rootfs.yml and trivyignore-watch.sh
+# all share (--severity HIGH,CRITICAL --ignore-unfixed), that module yields ZERO findings. An entry
+# would suppress nothing the gate reports, and since the watch script also scans --ignore-unfixed it
+# would be flagged OBSOLETE on the next weekly run — a mute existing only to be reported dead.
+# What would change that: compose moving to the docker 29 module path, which is what makes a finding
+# here fixable and therefore gating. `go list -m -versions github.com/docker/docker` is the check.
 # NOTE ON GO STDLIB FINDINGS — there are none listed here on purpose. The appliance rootfs used
 # to download upstream release binaries and inherit whichever Go toolchain built them, so every Go
 # stdlib CVE became an accepted finding we could not clear (nine of them by 2026-08). It now


### PR DESCRIPTION
Closes #1656.

## What this changes

One file. `CVE-2026-34040` is removed from `.trivyignore`, and the block that justified it is
replaced by a record of why nothing takes its place.

A mute standing over a finding that is no longer there means the scan can no longer tell "fixed"
from "hidden". That is this file's own stated rule, and the state two mutes were found in at #1153.

## The mute is dead — three routes, and they were derived separately

1. **`scripts/trivyignore-watch.sh`, scheduled run of 2026-08-31** (the weekly watch that exists for
   exactly this, #1174). Six images, **no ignore file applied**, trivy 0.74.0. Its report on #1382
   reads `CVE-2026-34040 | no | OBSOLETE — no covered image reports it`, and
   `obsolete=1 checked=7`. This is the authoritative image-level evidence and I did not generate it
   — I read it.
2. **The appliance lane's controlled scan pair**, found while proving #1649 and reported rather than
   fixed because this file is not their path. RELAYED, not re-run by me.
3. **An isolated module probe, run here today.** A `go.mod` requiring
   `github.com/docker/docker v28.5.2+incompatible` — the module the compiled docker-compose actually
   pulls in — scanned with the pinned `aquasec/trivy` image. `CVE-2026-34040` does not match it at
   all.

Route 3 is not a null result: the same scan reports **four** other findings against that module, so
the instrument demonstrably sees it. The absence is a measurement, not a silence.

**Likely mechanism, labelled because it is inferred and not proven:** the GitHub advisory for
`CVE-2026-34040` today names `go:github.com/moby/moby` and `go:github.com/moby/moby/v2`, and does
**not** name `github.com/docker/docker`. That would explain why it no longer matches our module. It
is read off the advisory's affected-package list; I did not prove trivy's matcher follows it. The
scan results above stand on their own either way.

## Nothing replaces it, and that is the decision the issue asked for

#1656 framed the open question as a choice between an expiring mute and accepting the finding for
`CVE-2026-41567` / `CVE-2026-42306`. Measured at the gate's own scope, there is no such choice,
because neither finding ever reaches the gate.

What that module reports today, at full scope:

| finding | severity | fixed |
|---|---|---|
| `CVE-2026-41567` | HIGH | NONE |
| `CVE-2026-42306` | HIGH | NONE |
| `CVE-2026-33997` | MEDIUM | 29.3.1 |
| `CVE-2026-41568` | MEDIUM | NONE |

`first_patched=NONE` for both HIGHs is confirmed independently against the GitHub advisory API, not
taken from the issue.

The gate's scope is `--severity HIGH,CRITICAL --ignore-unfixed`, shared by `ci.yml`,
`os-rootfs.yml` and `scripts/trivyignore-watch.sh:115`. Both HIGHs are unfixed; the one fixable
finding is below the severity floor. **A controlled pair, same probe and same engine with one
variable changed:**

```
wide scope  (all severities, unfixed included) -> 4 findings
gate scope  (--severity HIGH,CRITICAL --ignore-unfixed) -> 0 findings
```

So an entry for either would be worse than absent. It would suppress nothing the gate ever reports,
and because `trivyignore-watch.sh` scans with `--ignore-unfixed` too, it would be flagged OBSOLETE
on the very next weekly run — a mute that exists only to be reported dead. The block is left in
place, deliberately empty, with that reasoning in it so the next person does not re-add one.

What would change this: compose moving to the docker 29 module path, which is what makes a finding
here fixable and therefore gating. `go list -m -versions github.com/docker/docker` is the check.

## What was run

| | |
|---|---|
| `make lint-trivy-parity` | rc 0 |
| `make lint-file-budget` | rc 0 |
| `make lint-topology` | rc 0 |
| `make lint-docs-voice` | rc 0 |
| `bash scripts/trivyignore-watch.sh --self-test` | rc 0 |
| isolated module probe, pinned engine | wide 4 / gate 0, as above |

`.trivyignore` has no `file-budget.tsv` row; it is 64 lines — three SHORTER than the 67 it started at — well inside the 800 hard ceiling.

## What was NOT run, and why

- **I did not run the full six-image `trivyignore-watch.sh` scan myself.** It builds the appliance
  rootfs, which compiles docker-compose and cosign from source on a pinned Go toolchain — a heavy,
  bench-class job. The image-level evidence here is the 2026-08-31 **scheduled** run, three days
  old at the time of writing, plus today's module-level probe. The next Monday run is the natural
  confirmation and needs nothing from me; if it reports `obsolete=0 checked=6`, this landed
  correctly.
- **I did not verify the knock-on claim #1656 makes about #1649's acceptance text** (that "expect
  compose back to its single documented finding" is no longer satisfiable as written). It is
  plausible given the above and it belongs to the appliance lane's issue, not to this file. Flagging
  it rather than asserting it.
- **`develop`'s copy of `.trivyignore` is untouched by this PR.** The twins genuinely differ — seven
  active mutes each, but not the same seven: `develop` carries `CVE-2026-45447` and no
  `CVE-2026-34040`. That asymmetry is #1442's subject, not this one.

## Over-engineering pass (ponytail gate), and the finding I acted on

Done by hand on this diff, as this lane's gate behaviour requires.

**Finding, accepted and fixed in `894b2cf5`:** the replacement comment block ran to 34 lines to
document *zero* live entries, where the block it replaced was 26 lines documenting one. Documenting
less at greater length is the wrong direction. The methodology (the controlled wide/gate scan pair)
and the advisory-scoping caveat were moved out of the file and into this PR body, where they are
evidence for the reviewer rather than permanent weight on every future reader of `.trivyignore`.
The block is now 23 lines, and the file is **64 lines against the 67 it started at** — a change that
removes a mute should not make the file bigger.

**Considered and rejected: deleting the block outright.** It would be shorter still, but the block's
job is to stop the next person re-adding a mute for this module, and the failure mode is real —
#1153 found two obsolete mutes standing. A file whose entire design is one rationale per entry needs
a rationale for a deliberate non-entry too.

**Considered and rejected: keeping the historical x/text and grpc sentences out.** They are what
explain the premise change (vendored release binaries -> compiled from source), which is why a
finding on this module is fixable in principle at all. Without them the "nothing replaces it"
argument does not stand on its own.

No other over-engineering found: the change adds no mechanism, no script, no test scaffolding and no
new file. It deletes one line of configuration and rewrites the comment that justified it.
