### PR TITLE
fix(lint): file-budget gate enumerates untracked files, not just the index

### DIFF
--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -86,6 +86,20 @@ self_test() {
     rm -f "$tmp/new.sh"
     git -C "$tmp" rm -q --cached new.sh >/dev/null 2>&1 || true
 
+    # #1486 — `git ls-files` alone only sees the INDEX; an untracked new file must be a
+    # candidate too, or the gate reads a skip as a pass on exactly the file it exists to catch.
+    seq 1 500 >"$tmp/untracked.sh"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "an over-target file that is untracked (never git add'ed) still FAILS (#1486)" 1 "$rc"
+    if grep -q "untracked.sh is 500 lines (> 400 target) but has no" "$out"; then
+        echo "  self-test ok: names the untracked file, not a vacuous pass"
+    else
+        echo "  self-test FAIL: did not name the untracked file"
+        st_fail=1
+    fi
+    rm -f "$tmp/untracked.sh"
+
     printf '# test budget\nbudgeted.sh\t400\n' >"$tmp/$BUDGET_FILE"
     rc=0
     (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -2,8 +2,9 @@
 # The file-budget ratchet gate (#1105 Phase 0): stop the biggest files in the repo from getting
 # any bigger, without demanding anyone rewrite them today. Two rules:
 #
-#   1. A tracked file over the 400-line target must record a ceiling in
-#      docs/dev/file-budget.tsv; over 800 the refusal names the hard ceiling instead.
+#   1. A candidate file (tracked, or untracked and not gitignored — #1486) over the 400-line
+#      target must record a ceiling in docs/dev/file-budget.tsv; over 800 the refusal names the
+#      hard ceiling instead.
 #   2. An existing offender (already over 400 when this gate landed, or added to the budget
 #      since) gets its CURRENT line count recorded in docs/dev/file-budget.tsv as a personal
 #      ceiling. A PR may not grow that file past its recorded ceiling. Ceilings only ever go
@@ -121,10 +122,18 @@ count_lines() {
     awk 'END { print NR + 0 }' "$1" 2>/dev/null || echo 0
 }
 
-# Every tracked, non-exempt, non-binary file: "path<TAB>lines", one per line.
+# Every tracked OR untracked-but-not-gitignored, non-exempt, non-binary file: "path<TAB>lines",
+# one per line. `git ls-files` alone only lists the INDEX — a new file sits invisible right up
+# until `git add`, which is exactly the moment a budget gate exists to catch it (#1486). Union in
+# `--others --exclude-standard` (untracked, honoring .gitignore) so the working tree, not the
+# index, is what gets measured; the two lists are disjoint (`--others` never repeats a tracked
+# path) so no dedup is needed.
 list_candidates() {
     local f
-    git ls-files | while IFS= read -r f; do
+    {
+        git ls-files
+        git ls-files --others --exclude-standard
+    } | while IFS= read -r f; do
         [ -f "$f" ] || continue
         is_exempt "$f" && continue
         is_binary_or_empty "$f" && continue


### PR DESCRIPTION
The file-budget ratchet gate (`scripts/lint-file-budget.sh`) builds its candidate list from `git ls-files` alone, which only enumerates the index. A new file over the 400-line target that has never been `git add`'ed is invisible to the gate — the exact moment the gate exists to catch, since staging is the very next step. The gate reads that as zero over-target candidates and passes.

## What the gate now refuses

`list_candidates` unions `git ls-files` with `git ls-files --others --exclude-standard` (untracked, honoring `.gitignore`), so the working tree — not just the index — is what gets measured. The two lists are disjoint, so no dedup is needed. An over-target untracked file now fails the gate by name, the same as a tracked one.

## How it was proven

Deciding commands, run from the repo root:

```
bash scripts/lint-file-budget.sh --self-test
bash scripts/lint-file-budget.sh
```

(equivalently `make lint-file-budget`). Before the fix, a 500-line untracked file dropped into a scratch fixture tree passed the gate silently. After the fix, the same fixture fails with rc=1 and names the file.

## What the added test asserts

A new self-test case in `scripts/lint-file-budget-selftest.sh`: writes a 500-line `untracked.sh` into the fixture tree without `git add`, runs the gate, and asserts both that it exits non-zero and that the failure output names `untracked.sh` specifically — not a vacuous pass, and not a generic failure that could hold even if the untracked path were still silently skipped.

Refs #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
