### PR TITLE
test(os): #1676 leg 4 ages a x.y.0 running version across the minor boundary, and a failed aging costs one red

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -67,7 +67,7 @@ tests/integration/run.sh	2551
 tests/integration/selftest-e2e-phases.sh	507
 tests/integration/selftest.sh	686
 tests/os/failure-evidence.sh	567
-tests/os/run.sh	3437
+tests/os/run.sh	3423
 tests/stack/test-appliance-boot.sh	641
 tests/stack/test-appliance-identity-boot.sh	465
 tests/stack/test-appliance-identity.sh	483

--- a/tests/os/aged-version.sh
+++ b/tests/os/aged-version.sh
@@ -1,0 +1,107 @@
+# shellcheck shell=bash
+#
+# Shared by tests/os/run.sh's leg 4 (drives it against the checkout's VERSION before the guest's
+# OS-update run) and tests/stack/test-harness-tooling.sh (drives `--self-test`, tier 1, no guest):
+# the version leg 4 makes the guest CLAIM to be running, so that the bundle stamped with the real
+# VERSION is a genuine update. Both images come from the one checkout and the dashboard door refuses
+# an equal target on purpose, so without this the leg could never get past its first download.
+#
+# It has to be done on this side. The obvious move — stamp the BUNDLE one patch newer — produces a
+# bundle whose manifest and payload disagree, and that breaks two things at once. pithead-boot
+# writes the `rolled_back` verdict purely by comparing the in-flight target to the booted slot's
+# VERSION, before the health gate runs at all, so a mismatch reports a rollback that never
+# happened. And STACK_VERSION is derived from that same VERSION file and tags all five first-party
+# images, so a payload rewritten to match would send the post-update boot hunting image tags that
+# were never published — turning the fake rollback into a real one.
+#
+# #1676: the helper used to decrement only the PATCH component and give up at 0 — and every minor
+# release-prep tip is x.y.0, so the release gate (#1651) could not age the version on exactly the
+# tips it exists to prove. Any value the downgrade guard orders BELOW the bundle serves (the floor
+# leg plants its own 99.0.0 floor separately), so this steps down the lowest non-zero component and
+# zeroes the ones below it: 1.20.1 -> 1.20.0, 1.20.0 -> 1.19.0, 2.0.0 -> 1.0.0. Only 0.0.0 has
+# nothing below it.
+
+# $1 = a version as VERSION carries it: X.Y.Z, digits only, no "v".
+# Prints the aged version on stdout; exit 0 = aged, 1 = nothing sorts below it, or not X.Y.Z. On 1
+# it prints NOTHING — the caller must never write a half-parsed value into the guest.
+aged_version() {
+    local major minor patch
+    [[ "${1:-}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]] || return 1
+    major=$((10#${BASH_REMATCH[1]}))
+    minor=$((10#${BASH_REMATCH[2]}))
+    patch=$((10#${BASH_REMATCH[3]}))
+    if [ "$patch" -gt 0 ]; then
+        printf '%s.%s.%s' "$major" "$minor" "$((patch - 1))"
+    elif [ "$minor" -gt 0 ]; then
+        printf '%s.%s.0' "$major" "$((minor - 1))"
+    elif [ "$major" -gt 0 ]; then
+        printf '%s.0.0' "$((major - 1))"
+    else
+        return 1
+    fi
+}
+
+# --- self-test (#1676) -----------------------------------------------------------------------
+#
+# Driven by `tests/os/aged-version.sh --self-test`, tier 1, no guest: the three step-down shapes
+# (patch, minor, major), the one version with nothing below it, and the malformed inputs the helper
+# must refuse rather than half-parse. Every aged value is also checked against an INDEPENDENT
+# ordering (`sort -V`), so a helper that printed something not strictly older cannot pass on its
+# own say-so.
+_av_case() { # <input> <want-output|NONE> <want-rc>
+    local got rc
+    got=$(aged_version "$1")
+    rc=$?
+    if [ "$rc" != "$3" ]; then
+        printf '  FAIL %q: rc %s, want %s\n' "$1" "$rc" "$3"
+        return 1
+    fi
+    if [ "$2" = NONE ]; then
+        [ -z "$got" ] && return 0
+        printf '  FAIL %q: printed %q on refusal, want nothing\n' "$1" "$got"
+        return 1
+    fi
+    if [ "$got" != "$2" ]; then
+        printf '  FAIL %q: got %q, want %s\n' "$1" "$got" "$2"
+        return 1
+    fi
+    if [ "$got" = "$1" ] || [ "$(printf '%s\n%s\n' "$got" "$1" | sort -V | head -n 1)" != "$got" ]; then
+        printf '  FAIL %q: %s does not sort strictly below it\n' "$1" "$got"
+        return 1
+    fi
+}
+
+_av_self_test() {
+    local n=0 f=0 input want rc
+    while read -r input want rc; do
+        n=$((n + 1))
+        _av_case "$input" "$want" "$rc" || f=$((f + 1))
+    done <<'CASES'
+1.20.1 1.20.0 0
+1.20.10 1.20.9 0
+1.20.0 1.19.0 0
+0.1.0 0.0.0 0
+2.0.0 1.0.0 0
+1.0.0 0.0.0 0
+0.0.1 0.0.0 0
+0.0.0 NONE 1
+v1.20.0 NONE 1
+1.20 NONE 1
+1.20.0.1 NONE 1
+1.20.0-rc1 NONE 1
+CASES
+    # The empty input cannot ride the table (read collapses it), and it is the shape an unreadable
+    # VERSION hands the caller.
+    n=$((n + 1))
+    _av_case "" NONE 1 || f=$((f + 1))
+    if [ "$f" -gt 0 ]; then
+        printf '#1676 aged-version self-test FAILED: %s of %s cases\n' "$f" "$n"
+        return 1
+    fi
+    printf '#1676 aged-version self-test passed (%s cases)\n' "$n"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ] && [ "${1:-}" = "--self-test" ]; then
+    _av_self_test
+    exit $?
+fi

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -55,6 +55,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 . "$SCRIPT_DIR/reinstall-prefill-verdict.sh"
 # shellcheck source=tests/os/data-floor-fallback-leg.sh
 . "$SCRIPT_DIR/data-floor-fallback-leg.sh"
+# shellcheck source=tests/os/aged-version.sh
+. "$SCRIPT_DIR/aged-version.sh"
 
 IMAGE=""
 KEEP=0
@@ -252,30 +254,6 @@ _build_image() {
         return 1
     }
     printf 'os/rauc/build/system.img'
-}
-
-# The checkout's VERSION with the patch component DECREMENTED — the version leg 4 makes the guest
-# claim to be running, so that the bundle (stamped with the real VERSION) is a genuine update.
-#
-# It has to be done on this side. The obvious move — stamp the BUNDLE one patch newer — produces a
-# bundle whose manifest and payload disagree, and that breaks two things at once. pithead-boot
-# writes the `rolled_back` verdict purely by comparing the in-flight target to the booted slot's
-# VERSION, before the health gate runs at all, so a mismatch reports a rollback that never
-# happened. And STACK_VERSION is derived from that same VERSION file and tags all five first-party
-# images, so a payload rewritten to match would send the post-update boot hunting image tags that
-# were never published — turning the fake rollback into a real one.
-_prev_patch_version() {
-    local v major minor patch
-    v=$(tr -d ' \t\r\n' <VERSION)
-    major=${v%%.*}
-    patch=${v##*.}
-    minor=${v#*.}
-    minor=${minor%%.*}
-    [ "$patch" -gt 0 ] 2>/dev/null || {
-        printf '%s' "$v"
-        return 1
-    }
-    printf '%s.%s.%s' "$major" "$minor" "$((patch - 1))"
 }
 
 # Build an update bundle carrying $1 as its marker.
@@ -995,18 +973,26 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     # for a compromised container. Both images here are built from the one checkout, so without
     # this the guest is already running the version the bundle carries and leg 4 could never get
     # past its first download — it reported #976's path as broken while never offering it anything
-    # to install. Age the RUNNING side, never the bundle's stamp (see _prev_patch_version).
+    # to install. Age the RUNNING side, never the bundle's stamp (see tests/os/aged-version.sh).
     #
     # Safe here specifically: nothing renders .env or runs compose between this write and the
     # reboot — `pithead os-update` is a rauc install — and pithead-sync restores the slot's real
     # VERSION on the next boot, before pithead-boot reads it to judge the update. So the guest
     # claims the older version exactly for the length of the check/download/install window.
+    # #1676: a failed precondition here used to cost SEVEN reds — every later step fails on the
+    # same un-aged guest — so both failure shapes return after their one red.
     local aged
-    if aged=$(_prev_patch_version); then
-        _ssh "printf '%s\n' '$aged' > /data/pithead/VERSION" ||
-            bad "leg 4: could not age the guest's running version to $aged"
-    else
-        bad "leg 4: VERSION patch component is 0 — cannot age the running version below it"
+    if ! aged=$(aged_version "${tag#v}"); then
+        bad "leg 4: cannot age the running version ${tag#v} — nothing sorts below it (tests/os/aged-version.sh)"
+        kill "$srv_pid" 2>/dev/null
+        rm -rf "$srv"
+        return
+    fi
+    if ! _ssh "printf '%s\n' '$aged' > /data/pithead/VERSION"; then
+        bad "leg 4: could not age the guest's running version to $aged"
+        kill "$srv_pid" 2>/dev/null
+        rm -rf "$srv"
+        return
     fi
 
     local out st

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -93,6 +93,16 @@ echo "== unit: #1059 watch-report discrimination =="
 bash "$ROOT/tests/os/failure-evidence.sh" --self-test >/dev/null 2>&1
 assert_rc "#1059 watch-report self-test passes" "$?" "0"
 
+echo "== unit: #1676 version-aging helper self-test =="
+# tests/os/run.sh's leg 4 must make the guest claim a version OLDER than the bundle it is about to
+# install, and every minor release-prep tip is x.y.0 — the shape the helper used to refuse, which
+# reddened the release gate with seven reds for one cause. Its --self-test drives the three
+# step-down shapes, the one version with nothing below it, and the malformed inputs it must refuse,
+# each aged value checked against an independent ordering. Lives in tests/os/ (appliance lane);
+# driven here because tier 1 is the lowest tier that proves it and it needs no KVM.
+bash "$ROOT/tests/os/aged-version.sh" --self-test >/dev/null 2>&1
+assert_rc "#1676 aged-version self-test passes" "$?" "0"
+
 echo "== unit: tor healthcheck command-dependency self-test (#1372) =="
 # The #1098 pair above asks whether a healthcheck script EXISTS where its Dockerfile promises. This
 # asks the other half of the same contract: whether build/tor/healthcheck.sh can still RUN on


### PR DESCRIPTION
Closes nothing by keyword (everything lands on `develop-v2`; the controller closes #1676 by hand).

## What changed

`tests/os/run.sh` leg 4 makes the guest claim a version OLDER than the bundle it is about to install, because both images come from one checkout and the dashboard door refuses an equal target on purpose. The helper that produced that version only decremented the PATCH component and gave up at 0 — and every minor release-prep tip is `x.y.0`, so the release gate (#1651) could not age the version on exactly the tips it exists to prove. Worse, the `bad` at the aging site never returned, so every later step failed on the same un-aged guest: seven reds in leg 4 for one cause.

- **`tests/os/aged-version.sh` (new, 107 lines, under the 400-line budget target so no tsv row):** the helper as a pure function over `X.Y.Z`. It steps down the lowest non-zero component and zeroes the ones below it (`1.20.1 -> 1.20.0`, `1.20.0 -> 1.19.0`, `2.0.0 -> 1.0.0`), and fails closed — rc 1, prints nothing — on `0.0.0` or anything not `X.Y.Z`, so the caller can never write a half-parsed value into the guest. Any value the downgrade guard orders below the bundle serves: `semver_newer` compares per component numerically (`%d%05d%05d`), and the floor leg plants its own `99.0.0` floor separately. Its `--self-test` drives 13 cases and checks every aged value against an independent ordering (`sort -V`) as well as against the expected string.
- **`tests/os/run.sh`:** sources the sibling, ages `${tag#v}` (already the checkout's VERSION, read once at the top of the leg), and returns after either aging red with the bench release server torn down — the same shape as the leg's three other early returns. 3437 -> 3423 lines: the helper and its comment moved out (-24), the source pair (+2) and the two returns (+8).
- **`tests/stack/test-harness-tooling.sh` — SHARED file (`roles/_shared.paths`), disclosed per the serialization rule, not a grant:** a two-line driver for the self-test beside the existing `failure-evidence.sh` row, same reason as that row — tier 1 is the lowest tier that proves it and it needs no KVM. No open PR touches this file (checked per open PR's file list at creation time). 84 -> 94 lines, unrowed.
- **`docs/dev/file-budget.tsv`:** the one row this change touched, `tests/os/run.sh` 3437 -> 3423. `--generate` also wanted to lower four rows I did not touch; those are left alone.

## What was RUN (all at 667950d1 in the branch worktree)

- `bash tests/os/aged-version.sh --self-test`: passed, 13 cases.
- **Three mutants of the helper, each proven applied (1 changed line) and each FAILING the self-test:** M1 minor-branch disabled (the old patch-only behaviour) — 2 of 13 fail; M2 minor not decremented (`1.20.0 -> 1.20.0`) — 2 of 13 fail; M3 lenient parse (accepts `v` prefix and trailing text) — 3 of 13 fail. So the self-test is shown able to fail on each defect shape the issue names.
- `shellcheck -x` finding multiset on `tests/os/run.sh`, base vs head: identical (43 lines each, same SC codes and counts). `tests/os/aged-version.sh` and the driver file: clean at `--severity=warning`. `shfmt -i 4 -d` on all three: clean. Not `make lint-sh` (serialized fleet-wide; CI runs it).
- `scripts/lint-file-budget.sh` at the branch head against `origin/develop-v2`: OK. **Control:** with the run.sh row set one under its count, the gate FAILS naming `tests/os/run.sh` — then restored.
- `tests/inventory.sh`: `test-harness-tooling.sh — 10` sections, the new `unit: #1676 version-aging helper self-test` listed.
- Lane guard: an out-of-lane staged file was refused by name (positive control), then the commit with these four files passed.
- `tests/stack/run.sh`, full suite, detached at this head: rc 0, `pithead tests: 3138 passed, 0 failed`; the `#1676 version-aging helper self-test passes` row is in the log under its own `== unit ==` header. Zero ✗ glyphs.

## What was NOT run — the gap that keeps this DRAFT

- **Leg 4 on a KVM guest at this head.** The bench is held by the #1651 battery, which runs at the PRE-fix tip and is the negative baseline: its leg-4 block shows the seven reds quoted in the issue. Owed before ready-for-review: the update leg from this worktree on the bench, log posted here. Until then the run.sh change is proven by reading and by the suite's syntax/sourcing, not by a guest.

## Over-engineering pass (by hand — the ponytail gate reads this lane's pinned cwd and names an unrelated dead branch, so it cannot judge this diff)

- Not a pure move: the helper was rewritten (regex parse, three step-down branches) because the old body could not express the minor/major cases. The comment block moved verbatim into the sibling's header, with the #1676 paragraph appended.
- Placements available and rejected: rows in `run.sh` itself (tier 1 cannot source it — `test-appliance-boot.sh:620` reads it as text); rows in `test-appliance-identity-boot.sh` (465/465, fails both ways); rows in `test_appliance_hugepages.sh` (its charter is the #1103 gate). A `_leg4_abort` helper for the two new 4-line returns was available and rejected: the leg's three existing early returns use the inline form, and the helper would save one line.
