### PR TITLE
fix(dashboard): #1644 a failing payout sync no longer skips the steps beneath it

### DIFF
--- a/dashboard/mining_dashboard/service/data_service.py
+++ b/dashboard/mining_dashboard/service/data_service.py
@@ -71,7 +71,7 @@ from mining_dashboard.helper.utils import (
     pplns_block_time,
     shares_in_pplns_window,
 )
-from mining_dashboard.service import audit_service, worker_change_audit
+from mining_dashboard.service import audit_service, payout_sync, worker_change_audit
 from mining_dashboard.service.alert_service import AlertService
 from mining_dashboard.service.clearnet_sync import ClearnetSyncSupervisor
 from mining_dashboard.service.control_service import (
@@ -655,52 +655,14 @@ class DataService:
             )
 
     async def _sync_payouts(self):
-        """Confirm on-chain payouts from the view-only wallet-rpc (#381), throttled by the caller.
-
-        Seeds the query from the highest stored Monero payout height, so a restart re-scans only
-        the tip; ``add_payouts`` is idempotent on ``(chain, txid)``, so the overlap is dropped and
-        nothing replays. Every genuinely-new confirmed payout fires exactly one ``payout_confirmed``
-        alert. A wallet still doing its first-run scan (or briefly unreachable) returns ``[]`` — a
-        quiet no-op, no error. chain="monero" here; the Tari sibling (#462) reuses the same table."""
-        chain = "monero"
-        min_height = await asyncio.to_thread(self.state_manager.get_payout_max_height, chain)
-        payouts = await asyncio.to_thread(self.wallet_client.get_confirmed_payouts, min_height)
-        if not payouts:
-            return
-        new_rows = await asyncio.to_thread(self.state_manager.add_payouts, chain, payouts)
-        for r in new_rows:
-            logger.info(
-                "Payout confirmed on-chain: %.6f XMR (tx %s…) at height %d (#381)",
-                r["amount_atomic"] / 1e12,
-                r["txid"][:8],
-                r["height"],
-            )
-            await self.alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])
+        """Monero on-chain payout confirmation (#381). The body moved to ``payout_sync`` for #1644;
+        this stays as the poll body's call seam, and as the name the tests already reach for."""
+        await payout_sync.sync_monero(self.state_manager, self.wallet_client, self.alert_service)
 
     async def _sync_tari_payouts(self):
-        """Confirm Tari on-chain payouts from the view-only console wallet (#462), throttled by the
-        caller — the Tari sibling of ``_sync_payouts``.
-
-        Identical shape: seed from the highest stored Tari payout height, stream new confirmed
-        payouts, persist to the shared ``payouts`` table with chain="tari" (idempotent on
-        ``(chain, txid)`` so a restart replays nothing), and fire one ``payout_confirmed`` alert per
-        genuinely-new payout. ``amount_atomic`` is microTari here; the shared alert divides by the
-        Tari divisor. The Tari client is async (grpc.aio), so it's awaited directly rather than via
-        ``asyncio.to_thread``. An empty/unreachable scan is a quiet no-op."""
-        chain = "tari"
-        min_height = await asyncio.to_thread(self.state_manager.get_payout_max_height, chain)
-        payouts = await self.tari_wallet_client.get_confirmed_payouts(min_height)
-        if not payouts:
-            return
-        new_rows = await asyncio.to_thread(self.state_manager.add_payouts, chain, payouts)
-        for r in new_rows:
-            logger.info(
-                "Tari payout confirmed on-chain: %.6f XTM (tx %s…) at height %d (#462)",
-                r["amount_atomic"] / 1e6,
-                r["txid"][:8],
-                r["height"],
-            )
-            await self.alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])
+        """Tari on-chain payout confirmation (#462) — the sibling of ``_sync_payouts``, same shape
+        and same reason for staying here while its body lives in ``payout_sync``."""
+        await payout_sync.sync_tari(self.state_manager, self.tari_wallet_client, self.alert_service)
 
     async def _record_audit_event(self, source, actor, action, status, keys, event_id=None):
         """Write one out-of-band audit row (#530), through the SAME sanitizer #33's own audit
@@ -1416,13 +1378,18 @@ class DataService:
                     # 7d. On-chain payout confirmation (#381), every 10th poll (~5 min). Independent
                     # of XvB — gated on the view-only wallet-rpc being configured (local node + view
                     # key). Polls get_transfers, persists new confirmed payouts, fires one alert each.
+                    #
+                    # 7d/7e are the only steps in this body wrapped per-step (#1644): both take no
+                    # poll local and write no `self` attribute, so a failure in one cannot leave a
+                    # later step reading half-written state. Everything above stays under the single
+                    # handler below — see `payout_sync` for why widening this is its own change.
                     if self.wallet_client is not None and iteration_count % 10 == 0:
-                        await self._sync_payouts()
+                        await payout_sync.run_isolated("Monero payout sync", self._sync_payouts)
 
                     # 7e. Tari on-chain payout confirmation (#462), same cadence — gated on the
                     # view-only Tari console wallet being configured (local node + tari view key).
                     if self.tari_wallet_client is not None and iteration_count % 10 == 0:
-                        await self._sync_tari_payouts()
+                        await payout_sync.run_isolated("Tari payout sync", self._sync_tari_payouts)
 
                     # 8. New-release check over Tor (#224) — ONLY when explicitly enabled (default off,
                     # so the appliance never phones GitHub unbidden). The checker self-throttles to

--- a/dashboard/mining_dashboard/service/payout_sync.py
+++ b/dashboard/mining_dashboard/service/payout_sync.py
@@ -1,0 +1,95 @@
+"""On-chain payout confirmation for both chains (#381, #462), and the poll-step guard (#1644).
+
+Split out of ``data_service`` for a budget reason that is also a design one. ``data_service.py``
+sits one line under its recorded ceiling, so the per-step ``try``/``except`` #1644 needs did not
+fit inline; and these two steps are the only ones in the poll body proven independent enough to
+isolate, which makes them a coherent thing to own rather than an arbitrary slice. The bodies below
+are a pure move: byte-identical to their originals except that each now takes its collaborators as
+arguments instead of reading them off ``self``.
+
+**What #1644 is about.** ``DataService.run()``'s poll body is 33 awaited steps under a single
+``except Exception``, so any one of them raising skips every step below it for that poll. A
+malformed body out of the Monero wallet took the Tari payout sync, the release check and the price
+feed down with it — steps that have nothing to do with Monero payouts.
+
+**Why only these two are guarded here.** ``_sync_payouts`` and ``_sync_tari_payouts`` take no poll
+locals and write no ``self`` attribute: DB and alert side-effects only. Isolating them creates no
+cross-iteration edge. That is NOT true of the rest of the body, and :func:`run_isolated` is
+deliberately not applied more widely — the XvB block reads poll locals (``shares_list``,
+``p2pool_stats``) sourced by earlier collectors and must keep skipping as a unit, and the remaining
+steps have not been cleared. Widening this guard is a separate change that owes that clearing
+first; a guard whose correctness nobody has established is worse than the skip it replaces,
+because it looks like the work is done.
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger("DataService")
+
+
+async def run_isolated(label, step):
+    """Run one poll step so that its failure cannot skip the steps after it (#1644).
+
+    The loop's own ``except Exception`` already keeps the service alive across a failed poll; what
+    it cannot do is keep the REST OF THAT POLL running, because it sits at the bottom of the body.
+    This is the same catch moved up to one step, so the poll continues past it.
+
+    ``label`` names the step in the log. It is not cosmetic: the loop's handler logs one
+    undifferentiated "Data Collection Error", and a step that now fails without ending the poll
+    would otherwise be quieter than it was before it was guarded.
+    """
+    try:
+        await step()
+    except Exception as e:
+        logger.error("Poll step failed, continuing with the rest of the poll — %s: %s", label, e)
+
+
+async def sync_monero(state_manager, wallet_client, alert_service):
+    """Confirm on-chain payouts from the view-only wallet-rpc (#381), throttled by the caller.
+
+    Seeds the query from the highest stored Monero payout height, so a restart re-scans only
+    the tip; ``add_payouts`` is idempotent on ``(chain, txid)``, so the overlap is dropped and
+    nothing replays. Every genuinely-new confirmed payout fires exactly one ``payout_confirmed``
+    alert. A wallet still doing its first-run scan (or briefly unreachable) returns ``[]`` — a
+    quiet no-op, no error. chain="monero" here; the Tari sibling (#462) reuses the same table."""
+    chain = "monero"
+    min_height = await asyncio.to_thread(state_manager.get_payout_max_height, chain)
+    payouts = await asyncio.to_thread(wallet_client.get_confirmed_payouts, min_height)
+    if not payouts:
+        return
+    new_rows = await asyncio.to_thread(state_manager.add_payouts, chain, payouts)
+    for r in new_rows:
+        logger.info(
+            "Payout confirmed on-chain: %.6f XMR (tx %s…) at height %d (#381)",
+            r["amount_atomic"] / 1e12,
+            r["txid"][:8],
+            r["height"],
+        )
+        await alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])
+
+
+async def sync_tari(state_manager, tari_wallet_client, alert_service):
+    """Confirm Tari on-chain payouts from the view-only console wallet (#462), throttled by the
+    caller — the Tari sibling of :func:`sync_monero`.
+
+    Identical shape: seed from the highest stored Tari payout height, stream new confirmed
+    payouts, persist to the shared ``payouts`` table with chain="tari" (idempotent on
+    ``(chain, txid)`` so a restart replays nothing), and fire one ``payout_confirmed`` alert per
+    genuinely-new payout. ``amount_atomic`` is microTari here; the shared alert divides by the
+    Tari divisor. The Tari client is async (grpc.aio), so it's awaited directly rather than via
+    ``asyncio.to_thread``. An empty/unreachable scan is a quiet no-op."""
+    chain = "tari"
+    min_height = await asyncio.to_thread(state_manager.get_payout_max_height, chain)
+    payouts = await tari_wallet_client.get_confirmed_payouts(min_height)
+    if not payouts:
+        return
+    new_rows = await asyncio.to_thread(state_manager.add_payouts, chain, payouts)
+    for r in new_rows:
+        logger.info(
+            "Tari payout confirmed on-chain: %.6f XTM (tx %s…) at height %d (#462)",
+            r["amount_atomic"] / 1e6,
+            r["txid"][:8],
+            r["height"],
+        )
+        await alert_service.payout_confirmed_alert(chain, r["amount_atomic"], r["txid"])

--- a/dashboard/tests/service/test_data_loop_counter.py
+++ b/dashboard/tests/service/test_data_loop_counter.py
@@ -1,4 +1,9 @@
-"""#1637 — the data loop's poll counter must advance even when the poll raised.
+"""Two laws about what one failing poll step may cost: #1637 (cadence) and #1644 (siblings).
+
+#1637 is the counter law below. #1644 is the sibling law: a raise in one step must not skip
+unrelated steps beneath it for the rest of that poll. They meet in one place — the payout sync is
+both the gated step whose cadence #1637 pins and the step #1644 isolates — which is why they are
+tested together here rather than in two files that would each need the same 100-line harness.
 
 `DataService.run()` counts polls in a plain local, `iteration_count`, and three steps are gated on
 it with `iteration_count % 10 == 0`: the XvB stats sync, the Monero payout sync and the Tari payout
@@ -26,12 +31,14 @@ Lives in its own file rather than in `test_data_service.py`, which is at its rec
 `docs/dev/file-budget.tsv` row, because the gate fails a file that is under target AND has a row.
 """
 
+import asyncio
 import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import mining_dashboard.service.data_service as ds_mod
+from mining_dashboard.service.payout_sync import run_isolated
 from tests.service.test_data_service import _FakeClientSession, _make_service
 
 # Every collector `run()` touches before it reaches the gated steps, stubbed to something inert.
@@ -52,7 +59,7 @@ _INERT_COLLECTORS = {
 
 
 @contextlib.contextmanager
-def _driven_loop(sleep):
+def _driven_loop(sleep, enable_xvb=False):
     """Drive `run()` for a fixed number of polls, stopping it through its own `asyncio.sleep`.
 
     `sleep` is the mock installed over `asyncio.sleep`, which is the loop's only suspension point
@@ -78,8 +85,10 @@ def _driven_loop(sleep):
                 AsyncMock(return_value={"is_syncing": False, "percent": 100}),
             )
         )
-        # XvB off, so the ONLY thing standing on the `% 10 == 0` gate is the payout sync under test.
-        stack.enter_context(patch.object(ds_mod, "ENABLE_XVB", False))
+        # XvB off by default, so the ONLY thing standing on the `% 10 == 0` gate is the payout
+        # sync under test. The coupling law below turns it on, because the block it pins is inside
+        # `if ENABLE_XVB and ...` and is unreachable — silently — with the flag off.
+        stack.enter_context(patch.object(ds_mod, "ENABLE_XVB", enable_xvb))
         stack.enter_context(patch("asyncio.sleep", sleep))
         yield
 
@@ -98,10 +107,10 @@ def _service_with_payout_gate_open(payout_side_effect=None):
     return svc
 
 
-async def _run_for_polls(svc, polls):
+async def _run_for_polls(svc, polls, enable_xvb=False):
     """Run `svc` for exactly `polls` polls, then stop it at the sleep that follows the last one."""
     sleep = AsyncMock(side_effect=[None] * (polls - 1) + [StopAsyncIteration])
-    with _driven_loop(sleep):
+    with _driven_loop(sleep, enable_xvb=enable_xvb):
         with pytest.raises(StopAsyncIteration):
             await svc.run()
     assert sleep.await_count == polls, "the loop did not run the number of polls this test assumes"
@@ -130,20 +139,24 @@ class TestTheCounterAdvancesThroughAFailedPoll:
         """VACUITY GUARD for the law above. `await_count == 1` on the payout sync is ALSO what a
         loop that died on the first raise would report, and that would satisfy the law for entirely
         the wrong reason. The witness is `_sync_prices`, which sits BELOW the payout sync in the
-        body: it cannot have run on poll 1, because the raise above it skipped the rest of that
-        poll, so seeing it run at all means poll 2 happened.
+        body, so seeing it run at all means the loop kept going.
 
-        **Exactly once, not twice, and the shortfall is a second defect this issue does not fix.**
-        A raise at the payout sync also skips `_sync_tari_payouts` and `_sync_prices`, which have
-        nothing to do with payouts — #1637's point 2, filed separately because its fix is per-step
-        guards rather than counter placement. Fixing the counter cuts how OFTEN that happens by
-        about ten times and does not stop it. If this ever reads 2, that defect was fixed too and
-        this docstring is the thing that is now wrong."""
+        **Twice, and it used to be once.** The shortfall this docstring recorded as "a second defect
+        this issue does not fix" is #1644, and it is now fixed: the payout sync is wrapped per-step,
+        so its raise no longer skips `_sync_prices` on poll 1. Poll 1 and poll 2 both reach it.
+
+        Two polls are still the right run even though one would now do. The count has to stay a
+        statement about the loop CONTINUING, not about the guard swallowing: if the guard were
+        removed and the counter fix kept, this reads 1 rather than 0, so a single-poll version
+        would go green against a regression this two-poll version catches."""
         svc = _service_with_payout_gate_open(RuntimeError("monerod returned a malformed body"))
 
         await _run_for_polls(svc, 2)
 
-        assert svc._sync_prices.await_count == 1, "the loop did not complete a second poll at all"
+        assert svc._sync_prices.await_count == 2, (
+            "the price sync did not run on both polls — a raise in the payout sync above it is "
+            "skipping the rest of the poll again (#1644), or the loop did not complete poll 2"
+        )
 
 
 class TestTheGateStillFiresOnSchedule:
@@ -198,3 +211,103 @@ class TestTheHarnessCanSeeTheStepAtAll:
         await _run_for_polls(svc, 1)
 
         assert svc._sync_payouts.await_count == 1
+
+
+class TestAFailedStepDoesNotSkipItsIsolatedSibling:
+    """#1644's law, and the narrow half of it. Only the two payout steps are wrapped per-step, so
+    only they are claimed here — the coupling law below pins the other half deliberately."""
+
+    async def test_the_tari_sync_still_runs_on_the_poll_the_monero_sync_raised_on(self):
+        """THE LAW. Both payout gates are open on poll 1. `_sync_payouts` raises; `_sync_tari_payouts`
+        is the very next statement in the body and has nothing to do with Monero — it takes no poll
+        local and writes no `self` attribute, which is the ground the wrap was cleared on.
+
+        Before the wrap this read 0: the raise reached the loop's single `except Exception` at the
+        bottom of the body and everything between was skipped."""
+        svc = _service_with_payout_gate_open(RuntimeError("monerod returned a malformed body"))
+        svc.tari_wallet_client = MagicMock()  # opens the sibling gate this helper normally shuts
+        svc._sync_tari_payouts = AsyncMock()
+
+        await _run_for_polls(svc, 1)
+
+        assert svc._sync_payouts.await_count == 1, (
+            "the step under test never ran, so nothing raised"
+        )
+        assert svc._sync_tari_payouts.await_count == 1, (
+            "the Tari payout sync was skipped by a failure in the Monero one — the per-step wrap "
+            "is not isolating them (#1644)"
+        )
+
+    async def test_a_raising_step_is_logged_rather_than_swallowed(self, caplog):
+        """A guard that continues quietly is worse than the skip it replaces: the loop's own handler
+        logged one line per failed poll, and a step that now fails WITHOUT ending the poll would
+        otherwise disappear. Pins that the step is named, not just that something was logged."""
+        svc = _service_with_payout_gate_open(RuntimeError("monerod returned a malformed body"))
+
+        with caplog.at_level("ERROR"):
+            await _run_for_polls(svc, 1)
+
+        assert "Monero payout sync" in caplog.text, "the guarded failure did not name its step"
+        assert "monerod returned a malformed body" in caplog.text, "the cause was swallowed"
+
+
+class TestTheXvbBlockStillSkipsAsAUnit:
+    """The coupling that was KEPT, pinned so a later widening has to argue with a red test.
+
+    `_maybe_register_xvb(shares_list, p2pool_stats)` reads two poll locals written by collectors
+    near the top of the body. Wrapping the XvB steps individually would let a later one run on a
+    poll where those locals are stale or unset, so the block must keep failing whole.
+    """
+
+    async def test_a_raise_in_the_xvb_stats_sync_skips_the_rest_of_its_block(self):
+        """XvB on, poll 1 gated open, `_sync_xvb_stats` raises. The three steps below it in the same
+        `if ENABLE_XVB` block must not run. This is the assertion that reds if someone extends the
+        per-step wrap past the two cleared steps without doing the clearing work first."""
+        svc = _service_with_payout_gate_open()
+        svc._sync_xvb_stats = AsyncMock(side_effect=RuntimeError("xvb stats endpoint returned 502"))
+        svc._sync_xvb_reward_estimates = AsyncMock()
+        svc._maybe_register_xvb = AsyncMock()
+        svc._sync_xvb_winners = AsyncMock()
+
+        await _run_for_polls(svc, 1, enable_xvb=True)
+
+        assert svc._sync_xvb_stats.await_count == 1, "the XvB block never ran, so nothing raised"
+        assert svc._sync_xvb_reward_estimates.await_count == 0
+        assert svc._maybe_register_xvb.await_count == 0, (
+            "the XvB registration ran after its sibling raised — it reads poll locals and must stay "
+            "coupled; see the ruling on #1644"
+        )
+        assert svc._sync_xvb_winners.await_count == 0
+
+    async def test_the_block_runs_whole_when_nothing_raises(self):
+        """FIRING CONTROL for the law above. Four zeroes are also what an unreachable block reports,
+        and `ENABLE_XVB` plus a `% 10` gate is two ways to be silently unreachable. With no raise all
+        four must run, so the zeroes above are the coupling answering rather than the harness."""
+        svc = _service_with_payout_gate_open()
+        svc._sync_xvb_stats = AsyncMock()
+        svc._sync_xvb_reward_estimates = AsyncMock()
+        svc._maybe_register_xvb = AsyncMock()
+        svc._sync_xvb_winners = AsyncMock()
+
+        await _run_for_polls(svc, 1, enable_xvb=True)
+
+        assert svc._sync_xvb_stats.await_count == 1
+        assert svc._sync_xvb_reward_estimates.await_count == 1
+        assert svc._maybe_register_xvb.await_count == 1
+        assert svc._sync_xvb_winners.await_count == 1
+
+
+class TestTheGuardDoesNotOutrankShutdown:
+    """`run_isolated` catches `Exception`, and the width of that catch is load-bearing."""
+
+    async def test_task_cancellation_is_not_swallowed(self):
+        """A poll step is cancelled when the service shuts down. `CancelledError` derives from
+        `BaseException`, not `Exception`, so the guard lets it through and the task ends — but that
+        is a property of the spelling, not of the intent, and `except BaseException` would read as
+        a harmless widening while hanging shutdown behind an in-flight payout sync."""
+
+        async def cancelled():
+            raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_isolated("a step being torn down", cancelled)


### PR DESCRIPTION
Closes #1644.

## The defect

`DataService.run()`'s poll body is **33 awaited steps under one `except Exception`** at the bottom, so any step raising skips every step below it for that poll. A malformed body out of the Monero wallet took the Tari payout sync, the release check and the price feed down with it — steps with nothing to do with Monero payouts.

The `% 10` gates make it *worse* rather than *cause* it: work skipped there does not come back for ten polls. The issue title implies the gates are the subject; per the ruling, they are not. **The skip is structural, and this PR fixes it for two steps out of 33.**

## Scope — two steps, not thirty-three

`_sync_payouts` and `_sync_tari_payouts` take **no poll local and write no `self` attribute** (DB and alert side-effects only), so isolating them creates no cross-iteration edge. That is the ground they were cleared on — stronger than position in the body.

**Left coupled deliberately:**

- **The XvB block.** `_maybe_register_xvb(shares_list, p2pool_stats)` reads two poll locals written by collectors at the top of the body. Wrapping it per-step would let it run on a poll where those locals are stale or unset. There is a test that reds if someone widens the wrap to it.
- **The other 30 steps.** Not cleared. Widening owes the cross-poll enumeration (issue comment `5526436316`) and the **ten callees still marked `n/a (external)`** in the recon's swallow column — that means the callee was never resolved, not that it does not swallow.
- **`_sync_prices`.** Last statement before the handler, so isolating it protects no sibling. It *is* worth noting that it writes `self.latest_data` at `:653`, which the ruling's premise had as inert — that is a staleness question and belongs with the wall-clock issue, not here.

**No wall-clock conversion.** It dissolves #1637's defect, not this one: under `now - self._last_x >= 300` a raise at the payout sync still skips everything below it. Orthogonal, and its own issue.

## Shape, and why a new module

`data_service.py` was at **1453 against a ceiling of 1454** — one line. An inline `try`/`except`/`log` costs three lines per step, so this could not be done in place; that upgrades the issue's estimate to a measurement. Moving the two bodies into a new `service/payout_sync.py` (**95 lines**, under the 400 target, so no `file-budget.tsv` row) takes `data_service.py` to **1420**. The ceiling row is **not** lowered to match — freeing lines and then lowering the row nets zero headroom.

`_sync_payouts` / `_sync_tari_payouts` stay on `DataService` as **thin delegating wrappers**. Not ceremony: they keep the poll body's call seam and the name **ten existing tests in `test_data_service.py`** already reach for, and that file is at its own **2538 ceiling** with no room. Those ten tests are unchanged and drive a real `StateManager`, so they verify the moved dataflow rather than passing over a stub.

## What was RUN

- Full dashboard suite **2444 passed / 0 failed**; total coverage **97.39%**.
- **Patch coverage 100% on 33 changed lines**, with the gate's own non-vacuity check reporting both changed files present in `coverage.xml` — not the #1000 vacuous pass.
- `lint-py`, `lint-file-budget`, `lint-topology`, `lint-md` rc 0, run individually, **with the new module staged first** — the budget and topology gates enumerate the git index, so an untracked new file is invisible to them.
- `lint-sh` NOT run: it is shellcheck and this diff has no shell in it.

## Every new law was fired against a seed

Green tests prove nothing about laws nobody armed. Each was seeded in the direction it exists to catch:

| seed | reds | stays green |
|---|---|---|
| remove the wrap at both call sites | sibling-survival, the log line, the #1637 tripwire | the three #1637 cadence tests |
| wrap `_sync_xvb_stats` (the forbidden widening) | the XvB coupling law | everything else |
| `except BaseException` | the cancellation law | everything else |

The **#1637 tripwire moved as that issue's own docstring said it must**: `_sync_prices` across two polls with the payout sync raising now reads **2, not 1**, and the docstring explaining the shortfall is rewritten rather than left standing.

The XvB coupling law carries a **firing control** (`test_the_block_runs_whole_when_nothing_raises`), because four zeroes are also what an unreachable block reports, and `ENABLE_XVB` plus a `% 10` gate is two ways to be silently unreachable.

The **cancellation law** is not in the ruling's acceptance list; it is mine. `CancelledError` derives from `BaseException`, so shutdown already propagates through the guard — but that is a property of the *spelling*, and `except BaseException` reads as a harmless widening while hanging shutdown behind an in-flight payout sync.

**The guard logs.** The loop's handler emits one undifferentiated "Data Collection Error" per failed poll. A step that now fails *without* ending the poll would otherwise be **quieter than before it was guarded**, so `run_isolated` names the step and the cause.

## Over-engineering pass

One candidate found and **rejected with a reason**, rather than a clean bill:

- **The 5-line comment at call site 7d partly restates `payout_sync`'s module docstring** (`shrink`, ~3 lines). Kept: it is the only place a reader *of the poll body* learns why these two steps are special, and it sits exactly where a future editor would widen the wrap and break the invariant. It points to the module rather than restating the full reasoning.

Also considered: dropping the delegating wrappers entirely (rejected — see Shape; it would churn 10 tests in a file at its ceiling and force a lambda at the call site), and testing the log line directly against `run_isolated` instead of through the loop (rejected — the loop version pins the *label the poll body actually passes*, which a direct call cannot).

## Not done, deliberately

- **The structural defect stands for the other 31 steps.** This is a narrow fix by ruling, and saying so is the point: a guard applied where nobody established correctness would look like the work was done and stop the next contributor.
- **No docs change.** `repo-map.md` does not enumerate service modules — `data_helpers.py`, the precedent extraction from #1105 Phase 3, has no row there either — and the change is not operator-visible in `docs/dashboard.md`.
- **Nothing proven on hardware.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKUzVaEQWQSeUUgLB9vFFJ
