### PR TITLE
build(deps): #1425 #1650 Dependabot watches develop-v2, not just the frozen twin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,3 +92,108 @@ updates:
       # major/minor is a deliberate migration (compose flags, config compatibility), not a CVE fix.
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # ── develop-v2 coverage (#1425, #1650) ──────────────────────────────────────────────────────
+  # Everything above this line resolves against the DEFAULT branch, `develop`. That is not a
+  # style choice: Dependabot reads this file from the default branch only, and with no
+  # `target-branch:` it also resolves each `directory:` there and opens the PR there. So every
+  # entry above watches the FROZEN twin, and `develop-v2` — the branch all work actually lands
+  # on — was covered by the `/os/rootfs` entry and nothing else.
+  #
+  # Two distinct faults produced that, and they need different repairs (#1425):
+  #   * a WRONG DIRECTORY — `uv` and the docker group name `/build/dashboard`, which is 404 on
+  #     develop-v2 (the dashboard moved to `dashboard/` at #1106). Repair: name the real path.
+  #   * a MISSING TARGET — `github-actions` and `docker-compose` name `/`, which exists on both
+  #     twins. Nothing is mispointed; the entries simply never target develop-v2. Repair: a
+  #     second entry carrying `target-branch:`.
+  # A fix that treats these as one edit repairs the first and silently leaves the second.
+  #
+  # DO NOT "level the twins" by deleting these. `develop` is frozen but still takes critical
+  # patches under lane policy exception (a), so its entries stay; and moving an entry to
+  # develop-v2 is what makes it stop running, which is how the gap went unnoticed for so long
+  # (CONTRIBUTING.md § The two lanes; the /os/rootfs comment above states the same mechanism).
+  # The duplication ends when develop-side watching is retired — that is #1169, and it is
+  # blocked while develop still ships patches. Until then, two entries per surface is the cost.
+  #
+  # WHY EVERY SURFACE IS LISTED HERE AND NOT JUST THE DASHBOARD. The twins are held level by
+  # TWIN PRs, not by sync merges: every hand-made change on develop has a develop-v2 partner
+  # (#1438 -> #1440, #1313 -> #1356, #1290 -> #1344), so a merge-base or ahead/behind count
+  # cannot see the mechanism and says nothing about whether the twins have drifted.
+  # What has no twin mechanism is a DEPENDABOT RAISE: it is opened against the default branch,
+  # and nobody hand-writes the partner. Measured 2026-09-03, those are the only two develop-only
+  # changes with no develop-v2 equivalent — ruff (#1423), 0.16.4 on develop against 0.16.3 here,
+  # and actions/download-artifact (#1424), v8.0.1 against v7.0.0 here. The github-actions row is
+  # the sharpest case: it was level until #1424 merged, and went stale and silent in the same
+  # instant, because the open PR was the only signal that a newer version existed. So build/* and
+  # docker-compose are carried by twin PRs for hand-made changes, and by Dependabot on develop-v2
+  # for raises once these entries land.
+  #
+  # `tests/integration/tor-client/Dockerfile` is covered by NO entry on either twin, and that is
+  # DELIBERATE, recorded here so it is an omission on purpose rather than by accident: it is test
+  # scaffolding that is never shipped or flashed, so a stale base there costs a rebuild, not a
+  # CVE in a user's hands.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-v2:
+        patterns: ["*"]
+
+  # develop-v2's dashboard Python deps. Same subject as the `uv` entry above, different path:
+  # `dashboard/`, not `build/dashboard/` (#1106).
+  - package-ecosystem: "uv"
+    directory: "/dashboard"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-v2:
+        patterns: ["*"]
+    ignore:
+      # Same reason as the develop-side entry: protobuf/grpcio are pinned to what the vendored
+      # Tari gRPC stubs assert at import time (see dashboard/pyproject.toml on develop-v2); a
+      # major bump needs the stubs regenerated first.
+      - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "grpcio"
+        update-types: ["version-update:semver-major"]
+
+  # develop-v2's base-image digests. `/dashboard` is the moved path; the four `build/*` entries
+  # exist on both twins and are repeated here because nothing carries a develop-side bump across
+  # (see the measurement above). `/os/rootfs` is NOT repeated — it already has its own
+  # develop-v2 entry, and a second one naming the same directory would be a duplicate.
+  - package-ecosystem: "docker"
+    directories:
+      - "/dashboard"
+      - "/build/monero"
+      - "/build/p2pool"
+      - "/build/tor"
+      - "/build/xmrig-proxy"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-v2:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the develop-side docker entry: digest + patch within the pinned tag.
+      # Major/minor base bumps are deliberate migrations, not security updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # develop-v2's third-party image digests pinned directly in docker-compose.yml. The file exists
+  # on both twins, so this is the missing-target case, not the wrong-directory one.
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      compose-v2:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the develop-side entry: digest + patch within the pinned tag.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Closes #1425. Closes #1650.

## The finding, ahead of the diff

`develop-v2` — the branch every change actually lands on — had **no Dependabot coverage beyond the
appliance rootfs**, and the repo gave no sign of it. There is an open Dependabot PR stream, green
CI, and a `dependabot.yml` that reads as complete. The failure is silent in the direction that looks
like success.

Dependabot reads this file from the **default branch only**, and with no `target-branch:` it
resolves each `directory:` against that branch too. So eight of the nine entries watched `develop`,
the frozen twin.

## Two faults, two different repairs

This is the part that a single edit gets wrong, and #1425 is explicit about it:

| fault | entries | why | repair |
|---|---|---|---|
| **wrong directory** | `uv`, `docker` (`/build/dashboard`) | 404 on develop-v2 — #1106 moved the dashboard to `dashboard/` | name the real path |
| **missing target** | `github-actions`, `docker-compose` (`/`) | `/` exists on both twins; nothing is mispointed, the entry just never targets develop-v2 | a second entry with `target-branch:` |

A fix that treats these as one edit repairs the first and silently leaves the second.

## The gap is measured, not reasoned

Read per branch through the contents API, moving no local ref:

| path | develop | develop-v2 |
|---|---|---|
| `build/dashboard/pyproject.toml` | 4116 B | **absent** |
| `build/dashboard/Dockerfile` | 5208 B | **absent** |
| `dashboard/pyproject.toml` | **absent** | 4113 B |
| `dashboard/Dockerfile` | **absent** | 5208 B |
| `build/{monero,p2pool,tor,xmrig-proxy}/Dockerfile` | present | present |
| `os/rootfs/Dockerfile` | absent | 30937 B (already targeted ✔) |

And the drift it has already produced:

| pin | develop | develop-v2 |
|---|---|---|
| `ruff` (#1423, merged) | `0.16.4` | **`0.16.3`** |
| `actions/download-artifact` (#1424, merged) | `3e5f45b2` v8.0.1 | **`37930b1c`** v7.0.0 |

Neither has any mechanism left that would propose the bump again. The `github-actions` row is the
sharpest case: it was level until #1424 merged and went stale **and silent in the same instant**,
because the open PR was the only signal that a newer version existed.

## Why every surface, not just the dashboard — and a claim I got wrong first

I initially concluded from `git merge-base` that no develop→develop-v2 sync was running (merge-base
`ad928a92`, 2026-08-22, develop 15 ahead) and that a security fix was stranded. **That was wrong,
and I am recording it because the reasoning is the useful part.** Re-derived at source: the twins
are kept level by **twin PRs**, not sync merges — #1438 → #1440 (`3afc94ed`, and develop-v2's
`build/tor/Dockerfile:11` does carry the `apk add --no-cache --upgrade libcrypto3 libssl3`), #1313 →
#1356, #1290 → #1344. Ancestry cannot see that mechanism; it only sees that no merge ran. Credit to
the controller for the refutation, which I then checked rather than taking on confidence.

The corrected version is narrower and is this PR's actual claim: **hand-made changes stay level via
twin PRs; a Dependabot raise has no such partner**, because it is opened against the default branch
and nobody hand-writes the twin. That is the whole gap, and it is exactly #1425/#1650.

## The decisions #1650 asked to be stated either way

- **`build/{monero,p2pool,tor,xmrig-proxy}` and `docker-compose.yml`** — exist on both twins and
  their pinned digests are byte-identical today. Carried by twin PRs for hand-made changes, and by
  Dependabot on develop-v2 once this lands. Covered here.
- **`tests/integration/tor-client/Dockerfile`** — covered by no entry on either twin. Left
  uncovered **deliberately**, and now recorded in the file as such: it is test scaffolding, never
  shipped or flashed, so a stale base costs a rebuild rather than a CVE in a user's hands. This
  converts a silent omission into a recorded one.
- **`/os/rootfs` is not repeated** — it already has its own develop-v2 entry, and a second one
  naming the same directory would be a duplicate.

## The one construct I could not confirm from the docs, and how I settled it

`github-actions` at `/` now appears **twice**, differing only by `target-branch`. The `/os/rootfs`
precedent proves the same ecosystem may appear twice, but with a *different* directory — it does not
cover this. GitHub's reference only says values must be unique *"for a single target branch of an
ecosystem"*, which implies but does not state that differing targets are fine.

This mattered enough to settle rather than assume: **the config is validated only once it reaches
the default branch, so a rejected config would silently kill all watching** — worse than the gap
being fixed. Existence proof, from public repos' live configs:

| repo | ecosystem | directory | targets |
|---|---|---|---|
| `jline/jline3` | github-actions | `/` | `master`, `jline-3.x` |
| `openhpc/ohpc` | github-actions | `/` | default, `2.x`, `3.x` |
| `playframework/play-slick` | github-actions | `/` | default, `5.4.x`, `6.2.x` |
| `spring-projects/spring-batch` | github-actions | `/` | default, `5.2.x` |

Four actively-maintained repos using the exact construct at the exact path. Six of twelve configs
sampled used same-ecosystem-same-directory with differing targets.

## Base branch — read at source, not relayed

Lands on frozen `develop` under `STANDING-DIRECTIVE.md` exception (b), lines 50-53, which names
`dependabot` literally: these files "are read from the DEFAULT branch only". **Do not retarget this
to develop-v2** — the config is inert anywhere else, which is the trap the `/os/rootfs` comment
already documents and which this PR extends in the same voice.

## Shared file, and the guard readback the grant required

`.github/dependabot.yml` is a shared workflow-adjacent file, granted to the `currency` lane by the
controller (w89, expiring 2026-09-04T13:00Z). The stage was announced before staging. **No
`.lane-override` was used or present** — the grant is real, and I proved arming rather than assuming
it:

- **Positive** — `.github/dependabot.yml` staged alone → `lane-guard` rc **0**.
- **Negative control** — a *real index change* to an ungranted sibling (`release-gate.yml`) staged
  alongside → rc **1**, naming `release-gate.yml` only and not `dependabot.yml`. Reverted
  immediately; the commit is one file.

The control makes a real change on purpose: the guard reads `git diff --cached`, so staging an
unmodified file is a no-op that returns a false pass.

## What I ran

| check | result |
|---|---|
| `make lint-yaml` (all 14 tracked YAML) | rc **0** |
| yamllint **positive control** — a deliberately broken copy | rc **1**, syntax error at the seeded line |
| `make lint-file-budget` | rc 0, self-tests OK; `dependabot.yml` has no row, 800-line ceiling only |
| `make lint-topology` | rc 0, self-test OK |
| `make lint-operator-strings` | rc 0, self-test OK |
| config re-parsed and the entry table re-derived from the file | 9 entries, 17 directory rows, **0 duplicate `(ecosystem, directory, target-branch)` triples** |

## What I did NOT run, and did not verify

- **`make lint-sh` / `make test` were not run.** This change touches one YAML config and no shell,
  Python or JS. `lint-sh` is the serialized OOM path; running it for a config-only diff is not a
  cost I took. Say so if you want it anyway.
- **No live Dependabot run has exercised this config**, and none can before merge — the config is
  read from the default branch only. The existence proof above is what stands in for that. **The
  first post-merge check that would catch a rejected config is the repo's Dependabot config-error
  surface, and it is worth looking at once this lands.**
- **I did not verify from Dependabot's own job logs** that no PR was ever attempted for
  `dashboard/` on develop-v2 — inferred from the config plus the measured version drift, as #1650
  itself flagged.
- Whether `download-artifact` v7 → v8 is a compatible bump for develop-v2's `ci.yml` is **untouched
  here**. This PR restores the channel that will propose it; it makes no claim about the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkPjAa3yn7vMQUG56VXqxp

## Over-engineering pass (done by hand before opening; findings noted, not waved off)

**The strongest point first: this adds no new mechanism.** `target-branch:` is already in the file
and already load-bearing for `/os/rootfs`. The diff is four more entries in an existing shape.

Two findings I am recording rather than silently accepting:

1. **Covering `build/*` and `docker-compose` roughly doubles weekly Dependabot PR volume**, against
   a file whose own header says "Grouped + weekly to keep PR volume sane." I kept them, and the
   reasoning is falsifiable: those rows are level today only for *hand-made* changes, which twin
   PRs carry. A **raise** for them has no twin and would strand exactly as #1424 did — the same
   defect, not a speculative one. The duplication is temporary by design and ends when develop-side
   watching is retired (#1169, currently blocked while develop still ships patches). Both the cost
   and the exit are now written into the file.
   **If a reviewer would rather scope this to the dashboard + github-actions rows only, that is a
   coherent position** — say so and I will cut it to those and file the remainder.

2. **The comment block is 33 lines against 72 lines of added config**, which is at the upper end
   even for this file. It matches the house convention here — the existing `/os/rootfs` comment
   runs 10 lines for a 12-line entry, and #1650 explicitly asks that the asymmetry be written into
   the file — but I did not pre-emptively trim it, because the paragraph that took longest to get
   right is the one that stops the next reader from "levelling the twins" and undoing this.
   **A trim is a reasonable review ask**; I would defend the measured paragraph and cut the
   restatement before it.

Considered and rejected as genuine over-engineering: splitting this into two PRs (same file, same
defect class, and the routing was for one), and adding coverage for
`tests/integration/tor-client/Dockerfile` (recorded as a deliberate exclusion instead).
