### PR TITLE
fix(lint-sh): #1679 the shell gate refuses any shellcheck but the pinned one, from one source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,17 +423,17 @@ jobs:
       - name: "Install shellcheck + shfmt (pinned + sha256-verified, #286)"
         # Direct upstream-release downloads with a sha256 check (RigForge convention) instead of the
         # runner's preinstalled shellcheck / apt — reproducible, and immune to the apt-mirror
-        # flakiness of #64. Keep these pins in sync with the local-dev tooling.
+        # flakiness of #64. shellcheck's version comes from the Makefile (#1679); shfmt's is hand-kept.
         run: |
           curl -fsSL -o /tmp/shfmt \
             https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
           echo "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1  /tmp/shfmt" | sha256sum -c -
           sudo install -m 0755 /tmp/shfmt /usr/local/bin/shfmt
-          curl -fsSL -o /tmp/sc.tar.xz \
-            https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          SC=$(make -s print-shellcheck-version) # the Makefile is the pin; `make lint-sh` below refuses any other version (#1679)
+          curl -fsSL -o /tmp/sc.tar.xz "https://github.com/koalaman/shellcheck/releases/download/v$SC/shellcheck-v$SC.linux.x86_64.tar.xz"
           echo "8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198  /tmp/sc.tar.xz" | sha256sum -c -
           tar -xJf /tmp/sc.tar.xz -C /tmp
-          sudo install -m 0755 /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+          sudo install -m 0755 "/tmp/shellcheck-v$SC/shellcheck" /usr/local/bin/shellcheck
       - name: Lint pithead, build/* + dashboard/ container scripts, and test scripts (shellcheck + shfmt)
         # Single source of truth: the Makefile `lint-sh` target (so the file list can't drift
         # between here and the Makefile). Covers build/*/*.sh and dashboard/*.sh — the entrypoints

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Local test entry points (mirror the GitHub Actions CI jobs).
-.PHONY: test test-dashboard test-frontend test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml lint-topology lint-file-budget lint-pithead-parity lint-trivy-parity release release-smoke
+.PHONY: test test-dashboard test-frontend test-patch-coverage test-stack test-compose test-integration test-integration-selftest test-fakes test-mini-stack lint lint-sh lint-py lint-js lint-yaml lint-md lint-proto lint-toml lint-topology lint-file-budget lint-pithead-parity lint-trivy-parity print-shellcheck-version release release-smoke
 
 test: lint test-dashboard test-frontend test-stack test-compose test-integration-selftest test-fakes ## Run everything that doesn't need a server/docker
 
@@ -44,6 +44,16 @@ test-inventory: ## Write the test coverage inventory to docs/dev/test-inventory.
 test-integration: ## Run the live config-matrix integration suite (requires a test box; pass ARGS=...)
 	bash tests/integration/run.sh $(ARGS)
 
+# The shellcheck version this repo's lint gate MEANS, and the ONE place it is written (#1679).
+# `lint-sh` refuses to run on any other version, and ci.yml's installer derives its download URL
+# from this variable (`make -s print-shellcheck-version`), so the pin cannot drift between the two.
+# Bumping it here is most of the bump: ci.yml's sha256 line is tied to one tarball and fails loudly
+# until it is updated to match. shfmt is NOT covered — its pin is still a literal in ci.yml.
+SHELLCHECK_VERSION := 0.11.0
+
+print-shellcheck-version: ## Print the pinned shellcheck version (ci.yml's installer reads this)
+	@echo $(SHELLCHECK_VERSION)
+
 lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-pithead-parity lint-trivy-parity lint-proto lint-toml ## Lint/format-check every surface
 
 # Two shellcheck invocations, not one, and the split is load-bearing. shellcheck resolves a
@@ -57,6 +67,12 @@ lint: lint-sh lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-st
 # of being conserved by the split. The file SET is unchanged: every path below was in the old
 # single invocation, and none is listed twice.
 lint-sh: ## shellcheck + shfmt over the CLI, build/* + dashboard/ container scripts, release + test scripts
+	@# Refuse a version that is not the pin BEFORE linting anything: a different shellcheck reports
+	@# different findings over identical files, so its verdict is not this gate's (#1679).
+	@have=$$(shellcheck --version 2>/dev/null | awk '/^version:/ {print $$2}'); \
+		[ "$$have" = "$(SHELLCHECK_VERSION)" ] || { \
+			echo "lint-sh: shellcheck $${have:-not found} is not the pinned $(SHELLCHECK_VERSION) — its findings are not this gate's."; \
+			echo "lint-sh: install the pin (see docs/dev/release-server.md) or run the gate in CI."; exit 1; }
 	shellcheck --severity=warning pithead pithead-completion.bash install.sh scripts/*.sh build/*/*.sh dashboard/*.sh \
 		tests/stack/lib.sh tests/stack/test-*.sh tests/stack/test_compose.sh tests/stack/test_data_reset.sh \
 		tests/stack/test_os_update_recovery.sh tests/stack/test_firstboot_journal.sh tests/stack/test_appliance_hugepages.sh \

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -340,7 +340,10 @@ runs from the release-prep commit on `develop`, and `main` fast-forwards to the 
 one version and one GitHub Release.
 
 1. The release commit is green: `make lint && make test`, and `tests/os/run.sh --phase all`
-   on the bench.
+   on the bench. `make lint-sh` refuses to run on any shellcheck but the pinned one and names the
+   version it found alongside the one it wants; `make -s print-shellcheck-version` prints the pin.
+   A distro build reports different findings over the same files, so a skew reds the cut for
+   nothing — install the pin from [`release-server.md`](release-server.md#the-lintrelease-toolchain).
 2. Bump `VERSION`. The tag is `v<VERSION>` and every artifact derives from it —
    `STACK_VERSION` is the single place the registry tag comes from.
 3. Build the image and bundle with the **release key**, never the throwaway `--dev` chain. Point

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -106,14 +106,16 @@ owner-only, the dashboard is bound to localhost, and the backup/rollback net is 
 missing tool rather than dying mid-gate. Restore them with the same pinned versions CI uses
 ([`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)) — apt's `shellcheck`/`shfmt` are older
 and reformat differently, so a version skew would fail `make lint` on the box for diffs the merge
-gate never saw:
+gate never saw. `shellcheck`'s pin lives in the `Makefile` as `SHELLCHECK_VERSION`, which is what
+`ci.yml` installs and what `make lint-sh` refuses to run without; `make -s print-shellcheck-version`
+prints it, so the version below is a copy and that command is the source:
 
 ```bash
 # node 20 (brings npx) + the basics the harness also needs
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs jq curl git tar
 
-# shellcheck 0.11.0 + shfmt 3.13.1 (pinned, not apt's)
+# shellcheck 0.11.0 (= make -s print-shellcheck-version) + shfmt 3.13.1 (pinned, not apt's)
 curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz | tar -xJ -C /tmp
 sudo install -m 0755 /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
 sudo curl -fsSL -o /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64


### PR DESCRIPTION
## What this fixes

`make lint-sh` ran whatever `shellcheck` was first on PATH. A box with the distro package (v0.9.0) reds the `develop-v2` tip on `tests/integration/selftest-mergemine-probe.sh:159` SC2218, where the pinned v0.11.0 over the same files is rc 0 and silent. The #1653 release rehearsal stopped at `docs/dev/appliance-release.md` § Cutting a release step 1 on exactly that false red, and nothing printed which shellcheck had run or that it differed from the pin.

## The change

- `Makefile` gains `SHELLCHECK_VERSION := 0.11.0` — the one place the pinned version is written.
- `lint-sh` reads `shellcheck --version` and refuses **before linting anything**, naming the version it found beside the one it wants.
- `ci.yml`'s installer derives its download URL from `make -s print-shellcheck-version` instead of carrying the literal `v0.11.0` twice, so the two cannot drift.
- Both runbook steps name the pin and point at the command that prints it.

Deliberate design note: ci.yml's sha256 line stays a literal tied to one tarball. Bumping the Makefile alone therefore fails the checksum **loudly** rather than silently installing an unverified build. The Makefile comment says so.

## Evidence — the controlled pair, all run on this box

| Leg | shellcheck the guard saw | rc | guard message | shellcheck lint invocations |
|---|---|---|---|---|
| **FIRE** | real system 0.9.0 | 2 | yes — names `0.9.0` vs pinned `0.11.0` | **0** |
| **PASS** | real 0.11.0 | 0 | none | **2** (+1 shfmt) |
| **FIRE** | no version output (absent-proxy) | 2 | `shellcheck not found is not the pinned 0.11.0` | **0** |

The PASS leg's version handshake is served by the **genuine v0.11.0 binary**, downloaded from the same URL `ci.yml` uses and sha256-verified against ci.yml's own checksum (`8c3be12b…7198` → `sc.tar.xz: OK`). `shellcheck --version` is the guard's *entire* input, so the real binary covers the whole decision surface. That leg's lint invocations were short-circuited only to stay off the serialized OOM path; the linting itself is unchanged by this PR and is what CI's own `make lint-sh` step exercises.

Checked **before** writing the guard, because it was the one claim that could red CI for everyone: real 0.11.0 prints `version: 0.11.0`, and the Makefile's `awk '/^version:/ {print $2}'` extracts `0.11.0` from it. The output format did not change between 0.9.0 and 0.11.0.

The instrument discriminates in both directions: the FIRE legs show 0 lint invocations (the guard stopped execution), the PASS leg shows 2 (execution continued past it).

## Shared files — disclosure

- **`Makefile`** — shared/serialized. The lane-guard **blocks** it for this lane, so this commit spends a one-shot `.lane-override`, touched immediately before the commit and confirmed consumed. The guard named `Makefile` and nothing else, so the broad hatch let through only the intended file. Expect a conflict.
- **`.github/workflows/ci.yml`** — currency's standing named-file grant; announced to the controller before staging, and the route was accepted.
- **`docs/dev/appliance-release.md`**, **`docs/dev/release-server.md`** — `docs/` is `_shared`.

Lane-guard arming, each file staged **alone**:

| file | verdict |
|---|---|
| `Makefile` | BLOCKED (hence the override) |
| `.github/workflows/ci.yml` | ALLOWED |
| `docs/dev/appliance-release.md` | ALLOWED |
| `docs/dev/release-server.md` | ALLOWED |
| `.github/workflows/release-gate.yml` — **negative control** | BLOCKED |

## Budget

`ci.yml` had **one line of headroom** (512 against a 513 ceiling, and ceilings only ever go down). The edit is deliberately **line-neutral: 512 → 512**, so the headroom is preserved rather than spent. `Makefile` has no row (155 → 171, far under the 800 hard ceiling). Every `*.md` file is budget-exempt.

## Gates run

`lint-yaml` PASS · `lint-md` PASS · `lint-docs-voice` PASS · `lint-file-budget` PASS · `lint-operator-strings` PASS · `lint-topology` PASS · `zizmor@1.25.2 --offline` PASS (the same pin CI runs).

**Not run:** `make lint-sh` to completion over the real file list with a real shellcheck. That is the serialized OOM path, and this box has the wrong version regardless. CI's shell job is what proves it.

## What this does NOT do

- **shfmt is not covered, and the gap is LATENT rather than active — measured, not assumed.** Its pin (3.13.1) is still a literal in `ci.yml` and this box runs 3.8.0, so the *mechanism* is identical: the gate formats with whatever is on PATH. The *consequence* is not. I ran the real `shfmt -i 4 -d` invocation from `lint-sh` with 3.8.0 over the same file list: **rc 0, zero bytes of diff, zero files**. So shfmt reds nothing here today and there is no second false red to chase. I had written "the identical failure mode" here before measuring it; that was too strong and this is the corrected claim.
- Does not change what shellcheck checks. No file, severity or exclusion moved.
- **Behaviour change for local dev, named rather than buried:** `.pre-commit-config.yaml` runs `make lint-sh`, so a contributor on a distro shellcheck is now refused at pre-commit with the version message instead of silently getting different findings. That is the intent, but it is a change.
- The issue asked for "a one-line message"; the guard prints two — line 1 names found and expected, line 2 names the remedy. Flagging the deviation rather than claiming a match.

---

Fixes #1679 — but pithead's default branch is `develop` while this lands on `develop-v2`, so the keyword will **not** fire. Close by hand after merge.

---

## Over-engineering pass (ponytail gate, by hand)

Five things I put to the diff, and where each landed.

1. **Does `print-shellcheck-version` earn a target, or should ci.yml just grep the Makefile?** Kept. The grep alternative (`grep '^SHELLCHECK_VERSION' Makefile | cut …`) is longer, parses a Makefile with a regex, and inverts the natural direction. ci.yml's *existing* comment already says "Single source of truth: the Makefile `lint-sh` target" — deferring to a make target is the idiom in this exact file, not a new one.
2. **Is refusing over-built where printing would do?** No — printing is the thing that fails. A version that is only printed is not checked, and the issue asks for a refusal in those words.
3. **Two `echo` lines where the issue said "a one-line message".** Kept, and disclosed above. Line 1 carries everything the issue asked for; line 2 is the remedy, which is the actual complaint from the #1653 rehearsal (a cutter who cannot tell what to install).
4. **Five comment lines for a one-line variable.** Kept. They carry three facts a reader cannot recover from the code: why the value lives here, that ci.yml derives from it, and that the sha256 line will fail loudly on a lone bump. The surrounding `lint-sh` block runs ~20 comment lines, so this matches the file, not exceeds it.
5. **Scope.** Two extensions were available and both were declined rather than absorbed: shfmt's identical skew (would roughly double the diff, and is not what #1679 asks) and `scripts/release.sh`'s preflight (it checks presence, and `make lint` now refuses downstream of it anyway, so the message a cutter sees is already the right one).

One duplication I looked at and left: the two `@#` comment lines inside the recipe overlap slightly with the variable's comment block. They answer different questions — *why the check runs first* versus *what the pin is* — so trimming them would cost a reader more than it saves. Recorded rather than silently kept.
