### PR TITLE
fix(dashboard): #1566 an audit row id no longer collides with another rig's

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,12 +128,16 @@ The stack's defaults:
   row's own identifier is bounded separately (#1561): every audit row id
   is length-capped and whitelisted at the writer, the one field the trail's sanitizer used to skip,
   and `rig-drift`'s revision is validated to a short opaque token at the point it is read as well.
-  A rig does still CHOOSE its own `rig-edit` row's identifier — that id is built from a `change_id`
-  it picks freely — but it can no longer make one arbitrarily large or carry markup into it, which
-  is what matters on a table that is never pruned. What it cannot do is forge a `host-edit` or
-  `control.log` identifier: those are built from hardcoded prefixes a `rig-edit` id can never equal.
-  Inside the `rig-edit-` prefix, though, the ids are a plain concatenation and do not separate one
-  worker from another (#1566), so read that namespace as one shared space rather than as per-worker.
+  A rig does still CHOOSE the contents of its own `rig-edit` row's identifier — that id is built
+  from a `change_id` it picks freely — but it can no longer make one arbitrarily large or carry
+  markup into it, which is what matters on a table that is never pruned. Nor can it steer that id
+  onto a row that is not its own: each rig-chosen part is escaped before the parts are joined
+  (#1566), so an id is a one-to-one function of the worker name and the change id it was built
+  from. That is the property this table needs rather than a tidier one, because rows are written
+  with `INSERT OR IGNORE`: two detections that minted the same id produced no error and no second
+  row, and the later detection was DROPPED. The same escaping settles the `host-edit` and
+  `control.log` identifiers by construction instead of by reading the call sites — those carry no
+  `:` and every out-of-band id does, so a rig cannot mint one however it names itself.
   The `host-edit` and mirrored `control.log` rows are not attacker-controllable and are not capped.
 
 ### Telegram control commands (#338)

--- a/dashboard/mining_dashboard/service/audit_service.py
+++ b/dashboard/mining_dashboard/service/audit_service.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import time
+from urllib.parse import quote
 
 from mining_dashboard.config import config
 
@@ -45,17 +46,69 @@ def _clean(value, max_len=200):
     return _SAFE_CHARS.sub("", value)[:max_len]
 
 
-# The audit row id is the ONE field the #530 writer does not put through ``_clean``, and it is the
-# ``audit_events`` PRIMARY KEY on a table with no retention prune (#1561) — so an oversized id is
-# permanent. Callers build it from their own inputs, and on the rig-edit path that input is an
-# unauthenticated worker's ``change_id``, validated upstream only as a non-empty ``str`` inside a
-# body capped at 1 MiB. The bound has to clear every id this repo legitimately constructs: the
-# longest is ``rig-drift-{worker}-{revision}`` at 10 + 128 (``_WORKER_NAME_RE``) + 1 + 64
-# (``parse_config_meta``) = 203 characters.
+# The audit row id is the field the #530 writer used to skip while cleaning every other one, and it
+# is the ``audit_events`` PRIMARY KEY on a table with no retention prune (#1561) — so an oversized
+# id is permanent. It goes through ``clean_event_id`` below now. Callers build it from their own
+# inputs, and on the rig-edit path that input is an unauthenticated worker's ``change_id``,
+# validated upstream only as a non-empty ``str`` inside a body capped at 1 MiB. The bound clears
+# the id a well-behaved rig produces: ``rig-drift:{worker}:{revision}`` is 9 + 1 + 128 + 1 + 64 =
+# 203 characters for a name of the length ``_WORKER_NAME_RE`` allows and a ``parse_config_meta``
+# revision. That is a TYPICAL case and NOT a bound — ``_WORKER_NAME_RE`` governs the
+# ``config/worker_endpoints.py`` path and not this one, so ``worker`` arrives with no length
+# validation at all, and #1566's escaping can triple a part. A constructed id past the cap is the
+# digest branch below doing its job, not a defect.
 MAX_EVENT_ID_LEN = 256
 
 # Enough digest that distinct inputs stay distinct in practice; a sha256 prefix, not a truncation.
 _EVENT_ID_DIGEST_LEN = 16
+
+
+# The row id used to be a bare "-" join of two rig-chosen strings, so worker "victim-chg1" with
+# change_id "extra" and worker "victim" with change_id "chg1-extra" minted the SAME key; under
+# ``INSERT OR IGNORE`` the second write is dropped and a detection is LOST rather than duplicated
+# (#1566). Both components come off the unauthenticated worker feed, so the join has to be
+# one-to-one rather than merely tidy.
+_EVENT_ID_SEP = ":"
+
+
+def _escape_id_part(part):
+    """``part`` percent-encoded so it carries no ``:`` and no ``-`` (#1566).
+
+    ``quote`` leaves ``-`` and ``~`` alone and both have to go: ``-`` is what the old scheme joined
+    on and still reads as a separator to anyone splitting an id, and ``~`` is outside
+    ``_SAFE_CHARS``, so leaving it would push an otherwise-fine id onto the digest branch below.
+    Replacing AFTER quoting is unambiguous because ``quote`` never emits a bare ``%2D`` or ``%7E``
+    of its own — a literal ``%`` in the input has already become ``%25``. Everything this returns
+    is inside ``_SAFE_CHARS``, so an escaped id survives ``_clean`` verbatim.
+
+    ``errors="surrogatepass"`` for the same reason ``clean_event_id``'s digest uses it, and it is
+    load-bearing on one half specifically. A rig's JSON can carry U+D800 and ``json.loads`` hands it
+    back as a lone surrogate, which ``quote``'s default strict UTF-8 encode REFUSES — a raise inside
+    the poll loop, where the old bare join never encoded anything at all. Measured per position: a
+    surrogate in the WORKER NAME reaches here and is escaped to ``%ED%A0%80``; one in a
+    ``change_id`` never arrives, because ``worker_config_change_known`` passes it to sqlite first
+    and sqlite refuses it. That upstream raise is not this function's to fix and predates it."""
+    return quote(str(part), safe="", errors="surrogatepass").replace("~", "%7E").replace("-", "%2D")
+
+
+def build_event_id(namespace, *parts):
+    """An audit row id that is a ONE-TO-ONE function of ``(namespace, parts)`` (#1566).
+
+    ``namespace`` is a hardcoded literal from this repo; ``parts`` are rig-chosen. Each part is
+    escaped to contain no ``:`` and the pieces are joined on ``:``, so an id splits back into
+    ``(namespace, parts)`` exactly one way and no two distinct inputs can mint the same key. That
+    is the property ``INSERT OR IGNORE`` needs from this field: a collision here DROPS a detection,
+    where a collision in a display field would only look wrong.
+
+    It also separates these ids from every other writer's by construction rather than by
+    inspection. ``_record_audit_event``'s ``f"{source}-{uuid4()}"`` fallback and the mirrored
+    ``control.log`` ids carry no ``:`` at all, so a rig cannot forge one of those however it names
+    itself — the old ``rig-edit-`` prefix gave that only as a reading of the call sites.
+
+    Ids stay readable when there is nothing to escape, and stay correct when there is:
+    ``clean_event_id`` still caps length at the sink, and its digest branch keeps distinct inputs
+    distinct for an escaped id that runs long."""
+    return _EVENT_ID_SEP.join([namespace, *(_escape_id_part(p) for p in parts)])
 
 
 def clean_event_id(event_id):

--- a/dashboard/mining_dashboard/service/audit_service.py
+++ b/dashboard/mining_dashboard/service/audit_service.py
@@ -87,7 +87,7 @@ def _escape_id_part(part):
     the poll loop, where the old bare join never encoded anything at all. Measured per position: a
     surrogate in the WORKER NAME reaches here and is escaped to ``%ED%A0%80``; one in a
     ``change_id`` never arrives, because ``worker_config_change_known`` passes it to sqlite first
-    and sqlite refuses it. That upstream raise is not this function's to fix and predates it."""
+    and sqlite refuses it. That upstream raise predates this and is #1696, not this function's."""
     return quote(str(part), safe="", errors="surrogatepass").replace("~", "%7E").replace("-", "%2D")
 
 

--- a/dashboard/mining_dashboard/service/data_service.py
+++ b/dashboard/mining_dashboard/service/data_service.py
@@ -868,7 +868,7 @@ class DataService:
                     "rig-edit",
                     ctrl["status"],
                     f"change_id={ctrl['change_id']}",
-                    event_id=f"rig-edit-{worker}-{ctrl['change_id']}",
+                    event_id=audit_service.build_event_id("rig-edit", worker, ctrl["change_id"]),
                 )
 
     def _on_clearnet_transition(self, name, ok):

--- a/dashboard/mining_dashboard/service/worker_change_audit.py
+++ b/dashboard/mining_dashboard/service/worker_change_audit.py
@@ -17,6 +17,7 @@ import logging
 import time
 
 from mining_dashboard.client.rig_config_meta import parse_config_meta
+from mining_dashboard.service import audit_service
 
 logger = logging.getLogger("WorkerChangeAudit")
 
@@ -51,7 +52,7 @@ async def record_cap_marker(svc, worker, cap, tipped_by):
         "rate-limited",
         "dropped",
         f"rig-edit + revision-drift rows capped at {cap}/hour (tipped by {tipped_by})",
-        event_id=f"rig-edit-ratelimited-{worker}-{int(window_start)}",
+        event_id=audit_service.build_event_id("rig-edit-ratelimited", worker, int(window_start)),
     )
 
 
@@ -72,8 +73,11 @@ async def note_revision_drift(svc, worker_row, extra_stats, cap):
     body, straight off ``get_stats``, and nothing has parsed it yet — the merge that calls
     ``parse_rigforge`` runs later in the poll and on a different object. So the block goes through
     ``parse_config_meta`` before the store sees it, which is the store's own stated precondition.
-    Without it a rig chooses its own primary key: ``revision`` reaches ``event_id``, and ``event_id``
-    is the ONE field ``_record_audit_event`` does not put through ``audit_service._clean``.
+    Without it a rig chooses its own primary key: ``revision`` reaches ``event_id``. The sink bounds
+    and whitelists that field (#1561) and escapes it into its own slot before the join (#1566), so
+    neither an oversized value nor a collision survives it — but both of those are salvage. What
+    validating here buys is that a ``rig-drift`` row's id is a SHORT OPAQUE TOKEN rather than
+    whatever the rig sent, which is the difference between a readable key and a digest.
 
     Bounded by the shared #724 cap, because ``revision`` rides the same unauthenticated feed as
     ``change_id`` and has the same property: the store's dedup collapses a revision that has NOT
@@ -104,5 +108,5 @@ async def note_revision_drift(svc, worker_row, extra_stats, cap):
         "rig-drift",
         "detected",
         f"revision {drift['before']} -> {drift['after']} with no new change_id",
-        event_id=f"rig-drift-{worker}-{drift['after']}",
+        event_id=audit_service.build_event_id("rig-drift", worker, drift["after"]),
     )

--- a/dashboard/tests/service/test_audit_event_id.py
+++ b/dashboard/tests/service/test_audit_event_id.py
@@ -1,10 +1,15 @@
-"""The audit row id is sanitized like every other field the Security panel serves (#1561).
+"""The audit row id is sanitized (#1561) and is a one-to-one function of its parts (#1566).
 
 ``_record_audit_event`` cleans five fields through ``audit_service._clean`` and used to pass the
 sixth — ``id``, the ``audit_events`` PRIMARY KEY — through untouched. On the rig-edit path that id
 is built from an unauthenticated worker's ``change_id``, validated upstream only as a non-empty
 ``str`` inside a body capped at 1 MiB, and ``audit_events`` has no retention prune, so an oversized
 id is permanent.
+
+``build_event_id`` is the other half and the same stake: the id is the ``audit_events`` PRIMARY KEY
+under ``INSERT OR IGNORE``, so two distinct detections that mint the same id do not become two rows
+or an error — the second is DROPPED. #1561 bounds how large that field can be; #1566 makes the
+mapping into it one-to-one.
 
 Both halves are here because they are one behaviour and either alone is a false pass: the contract
 tests would stay green if ``_record_audit_event`` never called the helper, and the wiring test would
@@ -13,29 +18,56 @@ stay green against a naive truncation that silently merges two detections.
 
 import types
 import uuid
+from urllib.parse import unquote
 
 import pytest
 
 from mining_dashboard.service import audit_service
 from mining_dashboard.service.data_service import DataService
 
-# The longest id this repo legitimately constructs: "rig-drift-" + a worker name at the
-# _WORKER_NAME_RE bound (128) + "-" + a revision at the parse_config_meta bound (64) = 203.
-LONGEST_REAL_ID = f"rig-drift-{'w' * 128}-{'r' * 64}"
+# The longest id this repo constructs for a WELL-BEHAVED rig: "rig-drift" + ":" + a worker name at
+# the _WORKER_NAME_RE length (128) + ":" + a revision at the parse_config_meta bound (64) = 203 —
+# the same 203 the "-" join gave, since one separator became one separator. It is not a BOUND:
+# _WORKER_NAME_RE governs config/worker_endpoints.py and not this feed, and escaping can triple a
+# part. The cap, not this figure, is what makes an oversized id impossible.
+LONGEST_REAL_ID = f"rig-drift:{'w' * 128}:{'r' * 64}"
 
 HOSTILE = "rig-edit-miner1-" + "A" * 5000 + "\x00\n<script>"
 
 
 class TestCleanEventIdContract:
+    # What the builder emits today, pinned as LITERALS so a scheme change reddens this test rather
+    # than sliding through it. The assertion below ties each literal back to build_event_id, which
+    # is what keeps the pair honest: the literal alone could drift out of date, and deriving them
+    # from the builder alone would source the assertion from the thing under test.
+    BUILT_TODAY = {
+        ("rig-edit", "miner1", "chg1"): "rig-edit:miner1:chg1",
+        ("rig-edit", "miner1", "chg-2026-08-30T01:00:00Z"): (
+            "rig-edit:miner1:chg%2D2026%2D08%2D30T01%3A00%3A00Z"
+        ),
+        ("rig-edit-ratelimited", "miner1", 1756515600): "rig-edit-ratelimited:miner1:1756515600",
+    }
+
+    # Ids written under the pre-#1566 "-" join. Nothing builds these any more; deployed databases
+    # are full of them, and clean_event_id must keep resolving each to itself or the row it keys is
+    # orphaned the first time anything reads it back.
+    ALREADY_IN_DEPLOYED_DATABASES = (
+        "11111111-1111-4111-8111-111111111111",
+        "host-edit-11111111-1111-4111-8111-111111111111",
+        "rig-edit-miner1-chg-2026-08-30T01:00:00Z",
+        "rig-edit-ratelimited-miner1-1756515600",
+    )
+
     def test_real_ids_pass_through_verbatim(self):
-        """Every id the repo builds today keeps the key it already has — no row is orphaned by
-        this change, and ids stay readable in the table. A blanket digest would fail this."""
+        """Ids stay readable in the table rather than collapsing to digests, across BOTH
+        populations: the ids already written under the old join, and the ids built today. A blanket
+        digest would fail this, and so would a fix that only considered ids it mints itself."""
         assert len(LONGEST_REAL_ID) == 203
+        for parts, expected in self.BUILT_TODAY.items():
+            assert audit_service.build_event_id(*parts) == expected
         for real in (
-            "11111111-1111-4111-8111-111111111111",
-            "host-edit-11111111-1111-4111-8111-111111111111",
-            "rig-edit-miner1-chg-2026-08-30T01:00:00Z",
-            "rig-edit-ratelimited-miner1-1756515600",
+            *self.ALREADY_IN_DEPLOYED_DATABASES,
+            *self.BUILT_TODAY.values(),
             LONGEST_REAL_ID,
         ):
             assert audit_service.clean_event_id(real) == real
@@ -96,6 +128,116 @@ class TestCleanEventIdContract:
         """The caller's ``or f"{source}-{uuid4()}"`` fallback is written against a falsy return —
         a host-edit passes None and must still get a random id."""
         assert audit_service.clean_event_id(empty) == ""
+
+
+def _old_join(namespace, *parts):
+    """The pre-#1566 id scheme, kept HERE as the control rather than imported.
+
+    Every test below that claims a collision was real has to show it against something. Reading
+    "these two used to collide" proves nothing; a pair that does not actually collide under the old
+    rule would make the new-scheme assertion pass for the wrong reason."""
+    return "-".join([namespace, *(str(p) for p in parts)])
+
+
+class TestBuildEventIdIsOneToOne:
+    """#1566. A collision in this field is a LOST DETECTION, not a duplicate row."""
+
+    # Pairs a rig can present that the bare "-" join maps onto ONE id. The first is the pair
+    # measured against the real caller in the issue; the rest are the same ambiguity moved around.
+    COLLIDING = [
+        (("victim-chg1", "extra"), ("victim", "chg1-extra")),
+        (("a", "b-c"), ("a-b", "c")),
+        (("rig-1", "x-y"), ("rig", "1-x-y")),
+        (("w", "1-2-3"), ("w-1-2", "3")),
+    ]
+
+    def test_the_old_join_really_did_collapse_these_pairs(self):
+        """The firing control, and it comes first deliberately. If this goes green trivially the
+        pairs are not colliding pairs and the test below says nothing about #1566."""
+        for left, right in self.COLLIDING:
+            assert _old_join("rig-edit", *left) == _old_join("rig-edit", *right)
+
+    def test_and_the_new_scheme_keeps_them_apart(self):
+        build = audit_service.build_event_id
+        for left, right in self.COLLIDING:
+            assert build("rig-edit", *left) != build("rig-edit", *right)
+
+    def test_distinct_pairs_that_never_collided_still_get_distinct_ids(self):
+        """The other direction: a scheme that hashed everything to one constant would pass every
+        assertion above. This is what stops "keeps them apart" from being satisfiable by a bug."""
+        a = audit_service.build_event_id("rig-edit", "minerA", "chg1")
+        b = audit_service.build_event_id("rig-edit", "minerB", "chg1")
+        assert a != b
+        assert a == "rig-edit:minerA:chg1"
+
+    def test_the_id_decodes_back_to_exactly_the_parts_it_was_built_from(self):
+        """The general proof; the pairs above are only samples. A decoder existing IS injectivity —
+        no finite list of colliding inputs can establish that, and no future one can refute it."""
+        for worker, change_id in (
+            ("victim-chg1", "extra"),
+            ("rig:1", "chg-2"),
+            ("100% rig", "a b"),
+            ("~tilde~", "%2D"),
+            ("<script>", "\x00\n"),
+            ("w" * 128, "r" * 64),
+        ):
+            eid = audit_service.build_event_id("rig-drift", worker, change_id)
+            namespace, *parts = eid.split(":")
+            assert namespace == "rig-drift"
+            assert [unquote(p) for p in parts] == [worker, change_id]
+
+    def test_a_rig_edit_row_can_no_longer_forge_the_rate_limited_marker(self):
+        """Shape 1 as the issue states it: a device presenting as ``ratelimited-{victim}`` and
+        reporting the victim's window start used to mint the victim's OWN marker id, so the
+        victim's marker was dropped and the flood lost its Security-panel row."""
+        window = 1756515600
+        marker = audit_service.build_event_id("rig-edit-ratelimited", "victim", window)
+        forged = audit_service.build_event_id("rig-edit", "ratelimited-victim", window)
+        assert _old_join("rig-edit-ratelimited", "victim", window) == _old_join(
+            "rig-edit", "ratelimited-victim", window
+        )  # the control: it really was forgeable
+        assert marker != forged
+
+    def test_an_escaped_id_still_survives_the_sink_verbatim(self):
+        """Escaping is only worth having if it lands INSIDE ``_SAFE_CHARS``. Outside it, every id
+        carrying an unusual character would take ``clean_event_id``'s digest branch — still
+        collision-free, but every such row's key becomes unreadable. This is the check that the
+        fix did not quietly trade one property for the other."""
+        for hostile in ("a-b", "a~b", "a%b", "a b", "a:b", "a<b", "a\x00b", "\u00e9"):
+            eid = audit_service.build_event_id("rig-edit", hostile, "chg1")
+            assert audit_service.clean_event_id(eid) == eid
+
+    def test_a_lone_surrogate_is_escaped_rather_than_raising(self):
+        """The escape runs INSIDE the poll loop, upstream of every sanitizer. A rig's JSON can
+        carry U+D800 and ``json.loads`` hands it back as a lone surrogate, which ``quote``'s
+        default strict UTF-8 encode REFUSES — a raise the old bare join never had, because it
+        encoded nothing at all.
+
+        ``TestCleanEventIdContract`` has a same-named test and it does NOT cover this: that one
+        calls ``clean_event_id``, which sits downstream of the escape and so never sees the input
+        that raises. The first assertion is the control, pinning that this input really is
+        un-encodable so the test cannot pass by accident on an ordinary string."""
+        lone = "\ud800"
+        with pytest.raises(UnicodeEncodeError):
+            lone.encode("utf-8")
+        eid = audit_service.build_event_id("rig-edit", "miner1", lone)
+        assert eid == "rig-edit:miner1:%ED%A0%80"
+        assert audit_service.clean_event_id(eid) == eid
+
+    def test_a_built_id_can_never_equal_a_uuid_fallback_or_a_mirrored_control_id(self):
+        """``_record_audit_event`` falls back to ``f"{source}-{uuid4()}"`` and
+        ``_mirror_control_audit`` writes the #33 log's own id. Neither carries a ``:`` and every
+        built id does, so a rig cannot mint a key in either space however it names itself. The old
+        scheme had this only as a reading of the call sites."""
+        built = audit_service.build_event_id("rig-edit", "miner1", "chg1")
+        assert ":" in built
+        for other in (
+            "host-edit-11111111-1111-4111-8111-111111111111",
+            "rig-edit-11111111-1111-4111-8111-111111111111",
+            "11111111-1111-4111-8111-111111111111",
+        ):
+            assert ":" not in other
+            assert built != other
 
 
 class TestSinkActuallyUsesIt:

--- a/dashboard/tests/service/test_worker_change_audit.py
+++ b/dashboard/tests/service/test_worker_change_audit.py
@@ -1,4 +1,4 @@
-"""Revision-drift detection and the flood cap it shares with rig-edit (#1551, #724).
+"""Revision-drift, the flood cap it shares with rig-edit, and row-id separation (#1551, #724, #1566).
 
 Tier 1, against a real in-memory ``StateManager`` — a drift row has to be provable in the durable
 table, not merely "the mock was called", because the whole feature is a permanent audit row.
@@ -24,6 +24,13 @@ def _body(revision, change_id=None):
 def _poll(svc, worker, revision, change_id=None):
     """One poll of one worker through the real caller, so the wiring is what is under test."""
     asyncio.run(svc._reconcile_worker_config([{"name": worker}], [_body(revision, change_id)]))
+
+
+def _rig_edit(svc, worker, change_id):
+    """One poll of one worker down the RIG-EDIT branch: a terminal outcome this dashboard never
+    spooled, which is a change the rig applied on its own."""
+    ctrl = {"rigforge": {"control": {"change_id": change_id, "status": "applied"}}}
+    asyncio.run(svc._reconcile_worker_config([{"name": worker}], [ctrl]))
 
 
 def _rows(sm, action):
@@ -199,7 +206,7 @@ class TestTheFeedIsValidatedBeforeTheStoreSeesIt:
             _poll(svc, "rig1", "b" * 16)
             drift = _rows(sm, "rig-drift")
             assert len(drift) == 1
-            assert drift[0]["id"] == "rig-drift-rig1-" + "b" * 16
+            assert drift[0]["id"] == "rig-drift:rig1:" + "b" * 16
         finally:
             sm.close()
 
@@ -211,5 +218,113 @@ class TestTheFeedIsValidatedBeforeTheStoreSeesIt:
             for junk in (12345, {"nested": "dict"}, ["list"], True):
                 _poll(svc, "rig1", junk)
             assert _rows(sm, "rig-drift") == []
+        finally:
+            sm.close()
+
+
+class TestRowIdsSeparateOneDetectionFromAnother:
+    """#1566, proved against the real table because the failure mode is SILENT.
+
+    The row id is the ``audit_events`` PRIMARY KEY and the writer uses ``INSERT OR IGNORE``, so two
+    detections that mint one id neither raise nor land as two rows — the second is DROPPED. Under
+    the old bare-"-" join both components were rig-chosen, so a device could pick them.
+    """
+
+    def test_the_table_really_does_drop_a_second_row_on_a_repeated_id(self):
+        """The mechanism control, first on purpose. Every test below asserts that two detections
+        become two rows, and that claim is worth nothing until this table has been SHOWN to
+        collapse them when the ids do match."""
+        svc, sm = _svc()
+        try:
+            for keys in ("first", "second"):
+                asyncio.run(
+                    svc._record_audit_event(
+                        "rig-edit", "w", "rig-edit", "applied", keys, event_id="fixed-id"
+                    )
+                )
+            rows = sm.get_audit_events()
+            assert len(rows) == 1
+            assert rows[0]["keys"] == "first"  # the SECOND write is the one lost, silently
+        finally:
+            sm.close()
+
+    def test_two_rig_edits_that_used_to_share_an_id_land_as_two_rows(self):
+        svc, sm = _svc()
+        try:
+            # Measured against this same caller in the issue: ("victim-chg1", "extra") and
+            # ("victim", "chg1-extra") both minted "rig-edit-victim-chg1-extra".
+            assert "victim-chg1-extra" == "-".join(("victim-chg1", "extra"))
+            assert "victim-chg1-extra" == "-".join(("victim", "chg1-extra"))
+            _rig_edit(svc, "victim-chg1", "extra")
+            _rig_edit(svc, "victim", "chg1-extra")
+            rows = _rows(sm, "rig-edit")
+            assert len(rows) == 2
+            assert len({r["id"] for r in rows}) == 2
+        finally:
+            sm.close()
+
+    def test_two_drift_rows_that_used_to_share_an_id_land_as_two_rows(self):
+        """The same ambiguity on the sibling detection. Both halves of ``rig-drift-{worker}-
+        {revision}`` are rig-chosen too, so fixing only the rig-edit id would leave this open."""
+        svc, sm = _svc()
+        try:
+            assert "rig-1-2" == "-".join(("rig-1", "2")) == "-".join(("rig", "1-2"))
+            _poll(svc, "rig-1", "aaa")  # first sighting: baselines, writes nothing
+            _poll(svc, "rig-1", "2")
+            _poll(svc, "rig", "aaa")
+            _poll(svc, "rig", "1-2")
+            rows = _rows(sm, "rig-drift")
+            assert len(rows) == 2
+            assert len({r["id"] for r in rows}) == 2
+        finally:
+            sm.close()
+
+    def test_a_rig_edit_row_can_no_longer_suppress_another_workers_cap_marker(self):
+        """Shape 1 of the issue, end to end. A device presenting as ``ratelimited-{victim}`` and
+        reporting the victim's window start minted EXACTLY the victim's own marker id; landing
+        first, it made ``INSERT OR IGNORE`` drop the marker and the flood lost its Security-panel
+        row. The warning still logs either way, so the panel row is the whole loss."""
+        svc, sm = _svc()
+        try:
+            _poll(svc, "victim", "rev-0")  # first sighting — no row, no budget, no window
+            _poll(svc, "victim", "rev-1")  # first real drift — this is what opens the window
+            window = int(svc._rig_edit_window["victim"][0])
+
+            _rig_edit(svc, "ratelimited-victim", str(window))
+            forged = [e for e in sm.get_audit_events() if e["actor"] == "ratelimited-victim"]
+            # Two fixture controls, because the test below could otherwise go green from the
+            # attack never arming rather than from the fix working: the forged row LANDED, and the
+            # third assertion shows the two ids really were the same string under the old join —
+            # so the second assertion is the fix, not an arbitrary inequality.
+            assert len(forged) == 1
+            assert forged[0]["id"] != f"rig-edit-ratelimited-victim-{window}"
+            assert "-".join(("rig-edit-ratelimited", "victim", str(window))) == "-".join(
+                ("rig-edit", "ratelimited-victim", str(window))
+            )
+
+            for i in range(2, _RIG_EDIT_CAP_PER_HOUR + 8):
+                _poll(svc, "victim", f"rev-{i}")
+            markers = _rows(sm, "rate-limited")
+            assert len(markers) == 1
+            assert markers[0]["actor"] == "victim"
+        finally:
+            sm.close()
+
+    def test_a_lone_surrogate_worker_name_records_a_row_instead_of_raising(self):
+        """The id is now BUILT in the poll loop rather than only cleaned at the sink, which puts an
+        encode where there was none, and nothing upstream rejects a lone surrogate in a worker name.
+
+        The WORKER NAME is the position deliberately: measured per position, a surrogate
+        ``change_id`` never reaches the escape at all — ``worker_config_change_known`` hands it to
+        sqlite first and sqlite refuses it, which is a separate pre-existing raise on this path and
+        not what this test is about. Written against the reachable half, this goes RED without
+        ``errors="surrogatepass"``; written against the other it would have gone red for sqlite's
+        reason and proved nothing about the escape."""
+        svc, sm = _svc()
+        try:
+            _rig_edit(svc, "\ud800", "chg1")
+            rows = _rows(sm, "rig-edit")
+            assert len(rows) == 1
+            assert rows[0]["id"] == "rig-edit:%ED%A0%80:chg1"
         finally:
             sm.close()

--- a/dashboard/tests/service/test_worker_change_audit.py
+++ b/dashboard/tests/service/test_worker_change_audit.py
@@ -316,8 +316,8 @@ class TestRowIdsSeparateOneDetectionFromAnother:
 
         The WORKER NAME is the position deliberately: measured per position, a surrogate
         ``change_id`` never reaches the escape at all — ``worker_config_change_known`` hands it to
-        sqlite first and sqlite refuses it, which is a separate pre-existing raise on this path and
-        not what this test is about. Written against the reachable half, this goes RED without
+        sqlite first and sqlite refuses it — a separate pre-existing raise on this path, filed as
+        #1696, and not what this test is about. Written against the reachable half, this goes RED without
         ``errors="surrogatepass"``; written against the other it would have gone red for sqlite's
         reason and proved nothing about the escape."""
         svc, sm = _svc()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -319,8 +319,11 @@ them before the rest are dropped behind a single `rate-limited` marker. They sha
 rather than holding one each, since two would double what that device can make permanent. That cap
 bounds how many rows arrive and not how large each one is, so every audit row's own identifier is
 length-capped and whitelisted where it is written ([#1561](https://github.com/p2pool-starter-stack/pithead/issues/1561)) — the one field the trail's
-sanitizer used to skip, and the one a rig picks the input to. Between the two bounds, a rig holding
-one worker name is bounded in both how many rows it adds and how large each one is. The cap is
+sanitizer used to skip, and the one a rig picks the input to. The parts a rig chooses are escaped
+before that identifier is assembled ([#1566](https://github.com/p2pool-starter-stack/pithead/issues/1566)),
+so no rig can land a row on another rig's identifier — which used to drop the second detection
+rather than record it. Between these bounds, a rig holding one worker name is bounded in how many
+rows it adds, how large each one is, and whose rows it can displace. The cap is
 keyed on the name the device presents and a device chooses that freely, so one that rotates names
 draws a fresh budget per name ([#1566](https://github.com/p2pool-starter-stack/pithead/issues/1566)):
 read the bound as per name, not per device. A genuine occasional rig change still records


### PR DESCRIPTION
Closes #1566 (shape 1 only — see NOT DONE).

## The defect

The `audit_events` row id was a bare `-` join of two rig-chosen strings, so distinct detections
could mint the same key. Rows are written with `INSERT OR IGNORE`, so a collision is not an error
and not a duplicate row — the second detection is **DROPPED**, silently.

All three built ids were rig-chosen on both halves:

| id | both halves rig-chosen? |
|---|---|
| `rig-edit-{worker}-{change_id}` | yes |
| `rig-drift-{worker}-{revision}` | yes |
| `rig-edit-ratelimited-{worker}-{window}` | worker yes; forgeable as `ratelimited-{victim}` |

## The fix

`audit_service.build_event_id` percent-encodes each rig-chosen part so it carries no `:` and no
`-`, then joins on `:`. Two properties follow, and both are tested:

- **One-to-one.** The test proves it by DECODING an id back to the parts it was built from, not by
  listing colliding pairs — a finite list of pairs cannot establish injectivity and a future input
  could escape it.
- **Separate from every other writer's ids, by construction.** The `f"{source}-{uuid4()}"` fallback
  and the mirrored `control.log` ids carry no `:` and every built id does. The old scheme had this
  only as a reading of the call sites.

Escaped output stays inside `_SAFE_CHARS`, so ids still pass `clean_event_id` **verbatim** rather
than collapsing onto its digest branch — checked explicitly, because a fix that quietly sent every
unusual id to a digest would trade readability for correctness without saying so. `clean_event_id`
itself is unchanged and still bounds length at the sink.

## The over-engineering pass found a defect in my own fix

Building the id moves an **encode** into the poll loop, where the bare join never encoded anything.
A rig's JSON can carry `U+D800` and `quote`'s default strict UTF-8 encode raises on a lone
surrogate. Measured per component position, with each leg controlling the other:

```
surrogate in WORKER NAME -> reached the escape; raised in urllib/parse.py:909 without surrogatepass
surrogate in change_id   -> never arrives: worker_config_change_known hands it to sqlite first,
                            which refuses it (worker_config_store.py:242) — PRE-EXISTING, filed #1696
```

So `errors="surrogatepass"` is load-bearing on the worker-name half, and the claim is scoped to
that half in the docstring rather than stated generally. The existing surrogate test did not catch
this: it exercises `clean_event_id`, which sits **downstream** of the escape and never sees the
input that raises.

## Migration cost, stated

Deployed databases keep every id they already hold — `clean_event_id` returns those verbatim, and
the test pins that population separately from the ids built today. But a change still being
re-reported after the upgrade is recorded again under its new id, so expect **at most one extra row
per live (worker, change_id), once**. It is bounded by the same #724 cap as any other row.

## PROVEN BY ME, at the head pushed (`d3d635af`)

- Full dashboard suite **2457 passed / 0 failed**, rc 0, coverage **97.37%** (gate 80%).
- **Patch coverage 100% on 7 executable changed lines**, computed mechanically from a `coverage.xml`
  regenerated on this tree — not from `make test-patch-coverage`, whose script pins
  `COMPARE=origin/develop` and is no evidence on a `develop-v2` PR. **The non-vacuity assertion
  fired** (7 > 0); it caught a wrong path prefix on its first run, so the 100% is a reading and not
  an empty set. `data_service.py`'s one changed line reports 0 executable because it is a
  continuation line of a multi-line call; it is exercised by the wiring test, which drives the real
  `_reconcile_worker_config` and asserts the resulting ids.
- **13 tests added, 0 removed** (checked by grepping the diff for removed `def test_`).
- **Non-vacuity of the new tests: seeded the pre-#1566 bare join back in and 11 of them went RED**,
  the two intended controls staying green — the old-join witness and the INSERT-OR-IGNORE mechanism
  control, neither of which calls the builder. The two surrogate tests were proven by their own
  seeded control separately. Restored by sha256, verified by content.
- `lint-py` `lint-md` `lint-docs-voice` `lint-operator-strings` `lint-topology` `lint-file-budget`
  `lint-trivy-parity` `lint-yaml` `lint-toml` — each rc 0, run **individually** (that CI job runs
  six targets past the five in its name, and `make` stops at the first failure).
- Topology detector `clean` on this body and both filed issues.
- **NARROW case**: rebased, `git merge-base HEAD origin/develop-v2` == `git rev-parse
  origin/develop-v2` == `cf807597`. `develop-v2` moved under me mid-change when #1683 merged; every
  figure above is re-measured at the rebased head, not carried across.
- Budget: `data_service.py` **1420 / 1454** — the change there is exactly line-neutral. The other
  four touched files are `worker_change_audit.py` 112, `audit_service.py` 278,
  `test_audit_event_id.py` 286, `test_worker_change_audit.py` 330 — all under 400 and correctly
  rowless (the gate fails an under-target file that CARRIES a row as well as an over-target one
  lacking one). These four were re-measured after the surrogate tests landed; my first draft quoted
  the pre-surrogate figures.

## NOT DONE

- **Shape 2 of #1566 is not fixed** — the flood cap keyed on a worker name the device picks, so one
  rotating names draws a fresh budget per name. Filed as **#1695**. It is a different defect class
  with an existing home (`data_service.py` already defers it to #235), and a global ceiling has a
  real design tension: a flooding rig would then suppress *other* workers' genuine detections.
  **#1566 should stay open until #1695 lands, or be closed with a pointer to it** — reviewer's call.
- **#1696 is not fixed here** — the pre-existing sqlite surrogate raise on the `change_id` half.
- Not run on hardware; no live proxy feed. The collision is proved against the real writer and the
  real table in-memory, not against a physical rig.
- `lint-sh` not run: no shell in this diff, and it is the serialized OOM path.
- The `ponytail` PR gate verifies nothing; the over-engineering pass above was done on merits and is
  what found the surrogate defect. It is not reported as a review.

## Shared files touched (disclosed per `_shared.paths`)

- `SECURITY.md` — one sentence became **false** with this change: "the ids are a plain concatenation
  and do not separate one worker from another". Corrected, not deleted. No wholesale rewrite.
- `docs/operations.md` — the operator-facing half gains the guarantee it did not previously have.
- Both already said the cap is per NAME rather than per device; that prose is correct and untouched.
- No `CHANGELOG.md` entry: this repo touches it only at release prep, as its sibling #1561 did not.