### PR TITLE
fix(file-budget): gate refuses a new row that reserves headroom on first appearance

### DIFF
--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -236,6 +236,37 @@ self_test() {
     fi
     rm -rf "$tmp4"
 
+    # #1470 — a row with NO counterpart on the base ref is a first appearance, not a raise, so
+    # the monotonic loop above never visits it. Its own repo, so the 500/900 base state above
+    # cannot leak into it.
+    local tmp5
+    tmp5=$(mktemp -d)
+    git -C "$tmp5" init -q -b develop
+    git -C "$tmp5" config user.email test@example.invalid
+    git -C "$tmp5" config user.name test
+    mkdir -p "$tmp5/$(dirname "$BUDGET_FILE")"
+    seq 1 500 >"$tmp5/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp5/$BUDGET_FILE"
+    git -C "$tmp5" add -A && git -C "$tmp5" commit -q -m base
+
+    seq 1 500 >"$tmp5/newfile.sh"
+    printf '# test budget\nbudgeted.sh\t500\nnewfile.sh\t900\n' >"$tmp5/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp5" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a new row reserving headroom above the file's real size FAILS (#1470)" 1 "$rc"
+    if grep -q "adds newfile.sh as a new row at ceiling 900, but the file is 500 lines" "$out"; then
+        echo "  self-test ok: names the reserved headroom"
+    else
+        echo "  self-test FAIL: did not name the reserved headroom"
+        st_fail=1
+    fi
+
+    printf '# test budget\nbudgeted.sh\t500\nnewfile.sh\t500\n' >"$tmp5/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp5" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "control: a new row stating the file's real count on first appearance passes" 0 "$rc"
+    rm -rf "$tmp5"
+
     rc=0
     (
         cd "$tmp" || exit 90

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -244,52 +244,47 @@ check_monotonic() {
     old_lines=$(git show "$base:$BUDGET_FILE" 2>/dev/null | parse_budget || true)
     new_lines=$(parse_budget <"$BUDGET_FILE")
 
-    if [ -n "$old_lines" ]; then
-        while IFS=$'\t' read -r path old_ceiling; do
-            [ -n "$path" ] || continue
-            new_ceiling=$(printf '%s\n' "$new_lines" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
-            if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
-                if monotonic_exempt "$path"; then
-                    # A rise must RECORD the artifact, not grant it headroom. Without this the
-                    # exemption would let one PR set the row to any number it liked, and nothing
-                    # mechanical would object again until the file actually reached it — which
-                    # would retire the per-PR measurement while still reading as a ratchet.
-                    actual=$(count_lines "$path")
-                    if [ "$new_ceiling" != "$actual" ]; then
-                        echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling to $new_ceiling," \
-                            "but the file is $actual lines. That row records the un-split remainder, so a" \
-                            "rise must state the real count, not reserve headroom."
-                        fail=1
-                        continue
-                    fi
-                    echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling," \
-                        "matching the file. That row records the un-split remainder of the generated" \
-                        "pithead artifact, so it tracks it both ways (#1464). Every Phase 2 cut lowers" \
-                        "it." >&2
-                    continue
-                fi
-                echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
-                    "$new_ceiling. Ceilings only go down."
-                fail=1
-            fi
-        done <<<"$old_lines"
-    fi
-
-    # A path with no row on $base is a first appearance, not a raise, so the loop above never
-    # visits it — that gap is #1470: a new row could reserve any headroom above the file's real
-    # size and nothing would object again until the file actually grew into it. count_lines is
-    # the gate's own counter (not wc -l, which undercounts a file with no trailing newline) and
-    # falls back to 0 when the path can't be read, so a deleted or unreadable path mismatches any
-    # ceiling and fails closed rather than passing.
+    # One pass over the working-tree rows: a path with no row on $base is a first appearance
+    # (#1470), not a raise — it must record the file's real count rather than reserve headroom
+    # above it, or nothing mechanical would object again until the file actually grew into it.
+    # count_lines is the gate's own counter (not wc -l, which undercounts a file with no
+    # trailing newline) and falls back to 0 when the path can't be read, so a deleted or
+    # unreadable path mismatches any ceiling and fails closed rather than passing.
     while IFS=$'\t' read -r path new_ceiling; do
         [ -n "$path" ] || continue
         old_ceiling=$(printf '%s\n' "$old_lines" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
-        [ -n "$old_ceiling" ] && continue
-        actual=$(count_lines "$path")
-        if [ "$new_ceiling" != "$actual" ]; then
-            echo "file-budget: FAIL — $BUDGET_FILE adds $path as a new row at ceiling $new_ceiling," \
-                "but the file is $actual lines. A row's first appearance must record the real count," \
-                "not reserve headroom."
+        if [ -z "$old_ceiling" ]; then
+            actual=$(count_lines "$path")
+            if [ "$new_ceiling" != "$actual" ]; then
+                echo "file-budget: FAIL — $BUDGET_FILE adds $path as a new row at ceiling" \
+                    "$new_ceiling, but the file is $actual lines. A row's first appearance must" \
+                    "record the real count, not reserve headroom."
+                fail=1
+            fi
+            continue
+        fi
+        if [ "$new_ceiling" -gt "$old_ceiling" ]; then
+            if monotonic_exempt "$path"; then
+                # A rise must RECORD the artifact, not grant it headroom. Without this the
+                # exemption would let one PR set the row to any number it liked, and nothing
+                # mechanical would object again until the file actually reached it — which
+                # would retire the per-PR measurement while still reading as a ratchet.
+                actual=$(count_lines "$path")
+                if [ "$new_ceiling" != "$actual" ]; then
+                    echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling to $new_ceiling," \
+                        "but the file is $actual lines. That row records the un-split remainder, so a" \
+                        "rise must state the real count, not reserve headroom."
+                    fail=1
+                    continue
+                fi
+                echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling," \
+                    "matching the file. That row records the un-split remainder of the generated" \
+                    "pithead artifact, so it tracks it both ways (#1464). Every Phase 2 cut lowers" \
+                    "it." >&2
+                continue
+            fi
+            echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
+                "$new_ceiling. Ceilings only go down."
             fail=1
         fi
     done <<<"$new_lines"

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -228,9 +228,12 @@ monotonic_exempt() {
 }
 
 # Ceilings only ever go down. Compare the working-tree budget against the base branch's: any
-# path present in both whose ceiling ROSE is a rejected edit, proving the ratchet is real.
+# path present in both whose ceiling ROSE is a rejected edit, and any path with NO row on the
+# base ref (a first appearance) must record the file's real count rather than reserve headroom
+# under it — the same "a rise must record, not reserve" reasoning #1464 gave the one exempt row,
+# applied to the row's very first line instead of a later raise (#1470).
 check_monotonic() {
-    local base old_lines fail=0 path old_ceiling new_ceiling actual
+    local base old_lines new_lines fail=0 path old_ceiling new_ceiling actual
     base=$(resolve_base_ref)
     if [ -z "$base" ]; then
         echo "file-budget: NOTE — no base ref (origin/develop or develop) resolvable; skipping the" \
@@ -239,35 +242,58 @@ check_monotonic() {
     fi
     [ -f "$BUDGET_FILE" ] || return 0
     old_lines=$(git show "$base:$BUDGET_FILE" 2>/dev/null | parse_budget || true)
-    [ -n "$old_lines" ] || return 0
+    new_lines=$(parse_budget <"$BUDGET_FILE")
 
-    while IFS=$'\t' read -r path old_ceiling; do
-        [ -n "$path" ] || continue
-        new_ceiling=$(parse_budget <"$BUDGET_FILE" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
-        if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
-            if monotonic_exempt "$path"; then
-                # A rise must RECORD the artifact, not grant it headroom. Without this the
-                # exemption would let one PR set the row to any number it liked, and nothing
-                # mechanical would object again until the file actually reached it — which
-                # would retire the per-PR measurement while still reading as a ratchet.
-                actual=$(count_lines "$path")
-                if [ "$new_ceiling" != "$actual" ]; then
-                    echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling to $new_ceiling," \
-                        "but the file is $actual lines. That row records the un-split remainder, so a" \
-                        "rise must state the real count, not reserve headroom."
-                    fail=1
+    if [ -n "$old_lines" ]; then
+        while IFS=$'\t' read -r path old_ceiling; do
+            [ -n "$path" ] || continue
+            new_ceiling=$(printf '%s\n' "$new_lines" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
+            if [ -n "$new_ceiling" ] && [ "$new_ceiling" -gt "$old_ceiling" ]; then
+                if monotonic_exempt "$path"; then
+                    # A rise must RECORD the artifact, not grant it headroom. Without this the
+                    # exemption would let one PR set the row to any number it liked, and nothing
+                    # mechanical would object again until the file actually reached it — which
+                    # would retire the per-PR measurement while still reading as a ratchet.
+                    actual=$(count_lines "$path")
+                    if [ "$new_ceiling" != "$actual" ]; then
+                        echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling to $new_ceiling," \
+                            "but the file is $actual lines. That row records the un-split remainder, so a" \
+                            "rise must state the real count, not reserve headroom."
+                        fail=1
+                        continue
+                    fi
+                    echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling," \
+                        "matching the file. That row records the un-split remainder of the generated" \
+                        "pithead artifact, so it tracks it both ways (#1464). Every Phase 2 cut lowers" \
+                        "it." >&2
                     continue
                 fi
-                echo "file-budget: NOTE — $path's ceiling rises from $old_ceiling to $new_ceiling," \
-                    "matching the file. That row records the un-split remainder of the generated" \
-                    "pithead artifact, so it tracks it both ways (#1464). Every Phase 2 cut lowers it." >&2
-                continue
+                echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
+                    "$new_ceiling. Ceilings only go down."
+                fail=1
             fi
-            echo "file-budget: FAIL — $BUDGET_FILE raises $path's ceiling from $old_ceiling to" \
-                "$new_ceiling. Ceilings only go down."
+        done <<<"$old_lines"
+    fi
+
+    # A path with no row on $base is a first appearance, not a raise, so the loop above never
+    # visits it — that gap is #1470: a new row could reserve any headroom above the file's real
+    # size and nothing would object again until the file actually grew into it. count_lines is
+    # the gate's own counter (not wc -l, which undercounts a file with no trailing newline) and
+    # falls back to 0 when the path can't be read, so a deleted or unreadable path mismatches any
+    # ceiling and fails closed rather than passing.
+    while IFS=$'\t' read -r path new_ceiling; do
+        [ -n "$path" ] || continue
+        old_ceiling=$(printf '%s\n' "$old_lines" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')
+        [ -n "$old_ceiling" ] && continue
+        actual=$(count_lines "$path")
+        if [ "$new_ceiling" != "$actual" ]; then
+            echo "file-budget: FAIL — $BUDGET_FILE adds $path as a new row at ceiling $new_ceiling," \
+                "but the file is $actual lines. A row's first appearance must record the real count," \
+                "not reserve headroom."
             fail=1
         fi
-    done <<<"$old_lines"
+    done <<<"$new_lines"
+
     return "$fail"
 }
 


### PR DESCRIPTION
The file-budget ratchet gate's monotonic check only ever walked rows present on the base ref. A brand-new row — a path with no counterpart on `develop-v2` — never entered that loop, so a PR could add a new row to `docs/dev/file-budget.tsv` that reserved headroom above the file's real line count on its very first appearance, and nothing mechanical would object again until the file actually grew into that reserved ceiling. That is the same "a rise must record, not reserve" gap #1464 closed for a later raise on an existing row, left open for the row's first line.

`check_monotonic()` in `scripts/lint-file-budget.sh` now also walks every row in the working-tree budget that has no counterpart on the base ref, and fails unless its ceiling equals the file's actual line count (via the gate's own `count_lines`, not `wc -l`, so a file with no trailing newline isn't undercounted; a deleted or unreadable path falls back to 0 and so mismatches any ceiling and fails closed).

Proven with:
- `bash scripts/lint-file-budget.sh --self-test` — new fixture: a first-appearance row at ceiling 900 on a 500-line file FAILS and names the reserved headroom; a first-appearance row stating the real count (500) passes as a control. All prior fixtures still pass.
- `bash scripts/lint-file-budget.sh` — clean pass against the current repo state.
- `shellcheck` and `shfmt -d` on both touched files — clean.

`scripts/lint-file-budget-selftest.sh` adds the fixture: it asserts the FAIL case names the reserved headroom (`"adds newfile.sh as a new row at ceiling 900, but the file is 500 lines"`), and that the control case (real count on first appearance) passes with rc=0.

Refs #1470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
