### PR TITLE
build(deps): #1685 F1 the develop-v2 twin of dependabot.yml, inert on this branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,3 +97,117 @@ updates:
       # major/minor is a deliberate migration (compose flags, config compatibility), not a CVE fix.
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # ── INERT ON THIS BRANCH ─────────────────────────────────────────────────────────────────────
+  # Everything below is a verbatim copy of what `develop` carries, kept so the twins stay level
+  # (#1685 F1). Dependabot reads this file from the DEFAULT branch only, which is `develop`, so
+  # nothing in this file — above the line or below it — does anything while `develop-v2` is not
+  # the default branch. The copy exists so the retirement (#1169) inherits a config that already
+  # works, and so a hand-made change to one twin shows up as missing from the other. The prose
+  # below describes the config as Dependabot resolves it FROM `develop`, so its `/build/dashboard`
+  # references are about that branch's tree, not this one's.
+
+  # ── develop-v2 coverage (#1425, #1650) ──────────────────────────────────────────────────────
+  # Everything above this line resolves against the DEFAULT branch, `develop`. That is not a
+  # style choice: Dependabot reads this file from the default branch only, and with no
+  # `target-branch:` it also resolves each `directory:` there and opens the PR there. So every
+  # entry above watches the FROZEN twin, and `develop-v2` — the branch all work actually lands
+  # on — was covered by the `/os/rootfs` entry and nothing else.
+  #
+  # Two distinct faults produced that, and they need different repairs (#1425):
+  #   * a WRONG DIRECTORY — `uv` and the docker group name `/build/dashboard`, which is 404 on
+  #     develop-v2 (the dashboard moved to `dashboard/` at #1106). Repair: name the real path.
+  #   * a MISSING TARGET — `github-actions` and `docker-compose` name `/`, which exists on both
+  #     twins. Nothing is mispointed; the entries simply never target develop-v2. Repair: a
+  #     second entry carrying `target-branch:`.
+  # A fix that treats these as one edit repairs the first and silently leaves the second.
+  #
+  # DO NOT "level the twins" by deleting these. `develop` is frozen but still takes critical
+  # patches under lane policy exception (a), so its entries stay; and moving an entry to
+  # develop-v2 is what makes it stop running, which is how the gap went unnoticed for so long
+  # (CONTRIBUTING.md § The two lanes; the /os/rootfs comment above states the same mechanism).
+  # The duplication ends when develop-side watching is retired — that is #1169, and it is
+  # blocked while develop still ships patches. Until then, two entries per surface is the cost.
+  #
+  # WHY EVERY SURFACE IS LISTED HERE AND NOT JUST THE DASHBOARD. The twins are held level by
+  # TWIN PRs, not by sync merges: every hand-made change on develop has a develop-v2 partner
+  # (#1438 -> #1440, #1313 -> #1356, #1290 -> #1344), so a merge-base or ahead/behind count
+  # cannot see the mechanism and says nothing about whether the twins have drifted.
+  # What has no twin mechanism is a DEPENDABOT RAISE: it is opened against the default branch,
+  # and nobody hand-writes the partner. Measured 2026-09-03, those are the only two develop-only
+  # changes with no develop-v2 equivalent — ruff (#1423), 0.16.4 on develop against 0.16.3 here,
+  # and actions/download-artifact (#1424), v8.0.1 against v7.0.0 here. The github-actions row is
+  # the sharpest case: it was level until #1424 merged, and went stale and silent in the same
+  # instant, because the open PR was the only signal that a newer version existed. So build/* and
+  # docker-compose are carried by twin PRs for hand-made changes, and by Dependabot on develop-v2
+  # for raises once these entries land.
+  #
+  # `tests/integration/tor-client/Dockerfile` is covered by NO entry on either twin, and that is
+  # DELIBERATE, recorded here so it is an omission on purpose rather than by accident: it is test
+  # scaffolding that is never shipped or flashed, so a stale base there costs a rebuild, not a
+  # CVE in a user's hands.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-v2:
+        patterns: ["*"]
+
+  # develop-v2's dashboard Python deps. Same subject as the `uv` entry above, different path:
+  # `dashboard/`, not `build/dashboard/` (#1106).
+  - package-ecosystem: "uv"
+    directory: "/dashboard"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-v2:
+        patterns: ["*"]
+    ignore:
+      # Same reason as the develop-side entry: protobuf/grpcio are pinned to what the vendored
+      # Tari gRPC stubs assert at import time (see dashboard/pyproject.toml on develop-v2); a
+      # major bump needs the stubs regenerated first.
+      - dependency-name: "protobuf"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "grpcio"
+        update-types: ["version-update:semver-major"]
+
+  # develop-v2's base-image digests. `/dashboard` is the moved path; the four `build/*` entries
+  # exist on both twins and are repeated here because nothing carries a develop-side bump across
+  # (see the measurement above). `/os/rootfs` is NOT repeated — it already has its own
+  # develop-v2 entry, and a second one naming the same directory would be a duplicate.
+  - package-ecosystem: "docker"
+    directories:
+      - "/dashboard"
+      - "/build/monero"
+      - "/build/p2pool"
+      - "/build/tor"
+      - "/build/xmrig-proxy"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-v2:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the develop-side docker entry: digest + patch within the pinned tag.
+      # Major/minor base bumps are deliberate migrations, not security updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # develop-v2's third-party image digests pinned directly in docker-compose.yml. The file exists
+  # on both twins, so this is the missing-target case, not the wrong-directory one.
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    target-branch: "develop-v2"
+    schedule:
+      interval: "weekly"
+    groups:
+      compose-v2:
+        patterns: ["*"]
+    ignore:
+      # Same policy as the develop-side entry: digest + patch within the pinned tag.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
## What this is

**#1685's F1, discharged.** #1685 gave `develop-v2` its own Dependabot coverage and landed on `develop` under STANDING-DIRECTIVE exception (b) — which obliges a sync forward once firing is proven. Firing is proven; this is the forward half.

## The copy is inert on this branch, and that is the point

Dependabot reads this file from the **default branch only**, which is `develop`. Nothing in this file — the pre-existing entries or the block added here — does anything while `develop-v2` is not the default branch. The copy exists so that:

- the twins stay level, so a hand-made change to one shows up as missing from the other;
- the #1169 retirement inherits a config that already works, instead of one branch's worth of drift discovered at cutover.

A header comment in the file says this, including that the block's prose describes the config as Dependabot resolves it *from `develop`* — so its `/build/dashboard` references are about that branch's tree, not this one's.

## Firing proof — re-derived here, not relayed

`gh pr list --base develop-v2 --author app/dependabot` at the time of writing:

| PR | opened | what |
|---|---|---|
| #1689 | 2026-09-03T15:33:27Z | `actions/download-artifact` 7.0.0 → 8.0.1, `actions-v2` group |
| #1691 | 2026-09-03T15:33:58Z | `python` digest in `/dashboard`, `docker-v2` group |
| #1692 | 2026-09-03T15:35:19Z | `python-v2` group in `/dashboard`, 3 updates |

Three PRs against `develop-v2` within three minutes of #1685's 15:32:17Z merge. F1's stated prediction was that `download-artifact` v7 → v8 and the ruff bump would appear; #1689 is the first of those. The channel fires.

## Verification: "level" measured structurally, not by eyeball

Both files parsed and compared entry by entry, rather than diffed as text — comment reflow would have swamped a text diff:

- **9 entries on each side, 5 carrying `target-branch`** — same shape.
- **The develop-v2 coverage half (entries 5–8) is byte-identical to develop's.** Asserted programmatically, not read.
- **Exactly two entries differ, and only in one field:** entries 1 (`uv`) and 2 (`docker`) say `/dashboard` here and `/build/dashboard` on develop.

That last difference is **pre-existing and deliberate** — F1 names it explicitly ("`develop-v2`'s own copy of this file already differs from develop's; its `uv` entry names `/dashboard`"). Those are each branch's real paths: `build/dashboard` EXISTS on `develop` and 404s here, while `dashboard` is exactly mirrored. Measured at both tips. Making the files identical would break one branch or the other, so **"level" here means the hand-made change is paired, not that the files match byte for byte.**

## Gates run

`lint-yaml` PASS · `lint-file-budget` PASS · the YAML parses to 9 well-formed update entries. `.github/dependabot.yml` has no budget row and is 213 lines, under the 400-line target.

## Lane and grant disclosure

`.github/dependabot.yml` is currency's under the w89 grant block, and the lane-guard ALLOWED it staged alone. **Flagged rather than quietly relied on:** that block's own text says it expires "when the named fix PR merges, whichever is first", and the named PR (#1685) merged at 15:32:17Z — so by its own wording the grant reads *expired*, while the line is still present in `roles/currency.paths`. I re-armed nothing; this work was assigned by the controller in this cycle, naming this file. The grant text wants re-dating or retiring, and I have said so to the controller rather than leaving a live grant that reads as expired.

## Not done

- No claim that the *contents* of the develop-v2 coverage entries are optimal — this is a verbatim sync of an already-reviewed, already-merged change, deliberately not a redesign.
- `actions/download-artifact` v7 → v8 compatibility for develop-v2's `ci.yml` is untouched and belongs to #1689, the PR that proposes it.
- Nothing here can be exercised live: the config is inert on this branch by construction, so there is no run to point at. The firing evidence above is necessarily from `develop`.

---

## Over-engineering pass (ponytail gate, by hand)

The diff is +114 lines in one file, of which 105 are a verbatim copy and 8 are new comment. Four things put to it:

1. **Verbatim copy vs. rewriting the block's prose for this branch.** Verbatim, deliberately. Rewriting would produce two diverging explanations of one mechanism and would destroy the property that makes "level" checkable at all — that entries 5–8 parse byte-identical to develop's. The one real cost of copying (prose that says `/build/dashboard` on a branch where that path 404s) is paid off by one sentence in the header rather than by a rewrite.
2. **Eight comment lines for a copied block — too many?** Kept. They answer four questions a reader on this branch will otherwise ask and get wrong: why the file exists here, that it is inert, that retirement inherits it, and whose tree the block's prose describes. The file it joins is already ~90% comment, so this matches the surrounding density rather than exceeding it.
3. **Could this have ridden in #1685?** No. #1685 had to land on `develop` because that is the only branch Dependabot reads and the only place firing could be proven. This has to land on `develop-v2`. Different base is a hard constraint, not a preference.
4. **Is syncing inert entries worth doing at all?** That is the question F1 already answered and #1169 measures the cost of: unsynced twins are discovered at cutover, one broken watcher at a time. The cheap moment is now.

No simplification found that did not cost more than it saved. The only original content in this diff is the header comment; everything else is a sync of already-reviewed, already-merged content.
