### PR TITLE
docs+test(lint-file-budget): prove the #1375-shaped skip at check_monotonic is safe

### DIFF
--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -123,6 +123,19 @@ self_test() {
     expect "a budgeted file dropped below target still listed FAILS (stale entry)" 1 "$rc"
     seq 1 500 >"$tmp/budgeted.sh"
 
+    # Complement of the case above, and the one #1430 found untested: the base entry is not just
+    # stale, it is GONE from the new tsv. check_monotonic walks the working-tree rows, so a base
+    # row absent here is never visited — the file legitimately shrank to <= target — and the gate
+    # must PASS, not FAIL. Without this case, a regression that made that skip fail open again
+    # (#1375's construct) would go uncaught by this suite.
+    seq 1 300 >"$tmp/budgeted.sh"
+    printf '# test budget\n' >"$tmp/$BUDGET_FILE"
+    rc=0
+    (cd "$tmp" && run_gate) >"$out" 2>&1 || rc=$?
+    expect "a shrunk file whose entry was correctly removed PASSES (legitimate removal, #1430)" 0 "$rc"
+    seq 1 500 >"$tmp/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp/$BUDGET_FILE"
+
     # Two-lane shape: a develop-v2 branch cut BEFORE the lane tip advanced must still
     # ratchet against develop-v2, not fall back to develop and read this lane's larger
     # ceiling as a raise — the false RED that bit two live PRs the day the tip moved.

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -259,6 +259,15 @@ check_monotonic() {
     # count_lines is the gate's own counter (not wc -l, which undercounts a file with no
     # trailing newline) and falls back to 0 when the path can't be read, so a deleted or
     # unreadable path mismatches any ceiling and fails closed rather than passing.
+    # The complement of that case is #1375's construct, and it is unchecked BY CONSTRUCTION: a
+    # path with a row on $base and none here is never visited by this loop at all. It stays safe
+    # only because run_gate has already FAILed both of the other ways a path could go missing --
+    # an over-target file with no row (its own arm), and a row naming a file that is gone or now
+    # exempt (the loop above this one). So a base row absent here can only mean the file shrank
+    # to <= TARGET_LINES: the sanctioned removal. That argument leans on run_gate's candidate set
+    # being the WHOLE tree (list_candidates), never a diff -- narrow it to changed files and this
+    # skip fails open again, silently, because nothing here would change. #1430; the self-test
+    # covers the legitimate-removal PASS beside the still-listed-but-shrunk FAIL.
     while IFS=$'\t' read -r path new_ceiling; do
         [ -n "$path" ] || continue
         old_ceiling=$(printf '%s\n' "$old_lines" | awk -F'\t' -v p="$path" '$1==p {print $2; exit}')


### PR DESCRIPTION
## The gap

`check_monotonic` in `scripts/lint-file-budget.sh` skips its raise check with `[ -n "$new_ceiling" ]` whenever a base `docs/dev/file-budget.tsv` entry has no matching row in the new tsv. That is exactly #1375's construct — an entry vanishing between the base and the working tree — and read on its own the skip looks like it could fail open: nothing there explained why an absent new-side entry is safe to let through unchecked. The self-test suite had no case at all for "base entry present, new entry legitimately gone" — only the neighboring "still present but stale" case was covered, so a regression that made this skip fail open again would have gone uncaught.

## What changed

- `scripts/lint-file-budget.sh`: a comment at the skip explains why it's safe — by the time `check_monotonic` reaches this line, `run_gate`'s earlier arms have already FAILed the other two ways a path could go missing (an over-target file with no entry, or an entry naming a file that's gone/now exempt), so an absent new-side entry here can only mean the file legitimately shrank to ≤ `TARGET_LINES`. The comment also flags the argument's load-bearing assumption: it only holds because `run_gate`'s candidate set is the whole tree (`list_candidates`), never a diff.
- `scripts/lint-file-budget-selftest.sh`: adds the missing case — a budgeted file shrinks below target, its tsv row is correctly dropped, and `run_gate` must PASS. This is the direct complement of the existing "dropped below target but entry left stale" FAIL case, and it's the case that would catch a regression reintroducing #1375's construct.

## How it was proven

```
shellcheck scripts/lint-file-budget.sh scripts/lint-file-budget-selftest.sh   # rc=0
shfmt -d scripts/lint-file-budget.sh scripts/lint-file-budget-selftest.sh     # rc=0
make lint-file-budget
```

`make lint-file-budget` runs `bash scripts/lint-file-budget.sh --self-test` (all cases pass, including the new "a shrunk file whose entry was correctly removed PASSES (legitimate removal, #1430)" case) followed by the real gate against this repo, which reports OK.

## What the added test asserts

Given a budgeted file that shrinks to ≤ `TARGET_LINES` and its now-unnecessary `docs/dev/file-budget.tsv` row is removed in the same change, `run_gate` exits 0 — proving the `-n "$new_ceiling"` skip in `check_monotonic` passes the legitimate-removal case it exists for, not just any absent entry.

Refs #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Shared-file disclosure (moved into the body, where COMMON says it belongs)

`scripts/lint-file-budget-selftest.sh` is in **no role's `.paths` and not in `_shared.paths`**. Proved rather than assumed: staged alone, the lane-guard refuses it, rc 1, naming that exact path. `scripts/lint-file-budget.sh` is a live per-item grant to this lane.

**`git rebase --continue` does not run the `pre-commit` hook**, so the lane-guard never fired on this commit at all. The one-shot `.lane-override` I armed came through **unconsumed**; I removed it rather than leave it armed and invisible in `git status`. That is a mechanism gap worth having on the record: any lane can land an out-of-lane file via a rebase with no refusal and no trace.
