### PR TITLE
fix(trivyignore): #1156 53615 reddened on 2026-08-17, not 2026-08-19

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -50,9 +50,8 @@ CVE-2026-24049
 # pinned bases took the fix): `--ignore-unfixed` hid these until Debian published a fix, at
 # which point they reddened every branch at once with no change on our side. 53615 arrived that way
 # on 2026-08-17 and the other three on 2026-08-20, between one CI run and the next on a branch
-# nobody had touched. Each date is the day that ID's mute landed here, which is also how to check
-# one: `git log -S CVE-2026-53615 -- .trivyignore` names e0e4655 (2026-08-17). 53615 read 2026-08-19
-# here until that check was run against it; the other three are unchanged and match 4c42787.
+# nobody had touched. Each date is the day that ID's mute landed here, so
+# `git log -S <the ID> -- .trivyignore` re-derives one rather than trusting this line.
 #
 # Cleared when a base bump brings 2.41.5-0+deb13u1 in — `docker run --rm python:3.11-slim
 # dpkg-query -W util-linux` is the one-line check, and all four go together. Nothing re-surfaces

--- a/.trivyignore
+++ b/.trivyignore
@@ -49,8 +49,10 @@ CVE-2026-24049
 # Same shape as the openssl mute this file carried until 2026-08-24 (CVE-2026-45447, cleared once the
 # pinned bases took the fix): `--ignore-unfixed` hid these until Debian published a fix, at
 # which point they reddened every branch at once with no change on our side. 53615 arrived that way
-# on 2026-08-19 and the other three on 2026-08-20, between one CI run and the next on a branch
-# nobody had touched.
+# on 2026-08-17 and the other three on 2026-08-20, between one CI run and the next on a branch
+# nobody had touched. Each date is the day that ID's mute landed here, which is also how to check
+# one: `git log -S CVE-2026-53615 -- .trivyignore` names e0e4655 (2026-08-17). 53615 read 2026-08-19
+# here until that check was run against it; the other three are unchanged and match 4c42787.
 #
 # Cleared when a base bump brings 2.41.5-0+deb13u1 in — `docker run --rm python:3.11-slim
 # dpkg-query -W util-linux` is the one-line check, and all four go together. Nothing re-surfaces


### PR DESCRIPTION
## What

`.trivyignore`'s util-linux block dated CVE-2026-53615's arrival to **2026-08-19**. It was already reddening `develop`'s scheduled run on **2026-08-17** and was muted the same day. Comment-only fix, plus the check that re-derives it.

## Why it is wrong, from three sources that are not the file

| source | says |
|---|---|
| `e0e4655` (#1073) — the commit that **added** the 53615 mute | landed **2026-08-17T19:05Z** |
| the scheduled run it reddened | **2026-08-17T05:31Z**, ~13.5h earlier |
| #1377's own title | *"the 2026-08-17 CVE sweep went red unnoticed for a week"* |

The check, now named in the file so the next reader does not have to trust the prose:

```
git log -S CVE-2026-53615 -- .trivyignore   ->  e0e4655  2026-08-17
git log -S CVE-2026-53612 -- .trivyignore   ->  4c42787  2026-08-20
```

## Where the wrong date came from — visible in the commit that wrote it

`4c42787` (#1156) introduced the sentence, and the same commit body contains `2026-08-19 17:58`: the time CI had **last run** on that branch. A date belonging to one measurement was attached to a different fact. Worth naming because the failure leaves no trace — a wrong date under an otherwise correct paragraph reads exactly like a right one.

## Scope

- **The other three IDs are untouched.** `4c42787` added 53612/53613/53614 on 2026-08-20 and the file's date for them is correct. I dated them from the same check rather than assuming they moved with 53615.
- **No mute added, removed, or changed.** Comment lines only: `+3 / -2`, one file.
- `make lint-trivy-parity` green (self-test + `--check-parity`, all three trivy-action sites at v0.74.0). No shell changed, so `lint-sh` is not implicated.
- The mute itself is still necessary and was separately re-derived: `docker pull python:3.11-slim` resolves to the digest `dashboard/Dockerfile` already pins, and that image still ships util-linux `2.41-5`, not `2.41.5-0+deb13u1`. There is nothing to bump to.

## Ponytail pass

The gate's over-engineering review raised two findings on the first draft and **both were applied, not noted**:

- `delete:` a clause narrating this file's own edit history (*"53615 read 2026-08-19 here until..."*) — `git log` already answers it and the commit message carries it.
- `shrink:` naming `e0e4655` / `4c42787` inline pre-computed what the `git log -S` command returns. The command stays; the answers go.

Took the diff from `+4/-2` to `+3/-2`. Second commit on the branch is that cut, kept separate so the correction and the trim are reviewable apart.

## Twin note

The same wrong date is on `develop` (`.trivyignore:25`). **Not fixed here** — `develop` is frozen and this is a comment. It will come across with the next sync; flagging so it is not read as a missed site.

Path is this lane's exclusive (`.trivyignore` in `currency.paths`); no `.lane-override`, no shared file touched.

Follow-up to #1156. Not a `Closes` — #1156 is already closed, and this corrects a fact it recorded rather than reopening anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDMrKYAy4ih2gVbTtqGtJJ
