### PR TITLE
fix(tests): inventory's drift floor refuses a single survivor on both sides

### DIFF
--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -195,21 +195,32 @@ while IFS= read -r base; do
 done <<<"$EXPECTED"
 n_missing=$(printf '%s' "$MISSING" | count)
 n_expected=$(printf '%s' "$EXPECTED" | count)
-# Nothing to compare is itself drift, and it is the ONE case the set difference above cannot see. If
-# every expected domain file and every stanza disappear TOGETHER — a botched revert of the #1105
-# split — then SOURCED and EXPECTED empty at the same time, MISSING is empty, and the comparison is
-# vacuously satisfied. The emptiness test this replaced DID catch that, so it is asserted explicitly
-# rather than quietly lost with it. Its own sentence, not a share of the one below: two guards on
-# one string means either can silently cover for the other's deletion.
+# Collapsing together is itself drift, and it is the ONE case the set difference above cannot see.
+# If every expected domain file and every stanza disappear TOGETHER — a botched revert of the #1105
+# split — then SOURCED and EXPECTED shrink at the same time, MISSING stays empty, and the comparison
+# is vacuously satisfied no matter how far they fall. The floor is not just an emptiness test: #1429
+# showed that landing on 1-and-1 rather than 0-and-0 is exactly as vacuous, because lib.sh's bare
+# stanza (it is not in UNSOURCED, so it counts as expected, and it IS sourced) survives every
+# deletion and keeps satisfying both directions at that single entry. A set-difference guard cannot
+# tell "everything agrees because nothing is missing" from "everything agrees because there is
+# nothing left to disagree about" — the fallback has to come from outside the two sets it compares.
+# MIN_EXPECTED is deliberately generous — comfortably below today's count (54 at the time of #1429)
+# so an ordinary rename, split, or retirement of a file or two never needs to touch it — precisely so
+# that when it DOES fire, it means the domain layer collapsed, not that someone forgot to bump a
+# number. Raise it when the true count grows enough to make that margin thin; never lower it to make
+# a real drop pass, and give a reason in the commit if you do either.
+MIN_EXPECTED=20
 # Scope, stated because a comment that names a case this guard never sees is worse than no comment:
 # dropping the WHOLE directory does not reach here — `n_stack` counts 0 and the aggregate gate above
 # exits first, with byte-identical output whether this guard is alive or dead. What is unique to
 # this check is the narrower case where run.sh and the sectioned UNSOURCED files survive, keeping
-# `n_stack` non-zero, while the expected domain files and their stanzas both go.
-if [ "$n_expected" -eq 0 ]; then
-    echo "inventory drift: no domain files are expected to be sourced — every tests/stack file is" \
-        "run.sh, UNSOURCED, or gone, so there is nothing to check run.sh's stanzas against;" \
-        "restore the domain files, or update the pattern in tests/inventory.sh" >&2
+# `n_stack` non-zero, while the expected domain files and their stanzas collapse toward a shared
+# handful of survivors (as few as one) that satisfy the comparison above.
+if [ "$n_expected" -lt "$MIN_EXPECTED" ]; then
+    echo "inventory drift: only $n_expected domain files are expected to be sourced (floor is" \
+        "$MIN_EXPECTED) — the domain layer may have collapsed while a shared survivor (e.g." \
+        "lib.sh) kept run.sh's stanzas and the files on disk agreeing with each other; restore" \
+        "the missing files and stanzas, or lower MIN_EXPECTED in tests/inventory.sh with a reason" >&2
     exit 1
 fi
 if [ "$n_missing" -gt 0 ]; then


### PR DESCRIPTION
## Defect

`tests/inventory.sh`'s domain-file drift check (direction 2, #1357) compares two sets: the files `run.sh` sources (`SOURCED`) against the domain files on disk (`EXPECTED`). It only ever asked "is anything in `EXPECTED` missing from `SOURCED`" — a set-difference question that stays vacuously satisfied when both sets shrink together.

`lib.sh`'s `source` stanza is bare by design (a helper library, not a domain file with assertions), so it is not in `UNSOURCED` and always counts as both expected and sourced. Delete every hyphen-named domain file and its stanza, and `SOURCED`/`EXPECTED` both collapse to `{lib.sh}`: `MISSING` is empty, the prior `n_expected==0` guard doesn't fire (`n_expected` is 1, not 0), and the gate passes rc 0 while the entire domain layer — 24+ files' worth of assertions — silently stops running.

## What the gate now refuses

The prior `n_expected==0` emptiness guard is widened into a floor: `n_expected` must stay at or above `MIN_EXPECTED` (20, comfortably below today's 54, so an ordinary rename or retirement of a file or two never needs to touch it). A floor from outside the two colliding sets is the only thing that can tell "nothing disagrees because nothing is missing" from "nothing disagrees because there's nothing left to compare" — the same lesson #1420/#1428 already drew for the 0-and-0 case, now covering 1-and-1 (and everywhere between).

## How it was proven

Reproduced before the fix:

```
for f in tests/stack/test-*.sh; do rm -f "$f"; done
# + strip the matching `source "$HERE/test-...sh"` lines from run.sh
bash tests/inventory.sh; echo $?
# -> rc=0 (bug: passes with the entire domain layer gone)
```

Same mutation against the fixed gate (re-verified in this session, working tree restored after):

```
rc=1
inventory drift: only 1 domain files are expected to be sourced (floor is 20) — the domain layer
may have collapsed while a shared survivor (e.g. lib.sh) kept run.sh's stanzas and the files on
disk agreeing with each other; restore the missing files and stanzas, or lower MIN_EXPECTED in
tests/inventory.sh with a reason
```

Full mutation battery from the commit (control, #1429's 1-and-1 case, 0-and-0, single-stanza-only, single-file-only, deliberate single retirement, restore) — every case lands where its own guard's sentence says it should; only this session's rerun of the aimed case is repeated above.

`shellcheck --severity=warning tests/inventory.sh` and `shfmt -d tests/inventory.sh` both pass clean on the touched file (the pinned severity `lint-sh` actually gates on — the file's untouched lines carry two pre-existing SC2016 info-level notes, below that threshold).

## What the added test asserts

No new test file: this gate is repo introspection over the live tree, and its own prior two fixes (44b51461, 2c9783c3) proved themselves the same way rather than adding a fixture — a live mutation battery against the actual `tests/stack/` tree, reverted after. That battery (reproduced above) is the test.

Refs #1429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)