### PR TITLE
fix(dashboard): #1564 Worker Inspect reports the config change nothing recorded

### DIFF
--- a/dashboard/mining_dashboard/service/storage_service.py
+++ b/dashboard/mining_dashboard/service/storage_service.py
@@ -417,14 +417,14 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
             "(id TEXT PRIMARY KEY, ts TEXT, source TEXT, actor TEXT, action TEXT, status TEXT, "
             "keys TEXT)"
         )
-        # The config revision each rig was last OBSERVED serving (#1551), one row per worker.
-        # Additive, mirroring events / share_stats: no _migrate_db change, and the PRIMARY KEY is
-        # the only index it wants. Holding the rig's opaque `revision` NEXT TO the `last_change_id`
-        # beside it is the point: a later poll tells a recorded change (both moved) from an edit
-        # underneath RigForge (only the revision moved) — the door #1542 leaves open.
+        # The config revision each rig was last OBSERVED serving (#1551), one row per worker, plus
+        # the revision it drifted FROM while that drift is still current (#1564, migrated below).
+        # The PRIMARY KEY is the only index it wants. Holding the rig's opaque `revision` NEXT TO
+        # the `last_change_id` beside it is the point: a later poll tells a recorded change (both
+        # moved) from an edit underneath RigForge (only the revision moved) — #1542's open door.
         self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS worker_config_revision "
-            "(worker TEXT PRIMARY KEY, revision TEXT, last_change_id TEXT, ts REAL)"
+            "CREATE TABLE IF NOT EXISTS worker_config_revision (worker TEXT PRIMARY KEY, "
+            "revision TEXT, last_change_id TEXT, ts REAL, drift_from TEXT)"
         )
 
     def _create_indexes(self):
@@ -488,6 +488,7 @@ class StateManager(TelemetryStoreMixin, WorkerConfigStoreMixin):
         if "type" not in {info[1] for info in cursor.fetchall()}:
             self.logger.info("Migrating DB: Adding type column to worker_config")
             self._conn.execute("ALTER TABLE worker_config ADD COLUMN type TEXT DEFAULT 'apply'")
+        self._migrate_worker_config_revision(cursor)
 
     def load(self) -> None:
         """

--- a/dashboard/mining_dashboard/service/worker_config_store.py
+++ b/dashboard/mining_dashboard/service/worker_config_store.py
@@ -74,6 +74,27 @@ def _shaped(row: sqlite3.Row) -> dict:
     return d
 
 
+def _next_drift_from(
+    row: sqlite3.Row | None, revision: str, last_change_id: str | None
+) -> str | None:
+    """The ``drift_from`` to store on this poll (#1564), given the row read on the same poll.
+
+    Split out of ``note_worker_revision`` because it IS the currency rule and is worth settling
+    without a database: the Inspect note must survive the polls AFTER the one that raised it — a
+    drift the operator has not resolved is still true — and go quiet once the config is
+    accounted for again. ``None`` means say nothing, for two reasons: a first sighting has
+    nothing to compare, and a revision that moved WITH a new ``last_change_id`` is the RESOLVED
+    case — something recorded that change, so the line has nothing left to contradict.
+    """
+    if row is None:
+        return None
+    if row["revision"] == revision:
+        # The rig has not moved, so a drift already recorded against this revision is still the
+        # current one. INSERT OR REPLACE rewrites every column, so carrying it is not a no-op.
+        return row["drift_from"]
+    return row["revision"] if row["last_change_id"] == last_change_id else None
+
+
 class WorkerConfigStoreMixin:
     """The `worker_config` accessors of `StateManager`. Never instantiated on its own."""
 
@@ -265,6 +286,10 @@ class WorkerConfigStoreMixin:
         ``last_change_id`` beside it: a hand-edit underneath RigForge, which moves the revision and
         stamps nothing, so neither #1345's provenance line nor #1367's ``config_drift`` can see it.
 
+        The same write maintains ``drift_from`` for ``get_worker_revision_drift`` (#1564) — the
+        read and the comparison are already here, so the Inspect line costs no second query and no
+        second lock scope. ``_next_drift_from`` carries that rule.
+
         It fails CLOSED like ``get_worker_config_change``: any read/write error returns ``None`` and
         accuses nobody. A missed detection is a poll's delay — the next poll compares against the
         same stored row, because a failed write leaves it unchanged — whereas a false accusation is
@@ -280,14 +305,16 @@ class WorkerConfigStoreMixin:
                     return None
                 cursor = self._conn.cursor()
                 cursor.execute(
-                    "SELECT revision, last_change_id FROM worker_config_revision WHERE worker = ?",
+                    "SELECT revision, last_change_id, drift_from FROM worker_config_revision "
+                    "WHERE worker = ?",
                     (worker,),
                 )
                 row = cursor.fetchone()
+                drift_from = _next_drift_from(row, revision, last_change_id)
                 self._conn.execute(
                     "INSERT OR REPLACE INTO worker_config_revision "
-                    "(worker, revision, last_change_id, ts) VALUES (?, ?, ?, ?)",
-                    (worker, revision, last_change_id, time.time()),
+                    "(worker, revision, last_change_id, ts, drift_from) VALUES (?, ?, ?, ?, ?)",
+                    (worker, revision, last_change_id, time.time(), drift_from),
                 )
                 self._conn.commit()
         except sqlite3.Error as e:
@@ -301,6 +328,59 @@ class WorkerConfigStoreMixin:
         if row["last_change_id"] != last_change_id:
             return None
         return {"worker": worker, "before": row["revision"], "after": revision}
+
+    def _migrate_worker_config_revision(self, cursor: sqlite3.Cursor) -> None:
+        """Adds ``worker_config_revision.drift_from`` to a database created before #1564.
+
+        Called by ``storage_service._migrate_db`` (#1369). ``CREATE TABLE IF NOT EXISTS`` means
+        an existing install never gains the column from the create path — the feature would be
+        silently absent on exactly the installs that have run long enough to drift. Pre-existing
+        rows get NULL: "no drift recorded", the same thing a first sighting says.
+        """
+        cursor.execute("PRAGMA table_info(worker_config_revision)")
+        if "drift_from" not in {info[1] for info in cursor.fetchall()}:
+            self.logger.info("Migrating DB: Adding drift_from column to worker_config_revision")
+            self._conn.execute("ALTER TABLE worker_config_revision ADD COLUMN drift_from TEXT")
+
+    def get_worker_revision_drift(self, worker: str, revision: str | None) -> dict | None:
+        """The unrecorded config edit the Inspect provenance line should still be reporting for
+        ``worker`` (#1564), as ``{worker, before, after}`` — or ``None``, meaning say nothing.
+
+        Gated on CURRENCY, never on existence. The ``rig-drift`` audit row is permanent and that
+        durable record is the Security panel's job; this line describes the config the rig is
+        serving NOW, so it answers only while the drift we stored produced ``revision`` — what
+        the rig reports on THIS poll. "Ever drifted?" would accuse a rig forever, long after the
+        operator adopted the change.
+
+        Two states by construction, never three: no "checked and agrees" verdict, for the reason
+        ``config_drift`` withholds its ``[]`` — an all-clear here would be a reassurance bounded
+        by narrowings the operator cannot see from a badge, this feature's own defect inverted.
+
+        Deliberately NOT a lookup of the ``rig-drift`` audit row by its ``event_id``: that id is
+        deterministic and the join is cheaper, but its format is not a contract, and a lookup
+        built on one would fail SILENTLY when the format moved — the note would stop rendering
+        and every test written against the old shape would stay green.
+
+        Fails CLOSED: a read error or a closed handle returns ``None`` and the line says nothing.
+        """
+        if not worker or not revision:
+            return None
+        try:
+            with self._db_lock:
+                if not self._conn:
+                    return None
+                cursor = self._conn.cursor()
+                cursor.execute(
+                    "SELECT revision, drift_from FROM worker_config_revision WHERE worker = ?",
+                    (worker,),
+                )
+                row = cursor.fetchone()
+        except sqlite3.Error as e:
+            self._db_error("Worker Revision Read Error", e)
+            return None
+        if row is None or not row["drift_from"] or row["revision"] != revision:
+            return None
+        return {"worker": worker, "before": row["drift_from"], "after": revision}
 
     def get_last_applied_worker_config(self, worker: str) -> dict[str, Any]:
         """The merged writable config the dashboard last successfully applied to ``worker`` — the

--- a/dashboard/mining_dashboard/web/static/confighistory.mjs
+++ b/dashboard/mining_dashboard/web/static/confighistory.mjs
@@ -6,7 +6,7 @@
 // it", which is one subject. workerview.mjs imports these; nothing here imports back.
 
 import { html } from "./preact.mjs";
-import { configDriftNote, configOriginNote } from "./workerlogic.mjs";
+import { configDriftNote, configOriginNote, configRevisionDriftNote } from "./workerlogic.mjs";
 
 // A terminal status → a display variant + label. rolled_back and rejected/failed read as bad;
 // applied is good; accepted/pending are in-flight.
@@ -50,14 +50,18 @@ export function HistoryRow({ row }) {
 // THIS dashboard did; this line is the rig's own account, which is the only thing that can reveal
 // a change the table cannot contain. Renders nothing at all when the rig cannot answer — a rig
 // with no RigForge, or one older than the block, must not be made to look suspicious.
-export function ConfigProvenance({ origin, meta, drift }) {
+export function ConfigProvenance({ origin, meta, drift, revisionDrift }) {
   const note = configOriginNote(origin, meta);
   // #1367: the drift note QUALIFIES the origin line — it is the only thing on the page that can
   // contradict a calm "Last changed from this dashboard" over a config nothing recorded. So it is
   // rendered independently rather than nested: a rig serving a config but no ``config_meta`` has no
   // origin line at all, and can still be running something other than what we applied.
   const driftNote = configDriftNote(drift);
-  if (!note && !driftNote) return null;
+  // #1564: same posture, one layer further out. This one reports a config move nothing recorded
+  // at all, which is why it is rendered beside the other two rather than nested in either: a rig
+  // with no ``config_meta`` has no origin line, and a key we never applied leaves drift empty.
+  const revNote = configRevisionDriftNote(revisionDrift);
+  if (!note && !driftNote && !revNote) return null;
   return html`
     ${
       note
@@ -67,5 +71,6 @@ export function ConfigProvenance({ origin, meta, drift }) {
     </p>`
         : null
     }
-    ${driftNote ? html`<p class=${"text-small " + driftNote.cls} title=${driftNote.title}>${driftNote.label}</p>` : null}`;
+    ${driftNote ? html`<p class=${"text-small " + driftNote.cls} title=${driftNote.title}>${driftNote.label}</p>` : null}
+    ${revNote ? html`<p class=${"text-small " + revNote.cls} title=${revNote.title}>${revNote.label}</p>` : null}`;
 }

--- a/dashboard/mining_dashboard/web/static/workerlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/workerlogic.mjs
@@ -329,3 +329,25 @@ export function configDriftNote(drift) {
       .join(" · "),
   };
 }
+
+// #1564: the config edit nothing recorded — #1551's detection, surfaced on the one line it
+// contradicts. configOriginNote structurally cannot see it (a hand-edit underneath RigForge
+// stamps no new change id) and neither can configDriftNote (a key we never set has no left-hand
+// side to compare), so without this an operator reads a calm "Last changed from this dashboard"
+// over a config the Security panel has already flagged.
+//
+// Two states, never three. The server sends this key only while the drift it recorded is the one
+// that produced the revision the rig is serving NOW, so there is no "checked and agrees" object
+// to render and no bounded all-clear to leak through — the rule configDriftNote keeps by
+// withholding `[]`, kept here by having no third state to withhold in the first place.
+//
+// The revision is a digest over the whole writable config, so this can say only THAT the config
+// moved with nothing recording it, never which key — the same limit the audit row already states.
+export function configRevisionDriftNote(drift) {
+  if (!drift || !drift.after) return null;
+  return {
+    cls: "text-warn",
+    label: "The rig's config changed with nothing recording it",
+    title: `config revision ${drift.before || "unknown"} → ${drift.after}, with no new change id`,
+  };
+}

--- a/dashboard/mining_dashboard/web/static/workerview.mjs
+++ b/dashboard/mining_dashboard/web/static/workerview.mjs
@@ -387,7 +387,7 @@ export class WorkerInspect extends Component {
             }
 
             <h4 class="mt-2">History</h4>
-            <${ConfigProvenance} origin=${detail.config_origin} meta=${detail.rig_config_meta} drift=${detail.config_drift} />
+            <${ConfigProvenance} origin=${detail.config_origin} meta=${detail.rig_config_meta} drift=${detail.config_drift} revisionDrift=${detail.config_revision_drift} />
             ${
               (detail.history || []).length
                 ? html`

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -279,6 +279,15 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         "config_drift": config_drift(
             last_applied, rig_config, unsettled=_has_unsettled_apply(history)
         ),
+        # The unrecorded edit #1551 detects, served here while it is still the config the rig is
+        # running (#1564). It is the case BOTH lines above are structurally blind to: a hand-edit
+        # underneath RigForge stamps no new change id for `config_origin` to see, and a key we
+        # never set has no left-hand side for `config_drift` to compare. Without it an operator
+        # reads "Last changed from this dashboard" over a config the Security panel has flagged.
+        # {worker, before, after} or None — never an all-clear; the store gates on currency.
+        "config_revision_drift": state_mgr.get_worker_revision_drift(
+            name, (rig_meta or {}).get("revision")
+        ),
         "history": history,
         "hashrate_by_config": hashrate_by_config,
         "hashrate_history": build_worker_hashrate_history(state_mgr, name, range_arg, window),

--- a/dashboard/tests/frontend/confighistory.test.mjs
+++ b/dashboard/tests/frontend/confighistory.test.mjs
@@ -189,3 +189,30 @@ test("HistoryRow lists a config diff by its keys and an upgrade by its version",
   assert.match(up, /upgrade → 1\.10\.0/);
   assert.match(up, /Already up to date/);
 });
+
+// #1564 — the third line ConfigProvenance can carry.
+test("ConfigProvenance reports an unrecorded config change beside the origin line", () => {
+  // The defect this closes: `here` is the calmest verdict the origin line has, and it is exactly
+  // the one a hand-edit underneath RigForge leaves standing. Both lines must render together —
+  // replacing the origin line would hide which change the dashboard did make.
+  const out = renderToString(
+    ConfigProvenance({
+      origin: "here",
+      meta: META,
+      revisionDrift: { worker: "rig1", before: "aaa", after: "bbb" },
+    }),
+  );
+  assert.match(out, /Last changed from this dashboard/);
+  assert.match(out, /nothing recording it/);
+});
+
+test("ConfigProvenance renders the unrecorded-change line with no origin line at all", () => {
+  // A rig serving a config but no config_meta has no origin line, and can still have drifted.
+  const out = renderToString(ConfigProvenance({ origin: null, meta: null,
+    revisionDrift: { worker: "rig1", before: "aaa", after: "bbb" } }));
+  assert.match(out, /nothing recording it/);
+});
+
+test("ConfigProvenance stays silent when nothing at all has anything to say", () => {
+  assert.equal(renderToString(ConfigProvenance({ origin: null, meta: null, revisionDrift: null })), "");
+});

--- a/dashboard/tests/frontend/workerlogic.test.mjs
+++ b/dashboard/tests/frontend/workerlogic.test.mjs
@@ -12,6 +12,7 @@ import {
   buildFields,
   buildTableChanges,
   configDriftNote,
+  configRevisionDriftNote,
   fieldNote,
   jsonSyntaxError,
   markerLabel,
@@ -367,4 +368,28 @@ test("configDriftNote renders an absent rig value as 'not set', never as empty",
 test("configDriftNote renders an object value readably", () => {
   const note = configDriftNote([{ key: "pools", applied: [{ url: "a" }], rig: [{ url: "b" }] }]);
   assert.match(note.title, /\{"url":"a"\}/);
+});
+
+// #1564 — the unrecorded-edit note, beside the other two on the provenance line.
+test("configRevisionDriftNote says nothing unless the server sent a drift", () => {
+  // There is no third state to render: the server sends this key only while the drift it
+  // recorded is the one that produced the revision the rig is serving now. Nothing here may
+  // invent an all-clear out of a shape it does not recognise.
+  for (const v of [null, undefined, {}, { before: "aaa" }, "nonsense", []]) {
+    assert.equal(configRevisionDriftNote(v), null);
+  }
+});
+
+test("configRevisionDriftNote names both revisions and says nothing recorded the change", () => {
+  const note = configRevisionDriftNote({ worker: "rig1", before: "aaa", after: "bbb" });
+  assert.match(note.label, /nothing recording it/);
+  assert.match(note.title, /aaa/);
+  assert.match(note.title, /bbb/);
+  // It may never name a key: the revision is a digest over the whole writable config.
+  assert.doesNotMatch(note.title, /max_temp_c|DONATION/);
+});
+
+test("configRevisionDriftNote renders an absent 'before' as unknown, never as blank", () => {
+  const note = configRevisionDriftNote({ worker: "rig1", after: "bbb" });
+  assert.match(note.title, /unknown/);
 });

--- a/dashboard/tests/service/test_storage_schema.py
+++ b/dashboard/tests/service/test_storage_schema.py
@@ -319,6 +319,39 @@ class TestSchemaMigration:
         finally:
             sm.close()
 
+    def test_worker_config_revision_drift_from_added_on_upgrade(self, tmp_path):
+        # Intent (#1564): worker_config_revision is CREATE TABLE IF NOT EXISTS, so an install that
+        # has been running since #1551 keeps its pre-drift_from table forever and the Inspect note
+        # would be silently absent on exactly the rigs with the most history to have drifted.
+        db = str(tmp_path / "pre_1564.db")
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "CREATE TABLE worker_config_revision "
+            "(worker TEXT PRIMARY KEY, revision TEXT, last_change_id TEXT, ts REAL)"
+        )
+        conn.execute(
+            "INSERT INTO worker_config_revision (worker, revision, last_change_id, ts) "
+            "VALUES ('rig1', 'aaa', NULL, 100.0)"
+        )
+        conn.commit()
+        conn.close()
+
+        sm = StateManager(db_path=db)
+        try:
+            info = sm._conn.execute("PRAGMA table_info(worker_config_revision)").fetchall()
+            assert "drift_from" in {c[1] for c in info}
+            # The backfilled NULL accuses nobody, and the row it carried is still the one the next
+            # poll compares against — an upgrade must not read as a first sighting.
+            assert sm.get_worker_revision_drift("rig1", "aaa") is None
+            assert sm.note_worker_revision("rig1", {"revision": "bbb"}) == {
+                "worker": "rig1",
+                "before": "aaa",
+                "after": "bbb",
+            }
+            assert sm.get_worker_revision_drift("rig1", "bbb") is not None
+        finally:
+            sm.close()
+
 
 class TestRetention:
     """Long-running behavior: history/workers must not grow unbounded. Tests are white-box

--- a/dashboard/tests/service/test_worker_revision.py
+++ b/dashboard/tests/service/test_worker_revision.py
@@ -129,3 +129,116 @@ class TestFailsClosed:
             "before": "aaa",
             "after": "bbb",
         }
+
+
+class TestDriftFromIsMaintained:
+    """``drift_from`` (#1564): the column that lets Worker Inspect keep reporting the edit.
+
+    Driven through the real store rather than by calling ``_next_drift_from`` with stand-in rows.
+    The rule's whole subject is what gets STORED and read back across polls, and a dict stand-in
+    would be a different object from the ``sqlite3.Row`` production subscripts — the tier that
+    proves this honestly is the one that writes and re-reads.
+    """
+
+    def test_the_poll_that_reports_a_drift_records_where_it_came_from(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") == {
+            "worker": "rig1",
+            "before": "aaa",
+            "after": "bbb",
+        }
+
+    def test_the_note_survives_the_polls_after_the_one_that_raised_it(self, state_manager):
+        # The reason the column exists at all. ``note_worker_revision`` reports a drift ONCE, so
+        # a line reading its return value would flash for a single poll and then reassure again
+        # while the rig is still running the unrecorded config.
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        for _ in range(3):
+            state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None
+
+    def test_a_move_with_a_new_change_id_clears_it(self, state_manager):
+        # The resolved case: we applied over the drift, or the rig recorded its own change. The
+        # audit row stays in the Security panel; the Inspect line has nothing left to contradict.
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None  # armed
+        state_manager.note_worker_revision("rig1", _meta("ccc", "c1"))
+        assert state_manager.get_worker_revision_drift("rig1", "ccc") is None
+
+    def test_a_second_drift_names_the_revision_it_moved_from(self, state_manager):
+        # Not the original one. "before" is the config the rig was last seen running, which is
+        # what an operator comparing against the rig in front of them can act on.
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        state_manager.note_worker_revision("rig1", _meta("ccc"))
+        assert state_manager.get_worker_revision_drift("rig1", "ccc")["before"] == "bbb"
+
+    def test_a_first_sighting_records_no_drift(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        assert state_manager.get_worker_revision_drift("rig1", "aaa") is None
+
+    def test_a_rig_that_never_moved_records_no_drift(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa", "c1"))
+        state_manager.note_worker_revision("rig1", _meta("aaa", "c1"))
+        assert state_manager.get_worker_revision_drift("rig1", "aaa") is None
+
+
+class TestTheReadIsGatedOnCurrency:
+    """The note describes the config the rig is serving NOW, never its history."""
+
+    def test_it_is_silent_once_the_rig_serves_a_different_revision(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        # The positive control for the assertion below: at the revision the drift produced, this
+        # same stored row DOES answer. So the silence that follows is the gate, not an empty row.
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None
+        assert state_manager.get_worker_revision_drift("rig1", "zzz") is None
+
+    def test_it_says_nothing_when_the_rig_reports_no_revision(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", None) is None
+
+    def test_it_says_nothing_for_an_unnamed_worker(self, state_manager):
+        assert state_manager.get_worker_revision_drift("", "bbb") is None
+
+    def test_workers_do_not_share_a_drift(self, state_manager):
+        # rig2 has drifted and rig1 has not. A read keyed on anything but the worker would print
+        # rig2's accusation over rig1's Inspect line.
+        state_manager.note_worker_revision("rig2", _meta("aaa"))
+        state_manager.note_worker_revision("rig2", _meta("bbb"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig2", "bbb") is not None
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is None
+
+
+class TestTheReadFailsClosed:
+    """A store that cannot answer renders no note, rather than one it cannot stand behind."""
+
+    def test_closed_connection(self, state_manager):
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None  # armed
+        state_manager._conn = None
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is None
+
+    def test_read_error(self, state_manager):
+        import sqlite3
+        from unittest.mock import MagicMock
+
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        state_manager.note_worker_revision("rig1", _meta("bbb"))
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None  # armed
+
+        real_conn = state_manager._conn
+        broken = MagicMock()
+        broken.cursor.side_effect = sqlite3.OperationalError("database is locked")
+        state_manager._conn = broken
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is None
+        state_manager._conn = real_conn
+
+        # The failed read changed nothing: the row is still there for the next poll to serve.
+        assert state_manager.get_worker_revision_drift("rig1", "bbb") is not None

--- a/dashboard/tests/web/test_worker_config_drift.py
+++ b/dashboard/tests/web/test_worker_config_drift.py
@@ -236,3 +236,74 @@ class TestThroughTheWholePayload:
     ):
         d = self._detail(monkeypatch, {"max_temp_c": 80})
         assert "config_drift" in d
+
+
+class TestRevisionDriftReachesThePayload:
+    """#1564: the store's unrecorded-edit finding, served on the line it contradicts.
+
+    The store already owns the currency rule and its own tests. What can only be proven here is
+    the WIRING — that the payload asks with the revision the rig is serving on THIS poll, and not
+    with some other field of the same meta block. Passing ``last_change_id`` instead would make
+    every read miss and the note would vanish with nothing going red.
+    """
+
+    @staticmethod
+    def _detail(monkeypatch, revisions, current):
+        """Poll the store once per entry in ``revisions``, then build the payload at ``current``."""
+        from mining_dashboard.service.storage_service import StateManager
+        from mining_dashboard.web import views
+        from mining_dashboard.web.worker_detail import build_worker_detail
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9"}]
+        )
+        monkeypatch.setattr(views.config, "DASHBOARD_CONTROL_ENABLED", True)
+        sm = StateManager(db_path=":memory:")
+        try:
+            for rev, cid in revisions:
+                sm.note_worker_revision("rig1", {"revision": rev, "last_change_id": cid})
+            meta = {"revision": current, "changed_at": None, "source": "control"}
+            workers = [
+                {"name": "rig1", "status": "online", "h60": 1, "rigforge": {"config_meta": meta}}
+            ]
+            return build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+
+    def test_an_unrecorded_edit_reaches_the_payload(self, monkeypatch):
+        d = self._detail(monkeypatch, [("aaa", None), ("bbb", None)], "bbb")
+        assert d["config_revision_drift"] == {"worker": "rig1", "before": "aaa", "after": "bbb"}
+
+    def test_the_lookup_uses_the_revision_the_rig_serves_now(self, monkeypatch):
+        # The rig moved on after the drift was recorded. The audit row stays in the Security
+        # panel; this line describes the config in front of the operator, so it goes quiet.
+        d = self._detail(monkeypatch, [("aaa", None), ("bbb", None)], "ccc")
+        assert d["config_revision_drift"] is None
+
+    def test_a_rig_that_has_not_drifted_publishes_silence(self, monkeypatch):
+        d = self._detail(monkeypatch, [("aaa", None)], "aaa")
+        assert d["config_revision_drift"] is None
+
+    def test_a_rig_with_no_config_meta_publishes_silence(self, monkeypatch):
+        from mining_dashboard.service.storage_service import StateManager
+        from mining_dashboard.web import views
+        from mining_dashboard.web.worker_detail import build_worker_detail
+
+        monkeypatch.setattr(
+            views.config, "DASHBOARD_WORKERS", [{"name": "rig1", "host": "10.0.0.9"}]
+        )
+        sm = StateManager(db_path=":memory:")
+        try:
+            sm.note_worker_revision("rig1", {"revision": "aaa"})
+            sm.note_worker_revision("rig1", {"revision": "bbb"})
+            workers = [{"name": "rig1", "status": "online", "h60": 1, "rigforge": {}}]
+            d = build_worker_detail("rig1", {"workers": workers}, sm)
+        finally:
+            sm.close()
+        # A plain-xmrig rig cannot say what it is running, so nothing here may accuse it — even
+        # though the row from its RigForge days is still in the table.
+        assert d["config_revision_drift"] is None
+
+    def test_the_key_is_always_present(self, monkeypatch):
+        d = self._detail(monkeypatch, [("aaa", None)], "aaa")
+        assert "config_revision_drift" in d

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -467,8 +467,8 @@ running to record it — is not a recorded change, so the line keeps naming what
 On a rig where the dashboard applied the previous change, that reads as "Last changed from this
 dashboard" while the rig runs something else.
 
-**A second check answers that one directly.** Beside the provenance line, the dashboard compares
-what it last applied to this rig against the values the rig reports it is running, key by key, and
+**Two further checks answer that one directly.** The first, beside the provenance line, compares
+what this dashboard last applied to the values the rig reports it is running, key by key, and
 names each key that disagrees — "we applied `max_temp_c` 75, the rig is running 80". It needs
 nothing recorded on the rig, so it sees the hand-edit the provenance line cannot.
 
@@ -476,16 +476,32 @@ Three things bound what the comparison claims, and each bound is deliberate:
 
 - **It judges only keys this dashboard has set.** What it compares against is a record of the
   changes we pushed, not a copy of the rig's config, so a hand-edit to a key we have never applied
-  has nothing to disagree with and stays invisible.
+  has nothing to disagree with. The second check below is what covers that case.
 - **It never compares pool passwords.** RigForge strips the pool password and TLS fingerprint before
   serving its config, so the dashboard strips them from its own side too. A changed pool password
-  would otherwise read as drift on every rig, forever. Nothing on this side can see one either way.
+  would otherwise read as drift on every rig, forever. This comparison cannot see one either way.
 - **It says nothing while a change is in flight.** A change that has been sent and not yet settled
   is not in the applied record, though the rig may already be running it, so the comparison is held
   back until the outcome lands rather than reporting a key we ourselves just set.
 
-Where it is silent, the older reading still holds: treat the provenance line as an alarm that fires,
-not as an all-clear. Its silence is not proof that nothing changed.
+**The second check watches the config as a whole.** RigForge publishes a revision — a digest over
+every writable key, including the ones this dashboard has never set — and the dashboard records the
+one each rig is serving on every poll. When that revision moves with no new change id beside it,
+nothing recorded the change, and a line appears beside the provenance line saying so: *the rig's
+config changed with nothing recording it*. It covers the first bound above, at a coarser
+resolution. A digest cannot be read backwards, so this line can say only **that** the config moved,
+never which key; hover it for the two revisions.
+
+It reports the config the rig is running **now**. The moment the rig serves a revision this
+dashboard can account for — because someone applied a change through it, or the rig recorded one of
+its own — the line goes quiet, even though the earlier move stands. The durable record is the
+`rig-drift` row in the Security panel, which is written once and never withdrawn; this line is a
+statement about the config in front of you.
+
+Neither check has an all-clear. Both either report a disagreement or say nothing at all, and their
+silence is not evidence: a clear line would be a reassurance bounded by everything listed above,
+which is the reading the whole section exists to prevent. Where they are silent the older reading
+still holds — treat the provenance line as an alarm that fires, not as an all-clear.
 
 Everything behind it is the rig's own account, so a rig that has been taken over can also say
 whatever it likes, including replaying a change id you really did send it. Within what the rig does
@@ -1091,7 +1107,9 @@ appends them to the SAME audit trail:
   against and no per-key diff to take. The row names the worker and the revision either side of the
   move. It cannot say which setting moved either: the revision is a digest over the rig's whole
   writable config, so it says THAT the config changed and never what to. A rig seen for the first
-  time records nothing — there is no earlier revision to compare it against.
+  time records nothing — there is no earlier revision to compare it against. The same detection
+  also qualifies that rig's [provenance line](#worker-inspect) while the config it moved to is the
+  one the rig is still serving; this row is the durable half and is never withdrawn.
 
 The last two read off the same unauthenticated worker feed, so they share ONE rate cap per worker
 ([#724](https://github.com/p2pool-starter-stack/pithead/issues/724)): a rig reporting a fresh change id — or a fresh revision — every poll can add only


### PR DESCRIPTION
Closes #1564.

Worker Inspect's provenance line could read "Last changed from this dashboard" over a config the
Security panel had already flagged as a `rig-drift`. #1551 detects the unrecorded edit and writes
it to the audit trail; nothing carried it to the line it contradicts. This does.

The design was decided and posted before any code (issue comment `5528424303`), and the budget call
was ruled by the controller (`5528467402`). Both were followed as written; nothing below re-derives
them.

## What it does

`worker_config_revision` grows one column, `drift_from`, maintained inside `note_worker_revision`'s
existing read-then-write under the one `_db_lock` — the comparison already happens there, so no new
read and no new lock scope. `build_worker_detail` serves it as `config_revision_drift`, and
`ConfigProvenance` renders a third line beside the other two.

Two rules do the work:

- **Two states, never three.** The payload is a drift or `None`. There is deliberately no "checked
  and agrees" verdict, for the reason `configDriftNote` withholds its `[]`: an all-clear here would
  be a reassurance bounded by narrowings the operator cannot see from a badge. Having no third
  state is a stronger guarantee than suppressing one — there is nothing left to relax.
- **Gated on currency, not existence.** The note renders only while the drift we recorded is the one
  that produced the revision the rig is serving on this poll. A `rig-drift` audit row is permanent;
  "has this worker ever drifted?" would accuse a rig forever, including after the operator adopted
  the change. Once the rig moves on, the row stays in the Security panel and the line goes quiet.

**Not joined on the audit `event_id`.** That was the cheap route and it is rejected in the code with
its reason: #1698 (merged as the base of this branch) changed how that id is built, the format is
not a contract, and a lookup built on one fails *silently* — the note would stop rendering and every
test written against the old shape would stay green.

## File budget

- `storage_service.py` **1357 -> 1358, its ceiling, ZERO headroom** — as ruled. One line: the
  migration call. The column itself goes inside the existing `CREATE TABLE` string (0 lines) and the
  migration body lives in `worker_config_store.py`, the mixin that owns every accessor of this table
  (#1369). **That row cannot be raised — `check_monotonic` refuses any rise — so the next addition
  to that file SPLITS it.**
- `worker_config_store.py` 319 -> **399/400**, no row needed, one line spare. Recorded here so the
  next session sees it before planning.
- `test_storage_schema.py` 361 -> 394, `test_worker_revision.py` 131 -> 244,
  `test_worker_config_drift.py` 238 -> 309, `workerlogic.test.mjs` 370 -> 395 (five spare),
  `workerlogic.mjs` 331 -> 353, `confighistory.mjs` 71 -> 76, `worker_detail.py` 285 -> 294.
- `workerview.mjs` stays 443/443 (a one-line in-place edit to pass the prop).

Two docstring lines were deleted to stay under 400 in the mixin; both restated design reasoning that
lives permanently in the issue comment above. No comment-as-control and no test was shaved.

## What was run

- `make lint` — **rc 2 on `lint-sh` only**, and it is not this change: shellcheck here is 0.9.0
  against the 0.11.0 pin #1679 landed. This diff touches no shell. Every other target was then run
  individually (`make` stops at the first failure): `lint-py`, `lint-js`, `lint-yaml`, `lint-md`,
  `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget`,
  `lint-pithead-parity`, `lint-trivy-parity`, `lint-proto`, `lint-toml` — **all rc 0.**
- `make test-dashboard` — **2475 passed, rc 0**, total coverage 97.38% (gate 80%). `make test`
  itself aborts at its first prerequisite, `lint-sh`, for the reason above, so the suite was run
  directly rather than reported through a target that never reached it.
- **Patch coverage 29/29 executable added Python lines = 100%** (bar 90%), computed mechanically
  from the diff hunks against a `coverage.xml` regenerated on the tree shipped here — not from
  CI's rc, which is no evidence on a `develop-v2` PR (#1557). The first run of that came back
  "no lines matched": the path prefix was wrong, since `<source>` is the package dir. Reported
  only after the prefix was fixed and the match count was non-zero.
- Base moved twice mid-change (`d1c32cb6` -> `8ab235e5` -> `734a889d`). `git rev-parse
  <base>:dashboard` is **byte-identical** at the last two, so the program the suite ran did not
  change and no re-run was owed; rebased onto `734a889d` so the review is the narrow case.
  `lint-file-budget` re-run against #1699's **new** gate script: rc 0.
- `node --test dashboard/tests/frontend/` — **508 pass, 0 fail.**
- **Mutation battery, 6 seeded, 6 killed**, each restored and verified by sha256 (baseline green
  first, so a kill means something):

  | mutation | killed by |
  |---|---|
  | preservation dropped (`drift_from` not carried forward) | `test_the_note_survives_the_polls_after_the_one_that_raised_it` |
  | resolved case ignored (moved with a new change id still drifts) | `test_a_move_with_a_new_change_id_clears_it` |
  | currency gate removed | `test_it_is_silent_once_the_rig_serves_a_different_revision` |
  | empty `drift_from` rendered | 5 tests |
  | migration `ALTER` removed | `test_..._drift_from_added_on_upgrade` |
  | migration never called | `test_..._drift_from_added_on_upgrade` |

  Four of the six are single kills — one test per design decision, measured rather than asserted.
- Two frontend mutations (`configRevisionDriftNote` always silent; the component drops the line) —
  both killed, 4 and 2 tests respectively.

## Security pass, by hand

`revision` is rig-supplied off the unauthenticated worker feed and now reaches SQLite and the
browser. Re-derived at source rather than assumed: `parse_config_meta` bounds it to 64 chars against
`^[A-Za-z0-9._-]+$` (`rig_config_meta.py:63,73,78`), so no markup can reach the value, and preact
escapes it regardless. Both sides of the new comparison go through that same validator on the same
poll — the write via `worker_change_audit.note_revision_drift`, the read via `xmrig_client.py:108`
— so the equality is between two normalized tokens, not two parses. No new outbound fetch, no new
credential path, and the pool-password strip is untouched.

## Over-engineering pass

Done by hand on merits, not as a ceremony; the gate here verifies nothing. What it weighed:

- **A separate table for the drift** — rejected. One nullable column on the row that already
  records the revision costs no new read, no new lock scope and no new migration path beyond the
  `ALTER`; a table would need its own lifecycle and its own answer to "when is a row stale".
- **Doing the currency comparison in `build_worker_detail`** instead of passing the rig's revision
  into the accessor — rejected. It would put the rule in the layer that cannot test it at the
  service tier and add lines to a call site, to save a parameter.
- **Inlining `_next_drift_from`** into `note_worker_revision` — rejected. It is the whole of the
  currency rule and it is what four of the six mutations aim at; a named function is what let
  each be killed by exactly one test.
- **Reusing the row `note_worker_revision` already read** rather than a second `SELECT` in the
  reader — rejected as not available: those run at different times (a poll, and a page render).
- **The redundant `worker` key** in the returned dict is kept deliberately: it matches
  `note_worker_revision`'s existing return shape, and one consistent field beats two shapes.

## What I did NOT do

- **No `security-reviewer` subagent.** This session's harness instructions forbid spawning agents
  unasked, so the pass above was done by hand at source and is stated as mine, not a reviewer's.
- **Did not establish whether the rig's revision digest spans the stripped pool password.** That
  needs RigForge's source. Because of it I *scoped* an existing unqualified sentence in
  `docs/dashboard.md` ("Nothing on this side can see one either way" -> "This comparison cannot see
  one either way") rather than extending the claim to the new check. Nothing here asserts either way.
- **Did not close #1471 or touch its harness half** — that is `lane-e2e-01`'s.
- No new budget row anywhere, and no ceiling raised or lowered.
- The one-poll window is named rather than closed: if the Inspect payload is built from a poll
  older than the store's newest write, a fresh drift renders one poll late. That is the quiet
  direction — never a false accusation — and matches `note_worker_revision`'s documented posture.

## Docs

`docs/dashboard.md` gains the new line and — because this change falsified prose already there —
two corrections: "A second check" became "Two further checks", and the first check's "keys we have
never applied stay invisible" bound now points at the check that covers them. The `rig-drift` audit
entry gains a cross-link saying which half is durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKUzVaEQWQSeUUgLB9vFFJ
