### PR TITLE
fix(tests): dashboard-onion test no longer needs run.sh's source order (#1330)

### DIFF
--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -32,16 +32,20 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard.sh" && domain_ran test-dash
 # shellcheck source=tests/stack/test-dashboard-onion.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard-onion.sh" && domain_ran test-dashboard-onion.sh "$_d0" "$?" || domain_ran test-dashboard-onion.sh "$_d0" "$?"
 
-# Regression (#1330): test-dashboard-onion.sh must not depend on running after test-dashboard.sh —
-# source it alone, in a subshell so PASS/FAIL here are untouched, and require every assertion in
-# it to still pass with no global left behind by another file's source order.
+# Regression (#1330): test-dashboard-onion.sh must not depend on running after test-dashboard.sh.
+# A `( ... )` subshell is a fork of THIS process and inherits its whole variable table, exported
+# or not — including $auth_hb64/$caddy_https, already left behind here by test-dashboard.sh's
+# earlier `source` a few lines up, so a subshell guard would stay green even if this file went
+# back to reading those as globals. Only a genuinely separate `bash` process is isolated: it
+# inherits the environment (exported vars), never a parent shell's plain variables. $HERE isn't
+# exported either, so it's passed as an argument rather than read from the environment.
 # shellcheck disable=SC1090,SC2015  # STACK/HERE paths are dynamic by design
-(
+bash -c '
     set -uo pipefail
-    source "$HERE/lib.sh"
-    source "$HERE/test-dashboard-onion.sh" >/dev/null 2>&1
+    source "$1/lib.sh"
+    source "$1/test-dashboard-onion.sh" >/dev/null 2>&1
     [ "$FAIL" -eq 0 ] && [ "$PASS" -gt 0 ]
-)
+' _ "$HERE"
 assert_rc "test-dashboard-onion.sh does not depend on run.sh's source order (#1330)" "$?" "0"
 
 # shellcheck source=tests/stack/test-release.sh disable=SC2015

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -32,6 +32,18 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard.sh" && domain_ran test-dash
 # shellcheck source=tests/stack/test-dashboard-onion.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard-onion.sh" && domain_ran test-dashboard-onion.sh "$_d0" "$?" || domain_ran test-dashboard-onion.sh "$_d0" "$?"
 
+# Regression (#1330): test-dashboard-onion.sh must not depend on running after test-dashboard.sh —
+# source it alone, in a subshell so PASS/FAIL here are untouched, and require every assertion in
+# it to still pass with no global left behind by another file's source order.
+# shellcheck disable=SC1090,SC2015  # STACK/HERE paths are dynamic by design
+(
+    set -uo pipefail
+    source "$HERE/lib.sh"
+    source "$HERE/test-dashboard-onion.sh" >/dev/null 2>&1
+    [ "$FAIL" -eq 0 ] && [ "$PASS" -gt 0 ]
+)
+assert_rc "test-dashboard-onion.sh does not depend on run.sh's source order (#1330)" "$?" "0"
+
 # shellcheck source=tests/stack/test-release.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-release.sh" && domain_ran test-release.sh "$_d0" "$?" || domain_ran test-release.sh "$_d0" "$?"
 

--- a/tests/stack/test-dashboard-onion.sh
+++ b/tests/stack/test-dashboard-onion.sh
@@ -12,23 +12,20 @@
 # Caddyfile in the SAME run rather than waiting on a later, possibly-no-op apply (#356/#546), and
 # dashboard_onion_status's status/doctor resolver (the onion URL + reach-it hint, never the client
 # private key, #343).
-# Sourced by tests/stack/run.sh, immediately after test-dashboard.sh — REQUIRED order: this file
-# reads two globals set there and never redefined here: $auth_hb64 (the bcrypt hash fixture, used
-# throughout the onion vhost renders below) and $caddy_https (the plain secure-mode Caddyfile
-# render, read by the access-log section's "every vhost shares the log" count together with this
-# file's own $caddy_onion_https). Both are plain top-level assignments in test-dashboard.sh, so
-# they are still live globals when this file runs next in the same shell — do not source this file
-# before test-dashboard.sh, and do not run either file in a subshell.
+# Sourced by tests/stack/run.sh, conventionally after test-dashboard.sh — but not required (#1330):
+# $auth_hb64 and $caddy_https used to be globals left behind there, so a reordered/inserted source
+# line broke this file with a confusing empty-string mismatch. Both are re-derived locally below.
 #
-# Re-derivations: none. Everything below sources the real $STACK fresh per subshell against a
-# throwaway dir under $SANDBOX (or a dedicated dir under it, e.g. the rotate-Caddyfile-seed
-# fixtures), and touches neither $C nor its control-sandbox children ($REQS/$RESULTS/$STAGED/
-# $AUDIT/$MASKED) — several of the black-box flows here explicitly stub provision_control_runner
-# (and the rest of apply's/upgrade's heavy machinery) to a no-op precisely to keep this file's
-# proof self-contained; the real control-channel/control-runner build lives in the "dashboard
-# control channel" section, moved to test-control-core.sh by #1105 R12 and sourced well after.
+# Everything else below sources the real $STACK fresh per subshell against a throwaway dir under
+# $SANDBOX (or a dedicated dir under it, e.g. the rotate-Caddyfile-seed fixtures), and touches
+# neither $C nor its control-sandbox children ($REQS/$RESULTS/$STAGED/$AUDIT/$MASKED) — several of
+# the black-box flows here explicitly stub provision_control_runner (and the rest of apply's/
+# upgrade's heavy machinery) to a no-op precisely to keep this file's proof self-contained; the real
+# control-channel/control-runner build lives in the "dashboard control channel" section, moved to
+# test-control-core.sh by #1105 R12 and sourced well after.
 
 echo "== unit: generate_caddyfile onion vhost (#343) =="
+auth_hb64="$(printf '%s' '$2y$14$UNITTESTbcrypthashvalue000000000000000000000000000000' | openssl base64 -A)" # re-derivation (#1330), see header
 # With the dashboard onion enabled, generate_caddyfile appends a SECOND site bound to the bridge
 # gateway (NETWORK_PREFIX.1) — reachable only from the tor container, never the LAN — serving plain
 # HTTP (Tor is the transport) and carrying the SAME basic_auth block as the LAN site.
@@ -36,8 +33,6 @@ echo "== unit: generate_caddyfile onion vhost (#343) =="
 caddy_onion="$(
     cd "$SANDBOX" && source "$STACK" 2>/dev/null
     set +e
-    # shellcheck disable=SC2154  # auth_hb64 is set in test-dashboard.sh, sourced immediately
-    # before this file in run.sh — see this file's header.
     DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_USER=admin DASHBOARD_AUTH_HASH_B64="$auth_hb64" \
         DASHBOARD_ONION_ENABLED=true NETWORK_PREFIX=172.28.0 generate_caddyfile >/dev/null 2>&1
     cat Caddyfile
@@ -101,11 +96,16 @@ assert_contains "onion HTTP vhost renders even before the address is captured (#
 assert_not_contains "no HTTPS onion vhost until the .onion address is provisioned (#343)" "$caddy_onion_ph" "https://placeholder"
 
 echo "== unit: generate_caddyfile access log (#349) =="
+# shellcheck disable=SC1090  # STACK path is dynamic by design; re-derivation (#1330), see header
+caddy_https="$(
+    cd "$SANDBOX" && source "$STACK" 2>/dev/null
+    set +e
+    DASHBOARD_SECURE=true HOST_IP=box.lan DASHBOARD_AUTH_HASH_B64="" generate_caddyfile >/dev/null 2>&1
+    cat Caddyfile
+)"
 # Every vhost logs each request as one JSON line to a shared file. Growth is bounded by Caddy's
 # native rolling (4 MiB per file, current + 2 rolled); mode 0644 lets the non-root dashboard
 # read what root-run Caddy writes (Caddy's own default is 0600, unreadable across the mount).
-# shellcheck disable=SC2154  # caddy_https is set in test-dashboard.sh's scheme unit test,
-# sourced immediately before this file in run.sh — see this file's header.
 assert_contains "access log block rendered" "$caddy_https" "output file /var/log/caddy/access.log"
 assert_contains "access log is JSON" "$caddy_https" "format json"
 assert_contains "access log growth is bounded (roll_size)" "$caddy_https" "roll_size 4MiB"

--- a/tests/stack/test-dashboard.sh
+++ b/tests/stack/test-dashboard.sh
@@ -11,11 +11,10 @@
 # status` (#384).
 #
 # The dashboard-onion cluster (vhost render, client-auth crypto, rotate/upgrade/apply capture
-# flows, status) is its own domain in test-dashboard-onion.sh, stacked on this file: it is sourced
-# immediately after this one in run.sh and reads two globals this file sets ($auth_hb64, the bcrypt
-# hash fixture from the dashboard-auth unit test; $caddy_https, the plain secure-mode Caddyfile
-# render from the scheme unit test) — plain top-level assignments, so they survive the handoff
-# between the two sourced files in the same shell. Do not reorder the two `source` lines in run.sh.
+# flows, status) is its own domain in test-dashboard-onion.sh, conventionally sourced after this
+# one in run.sh. It used to read two globals this file sets ($auth_hb64, $caddy_https) as a
+# cross-file source-order dependency; #1330 re-derives both locally there instead, so this file's
+# source position no longer matters to it.
 # Sourced by tests/stack/run.sh.
 #
 # Re-derivations:


### PR DESCRIPTION
The defect: test-dashboard-onion.sh read two globals — `$auth_hb64` (the
bcrypt hash fixture) and `$caddy_https` (a rendered Caddyfile) — left behind
in the shell by test-dashboard.sh's earlier `source` in run.sh. The suite
passed, but only because run.sh happened to source the two files in the
right order; a reorder, an inserted `source` line, or running the file on
its own broke it with a confusing empty-string mismatch instead of a clear
"undefined" error, and nothing in the suite would have caught the drift.

What changed: test-dashboard-onion.sh now re-derives both values locally —
`auth_hb64` from a fixed bcrypt hash, `caddy_https` from its own
`generate_caddyfile` render — so it no longer depends on what ran before it.
run.sh gained a regression guard that sources lib.sh + test-dashboard-onion.sh
alone in a genuinely separate `bash -c` process (not a `( ... )` subshell,
which forks and inherits the whole variable table, so it would have stayed
green even with the bug still there) and asserts the domain still passes with
`FAIL=0` and `PASS>0`.

How it was proven:
- `shellcheck --severity=warning tests/stack/lib.sh tests/stack/test-dashboard-onion.sh tests/stack/test-dashboard.sh` — clean (tests/stack/run.sh itself is excluded per this repo's OOM note, #1206/#1333).
- `shfmt -i 4 -d tests/stack/run.sh tests/stack/test-dashboard-onion.sh tests/stack/test-dashboard.sh` — no diff.
- Sourcing test-dashboard-onion.sh alone (lib.sh + the file, nothing else) passes 48/48 with FAIL=0 — the fix holds with no source-order dependency.
- Reverting just the `auth_hb64` re-derivation and re-running the new isolated-process check reproduces the regression: FAIL=11, guard exits 1 — confirming the guard is a real GUARD (fails on the defect case), not a grep that stays green regardless.

What the added test asserts: tests/stack/run.sh's new block asserts that
test-dashboard-onion.sh, sourced in a fresh `bash -c` process with only
lib.sh ahead of it, finishes with zero failures and at least one passing
assertion — i.e., the file's correctness no longer depends on run.sh's
source order.

Refs #1330