### PR TITLE
fix(tests): #1495 the #1342 mutation-lock wait refuses to give up on a live holder

### DIFF
--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -75,6 +75,18 @@ run_sourced() {
     )
 }
 
+# Poll CHECK (a predicate function name) until it succeeds, but never past the point where PID
+# has already exited -- callers learn "the process gave up trying" rather than counting ticks
+# that a loaded box may not owe it (#1495: a fixed 200x0.05s budget reddened the #1342 mutation-
+# lock test under concurrent runs). `kill -0` reads bash's own job table, so it flips the instant
+# the backgrounded job dies, no explicit reap needed. Returns 1 if PID dies before CHECK succeeds.
+wait_while_alive() { # <pid> <check-fn-name>
+    while ! "$2"; do
+        kill -0 "$1" 2>/dev/null || return 1
+        sleep 0.05
+    done
+}
+
 # A throwaway sandbox dir, cleaned on exit. Physical path (#695): pithead canonicalizes its
 # own directory with pwd -P, so a sandbox spelled through a symlink (macOS /var -> /private/var)
 # would render .env paths that no longer string-match the $SANDBOX-based assertions.

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -103,3 +103,46 @@ echo "== unit: tor healthcheck command-dependency self-test (#1372) =="
 # a leaking PATH would pass every case on the host's own commands and prove nothing.
 bash "$ROOT/build/tor/healthcheck-selftest.sh" --self-test >/dev/null 2>&1
 assert_rc "tor healthcheck runs on the commands its own image ships (#1372)" "$?" "0"
+
+echo "== unit: wait_while_alive polls on liveness, not a tick count (#1495) =="
+# The #1342 stanza's OLD shape -- a fixed tick*interval budget -- is reproduced here at a scale
+# that proves the point in under a second: a holder delayed past a budget it does not owe read as
+# a false "the lock is free" under load. Shown against the very shape it replaced, side by side,
+# rather than asserted from a description of it.
+whwa_flag="$SANDBOX/whwa-ready"
+whwa_ready() { [ -e "$whwa_flag" ]; }
+whwa_old_wait() { # <pid> <check-fn> <ticks> -- the fixed-budget shape #1495 removed
+    local i=0
+    while [ "$i" -lt "$3" ]; do
+        "$2" && return 0
+        sleep 0.05
+        i=$((i + 1))
+    done
+    return 1
+}
+rm -f "$whwa_flag"
+(
+    sleep 0.4
+    : >"$whwa_flag"
+    sleep 2
+) &
+whwa_pid=$!
+whwa_old_wait "$whwa_pid" whwa_ready 4 # ~0.2s budget: exhausts before the 0.4s delay lands
+assert_rc "the fixed-budget shape this replaced gives up on a delayed-but-live holder" "$?" "1"
+wait_while_alive "$whwa_pid" whwa_ready
+assert_rc "wait_while_alive rides out the same delay because the holder is still alive" "$?" "0"
+kill "$whwa_pid" 2>/dev/null
+wait "$whwa_pid" 2>/dev/null
+
+# The other half: a holder that exits WITHOUT ever satisfying CHECK must be reported as gone
+# immediately, not waited out to whatever budget happens to be generous enough to cover it.
+rm -f "$whwa_flag" # the first case's holder left this behind; a stale flag would satisfy CHECK for free
+whwa_start="$SECONDS"
+(exit 1) &
+whwa_pid=$!
+wait_while_alive "$whwa_pid" whwa_ready
+assert_rc "gives up the moment a holder that never checks in has already died" "$?" "1"
+assert_rc "and does so in under a second, not a fixed wait" \
+    "$([ "$((SECONDS - whwa_start))" -lt 2 ] && echo 0 || echo 1)" "0"
+unset -f whwa_ready whwa_old_wait
+rm -f "$whwa_flag"

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -475,12 +475,8 @@ assert_eq "while the kernel has already given the window itself back" "$(lock_st
     exec sleep 60
 ) &
 LKEXT=$!
-i=0
-while [ "$i" -lt 200 ]; do
-    [ "$(lock_state)" = "held" ] && break
-    sleep 0.05
-    i=$((i + 1))
-done
+lock_held() { [ "$(lock_state)" = "held" ]; } # #1495: see wait_while_alive in lib.sh
+wait_while_alive "$LKEXT" lock_held
 # A poll that gives up must say so. If this one exhausts, the external holder never took the
 # window: the two rc/message cases below would be reporting on an uncontended run, and the third
 # passes for the worst reason available — nothing was reported under ANY name, so "never under
@@ -952,7 +948,7 @@ assert_eq "a backup that stops a running stack holds one window across the archi
     "$(lock_backup_running_probe)" "running|held"
 unset -f lock_backup_running_probe
 
-unset -f lock_hold_bg lock_await_record lock_state lock_reinvoke_probe lock_nest_probe
+unset -f lock_hold_bg lock_await_record lock_state lock_held lock_reinvoke_probe lock_nest_probe
 unset -f lock_sibling_probe lock_wiring_fixture lock_wiring_probe lock_wiring_pair lock_wiring_balance
 
 echo "== unit: the appliance boot leg tells lock contention from a bad slot (#1342) =="


### PR DESCRIPTION
## The defect

The #1342 mutation-lock test polled for the lock reaching `held` with a fixed
200 × 0.05s (~10s) tick budget. That budget was sized for an idle box; under
concurrent runs (parallel test invocations, a loaded CI runner) a live holder
can legitimately take longer to record itself as `held`. When the budget ran
out first, the test read that as "the external holder never took the
window" and reported on an uncontended run — a false red on a perfectly
correct lock, not a real defect.

## What changed

Replaced the fixed-tick loop with `wait_while_alive` (new in `tests/stack/lib.sh`):
it polls a check predicate but only gives up when the PID it's waiting on has
actually exited (`kill -0`), never on a tick count. A live holder is waited
out for as long as it's alive; a holder that dies without ever satisfying the
check is reported as gone immediately, not walked out to whatever budget
happened to be generous enough to cover it.

`tests/stack/test-lifecycle.sh`'s #1342 stanza now calls `wait_while_alive
"$LKEXT" lock_held` instead of the old inline loop.

## How it was proven

New unit test in `tests/stack/test-harness-tooling.sh` reproduces the OLD
fixed-budget shape (`whwa_old_wait`) side by side with the new one, at a
scale that proves the point in under a second:

- a holder delayed 0.4s past an ~0.2s fixed budget: the old shape gives up
  (false negative), `wait_while_alive` rides it out because the holder is
  still alive.
- a holder that exits without ever satisfying the check: `wait_while_alive`
  gives up immediately (asserted at under a second, not a fixed wait).

Deciding commands (run from the worktree):

```
shellcheck --severity=warning tests/stack/lib.sh tests/stack/test-harness-tooling.sh tests/stack/test-lifecycle.sh
shfmt -d tests/stack/lib.sh tests/stack/test-harness-tooling.sh tests/stack/test-lifecycle.sh
```

both clean, plus sourcing the harness pattern directly (`source
tests/stack/lib.sh` then each changed test file) — 16/16 assertions in
test-harness-tooling.sh and 105/105 in test-lifecycle.sh, including the full
#1342 mutation-lock stanza that now consumes `wait_while_alive`.

## What the added test asserts

1. The pre-#1495 fixed-budget shape gives up on a delayed-but-live holder (rc 1).
2. `wait_while_alive` rides out the same delay because the holder is still alive (rc 0).
3. `wait_while_alive` gives up the moment a holder that never checks in has already died (rc 1).
4. ...and does so in under a second, not a fixed wait.

Refs #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)