### PR TITLE
fix(tests): #1657 a tests/stack domain file refuses a direct run instead of exiting 0 over its own missing assertions

### DIFF
--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -40,6 +40,14 @@ assertions; `tests/stack/run.sh` itself is the tier-1 shell **suite** — it sou
 file rather than holding assertions of its own (see the test-inventory note under
 [Production-readiness posture](#production-readiness-posture) for how that sourcing is checked).
 
+A domain file is a fragment, not a script. It holds no assertion primitives of its own, so running
+one directly printed every `assert_*` call as `command not found` and still exited 0 for 21 of the
+55 — a domain reporting success having executed nothing, and building its fixtures in the caller's
+working directory on the way past. Each fragment now opens by dereferencing a marker `lib.sh` sets
+on the sourced path, so a direct run is refused with a message naming `run.sh` (#1657). The five
+`tests/stack/test_*.sh` files are the deliberate exception: the Makefile runs each of those
+directly, so they carry no marker check and must not gain one.
+
 ### A. Configuration permutations
 
 The deploy-time axes — each changes a real runtime path. Full table and assertions in

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -19,9 +19,9 @@
 # would silently disarm all 55 fragments at once; test-harness-tooling.sh's #1657 rows say so.
 # The five standalone test_*.sh files are NOT fragments (the Makefile runs each one directly, and
 # tests/inventory.sh lists them as UNSOURCED) — they carry no marker check and must not gain one.
+# shellcheck disable=SC2034  # sourced library: this marker and the fixtures are read by run.sh
 STACK_SUITE=1
 
-# shellcheck disable=SC2034  # sourced library: fixture constants are consumed by run.sh
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STACK="$ROOT/pithead"
 PASS=0

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -9,6 +9,18 @@
 # Mechanical move only: this is the SAME code that used to sit at the top of run.sh, moved
 # here verbatim so run.sh can source it. No behaviour changed.
 
+# Every test-*.sh domain file is a FRAGMENT: run.sh sources it after this file, and it carries no
+# assertion primitives of its own. Run one directly and all 60-odd assert_* calls are "command not
+# found" while the file still exits 0 — a domain reporting success having executed nothing (#1657).
+# So each fragment opens by dereferencing this marker with :?, which is set only on the sourced
+# path; bash then refuses the direct run with a message naming run.sh, and exits non-zero.
+# ⛔ NEVER export this. A plain assignment is what makes the marker work: a child bash cannot
+# inherit it, so `bash tests/stack/test-cli.sh` refuses even from inside a suite run. Exporting it
+# would silently disarm all 55 fragments at once; test-harness-tooling.sh's #1657 rows say so.
+# The five standalone test_*.sh files are NOT fragments (the Makefile runs each one directly, and
+# tests/inventory.sh lists them as UNSOURCED) — they carry no marker check and must not gain one.
+STACK_SUITE=1
+
 # shellcheck disable=SC2034  # sourced library: fixture constants are consumed by run.sh
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STACK="$ROOT/pithead"

--- a/tests/stack/test-appliance-boot-release.sh
+++ b/tests/stack/test-appliance-boot-release.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # The post-commit release of the held chain services retries, keeps its order, and alerts (#1684).
 # A data_migration update boots with the chain services held; once the slot commits, pithead-boot
 # releases them with `./pithead up`. On the bench that `up` landed while p2pool — started by the

--- a/tests/stack/test-appliance-boot-remint.sh
+++ b/tests/stack/test-appliance-boot-remint.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # The boot gate's certificate re-mint and the rollback verdict that names its cause (#1265).
 # render mints the dashboard certificate BEFORE `up`, from the box's address list as it stands
 # then; doctor re-checks coverage inside the gate loop AFTER `up`, when the list has settled. An

--- a/tests/stack/test-appliance-boot.sh
+++ b/tests/stack/test-appliance-boot.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance boot domain (#1105 Phase 1, develop-v2 lane): what an appliance does between power-on
 # and a slot it is willing to keep. The baked image store is loaded by archive digest rather than
 # by tag, rebuilds itself when an interrupted write leaves it damaged, and narrates a slow load

--- a/tests/stack/test-appliance-caddyfile-optional-env.sh
+++ b/tests/stack/test-appliance-caddyfile-optional-env.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Optional .env keys under `set -u` (#1246): generate_caddyfile must DEGRADE when an optional key
 # is absent from the sourced .env, not abort the command that sourced it. Sourced by run.sh.
 #

--- a/tests/stack/test-appliance-data-floor.sh
+++ b/tests/stack/test-appliance-data-floor.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # The /data migration floor after a data_migration update that FAILED its gate (#1393). os-update
 # raises the floor at install time, before the migration runs; the migration hold (#851) then
 # keeps the chain services down until the slot commits, so a slot that fails its gate falls back

--- a/tests/stack/test-appliance-defaults.sh
+++ b/tests/stack/test-appliance-defaults.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance defaults domain (#1105 Phase 1, develop-v2 lane): two sections covering what a first
 # boot writes into a config the operator did not finish. apply_appliance_defaults fills tor
 # .auto_heal only where the key is ABSENT — an operator who wrote false meant it — and turns the

--- a/tests/stack/test-appliance-firstboot-install-lock.sh
+++ b/tests/stack/test-appliance-firstboot-install-lock.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # firstboot install-path lock wiring (#1482): the wizard's install paths take the mutation lock, and
 # take it in the one place that is correct. Sourced by tests/stack/run.sh.
 #

--- a/tests/stack/test-appliance-identity-boot.sh
+++ b/tests/stack/test-appliance-identity-boot.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance identity and boot-provisioning domain (#1105 Phase 1, develop-v2 lane): the overlay
 # units that give a freshly imaged machine an identity of its own, and the boot-time work whose
 # success a later boot has to be able to prove. pithead-machine-id restores THROUGH

--- a/tests/stack/test-appliance-identity.sh
+++ b/tests/stack/test-appliance-identity.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance identity domain (#1105 Phase 1, develop-v2 lane): who the appliance says it is, and
 # everything the machine derives from that answer. The browsable name a headless setup resolves —
 # never the bare hostname, which served a name no LAN client could look up; the ssh access derived

--- a/tests/stack/test-appliance-install.sh
+++ b/tests/stack/test-appliance-install.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance install domain (#1105 Phase 1, develop-v2 lane): getting Pithead onto a machine, and
 # what the next install reads back off the one before it. The installer gate retries a device
 # probe that has not settled yet, so a reinstall boot does not fall through into setup mode; the

--- a/tests/stack/test-appliance-kernel-boot.sh
+++ b/tests/stack/test-appliance-kernel-boot.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance kernel and OS-image build domain (#1105 Phase 1, develop-v2 lane): the guards that
 # stand between a build host and a slot the fleet would be wrong to trust. optimize_kernel's
 # HugePages write is grow-only, because with a co-located miner the pool has a single writer that

--- a/tests/stack/test-appliance-machine-id-journal.sh
+++ b/tests/stack/test-appliance-machine-id-journal.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # pithead-machine-id's journald hand-off (#1659). Sourced by tests/stack/run.sh.
 #
 # SCOPE. test-appliance-identity-boot.sh proves the RESTORE — the persisted id lands in

--- a/tests/stack/test-appliance-media.sh
+++ b/tests/stack/test-appliance-media.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance media domain (#1105 Phase 1, develop-v2 lane): the physical-presence config channel
 # (#786 sub-issue D) — a FAT stick carrying pithead-config.json, consumed on the boot leg by
 # os/overlay/pithead-media-config. Nine sections cover removable-partition discovery, finding and

--- a/tests/stack/test-appliance-os-update-lock.sh
+++ b/tests/stack/test-appliance-os-update-lock.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # OS-update lock contention (#1482): the appliance's `os-install` verb takes the mutation lock, so
 # an install that arrives while another pithead operation holds the machine must come back as
 # `rejected` — never as a `failed` install. The distinction is the whole point: "failed" tells an

--- a/tests/stack/test-appliance-os-update-verbs.sh
+++ b/tests/stack/test-appliance-os-update-verbs.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance os-update verbs domain (#1105 Phase 1, develop-v2 lane): the dashboard-driven A/B
 # update path, exercised through the control channel the way an operator reaches it. Two black-box
 # sections drive a release-shaped appliance sandbox — control channel on, PITHEAD_APPLIANCE forced,

--- a/tests/stack/test-appliance-os-update.sh
+++ b/tests/stack/test-appliance-os-update.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance os-update domain (#1105 Phase 1, develop-v2 lane): the host side of an A/B OS update —
 # the consent gate that decides whether an install may proceed at all, and the reporting layer that
 # turns rauc's own output into something an operator can act on. Five sections. The variant gate

--- a/tests/stack/test-appliance-reset-lock.sh
+++ b/tests/stack/test-appliance-reset-lock.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Reset-verb lock wiring (#1482): factory-reset, config-reset and reset-dashboard each take the
 # mutation lock, and take it in the one place that is correct. Sourced by tests/stack/run.sh.
 #

--- a/tests/stack/test-appliance-reset.sh
+++ b/tests/stack/test-appliance-reset.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance reset domain (#1105 Phase 1, develop-v2 lane): the two-tier reset, and the boot-time
 # wipe that carries out its heavier half. config-reset clears the operator's configuration and the
 # rendered files that came from it while leaving the chain data alone, because re-running setup must

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance rig-miner domain (#1105 Phase 1, develop-v2 lane): a machine that mines instead of
 # coordinating. The rig role's pre-fill dials for a Pithead on the host side and publishes what it
 # finds to the spool, failing open when it finds nothing (#797 R3); first boot consumes that

--- a/tests/stack/test-appliance-rotate-secrets-lock.sh
+++ b/tests/stack/test-appliance-rotate-secrets-lock.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # rotate-secrets lock wiring (#1482): the rotate-secrets verb takes the mutation lock, and takes it
 # in the one place that is correct. Sourced by tests/stack/run.sh.
 #

--- a/tests/stack/test-appliance-setup.sh
+++ b/tests/stack/test-appliance-setup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Appliance setup domain (#1105 Phase 1, develop-v2 lane): the firstboot provisioning path an
 # appliance walks the first time it is powered on, and the uninstall contract that path has to
 # survive — the wizard's minted pairing token and its spool consume (#77 phase 3), the

--- a/tests/stack/test-backup.sh
+++ b/tests/stack/test-backup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Backup domain (#1105 Phase 1, develop-v2 lane): the archive/restore round-trip and the
 # reset-dashboard verb — stack_backup's bounded retry on a tar race (#970), the
 # backup_require_items/backup_diagnose_items preflight that names a missing or dangling item

--- a/tests/stack/test-cli.sh
+++ b/tests/stack/test-cli.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # CLI domain (#1105 Phase 1): dispatch, subcommand chaining, completion, guards, the small input
 # validators, host/deps detection, version, and the first-run epilogue. Sourced by
 # tests/stack/run.sh after lib.sh. (The apply --dry-run and symlink-invocation sections stay

--- a/tests/stack/test-config.sh
+++ b/tests/stack/test-config.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Config domain (#1105 Phase 1, develop-v2 lane): what decides whether a config.json is admissible
 # and what it renders into — the multi-field validator that refuses a bad config before anything is
 # written (wallet address forms and their checksums, the two worker shapes, energy, the /24 subnet

--- a/tests/stack/test-confirm-approval.sh
+++ b/tests/stack/test-confirm-approval.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel confirm-gate domain (#1105 Phase 1, develop-v2 lane): the sections that prove an
 # in-scope disruptive change cannot land on a plain commit, and that the typed APPLY token which
 # unlocks it is scoped to the change itself rather than to the perimeter. A disruptive edit staged

--- a/tests/stack/test-control-add-only-ssrf.sh
+++ b/tests/stack/test-control-add-only-ssrf.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # The approval gate (#33): the control channel's default-deny on security-sensitive changes,
 # reunited into one file (#1105 R13), together with workers.list[]'s add-only exception (#893's
 # click-to-adopt) and the #122 SSRF floor on what a newly-appended entry may point at

--- a/tests/stack/test-control-backup.sh
+++ b/tests/stack/test-control-backup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel backup-verb domain (#1105 Phase 1, develop-v2 lane): the backup verb sections
 # (#908). control_backup generates its OWN passphrase rather than accepting one from the container
 # and runs the real backup as a child "$self backup -y", so stack_backup's own error() exit cannot

--- a/tests/stack/test-control-core.sh
+++ b/tests/stack/test-control-core.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel core domain (#1105 Phase 1, develop-v2 lane): the six black-box sections that
 # build the control sandbox and drive it. First `apply` — fail-closed when the
 # control channel is enabled without a dashboard password, the .env render of the control keys and

--- a/tests/stack/test-control-deploy.sh
+++ b/tests/stack/test-control-deploy.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-deploy domain (#1105 Phase 1, module 9): the bundle-deploy layout mechanics —
 # update_current_symlink's `current ->` pointer, migrate_dashboard_data's move/warn/conflict
 # rules for the pre-#455 in-install-dir default, and their end-to-end wiring through a real

--- a/tests/stack/test-control-editable-allowlist.sh
+++ b/tests/stack/test-control-editable-allowlist.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Every key on CONTROL_DASHBOARD_EDITABLE_KEYS must actually round-trip a real preview->commit
 # through the approval gate and land in config.json (#522) — not just pass a describe_change unit
 # check. Split out of run.sh by #1105 R14; the section's own contract is stated at its header below.

--- a/tests/stack/test-control-provisioning.sh
+++ b/tests/stack/test-control-provisioning.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-runner provisioning domain (#1105 Phase 1, develop-v2 lane): the two sections that prove
 # provision_control_runner only ever touches the systemd units belonging to the checkout invoking
 # it. The unit names pithead-control.{path,service} are box-global, but a release bench holds

--- a/tests/stack/test-control-status-vocabulary.sh
+++ b/tests/stack/test-control-status-vocabulary.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # #1422: the control-status vocabulary lives in three places — xmrig_client._CONTROL_TERMINAL,
 # worker_config_store._RECONCILE_TERMINAL (guarded against each other by
 # dashboard/tests/service/test_storage_service.py, which asserts them equal verbatim) and this

--- a/tests/stack/test-control-telegram.sh
+++ b/tests/stack/test-control-telegram.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel Telegram lifecycle domain (#1105 Phase 1, develop-v2 lane): the bounded Telegram
 # control verbs (#338). The #33 runner dispatches each accepted verb to a FIXED pithead command and
 # audits it; an unknown verb is rejected, and no host command runs on the rejection path.

--- a/tests/stack/test-control-upgrade.sh
+++ b/tests/stack/test-control-upgrade.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-upgrade domain (#1105 Phase 1, module 8): the one-click upgrade verb end to end —
 # ordering safety (a failed upgrade never repoints the control-runner units, #1070), the shared
 # GitHub release-fetch helper (a spent rate limit read honestly instead of blamed on Tor, #1081/

--- a/tests/stack/test-dashboard-onion.sh
+++ b/tests/stack/test-dashboard-onion.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Dashboard-onion domain (#1105 Phase 1, develop-v2 lane): the dashboard-onion cluster stacked on
 # test-dashboard.sh — generate_caddyfile's onion vhost render (the bridge-gateway HTTP site plus,
 # once the .onion address is provisioned, its own self-signed HTTPS vhost, #343), the shared

--- a/tests/stack/test-dashboard.sh
+++ b/tests/stack/test-dashboard.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Dashboard domain (#1105 Phase 1, develop-v2 lane): the dashboard's own login (Caddy basic_auth
 # enable/disable/change previews plus the actual basic_auth block in the rendered Caddyfile, #8),
 # generate_caddyfile's scheme/port/Host-header render (secure vs. plain HTTP; a custom HOST_PORT

--- a/tests/stack/test-data-management.sh
+++ b/tests/stack/test-data-management.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel data-management domain (#1105 Phase 1, develop-v2 lane): the sections that prove
 # where a dashboard-confirmed data-dir move may point, and that the confirm gate does not tax the
 # ordinary case. #719 made the *_DATA_DIR moves confirm-gated, but assert_safe_dir is a BLOCKLIST,

--- a/tests/stack/test-doctor-appliance.sh
+++ b/tests/stack/test-doctor-appliance.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Doctor domain, appliance half (#1105 Phase 1, module 7): engine-aware checks (container_engine /
 # docker_boot_enabled), `doctor --json` + support-bundle, the wipe-note surfaced through doctor,
 # and the appliance-only control-unit-location and certificate SAN/expiry checks. Sourced by

--- a/tests/stack/test-doctor.sh
+++ b/tests/stack/test-doctor.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Doctor domain (#1105 Phase 1, module 7): the doctor/status/exposure checks that run against a
 # throwaway sandbox with no shared control/config state — is_public_ip and check_stratum_exposure
 # (the classifier feeds doctor's own exposure warning, same dual setup/doctor reasoning module 6

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Repo-tooling self-tests (#1105 Phase 1 domain: harness core). Sourced by tests/stack/run.sh
 # after lib.sh — the harness (ok/bad/assert_*, SANDBOX) is already loaded.
 echo "== unit: lint-docs-voice self-test (#1441) =="
@@ -156,3 +156,30 @@ assert_rc "and does so in under a second, not a fixed wait" \
     "$([ "$((SECONDS - whwa_start))" -lt 2 ] && echo 0 || echo 1)" "0"
 unset -f whwa_ready whwa_old_wait
 rm -f "$whwa_flag"
+
+echo "== unit: every run.sh fragment refuses a direct run (#1657) =="
+# A test-*.sh domain file carries no assertion primitives of its own: run one directly and its
+# assert_* calls are "command not found" while the file still exits 0 for 21 of the 55 — a domain
+# reporting success having executed nothing. test-backup.sh goes further and builds its fixture
+# roots in the caller's working tree on the way past, because `cd "" && pwd -P` returns the cwd.
+# Enumerating every fragment rather than sampling one is the whole point: the regression this
+# guards against is a NEW fragment added without the marker check, and a fixed list would never
+# see it. STACK_SUITE is deliberately NOT unset here — lib.sh sets it as a plain assignment and
+# never exports it, so a child bash cannot inherit it; if someone ever exports it, every fragment
+# stops refusing at once and this row is what says so.
+frag_probe="$SANDBOX/fragment-refusal"
+mkdir -p "$frag_probe"
+frag_bad=""
+for frag in "$ROOT"/tests/stack/test-*.sh; do
+    frag_out=$(cd "$frag_probe" && bash "$frag" 2>&1) &&
+        frag_bad="$frag_bad $(basename "$frag"):exited-0"
+    case "$frag_out" in
+    *"tests/stack/run.sh"*) ;;
+    *) frag_bad="$frag_bad $(basename "$frag"):refusal-does-not-name-run.sh" ;;
+    esac
+done
+assert_eq "every tests/stack/test-*.sh refuses a direct run, naming run.sh" "$frag_bad" ""
+# The row above asserts the exit status; this one asserts the consequence that status exists to
+# prevent. They are not the same arm: a guard moved below a fixture-building line would still
+# refuse, and only this row would notice the files it wrote on the way there.
+assert_eq "no fragment writes into the caller's directory before refusing" "$(ls -A "$frag_probe")" ""

--- a/tests/stack/test-install-verify.sh
+++ b/tests/stack/test-install-verify.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # install.sh verification domain (#1105 Phase 1, develop-v2 lane): everything the installer does
 # before it will put a bundle on a box. The host gate that hard-fails on a platform the stack
 # cannot run on, before any download at all (#77 phase 1), and the download-verification path that

--- a/tests/stack/test-lifecycle.sh
+++ b/tests/stack/test-lifecycle.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Lifecycle & data domain (#1105 Phase 1, develop-v2 lane): the stack's recovery paths, scoped
 # restarts, and filesystem ownership discipline — `restart`'s whole-stack vs. tor-only vs.
 # monerod-only scoping (#424/#972), the mkdir-before-chown ordering that keeps

--- a/tests/stack/test-monero-tari.sh
+++ b/tests/stack/test-monero-tari.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Monero+Tari domain (#1105 Phase 1, develop-v2 lane): the merge-mining stack's node-facing
 # behaviour on both chains, moved as one file because p2pool merge-mines them together — monero
 # flags + the p2pool entrypoint's word-splitting and Tor-loopback bridge for the Tari gRPC (#165/

--- a/tests/stack/test-rauc-loop-wait.sh
+++ b/tests/stack/test-rauc-loop-wait.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # RAUC loop-partition wait domain (#1105 Phase 1, develop-v2 lane): the one section covering
 # os/rauc/loop-wait.sh's wait_loop_partitions. It proves the negative half of that contract, which
 # is all a non-root tier honestly can: partition nodes that never appear exhaust the poll and

--- a/tests/stack/test-release-signing.sh
+++ b/tests/stack/test-release-signing.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Release-signing domain (#1105 Phase 1): verify_release_images' fail-closed image-verification
 # gate, cosign_container_path's host-to-container path mapping, and release.sh's signing/refusal/
 # pinned-verifier-image checks (sign the promoted digests, refuse to publish unsigned, validate

--- a/tests/stack/test-release.sh
+++ b/tests/stack/test-release.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Release domain (#1105 Phase 1): release.sh's side-effect-free logic (semver/image-name helpers,
 # the ingredient manifest, bundle-contents/build-mounts checks), the GHCR read-after-push retry,
 # the release-toolchain preflight, release-smoke's upgraded-install resolution, pull-vs-build mode

--- a/tests/stack/test-render-quadlet.sh
+++ b/tests/stack/test-render-quadlet.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Quadlet-render parity domain (#1105 Phase 1, develop-v2 lane): the one section that pins
 # render_quadlet_units against the os/quadlet fixtures committed from the #78 spike. It renders
 # each of its three modes off that mode's fixture env file — the default remote-node set, the

--- a/tests/stack/test-rig-worker.sh
+++ b/tests/stack/test-rig-worker.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Rig/worker domain (#1105 Phase 1, develop-v2 lane): the merge-mining rig's stratum-facing
 # surface and the control channel's per-rig worker-config/worker-upgrade verbs — xmrig-proxy's
 # stratum auth + donate-level knobs (#152/#173), the co-located built-in miner's opt-in announce

--- a/tests/stack/test-secrets-masking.sh
+++ b/tests/stack/test-secrets-masking.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel secrets-masking domain (#1105 Phase 1, develop-v2 lane): the four sections that
 # prove a secret never leaves the host in the clear. The pre-masked prefill copy and the host-side
 # secret merge the dashboard container reads instead of the raw config.json (#440), the per-field

--- a/tests/stack/test-secrets.sh
+++ b/tests/stack/test-secrets.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Secrets domain (#1105 Phase 1, develop-v2 lane): apply's secret propagation and redaction, the
 # payout-wallet typed confirm, secret-file permissions, and rotate-secrets end to end — apply
 # propagating telegram/webhook/ntfy secrets into .env while never printing them in the change

--- a/tests/stack/test-spool-audit.sh
+++ b/tests/stack/test-spool-audit.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Control-channel spool + audit hardening domain (#1105 Phase 1, develop-v2 lane): the sections
 # that prove the control channel's own storage cannot be grown without bound by a caller. The
 # audit log is trimmed to its newest entries BEFORE an append once it passes the size cap, so the

--- a/tests/stack/test-tor-network.sh
+++ b/tests/stack/test-tor-network.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Tor-network domain (#1105 Phase 1, develop-v2 lane): the Tor-only egress boundary and the
 # Tor<->clearnet transport switch — tor_egress_rules + render_tor_egress_nft (both the legacy
 # iptables/DOCKER-USER path and the v2 nftables/podman path, including the IPv6 backstop and its

--- a/tests/stack/test-unit-helpers.sh
+++ b/tests/stack/test-unit-helpers.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Unit-helper domain (#1105 Phase 1, develop-v2 lane): the cluster of small helper tests that sat
 # at the head of run.sh. Four of them drive a pithead function through run_sourced and assert its
 # return code or its stdout — docker_boot_enabled (a systemctl stub on PATH decides which unit

--- a/tests/stack/test-wizard-setup.sh
+++ b/tests/stack/test-wizard-setup.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Wizard + setup domain (#1105 Phase 1): the interactive wizard flows, the setup e2e paths, and the
 # setup-time kernel/GRUB tuning (optimize_kernel runs inside cmd_setup). Sourceable standalone (#1387).
 WALLET="${WALLET:-$VALID_PRIMARY}" # exactly build_val_sandbox's own default; a no-op under run.sh

--- a/tests/stack/test-worker-config.sh
+++ b/tests/stack/test-worker-config.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-#
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
 # Worker-config domain (#1105 Phase 1, develop-v2 lane): per-worker token masking and host-side
 # restore, across the two config shapes that carry rig credentials. A per-rig token lives in a
 # VARIABLE-LENGTH array, which puts it outside the fixed CONTROL_SECRET_PATHS walk that covers the


### PR DESCRIPTION
## The defect

Every `tests/stack/test-*.sh` is a **fragment**: `run.sh` sources it after `lib.sh`, and it holds no
assertion primitives of its own. Run one directly and every `assert_*` call is `command not found`
while the file still exits 0 — a domain reporting success having executed nothing.

The issue's own evidence reproduces exactly: `test-doctor-appliance.sh` standalone gives rc **0** and
**64** `command not found` lines, in the same breakdown the issue lists (`assert_contains` 26,
`assert_eq` 18, `assert_not_contains` 11, `run_sourced` 8, `make_stubs` 1).

**One figure in the issue needed correcting.** It reads as though every fragment exits 0. Measured
across all 55 on `develop-v2`: **21 exit 0**; the other 34 exit non-zero only by accident of what
their last command happened to be. So the fix does two things — it closes the false green for the 21,
and it replaces an accidental status with a deliberate, message-bearing one for the other 34.

A second consequence, from this issue's own comment thread: `test-backup.sh` builds its fixture roots
in the **caller's working tree**, because `cd "$SANDBOX" && pwd -P` with an empty `SANDBOX` returns the
cwd and exits 0. Running the batch leaves **three** top-level entries — `backup/`, `backup-retry/`, and
`.env.apply-incomplete`. That third one is new here; my comment on the issue reported only the first two.

## The fix

`lib.sh` sets a **non-exported** `STACK_SUITE=1`. Each fragment's line 2 becomes

```sh
: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
```

a no-op on the sourced path, and on a direct run bash refuses with a message naming `run.sh` and exits
non-zero. Non-export is load-bearing: a child `bash` cannot inherit it, so the guard fires even from
inside a suite run. `lib.sh` says so where someone would be tempted to add `export`.

**Why it replaces the bare `#` on line 2 rather than adding a line.** That is forced, not stylistic:
**22 of the 55 fragments sit exactly at their `docs/dev/file-budget.tsv` ceiling**, and
`scripts/lint-file-budget.sh` rejects any budget edit that raises one. Every fragment is therefore
**net zero lines**, and `lint-file-budget` passes unchanged. The `#` it replaces was a separator
carrying no information.

**The five standalone `tests/stack/test_*.sh` files are deliberately NOT guarded.** The `Makefile`
runs each of them directly (`Makefile:18-24`) and `tests/inventory.sh:148` already lists them as
`UNSOURCED`. Guarding all 59 `.sh` files would have broken five `make` targets. `run.sh` needs no edit
at all — it sources `lib.sh` before any fragment, so the marker is already set.

## Evidence

**Refusal, all 55, from a throwaway directory.** 55/55 exit non-zero; 55/55 name `tests/stack/run.sh`;
**0** entries left in the cwd.

**Presence control fired** — an absence discriminates nothing until the presence case fires. Same file,
same probe, one variable:

| | rc | left in cwd |
|---|---|---|
| `test-backup.sh` at `develop-v2` | 127 | `backup/`, `backup-retry/` |
| `test-backup.sh` with the guard | 1 | *(nothing)* |

**Narrowness control.** All five `test_*.sh` run with no `STACK_SUITE` in their output — the guard does
not reach them.

**Tier-1 suite: `3168 passed, 0 failed`, rc 0** on the shipped guards. (That run was taken before the
rebase across #1711/#1712; the post-rebase re-run is in flight, and CI's `Shell tests` job is the
gate on it.)

**Mutation battery — per-arm attribution, each leg proving it mutated by `cmp` first:**

| Mutation | row 1 (refuses, names run.sh) | row 2 (writes nothing first) |
|---|---|---|
| baseline (shipped bytes) | PASS | PASS |
| M1 drop the guard from `test-doctor-appliance.sh` | **FAIL** | PASS |
| M2 move `test-backup.sh`'s guard *below* its fixture-building lines | PASS | **FAIL** |
| M3 `export` the marker in `lib.sh` | **FAIL** | **FAIL** |

M2 is the leg that earns the second row: a guard moved down still refuses, and only that row notices
the files it wrote getting there. All three files restored byte-identical afterwards.

**The control enumerates every fragment rather than sampling one**, because the regression it guards
against is a *new* fragment added without the marker, which a fixed list would never see.

**Lint:** `lint-file-budget` OK · `lint-docs-voice` OK · `make lint-md` 0 errors · `shfmt -i 4 -d` over
the Makefile's exact glob clean, with a control proving shfmt can still report a diff.

## What I did NOT do

- **`shellcheck` was not run.** The fleet-wide `~/.shellcheck-serialize.lock` was held by another lane
  for the whole cycle. CI's pinned run is the gate; this is the one check I am handing over unrun.
- The post-rebase tier-1 re-run had not finished when this was opened (see above).
- `cd "${SANDBOX:?}"` at the ~57 call sites across 12 files is **not** done. With this guard and #1661
  both landed, neither route to an empty `SANDBOX` is reachable, so it is defence-in-depth rather than
  load-bearing. Stated rather than silently skipped.
- I did not check whether suites outside `tests/stack/` use the same fragment idiom.

## Lane disclosure

`tests/stack/test-` was granted as a single prefix line on `roles/e2e.paths` (controller w97), for
#1657 only. Arming proven with the real `lane-guard.sh`, each file staged alone: target
REFUSED→ACCEPTED, `test_compose.sh` REFUSED→REFUSED (so it is not a widened `tests/stack/` reading),
`run.sh` and `test_appliance_hugepages.sh` REFUSED→REFUSED (**both of appliance's live lines are
untouched by this fix**), in-lane control ACCEPTED on both legs.

Shared files touched, per `_shared.paths`: `docs/dev/testing-strategy.md` (the paragraph that told
readers `run.sh` sources every domain, without saying what happens if you run one) and
`tests/stack/test-harness-tooling.sh` (an additive control block, plus its own line-2 guard like every
other fragment — the line-2 edit is a modification, not an additive registration, so it is called out).

Closes nothing automatically: `Closes` cannot fire here, since PRs merge to `develop-v2` while the
default branch is `develop`. #1657 to be closed by hand on merge.

## Over-engineering pass (ponytail), on my own diff

Findings I acted on, and the ones I declined and why:

- **I did MORE than the issue asked, deliberately.** It asked for "a single control that executes one
  fragment directly". The control enumerates all 55 instead. Kept: the regression worth guarding is a
  *new* fragment added without the marker, and a one-file control cannot see that. Cost is 55 bash
  processes that each exit at line 2.
- **Two assertion rows, not one.** Challenged as redundant, then settled by mutation rather than by
  argument: M2 (guard moved below the fixture-building lines) kills row 2 while row 1 stays green, so
  they are different arms. Kept.
- **The refusal message is long** (~105 chars) where `:?run tests/stack/run.sh` would do. Kept, because
  it is the entire user-facing output of the refusal and it says what the file *is*, not only what to
  run. Recorded as the finding most reasonably decided the other way.
- **Declined: guarding `lib.sh` itself.** `bash tests/stack/lib.sh` also exits 0 standalone. It is
  arguably the same class, but it is not a fragment, nothing in the issue names it, and its EXIT trap
  cleans up the sandbox it makes — so the harm the issue is about is absent. Left alone rather than
  quietly widened.
- **Declined: `cd "${SANDBOX:?}"` at ~57 sites.** Scope creep, and no longer load-bearing (above).
- **Considered and rejected: a `require_sourced` helper in `lib.sh`.** A fragment run directly never
  sources `lib.sh`, so the helper would be `command not found` and the refusal message would be bash's,
  not ours. The marker dereference is one statement, gives the message, and survives `shfmt` — which a
  braced `{ echo …; exit 1; }` one-liner does not.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUjWZYieLZQHsdRwbUoJL8
