### PR TITLE
fix(tests): #1595 the inventory source-agreement gate now covers tests/integration/ too

### DIFF
--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -121,117 +121,160 @@ for f in tests/integration/selftest*.sh; do
     fi
 done
 
-# run.sh's `source` line and the file it names have to agree, and they can disagree in EITHER
-# direction. Both ways end identically: `source` of a missing file does not stop run.sh (see
-# above), so the suite goes green having skipped every assertion in that domain, and neither the
-# aggregate nor the per-file gate can see it. The hyphen-named domain files have no standalone CI
-# invocation of their own — the underscore-named test_*.sh suites do, and fail their own step — so
-# for them these two checks are the whole safety net. Both read one SOURCED list, so the pattern
-# cannot drift between them, and a pattern that stops matching cannot quietly satisfy both loops at
-# once: direction 2 compares the list against the files on disk and reports how many are missing.
+# A sourcer's `source` line and the file it names have to agree, and they can disagree in EITHER
+# direction. Both ways end identically: `source` of a missing file does not stop the sourcer —
+# neither tests/stack/run.sh nor tests/integration/run.sh sets `-e` — so the suite goes green
+# having skipped every assertion in that domain, and neither the aggregate nor the per-file gate
+# can see it. The hyphen-named domain files have no standalone CI invocation of their own — the
+# underscore-named test_*.sh suites do, and fail their own step — so for them these two checks are
+# the whole safety net. Both directions read one SOURCED list, so the pattern cannot drift between
+# them, and a pattern that stops matching cannot quietly satisfy both loops at once: direction 2
+# compares the list against the files on disk and reports how many are missing.
 #
 # The pattern is anchored to the start of the line and admits no `#` ahead of the `source`, and
 # that is the load-bearing half: without it a commented-out `# source "$HERE/x.sh"` reads here as
-# a live one, so the file counts as sourced while run.sh never runs it — the same silent skip by
-# another route, and the likeliest thing for a conflict resolution to leave behind. It does not
+# a live one, so the file counts as sourced while the sourcer never runs it — the same silent skip
+# by another route, and the likeliest thing for a conflict resolution to leave behind. It does not
 # require `source` to open the line, deliberately: #1400 put a guard prefix on every domain
 # stanza, and a pattern that only matched a bare `source` stopped seeing 24 of the 25. What stays
 # out of reach is a line that is live text but dead code: a `source` inside a branch that never
 # runs, or inside a function nothing calls, still reads as present. Telling those apart needs
 # control flow rather than grep, and is not claimed.
-SOURCED=$(grep -oE '^[^#]*source "\$HERE/[A-Za-z0-9_.-]+\.sh"' tests/stack/run.sh |
-    sed -E 's|^.*source "\$HERE/||; s|"$||')
-# The domain files run.sh is expected to source: every tests/stack/*.sh but the sourcer itself and
-# the suites that carry their own CI step and fail there. Hoisted above both directions because the
-# floor below needs its size, and both loops need its membership.
-# Not sourced by run.sh, by design — each is invoked as its own CI step and fails there:
-UNSOURCED="test_appliance_hugepages.sh test_compose.sh test_data_reset.sh \
-    test_firstboot_journal.sh test_os_update_recovery.sh"
-EXPECTED=""
-for f in tests/stack/*.sh; do
-    base="${f#tests/stack/}"
-    if [ "$base" = "run.sh" ]; then continue; fi # the sourcer itself
-    case " $UNSOURCED " in *" $base "*) continue ;; esac
-    EXPECTED="${EXPECTED}${base}"$'\n'
-done
+#
+# Taken over a (sourcer, directory) PAIR rather than copied once per directory (#1595): a second
+# copy of a gate this dense drifts, and the drifted copy is the one nobody is reading at the
+# moment it goes quiet. Arguments: the sourcer, its directory, a space-separated list of GLOB
+# PATTERNS for files in it the sourcer is not expected to source, and the floor checked below.
+check_source_agreement() {
+    local sourcer="$1" dir="$2" unsourced="$3" min_expected="$4"
+    local SOURCED EXPECTED MISSING f base want pat skipped n_missing n_expected unsourced_pats
+    SOURCED=$(grep -oE '^[^#]*source "\$HERE/[A-Za-z0-9_.-]+\.sh"' "$sourcer" |
+        sed -E 's|^.*source "\$HERE/||; s|"$||')
+    # The domain files the sourcer is expected to source: every $dir/*.sh but the sourcer itself
+    # and whatever $unsourced excludes. Hoisted above both directions because the floor below
+    # needs its size, and both loops need its membership.
+    # `read -ra` splits on IFS but does NOT glob-expand, which a bare `for pat in $unsourced`
+    # would: an unquoted `selftest*.sh` there is matched against the CWD before `case` sees it.
+    IFS=' ' read -ra unsourced_pats <<<"$unsourced"
+    EXPECTED=""
+    for f in "$dir"/*.sh; do
+        base="${f##*/}"
+        if [ "$base" = "${sourcer##*/}" ]; then continue; fi # the sourcer itself
+        # Matched pattern by pattern, not against one space-delimited haystack, so an entry may be
+        # a glob: an exact-name list of tests/integration/'s selftests would be a standing drift
+        # hazard. The five tests/stack/ entries carry no metacharacter and match exactly as before.
+        skipped=""
+        for pat in "${unsourced_pats[@]}"; do
+            # shellcheck disable=SC2254  # glob matching is the point: these entries ARE patterns
+            case "$base" in $pat)
+                skipped=1
+                break
+                ;;
+            esac
+        done
+        if [ -n "$skipped" ]; then continue; fi
+        EXPECTED="${EXPECTED}${base}"$'\n'
+    done
 
-# Direction 1 (#1336) — every file run.sh claims to source must exist. Catches a domain file
-# deleted or renamed out from under a live `source` line.
-while read -r want; do
-    # A here-string over an empty SOURCED yields ONE blank line, not zero, so without this the
-    # loop would test `tests/stack/` and report a garbled name for a pattern that matched nothing.
-    if [ -z "$want" ]; then continue; fi
-    if [ ! -f "tests/stack/$want" ]; then
-        echo "inventory drift: run.sh sources tests/stack/$want, which does not exist — the file" \
-            "was moved or renamed and the suite would still pass, silently skipping it" >&2
+    # Direction 1 (#1336) — every file the sourcer claims to source must exist. Catches a domain
+    # file deleted or renamed out from under a live `source` line.
+    while read -r want; do
+        # A here-string over an empty SOURCED yields ONE blank line, not zero, so without this the
+        # loop would test "$dir/" and report a garbled name for a pattern that matched nothing.
+        if [ -z "$want" ]; then continue; fi
+        if [ ! -f "$dir/$want" ]; then
+            echo "inventory drift: $sourcer sources $dir/$want, which does not exist — the file" \
+                "was moved or renamed and the suite would still pass, silently skipping it" >&2
+            exit 1
+        fi
+    done <<<"$SOURCED"
+
+    # Direction 2 (#1357) — every domain file on disk must be sourced. The loop above can only
+    # examine the `source` lines that are PRESENT, so a line deleted while its file stays on disk
+    # is never looked at; the per-file section gate then finds the orphaned file with its headers
+    # intact and passes it. Nothing else asks the question in this direction.
+    #
+    # This is a FLOOR, not an emptiness test, and it collects rather than exiting on the first
+    # offender (#1420). It used to be guarded by `[ -z "$SOURCED" ]`, on the reasoning that the
+    # pattern going quiet must not read as "all present" — and that guard failed open on a real
+    # 24-of-25 breakage, because lib.sh's stanza is bare by design and kept matching. A fallback
+    # condition of "the set is empty" is defeated by a single survivor. Comparing the two sets
+    # makes one survivor as loud as none. Exiting on the first offender was the other half: it
+    # named one file, alphabetically first, for a 24-file regression, and the reader sizes the
+    # problem from that message.
+    MISSING=""
+    # `IFS=` is load-bearing: `read -r` into a single variable strips leading and trailing IFS
+    # whitespace, so a file on disk whose name STARTS with a space, sourced by nothing, would be
+    # stripped to its bare name — which IS in SOURCED — and silently accepted. A mid-name space
+    # was caught either way, which is what made this invisible. Direction 1's identical construct
+    # above needs no such fix: SOURCED comes from a character class that cannot emit a space.
+    while IFS= read -r base; do
+        if [ -z "$base" ]; then continue; fi
+        # Matched between newlines, not spaces: a filename containing a space would survive the
+        # glob above (it is iterated directly) only to be split apart by a space-delimited lookup.
+        case $'\n'"$SOURCED"$'\n' in *$'\n'"$base"$'\n'*) continue ;; esac
+        MISSING="${MISSING}${base}"$'\n'
+    done <<<"$EXPECTED"
+    n_missing=$(printf '%s' "$MISSING" | count)
+    n_expected=$(printf '%s' "$EXPECTED" | count)
+    # Collapsing together is itself drift, and it is the ONE case the set difference above cannot
+    # see. If every expected domain file and every stanza disappear TOGETHER — a botched revert of
+    # the #1105 split — then SOURCED and EXPECTED shrink at the same time, MISSING stays empty,
+    # and the comparison is vacuously satisfied no matter how far they fall. The floor is not just
+    # an emptiness test: #1429 showed that landing on 1-and-1 rather than 0-and-0 is exactly as
+    # vacuous, because lib.sh's bare stanza (it is in neither directory's exclusions, so it counts
+    # as expected, and it IS sourced) survives every deletion and keeps satisfying both directions
+    # at that single entry. A set-difference guard cannot tell "everything agrees because nothing
+    # is missing" from "everything agrees because there is nothing left to disagree about" — the
+    # fallback has to come from outside the two sets it compares. Each floor is deliberately
+    # generous — comfortably below today's count for its own pair — so an ordinary rename, split,
+    # or retirement of a file or two never needs to touch it, precisely so that when it DOES fire,
+    # it means the domain layer collapsed, not that someone forgot to bump a number. Raise one
+    # when the true count grows enough to make that margin thin; never lower one to make a real
+    # drop pass, and give a reason in the commit if you do either.
+    if [ "$n_expected" -lt "$min_expected" ]; then
+        echo "inventory drift: only $n_expected domain files in $dir are expected to be sourced" \
+            "(floor is $min_expected) — the domain layer may have collapsed while a shared" \
+            "survivor (e.g. lib.sh) kept $sourcer's stanzas and the files on disk agreeing with" \
+            "each other; restore the missing files and stanzas, or lower the floor for this pair" \
+            "in tests/inventory.sh with a reason" >&2
         exit 1
     fi
-done <<<"$SOURCED"
+    if [ "$n_missing" -gt 0 ]; then
+        echo "inventory drift: $n_missing of $n_expected domain files in $dir are not sourced by" \
+            "$sourcer — a 'source' line was deleted, or, the closer this count runs to" \
+            "$n_expected, the pattern above stopped matching. Either way the suite would still" \
+            "pass, silently skipping every section in these files. Restore the line, fix the" \
+            "pattern, or add the file to this pair's exclusions with a reason:" >&2
+        printf '%s' "$MISSING" | sed 's/^/  /' >&2
+        exit 1
+    fi
+}
 
-# Direction 2 (#1357) — every domain file on disk must be sourced. The loop above can only examine
-# the `source` lines that are PRESENT, so a line deleted while its file stays on disk is never
-# looked at; the per-file section gate then finds the orphaned file with its headers intact and
-# passes it. Nothing else asks the question in this direction.
-#
-# This is a FLOOR, not an emptiness test, and it collects rather than exiting on the first offender
-# (#1420). It used to be guarded by `[ -z "$SOURCED" ]`, on the reasoning that the pattern going
-# quiet must not read as "all present" — and that guard failed open on a real 24-of-25 breakage,
-# because lib.sh's stanza is bare by design and kept matching. A fallback condition of "the set is
-# empty" is defeated by a single survivor. Comparing the two sets makes one survivor as loud as
-# none. Exiting on the first offender was the other half: it named one file, alphabetically first,
-# for a 24-file regression, and the reader sizes the problem from that message.
-MISSING=""
-# `IFS=` is load-bearing: `read -r` into a single variable strips leading and trailing IFS
-# whitespace, so a file on disk whose name STARTS with a space, sourced by nothing, would be
-# stripped to its bare name — which IS in SOURCED — and silently accepted. A mid-name space was
-# caught either way, which is what made this invisible. Direction 1's identical construct above
-# needs no such fix: SOURCED comes from a character class that cannot emit a space.
-while IFS= read -r base; do
-    if [ -z "$base" ]; then continue; fi
-    # Matched between newlines, not spaces: a filename containing a space would survive the glob
-    # above (it is iterated directly) only to be split apart by a space-delimited lookup here.
-    case $'\n'"$SOURCED"$'\n' in *$'\n'"$base"$'\n'*) continue ;; esac
-    MISSING="${MISSING}${base}"$'\n'
-done <<<"$EXPECTED"
-n_missing=$(printf '%s' "$MISSING" | count)
-n_expected=$(printf '%s' "$EXPECTED" | count)
-# Collapsing together is itself drift, and it is the ONE case the set difference above cannot see.
-# If every expected domain file and every stanza disappear TOGETHER — a botched revert of the #1105
-# split — then SOURCED and EXPECTED shrink at the same time, MISSING stays empty, and the comparison
-# is vacuously satisfied no matter how far they fall. The floor is not just an emptiness test: #1429
-# showed that landing on 1-and-1 rather than 0-and-0 is exactly as vacuous, because lib.sh's bare
-# stanza (it is not in UNSOURCED, so it counts as expected, and it IS sourced) survives every
-# deletion and keeps satisfying both directions at that single entry. A set-difference guard cannot
-# tell "everything agrees because nothing is missing" from "everything agrees because there is
-# nothing left to disagree about" — the fallback has to come from outside the two sets it compares.
-# MIN_EXPECTED is deliberately generous — comfortably below today's count (54 at the time of #1429)
-# so an ordinary rename, split, or retirement of a file or two never needs to touch it — precisely so
-# that when it DOES fire, it means the domain layer collapsed, not that someone forgot to bump a
-# number. Raise it when the true count grows enough to make that margin thin; never lower it to make
-# a real drop pass, and give a reason in the commit if you do either.
-MIN_EXPECTED=20
-# Scope, stated because a comment that names a case this guard never sees is worse than no comment:
-# dropping the WHOLE directory does not reach here — `n_stack` counts 0 and the aggregate gate above
-# exits first, with byte-identical output whether this guard is alive or dead. What is unique to
-# this check is the narrower case where run.sh and the sectioned UNSOURCED files survive, keeping
-# `n_stack` non-zero, while the expected domain files and their stanzas collapse toward a shared
-# handful of survivors (as few as one) that satisfy the comparison above.
-if [ "$n_expected" -lt "$MIN_EXPECTED" ]; then
-    echo "inventory drift: only $n_expected domain files are expected to be sourced (floor is" \
-        "$MIN_EXPECTED) — the domain layer may have collapsed while a shared survivor (e.g." \
-        "lib.sh) kept run.sh's stanzas and the files on disk agreeing with each other; restore" \
-        "the missing files and stanzas, or lower MIN_EXPECTED in tests/inventory.sh with a reason" >&2
-    exit 1
-fi
-if [ "$n_missing" -gt 0 ]; then
-    echo "inventory drift: $n_missing of $n_expected domain files on disk are not sourced by" \
-        "run.sh — a 'source' line was deleted, or, the closer this count runs to $n_expected, the" \
-        "pattern above stopped matching. Either way the suite would still pass, silently skipping" \
-        "every section in these files. Restore the line, fix the pattern, or add the file to" \
-        "UNSOURCED with a reason:" >&2
-    printf '%s' "$MISSING" | sed 's/^/  /' >&2
-    exit 1
-fi
+# tests/stack/ — the excluded five are not sourced by run.sh by design: each is invoked as its own
+# CI step and fails there. Floor 20, comfortably below the 54 counted at #1429.
+check_source_agreement tests/stack/run.sh tests/stack \
+    "test_appliance_hugepages.sh test_compose.sh test_data_reset.sh \
+    test_firstboot_journal.sh test_os_update_recovery.sh" 20
+
+# tests/integration/ (#1595) — run.sh sources eight domain files by the identical `$HERE/` shape,
+# six of them hyphen-named with no standalone CI step of their own, and until now nothing checked
+# either direction for any of them (the measured before/after is on #1595). The exclusions:
+#   selftest*.sh          harness self-tests, run by their own target and gated per-file above;
+#                         a glob because this lane adds one routinely (see the note in the loop).
+#   e2e.sh                the release-gate driver — it sources run.sh's directory, not vice versa.
+#   restore-proof.sh
+#   rig-supply.sh         sourced by e2e.sh, not by run.sh.
+#   skip-accounting.sh    sourced by lib.sh, by a `${BASH_SOURCE[0]%/*}` path with its own
+#                         fail-closed guard (lib.sh:49-55), so run.sh reaches it transitively.
+#   build-pruned-chain.sh
+#   compact-chain.sh
+#   system-info.sh        box-side operator scripts, run by hand on the bench; not harness domains.
+# Floor 5 against the 8 expected today — the same "generous, but a collapse to a lone survivor
+# still fires" margin the stack pair carries, sized for a set an order of magnitude smaller.
+check_source_agreement tests/integration/run.sh tests/integration \
+    "selftest*.sh e2e.sh restore-proof.sh rig-supply.sh skip-accounting.sh \
+    build-pruned-chain.sh compact-chain.sh system-info.sh" 5
 
 # --- emit -----------------------------------------------------------------
 cat <<EOF


### PR DESCRIPTION
Addresses #1595. No `Closes` keyword: PRs here merge to `develop-v2` while the default branch is
`develop`, so it never fires — the issue is closed by hand on merge.

## What was wrong

`tests/inventory.sh` carries the source-agreement gate from #1336 (direction 1 — every file a
runner claims to `source` must exist) and #1357 (direction 2 — every domain file on disk must be
sourced). Its own comment states the stakes: `source` of a missing file does not stop a runner that
is not `set -e`, so the suite goes green having skipped every assertion in that domain, and neither
the aggregate nor the per-file gate can see it.

It was applied to `tests/stack/run.sh` only. `tests/integration/run.sh` sources eight domain files
by the identical `source "$HERE/x.sh"` shape — six of them hyphen-named, so, exactly as the #1336
comment says, they have no standalone CI step of their own to fail in — and nothing checked either
direction for any of them.

## Measured on the unfixed script first, because the issue asked for it

The issue is explicit that the consequence was argued, not observed: *"I have not tried the rename
to watch it go green ... That check is cheap and should be the first thing whoever takes this
does."* Both scripts run from the repo root at base `ffc29531`, mutation proven applied each time,
tree restored and verified after each leg:

| mutation | `origin/develop-v2` script | this branch |
|---|---|---|
| none | rc 0 | rc 0 |
| `tests/integration/zmq-probe.sh` renamed out from under its live `source` line | **rc 0, empty stderr** | rc 1, names the file |
| `source "$HERE/mergemine-probe.sh"` deleted, the file left on disk | **rc 0, empty stderr** | rc 1, `1 of 8` |
| `tests/stack/test-lifecycle.sh` renamed | rc 1 | rc 1 |
| stack `source` line deleted, file left on disk | rc 1, `1 of 56` | rc 1, `1 of 56` |

One result is sharper than the issue claimed: on row 2 the **generated inventory is byte-identical**
to the healthy run — so the silence was not only in the exit code, and nothing reading the generated
file downstream could have seen it either.

## The change

Hoisted into `check_source_agreement <sourcer> <dir> <exclusion globs> <floor>`, called twice,
rather than a second copy — the issue's own reasoning, that a duplicated gate that drifts is worse
than the gap. Both directions, the `IFS=` handling, the `#1420` collect-don't-exit behaviour and the
collapse floor are the existing code, parameterised; the messages now name the pair they fired for.

The exclusion list became **glob patterns** rather than exact names. `tests/integration/` gains a
`selftest-*.sh` routinely and those files already have their own per-file gate above, so an
exact-name list there would be a standing drift hazard. The five `tests/stack/` entries carry no
metacharacter, so they match exactly as before.

The eight `tests/integration/` exclusions each carry their reason in the file: the self-tests;
`e2e.sh`, `restore-proof.sh` and `rig-supply.sh` (the release-gate driver and what it sources);
`skip-accounting.sh` (reached transitively, `lib.sh` sources it by a `${BASH_SOURCE[0]%/*}` path
with its own fail-closed guard); and `build-pruned-chain.sh`, `compact-chain.sh`, `system-info.sh`
(box-side operator scripts, not harness domains).

## Coverage — every new check shown able to fail

Eight legs, each proving its mutation landed before running, and restoring after:

| leg | expect | got |
|---|---|---|
| control, unmutated tree | rc 0 | rc 0 |
| integration direction 1 — domain file renamed | rc 1 | rc 1 |
| integration direction 2 — `source` line deleted | rc 1 | rc 1 |
| **narrowness** — a new *unsourced* `newdomain.sh` must be seen | rc 1 | rc 1 |
| **the glob is the point** — a new `selftest-newthing.sh` must NOT red | rc 0 | rc 0 |
| stack direction 1 — regression control | rc 1 | rc 1 |
| stack direction 2 — regression control | rc 1 | rc 1 |
| stack exclusions still not red | rc 0 | rc 0 |

The last two rows of that table and rows 4–5 of the first are the controls that matter: the pair
`newdomain.sh` reds / `selftest-newthing.sh` does not is what shows the new exclusion is *narrow*
rather than swallowing the directory.

**The floor for the new pair is proven armed but not proven correct.** Raising it from 5 to 9
against today's 8 fires with the right message; that tests the mechanism and the parameterisation.
Nothing here demonstrates 5 is the right number — it is the same "generous, but a collapse to a lone
survivor still fires" margin the stack pair carries, sized for a set an order of magnitude smaller,
and I am saying so rather than implying it was measured.

## A defect in my own first draft, found by attacking it

The pattern loop was `for pat in $unsourced`. An unquoted `selftest*.sh` in a `for` list is
**pathname-expanded against the cwd** before `case` ever sees it; it stayed literal only because
this script runs from the repo root, which happens to hold no matching file. Demonstrated on a
fixture directory containing two such files — the `for` form yielded the two filenames, `read -ra`
yielded the pattern — and fixed to `read -ra`. Incidentally correct is not correct.

## Checks run

- `bash -n`, `shfmt -i 4 -d` over the changed file (the Makefile's own glob): clean.
- `make lint-file-budget` after `git add`: OK. The file is **398 lines against the 400 target**, so
  it needs no `docs/dev/file-budget.tsv` row; I trimmed my own new prose to keep headroom rather
  than land on 400 exactly.
- `make lint-md`: 48 files, 0 errors. No doc change was needed —
  `docs/dev/testing-strategy.md:274` already describes the check as *"every domain file is
  sourced"*, which was generous before this and is accurate now. I checked for a doc asserting the
  narrower scope and found none.
- Generated inventory output on a healthy tree is **byte-identical** before and after: this is a
  gate change, not a content change.

## What I did NOT do

- **`shellcheck` did not run.** The `~/.local/bin` wrapper serialises fleet-wide on
  `~/.shellcheck-serialize.lock` and another lane held it for this whole cycle; my run was still
  queued at hand-off. CI's pinned `shellcheck 0.11.0` full-glob run is the gate. Same as the
  previous cycle, and stated rather than skipped quietly.
- **Nothing outside `tests/inventory.sh`** — one file, granted to this lane for this issue.
- A line that is live text but dead code (a `source` inside a branch that never runs) still reads
  as present. That limitation is pre-existing, documented in the file, and unchanged here.

## Queue disclosure

#1595 sits in `maintenance & gates`, which the meter freezes above 1,000M; `tokens.py` reads GRAND
**1,762M**. I worked it on the controller's max-push header, which states the freeze is lifted for
this window and lists #1595 as an item. Flagging it so the controller can overrule — the other
queue items were checked first and are genuinely blocked: #1506's remainder is box-side at a
controller-ruled resting point, #1446 and #1236 are parked on operator inputs.

## Over-engineering pass on my own diff, and what I declined

- **The strongest case against this diff: direction 2 could have been left out.** Direction 1 alone
  closes the demonstrated gap with *zero* configuration — it keys off the `source` lines themselves
  and needs no exclusion list at all. Direction 2 is what costs: an eight-entry list a future
  contributor has to maintain. I kept it because the issue names both directions, because leg 2
  above shows it fires on a real regression nothing else can see (a `source` line deleted while its
  file stays on disk, which the per-file section gate then passes), and because a wrong exclusion
  fails **red**, never silent. Recording it as the trade-off a reviewer should push back on if they
  disagree.
- **The second floor is the weakest thing here.** It costs one argument and one number, and it
  guards a case (all eight files *and* all eight stanzas disappearing together) that is remote for a
  set this small. I kept it for consistency with the stack pair rather than because I measured a
  need, and the section above says plainly that 5 is not a measured number.
- **Declined:** collapsing the two `while read` loops into one pass. They answer different questions
  over different sets, and the file's own comments explain at length why the second exists; merging
  them would save lines and cost the reasoning.
- **Declined:** making `UNSOURCED` a bash array literal at each call site. Marginally cleaner, but it
  would change both call sites' shape for no behaviour, and the `\`-continued string is what the
  stack pair already used.
