### PR TITLE
fix(dashboard): #1231 the XvB Odds cell names what it waits for instead of dashing

### DIFF
--- a/dashboard/mining_dashboard/web/static/xvbview.mjs
+++ b/dashboard/mining_dashboard/web/static/xvbview.mjs
@@ -48,6 +48,24 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
   // Fiat mirror (#520) for the best sustainable net only — one line, never a fiat number whose
   // XMR figure is hidden.
   const best = rows.filter((r) => r.sustainable && r.net).sort((a, b) => b.net[1] - a.net[1])[0];
+  // #1231: the Odds cell rendered a bare "—" on a box that has never enabled XvB, which reads as
+  // "the odds are zero" rather than "nothing has been read yet". The winners feed that fills the
+  // round-stats cache is ENABLE_XVB-gated (build_xvb_calc's own fallback keys on the same flag),
+  // so a disabled box structurally has nothing to show and an enabled one is merely waiting. Name
+  // which of the two it is, off the `calc.enabled` every other live-donation surface already uses.
+  // #1214's constraint holds: nothing here is derived or estimated, only named.
+  //
+  // "awaiting sync" rather than the issue's suggested "computed after first sync": build_xvb_calc
+  // empties round_types when the cache is STALE as well as when it was never filled, so an
+  // enabled box reaching this branch may well have synced before. The payload publishes staleness
+  // for the reward-estimates cache only — a different cache — so the two cannot be told apart
+  // here, and wording that claims no sync has ever happened would be false for half of them.
+  const oddsPending = calc.enabled ? "awaiting sync" : "needs XvB enabled";
+  const oddsTitle =
+    "How often this tier's rounds pay out, and among how many qualifiers — from XvB's public winners feed.";
+  const oddsPendingTitle = calc.enabled
+    ? "No round statistics are cached right now — XvB's winners feed fills this in at the next sync."
+    : "XvB is off, so its winners feed is never read — and that feed is the only source for draw frequency and qualifier counts. Enable XvB to compute this.";
   return html`
         <div class="xvb-comparison">
             <label class="xvb-compare-label">Should I donate? — per-tier verdict (per year)</label>
@@ -79,7 +97,7 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
                     <span title="P2Pool earnings forgone by donating the tier threshold for a year, at your current rate.">Cost ${r.cost !== null ? formatXmr(r.cost) : "—"}</span> ·
                     <span title="XvB's own published expected reward — face value: prices every bonus hash at full block reward.">XvB says ${r.xvbSays !== null ? formatXmr(r.xvbSays) : "—"}</span> ·
                     <span title=${`${estTitle} ${bandNote(est)}`}>${estLabel} ${fmtMid(est)}</span> ·
-                    <span title="How often this tier's rounds pay out, and among how many qualifiers — from XvB's public winners feed.">Odds / 30d ${r.oddsPer30d ? `≈ ${Number(r.oddsPer30d.toPrecision(2))} wins · ${Number((r.players || 0).toPrecision(2))} players` : "—"}</span>
+                    <span title=${r.oddsPer30d ? oddsTitle : oddsPendingTitle}>Odds / 30d ${r.oddsPer30d ? `≈ ${Number(r.oddsPer30d.toPrecision(2))} wins · ${Number((r.players || 0).toPrecision(2))} players` : oddsPending}</span>
                 </p>
               </div>`;
             })}
@@ -128,8 +146,8 @@ export function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
                     : calc.estimates_source === "live"
                       ? ", so the reward columns run from the last live read"
                       : ""
-                }. The odds column needs the live winners feed, so it stays empty until
-                XvB runs again.</p>`
+                }. The odds column needs the live winners feed, so each row names what it
+                is waiting for instead of a figure until XvB runs again.</p>`
         }
         <div class="stat-grid">
             <${StatCard} label="Sustainable Tier" value=${t ? t.tier : "None"} cls="c-purple"

--- a/dashboard/tests/frontend/xvbodds.test.mjs
+++ b/dashboard/tests/frontend/xvbodds.test.mjs
@@ -1,0 +1,151 @@
+// #1231: what the XvB decision table's "Odds / 30d" cell says when there is no odds figure yet.
+//
+// A bare "—" there was indistinguishable from a measured zero. The column is filled from XvB's
+// public winners feed, and the sync that fills the round-stats cache is ENABLE_XVB-gated
+// (build_xvb_calc), so there are exactly two empty states and the payload already separates
+// them: XvB never enabled (nothing will ever arrive until it is), and XvB on but not yet synced.
+// The cell names which one it is.
+//
+// A new file rather than more of xvbview.test.mjs: that file sits at its recorded file-budget
+// ceiling (431), and this gate's ceilings only ever go down.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { XvbTierBlock } from '../../mining_dashboard/web/static/xvbview.mjs';
+import { render } from './helpers/render.mjs';
+
+// Two tiers is enough to show the placeholder is per-row; the decision table renders one block
+// per tier regardless. `hr`/`coeffDay` are the what-if inputs — held fixed across every case
+// here so the only variable is the odds data itself.
+const HR = 200_000;
+const COEFF_DAY = 1e-7;
+
+function calc({ enabled = true, odds = null, players = null } = {}) {
+    return {
+        enabled,
+        max_fraction: 0.85,
+        estimates_available: false,
+        estimates_stale: false,
+        estimates_source: enabled ? 'none' : 'published',
+        estimates_published_date: '2026-08-01',
+        current_tier: 'None',
+        target_tier: 'None',
+        target_threshold: 10_000,
+        sustainable: true,
+        realization_pct: null,
+        realization_wins: null,
+        note: 'An XvB tier is raffle status, not an XMR payout.',
+        mode_note: null,
+        tiers: [
+            {
+                name: 'Vip (10.00 kH/s+)', threshold: 10_000, expected_reward_year: 0.81,
+                realized_reward_year: null, assumed_reward_year_range: null,
+                win_odds_day: odds, players_avg: players,
+            },
+            {
+                name: 'Whale (100.00 kH/s+)', threshold: 100_000, expected_reward_year: 6.17,
+                realized_reward_year: null, assumed_reward_year_range: null,
+                win_odds_day: odds, players_avg: players,
+            },
+        ],
+    };
+}
+
+const draw = (c) => render(XvbTierBlock, { calc: c, hr: HR, coeffDay: COEFF_DAY });
+
+// --- the two empty states are named, and named differently ------------------------------
+
+test('#1231: a box that has never enabled XvB says so in the Odds cell, not with a dash', () => {
+    const out = draw(calc({ enabled: false }));
+    // Positive assertion anchored to the label, so it cannot pass off some other cell's text:
+    // the two tiers each render "Odds / 30d needs XvB enabled".
+    assert.match(out, /Odds \/ 30d needs XvB enabled/);
+    assert.equal(out.match(/Odds \/ 30d needs XvB enabled/g).length, 2);
+    // The old rendering, and the other state's wording, are both absent.
+    assert.doesNotMatch(out, /Odds \/ 30d —/);
+    assert.doesNotMatch(out, /awaiting sync/);
+});
+
+test('#1231: an enabled box with nothing synced yet says it is waiting, not that XvB is off', () => {
+    const out = draw(calc({ enabled: true }));
+    assert.match(out, /Odds \/ 30d awaiting sync/);
+    assert.equal(out.match(/Odds \/ 30d awaiting sync/g).length, 2);
+    assert.doesNotMatch(out, /Odds \/ 30d —/);
+    assert.doesNotMatch(out, /needs XvB enabled/);
+});
+
+test('#1231: the two states are distinguishable — the same fixture differing only in `enabled`', () => {
+    // The discriminator is the payload field the server already sets, so this pins that the cell
+    // reads `enabled` and nothing else: one flag flipped, two different answers.
+    const off = draw(calc({ enabled: false }));
+    const on = draw(calc({ enabled: true }));
+    assert.notEqual(off, on);
+    assert.match(off, /needs XvB enabled/);
+    assert.match(on, /awaiting sync/);
+});
+
+// --- the tooltip carries the reason, and it is state-specific ---------------------------
+
+test('#1231: the empty cell tooltip explains the state it is actually in', () => {
+    const off = draw(calc({ enabled: false }));
+    assert.match(off, /XvB is off, so its winners feed is never read/);
+    assert.doesNotMatch(off, /No round statistics are cached right now/);
+
+    const on = draw(calc({ enabled: true }));
+    assert.match(on, /No round statistics are cached right now/);
+    assert.doesNotMatch(on, /XvB is off, so its winners feed is never read/);
+});
+
+// --- no regression: a real figure still renders, and the placeholders stay away ---------
+
+test('#1231: a measured figure still renders, with the original tooltip and no placeholder', () => {
+    // 0.84/day x 30 = 25.2 -> toPrecision(2) = 25; players_avg 8.2 renders as-is.
+    const out = draw(calc({ enabled: true, odds: 0.84, players: 8.2 }));
+    assert.match(out, /Odds \/ 30d ≈ 25 wins · 8\.2 players/);
+    assert.doesNotMatch(out, /needs XvB enabled/);
+    assert.doesNotMatch(out, /awaiting sync/);
+    // The measured cell keeps the descriptive tooltip, not either waiting-state one.
+    assert.match(out, /How often this tier's rounds pay out/);
+    assert.doesNotMatch(out, /No round statistics are cached right now/);
+});
+
+test('#1231: the placeholder assertions can fail — the same probe over measured data', () => {
+    // A negative control for the two tests above: if `Odds / 30d needs XvB enabled` could match
+    // whatever the table renders, it would match here too. It does not, so a match there is a
+    // reading of the placeholder and not of the probe.
+    const measured = draw(calc({ enabled: false, odds: 0.84, players: 8.2 }));
+    assert.doesNotMatch(measured, /Odds \/ 30d needs XvB enabled/);
+    assert.doesNotMatch(measured, /Odds \/ 30d awaiting sync/);
+    assert.match(measured, /Odds \/ 30d ≈ 25 wins/);
+});
+
+// --- the boundary the render condition actually tests -----------------------------------
+
+test('#1231: a zero or absent rate is a waiting state, not a rendered zero', () => {
+    // The cell keys on `oddsPer30d` being truthy, and xvbDecisionRows only sets it for
+    // win_odds_day > 0. A zero rate is XvB reporting no rounds of that type in the window —
+    // not "you will win zero times" — so it belongs in the waiting state, and a qualifier count
+    // arriving without a rate must not drag a bare number onto the row on its own.
+    const zero = draw(calc({ enabled: true, odds: 0, players: 8.2 }));
+    assert.match(zero, /Odds \/ 30d awaiting sync/);
+    assert.doesNotMatch(zero, /Odds \/ 30d ≈/);
+
+    const playersOnly = draw(calc({ enabled: false, odds: null, players: 31.4 }));
+    assert.match(playersOnly, /Odds \/ 30d needs XvB enabled/);
+    assert.doesNotMatch(playersOnly, /31\.4 players/);
+});
+
+// --- the block-level note and the per-row cell must not contradict each other ------------
+
+test('#1231: the disabled note no longer claims the column stays empty', () => {
+    const out = draw(calc({ enabled: false }));
+    assert.match(out, /id="xvb-disabled-note"/);
+    // The note used to say the odds column "stays empty"; the rows now say what they wait for,
+    // so the note says that instead. A doc/prose claim the rendering contradicts is the defect
+    // this assertion exists to catch.
+    assert.match(out, /names what it\s+is waiting for instead of a figure/);
+    assert.doesNotMatch(out, /odds column needs the live winners feed, so it stays empty/);
+});

--- a/dashboard/tests/frontend/xvbview.test.mjs
+++ b/dashboard/tests/frontend/xvbview.test.mjs
@@ -342,8 +342,8 @@ test('XvB decision table: the vendored-fallback reward columns render values and
     assert.match(up, /Range: 0\.226800 XMR … 0\.315900 XMR/);
     assert.doesNotMatch(up, /tier costs only/);
     assert.match(up, /last published table \(2026-08-10\)/);
-    // Odds have no such fallback — same root cause, still honestly empty (#1214).
-    assert.match(up, /Odds \/ 30d —/);
+    // Odds have no such fallback — same root cause; the cell names what it waits for (#1231).
+    assert.match(up, /Odds \/ 30d needs XvB enabled/);
 });
 
 test('XvB decision block: in the operator\'s render state (XvB OFF) no figure is a sideways-panning range (#1316)', () => {
@@ -391,8 +391,8 @@ test('XvB decision block: in the operator\'s render state (XvB OFF) no figure is
     assert.doesNotMatch(block, /table-scroll/);
     assert.doesNotMatch(block, /<table/);
 
-    // Odds have no fallback while XvB is off, so they stay honestly empty — once per tier.
-    assert.equal(block.match(/Odds \/ 30d —/g).length, 4);
+    // Odds have no fallback while XvB is off; each tier names what it waits for (#1231).
+    assert.equal(block.match(/Odds \/ 30d needs XvB enabled/g).length, 4);
 
     // Every visible XMR figure is a single number, and none of them is an 8-dp negative.
     const figures = visible.match(/-?\d+\.\d+ XMR/g) || [];

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -851,8 +851,9 @@ xmrvsbeast.com — the reward columns run from the last cached read when one exi
 from a bundled snapshot of XvB's own published table, labelled with the date it was captured so
 you can see how old it is; either way nothing is fetched to produce it. The odds column has no
 such stand-in — draw frequency and qualifier counts are live numbers XvB's winners feed alone
-carries, so it stays empty on a box that has never enabled XvB, filling in once XvB runs and that
-feed is read for the first time. The raffle winner is drawn at random among everyone above
+carries. Rather than a bare dash, which reads as odds of zero, each row says what it is waiting
+for: `needs XvB enabled` on a box that has never turned XvB on, and `awaiting sync` on one that
+has, until that feed is read again. The raffle winner is drawn at random among everyone above
 the threshold, so donating more than the threshold buys zero extra win chance — but the odds
 themselves are knowable: XvB's winners file publishes the qualifier count for every round, and
 the comparison below shows them.
@@ -869,7 +870,7 @@ the whole choice is visible at once:
 
 | Column | Meaning |
 |---|---|
-| **Odds / 30d** | How often this tier's rounds pay out and among how many qualifiers, computed from XvB's public winners feed. The draw is random among qualifiers — donating above a threshold buys no extra odds. |
+| **Odds / 30d** | How often this tier's rounds pay out and among how many qualifiers, computed from XvB's public winners feed. The draw is random among qualifiers — donating above a threshold buys no extra odds. With no round statistics cached the cell names what it needs — `needs XvB enabled`, or `awaiting sync` once XvB is on — never a dash, which would read as odds of zero. |
 | **Cost / yr** | The P2Pool earnings given up by donating the tier threshold for a year, at your current rate. |
 | **XvB says / yr** | XvB's own published expected reward — **face value**: it prices every bonus hash at full block reward. Shown as their number, never blended. |
 | **Study est. / yr** | The same figure scaled by the **measured delivery band**: across 25 audited won rounds, verified on-chain across all three P2Pool sidechains (June–August 2026), winners received 33% of the advertised prize work (95% CI 28–39%; single-wallet on-chain audit, corroborated by a 14-winner public crawl), with at most a small margin effect. Once this box has enough measured wins of its own, the column becomes **Yours (N% × M wins)** and uses your wallet's measured figure instead. The full record — method, data, and scripts — is the [XvB delivery study](research/xvb-delivery-study/PAPER.md). |


### PR DESCRIPTION
Closes #1231.

## What it does

The per-tier XvB decision table rendered a bare `—` in **Odds / 30d** whenever no odds figure existed. On a box that has never enabled XvB that is indistinguishable from a measured zero — the column meant to inform the enable/don't-enable decision instead reads as "your odds are nil".

The winners feed that fills the round-stats cache is `ENABLE_XVB`-gated, so `build_xvb_calc` already separates the two empty states through `calc.enabled` — the same flag its own vendored-reward fallback keys on (`fallback_eligible = not metrics.xvb_enabled`). The cell now names which state it is in:

| State | Cell reads |
|---|---|
| XvB off | `needs XvB enabled` |
| XvB on, no round statistics cached | `awaiting sync` |
| odds present | unchanged — `≈ N wins · M players` |

Each empty state carries its own tooltip. This is #1231's first candidate shape, the one its own body calls "a wording fix, no data problem". **Nothing is derived, estimated, or dialled out while disabled** — #1214's carried constraint holds because nothing here is computed, only named.

## Where I deviated from the issue, and why

#1231 suggested the wording "computed after first sync". I did not use it. `build_xvb_calc` empties `round_types` when the round-stats cache is **stale** as well as when it was never filled, and the payload publishes staleness only for the *separate* reward-estimates cache — so the two cannot be told apart in the client, and an enabled box reaching this branch may well have synced before. "computed after first sync" would be false for that half. `awaiting sync` is true in both sub-cases. The reasoning is in the source comment so the next reader does not re-litigate it.

## Prose the change falsified, swept

Three sentences claimed the column "stays empty", which is no longer true:
- the block-level `#xvb-disabled-note` in `xvbview.mjs`
- `docs/dashboard.md`'s XvB Tier narrative
- `docs/dashboard.md`'s Odds / 30d table row

All three updated. The footnote's "Win odds ... stay unavailable until XvB runs again" is still true and is left alone.

## Evidence — what I actually ran

- **`make test-frontend` rc 0 — 516 tests, 516 pass, 0 fail** on the tree being shipped.
- **New file `dashboard/tests/frontend/xvbodds.test.mjs`, 8 tests, with a fired negative control.** Restoring `xvbview.mjs` to its `origin/develop-v2` content and re-running that file gives **6 failed / 2 passed**. The two that pass on both sides are by design and named as such: the no-regression test (a measured figure still renders) and the control test itself. The other six all discriminate. The base file was restored from a scratchpad copy and the restore **verified by sha256 content match**, not by an exit code.
- **Gates run individually, each rc captured without a pipeline:** `lint-js`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget`, `lint-py`, `test-frontend` — **all rc 0**.
- Branch cut from `origin/develop-v2` at `3eeb1b28`, re-derived at cut time.

## What I did NOT do

- **I did not run `make lint-sh`.** The diff touches no shell file, and that target is the serialized OOM path with other lanes live on this box. CI runs it.
- **I did not run `make test-dashboard` or `make test-patch-coverage`.** The diff changes no Python. Patch coverage over a zero-Python diff returns "No lines with coverage" and passes vacuously, so it would be evidence of nothing here; the frontend tests are the instrument that applies.
- **I did not touch the two remaining candidate shapes in #1231** — the historical odds band from the delivery study's archived round data. That one needs the study's data to actually support a stable band, which I did not evaluate. This PR deliberately takes only the wording fix; if the band is still wanted, it wants its own issue and its own evidence.
- I did not change any server-side odds computation. `_odds_day` and the round-stats staleness rule are untouched.

## Over-engineering pass (done by hand, on merits)

Findings, both addressed above rather than left as notes:

1. **The wording was wrong for one of the two enabled sub-cases.** I had written "after first sync"; re-reading `build_xvb_calc` showed `round_types` is also emptied on a STALE cache, so that sentence would be false for a box that had synced and gone stale. Changed to `awaiting sync`, which is true in both. This is the finding the pass was worth doing for.
2. **Three prose claims that the column "stays empty"** were falsified by the change itself and would have shipped stale. Swept — listed above.
3. Considered and rejected: distinguishing the stale case using `estimates_stale`. That field describes the reward-estimates cache, a *different* cache from round stats; using it would conflate two sources to manufacture a distinction the payload does not actually publish.
4. `oddsPending` / `oddsTitle` / `oddsPendingTitle` are computed once per render, not per row — they do not vary per tier.

The gate itself verifies nothing (its skill does not load in this environment); this pass was done on merits, and the gate cleared on the identical retry.

## Budget

`xvbview.test.mjs` carries a 431-line ceiling and sat at exactly 431. Both pinned assertions were replaced **in place**, one line for one line — the file is still 431 records (the gate counts by record, not `wc -l`). The new test file is 151 lines, under the 400-line target, so it correctly carries **no** tsv row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzwiryicFnQLeDsE7RJ9Ln
