### PR TITLE
fix(ci): #1419 the weekly link check can signal again

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check links in Markdown
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: "--no-progress './**/*.md'"
+          args: "--no-progress --exclude-path docs/research/xvb-delivery-study/data/sources './**/*.md'"
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # higher github.com rate limit for repo links

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -354,7 +354,7 @@ the latest RigForge release itself — the per-worker twin of the stack's one-cl
 The rig side must opt in: RigForge's `control_upgrade` capability (default off, on top of its
 `control` flag, bearer token, and source pin) and RigForge **v1.11.2 or newer** — earlier versions
 refuse legitimate upgrades on a fresh clone. See
-[RigForge › ADR 0002](https://github.com/p2pool-starter-stack/rigforge/blob/main/docs/adr/0002-remote-upgrade.md)
+[RigForge › ADR 0002](https://github.com/p2pool-starter-stack/rigforge/blob/main/docs/adr/0002-remote-worker-upgrade.md)
 for the rig's own guard chain (monotonic version, tag must be an ancestor of `main`, rollback when
 the miner doesn't come back live, and a six-hour throttle between attempts).
 


### PR DESCRIPTION

## Design-scrutiny pass (over-engineering)

Done by hand on this diff, which is two changed lines.

- **Simplest mechanism that works?** Yes. The alternatives are worse: URL-regex exclusions in `.lycheeignore` would need roughly seven patterns and would mask the same dead hosts *everywhere else in the repo*, and the input glob cannot be negated. `--exclude-path` is lychee's own path mechanism and is the narrowest of the three.
- **Anything speculative added?** No new files, no new config surface, no abstraction, no options nobody asked for.
- **One real finding, accepted rather than fixed:** the exclusion is a *tree*, so a first-party doc later added under `data/sources/` would go silently unchecked. That is the correct trade today — everything in that directory is vendored by construction, and `MANIFEST.md` says so — but it is a scope the next person should know is broad. Narrowing it to a per-file list would break the moment the study vendors another source, which is the more likely failure.
