### PR TITLE
fix(ci): #1419 the develop-v2 twin of the link-check restore

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check links in Markdown
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: "--no-progress './**/*.md'"
+          args: "--no-progress --exclude-path docs/research/xvb-delivery-study/data/sources './**/*.md'"
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # higher github.com rate limit for repo links

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -8,3 +8,7 @@ https?://example\.(com|org).*
 # gitlab.torproject.org returns 403 to non-browser clients (the link is valid — verified by hand
 # 2026-07). Ignore the host, not a global --accept 403 that would mask real dead links. #415.
 https://gitlab\.torproject\.org.*
+# The appliance's own mDNS hostname, used in docs as the address you browse to after flashing.
+# Resolvable only on the appliance's LAN, never from CI — same class as the localhost entries
+# above, not a dead link. #1419.
+https?://pithead\.local.*

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -365,7 +365,7 @@ the latest RigForge release itself — the per-worker twin of the stack's one-cl
 The rig side must opt in: RigForge's `control_upgrade` capability (default off, on top of its
 `control` flag, bearer token, and source pin) and RigForge **v1.11.2 or newer** — earlier versions
 refuse legitimate upgrades on a fresh clone. See
-[RigForge › ADR 0002](https://github.com/p2pool-starter-stack/rigforge/blob/main/docs/adr/0002-remote-upgrade.md)
+[RigForge › ADR 0002](https://github.com/p2pool-starter-stack/rigforge/blob/main/docs/adr/0002-remote-worker-upgrade.md)
 for the rig's own guard chain (monotonic version, tag must be an ancestor of `main`, rollback when
 the miner doesn't come back live, and a six-hour throttle between attempts).
 


### PR DESCRIPTION
- **The `.lycheeignore` addition, checked on the same terms:** it is one anchored URL pattern beside three of identical shape that already sit there, not a new mechanism. The alternative — making `pithead.local` resolve, or dropping it from the docs — would damage the doc to satisfy a link checker, which is the wrong direction.
