### PR TITLE
fix(tests): #1705 a tests/stack sandbox is built through one fail-closed constructor, never a bare mktemp assignment

### DIFF
--- a/tests/integration/selftest-stack-sandbox.sh
+++ b/tests/integration/selftest-stack-sandbox.sh
@@ -136,5 +136,38 @@ else
 fi
 
 echo ""
+echo "== every tests/stack sandbox is built through mk_tmpdir, not a bare assignment (#1705) =="
+
+# The constructor is only half the fix. The other half is that the call sites in the domain files
+# actually reach it, and a list of the converted names would rot on the next file added. So this
+# is the invariant instead: in the files #1705 covered, `mktemp -d` may appear only inside a
+# guarded expression, never as a bare `VAR=$(mktemp -d)` whose failure leaves VAR set-but-empty
+# for a later `rm -rf "$VAR/store"` to expand against /store.
+#
+# tests/stack/run.sh and the standalone tests/stack/test_*.sh are NOT covered and still carry the
+# old form. They belong to other lanes, so #1705's conversion stopped at the grant boundary. They
+# are excluded by name rather than by silence, so that this row says what it does not check.
+BARE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\(mktemp -d\)"?[[:space:]]*$'
+STACK_DIR="$HERE/../stack"
+
+# The pattern must be shown able to match before its absence anywhere means anything.
+CTRL="$TMP/bare-control.sh"
+printf 'RSB=$(mktemp -d)\nrm -rf "$RSB/store"\n' >"$CTRL"
+if grep -Eq "$BARE" "$CTRL"; then
+    it_pass "the bare-assignment pattern matches the pre-fix form (control arms)"
+else
+    it_fail "the bare-assignment pattern matches the pre-fix form" \
+        "it matched nothing, so the absence checked below proves nothing"
+fi
+
+found=$(grep -El "$BARE" "$STACK_DIR/lib.sh" "$STACK_DIR"/test-*.sh 2>/dev/null | tr '\n' ' ')
+if [ -z "$found" ]; then
+    it_pass "no bare mktemp -d assignment survives in lib.sh or the test-*.sh domain files"
+else
+    it_fail "no bare mktemp -d assignment survives in lib.sh or the test-*.sh domain files" \
+        "still bare in: $found"
+fi
+
+echo ""
 echo "selftest-stack-sandbox: $IT_PASS passed, $IT_FAIL failed"
 [ "$IT_FAIL" -eq 0 ] || exit 1

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -99,19 +99,35 @@ wait_while_alive() { # <pid> <check-fn-name>
     done
 }
 
+# mk_tmpdir <varname> — create a throwaway directory and ASSIGN IT BY NAME, or refuse the run.
+#
+# Assigning by name rather than printing is the whole point (#1705). The obvious constructor,
+# called as `X=$(mk_tmpdir)`, cannot fail closed: its `exit` ends only the command substitution's
+# subshell, the assignment still succeeds with X empty, and tests/stack/run.sh sets no `-e`, so
+# the run carries on. `set -u` does not fire either — the variable IS set, it is empty. A later
+# `rm -rf "$X/store"` then targets /store. Assigning through the caller's own shell is what puts
+# the refusal somewhere it can stop the run.
+mk_tmpdir() {
+    local _mk_d
+    _mk_d="$(mktemp -d)" && [ -d "$_mk_d" ] || {
+        printf 'lib.sh: mktemp -d did not create a directory for %s — refusing to run (#1705)\n' "$1" >&2
+        exit 1
+    }
+    printf -v "$1" '%s' "$_mk_d"
+}
+
 # A throwaway sandbox dir, cleaned on exit. Physical path (#695): pithead canonicalizes its
 # own directory with pwd -P, so a sandbox spelled through a symlink (macOS /var -> /private/var)
 # would render .env paths that no longer string-match the $SANDBOX-based assertions.
-# Fail closed if mktemp -d fails (#1661). It writes its diagnostic to stderr and prints NOTHING
-# on stdout, so the old one-liner collapsed to `cd "" && pwd -P` — and `cd ""` returns 0 without
-# moving, so SANDBOX became the directory the suite was invoked from (the repo root, per
-# tests/stack/run.sh's documented invocation) and the trap below armed rm -rf on the working tree.
-# Every downstream "$SANDBOX/..." still resolved, so nothing downstream could notice.
-_sbx="$(mktemp -d)"
-if [ ! -d "$_sbx" ]; then
-    printf 'lib.sh: mktemp -d did not create a sandbox — refusing to run (#1661)\n' >&2
-    exit 1
-fi
+# The refusal is mk_tmpdir's. #1661 built it inline here, against the one-liner that collapsed to
+# `cd "" && pwd -P` and armed the trap below on the working tree; #1705 made it the single
+# constructor so that recipe cannot drift between this file and the domain files.
+mk_tmpdir _sbx
+# mk_tmpdir assigns through `printf -v`, which shellcheck cannot follow, so it reads _sbx as
+# never assigned. The 38 call sites in the domain files are not flagged only because their names
+# are uppercase and shellcheck assumes those may come from the environment — so this directive
+# is narrower than it looks, and a lowercase name added later will need its own.
+# shellcheck disable=SC2154
 SANDBOX="$(cd "$_sbx" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 

--- a/tests/stack/test-appliance-boot.sh
+++ b/tests/stack/test-appliance-boot.sh
@@ -62,7 +62,7 @@ echo "== unit: load_baked_images — the archive digest, not the tag, decides a 
 # image it ever loaded. Both boot owners (pithead-boot and the first-boot wizard) run this ONE
 # loader; the digest record beside the store is what makes a keep-reinstall or A/B update
 # converge on the shipped containers.
-WSB=$(mktemp -d)
+mk_tmpdir WSB
 mkdir -p "$WSB/images" "$WSB/bin"
 printf 'v1-archive' >"$WSB/images/dashboard.tar.gz"
 cat >"$WSB/bin/podman" <<'EOF'
@@ -120,7 +120,7 @@ echo "== unit: load_baked_images — a store damaged by an interrupted write is 
 # guards above both pass and the reload was skipped — which is what made the damage permanent and
 # left an appliance unable to install from its own stick. A base layer carries no `lower` file at
 # all, so a zero-length one is damage, never a legitimate state.
-RSB=$(mktemp -d)
+mk_tmpdir RSB
 mkdir -p "$RSB/images" "$RSB/bin" "$RSB/data"
 printf 'archive' >"$RSB/images/dashboard.tar.gz"
 cat >"$RSB/bin/podman" <<'EOF'
@@ -174,7 +174,7 @@ echo "== unit: load_baked_images — a slow load narrates itself, a fast one sta
 # A rising elapsed count is what tells slow apart from stuck. The load stays in the FOREGROUND
 # and the heartbeat is the background job: polling a backgrounded load with `kill -0` would make
 # a fast load pay a full sleep, because a finished-but-unwaited child still answers.
-HSB=$(mktemp -d)
+mk_tmpdir HSB
 mkdir -p "$HSB/images" "$HSB/bin" "$HSB/data"
 printf 'archive' >"$HSB/images/dashboard.tar.gz"
 cat >"$HSB/bin/podman" <<'EOF'
@@ -489,7 +489,7 @@ echo "== unit: pithead-sync's rigforge leg — program replaced, state preserved
 # build cache) are state. The prebuilt binary seeds the workspace so the appliance never needs
 # RigForge's clone path — github over clearnet, unreachable from a Tor-only box.
 SYNCSCRIPT="$ROOT/os/overlay/pithead-sync"
-SSB=$(mktemp -d)
+mk_tmpdir SSB
 mkdir -p "$SSB/opt-pithead" "$SSB/opt-rigforge/util" "$SSB/opt-rigforge/prebuilt/xmrig/build"
 for f in pithead pithead-completion.bash VERSION docker-compose.yml \
     config.reference.json config.core-keys.json config.minimal.json cosign.pub; do

--- a/tests/stack/test-appliance-defaults.sh
+++ b/tests/stack/test-appliance-defaults.sh
@@ -32,7 +32,7 @@
 # reads either way.
 
 echo "== unit: preflight_remote_nodes dials before provisioning commits =="
-PFSB=$(mktemp -d)
+mk_tmpdir PFSB
 printf '{"monero":{"mode":"local"},"tari":{"mode":"local"}}' >"$PFSB/local.json"
 run_sourced "$PFSB" preflight_remote_nodes "$PFSB/local.json" >/dev/null 2>&1
 assert_rc "all-local config -> nothing to dial, rc 0" "$?" "0"
@@ -98,7 +98,7 @@ unset PFSB out PFZ_LIVE PFZ_HTTP PFZ_ZMTP2
 
 echo "== unit: appliance defaults (tor.auto_heal) =="
 # Applied only where ABSENT: an operator who wrote false meant it.
-ADSB=$(mktemp -d)
+mk_tmpdir ADSB
 printf '{"monero":{"wallet_address":"x"}}' >"$ADSB/config.json"
 PITHEAD_CONFIG_FILE="$ADSB/config.json" run_sourced "$ADSB" apply_appliance_defaults >/dev/null 2>&1
 assert_eq "absent auto_heal -> enabled" "$(jq -r '.tor.auto_heal' "$ADSB/config.json")" "true"

--- a/tests/stack/test-appliance-identity.sh
+++ b/tests/stack/test-appliance-identity.sh
@@ -143,7 +143,7 @@ echo "== unit: the dashboard certificate exists whenever the Caddyfile names it 
 # already held config.json) still gets a certificate: the Caddyfile named a file only the wizard
 # used to create, so Caddy answered :443 with no usable cert and the dashboard failed the TLS
 # handshake outright — a bench machine looked hung while serving a broken listener.
-TLSSB=$(mktemp -d)
+mk_tmpdir TLSSB
 export PITHEAD_TLS_DIR="$TLSSB/tls"
 fp1=$(run_sourced "$SANDBOX" appliance_mint_cert 2>/dev/null)
 [ -s "$TLSSB/tls/wizard.crt" ] && ok "mints a certificate on demand" || bad "mints a certificate on demand" "no crt"
@@ -165,7 +165,7 @@ echo "== unit: the certificate SAN list and Caddy's site list agree, for a given
 # different name lists any more.
 # MUTATION PROOF: hardcode site_hosts back to "$HOST_IP" in generate_caddyfile, or the old
 # unconditional alt= string back into appliance_mint_cert, and every scenario below goes red.
-NL=$(mktemp -d)
+mk_tmpdir NL
 export PITHEAD_TLS_DIR="$NL/tls"
 nl_render() { # sets $NL/Caddyfile and mints $NL/tls/wizard.crt for the given identity; prints the
     # canonical name list both consumers should agree on.
@@ -413,7 +413,7 @@ echo "== unit: the certificate re-mints when the served name list changes, not o
 # fingerprint loses that trust on every unnecessary replacement, so a re-mint must be conservative.
 # MUTATION PROOF: drop the comparison (always re-mint) -> "an unchanged list does not re-mint"
 # goes red. Drop the re-mint branch (never re-mint) -> "a changed list re-mints" goes red.
-RM=$(mktemp -d)
+mk_tmpdir RM
 export PITHEAD_TLS_DIR="$RM/tls"
 RM_IPS="192.168.1.20"
 rm_run() {
@@ -452,7 +452,7 @@ echo "== unit: stage_wizard_spool re-arms a wiped spool, so a retry keeps its TL
 # setup page (payout address, dashboard password, node secrets) in CLEARTEXT while the console
 # still advertised HTTPS and a fingerprint. MUTATION PROOF: stage once before the loop again and
 # "a wiped spool is fully re-armed" + "the retry can still serve TLS" go red.
-SWS=$(mktemp -d)
+mk_tmpdir SWS
 export PITHEAD_TLS_DIR="$SWS/tls"
 sws_fp=$(run_sourced "$ROOT" stage_wizard_spool "$SWS/spool" 2>/dev/null)
 assert_contains "staging prints the certificate fingerprint the console advertises" "$sws_fp" ":"

--- a/tests/stack/test-appliance-install.sh
+++ b/tests/stack/test-appliance-install.sh
@@ -49,7 +49,7 @@ echo "== unit: the installer gate outlasts a slow device probe =="
 # An empty FIRST inventory put a reinstall boot into setup mode (KVM keep leg): the gate runs
 # ~18s into boot and races udev settling the target's partitions. It now retries before giving
 # up — a probe that answers on the third try still opens the installer.
-IGSB=$(mktemp -d)
+mk_tmpdir IGSB
 cat >"$IGSB/fake-install" <<'FAKE'
 #!/usr/bin/env bash
 [ "$1" = "--list" ] || exit 0
@@ -76,7 +76,7 @@ unset IGSB igout
 
 echo "== unit: pre-seeding from the installation medium =="
 # The ESP is FAT and anyone can write it, so both readers treat its contents as input, not truth.
-PSD=$(mktemp -d)
+mk_tmpdir PSD
 export PITHEAD_PRESEED_DIR="$PSD"
 
 run_sourced "$SANDBOX" preseed_token >/dev/null 2>&1
@@ -122,7 +122,7 @@ echo "== unit: data_wipe_note / publish_data_wipe_note — the wipe note reader 
 # discriminates a deliberate factory-reset (the operator asked for it, nothing to warn about)
 # from the wedged-/data case, where the wizard's next-move advice differs: restore a backup,
 # don't set up as if this were a fresh machine.
-DWN=$(mktemp -d)
+mk_tmpdir DWN
 mkdir -p "$DWN/esp" "$DWN/spool"
 export PITHEAD_PRESEED_DIR="$DWN/esp"
 
@@ -199,7 +199,7 @@ echo "== unit: consume_install_request (disk installer host side) =="
 # The request file is operator input arriving through a web form; the host must validate it
 # against its own inventory and never trust a browser-supplied target. Driven against a fake
 # pithead-install via PITHEAD_INSTALL_BIN — the real one partitions disks.
-INSTSB=$(mktemp -d)
+mk_tmpdir INSTSB
 cat >"$INSTSB/fake-install" <<'FAKE'
 #!/usr/bin/env bash
 case "$1" in
@@ -264,7 +264,7 @@ echo "== unit: strip_config_secrets — no secret class survives the reinstall p
 # The strip runs before a previous install's config may be SHOWN on the setup page. Every
 # secret carries the same marker value, so one grep proves the whole list at once; the
 # non-secret answers (the point of the pre-fill) must all survive.
-SCS=$(mktemp -d)
+mk_tmpdir SCS
 cat >"$SCS/prev.json" <<'PREV'
 {
   "monero": {"wallet_address": "4KEEP-WALLET", "mode": "remote",
@@ -314,7 +314,7 @@ echo "== unit: prefill_from_previous_install — fail open, publish only the str
 # The orchestration around the strip: exactly one disk with an install, a read-only mount, and
 # every failure degrading to "no pre-fill" — never to a blocked install. mount/umount/lsblk are
 # PATH stubs; the fake mount copies a fixture tree under the mountpoint.
-PFSB=$(mktemp -d)
+mk_tmpdir PFSB
 mkdir -p "$PFSB/bin" "$PFSB/spool" "$PFSB/prev/pithead"
 printf '#!/bin/bash\necho "/dev/fake2 data"\n' >"$PFSB/bin/lsblk"
 cat >"$PFSB/bin/mount" <<'MNT'

--- a/tests/stack/test-appliance-kernel-boot.sh
+++ b/tests/stack/test-appliance-kernel-boot.sh
@@ -56,7 +56,7 @@ echo "== unit: optimize_kernel's HugePages write is grow-only =="
 # With a co-located miner the pool is shared and RigForge (grow-only by design) sizes it as the
 # single writer — pithead writing its absolute 3072 on top would shrink a grown pool to the
 # in-use floor and starve whichever side restarts next.
-OKSB=$(mktemp -d)
+mk_tmpdir OKSB
 mkdir -p "$OKSB/bin"
 printf '#!/usr/bin/env bash\necho "sudo:$*" >>"${OKLOG:?}"\n' >"$OKSB/bin/sudo"
 # OS_TYPE is readonly once sourced, so the Linux arm is selected the way pcr791 does it: a
@@ -114,7 +114,7 @@ unset OKSB
 # the old code running. The guard extracts the tarball's own opt/pithead/BUILD_COMMIT stamp and
 # compares it to the working tree, proven here with a fabricated fixture tarball (no image build).
 echo "== unit: os/rauc stale-tarball guard =="
-VTC_TMP=$(mktemp -d)
+mk_tmpdir VTC_TMP
 # The same commit+dirty-suffix computation verify_tarball_commit does, so the "match" fixture is
 # honest about the state of THIS working tree (it may itself be dirty mid-change).
 VTC_HEAD_SHA=$(cd "$ROOT" && git rev-parse HEAD)
@@ -125,7 +125,7 @@ VTC_HEAD="$VTC_HEAD_SHA"
 # $2=NONE fabricates a tarball with the directory but no stamp file (an old/broken build).
 mk_vtc_fixture() { # $1=out-path $2=stamp-content|NONE
     local d
-    d=$(mktemp -d)
+    mk_tmpdir d
     mkdir -p "$d/opt/pithead"
     [ "$2" = NONE ] || printf '%s\n' "$2" >"$d/opt/pithead/BUILD_COMMIT"
     tar -cf "$1" -C "$d" opt
@@ -203,12 +203,12 @@ assert_contains "the message names the floor field" "$out" "PITHEAD_MIN_OS_VERSI
 # image build. The guard is the safety fix: a dev cert must never become the fleet's update trust
 # root because a build host happened to have one lying around.
 RSM="$ROOT/os/rauc/populate-slot.sh"
-RSMTMP=$(mktemp -d)
+mk_tmpdir RSMTMP
 # Run the resolver in an isolated cwd (it writes os/rauc/certs/ relative to $PWD). $1=dev(0/1),
 # $2=where to send stderr. Prints: rc=<n> cert=<..> key=<..> keyring=<..>
 rsm() {
     local dev="$1" errto="$2" d
-    d=$(mktemp -d)
+    mk_tmpdir d
     (
         cd "$d" || exit
         # shellcheck disable=SC1090

--- a/tests/stack/test-appliance-os-update.sh
+++ b/tests/stack/test-appliance-os-update.sh
@@ -60,7 +60,7 @@ assert_rc "release -> release passes (the fleet's normal update)" "$?" "1"
 run_sourced "$SANDBOX" os_update_needs_confirmation unknown release
 assert_rc "unstamped system + release bundle passes — stays shell-less, no channel flips" "$?" "1"
 
-OUSB=$(mktemp -d)
+mk_tmpdir OUSB
 mkdir -p "$OUSB/bin"
 # A fake rauc: logs every call, answers `info` with a canned shell-format body —
 # the format the real os_bundle_meta parses (RAUC 1.11's JSON output omits [meta.*]). Two escape
@@ -193,7 +193,7 @@ echo "== integration: os-update surfaces rauc's own diagnosis instead of a bare 
 # tripped the ERR trap with nothing to show for it — three bare "aborted unexpectedly" lines and
 # no clue rauc had already diagnosed it precisely on its own stderr. Runs the REAL script as a
 # subprocess (not sourced) so the ERR trap this bug lives in is actually armed.
-OUB=$(mktemp -d)
+mk_tmpdir OUB
 mkdir -p "$OUB/bin"
 cp "$STACK" "$OUB/pithead"
 chmod +x "$OUB/pithead"

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -42,7 +42,7 @@ echo "== unit: publish_rig_defaults — host-side pool discovery, fail open (#79
 # The rig role's pre-fill: the HOST dials for a Pithead and publishes the finding to the spool
 # like the disk inventory. The dial is 'timeout N bash -c </dev/tcp/...' — timeout is a PATH
 # stub here (like mount in the pre-fill tests), so the probe answers deterministically.
-RDSB=$(mktemp -d)
+mk_tmpdir RDSB
 mkdir -p "$RDSB/bin" "$RDSB/spool"
 printf '#!/bin/bash\nexit 0\n' >"$RDSB/bin/timeout"
 chmod +x "$RDSB/bin/timeout"
@@ -59,7 +59,7 @@ rm -rf "$RDSB"
 unset RDSB
 
 echo "== unit: firstboot_consume_rig — the pool is dialed BEFORE anything irreversible (#797 R3) =="
-RCSB=$(mktemp -d)
+mk_tmpdir RCSB
 mkdir -p "$RCSB/bin" "$RCSB/spool"
 printf '#!/bin/bash\nexit 0\n' >"$RCSB/bin/timeout"
 chmod +x "$RCSB/bin/timeout"
@@ -95,7 +95,7 @@ rm -rf "$RCSB"
 unset RCSB
 
 echo "== unit: the machine-role marker, written and read back (#797 R3/R4) =="
-MRSB=$(mktemp -d)
+mk_tmpdir MRSB
 printf '{"local_miner":{"enabled":true}}' >"$MRSB/config.json"
 assert_eq "local_miner on -> both (the role IS the switch)" "$(run_sourced "$MRSB" machine_role_from_config "$MRSB/config.json")" "both"
 printf '{}' >"$MRSB/config.json"
@@ -115,7 +115,7 @@ echo "== unit: the rig boot leg — a role=rig machine mines instead of coordina
 # contract. Driven against a fake rigforge.sh, like the Both role's leg — the real one compiles
 # miners and tunes kernels. What this owns: the derived config (pool + worker + password), the
 # invocation contract, and the refusals.
-RIGL=$(mktemp -d)
+mk_tmpdir RIGL
 mkdir -p "$RIGL/rigforge" "$RIGL/bin" "$RIGL/run" "$RIGL/journal"
 cat >"$RIGL/rigforge/rigforge.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -199,8 +199,8 @@ echo "== unit: a rig's first boot mines — wizard side and staged-install side 
 # Both boots that ACCEPT a role end mining on that same boot: no second wizard, no reboot to
 # wait for. Every LATER boot skips this unit entirely (its condition now excludes rig.json) and
 # goes through pithead-boot instead.
-RPSB=$(mktemp -d)
-RPESP=$(mktemp -d)
+mk_tmpdir RPSB
+mk_tmpdir RPESP
 mkdir -p "$RPSB/rigforge"
 cat >"$RPSB/rigforge/rigforge.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -234,7 +234,7 @@ echo "== unit: render_local_miner_config — the built-in miner's config is DERI
 # rebuilt on every render like the Caddyfile: the stack's own stratum over loopback, the stratum
 # password when one is set, and the stack's HugePages budget declared as headroom — the hand-off
 # that makes RigForge the pool's single (grow-only) writer.
-LMR=$(mktemp -d)
+mk_tmpdir LMR
 mkdir -p "$LMR/rigforge"
 printf '{"local_miner":{"enabled":true}}' >"$LMR/config.json"
 printf 'STRATUM_PORT=3333\n' >"$LMR/.env"
@@ -285,7 +285,7 @@ echo "== unit: provision_local_miner — the boot leg converges the miner (#796)
 # Driven against a fake rigforge.sh: the real one compiles miners and tunes kernels. What this
 # owns: the invocation contract (appliance flag set, run from the tree on /data, config rendered
 # first) and both convergence directions (enabled -> setup, disabled -> stop).
-LMP=$(mktemp -d)
+mk_tmpdir LMP
 mkdir -p "$LMP/rigforge" "$LMP/bin"
 cat >"$LMP/rigforge/rigforge.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/stack/test-cli.sh
+++ b/tests/stack/test-cli.sh
@@ -134,7 +134,7 @@ assert_rc "rejects 254 chars, past the bound (#558)" "$?" "1"
 echo "== unit: first-run epilogue shows once after up (#384) =="
 # The "what happens next" onboarding note: prints on the first up in a fresh deploy dir, drops a
 # marker beside .env, and stays silent on every later restart.
-FR="$(mktemp -d)"
+mk_tmpdir FR
 out="$(run_sourced "$FR" print_first_run_epilogue 2>&1)"
 assert_contains "first-run: epilogue explains the sync-then-mine hold" "$out" "held until Monero and Tari finish their first sync"
 assert_eq "first-run: silent on the second up (marker respected)" \

--- a/tests/stack/test-dashboard-onion.sh
+++ b/tests/stack/test-dashboard-onion.sh
@@ -394,7 +394,7 @@ echo "== unit: dashboard_onion_status surfaces the onion URL for status/doctor (
 # reach-it hint ONLY when the onion is enabled AND provisioned, and NEVER the client private key.
 onion_env_dir() { # <enabled> <address> <client_auth> -> a dir whose .env carries those keys
     local d
-    d="$(mktemp -d)"
+    mk_tmpdir d
     {
         echo "DASHBOARD_ONION_ENABLED=$1"
         echo "DASHBOARD_ONION_ADDRESS=$2"

--- a/tests/stack/test-dashboard.sh
+++ b/tests/stack/test-dashboard.sh
@@ -509,7 +509,7 @@ echo "== unit: dashboard_sync_progress re-renders per-chain sync from /api/state
 # The one-curl re-render behind `pithead status`: read the dashboard's own /api/state (host-local,
 # no auth) and print per-chain progress, skipping synced chains and degrading quietly when the app
 # isn't up. Stub curl to serve a canned body — real jq parses it, matching the dashboard's shape.
-SP="$(mktemp -d)"
+mk_tmpdir SP
 mkdir -p "$SP/bin"
 cat >"$SP/bin/curl" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/stack/test-doctor-appliance.sh
+++ b/tests/stack/test-doctor-appliance.sh
@@ -76,7 +76,7 @@ echo "== unit: check_data_wipe_note — doctor surfaces the wipe note, a support
 # Same shape as the pre-seeding block: PITHEAD_PRESEED_DIR stands in for the ESP. Appliance-only
 # (the note only ever exists on that channel), so PITHEAD_APPLIANCE has to be forced on here —
 # tests run off the appliance.
-CDW=$(mktemp -d)
+mk_tmpdir CDW
 mkdir -p "$CDW/esp"
 export PITHEAD_PRESEED_DIR="$CDW/esp"
 

--- a/tests/stack/test-install-verify.sh
+++ b/tests/stack/test-install-verify.sh
@@ -49,7 +49,7 @@ echo "== unit: install.sh download verification fails CLOSED (#868) =="
 # extracted has already won — so a mismatch must install NOTHING. The stubs model each remote
 # artifact as a file served by basename; absent file = curl -f failure, exactly the shape the
 # script distinguishes (absent degrades politely, present-but-wrong is fatal).
-ISB=$(mktemp -d)
+mk_tmpdir ISB
 mkdir -p "$ISB/bin" "$ISB/srv" "$ISB/work"
 printf '#!/bin/bash\ncase "$1" in -s) echo Linux ;; -m) echo x86_64 ;; esac\n' >"$ISB/bin/uname"
 cat >"$ISB/bin/curl" <<'EOF'

--- a/tests/stack/test-release.sh
+++ b/tests/stack/test-release.sh
@@ -490,7 +490,7 @@ assert_contains "release.sh guards the bundle against xattr pax headers" \
 # Tar a file that carries an xattr where we can set one (macOS: xattr -w / Linux: setfattr; a
 # no-op elsewhere), and assert no LIBARCHIVE.xattr/SCHILY.xattr pax header survives — the exact
 # check release.sh runs. Reproduces #252 on macOS; a clean no-op on GNU tar.
-RELTMP="$(mktemp -d)"
+mk_tmpdir RELTMP
 mkdir -p "$RELTMP/pithead"
 echo hi >"$RELTMP/pithead/f"
 xattr -w com.test val "$RELTMP/pithead/f" 2>/dev/null ||

--- a/tests/stack/test-tor-network.sh
+++ b/tests/stack/test-tor-network.sh
@@ -645,7 +645,7 @@ assert_contains "doctor OK when p2pool IS routed over Tor (#273)" \
 TOR_ENTRY="$ROOT/build/tor/entrypoint.sh"
 tor_torrc() { # <DASHBOARD_ONION_ENABLED> [COMPOSE_PROFILES] -> the torrc the entrypoint would hand to `tor -f`
     local d
-    d="$(mktemp -d)"
+    mk_tmpdir d
     # The stub cats the SANDBOX path, not /tmp/torrc (#1104). That is what makes the TORRC_OUT seam
     # load-bearing: if the entrypoint ignored it and wrote the host-global file, this prints nothing
     # and every assertion below goes red. Catting /tmp/torrc instead would keep passing off a stale


### PR DESCRIPTION
Addresses #1705. No `Closes` keyword: PRs here merge to `develop-v2` while the default branch is `develop`, so it never fires. The issue is closed by hand on merge.

## What was wrong

`VAR=$(mktemp -d)` leaves `VAR` set-but-empty when `mktemp` fails. `tests/stack/run.sh` is `set -uo pipefail` with no `-e`, so a failed assignment does not abort the run, and `set -u` does not fire either, because the variable *is* set. A later `rm -rf "$VAR/store"` then expands against `/store`.

#1661 fixed the *composed* form in `tests/stack/lib.sh`, where the collapse was `cd ""`. This is the plain form, at the 38 remaining sites.

## The shape of the fix, which is the part worth reviewing

The constructor **assigns by name** rather than printing, and that is load-bearing rather than a style choice. The obvious helper, called as `X=$(mk_tmpdir)`, **cannot fail closed**: its `exit` ends only the command substitution's subshell, the assignment still succeeds with `X` empty, and the run carries on — the defect completely unchanged, now with a guard in front of it that reads as a fix. Assigning through the caller's own shell is what puts the refusal somewhere it can stop the run.

`lib.sh`'s own #1661 block now calls the same constructor, so the recipe cannot drift between that file and the domain files.

## Measured, with a control that fires

Proven on this box against the unfixed form, not argued:

| leg | expect | got |
|---|---|---|
| new form, failing `mktemp` shim | refuse | rc 1, names the variable, no `CONTINUED` line |
| same, the caller's seeded directory | intact | sentinel and nested file both survive |
| **old form, same shim — the control that must arm** | continue | rc 0, `X=[]`, `rm would target: [/store]` |
| new form, working `mktemp` | a real dir | rc 0, `ISDIR` |

The third row is the one that matters: without it the first two could be green because the shim never armed.

## Coverage

- The existing `tests/integration/selftest-stack-sandbox.sh` already pins the refusal and carries its own arming control, and it now exercises the shared constructor because `SANDBOX` is built through it. **7 of 7 pass unchanged after the refactor.**
- Added there: a **mechanical invariant** rather than a list of 38 names, which would rot on the next file added. A `mktemp -d` may appear only inside a guarded expression, never as a bare assignment. **Its pattern is proven able to match** against a reconstructed pre-fix line before its absence elsewhere is read as evidence. 9 of 9 pass.

## Scope, and what I did NOT convert

`tests/stack/run.sh` (3 sites) and `tests/stack/test_data_reset.sh` (1 site) still carry the old form. They are outside this lane's grant — `run.sh` is the appliance lane's live line. The invariant **excludes them by name rather than by silence**, so the row states what it does not check. Those 4 sites want a follow-up from whoever owns them.

## Placement

All 14 domain files are **exactly line-neutral** — the conversion is one-for-one, which matters because several sit at a zero-headroom ceiling. Only `lib.sh` (298 to 314) and the self-test (140 to 173) grow, and both are under the 400-line budget threshold, so neither needs a row. `make lint-file-budget` green against the staged index.

## Lint

`shellcheck --severity=warning` over `tests/stack/lib.sh tests/stack/test-*.sh os/overlay/pithead-boot` (the grouping the Makefile uses, so the pairing that suppresses the known SC2034s is preserved): **rc 0**. `shfmt -i 4 -d` over every changed file: clean.

One real finding came out of the first lint pass and is fixed rather than papered over: shellcheck cannot follow `printf -v`, so it read `_sbx` as never assigned. The directive that silences it carries the reason and says why it is narrower than it looks — the 38 uppercase call sites are unflagged only because shellcheck assumes uppercase names may come from the environment, so a lowercase one added later will need its own.

## The gap, stated rather than implied

**The full tier-1 `tests/stack/run.sh` suite was still running when I hit my context bar.** It was progressing normally with no failures in the first 1,684 lines. It is not a green I am claiming, and this should not merge until someone reads it. The log is at `stack-run.log` in this session's scratchpad, and the run is cheap to repeat.

## Over-engineering review of my own diff, with what I declined

Run off disk against the diff, not skipped.

**I did more than the issue asked, and here it is.** #1705 names roughly ten files and the sites with a downstream `rm -rf`. I converted **every** bare assignment in the granted files — 38 sites in 14 files — because the root cause is the unguarded assignment, not the `rm`. An empty variable also reaches `tar -C ""` and a `mkdir -p` under the filesystem root; keying the fix to one landing site would leave the class half-closed, and the next site would read as guarded when it is not.

**I refactored working, shipped code.** The #1661 block in `lib.sh` did not have to change. I changed it so there is one constructor rather than two copies of the same recipe, which is the duplication that drifts. The risk is real and the check is direct: that self-test passes 7 of 7 unchanged, including its own arming control.

**Declined — canonicalizing inside the constructor.** Making it do `pwd -P` would be more uniform, and the sandbox needs it for the macOS symlink reason #695 records. I left it out: it would change the path *value* at all 38 sites, and any assertion comparing a non-canonical path would move under it. Uniformity is not worth an unmeasured change at 38 sites in one PR.

**Declined — a sibling for the non-directory `mktemp`.** No evidence of the same hazard for that form here, so it would be a guard with no demonstrated case.

**Kept deliberately, though both are long for what they wrap:** the comment above the constructor, because the by-name shape is precisely what a later reader would "simplify" back into a command substitution and silently restore the defect; and the four lines on the lint directive, because they say why it is narrower than it looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVbsFVAnHPC5SrZtY6cRX3
