### PR TITLE
fix(build): #1722 build-pithead sets 0755 outright so macOS gets a FAIL, not a truncated self-test

### DIFF
--- a/scripts/build-pithead.sh
+++ b/scripts/build-pithead.sh
@@ -127,8 +127,8 @@ build() {
 
 write_artifact() {
     local tmp
-    # Build beside the artifact, then rename over it. Two reasons, and the mode is carried across
-    # explicitly so nothing is given up by not writing in place:
+    # Build beside the artifact, then rename over it. Two reasons, and the mode is set explicitly
+    # so nothing is given up by not writing in place:
     #
     #   - `cat >"$ARTIFACT"` truncates at OPEN time, before a single byte is written and whatever
     #     `set -e` does afterwards. A rebuild interrupted at that instant — Ctrl-C, a full disk, a
@@ -148,11 +148,9 @@ write_artifact() {
     # shellcheck disable=SC2064  # expand now: the trap must name THIS file, not whatever $tmp is later
     trap "rm -f -- '$tmp'" EXIT
     build >"$tmp"
-    if [ -e "$ARTIFACT" ]; then
-        chmod --reference="$ARTIFACT" "$tmp"
-    else
-        chmod 0755 "$tmp"
-    fi
+    # Always 0755: the artifact is tracked at that mode, an operator runs `./pithead`, release.sh
+    # bundles it as-is, and `chmod --reference` (carrying a mode across) is GNU-only — macOS refuses.
+    chmod 0755 "$tmp"
     mv -f "$tmp" "$ARTIFACT"
     echo "build-pithead: wrote $ARTIFACT from $(list_slices | wc -l | tr -d ' ') slice(s)."
 }
@@ -304,15 +302,16 @@ self_test() {
         rm -rf "$blank"
     done
 
-    # 8. A rebuild is idempotent and keeps the artifact's mode — an operator runs ./pithead.
+    # 8. A rebuild over an existing artifact exits 0 and leaves it executable — an operator runs
+    #    ./pithead. Guarded like every other case: unguarded, `set -e` aborted the whole self-test
+    #    here with both streams already redirected, so cases 9+ silently never ran (macOS, #1722).
     chmod 0755 "$tmp/pithead"
-    PITHEAD_BUILD_ROOT="$tmp" bash "${BASH_SOURCE[0]}" >/dev/null 2>&1
-    if [ -x "$tmp/pithead" ]; then
-        echo "  ok   — a rebuild preserves the artifact's executable bit"
-    else
-        echo "  FAIL — a rebuild dropped the artifact's executable bit"
-        fail=1
-    fi
+    rc=0
+    PITHEAD_BUILD_ROOT="$tmp" bash "${BASH_SOURCE[0]}" >/dev/null 2>&1 || rc=$?
+    _case "a rebuild over an existing artifact exits 0" 0 "$rc"
+    rc=0
+    [ -x "$tmp/pithead" ] || rc=1
+    _case "a rebuild preserves the artifact's executable bit" 0 "$rc"
 
     # 9. The slice order is LC_ALL=C LEXICAL, not numeric or version ordering. NO case above can
     #    see this: 00/10/99 sort identically under `sort` and `sort -V`, so a mutant that swapped


### PR DESCRIPTION
## The defect

`scripts/build-pithead.sh --self-test` truncated itself silently on macOS. Case 8 (the rebuild-keeps-the-executable-bit check) ran the build unguarded — no `|| rc=$?` — with both streams already sent to `/dev/null`. On macOS `write_artifact` reached `chmod --reference="$ARTIFACT"`, which BSD `chmod` does not have, the build exited 1, and `set -e` aborted the whole self-test right there: cases 9 onward never ran, no `FAIL` line, no `FAILED`/`passed` summary, and the only signal was a bare `rc=1` with the last printed line reading `ok`.

## What changed

- `write_artifact` sets `0755` outright. The artifact is tracked at that mode, an operator runs `./pithead`, and `release.sh` bundles it as-is — there was never a mode to carry across, and `chmod --reference` is GNU-only.
- Case 8 is guarded like every other case: the rebuild's rc is captured and asserted through `_case`, then the executable bit is asserted as its own case. A rebuild that fails now prints a `FAIL` line and the summary says `FAILED`, instead of the self-test stopping mid-list.

This is a guard, not a grep: with the GNU-only `chmod` put back (and case 8 left guarded) the self-test prints `FAIL — a rebuild over an existing artifact exits 0 (expected rc=0, got rc=1)`, ends with `build-pithead --self-test: FAILED`, and exits 1 — and it cannot be green if a consumer ignores the exit code, because the `FAIL` line and the summary are on stdout.

## Proof

All on this mac (Darwin 25.5.0, BSD chmod: `chmod --reference=/etc/hosts /dev/null` -> `chmod: illegal option -- -`), all in the worktree.

Repro on the unmodified `origin/develop-v2` script:

```
rc=0; bash scripts/build-pithead.sh --self-test >repro.txt 2>&1 || rc=$?; echo rc=$rc; wc -l repro.txt
```

-> `rc=1`, 8 lines; the last line printed is `  ok   — --check REFUSES a slice with a trailing blank line (the separator is the build's)` (case 7), no `FAIL` line, no `FAILED`/`passed` summary line.

On this branch:

- `--self-test` -> `rc=0`, 24 lines, `build-pithead --self-test: all cases passed` (all 23 cases print, including the two halves of case 8 and cases 9-12).
- `--check` -> `rc=0` (the committed artifact still matches the slices; nothing under `lib/pithead/` was touched).
- Mutant (GNU `chmod --reference` restored in `write_artifact`, case 8 guarded): `rc=1`, 24 lines, line 9 is the `FAIL` above, last line `build-pithead --self-test: FAILED`.

Refs #1722, #1463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
