### PR TITLE
fix(tests): #1723 the redact selftest classifies an array on its own account, so an array-borne secret cannot enter the schema unseen

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -98,9 +98,15 @@ The test box holds real synced nodes and real keys. Treat it as production-sensi
   reaches the 48-character form, and no bound reaches the emoji form at all.
   **The JSON rule is keyed on the field NAME, not the value, and that is forced**:
   a view key and a container digest are both 64 hex characters, so nothing in the value separates
-  them. **The name list is open, and one field is out of the FILTER's reach** — `notifications.ntfy.url`
+  them. **The name list is open, and three fields are out of the FILTER's reach** — `notifications.ntfy.url`
   is a capability URL whose key is the bare word `url`, which only its nesting separates from the
-  public `xvb.url`, and a line-wise filter cannot see nesting. That is a limit of the filter, not
+  public `xvb.url`, and a line-wise filter cannot see nesting. `notifications.webhooks[]` is the
+  same kind of URL one shape over: the rule needs the key's colon to be followed by the value's own
+  quote, and a JSON list puts a bracket in between. The list shape alone is enough to defeat it —
+  `webhook_urls` sits in the redactor's vocabulary, and a value written as `["…"]` under that very
+  key still comes through raw. `xvb.standby.source` is the third, and it is a plain name gap: the
+  masked-config pass treats it as a secret, and no suffix in either vocabulary carries the bare
+  word `source`. That is a limit of the filter, not
   of the bundle: since [#1630](https://github.com/p2pool-starter-stack/pithead/issues/1630) the
   `config.json` artifact is masked BY PATH before it reaches the filter (*Artifacts & triage*
   below), so the topic does not survive a capture. The self-test states the filter's gap rather
@@ -755,7 +761,13 @@ than that a `<redacted>` marker appeared, since a marker can come from some othe
 same line. Its JSON population is derived from `config.reference.json` rather than
 listed in the file, under a screen deliberately wider than the redactor's own list, so a sensitive
 field added to the schema fails the test by name until someone classifies it as redacted or as a
-stated survivor. It also guards the other direction: a sha256 digest, a non-secret flag value, the
+stated survivor. Arrays are classified on their own account rather than by name
+([#1723](https://github.com/p2pool-starter-stack/pithead/issues/1723)): an empty list yields no
+element for the screen to read, and a list element's path ends in `[]`, which no suffix rule can
+match, so all four of the schema's arrays sat outside that guarantee — three of them carrying
+secrets the masked-config pass covers by path. Checking that pass's own path list against this
+file's classification is what turned up `xvb.standby.source`, which the screen now reaches; the
+check itself is not yet mechanical here. It also guards the other direction: a sha256 digest, a non-secret flag value, the
 reserved IP ranges and a HAProxy timestamp must survive, because an artifact with its image pins or
 its port map stripped is useless for the triage it exists for. That timestamp is not a hypothetical
 near-miss: HAProxy's `DD/Mon/YYYY:HH:MM:SS` reads as an IPv6 address, because a four-digit year

--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -133,7 +133,8 @@ structurally cannot.
 - Secrets: never print tokens, creds, or onions. The harness redacts artifacts and hashes secrets
   on the box. If you add a secret-bearing field to `config.reference.json`,
   `tests/integration/selftest-redact.sh` fails until you classify it — either `redact()` covers it,
-  or the file records why it is safe to keep.
+  or the file records why it is safe to keep. An array you add is classified as an array, whether
+  or not the reference populates it.
 
 ## Gotchas learned on real hardware
 

--- a/tests/integration/selftest-redact-env.sh
+++ b/tests/integration/selftest-redact-env.sh
@@ -96,7 +96,7 @@ case "$OUT" in
 esac
 
 echo "== redact: the KEY=value over-redaction guard — debugging value must survive =="
-# The same four fields selftest-redact.sh pins as JSON survivors, in the spelling `.env` uses.
+# The scalar fields selftest-redact.sh pins as JSON survivors, in the spelling `.env` uses.
 # Holding the two syntaxes to one vocabulary means holding them to the same survivors too: a
 # bundle with its endpoints and routing ids stripped is useless for the triage it exists for.
 # `XVB_URL` is the sharp one — only `PING_URL` is in the vocabulary, so a bare `_URL` survives.

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -167,7 +167,9 @@ ssh.authorized_key healthchecks.ping_url telegram.bot_token notifications.ntfy.t
 #   xvb.url / xmrig_proxy.url  public service endpoints
 #   workers.api_auth           an auth MODE string ("token"/"none"), not a credential
 #   telegram.chat_id           a routing id, not a secret
-MUST_SURVIVE="xvb.url xmrig_proxy.url workers.api_auth telegram.chat_id"
+#   telegram.control.allowed_ids[]  routing ids, the same class as telegram.chat_id
+MUST_SURVIVE="xvb.url xmrig_proxy.url workers.api_auth telegram.chat_id
+telegram.control.allowed_ids[]"
 # ⛔ NOT a survivor on merit. `notifications.ntfy.url` IS a capability URL and ought to be
 # redacted; a line-wise filter cannot reach it, because the key is the bare word "url" and only
 # its NESTING distinguishes it from xvb.url. Asserted at its CURRENT behaviour so the gap is
@@ -186,7 +188,19 @@ MUST_SURVIVE="xvb.url xmrig_proxy.url workers.api_auth telegram.chat_id"
 # measured against config.reference.json it reaches nothing, which is why this pin stays. The
 # vocabulary entry is the price of the invariant, not evidence of coverage; this row is the
 # evidence, and it asserts the value is NOT reached.
-KNOWN_GAP="notifications.ntfy.url"
+# ⛔ `notifications.webhooks[]` is the SAME gap one shape over, invisible here until #1723: the
+# whole URL is the bearer secret (#848), redact() reaches no part of it, and the array ships empty
+# so no walk produced a path to classify. The bundle is covered as ntfy.url's is, by
+# render_masked_config's per-entry mask; this row measures the STREAM filter alone.
+# ⛔ `xvb.standby.source` is the third of these, and it is a NAME gap rather than a shape one:
+# `render_masked_config` masks it by path, redact() carries no suffix that reaches the bare word
+# `source`, and until #1723 widened the screen this file could not see it to say so.
+KNOWN_GAP="notifications.ntfy.url notifications.webhooks[] xvb.standby.source"
+# Arrays OF OBJECTS: not a gap in redact() but in what an EMPTY value document can say about a
+# schema. Their `.token` entries are masked by render_masked_config (#172, and the deprecated
+# fallback) and covered at tier 1 in tests/stack/test-worker-config.sh; populate either and
+# `.token` returns to the name rule through the screen above.
+ELEMENT_SHAPE_UNKNOWN="workers.list[] dashboard.workers[]"
 
 SENTINEL="S3nt1nelVALUE" # short, alphanumeric: reachable by the NAME rule and by no other
 SCREENED="$(
@@ -196,8 +210,17 @@ import json, re, sys
 # INVARIANT: this screen must be a SUPERSET of redact()'s JSON name list, or a field carrying
 # that suffix is never classified and the drift alarm above cannot fire for it. `wallet` is here
 # for exactly that reason — it is in redact() and is reachable by no other alternative.
+# `source` is here for xvb.standby.source, which CONTROL_SECRET_PATHS masks and no other
+# alternative reaches — found by cross-checking that list against this one (#1723).
 SCREEN = re.compile(r"(password|passwd|secret|token|login|username|user|key|wallet|address"
-                    r"|seed|mnemonic|credential|urls?|hash_b64|pw_fp|auth|_id)$")
+                    r"|seed|mnemonic|credential|urls?|hash_b64|pw_fp|auth|_id|source)$")
+
+
+# An ARRAY is classified on its own account, whatever its name and whether the reference
+# populates it (#1723). Two blind spots meet: an empty list yields no element to screen, and a
+# scalar element's path ends in "[]", which no `$`-anchored suffix can match. All four arrays in
+# the schema ship empty, three of them carrying secrets render_masked_config masks.
+ARRAY = object()
 
 
 def walk(node, path=""):
@@ -205,6 +228,7 @@ def walk(node, path=""):
         for k, v in node.items():
             yield from walk(v, f"{path}.{k}" if path else k)
     elif isinstance(node, list):
+        yield path + "[]", ARRAY
         for v in node:
             yield from walk(v, path + "[]")
     else:
@@ -212,7 +236,9 @@ def walk(node, path=""):
 
 
 for path, value in walk(json.load(open(sys.argv[1], encoding="utf-8"))):
-    if isinstance(value, str) and SCREEN.search(path.split(".")[-1]):
+    if value is ARRAY:
+        print(path)
+    elif isinstance(value, str) and SCREEN.search(path.split(".")[-1]):
         print(path)
 # The invariant above, MECHANICALLY (#1590): it shipped as a comment and was already false once,
 # at `wallet`. Both lists are READ OUT of lib.sh — a list restated here is the drift this asserts.
@@ -249,11 +275,22 @@ in_list() { # <field> <list>
 }
 
 for field in $SCREENED; do
-    key="${field##*.}"
-    out="$(printf '  "%s": "%s",\n' "$key" "$SENTINEL" | redact)"
-    if ! in_list "$field" "$MUST_REDACT $MUST_SURVIVE $KNOWN_GAP"; then
+    # Probe each field in the SHAPE the schema gives it — a scalar probe over an array field would
+    # measure a line the bundle never contains, which is a green row about nothing.
+    case "$field" in
+    *"[]")
+        key="${field%"[]"}"
+        key="${key##*.}"
+        out="$(printf '  "%s": ["%s"],\n' "$key" "$SENTINEL" | redact)"
+        ;;
+    *)
+        key="${field##*.}"
+        out="$(printf '  "%s": "%s",\n' "$key" "$SENTINEL" | redact)"
+        ;;
+    esac
+    if ! in_list "$field" "$MUST_REDACT $MUST_SURVIVE $KNOWN_GAP $ELEMENT_SHAPE_UNKNOWN"; then
         it_fail "config.reference.json field $field is classified" \
-            "new sensitive-looking field — add it to MUST_REDACT or MUST_SURVIVE with a reason"
+            "new sensitive-looking field or array — classify it, with a reason, in MUST_REDACT / MUST_SURVIVE / KNOWN_GAP / ELEMENT_SHAPE_UNKNOWN"
         continue
     fi
     if in_list "$field" "$MUST_REDACT"; then
@@ -266,12 +303,23 @@ for field in $SCREENED; do
     # The gap gets a label that cannot be misread as approval. A green row saying a secret-bearing
     # field "survives redaction" is exactly the confidence this file exists to refuse.
     if in_list "$field" "$KNOWN_GAP"; then
-        assert_contains "KNOWN GAP (#1630) — $field is NOT redacted by the STREAM filter" "$out" "$SENTINEL"
+        case "$field" in
+        *webhooks*) gap_ref="#848" ;;
+        *standby.source) gap_ref="#1723" ;;
+        *) gap_ref="#1630" ;;
+        esac
+        assert_contains "KNOWN GAP ($gap_ref) — $field is NOT redacted by the STREAM filter" "$out" "$SENTINEL"
+        continue
+    fi
+    # No assertion is possible against an empty object array, and a passing row here would read as
+    # coverage it does not have. The classification requirement above is what this list buys.
+    if in_list "$field" "$ELEMENT_SHAPE_UNKNOWN"; then
+        it_warn "NOT MEASURED (#1723): $field is an array of objects and the reference carries no element — its .token entries are covered by render_masked_config and by tier 1, not by this filter."
         continue
     fi
     assert_contains "$field survives redaction" "$out" "$SENTINEL"
 done
-it_warn "KNOWN GAP (#1630): $KNOWN_GAP is a capability URL that redact() cannot reach — nesting is invisible to a line-wise filter. Captured bundles are covered by the path-keyed pass in capture_artifacts, not by this filter."
+it_warn "KNOWN GAPS (#1630, #848, #1723): $KNOWN_GAP are values render_masked_config masks that redact() cannot reach — nesting, list position and a name no suffix carries are all invisible to a line-wise filter. Captured bundles are covered by the path-keyed pass in capture_artifacts, not by this filter."
 
 # A value containing an escaped quote must be replaced WHOLE. A pattern stopping at the first
 # quote would leave the tail behind, which is the partial-redaction failure this file exists for.


### PR DESCRIPTION
Closes nothing automatically — #1723 is closed by hand at merge, as this repo's PRs land on
`develop-v2` while the default branch is `develop`.

## What was wrong

`selftest-redact.sh` derives its classification population by walking `config.reference.json`'s
values, and promises in its own comment that "a sensitive field added to the schema later cannot
quietly go uncovered". That promise did not extend to anything inside an array, for two
independent reasons:

1. **An empty list yields no element to screen.** All four arrays in the schema ship empty, so not
   one of them reached the population.
2. **A list element's path ends in `[]`, which no `$`-anchored suffix rule can match** — so a
   scalar-element array is unclassifiable by name even when populated.

Three of those four arrays carry values `render_masked_config` masks by path:
`workers.list[].token` (#172), `dashboard.workers[].token`, and `notifications.webhooks[]` (#848).

**Severity is low and I want to be exact about it.** The behaviours are stated elsewhere —
`selftest-capture-config.sh:99` asserts the webhook gap, tier 1 covers the worker tokens and the
standby source. What was missing is the *drift alarm*: the only check that fires when an
unclassified sensitive field enters the schema, and so the only one that catches the next one. My
first framing on the issue overstated this; [corrected there](https://github.com/p2pool-starter-stack/pithead/issues/1723#issuecomment-5533464748).

## What was RUN

`selftest-redact.sh` **58 passed, 0 failed** (55 before this change). Every other integration
selftest, unchanged: `selftest.sh` 214/0, `selftest-skip-accounting.sh` 76/0 — that one matters,
since it fails a skip leaving through a bare `it_warn` and this change adds two —
`selftest-e2e-phases.sh` 80/0, `selftest-capture-config.sh` 8/0, `selftest-zmq-probe.sh` 69/0,
`selftest-redact-vocab.sh` 37/0, `selftest-redact-env.sh` 15/0, `selftest-redact-ip.sh` 21/0,
`selftest-rigforge-writable-keys.sh` 57/0, `selftest-abort-traps.sh` 55/0, and the remaining nine
all 0 failed.

`shellcheck -x` (0.11.0, the CI pin) rc 0; `shfmt -i 4 -d` over the Makefile's exact glob rc 0, no
diff; `make lint-md` 0 errors; `make lint-docs-voice` OK; `make lint-file-budget` OK, run after
`git add` since the ratchet is blind to untracked files. `make lint-sh` was NOT run — it is the
serialized OOM path on this box; the targeted shellcheck + full-glob shfmt above is the sanctioned
substitute.

### Mutation battery — every new row shown able to fail

| mutation | expected | observed |
|---|---|---|
| drop `notifications.webhooks[]` from `KNOWN_GAP` | classification alarm fires | ✗ `field notifications.webhooks[] is classified` — 56/1 |
| add a NEW array `notifications.webhook_urls` to the schema, **this commit** | fails as unclassified | ✗ `field notifications.webhook_urls[] is classified` — 57/1 |
| the same schema, **parent commit** | silent — the defect | 55 passed, **0 failed** |
| give `redact()` an array-aware `webhooks` arm | the KNOWN GAP row reds | ✗ `KNOWN GAP (#848)` — 56/1 |
| give `redact()` an `allowed_ids` arm | the survivor row reds | ✗ `telegram.control.allowed_ids[] survives redaction` — 56/1 |
| give `redact()` a `source` arm | the KNOWN GAP row reds | ✗ `KNOWN GAP (#1723)` — 57/1 |
| drop `xvb.standby.source` from `KNOWN_GAP` | classification alarm fires | ✗ `field xvb.standby.source is classified` — 57/1 |
| remove the `ARRAY` yield from the walk | the four array rows disappear | back to 55/0 |

Each mutation was proven to have changed the file on disk (`git diff --numstat`) before its run —
two anchors in an earlier draft of this battery silently did not match, and the legs still printed
a plausible count.

The discriminating pair is rows 2 and 3: identical mutated schema, one commit apart, under a key
ending in `urls` — a word the screen explicitly carries. It is invisible only because it is a list
element.

There is also a control worth keeping in view: `"webhook_urls": "…"` redacts, and
`"webhook_urls": ["…"]` under that very same key comes through raw. The list shape alone defeats
the filter, independent of the name.

## Disclosures

**More than the issue asked for, deliberately.** Cross-checking the product's own
`CONTROL_SECRET_PATHS` against this file's lists turned up a third unclassified secret by a
different mechanism: `xvb.standby.source`. The masked-config pass treats it as a secret,
`redact()` carries no suffix reaching the bare word `source`, and the screen could not see it to
say so. The screen now carries `source`; **measured**, that widening reaches exactly one field and
no other. Leaving a known product-secret unclassified while editing this exact machinery was not
defensible. The cross-check is 12/12 after this change and 11/12 before it.

**Shared files.** `docs/dev/integration-testing.md` and `docs/dev/testing-guide.md` under
`_shared.paths`: the first said one field is out of the filter's reach and now says three; both
stated the drift guarantee without its array exception. `selftest-redact-env.sh`'s comment said
"the same four fields" are pinned as JSON survivors, which this change makes five.

**Line budget.** `selftest-redact.sh` goes 337 → 385 against `lint-file-budget`'s 400-line target,
so it still takes no budget row — 15 lines of headroom. That file is deliberately kept under the
target by splitting (`selftest-redact-vocab.sh`, `-env.sh`, `-ip.sh` all exist for this reason);
whoever needs the next 25 lines should split rather than raise.

## Findings I declined, and why

- **The lists are not proven disjoint.** A field in two of the four gets the first branch's
  treatment silently. Pre-existing — `MUST_REDACT` already won over `MUST_SURVIVE` this way — and
  my change adds a fourth list, so it is one degree worse. Mitigated rather than fixed: the new
  list is checked LAST, so it can never override an assertion a stronger list would have made. A
  real fix is a disjointness assertion, which is machinery this PR does not need.
- **`ELEMENT_SHAPE_UNKNOWN` asserts nothing.** For an array of objects an empty reference document
  carries no element shape, so there is nothing honest to assert; a passing row would read as
  coverage it does not have. The list buys the classification *requirement*, not a measurement,
  and the warn says `NOT MEASURED` in those words. Worth watching that it does not become a
  dumping ground.
- **The closing `it_warn` interpolates the static `$KNOWN_GAP` list**, so if someone removes the
  array yield the warning names a row that no longer runs. Visible in the last battery row.
  Pre-existing shape; not worth machinery.
- **Comment volume against a hard ceiling** — the one thing the over-engineering pass acted on.
  This file's house style is heavily commented and the reasons are load-bearing, but 20 added
  comment lines against 15 remaining lines of headroom is the wrong trade. Cut back by 2 lines
  where the prose restated the code rather than explaining it. The `gap_ref` case (4 lines, to put
  an issue number in the row label) survived the pass as the most optional thing still in the
  diff.
- **The cross-check that found `xvb.standby.source` is not mechanical.** It should be: nothing
  today asserts that every `CONTROL_SECRET_PATHS` entry is classified in this file. Filing
  separately rather than growing this file into its remaining headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVbsFVAnHPC5SrZtY6cRX3
