### PR TITLE
fix(tests): #1679 selftest-mergemine-probe.sh defines its stubs inside the subshell that calls them, so no call precedes a definition

### DIFF
--- a/tests/integration/selftest-mergemine-probe.sh
+++ b/tests/integration/selftest-mergemine-probe.sh
@@ -168,26 +168,33 @@ unset -f rx
 
 echo "== the leg reports PASS, FAIL or a COUNTED skip — never a silent green =="
 
-# The leg is driven with its two collaborators stubbed, so all three outcomes are reachable
-# without a stack. Stubbing is what makes the skip path testable at all: on the boxes this
-# harness runs on monerod IS synced, so that branch would otherwise never be exercised here.
-monero_caught_up() { return "$MM_STUB_SYNCED"; }
-# The sentinel matters. `mm_capture_startup` has TWO distinct empty outcomes in production and
-# the leg treats them differently: it returns non-zero when the container's start time cannot be
-# read at all, and returns ZERO with empty output when the log simply held no MergeMiningClientTari
-# line (its `grep` is `|| true`). A stub keyed only on emptiness collapses them, and the case
-# named for the second silently exercises the first — which is how the `absent` branch survived a
-# mutation to `it_pass` here.
-mm_capture_startup() {
-    [ "$MM_STUB_CAPTURE" = "@FAIL" ] && return 1
-    printf '%s' "$MM_STUB_CAPTURE"
-}
-
-# Run the leg in a SUBSHELL with the harness counters zeroed, and report them as a line. Three
-# of the four cases below provoke a leg FAILURE on purpose; left in this file's own totals they
-# would make a working self-test report red, which is how a suite learns to be read past.
+# Run the leg in a SUBSHELL with its two collaborators stubbed and the harness counters zeroed,
+# and report the counters as a line. Three of the four cases below provoke a leg FAILURE on
+# purpose; left in this file's own totals they would make a working self-test report red, which
+# is how a suite learns to be read past.
+#
+# The stubs live INSIDE the subshell, not at the top level of this file. The capture section
+# above calls the REAL `mm_capture_startup`, so a top-level stub of the same name has to come
+# after those calls — and shellcheck 0.9.0 reads a call that precedes a same-file definition as
+# use-before-definition (SC2218), which is what stopped the #1653 release rehearsal (#1679).
+# Scoping the stubs to the subshell is the same behaviour: nothing outside it ever called them.
 mm_leg_outcome() { # <synced-rc> <capture> -> "<pass> <fail> <skipped-legs> <by-design> <names>"
     (
+        # The leg is driven with its two collaborators stubbed, so all three outcomes are
+        # reachable without a stack. Stubbing is what makes the skip path testable at all: on the
+        # boxes this harness runs on monerod IS synced, so that branch would otherwise never be
+        # exercised here.
+        monero_caught_up() { return "$MM_STUB_SYNCED"; }
+        # The sentinel matters. `mm_capture_startup` has TWO distinct empty outcomes in production
+        # and the leg treats them differently: it returns non-zero when the container's start time
+        # cannot be read at all, and returns ZERO with empty output when the log simply held no
+        # MergeMiningClientTari line (its `grep` is `|| true`). A stub keyed only on emptiness
+        # collapses them, and the case named for the second silently exercises the first — which
+        # is how the `absent` branch survived a mutation to `it_pass` here.
+        mm_capture_startup() {
+            [ "$MM_STUB_CAPTURE" = "@FAIL" ] && return 1
+            printf '%s' "$MM_STUB_CAPTURE"
+        }
         MM_STUB_SYNCED="$1"
         MM_STUB_CAPTURE="$2"
         IT_PASS=0 IT_FAIL=0 IT_SKIPPED_LEGS=0 IT_SKIPPED_BY_DESIGN=0 IT_SKIPPED_MISSING=0 IT_SKIPPED_NAMES=""


### PR DESCRIPTION
## What changed

`tests/integration/selftest-mergemine-probe.sh` defined its two stubs — `monero_caught_up` and `mm_capture_startup` — at the **top level** of the file, textually after the case at `:159` that deliberately calls the **production** `mm_capture_startup`. Both definitions move inside the subshell in `mm_leg_outcome()`, which is the only place that ever called them.

One file. No behaviour change: nothing outside that subshell ever used the stubs, so scoping them to it is the same program.

## Why — structure, not a gate fix

**This does not fix a red gate, and selling it as one would be false.** `make lint-sh` at the pinned shellcheck was never red on this file.

Measured on both revisions over `tests/integration/*.sh`, so that the sourced provider — `mergemine-probe.sh`, which defines `mm_capture_startup` — is named on the same command line and the `# shellcheck source=` directive actually resolves:

| tree | shellcheck 0.9.0 | shellcheck 0.11.0 (the pin) |
|---|---|---|
| merge-base `48e0546d` | **1 finding — SC2218 at `:159`**, rc 1 | 0 findings, rc 0 |
| head `db55524a` | 0 findings, rc 0 | 0 findings, rc 0 |

The non-author reviewer reproduced this independently with a different invocation and `-f gcc` output, landing on the same single hit at the same line, and corrected an inherited figure of two down to one (comment 5533529493). Two measurements, two invocations, one answer.

That invocation shape is load-bearing and worth stating, because getting it wrong manufactures findings: running this file **alone** additionally reports `SC2034 IT_SKIPPED_MISSING appears unused`, which does not exist under `make lint-sh` — the reader lives in `lib.sh`, and shellcheck only sees it when `lib.sh` is on the same command line.

So SC2218 here is a **distro-0.9.0-only** diagnostic, and a no-op for CI. `Makefile:52` pins `SHELLCHECK_VERSION := 0.11.0`, and `Makefile:72-75` makes `lint-sh` refuse any other version before it lints anything:

```
$ env PATH=/usr/bin:/bin make lint-sh
lint-sh: shellcheck 0.9.0 is not the pinned 0.11.0 — its findings are not this gate's.
lint-sh: install the pin (see docs/dev/release-server.md) or run the gate in CI.
```

The change is therefore hygiene for anyone running a distro shellcheck by hand — plus the argument that actually justifies it:

**The old ordering was load-bearing by accident.** The top-level stub *had* to sit textually after `:159`, or it would have captured that production call. Nothing recorded that constraint and nothing enforced it. Nesting the stubs in the subshell makes the separation structural, so a later edit that moves the stub block cannot silently re-point `:159` at a stub — which a green `40 passed, 0 failed` would not catch, because a stub there passes quietly. That is a stronger guarantee than the ordering it replaces, and it is the reason to take this change.

## That `:159` still reaches production — proven, not reasoned

Settled by the non-author reviewer with two aimed mutations on this head (comment 5533529493):

- **A** — production `mergemine-probe.sh:109`, `[ -n "$started" ] || return 1` -> `|| return 0`: kills only *an unreadable start time refuses the capture* (39 passed, 1 failed); every leg case stayed green.
- **B** — the subshell stub's `@FAIL` arm at `:195`: kills only a leg case (39 passed, 1 failed); the `:159` case stayed green.

Disjoint targets, one named kill each, zero bystanders, control `40 passed, 0 failed` either side, each edit verified landed and then restored. A says `:159` reaches the production function on this head; B says the leg section still gets the subshell stub. The pair rules out what a single mutation cannot — that both sites resolve to the same definition.

## What was NOT run

- **I did not run the suite on this head.** The `40 passed / 0 failed` control and both mutation legs are the reviewer's measurements, cited as theirs, not re-derived here.
- **No run of the Makefile's exact `lint-sh` file set under 0.9.0.** That verdict is unobservable through the gate by construction — it refuses 0.9.0 — and on this box that root is the historical OOM path. The table above is the `tests/integration/*.sh` set, run under a 6 G cap.
- One reading per cell, not a distribution.
- Nothing about macOS, `build-pithead.sh`, or `chmod --reference`. That is #1727's subject; its body sat on this PR in error until now, describing a diff this PR does not contain.