### PR TITLE
feat(ci): #1377 the develop-v2 twin of the scheduled-run watch

### DIFF
--- a/.github/workflows/scheduled-run-watch.yml
+++ b/.github/workflows/scheduled-run-watch.yml
@@ -1,0 +1,136 @@
+name: Scheduled-run watch
+
+# The Monday run of ci.yml IS the CVE sweep (#833, #1313). A scheduled run has no pull request, so
+# nothing draws a person to its result — and on 2026-08-17 `build-images` went red and nobody was
+# told for seven days (#1377). This watcher is that run's reader.
+#
+# ci.yml's own header currently justifies `build-images` having no reader with "the run reddening
+# in the Actions tab is its alert (the lychee.yml posture)". That justification does not survive
+# contact with lychee.yml: it was red for NINE consecutive Mondays (2026-06-29 to 2026-08-24, last
+# green 06-22) and nobody noticed, because a gate that is already red has no transition left to
+# make and so cannot signal a new break (#1419). A red tick is not a notification.
+#
+# WHY A WEEKLY REPORT AND NOT A FAILURE-TRIGGERED NOTICE. A notifier that speaks only on failure is
+# indistinguishable from one that has died — it is COMMON's "arrives by absence" shape, and it is
+# the same defect class this whole lane exists for. This one upserts its issue on EVERY run,
+# passing or failing, and stamps the last fully successful check, so silence is readable. That is
+# also why the report carries a history table: a single red says little, a streak says the gate has
+# stopped being an instrument.
+#
+# WHY NOT `workflow_run`, which is the obvious event-driven shape: zizmor's `dangerous-triggers`
+# audit rejects it at HIGH ("workflow_run is almost always used insecurely"), measured on a draft
+# against the pinned zizmor 1.25.2 that ci.yml runs. The repo has ZERO zizmor suppressions today
+# (`No findings to report`, measured on develop the same day), so taking that route would have made
+# this change the first security-audit mute in the tree — to save a cron slot, in a lane whose
+# standing rule is not to mute a scanner to clear a gate.
+#
+# WHY NOT A JOB INSIDE ci.yml. The reader ci.yml already has is `sweep-shipped-report`, whose
+# tracking issue is titled "Shipped-image CVE sweep" — and that title is also the upsert key, so it
+# cannot be widened without orphaning the issue and filing a duplicate. Filing a `build-images` red
+# under it would put a REBUILD finding inside the one report whose premise is that it scanned the
+# bytes users pulled, and would make its "Last fully successful sweep" stamp span two questions.
+# Separately, ci.yml is at 512 lines against a 513 ceiling on develop-v2, so a job there could not
+# be synced to the twin at all.
+#
+# This file lives on the DEFAULT branch on purpose: a `schedule:` is read from the default branch
+# only — pin-watch.yml's header carries the history of learning that the hard way (#1048, #1064,
+# #1146).
+on:
+  schedule:
+    # Mondays 08:00 UTC. THE ORDERING IS LOAD-BEARING, not tidiness: this job reports on the
+    # 05:00 sweep, so it must run after that sweep has FINISHED (ci.yml's own jobs are capped at
+    # 30 minutes each). Move this line earlier and the watch reads a run still in progress, which
+    # it correctly refuses as UNCHECKED — a self-inflicted red every Monday. It also sits after
+    # the 06:00 os-rootfs/lychee, 06:30 pin-watch and 07:00 trivyignore-watch slots so the whole
+    # Monday block stays in one readable order.
+    - cron: "0 8 * * 1"
+    # TEMPORARY PROOF SLOT (#1377), and it must be retired. The YAML existing proves nothing — a
+    # `schedule:` on the wrong branch is silent and reports green, which is the false-green trap
+    # this lane is repeatedly asked to prove against. So registration is proven the way #1257
+    # proved trivyignore-watch's: a near-term slot fires once, the `event=schedule` run is put on
+    # record, and then THIS LINE IS DELETED. Retire it in a follow-up PR that cites the run id.
+    - cron: "23 * * * *"
+  workflow_dispatch:
+
+# Least privilege (#282). `actions: read` is what lets the job read ci.yml's own run history — it
+# is a read of this repo's Actions metadata and nothing else. `issues: write` is the job's one
+# output: it never pushes, comments on a PR, or publishes.
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  scheduled-run-watch:
+    name: Report whether the Monday CVE sweep ran and passed
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Collect ci.yml's scheduled-run history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # NOT `set -e`: a lookup that could not run is a result to publish, not a reason to
+          # publish nothing. Every failure here lands as a missing or empty file, and the render
+          # script refuses on exactly that and says UNCHECKED — which is the reader's answer.
+          mkdir -p watch
+          gh run list --workflow ci.yml --event schedule \
+            --json databaseId,url,createdAt,status,conclusion --limit 20 >watch/runs.json
+          # The jobs of the newest run, so a failure can name WHICH job failed. Fetched
+          # unconditionally: deciding whether it is needed is the render script's job, and asking
+          # the question twice in two places is how the two answers drift.
+          id=$(jq -r 'sort_by(.createdAt) | reverse | .[0].databaseId // empty' watch/runs.json 2>/dev/null)
+          [ -n "$id" ] && gh run view "$id" --json jobs >watch/jobs.json
+          exit 0
+      - name: Render the report
+        id: report
+        run: |
+          set -uo pipefail
+          # The rc is carried to the last step rather than failing here, so a watch that could not
+          # do its job still publishes the fact that it could not — and still fails the run.
+          bash scripts/scheduled-run-watch.sh watch >report.md
+          rc=$?
+          # An empty report is itself a failure to report — never publish silence.
+          [ -s report.md ] || { echo "The scheduled-run watch produced no report at all — see the run log." >report.md; rc=1; }
+          echo "rc=$rc" >>"$GITHUB_OUTPUT"
+      - name: Publish it to the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC: ${{ steps.report.outputs.rc }}
+        run: |
+          set -Eeuo pipefail
+          # The title is the upsert key and it lives in the script, so there is exactly one
+          # spelling of it anywhere. A second spelling here would file a second issue on the very
+          # next run and then keep both stale.
+          TITLE="$(bash scripts/scheduled-run-watch.sh --title)"
+          body=$(cat report.md)
+          # Exact title match over the open list, NOT `--search`: the search index lags issue
+          # creation by minutes, so a search-based dedup files a second issue on the next run.
+          n=$(gh issue list --state open --limit 200 --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          # A run that could not do its job must not DELETE the "last fully successful" date —
+          # that date is the only thing separating "failed once this morning" from "has been dead
+          # for six weeks". Stamp it on success, carry it forward on failure (pin-watch pattern).
+          if [ "$RC" = "0" ]; then
+            body="$body"$'\n\n'"_Last fully successful check: $(date -u +%F)_"
+          elif [ -n "$n" ]; then
+            prev=$(gh issue view "$n" --json body --jq .body | grep -a "^_Last fully successful check:" || true)
+            if [ -n "$prev" ]; then
+              body="$body"$'\n\n'"$prev (this run could not complete)"
+            fi
+          fi
+          if [ -n "$n" ]; then
+            gh issue edit "$n" --body "$body"
+            echo "updated #$n"
+          else
+            gh issue create --title "$TITLE" --label infra --body "$body"
+          fi
+      - name: Fail the run if the watch could not do its job
+        if: steps.report.outputs.rc != '0'
+        run: |
+          echo "::error::the scheduled-run watch could not determine whether the Monday sweep passed — that run is UNCHECKED, not clean"
+          exit 1

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -60,6 +60,33 @@ A lookup that could not be made is reported as unchecked, never as current, and 
 report carries the date of the last fully successful check, so a watcher that has stopped looks
 different from one with nothing to say.
 
+## The Monday sweep, and who reads it
+
+CI runs a weekly CVE sweep on Mondays at 05:00 UTC from `develop`. It answers two questions with
+two jobs: `build-images` rebuilds every image from the branch and scans the rebuild, so a fixable
+CVE is caught before a cut; `sweep-shipped` scans the images already published, each tag resolved
+to a digest, so a CVE in the bytes users are running is caught after one.
+
+A scheduled run has no pull request, so nothing draws a person to its result. On 2026-08-17 the
+rebuild scan went red and nobody was told for seven days
+([#1377](https://github.com/p2pool-starter-stack/pithead/issues/1377)).
+[`scheduled-run-watch.yml`](../../.github/workflows/scheduled-run-watch.yml) is that run's reader:
+it runs at 08:00 the same morning, reads the sweep's own run history, and keeps one tracking issue
+up to date with the result and the six most recent scheduled runs. Six rows rather than one because
+a single red says little and a streak says the gate has stopped being an instrument — the weekly
+link check was red for nine consecutive Mondays before anyone noticed
+([#1419](https://github.com/p2pool-starter-stack/pithead/issues/1419)).
+
+It reports on every run, not only on failures. A notifier that speaks only when something breaks
+cannot be told apart from one that has died, so this one writes the issue whether the sweep passed
+or failed, and stamps the date of the last fully successful check. Its own run goes red only when
+the watch could not work out what happened: an unfinished sweep, a run history it could not read,
+and a failure whose jobs it could not name are all reported as unchecked, never as clean.
+
+What it does not cover is a scheduled run that never happens. GitHub drops scheduled runs under
+load, and a dropped run leaves no history to read, so the gap shows up to a person reading the
+table and to nothing else ([#1418](https://github.com/p2pool-starter-stack/pithead/issues/1418)).
+
 ## Published images: GHCR, single-tag model
 
 Images are published to GitHub Container Registry (`ghcr.io/p2pool-starter-stack/*`). Public

--- a/scripts/scheduled-run-watch.sh
+++ b/scripts/scheduled-run-watch.sh
@@ -79,12 +79,17 @@ usage() {
 
 # A conclusion as a table cell. `cancelled` and `timed_out` are NOT folded into failure: they mean
 # the sweep did not run to completion, which is a different thing from the sweep finding something,
-# and a reader deciding whether to cut a patch release needs to tell them apart.
+# and a reader deciding whether to cut a patch release needs to tell them apart — so the conclusion
+# is printed verbatim rather than bucketed.
+#
+# THE SAME RULE IS SPELLED TWICE: here, and in `render_history`'s jq, because one table is built in
+# bash and the other in jq. They had already drifted once (this said `**FAILED**` where jq said
+# `**failure**` for the same run), so the self-test below renders one run through BOTH and asserts
+# the cells are identical. Change one spelling and that assertion fails.
 conclusion_cell() {
     case "$1" in
     success) printf 'ok' ;;
-    failure) printf '**FAILED**' ;;
-    "") printf '**UNCHECKED** (no conclusion)' ;;
+    "") printf '**UNCHECKED**' ;;
     *) printf '**%s**' "$1" ;;
     esac
 }
@@ -174,7 +179,7 @@ render_history() {
     printf '## Recent scheduled runs\n\n'
     printf '| Run | Started | Result |\n|---|---|---|\n'
     printf '%s' "$1" | jq -r --argjson n "$HISTORY_ROWS" \
-        '.[:$n][] | "| [\(.databaseId)](\(.url)) | \(.createdAt) | \(if .conclusion == "success" then "ok" elif .conclusion == null or .conclusion == "" then "(no conclusion)" else "**" + .conclusion + "**" end) |"'
+        '.[:$n][] | "| [\(.databaseId)](\(.url)) | \(.createdAt) | \(if .conclusion == "success" then "ok" elif .conclusion == null or .conclusion == "" then "**UNCHECKED**" else "**" + .conclusion + "**" end) |"'
     printf '\n'
 }
 
@@ -247,7 +252,10 @@ if [ "${1:-}" = "--self-test" ]; then
     st "the failing job is named" "$(printf '%s' "$out" | grep -cF 'Build image (dashboard)')" "1"
     st "a passing job is not listed as failing" "$(printf '%s' "$out" | grep -cF '| `Shell tests` |')" "0"
     st "a SKIPPED job is not listed as failing" "$(printf '%s' "$out" | grep -cF '| `Lint` |')" "0"
-    st "the newest row is marked FAILED" "$(printf '%s' "$out" | grep -c '\*\*FAILED\*\*')" "1"
+    # The SAME run renders in both tables, one built in bash and one in jq. Asserting the count is
+    # 2 is what pins the two spellings together — it fails if either side drifts.
+    st "the failed run is marked in both tables, identically" \
+        "$(printf '%s' "$out" | grep -c '| \*\*failure\*\* |')" "2"
 
     # --- the refusals. Each is pinned on the ONE input only it rejects. ---
 

--- a/scripts/scheduled-run-watch.sh
+++ b/scripts/scheduled-run-watch.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+#
+# Scheduled-run watch (#1377).
+#
+# The Monday run of ci.yml IS the CVE sweep: `build-images` rebuilds every image and scans the
+# rebuild (#833), `sweep-shipped` scans the published digests (#1313). A scheduled run has no pull
+# request, so nothing draws a person to it — and on 2026-08-17 `build-images` went red and nobody
+# was told for seven days. This watcher is that run's reader.
+#
+# WHY IT IS NOT A JOB INSIDE ci.yml. Two reasons, both measured rather than assumed:
+#
+#   1. SUBJECT. The one reader ci.yml already has is `sweep-shipped-report`, and its tracking issue
+#      is titled "Shipped-image CVE sweep" — a title that is also the upsert key, so it cannot be
+#      widened without orphaning the existing issue and filing a duplicate on the next run. Filing
+#      a `build-images` red under it would put a finding about a REBUILD of the branch inside the
+#      one report whose whole premise is that it scanned the bytes users pulled, and would make its
+#      "Last fully successful sweep" stamp span two different questions.
+#   2. IT GENERALISES. `build-images` is the job that reddened, but it is not the only job that can.
+#      Watching the RUN covers every job the schedule reaches, including ones added later — the
+#      failure mode of a per-job reader is that it silently stops covering the thing it was named
+#      for.
+#
+# REPORT-ONLY, like its two siblings. A failed sweep is reported into a tracking issue rather than
+# reddening this run, because "the Monday sweep found a CVE" asks for a decision a person makes,
+# and because reddening a scheduled run is precisely the notification that was proven not to work.
+# This run goes red only when the WATCHER could not do its job.
+#
+# WHAT THIS SCRIPT IS. It does no lookups and touches no network. The workflow calls `gh` and
+# leaves two JSON files in a directory; this script reads them and renders the tracking-issue body.
+# Keeping the render out of the workflow is what makes it testable: `--self-test` drives the clean
+# path and every refusal below through fixtures, with no network and no gh. That matters more here
+# than usual, because the red path CANNOT be exercised live — staging it would mean making the
+# default branch's CI genuinely fail.
+#
+# INCOMPLETE IS NEVER CLEAN. Every refusal below exits 1 and says UNCHECKED rather than printing a
+# reassuring "no failures". A watcher with nothing to say and a watcher that has quietly died look
+# identical from the Actions tab.
+#
+#   - the directory is missing, or holds no runs file
+#   - the runs file cannot be parsed, or lists no scheduled run at all
+#   - the newest scheduled run has not finished, so nothing can be said about whether it passed
+#   - the newest scheduled run failed and its jobs file is missing, unparseable, or names no job
+#
+# NOT COVERED, deliberately, and filed as #1418: a scheduled run that never HAPPENS. This watcher
+# reads the runs it can see, so a dropped cron is invisible to it in exactly the way it is
+# invisible to everything else. The history table below is the human-readable half of that — a
+# reader can see the gap — but nothing here decides that a gap is too long.
+#
+# Usage:
+#   scripts/scheduled-run-watch.sh <dir>    Render the report for the JSON in <dir> on stdout.
+#                                           <dir>/runs.json  = gh run list --json ... (an array)
+#                                           <dir>/jobs.json  = gh run view --json jobs (an object)
+#                                           rc 1 if the watch could not do its job.
+#   scripts/scheduled-run-watch.sh --title  Print the tracking issue's title, nothing else.
+#   scripts/scheduled-run-watch.sh --self-test
+#                                           Drive the render and every refusal above through
+#                                           fixtures. No network, no gh.
+
+set -Eeuo pipefail
+
+# THE TITLE IS A CONSTANT AND MUST NEVER BE EDITED. The workflow upserts the tracking issue by
+# EXACT title match over the open issue list. Change this string and the next run silently files a
+# SECOND issue instead of updating the first, then keeps both — the old one frozen at whatever it
+# last said, which reads as a watch that found nothing new. Renaming the issue by hand in the web
+# UI breaks it the same way.
+WATCH_ISSUE_TITLE="Scheduled CI run watch (weekly report)"
+
+# How many past scheduled runs the history table prints. It exists to make a STREAK visible: the
+# second-order finding from #1419 is that a gate red for nine consecutive runs has no transition
+# left to make, so it can no longer signal a new break — and that is invisible in any report that
+# shows only the newest run.
+HISTORY_ROWS=6
+
+usage() {
+    sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# --- render helpers -----------------------------------------------------------------------------
+
+# A conclusion as a table cell. `cancelled` and `timed_out` are NOT folded into failure: they mean
+# the sweep did not run to completion, which is a different thing from the sweep finding something,
+# and a reader deciding whether to cut a patch release needs to tell them apart.
+conclusion_cell() {
+    case "$1" in
+    success) printf 'ok' ;;
+    failure) printf '**FAILED**' ;;
+    "") printf '**UNCHECKED** (no conclusion)' ;;
+    *) printf '**%s**' "$1" ;;
+    esac
+}
+
+render_report() {
+    local dir="$1" runs newest id url created status conclusion rc=0
+
+    printf 'The Monday run of `ci.yml` is the CVE sweep — `build-images` scans a rebuild of this\n'
+    printf 'branch (#833) and `sweep-shipped` scans the published digests (#1313). A scheduled run\n'
+    printf 'has no pull request, so nothing draws anyone to its red tick. This issue is its reader\n'
+    printf '(#1377); it is rewritten in place every week.\n\n'
+
+    if [ ! -d "$dir" ] || [ ! -s "$dir/runs.json" ]; then
+        printf 'UNCHECKED: no run history was collected, so this report cannot say whether the\n'
+        printf 'scheduled sweep ran, passed, or failed. See the run log.\n'
+        return 1
+    fi
+
+    # Sort here rather than trusting gh to return newest-first: the ordering is not part of the
+    # documented contract, and a report that names the wrong run as "newest" is worse than none.
+    runs="$(jq -c 'sort_by(.createdAt) | reverse' "$dir/runs.json" 2>/dev/null || true)"
+    if [ -z "$runs" ] || [ "$runs" = "null" ] || [ "$(printf '%s' "$runs" | jq -r 'length')" = "0" ]; then
+        printf 'UNCHECKED: the run history could not be parsed, or lists no scheduled run at all.\n'
+        printf 'A watcher that cannot see the runs it watches has not checked anything.\n'
+        return 1
+    fi
+
+    newest="$(printf '%s' "$runs" | jq -c '.[0]')"
+    id="$(printf '%s' "$newest" | jq -r '.databaseId // empty')"
+    url="$(printf '%s' "$newest" | jq -r '.url // empty')"
+    created="$(printf '%s' "$newest" | jq -r '.createdAt // empty')"
+    status="$(printf '%s' "$newest" | jq -r '.status // empty')"
+    conclusion="$(printf '%s' "$newest" | jq -r '.conclusion // empty')"
+
+    printf '## The most recent scheduled run\n\n'
+    printf '| Run | Started | Result |\n|---|---|---|\n'
+    printf '| [%s](%s) | %s | %s |\n\n' "$id" "$url" "$created" "$(conclusion_cell "$conclusion")"
+
+    if [ "$status" != "completed" ]; then
+        printf 'UNCHECKED: that run has not finished (`status: %s`), so nothing here says whether\n' "${status:-unknown}"
+        printf 'the sweep passed. An unfinished run is not a passing one.\n\n'
+        rc=1
+    elif [ "$conclusion" = "success" ]; then
+        printf 'The sweep completed and found nothing it had to report.\n\n'
+    else
+        # Called for its OUTPUT and its rc, so it must not be captured: `rc=$(render_failed_jobs)`
+        # assigns the rendered table to rc and drops it from the report — the table vanishes and
+        # the exit code becomes a string. Caught by the self-test below, never by reading.
+        render_failed_jobs "$dir" || rc=$?
+    fi
+
+    render_history "$runs"
+    return "$rc"
+}
+
+# The failed-job table for a run that did not succeed. Returns 1 when the jobs could not be read —
+# knowing the run failed while being unable to say WHICH job failed is a half-answer, and the
+# report must not present it as a whole one.
+render_failed_jobs() {
+    local dir="$1" failed count
+    if [ ! -s "$dir/jobs.json" ]; then
+        printf 'UNCHECKED: the run failed, but its job list was not collected — this report cannot\n'
+        printf 'name which job failed. See the run log.\n\n'
+        return 1
+    fi
+    failed="$(jq -r '[.jobs[]? | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != null)]' "$dir/jobs.json" 2>/dev/null || true)"
+    if [ -z "$failed" ] || [ "$failed" = "null" ]; then
+        printf 'UNCHECKED: the run failed, but its job list could not be parsed.\n\n'
+        return 1
+    fi
+    count="$(printf '%s' "$failed" | jq -r 'length')"
+    if [ "$count" = "0" ]; then
+        printf 'UNCHECKED: the run failed, but no failing job could be identified in its job list.\n'
+        printf 'The failure is real — something outside the jobs, or a job list read too early.\n\n'
+        return 1
+    fi
+    printf '## Jobs that did not pass\n\n'
+    printf '| Job | Result |\n|---|---|\n'
+    printf '%s' "$failed" | jq -r '.[] | "| `\(.name)` | \(.conclusion) |"'
+    printf '\n'
+    return 0
+}
+
+# The history table. A single red tells a reader almost nothing; a streak tells them the gate has
+# stopped being an instrument (#1419).
+render_history() {
+    printf '## Recent scheduled runs\n\n'
+    printf '| Run | Started | Result |\n|---|---|---|\n'
+    printf '%s' "$1" | jq -r --argjson n "$HISTORY_ROWS" \
+        '.[:$n][] | "| [\(.databaseId)](\(.url)) | \(.createdAt) | \(if .conclusion == "success" then "ok" elif .conclusion == null or .conclusion == "" then "(no conclusion)" else "**" + .conclusion + "**" end) |"'
+    printf '\n'
+}
+
+# --- entry points -------------------------------------------------------------------------------
+
+if [ "${1:-}" = "--title" ]; then
+    printf '%s\n' "$WATCH_ISSUE_TITLE"
+    exit 0
+fi
+
+if [ "${1:-}" = "--self-test" ]; then
+    st_fail=0
+    st() { # <label> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  self-test ok: $1"
+        else
+            echo "  self-test FAIL: $1 (got [$2], want [$3])"
+            st_fail=1
+        fi
+    }
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    # <dir> <conclusion-of-newest> [older-conclusions...]
+    runs_fixture() {
+        local dir="$1" i=0 c
+        shift
+        mkdir -p "$dir"
+        for c in "$@"; do
+            printf '{"databaseId":%d,"url":"https://x/%d","createdAt":"2026-08-%02dT05:00:00Z","status":"completed","conclusion":"%s"}\n' \
+                $((100 + i)) $((100 + i)) $((28 - i)) "$c"
+            i=$((i + 1))
+        done | jq -s '.' >"$dir/runs.json"
+    }
+    jobs_fixture() { # <dir> <name:conclusion>...
+        local dir="$1" spec
+        shift
+        for spec in "$@"; do
+            printf '{"name":"%s","conclusion":"%s"}\n' "${spec%%:*}" "${spec##*:}"
+        done | jq -s '{jobs: .}' >"$dir/jobs.json"
+    }
+
+    # The GREEN path has to be REACHABLE. A check that can only ever say "incomplete" is as
+    # useless as one that only ever says "clean".
+    # Eight runs against HISTORY_ROWS=6, so the cap is EXERCISED rather than merely configured. A
+    # fixture smaller than the cap can never tell a working limit from an absent one.
+    ok="$tmp/ok"
+    runs_fixture "$ok" success success success success success success success success
+    out="$(render_report "$ok")" && rc=0 || rc=$?
+    hist() { printf '%s' "$1" | sed -n '/## Recent scheduled runs/,$p' | grep -c '^| \['; }
+    st "a passing newest run exits 0" "$rc" "0"
+    st "a passing run says so" "$(printf '%s' "$out" | grep -c 'found nothing it had to report')" "1"
+    st "the history table is capped at HISTORY_ROWS" "$(hist "$out")" "$HISTORY_ROWS"
+    st "a clean report names no failing job" "$(printf '%s' "$out" | grep -c 'did not pass')" "0"
+
+    # A shorter history than the cap prints what exists, not a padded table.
+    short="$tmp/short"
+    runs_fixture "$short" success success
+    out="$(render_report "$short")" && rc=0 || rc=$?
+    st "a history shorter than the cap prints only the runs it has" "$(hist "$out")" "2"
+
+    # A failed run is REPORTED, not reddened: rc stays 0 because the WATCHER did its job. This is
+    # the assertion that separates this watcher from the red tick it exists to replace.
+    red="$tmp/red"
+    runs_fixture "$red" failure success success
+    jobs_fixture "$red" "Build image (dashboard):failure" "Shell tests:success" "Lint:skipped"
+    out="$(render_report "$red")" && rc=0 || rc=$?
+    st "a FAILED newest run still exits 0 — it is a finding, not a broken watcher" "$rc" "0"
+    st "the failing job is named" "$(printf '%s' "$out" | grep -cF 'Build image (dashboard)')" "1"
+    st "a passing job is not listed as failing" "$(printf '%s' "$out" | grep -cF '| `Shell tests` |')" "0"
+    st "a SKIPPED job is not listed as failing" "$(printf '%s' "$out" | grep -cF '| `Lint` |')" "0"
+    st "the newest row is marked FAILED" "$(printf '%s' "$out" | grep -c '\*\*FAILED\*\*')" "1"
+
+    # --- the refusals. Each is pinned on the ONE input only it rejects. ---
+
+    miss="$tmp/missing"
+    out="$(render_report "$miss")" && rc=0 || rc=$?
+    st "a missing directory fails" "$rc" "1"
+    st "a missing directory says UNCHECKED" "$(printf '%s' "$out" | grep -c UNCHECKED)" "1"
+
+    empty="$tmp/empty"
+    mkdir -p "$empty"
+    printf '[]\n' >"$empty/runs.json"
+    out="$(render_report "$empty")" && rc=0 || rc=$?
+    st "an empty run list fails" "$rc" "1"
+
+    bad="$tmp/bad"
+    mkdir -p "$bad"
+    printf 'not json at all\n' >"$bad/runs.json"
+    out="$(render_report "$bad")" && rc=0 || rc=$?
+    st "an unparseable run list fails" "$rc" "1"
+
+    # An unfinished run is the case a naive reader calls "not failed". It is UNCHECKED.
+    running="$tmp/running"
+    mkdir -p "$running"
+    printf '[{"databaseId":1,"url":"https://x/1","createdAt":"2026-08-31T05:00:00Z","status":"in_progress","conclusion":null}]\n' >"$running/runs.json"
+    out="$(render_report "$running")" && rc=0 || rc=$?
+    st "an unfinished newest run fails rather than reading as passing" "$rc" "1"
+    st "an unfinished run is not called a success" "$(printf '%s' "$out" | grep -c 'found nothing')" "0"
+
+    # Knowing a run failed but not WHICH job is a half-answer and must not read as a whole one.
+    nojobs="$tmp/nojobs"
+    runs_fixture "$nojobs" failure success
+    out="$(render_report "$nojobs")" && rc=0 || rc=$?
+    st "a failed run with no jobs file fails" "$rc" "1"
+
+    badjobs="$tmp/badjobs"
+    runs_fixture "$badjobs" failure success
+    printf 'nope\n' >"$badjobs/jobs.json"
+    out="$(render_report "$badjobs")" && rc=0 || rc=$?
+    st "a failed run with an unparseable jobs file fails" "$rc" "1"
+
+    nofail="$tmp/nofail"
+    runs_fixture "$nofail" failure success
+    jobs_fixture "$nofail" "Shell tests:success"
+    out="$(render_report "$nofail")" && rc=0 || rc=$?
+    st "a failed run whose jobs all passed fails rather than reporting nothing" "$rc" "1"
+
+    # Every case above calls render_report inside an `&&` list, where bash suppresses `set -e` for
+    # the whole dynamic extent of the call — so none of them can see an error-exit that only bites
+    # the way CI actually invokes this: bare, in its own process.
+    out="$(bash "${BASH_SOURCE[0]}" "$ok")" && rc=0 || rc=$?
+    st "the clean path survives a real subprocess invocation" "$rc" "0"
+    out="$(bash "${BASH_SOURCE[0]}" "$red")" && rc=0 || rc=$?
+    st "a reported failure survives a real subprocess invocation, still 0" "$rc" "0"
+    out="$(bash "${BASH_SOURCE[0]}" "$empty")" && rc=0 || rc=$?
+    st "a refusal still exits 1 from a real subprocess" "$rc" "1"
+
+    # The title is the upsert key; a change here silently files a second issue for ever.
+    st "--title prints the constant and nothing else" \
+        "$(bash "${BASH_SOURCE[0]}" --title)" "$WATCH_ISSUE_TITLE"
+
+    [ "$st_fail" = 0 ] && echo "scheduled-run-watch self-test OK"
+    exit "$st_fail"
+fi
+
+if [ $# -ne 1 ] || [ "${1:0:2}" = "--" ]; then
+    usage >&2
+    exit 2
+fi
+
+render_report "$1"

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -205,3 +205,11 @@ case "$vd_hb_out" in
 *) ok "the heartbeat PASS line carries no measured elapsed value" ;;
 esac
 unset vd_id_out vd_hb_out
+
+echo "== unit: scheduled-run watch self-test (#1377) =="
+# The Monday CVE sweep's reader. Its red path CANNOT be exercised live — staging it would mean
+# making the default branch's CI genuinely fail — so the fixtures here are the only place the
+# failure branch runs at all. They also pin the distinction the watcher exists for: a sweep that
+# FAILED is reported and exits 0 (a finding), while a sweep it could not read exits 1 (UNCHECKED).
+bash "$ROOT/scripts/scheduled-run-watch.sh" --self-test >/dev/null 2>&1
+assert_rc "scheduled-run watch self-test passes" "$?" "0"


### PR DESCRIPTION
The `develop-v2` twin of #1733. Same two commits, cherry-picked.

#1377 lands on `develop` because `schedule:` is read from the default branch only — the `STANDING-DIRECTIVE` exception (b) case. This twin keeps the branches level; **the workflow is inert here**, exactly as `ci.yml`'s own cron block is, and that is the intended state rather than a gap.

**Read #1733 for the reasoning and the measurements** — the two overruled design rulings, the zizmor baseline, the budget table, and the real-data controls. Not repeated here, because it is one change and one argument.

## What differs from #1733

Nothing in the shipped behaviour. One conflict, in `tests/stack/test-harness-tooling.sh`: this lane's copy carries five registrations `develop` does not have (#1059, #1676, #1372, #1495, #1657), and my block appends at the same tail position. Resolved by **keeping both** — theirs in order, mine appended last — which is what an append-only registry means. No other file conflicted; `docs/dev/releasing.md` merged clean around this lane's extra RigForge-pin paragraph.

## Verification on this branch, not inherited from #1733

- Self-test **23/23**, run here.
- `zizmor@1.25.2 --offline` over this branch's workflow directory **including the new file**: `No findings to report`.
- `shellcheck --severity=warning` clean, `shfmt -i 4 -d` clean over both touched shell files, `lint-docs-voice` clean (41 docs), `lint-file-budget` clean.
- `tests/stack/run.sh` green here — the conflict resolution is in that run, so the merged registry is proven to execute rather than merely to parse.
- Neither new file needs a budget row: both are under the 400-line target, and `tests/stack/test-harness-tooling.sh` (193 lines after the merge) has no row either.

## Design-scrutiny pass (ponytail)

The code diff is byte-identical to #1733's — same two commits, cherry-picked — so the pass that produced the second commit there covers it, and its three findings are recorded in that PR's body rather than restated here. The only content unique to this branch is the conflict resolution, and the question the pass asks of it is whether keeping both sides is the cheap resolution or the right one: it is the right one, because the file is an append-only registry of harness self-tests owned by four different lanes, and dropping either side would silently stop running someone's test while the PR still read as clean.

## Lane disclosure

Same as #1733: both new files are covered by the exact-path grant in `roles/currency.paths` (controller w101, expiring on merge), and **no `.lane-override` was used**. `docs/dev/releasing.md` and `tests/stack/test-harness-tooling.sh` are `_shared`; the harness edit is an additive registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Rq9E7F4L6XMGqW8sPZ4gc
