### PR TITLE
fix(ci): #1452 #1608 the file-budget ratchet actually runs in CI, and its NOTE stops saying it never skips there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0  # lint-file-budget's ratchet needs origin/develop-v2 to exist, or it skips (#1452, #1608)
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -245,8 +245,12 @@ check_monotonic() {
     local base old_lines new_lines fail=0 path old_ceiling new_ceiling actual
     base=$(resolve_base_ref)
     if [ -z "$base" ]; then
-        echo "file-budget: NOTE — no base ref (origin/develop or develop) resolvable; skipping the" \
-            "monotonic-ceiling check. This never happens in CI." >&2
+        # It DID happen in CI — on every pull_request run, until lint-surfaces was given
+        # fetch-depth: 0 (#1452, #1608). A depth-1 checkout resolves none of the four candidates,
+        # so the ratchet skipped here while the gate went on to print "file budget OK".
+        echo "file-budget: NOTE — no base ref (origin/develop-v2, develop-v2, origin/develop or" \
+            "develop) resolvable; skipping the monotonic-ceiling check. A checkout without the base" \
+            "branch refs does this; in CI it means the job has lost its fetch-depth: 0 (#1452)." >&2
         return 0
     fi
     [ -f "$BUDGET_FILE" ] || return 0


### PR DESCRIPTION
## The finding, ahead of the fix

`Lint per-surface` has been asserting the file budget is monotonic **in the same run in which it printed the skip that means it never checked**. `check_monotonic` could not resolve a base ref, took its resolve-failure path, returned 0, and `run_gate` went on to print

```
file budget OK — every over-target file has a ceiling, none grew past it, docs/dev/file-budget.tsv is monotonic.
```

Ceilings-only-go-down is the ratchet the whole file budget rests on, and several standing review rulings reason about how it behaves against a moved base. On CI pull-request runs it has not been enforced at all. It fired only on a developer machine running `make lint` locally — a gate that works everywhere except the place it is relied on.

The per-row half (this file is over its recorded ceiling) is unaffected and does run. This is a partial hole, not a dead gate.

## Cause

`lint-surfaces`' `actions/checkout` set only `persist-credentials: false`, so `fetch-depth` defaulted to 1. `resolve_base_ref` tries `origin/develop-v2`, `develop-v2`, `origin/develop`, `develop`; a depth-1 checkout has none of them, and a `pull_request` event materialises a single detached merge-ref SHA with no branch refs at all.

## The fix, and why the one line is the right one

`fetch-depth: 0` on that checkout — matching the two jobs in this same file that already set it (lines 50 and 383) for the same class of reason.

**Proven at the pinned action sha, not taken from memory.** `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1`, `dist/index.js`:

- line 41816 — `if (settings.fetchDepth <= 0) {` … `let refSpec = getRefSpecForAllHistory(settings.ref, settings.commit)`
- line 41506 — `getRefSpecForAllHistory` returns `['+refs/heads/*:refs/remotes/origin/*', tagsRefSpec]`

So `fetch-depth: 0` populates `refs/remotes/origin/*` and `origin/develop-v2` exists afterwards. I read that file at the pinned sha rather than reasoning about what the action "should" do.

## The NOTE is the second half of the defect

`This never happens in CI.` was a false statement in durable in-repo text, sitting exactly where the next reader would stop investigating: grep the skip, find the reassurance, conclude it is a local-only artifact. It now says what is true, names a ref-less checkout as the cause, and points at the flag whose removal would bring the skip back. The candidate list in the message was also stale — it said `(origin/develop or develop)` for a function that tries four candidates, including both `develop-v2` forms.

## Budget

`.github/workflows/ci.yml` goes **512 -> 513** against its recorded ceiling of **513**. That is AT the ceiling, and `run_gate`'s comparison is `-gt`, so it passes with zero headroom left. The `lint-surfaces` block is not reflowed. `scripts/lint-file-budget.sh` goes 347 -> 351 and has no row (under the 400 target).

## Overlap with PR #1701, checked before editing

#1701 is open against the same file. I read its diff first. Its hunk is inside `check_monotonic`'s `while` loop and documents a **different** skip — the `-n "$new_ceiling"` absent-new-row case (#1430). Mine is the base-ref resolve-failure arm about twenty lines above it. No textual overlap and no semantic tension: #1701 argues its skip is safe, this PR is about a skip that was not.

## Lane-guard arming — the readback

Proven both ways, each file staged ALONE, with a negative control fired first-class rather than assumed:

| staged alone | lane-guard rc |
|---|---|
| `.github/workflows/ci.yml` (named-file grant) | **0** |
| `scripts/lint-file-budget.sh` (controller w101 grant) | **0** |
| `scripts/lint-file-budget-selftest.sh`, ungranted sibling, **real 2-line modification** | **1**, and it named the path |

The negative control carried a real diff (`git diff --cached --numstat` = `2 0`), not a `touch` — a `touch` stages nothing and passes vacuously.

## What was RUN

```
make lint-file-budget          # rc 0 — 31 self-test assertions ok, 0 FAIL, then the real gate: "file budget OK"
shfmt -i 4 -d scripts/lint-file-budget.sh              # rc 0
shellcheck --severity=warning -x scripts/lint-file-budget.sh   # rc 0 (the pin's own severity, per lint-sh)
uvx yamllint .github/workflows/ci.yml                  # rc 0
```

## What this PR does NOT do

- **#1608's suggestion 3 — make an unresolvable base ref FATAL under `GITHUB_ACTIONS` — is not here.** It is filed as its own issue so it survives #1608 closing. I checked it would have been safe to add (`lint-file-budget` is invoked from exactly one workflow job, and the self-test's synthetic repos all resolve a base because they are `git init -b develop`, which is why the existing "raising a ceiling FAILS" case is green today) — but an arm that no self-test exercises is the shape this repo files issues about, and the routing for this PR was to keep the edit minimal. Without it, `fetch-depth: 0` is one deleted line from silently restoring the defect.
- It does not check whether any **other** job depends on unfetched refs the same way. #1452 says only `lint-file-budget` was checked; that is still true.

## Consequence worth stating plainly

This turns the monotonic ratchet ON for every pull-request run. A PR that raises a ceiling has been passing `Lint per-surface` and failing only on someone's local `make lint`. After this merges it goes RED in CI. That is the rule being enforced, not a new gate — but a lane meeting it for the first time will read it as one.

Refs #1452, #1608

## Over-engineering pass (by hand, before opening — findings and what happened to each)

1. **CUT, applied.** The new comment's last line ("any job that reaches this line has a checkout without the base branch refs") restated what the `echo` two lines below it now prints. Removed. The script edit is +4 lines, not +5.
2. **Rejected as over-engineering for this scope:** a `GITHUB_ACTIONS` fail-closed arm. Reasoning above; filed separately rather than dropped.
3. **Nothing abstracted.** No helper, no flag, no new config key. The CI half of the fix is one YAML line and could not be fewer.
4. **No test added, deliberately.** What broke is the CI checkout, not the script — `resolve_base_ref` was always correct, which is why the existing suite is green over it. The self-test already asserts the resolve path in both lane directions ("a v2-lane branch behind the moved lane tip still ratchets against develop-v2", "a develop-lane checkout still resolves to develop"). A test that asserted `fetch-depth: 0` is present in the YAML would be a static assertion proving the text, not the behaviour — this repo's own named anti-pattern. The behaviour is proven by the CI control below instead.

