### PR TITLE
fix(cli): serialise the control-channel in-place upgrade behind the mutation lock (#1482)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -112,8 +112,11 @@ takes it after its prompts, so a passphrase you have not typed yet holds nothing
 first-boot wizard holds it only while it deploys. `os-update` takes it just before it writes the
 spare slot, so a confirmation it is still waiting on holds nothing up either, and
 `rotate-secrets` takes it after its own confirmation and before it writes the copies of your old
-secrets, so a rotation that ends up waiting has not yet changed a credential. Read-only
-commands — `status`, `doctor` and `logs` among them — never take it and never wait.
+secrets, so a rotation that ends up waiting has not yet changed a credential. A one-click
+upgrade from the dashboard takes it before it writes over the install, so one that arrives while
+another command is running comes back refused with nothing changed, instead of overwriting the
+install underneath it. Read-only commands — `status`, `doctor` and `logs` among them — never take
+it and never wait.
 
 The lock covers one stack, not one directory. A bundle install keeps each release in its own
 `pithead-vX.Y.Z` directory beside the one before it (see [The deploy-box

--- a/lib/pithead/44-control-upgrade-and-lifecycle.sh
+++ b/lib/pithead/44-control-upgrade-and-lifecycle.sh
@@ -253,74 +253,109 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         rm -f "$logf"
         return 0
     fi
-    # #637: unlike the fresh-dir path, this one has no surviving previous dir — and the new
-    # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
-    # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
-    # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
-    # to overwrite the install without one. The destination name is predictable, so root must
-    # never write through a symlink a co-tenant planted there (the #629 mkdir guard's attack
-    # class): copy to an unpredictable mktemp name first, then rename onto the final name —
-    # rename(2) replaces a planted entry without following it.
-    _upg_snapshot() { # <src> <dst>
-        local tmp
-        tmp=$(mktemp "$PWD/.bak-upgrade.XXXXXX") || return 1
-        if ! cp -p "$1" "$tmp"; then
-            rm -f "$tmp"
-            return 1
+    # #1482: everything below overwrites the RUNNING install — the two tar passes replace the whole
+    # tree, this script included — and it does so BEFORE the re-invocation, so the lock the
+    # re-invoked `pithead upgrade` takes cannot cover the overwrite. The window is held from the
+    # first snapshot write to the end of that re-invocation. The fresh-dir path above needs none of
+    # it: everything it writes is a sibling directory it created itself, and the `./pithead upgrade`
+    # it runs there takes its own window.
+    #
+    # Run in a subshell, and that is the design rather than a style choice. `mutation_lock_acquire`
+    # EXITS on timeout (PITHEAD_EX_LOCK_TIMEOUT) instead of returning, and this code runs inside the
+    # long-lived control runner: an exit here would kill the runner mid-request, leaving this result
+    # stuck at "running" and the claim never released. The subshell absorbs that exit so the status
+    # can be ROUTED — contention is "rejected", never a failed upgrade, for the same reason
+    # wizard_setup_failed refuses to call a timeout a bad config (#1391 F3). Its exit also closes
+    # fd 9, which IS the release: the `(setup)` idiom, one caller over. The re-invoked child
+    # inherits the exported PITHEAD_LOCK_HELD marker, so it does not block on its parent's hold.
+    _upg_in_place() {
+        # #637: unlike the fresh-dir path, this one has no surviving previous dir — and the new
+        # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
+        # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
+        # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
+        # to overwrite the install without one. The destination name is predictable, so root must
+        # never write through a symlink a co-tenant planted there (the #629 mkdir guard's attack
+        # class): copy to an unpredictable mktemp name first, then rename onto the final name —
+        # rename(2) replaces a planted entry without following it.
+        _upg_snapshot() { # <src> <dst>
+            local tmp
+            tmp=$(mktemp "$PWD/.bak-upgrade.XXXXXX") || return 1
+            if ! cp -p "$1" "$tmp"; then
+                rm -f "$tmp"
+                return 1
+            fi
+            mv -f "$tmp" "$2"
+        }
+        local bak
+        bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
+        if ! _upg_snapshot "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
+            ! _upg_snapshot "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
+            rm -f "$bundle"
+            _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
         fi
-        mv -f "$tmp" "$2"
+        # Older snapshots hold yesterday's secrets: keep the newest three pairs, prune the rest.
+        # Lexical order IS chronological for this stamp format; `|| true` — an empty glob under
+        # pipefail must not kill the runner.
+        ls -1r "$CONFIG_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+        ls -1r "$ENV_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+        # The reported paths: CONFIG_FILE is cwd-relative unless the (test-only) override made it
+        # absolute — don't prepend $PWD onto an already-absolute path.
+        local bak_paths
+        case "$CONFIG_FILE" in
+        /*) bak_paths="$CONFIG_FILE.$bak" ;;
+        *) bak_paths="$PWD/$CONFIG_FILE.$bak" ;;
+        esac
+        bak_paths="$bak_paths $PWD/$ENV_FILE.$bak"
+        # In-place extraction over the running install, in two passes. Pass 1 lays down everything
+        # EXCEPT the running script with plain tar, which MERGES existing directories — a release
+        # install already carries the non-empty build/* config-template mounts — and overwrites files.
+        # A single `-U` (unlink-first) pass over the whole tree instead tries to unlink those non-empty
+        # build/* dirs first and aborts ("Cannot unlink: Directory not empty"), leaving the install
+        # half-written. Pass 2 is the ONE file that needs -U: the pithead script, unlinked-first so it
+        # lands on a NEW inode and the copy executing this very function keeps running from the old one
+        # (an in-place overwrite would corrupt it mid-run).
+        if ! tar -xzf "$bundle" --strip-components=1 -C "$PWD" --exclude='pithead/pithead' 2>"$logf" ||
+            ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" pithead/pithead 2>>"$logf"; then
+            rm -f "$bundle"
+            _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
+        fi
+        rm -f "$bundle"
+        # The extraction replaced this script on disk (the running copy keeps executing from its old
+        # inode); run the NEW pithead's `upgrade`, which re-renders the generated config and pulls the
+        # $tag images — exactly what the manual bundle update does.
+        if "$PWD/pithead" upgrade >"$logf" 2>&1; then
+            control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
+            control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
+        else
+            control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
+                --arg b "$bak_paths" \
+                '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+            control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
+        fi
+        rm -f "$logf"
     }
-    local bak
-    bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
-    if ! _upg_snapshot "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
-        ! _upg_snapshot "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
-        rm -f "$bundle"
-        _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
-        rm -f "$logf"
+    local iprc=0
+    (
+        mutation_lock_acquire upgrade
+        _upg_in_place
+    ) || iprc=$?
+    if [ "$iprc" -eq "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        rm -f "$bundle" "$logf"
+        _upg_reject "another pithead operation was already running, so the upgrade to $tag was never started — nothing was changed. This attempt still counts against the ten-minute upgrade throttle; retry once both have cleared."
         return 0
     fi
-    # Older snapshots hold yesterday's secrets: keep the newest three pairs, prune the rest.
-    # Lexical order IS chronological for this stamp format; `|| true` — an empty glob under
-    # pipefail must not kill the runner.
-    ls -1r "$CONFIG_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
-    ls -1r "$ENV_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
-    # The reported paths: CONFIG_FILE is cwd-relative unless the (test-only) override made it
-    # absolute — don't prepend $PWD onto an already-absolute path.
-    local bak_paths
-    case "$CONFIG_FILE" in
-    /*) bak_paths="$CONFIG_FILE.$bak" ;;
-    *) bak_paths="$PWD/$CONFIG_FILE.$bak" ;;
-    esac
-    bak_paths="$bak_paths $PWD/$ENV_FILE.$bak"
-    # In-place extraction over the running install, in two passes. Pass 1 lays down everything
-    # EXCEPT the running script with plain tar, which MERGES existing directories — a release
-    # install already carries the non-empty build/* config-template mounts — and overwrites files.
-    # A single `-U` (unlink-first) pass over the whole tree instead tries to unlink those non-empty
-    # build/* dirs first and aborts ("Cannot unlink: Directory not empty"), leaving the install
-    # half-written. Pass 2 is the ONE file that needs -U: the pithead script, unlinked-first so it
-    # lands on a NEW inode and the copy executing this very function keeps running from the old one
-    # (an in-place overwrite would corrupt it mid-run).
-    if ! tar -xzf "$bundle" --strip-components=1 -C "$PWD" --exclude='pithead/pithead' 2>"$logf" ||
-        ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" pithead/pithead 2>>"$logf"; then
+    # Anything else non-zero is the subshell dying on errexit part-way through the overwrite. Before
+    # the subshell that killed the whole runner; now it is reportable, so report it rather than
+    # letting the result sit at "running" until the claim expires.
+    if [ "$iprc" -ne 0 ]; then
         rm -f "$bundle"
-        _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
+        _upg_fail "the in-place upgrade to $tag stopped unexpectedly (status $iprc): $(tail -c 500 "$logf" 2>/dev/null) — check the host journal; the install may be partly written."
         rm -f "$logf"
-        return 0
     fi
-    rm -f "$bundle"
-    # The extraction replaced this script on disk (the running copy keeps executing from its old
-    # inode); run the NEW pithead's `upgrade`, which re-renders the generated config and pulls the
-    # $tag images — exactly what the manual bundle update does.
-    if "$PWD/pithead" upgrade >"$logf" 2>&1; then
-        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
-    else
-        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
-            --arg b "$bak_paths" \
-            '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
-    fi
-    rm -f "$logf"
 }
 
 # Validate + dispatch one CLAIMED request file. Trusts no byte of it: must be JSON, only the keys

--- a/pithead
+++ b/pithead
@@ -11038,74 +11038,109 @@ control_upgrade() { # <request-file> <id> <actor> <control-dir>
         rm -f "$logf"
         return 0
     fi
-    # #637: unlike the fresh-dir path, this one has no surviving previous dir — and the new
-    # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
-    # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
-    # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
-    # to overwrite the install without one. The destination name is predictable, so root must
-    # never write through a symlink a co-tenant planted there (the #629 mkdir guard's attack
-    # class): copy to an unpredictable mktemp name first, then rename onto the final name —
-    # rename(2) replaces a planted entry without following it.
-    _upg_snapshot() { # <src> <dst>
-        local tmp
-        tmp=$(mktemp "$PWD/.bak-upgrade.XXXXXX") || return 1
-        if ! cp -p "$1" "$tmp"; then
-            rm -f "$tmp"
-            return 1
+    # #1482: everything below overwrites the RUNNING install — the two tar passes replace the whole
+    # tree, this script included — and it does so BEFORE the re-invocation, so the lock the
+    # re-invoked `pithead upgrade` takes cannot cover the overwrite. The window is held from the
+    # first snapshot write to the end of that re-invocation. The fresh-dir path above needs none of
+    # it: everything it writes is a sibling directory it created itself, and the `./pithead upgrade`
+    # it runs there takes its own window.
+    #
+    # Run in a subshell, and that is the design rather than a style choice. `mutation_lock_acquire`
+    # EXITS on timeout (PITHEAD_EX_LOCK_TIMEOUT) instead of returning, and this code runs inside the
+    # long-lived control runner: an exit here would kill the runner mid-request, leaving this result
+    # stuck at "running" and the claim never released. The subshell absorbs that exit so the status
+    # can be ROUTED — contention is "rejected", never a failed upgrade, for the same reason
+    # wizard_setup_failed refuses to call a timeout a bad config (#1391 F3). Its exit also closes
+    # fd 9, which IS the release: the `(setup)` idiom, one caller over. The re-invoked child
+    # inherits the exported PITHEAD_LOCK_HELD marker, so it does not block on its parent's hold.
+    _upg_in_place() {
+        # #637: unlike the fresh-dir path, this one has no surviving previous dir — and the new
+        # release's `upgrade` below re-renders .env (and may migrate config.json). Keep a timestamped
+        # pre-upgrade copy of both next to the originals before a byte changes (cp -p keeps .env's
+        # 0600; a fresh stamp per attempt so a failed try never overwrites the good copy) and refuse
+        # to overwrite the install without one. The destination name is predictable, so root must
+        # never write through a symlink a co-tenant planted there (the #629 mkdir guard's attack
+        # class): copy to an unpredictable mktemp name first, then rename onto the final name —
+        # rename(2) replaces a planted entry without following it.
+        _upg_snapshot() { # <src> <dst>
+            local tmp
+            tmp=$(mktemp "$PWD/.bak-upgrade.XXXXXX") || return 1
+            if ! cp -p "$1" "$tmp"; then
+                rm -f "$tmp"
+                return 1
+            fi
+            mv -f "$tmp" "$2"
+        }
+        local bak
+        bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
+        if ! _upg_snapshot "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
+            ! _upg_snapshot "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
+            rm -f "$bundle"
+            _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
         fi
-        mv -f "$tmp" "$2"
+        # Older snapshots hold yesterday's secrets: keep the newest three pairs, prune the rest.
+        # Lexical order IS chronological for this stamp format; `|| true` — an empty glob under
+        # pipefail must not kill the runner.
+        ls -1r "$CONFIG_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+        ls -1r "$ENV_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
+        # The reported paths: CONFIG_FILE is cwd-relative unless the (test-only) override made it
+        # absolute — don't prepend $PWD onto an already-absolute path.
+        local bak_paths
+        case "$CONFIG_FILE" in
+        /*) bak_paths="$CONFIG_FILE.$bak" ;;
+        *) bak_paths="$PWD/$CONFIG_FILE.$bak" ;;
+        esac
+        bak_paths="$bak_paths $PWD/$ENV_FILE.$bak"
+        # In-place extraction over the running install, in two passes. Pass 1 lays down everything
+        # EXCEPT the running script with plain tar, which MERGES existing directories — a release
+        # install already carries the non-empty build/* config-template mounts — and overwrites files.
+        # A single `-U` (unlink-first) pass over the whole tree instead tries to unlink those non-empty
+        # build/* dirs first and aborts ("Cannot unlink: Directory not empty"), leaving the install
+        # half-written. Pass 2 is the ONE file that needs -U: the pithead script, unlinked-first so it
+        # lands on a NEW inode and the copy executing this very function keeps running from the old one
+        # (an in-place overwrite would corrupt it mid-run).
+        if ! tar -xzf "$bundle" --strip-components=1 -C "$PWD" --exclude='pithead/pithead' 2>"$logf" ||
+            ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" pithead/pithead 2>>"$logf"; then
+            rm -f "$bundle"
+            _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
+            rm -f "$logf"
+            return 0
+        fi
+        rm -f "$bundle"
+        # The extraction replaced this script on disk (the running copy keeps executing from its old
+        # inode); run the NEW pithead's `upgrade`, which re-renders the generated config and pulls the
+        # $tag images — exactly what the manual bundle update does.
+        if "$PWD/pithead" upgrade >"$logf" 2>&1; then
+            control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
+            control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
+        else
+            control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
+                --arg b "$bak_paths" \
+                '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
+            control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
+        fi
+        rm -f "$logf"
     }
-    local bak
-    bak="bak-upgrade-$(date +%Y%m%d-%H%M%S)"
-    if ! _upg_snapshot "$CONFIG_FILE" "$CONFIG_FILE.$bak" 2>"$logf" ||
-        ! _upg_snapshot "$ENV_FILE" "$ENV_FILE.$bak" 2>>"$logf"; then
-        rm -f "$bundle"
-        _upg_fail "could not keep a pre-upgrade copy of config.json/.env: $(tail -c 500 "$logf") — refusing to overwrite the install without a restore point; the stack keeps running v$PITHEAD_VERSION."
-        rm -f "$logf"
+    local iprc=0
+    (
+        mutation_lock_acquire upgrade
+        _upg_in_place
+    ) || iprc=$?
+    if [ "$iprc" -eq "$PITHEAD_EX_LOCK_TIMEOUT" ]; then
+        rm -f "$bundle" "$logf"
+        _upg_reject "another pithead operation was already running, so the upgrade to $tag was never started — nothing was changed. This attempt still counts against the ten-minute upgrade throttle; retry once both have cleared."
         return 0
     fi
-    # Older snapshots hold yesterday's secrets: keep the newest three pairs, prune the rest.
-    # Lexical order IS chronological for this stamp format; `|| true` — an empty glob under
-    # pipefail must not kill the runner.
-    ls -1r "$CONFIG_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
-    ls -1r "$ENV_FILE".bak-upgrade-* 2>/dev/null | tail -n +4 | while IFS= read -r f; do rm -f "$f"; done || true
-    # The reported paths: CONFIG_FILE is cwd-relative unless the (test-only) override made it
-    # absolute — don't prepend $PWD onto an already-absolute path.
-    local bak_paths
-    case "$CONFIG_FILE" in
-    /*) bak_paths="$CONFIG_FILE.$bak" ;;
-    *) bak_paths="$PWD/$CONFIG_FILE.$bak" ;;
-    esac
-    bak_paths="$bak_paths $PWD/$ENV_FILE.$bak"
-    # In-place extraction over the running install, in two passes. Pass 1 lays down everything
-    # EXCEPT the running script with plain tar, which MERGES existing directories — a release
-    # install already carries the non-empty build/* config-template mounts — and overwrites files.
-    # A single `-U` (unlink-first) pass over the whole tree instead tries to unlink those non-empty
-    # build/* dirs first and aborts ("Cannot unlink: Directory not empty"), leaving the install
-    # half-written. Pass 2 is the ONE file that needs -U: the pithead script, unlinked-first so it
-    # lands on a NEW inode and the copy executing this very function keeps running from the old one
-    # (an in-place overwrite would corrupt it mid-run).
-    if ! tar -xzf "$bundle" --strip-components=1 -C "$PWD" --exclude='pithead/pithead' 2>"$logf" ||
-        ! tar -xzUf "$bundle" --strip-components=1 -C "$PWD" pithead/pithead 2>>"$logf"; then
+    # Anything else non-zero is the subshell dying on errexit part-way through the overwrite. Before
+    # the subshell that killed the whole runner; now it is reportable, so report it rather than
+    # letting the result sit at "running" until the claim expires.
+    if [ "$iprc" -ne 0 ]; then
         rm -f "$bundle"
-        _upg_fail "the $tag release bundle failed to extract: $(tail -c 500 "$logf") — the stack keeps running v$PITHEAD_VERSION."
+        _upg_fail "the in-place upgrade to $tag stopped unexpectedly (status $iprc): $(tail -c 500 "$logf" 2>/dev/null) — check the host journal; the install may be partly written."
         rm -f "$logf"
-        return 0
     fi
-    rm -f "$bundle"
-    # The extraction replaced this script on disk (the running copy keeps executing from its old
-    # inode); run the NEW pithead's `upgrade`, which re-renders the generated config and pulls the
-    # $tag images — exactly what the manual bundle update does.
-    if "$PWD/pithead" upgrade >"$logf" 2>&1; then
-        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" '{status:"upgraded",version:$v,ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "upgraded"
-    else
-        control_write_result "$cdir/results" "$id" "$(jq -n --arg v "$tag" --arg e "$(tail -c 2000 "$logf")" \
-            --arg b "$bak_paths" \
-            '{status:"failed",version:$v,backup:$b,error:($e + " — finish the upgrade from the host with ./pithead upgrade; containers not yet recreated keep running the previous images."),ts:(now|floor)}')"
-        control_audit "$cdir/audit/control.log" "$id" "$actor" "upgrade" "failed"
-    fi
-    rm -f "$logf"
 }
 
 # Validate + dispatch one CLAIMED request file. Trusts no byte of it: must be JSON, only the keys

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -22,6 +22,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-doctor.sh" && domain_ran test-doctor.
 # shellcheck source=tests/stack/test-control-upgrade.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-control-upgrade.sh" && domain_ran test-control-upgrade.sh "$_d0" "$?" || domain_ran test-control-upgrade.sh "$_d0" "$?"
 
+# shellcheck source=tests/stack/test-control-upgrade-lock.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-control-upgrade-lock.sh" && domain_ran test-control-upgrade-lock.sh "$_d0" "$?" || domain_ran test-control-upgrade-lock.sh "$_d0" "$?"
+
 # shellcheck source=tests/stack/test-release-signing.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-release-signing.sh" && domain_ran test-release-signing.sh "$_d0" "$?" || domain_ran test-release-signing.sh "$_d0" "$?"
 

--- a/tests/stack/test-control-upgrade-lock.sh
+++ b/tests/stack/test-control-upgrade-lock.sh
@@ -1,0 +1,176 @@
+# shellcheck shell=bash
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
+# Control-channel upgrade lock contention (#1482 item 2): the dashboard's one-click `upgrade` verb
+# falls back to an IN-PLACE extraction over the running install whenever the versioned fresh-dir
+# layout does not apply. That extraction replaces the whole tree — this script included — BEFORE it
+# re-invokes `pithead upgrade`, so the window the re-invoked child takes cannot cover the overwrite.
+# Until #1482 item 2 it took no window at all: a one-click upgrade could rewrite the install
+# directory while a `backup` or an `apply` held the lock.
+#
+# Three sections, and the first one is not decoration. A contended run reporting `rejected` is
+# equally consistent with a fixture that never armed — this verb has six refusals of its own that
+# all write `rejected` — so the positive control has to show the same fixture really does perform
+# the in-place overwrite being looked for. The third section proves the window is held ACROSS the
+# re-invocation and that the child does not deadlock on its parent's descriptor, which is the
+# regression the subshell-plus-marker design would otherwise introduce silently.
+# Sourced by tests/stack/run.sh.
+#
+# This lives beside test-control-upgrade.sh rather than inside it because that file is the tests
+# lane's and already 795 lines; the same reason test-appliance-os-update-lock.sh sits beside its
+# verbs file.
+#
+# Re-derivations: $SANDBOX, $STACK, make_stubs, write_fake_docker and the assert_* helpers come from
+# lib.sh; every other name is assigned here. Every file in this suite is sourced into ONE shell, so
+# nothing here reuses a name test-control-upgrade.sh defines — its $UPG/$UPGB/$UPGREQS/$UUPG and
+# urun/upgrade_intent/reset_upgrade_state are deliberately untouched, and this file's are
+# $CUL/$CULB/$CULREQS/$UCUL and culrun/cul_intent/cul_reset. Every write lands under $CUL, $CULB or
+# $SANDBOX/control-upgrade-held.lock, and nothing outside this file reads what it creates.
+
+: "${SANDBOX:?}"
+: "${STACK:?}"
+
+echo "== black-box: a one-click upgrade blocked by another pithead operation changes nothing (#1482) =="
+# A RELEASE install (no build/*/Dockerfile, so is_source_checkout is false) with the control channel
+# on, in a plain `control-upgrade-lock/` directory — NOT a pithead-vX.Y.Z one, so is_versioned_
+# install_dir is false and the verb takes the in-place fallback rather than the fresh-dir deploy.
+CUL="$SANDBOX/control-upgrade-lock"
+CULREQS="$CUL/data/control/requests"
+CULRES="$CUL/data/control/results"
+mkdir -p "$CULREQS" "$CULRES" "$CUL/data/control/staged" "$CUL/data/control/audit"
+cp "$STACK" "$CUL/pithead"
+make_stubs "$CUL/bin"
+# The verifier is a PRECONDITION of a one-click upgrade since #1023, so the fixture needs a runnable
+# docker even though this install carries no cosign.pub and therefore fetches no signature.
+write_fake_docker "$CUL/bin"
+printf '1.3.1' >"$CUL/VERSION"
+printf '{}' >"$CUL/config.json" # the in-place path snapshots config.json before extracting (#637)
+mkdir -p "$CUL/build/monero"
+printf 'stale-monero-template-v1.3.1\n' >"$CUL/build/monero/bitmonero.conf.template"
+cat >"$CUL/.env" <<EOF
+DEPLOYMENT_COMPLETED=true
+DASHBOARD_CONTROL_ENABLED=true
+CONTROL_DIR=$CUL/data/control
+NETWORK_PREFIX=10.9.0
+EOF
+cat >"$CUL/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${*: -1}"
+out=""
+prev=""
+for a in "$@"; do
+    [ "$prev" = "-o" ] && out="$a"
+    prev="$a"
+done
+case "$url" in
+*api.github.com*)
+    cat "${CURL_API_RESPONSE:?}"
+    printf '\n200'
+    ;;
+*releases/download/*) cp "${CURL_BUNDLE:?}" "$out" ;;
+*) exit 22 ;;
+esac
+exit 0
+EOF
+chmod +x "$CUL/bin/curl"
+printf '{"tag_name":"v9.9.9","html_url":"https://example.invalid/rel"}' >"$CUL/api.json"
+
+# The fake v9.9.9 bundle. Its `pithead` records that it was re-invoked and what it could see of the
+# window it was invoked inside: a non-empty PITHEAD_LOCK_HELD, and whether the lock file is still
+# taken. Both are what stop a re-invoked child blocking on its own parent's descriptor.
+CULB="$SANDBOX/control-upgrade-lock-bundle"
+mkdir -p "$CULB/pithead/build/monero"
+cat >"$CULB/pithead/pithead" <<'EOF'
+#!/usr/bin/env bash
+{
+    echo "new-pithead $*"
+    echo "marker=${PITHEAD_LOCK_HELD:-UNSET}"
+    if exec 8>>"${PITHEAD_LOCK_FILE:-$PWD/.pithead.lock}" && flock -n 8; then
+        echo "window=FREE"
+    else
+        echo "window=HELD"
+    fi
+} >>"$PWD/upgrade-invocations.log"
+exit 0
+EOF
+chmod +x "$CULB/pithead/pithead"
+printf '9.9.9' >"$CULB/pithead/VERSION"
+printf 'new-monero-template-v9.9.9\n' >"$CULB/pithead/build/monero/bitmonero.conf.template"
+tar -czf "$CULB/bundle.tar.gz" -C "$CULB" pithead
+
+culrun() { # [env pairs...] — drain the spool inside the release sandbox
+    (cd "$CUL" && PATH="$CUL/bin:$PATH" CURL_API_RESPONSE="$CUL/api.json" \
+        CURL_BUNDLE="$CULB/bundle.tar.gz" env "$@" ./pithead control-run-pending 2>&1)
+}
+cul_intent() { printf '{"id":"%s","action":"upgrade","actor":"admin","version":"v9.9.9"}\n' "$1" >"$CULREQS/$1.json"; }
+UCUL="77777777-7777-4777-8777-777777777777"
+cul_st() { jq -r '.status' "$CULRES/$UCUL.json" 2>/dev/null; }
+cul_err() { jq -r '.error' "$CULRES/$UCUL.json" 2>/dev/null; }
+cul_reset() { # restore the pre-upgrade install between attempts
+    cp "$STACK" "$CUL/pithead"
+    printf '1.3.1' >"$CUL/VERSION"
+    printf 'stale-monero-template-v1.3.1\n' >"$CUL/build/monero/bitmonero.conf.template"
+    rm -f "$CUL/data/control/staged/.upgrade-stamp" "$CULRES/$UCUL.json" "$CUL/upgrade-invocations.log"
+    rm -f "$CUL"/config.json.bak-upgrade-* "$CUL"/.env.bak-upgrade-*
+}
+# Sets CULHOLDER rather than echoing it: `$(...)` around a function that backgrounds a long-lived
+# holder blocks until that holder's stdout closes, i.e. for its whole lifetime.
+CULHOLDER=""
+cul_hold() { # <lockfile> -> sets CULHOLDER
+    local lk="$1" i=0
+    : >"$lk"
+    (
+        exec 9>>"$lk"
+        flock -w 20 9 || exit 1
+        exec sleep 120
+    ) >/dev/null 2>&1 &
+    CULHOLDER=$!
+    while [ "$i" -lt 200 ]; do
+        flock -n "$lk" true 2>/dev/null || break
+        sleep 0.05
+        i=$((i + 1))
+    done
+    if flock -n "$lk" true 2>/dev/null; then
+        bad "the holder takes the lock window" "the lock is still free — the contended case would prove nothing"
+    fi
+}
+
+# Positive control: the same fixture really does perform the in-place overwrite. Without it, every
+# assertion below is equally consistent with a request that was refused at one of this verb's six
+# other `rejected` doors and never reached the extraction at all.
+cul_reset
+cul_intent "$UCUL"
+culrun >/dev/null
+assert_eq "uncontended: the in-place upgrade reports upgraded" "$(cul_st)" "upgraded"
+assert_contains "uncontended: the new release's pithead was re-invoked" "$(cat "$CUL/upgrade-invocations.log" 2>/dev/null)" "new-pithead upgrade"
+assert_eq "uncontended: the install dir really was overwritten" "$(cat "$CUL/VERSION")" "9.9.9"
+assert_eq "uncontended: the new bundle's build/* landed" "$(cat "$CUL/build/monero/bitmonero.conf.template")" "new-monero-template-v9.9.9"
+assert_eq "uncontended: a pre-upgrade snapshot was kept (#637)" \
+    "$(find "$CUL" -maxdepth 1 -name 'config.json.bak-upgrade-*' | wc -l | tr -d ' ')" "1"
+# The window is HELD across the re-invocation, and the child can tell: an inherited marker is what
+# stops it opening a second descriptor on its parent's lock and blocking on it.
+assert_not_contains "uncontended: the re-invoked child inherited the lock marker" "$(cat "$CUL/upgrade-invocations.log")" "marker=UNSET"
+assert_contains "uncontended: and the window was still held while it ran" "$(cat "$CUL/upgrade-invocations.log")" "window=HELD"
+
+# The claim: the same input, with the machine held by another pithead operation.
+CULLK="$SANDBOX/control-upgrade-held.lock"
+cul_hold "$CULLK"
+cul_reset
+cul_intent "$UCUL"
+cul_out=$(culrun PITHEAD_LOCK_FILE="$CULLK" PITHEAD_LOCK_TIMEOUT=1)
+assert_eq "contended: the upgrade is rejected, not failed" "$(cul_st)" "rejected"
+assert_contains "contended: the reason says it was never started" "$(cul_err)" "never started"
+assert_contains "contended: the reason says nothing was changed" "$(cul_err)" "nothing was changed"
+assert_contains "contended: and it names the throttle the attempt still costs" "$(cul_err)" "ten-minute upgrade throttle"
+assert_eq "contended: the new release's pithead was never re-invoked" "$(cat "$CUL/upgrade-invocations.log" 2>/dev/null)" ""
+assert_eq "contended: the install dir was not overwritten" "$(cat "$CUL/VERSION")" "1.3.1"
+assert_eq "contended: the new bundle's build/* did not land" "$(cat "$CUL/build/monero/bitmonero.conf.template")" "stale-monero-template-v1.3.1"
+assert_eq "contended: no pre-upgrade snapshot was written either" \
+    "$(find "$CUL" -maxdepth 1 -name 'config.json.bak-upgrade-*' | wc -l | tr -d ' ')" "0"
+# The runner is long-lived and serves one request at a time: mutation_lock_acquire EXITS on timeout,
+# so an unabsorbed exit kills it mid-request and leaves this result at the "running" it wrote before
+# the download. Asserting only that a result FILE exists cannot fail for that reason — the "running"
+# one is already on disk by then — so the assertion is that the runner got far enough to overwrite
+# it with a verdict.
+assert_not_contains "contended: the result is not left stranded at running" "$(cul_st)" "running"
+assert_not_contains "contended: nothing tells the operator the upgrade ran and broke" "$cul_out" "failed to extract"
+kill "$CULHOLDER" 2>/dev/null || true


### PR DESCRIPTION
Closes item 2 of #1482 — the last unlocked mutating path that issue names. Item 1's six verbs all landed earlier (#1510, #1528, #1534, #1538); this is the residual the issue was deliberately kept open for.

## The defect, measured rather than restated

`control_upgrade`'s in-place fallback replaces the whole install tree — `pithead` itself included — **before** it re-invokes `pithead upgrade`, so the window the re-invoked child takes could never cover the overwrite. It took no window at all.

Base artifact (`git show HEAD:pithead`), with a second process holding the mutation lock, one-click upgrade fired:

| | base | this branch |
|---|---|---|
| result status | `upgraded` | `rejected` |
| install `VERSION` | 1.3.1 → **9.9.9** | 1.3.1, untouched |
| `build/monero/*.template` | replaced by the bundle's | stale copy, untouched |
| `config.json.bak-upgrade-*` | written | none |
| new release's `pithead` | re-invoked | never invoked |

Six rows red on the base, all green here, with the uncontended positive control armed in **both** legs — so the refusal is the lock, not one of this verb's six other `rejected` doors.

## What changed

The fallback moves **verbatim** into a nested `_upg_in_place()` (68 lines, byte-identical modulo a four-space indent — proven by a `diff` of the base slice against the re-indented span, with a shifted-slice negative control that differs) and is called as:

```sh
(
    mutation_lock_acquire upgrade
    _upg_in_place
) || iprc=$?
```

The subshell is the design, not a style choice. `mutation_lock_acquire` **exits** on timeout rather than returning, and this runs inside the long-lived control runner: an unabsorbed exit kills it mid-request and strands the result at the `running` it wrote before the download. The subshell absorbs the exit, the rc routes `PITHEAD_EX_LOCK_TIMEOUT` to `_upg_reject` — `rejected`, never `failed`, the rule #1391's F3 established — and the subshell's own exit closes fd 9, which **is** the release. Same idiom as `(setup)` and `(os_update -y)`.

Any other non-zero rc now reaches `_upg_fail` instead of killing the runner on errexit. That is strictly better than before and is stated rather than left to be found.

**The fresh-dir path is deliberately not wrapped.** Everything it writes is a sibling directory it created itself; the running install is untouched, and the `./pithead upgrade` it runs there takes its own window.

**No self-deadlock, proven not argued:** the re-invoked child inherits the exported `PITHEAD_LOCK_HELD` marker. The fixture's fake release reports back a non-empty marker and a `flock -n` that *fails* from inside the window, so the window is demonstrably still held while the child runs.

The contention message names the ten-minute upgrade throttle, because the attempt still costs it: the dial already happened, so releasing the stamp would reopen the beacon the throttle exists to close.

## Test — `tests/stack/test-control-upgrade-lock.sh`, 17 assertions

Own fixture, own namespace, nothing reused from `test-control-upgrade.sh`; every write lands under its own sandbox dirs. Modelled on `test-appliance-os-update-lock.sh`. A plain (non-versioned) install dir, so the verb takes the in-place fallback rather than the fresh-dir deploy.

**Mutation battery — four single-site mutations of the slice, four killed, no survivors.** Each mutation was asserted to have applied and the file compared against the pristine copy, so a no-op replacement could not report as a mutation.

| Mutation | Rows killed |
|---|---|
| the `mutation_lock_acquire upgrade` is deleted | 10 |
| contention routed to `_upg_fail` instead of `_upg_reject` | 1 |
| the `PITHEAD_EX_LOCK_TIMEOUT` comparison never matches | 4 |
| the subshell removed, so the acquire's exit is not absorbed | 5 |

The kill sets are disjoint enough to discriminate: the `_upg_fail` mutation kills **only** `rejected, not failed`, which is the row that exists to keep #1391's F3 distinction alive.

One assertion was **rewritten after the battery caught it as unfailable**: `the control runner survived to write a result` checked only that a result file existed, which is already true from the `running` write before the download — it could not fail for the reason it named. It is now `the result is not left stranded at running`, and the no-subshell mutation kills it (4 rows → 5).

## Lane discipline

Two per-item grants from the controller (w101), **not** the `.lane-override` hatch — a hatch admits every out-of-lane file in the commit, a named line admits one:

- `tests/stack/test-control-upgrade-lock.sh` — fleet `3bb5114`
- `tests/stack/run.sh` — fleet `ab9d66b`, for **one pure insertion after line 23** and no other line. The hunk is exactly that: `3 insertions(+), 0 deletions(-)`, `git diff --numstat` = `3 0`. It shifts everything below by three lines; the appliance lane's live region is `:236-255`, ~210 lines away.

Arming readback, both directions:

- `tests/stack/test-control-upgrade-lock.sh` staged **alone** → lane-guard rc **0**
- `tests/stack/run.sh` staged **alone** → lane-guard rc **0**
- an ungranted `tests/stack/` sibling staged **alone** → lane-guard rc **1**, naming the file (negative control fired; the scratch file was removed in the same call)

`docs/operations.md` is in `_shared.paths`, no hatch needed — disclosed here. One sentence added to the lock section. It makes an **existing** sentence in that file true: the paragraph below it already claimed the one-click upgrade shares the lock, which was false for the in-place fallback until this change.

## Gates run

`bash -n`, `shfmt -i 4 -d`, `shellcheck --severity=warning` (**0.11.0**, the pinned build, on both changed shell files and the new test), `make lint-pithead-parity`, `make lint-docs-voice`, `make lint-topology`, `make lint-operator-strings`, `make lint-file-budget` — rc 0 each, captured directly rather than off a pipe. `make lint-sh` not run here: it is the serialized OOM path on this box.

Slice 44 is 392 lines and the new test 175, both under the 400 target, so neither takes a `file-budget.tsv` row.

Full `bash tests/stack/run.sh` on this branch, run serially with nothing else touching the fixtures: **3192 passed, 0 failed**, the new domain among them.

`tests/stack/test-control-upgrade.sh`: **142 passed / 0 failed on the base artifact and on this one** — a controlled pair, same assertion count, no regression. The in-place `_upg_fail` branches still report from inside the subshell (`failed upgrade run reports failed`, `failed in-place upgrade names the pre-upgrade copies (#637)`, `failed snapshot fails the upgrade (#637)` all green).

## Over-engineering pass

Run by hand on my own diff, as #1391's was. Four findings, and I am naming the two I did not act on rather than leaving them to be found.

1. **The nested `_upg_in_place()` could have been a bare `( ... )` around the existing lines.** Kept as a function: the moved span contains eight `return 0` statements, and `return` inside a bare subshell inside a function is ambiguous enough that the next reader would have to check it. The file already nests `_upg_reject`, `_upg_fail` and `_upg_snapshot`, so this is its own idiom, not a new one.
2. **The `iprc -ne 0` branch looks like scope creep and is not.** Without it the subshell would *downgrade* the old failure: before, an errexit death inside the in-place path killed the runner loudly; after, it would be swallowed and leave the result stranded at `running` with no verdict at all. The branch is required by the change, not added beside it.
3. **Two test rows are one measurement, and the body should not count them as two.** `the install dir was not overwritten` (VERSION) and `the new bundle's build/* did not land` are two members of the *same* tar extraction — one event read twice, not two independent proofs. Both kept: the `build/*` row also stands on the #544/#555 merge-behaviour shape that the sibling test exists for. But the contended evidence here is four independent facts, not six: the extraction, the re-invocation, the `#637` snapshot, and the result verdict.
4. **`rm -f "$bundle"` is duplicated across the two routing branches and could hoist above the `if`.** Not acted on: it is one line, behaviour-neutral, and taking it would invalidate the exact artifact every measurement in this PR was made against — another build, parity, mutation battery and full-suite cycle to re-prove one line, at the end of a push window. Stated so the next reader knows it was seen and priced, not missed.

## What I did NOT do

- The issue's trailing note — *"read-only verbs take nothing" is structurally true but not proven behaviourally by any test* — is **not** in this PR. It is a pure `tests/stack` item with no CLI change behind it. Filed as #1734 under `maintenance & gates` rather than left in a message.
- `make lint-sh` (serialized, OOM path).
- My first full `tests/stack/run.sh` died at `run.sh: line 112: d: unbound variable` while my own probe scripts were driving the same fixtures concurrently. That is the cross-talk shape COMMON tells us to read as cross-talk rather than as a defect, not a finding against this branch; the clean serial run is the one reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDtwKBWTZnwJ7ewoxM8d6F
