### PR TITLE
test(integration): #1730 every path render_masked_config masks is held against selftest-redact.sh's classification, so the next drift reds instead of waiting to be noticed

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -798,6 +798,28 @@ as survivors. A bare `AUTH` suffix would redact the pair and protect nothing, an
 would take every public endpoint while still missing the webhook key, which ends in `URLS`. Four
 onion addresses are listed apart again, because a shape rule rather than the name rule covers them
 and a name-shaped fixture would report them as leaking.
+`selftest-redact-paths.sh` holds the other classification against this one. The stack masks
+`config.json` by PATH, in `CONTROL_SECRET_PATHS` plus three jq stanzas for the variable-length
+arrays, while `selftest-redact.sh` classifies the same document by a name screen. Two hand-kept
+classifications of one document, and until [#1730](https://github.com/p2pool-starter-stack/pithead/issues/1730) nothing held them against each
+other, so they drifted: `xvb.standby.source` is masked by the product and was in none of the
+self-test's lists, because no suffix in either vocabulary carries the bare word `source`. It was
+found by someone happening to look, which is the thing this file replaces. The check is one-way
+by design — every path the product masks must be classified, never the reverse, because the
+self-test classifies more than the product masks and should: the public endpoints and routing
+ids are what a bundle exists to carry. The population is measured rather than parsed, since a
+read of the `CONTROL_SECRET_PATHS` literal sees twelve fixed paths and misses all three array
+stanzas; the file runs the real masker over a populated fixture and reads back the fifteen paths
+that became `{"__secret__": true}`. A path inside an array is satisfied by its enclosing `[]`
+path being classified, which is what `workers.list[].token` needs. The arming control is the
+load-bearing part: `render_masked_config` warns and returns 0 when its jq fails, so a test
+reading its return code greens over a document that was never written and every containment row
+then passes over an empty population. The file asserts the artifact exists and holds exactly
+the set of paths the fixture populated, named entry for entry, before it reads a single
+verdict. One more thing a populated fixture cannot tell you on its own: a jq assignment
+creates an absent path, so the presence of each populated leaf is checked against the shipped
+schema first — without that row, deleting `xvb.standby` from the reference leaves every other
+row green over a path the product no longer carries.
 `selftest-zmq-probe.sh` drives the ZMTP verdicts from captured and hand-built wire fixtures,
 so every failure class — a silent peer, a non-ZMQ listener, a ZMTP peer that is not a publisher, a
 READY frame carrying a decoy `Socket-Type` value — is reachable with no socket and no stack. It

--- a/tests/integration/selftest-redact-paths.sh
+++ b/tests/integration/selftest-redact-paths.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# Self-test: every path `render_masked_config` masks is CLASSIFIED by selftest-redact.sh (#1730).
+#
+# WHY THIS EXISTS. The stack classifies config.json by PATH, in CONTROL_SECRET_PATHS
+# (30-release-fetch-and-masked-config.sh) plus three jq array stanzas. selftest-redact.sh
+# classifies the same document by a NAME screen over config.reference.json. Two classifications of
+# one document, kept by hand, and nothing held them against each other — so they drifted, and the
+# drift was found by someone happening to look: `xvb.standby.source` is masked by the product and
+# was in none of the self-test's lists, because no suffix in either vocabulary carries the bare
+# word `source` (#1723). This file is the check that fires instead of the next person looking.
+#
+# THE DIRECTION IS ONE-WAY, AND THAT IS DELIBERATE. This asserts product ⊆ self-test, never
+# equality. The self-test classifies MORE than the product masks — public endpoints, routing ids —
+# and it should; those are the rows a bundle exists to carry. What must not happen is the product
+# calling something a secret that the self-test has never heard of, because such a field is
+# outside the drift alarm entirely: nothing reds when it changes.
+#
+# THE POPULATION IS MEASURED, NOT LISTED. A parse of the CONTROL_SECRET_PATHS literal would see 12
+# fixed paths and miss all three variable-length array stanzas (workers.list[].token, the
+# deprecated dashboard.workers[].token, notifications.webhooks[]), which are masked in jq rather
+# than in the list. So this runs the REAL masker over a populated fixture and reads back which
+# paths became {"__secret__": true} — 15 of them. The four classification lists are likewise read
+# out of selftest-redact.sh rather than restated here; restating them is what drifts.
+#
+# ⛔ THREE THINGS THAT COST ATTEMPTS — each one silently produces a GREEN.
+#
+# 1. `render_masked_config` RETURNS 0 WHEN ITS jq FAILS. It warns on stderr, removes the temp
+#    file, and falls off the end — so its rc is the warn's. A test that reads that rc passes over
+#    a document that was never written, and every "is classified" row below then passes
+#    vacuously over an empty population. THE ARMING CONTROL BELOW IS NOT OPTIONAL: assert the
+#    ARTIFACT exists and carries the expected number of masked paths, never the rc.
+# 2. THE FIXTURE MUST GIVE EACH ARRAY THE ELEMENT TYPE ITS STANZA EXPECTS. workers.list[] and
+#    dashboard.workers[] are arrays of OBJECTS — the stanzas do `.token` on each element, so a
+#    string element makes jq fail, and per (1) it fails quietly. notifications.webhooks[] is an
+#    array of STRINGS. config.reference.json ships all of them EMPTY and so cannot tell you this;
+#    it has to be hand-specified, which is the same limitation #1723 hit from the other side.
+# 3. DO NOT PIPE THE `source`. `source ./pithead 2>&1 | tail` runs it in a SUBSHELL, so
+#    render_masked_config is undefined and CONFIG_FILE reads empty afterwards — which looks
+#    exactly like the product being broken. Sourcing is safe (00-prelude.sh:98-101 sets
+#    _STACK_SOURCED and skips the cd, the traps and main); EXECUTING ./pithead is the deploy trap.
+#
+# Every value in the fixture is synthetic.
+#
+# Run: tests/integration/selftest-redact-paths.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+REPO="$(cd "$HERE/../.." && pwd)"
+REF="$REPO/config.reference.json"
+CLASSIFIER="$HERE/selftest-redact.sh"
+
+# The paths this fixture populates, in the masked-walk notation. THIS IS THE ARMING CONTROL, and
+# it is a SET, not a count: the walk's result is compared against it entry-for-entry, so a masker
+# that silently wrote nothing (gotcha 1) or masked a different set cannot leave the containment
+# rows passing over an empty or unexpected population. It also makes this list load-bearing — a jq
+# stanza added to the product without an entry here reds, rather than arriving unmeasured.
+FIXTURE_PATHS="monero.node_username monero.node_password monero.view_key tari.view_key
+p2pool.stratum_password xvb.standby.source dashboard.auth.password workers.api_token
+healthchecks.ping_url telegram.bot_token notifications.ntfy.url notifications.ntfy.token
+workers.list[].token dashboard.workers[].token notifications.webhooks[]"
+
+echo "== render_masked_config's masked paths are all classified by selftest-redact.sh (#1730) =="
+
+BOX="$(mktemp -d)" || {
+    it_fail "sandbox" "mktemp -d failed"
+    echo "selftest-redact-paths: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+}
+# EXIT alone. An INT/TERM handler that RETURNS does not die — the run carries on (#1401).
+trap 'rm -rf "$BOX"' EXIT
+
+# ⛔ A jq ASSIGNMENT CREATES AN ABSENT PATH, so populating the fixture cannot tell you the schema
+# still HAS these leaves — drop `xvb.standby` from config.reference.json and every row below still
+# passes, certifying a path the product no longer carries. Measured, not reasoned: that is exactly
+# what happened when it was tried. So each populated path's presence is asserted FIRST against the
+# shipped schema, and the containment rows below are only as meaningful as this row is green.
+MISSING="$(
+    python3 - "$REF" "$FIXTURE_PATHS" <<'SCHEMA_PROBE'
+import json, sys
+doc = json.load(open(sys.argv[1], encoding="utf-8"))
+for path in sys.argv[2].split():
+    # An array path is present when its CONTAINER is: workers.list[].token -> workers.list.
+    probe, node = path.split("[", 1)[0], doc
+    for seg in probe.split("."):
+        if isinstance(node, dict) and seg in node:
+            node = node[seg]
+        else:
+            print(path)
+            break
+SCHEMA_PROBE
+)"
+assert_eq "every path the fixture populates is still in config.reference.json" "${MISSING:-none}" "none"
+
+# The fixture is DERIVED from the shipped schema, then populated at exactly the leaves the masker
+# claims, with each array given the element type its stanza expects (gotcha 2). Deriving rather
+# than hand-writing means a schema change cannot leave this fixture describing a document the
+# product no longer produces.
+jq '
+    .monero.node_username = "fixture-node-user"
+  | .monero.node_password = "fixture-node-pass"
+  | .monero.view_key      = "fixture-monero-viewkey"
+  | .tari.view_key        = "fixture-tari-viewkey"
+  | .p2pool.stratum_password = "fixture-stratum-pass"
+  | .xvb.standby.source   = "fixture-standby-source"
+  | .dashboard.auth.password = "fixture-dash-pass"
+  | .workers.api_token    = "fixture-api-token"
+  | .healthchecks.ping_url = "https://hc.example.invalid/fixture-ping"
+  | .telegram.bot_token   = "fixture-bot-token"
+  | .notifications.ntfy.url   = "https://ntfy.example.invalid/fixture"
+  | .notifications.ntfy.token = "fixture-ntfy-token"
+  | .workers.list      = [{"name": "w1", "token": "fixture-worker-token"}]
+  | .dashboard.workers = [{"name": "w2", "token": "fixture-depr-token"}]
+  | .notifications.webhooks = ["https://hook.example.invalid/fixture"]
+' "$REF" >"$BOX/config.json" || {
+    it_fail "fixture renders" "jq could not populate the fixture from $REF"
+    echo "selftest-redact-paths: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+}
+
+ln -s "$REPO/pithead" "$BOX/pithead"
+CTL="$BOX/control"
+mkdir -p "$CTL"
+
+# PITHEAD_CONFIG_FILE must be exported BEFORE the source: 00-prelude.sh:50 makes CONFIG_FILE
+# readonly from it, so there is no second chance. Absolute, because a sourced pithead deliberately
+# skips the cd to its own dir and a relative path would resolve against OUR cwd.
+export PITHEAD_CONFIG_FILE="$BOX/config.json"
+# shellcheck disable=SC1091  # the product script, symlinked into the sandbox above
+source "$BOX/pithead" >/dev/null 2>&1
+
+if ! declare -F render_masked_config >/dev/null; then
+    it_fail "render_masked_config is defined after sourcing ./pithead" \
+        "not defined — a piped source would do this (gotcha 3)"
+    echo "selftest-redact-paths: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+fi
+it_pass "render_masked_config is defined after sourcing ./pithead"
+
+# The rc is deliberately DISCARDED. It is 0 whether or not the document was written (gotcha 1);
+# the artifact is the only honest witness.
+render_masked_config "$CTL" >/dev/null 2>&1
+MASKED_DOC="$CTL/masked/config.json"
+
+if [ ! -s "$MASKED_DOC" ]; then
+    it_fail "the masker wrote a masked document" \
+        "$MASKED_DOC missing or empty — note render_masked_config returns 0 in this case"
+    echo "selftest-redact-paths: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+fi
+it_pass "the masker wrote a masked document"
+
+# Walk the masked document for {"__secret__": true}, in the dotted-with-[] notation
+# selftest-redact.sh classifies in, and hold each against that file's four lists. The lists are
+# READ OUT OF the classifier, never restated: a copy here would be one more thing to drift.
+VERDICTS="$(
+    python3 - "$MASKED_DOC" "$CLASSIFIER" <<'PY'
+import json, re, sys
+
+masked_doc, classifier = sys.argv[1], sys.argv[2]
+src = open(classifier, encoding="utf-8").read()
+
+# The judgement lives in these four names. A masked path in NONE of them is the finding.
+LISTS = {}
+for name in ("MUST_REDACT", "MUST_SURVIVE", "KNOWN_GAP", "ELEMENT_SHAPE_UNKNOWN"):
+    m = re.search(r'^%s="([^"]*)"' % name, src, re.M | re.S)
+    if not m:
+        print("LISTFAIL %s" % name)
+        sys.exit(0)
+    LISTS[name] = set(m.group(1).split())
+
+SECRET = {"__secret__": True}
+
+def walk(node, path, out):
+    if isinstance(node, dict):
+        if node == SECRET:
+            out.add(path)
+            return
+        for k, v in node.items():
+            walk(v, "%s.%s" % (path, k) if path else k, out)
+    elif isinstance(node, list):
+        # Every element of an array collapses to one `[]` path — the notation the classifier uses,
+        # and the reason an index never appears in a verdict.
+        for item in node:
+            walk(item, path + "[]", out)
+
+found = set()
+walk(json.load(open(masked_doc, encoding="utf-8")), "", found)
+print("COUNT %d" % len(found))
+
+def satisfied_by(p):
+    for name, entries in LISTS.items():
+        if p in entries:
+            return name, p
+    # A path inside an array is satisfied by its ENCLOSING [] path being classified: that is what
+    # workers.list[].token needs, and precisely what ELEMENT_SHAPE_UNKNOWN means. Only a classified
+    # entry ending in [] can enclose anything, so those are the only ones worth testing; the
+    # LONGEST match wins, so the verdict names the most specific entry that covers the path.
+    best = (None, None)
+    for name, entries in LISTS.items():
+        for entry in entries:
+            if entry.endswith("[]") and p.startswith(entry) and len(entry) > len(best[1] or ""):
+                best = (name, entry)
+    return best
+
+for p in sorted(found):
+    name, entry = satisfied_by(p)
+    print("OK %s %s %s" % (p, name, entry) if name else "UNCLASSIFIED %s" % p)
+PY
+)"
+
+case "$VERDICTS" in
+*LISTFAIL*)
+    it_fail "the classifier's four lists parse out of selftest-redact.sh" \
+        "$(printf '%s' "$VERDICTS" | grep LISTFAIL)"
+    ;;
+*)
+    it_pass "the classifier's four lists parse out of selftest-redact.sh"
+    ;;
+esac
+
+# ARMING CONTROL. Without it, a masker that wrote a document with nothing masked in it would give
+# an empty walk and NO failing rows — a green built on zero measurements. Compared as a SET, so
+# the row names WHICH path appeared or vanished, which a count cannot.
+WALKED="$(printf '%s\n' "$VERDICTS" | awk '/^(OK|UNCLASSIFIED) /{print $2}' | sort | tr '\n' ' ')"
+# shellcheck disable=SC2086  # deliberate word-splitting: FIXTURE_PATHS is a whitespace-separated set
+EXPECTED="$(printf '%s\n' $FIXTURE_PATHS | sort | tr '\n' ' ')"
+assert_eq "the masker masked exactly the paths this fixture populates" "$WALKED" "$EXPECTED"
+
+while read -r verdict path list entry; do
+    case "$verdict" in
+    OK)
+        if [ "$path" = "$entry" ]; then
+            it_pass "$path is classified ($list)"
+        else
+            it_pass "$path is classified via its enclosing $entry ($list)"
+        fi
+        ;;
+    UNCLASSIFIED)
+        it_fail "$path is classified by selftest-redact.sh" \
+            "render_masked_config masks it and the self-test has never heard of it — classify it, with a reason, in MUST_REDACT / MUST_SURVIVE / KNOWN_GAP / ELEMENT_SHAPE_UNKNOWN"
+        ;;
+    esac
+done <<EOF
+$(printf '%s\n' "$VERDICTS" | grep -E '^(OK|UNCLASSIFIED) ')
+EOF
+
+echo "selftest-redact-paths: $IT_PASS passed, $IT_FAIL failed"
+[ "$IT_FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## The defect

The stack classifies `config.json` by PATH — `CONTROL_SECRET_PATHS` plus three jq stanzas for the variable-length arrays. `selftest-redact.sh` classifies the same document by a name screen over `config.reference.json`. Two hand-kept classifications of one document, and nothing held them against each other, so they drifted: `xvb.standby.source` is masked by the product and was in none of the self-test's lists, because no suffix in either vocabulary carries the bare word `source`. It was found at #1723 by someone happening to look. This is the check that fires instead of the next person looking.

## What this adds

`tests/integration/selftest-redact-paths.sh` (new, 253 lines — under `TARGET_LINES=400`, so no budget row, and `Makefile:29` globs `selftest*.sh` so no registration).

**The containment is one-way, deliberately: product ⊆ self-test, never equality.** The self-test classifies more than the product masks — public endpoints, routing ids — and it should; those are what a bundle exists to carry. What must not happen is the product calling something a secret the self-test has never heard of, because such a field sits outside the drift alarm entirely.

**The population is measured, not parsed.** A read of the `CONTROL_SECRET_PATHS` literal sees 12 fixed paths and misses all three array stanzas (`workers.list[].token`, the deprecated `dashboard.workers[].token`, `notifications.webhooks[]`). So the file runs the REAL masker over a populated fixture in a sandbox box and reads back the 15 paths that became `{"__secret__": true}`. The four classification lists are likewise read out of `selftest-redact.sh` rather than restated — restating them is what drifts. A path inside an array is satisfied by its enclosing `[]` path being classified, which is what `workers.list[].token` needs and precisely what `ELEMENT_SHAPE_UNKNOWN` means.

## ⛔ This is STACKED on #1728 and must not merge before it

Base is `fix/1723-redact-selftest-array-blind`, not `develop-v2`, and that is measured rather than preferred: `git diff --stat origin/develop-v2 HEAD` on a develop-v2 base shows **9 files** including `scripts/build-pithead.sh`, `.lycheeignore` and `lychee.yml` — this branch is merely BEHIND develop-v2 by #1727's merge, so a develop-v2-based PR would propose reverting it. The diff against the stack base is the 2 files here.

`ELEMENT_SHAPE_UNKNOWN` exists only on #1728's branch (4 occurrences there, 0 on `develop-v2`). Run against `develop-v2` today this file fails loudly on the list parse rather than passing quietly — the correct direction, but it means **#1728 merges first**, and this needs `rebase --onto` afterwards because #1728 will be squashed. I will re-prove by patch bytes after that rebase, not by shas.

## Proof — a six-arm mutation battery, each arm attacking a DIFFERENT mechanism

Every arm verified it mutated (sha before/after, anchor required to match exactly once) and every file was restored and re-baselined. Baseline 20 passed / 0 failed; post-battery baseline identical.

| arm | what it attacks | result |
|---|---|---|
| A1 | unclassify `xvb.standby.source` — the drift already found | 19/**1**, only that row |
| A2 | drop `workers.list[]` — the enclosing-`[]` clause | 19/**1**, only `workers.list[].token` |
| A3 | product masks a path nothing classifies — **the NEXT disagreement** | 19/**2**, unclassified + set moved |
| A4 | masker jq fails and returns 0 — the false-green | **2/1**, dies at the arming control |
| A5 | product masks one fewer | 18/**1**, the set row alone |
| A6 | schema drops `xvb.standby`, fixture resurrects it | 19/**1**, the schema-presence row |

Distinct signatures, so this is per-arm attribution rather than one mutation reddening everything.

**A4 and A6 are the two that changed the file.** `render_masked_config` warns and returns 0 when its jq fails, so a test reading its rc greens over a document that was never written — the arming control asserts the artifact and its exact path SET before any verdict is read. And A6 was found by attacking my own first draft: a jq assignment CREATES an absent path, so with `xvb.standby` deleted from the schema the first version still passed 19/19, certifying a path the product no longer carries. It now asserts each populated leaf against the shipped schema first. A6 is a controlled before/after on that same defect — it passed before the fix and reds after.

## What was run

- The new file: 20 passed / 0 failed. Full `tests/integration/selftest*.sh` glob: **24 files, all green**, no sibling disturbed.
- `shellcheck` **0.11.0** (the `Makefile:52` pin) and `shfmt -i 4 -d`: both clean, rc 0.
- `make lint-md`, `make lint-docs-voice`, `make lint-file-budget` (run AFTER `git add` — the ratchet is blind to untracked files, #1486): all clean.
- `make lint-pithead-parity`: clean. This matters here because the test sources the BUILT `pithead`; parity is what makes that equivalent to sourcing the slices.
- Verified cwd-independent (run from `/tmp`).

## Findings I considered and did NOT act on, with reasons

- **`source "$BOX/pithead" >/dev/null 2>&1` hides stderr**, which is the shape that returns empty and reads clean. Kept, because the prescribed mitigation is present and load-bearing: `declare -F render_masked_config` is asserted immediately after, and A4 shows the file dies rather than greening when the product misbehaves.
- **`EXPECTED=` relies on deliberate word-splitting** over `FIXTURE_PATHS`. Kept with a scoped `# shellcheck disable=SC2086` and a stated reason; the alternative is an array that `assert_eq` cannot compare as cleanly.
- **The set-equality row prints two long strings on failure.** Noisier than a count, and kept anyway: a count cannot name WHICH path appeared or vanished, and A3/A5 are exactly the cases where that name is the finding.
- **`while read -r verdict path list entry`** would break on a path containing whitespace. Not defended against — config paths are dotted identifiers and cannot contain any.

## /ponytail-review — over-engineering pass, run off disk on this diff

1. **Acted on.** The enclosing-`[]` lookup scanned every character prefix of a path when only a classified entry ending in `[]` can enclose anything. Replaced with a direct scan of the `[]`-suffixed entries, longest match winning. Behaviour preserved: every arm of the six-arm battery reproduces its exact signature before and after, and the baseline is 20/0 on both sides.
2. **Declined** — the 45-line header. It matches the sibling redact self-tests' practice, and each block is a trap that cost an attempt (the masker's rc, the array element types, the piped `source`) rather than a restatement of the code beneath it.
3. **Declined** — collapsing the two python blocks into one. The schema-presence guard has to run BEFORE the fixture is rendered and the walk necessarily runs after the masker; merging them would move the presence check downstream of the very thing it exists to gate.
4. **Declined** — a count instead of a set in the arming control. A3 and A5 are exactly the cases where the failing row has to name WHICH path moved, and a count cannot.

## Disclosure

`docs/dev/integration-testing.md` is under `_shared.paths`; the change is one paragraph joining the existing redact-selftest enumeration, in the house voice, plus one sentence corrected after the A6 fix made it stale.

Refs #1730 (`Closes` cannot fire — this targets `develop-v2` while the default branch is `develop`; closing by hand at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVbsFVAnHPC5SrZtY6cRX3
