### PR TITLE
fix(ci): #1726 the weekly link check stops going red on a host that rate-limits it

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -12,3 +12,7 @@ https://gitlab\.torproject\.org.*
 # Resolvable only on the appliance's LAN, never from CI — same class as the localhost entries
 # above, not a dead link. #1419.
 https?://pithead\.local.*
+# www.gnu.org rate-limits and times out non-browser clients (measured 2026-09-03: [TIMEOUT] and
+# [429] on the same link four minutes apart). The link is valid — the GPL-3.0 text, cited from a
+# license notice. Ignore the host, not a global --accept 429 that would mask real dead links. #1726.
+https://www\.gnu\.org.*


### PR DESCRIPTION
## The finding

`lychee.yml` runs on `schedule` only, from the default branch, with `fail: true`. So a host that rate-limits non-browser clients reds the weekly run permanently, with nothing anyone in this repo can fix — and **a gate that is always red has no transition left to make, so it cannot signal a new break.** That is #1419's second-order finding, arriving again three weeks later with a different host. #1419 was worth fixing because the link check had been red for nine consecutive Mondays; leaving this one in place walks it straight back there.

## Measured (from #1726, re-checked here)

`THIRD_PARTY_LICENSES.md:20` cites `<https://www.gnu.org/licenses/gpl-3.0.txt>`. On 2026-09-03 that one link failed **two different ways four minutes apart** on dispatched runs — `[TIMEOUT]` on `33816940119`, then `[429] Too Many Requests` on `33817230727` — and it also times out from a Linux host outside GitHub's runners. Every other link on the branch passed (833 checked, 830 ok, 2 excluded). The `develop` dispatch happened to pass once (`33817233000`); that is one sample against the twin's 2-of-2 failure, which is why "it passed once" is not treated as evidence here.

The link is valid by hand — it is the GPL-3.0 text — and the file is a license notice, so the reference must stay.

## The fix

One anchored host pattern in `.lycheeignore`, carrying its reason and issue number, exactly the treatment already given to `gitlab.torproject.org` (which returns 403 to non-browser clients). **Not** a global `--accept 429`, which would mask genuinely dead rate-limited links elsewhere.

Pattern verified against the real URL rather than eyeballed, with controls that can return the other answer:

```
https://www\.gnu\.org.*        vs  https://www.gnu.org/licenses/gpl-3.0.txt   -> match
                               vs  https://www.kernel.org/doc.txt            -> no match
                               vs  https://gnu.org/x  (no www)               -> no match
```

## The cost of the host-level form, stated rather than left implicit

`https://www.gnu.org/licenses/gpl-3.0.txt` is the **only** gnu.org link in the repository — one hit across all Markdown — so this masks nothing today. It **would** silently cover a future second gnu.org link. That is the cost of the host pattern the issue asked for, and it is the same cost the `gitlab.torproject.org` entry has been carrying since #415. Naming it so the next person adding a gnu.org link knows it will not be checked.

## Shared file disclosure

`.lycheeignore` is in no role's `.paths` and in no `_shared.paths` class, so this needed the one-shot `.lane-override` hatch. Readback from the guard, quoted because the hatch admits *every* out-of-lane file in the commit and not just the one you meant:

```
lane-guard: OVERRIDE present — allowing out-of-lane files for role currency:
  .lycheeignore
lane-guard: override CONSUMED (one-shot) — touch it again for the next commit.
```

It named `.lycheeignore` and nothing else, the commit stages that one file, and the marker is gone from the tree (`ls .lane-override` -> No such file). The guard was confirmed to actually refuse this path first (staged alone, no override: **rc 1**), so the hatch was proven necessary rather than reached for.

## Twin

The `develop` twin ships alongside this one and is the half that matters for the weekly run, since `schedule:` is read from the default branch only. The two files are legitimately different below this addition — `develop-v2` carries one extra appliance-only entry that `develop` has no reason to have — so this is an append to each, not a sync.

## What was NOT done

The fix is not verified by a green scheduled run yet, and cannot be until one fires from `develop` after the twin merges. A merged PR is not evidence — this repo's own rule. The acceptance check is a `lychee.yml` run with `event=schedule` and conclusion `success`, read from `gh run list --json event`, and it is owed after the develop twin lands.

Refs #1726

## Over-engineering pass (by hand, before opening)

1. **CUT, applied.** The first version carried a 5-line comment for a 1-line pattern — longer than any other entry in a file whose two annotated entries run 2 and 3 comment lines. Trimmed to 3, keeping only what a reader needs at the line: the host misbehaves, the measurement date, the link is valid, host-not-global, and the issue number that points at the full evidence. The two run ids and the off-runner reproduction live in #1726 and in this body, which is where they belong.
2. **Considered and rejected:** a path-anchored pattern (`.../licenses/gpl-3.0\.txt`) instead of the host. It would be narrower, but #1726 asked for the `gitlab.torproject.org` treatment specifically, the failure is a property of the host rather than the path, and a path pattern would go stale the moment the notice cited a different GNU page. The masking cost of the host form is stated above rather than avoided by a form the issue did not ask for.
3. **Nothing else to cut.** One regex, one comment. No script, no flag, no workflow change — `lychee.yml` is untouched.
