### PR TITLE
docs(contributing): green checks are not permission to merge (#1359)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,18 @@ The Dependabot equivalent of the first check is to group its PRs by `baseRefName
 - Make sure `make test` passes; CI runs the same checks.
 - PRs require review before merging; reviewers are requested automatically via
   [CODEOWNERS](.github/CODEOWNERS).
+- Green checks are not permission to merge. Read the merge fields directly, before reviewing a
+  diff and again before merging it:
+
+  ```bash
+  gh pr view <N> --json mergeable,mergeStateStatus
+  ```
+
+  `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY` means the branch cannot merge as it
+  stands, whatever the check rollup says: those checks passed against a base the branch no longer
+  targets, so the diff under review is not the diff that would land. Rebase, then read the field
+  again. A conflicting PR does not necessarily show an empty rollup — #1359 records one that
+  reported 16 of 16 checks SUCCESS while conflicting.
 
 ## Style
 


### PR DESCRIPTION
## What this is

The docs half of #1359. `CONTRIBUTING.md` now names `mergeable` / `mergeStateStatus` as the field
that says whether a PR can merge, and says why the check rollup is not that field. One bullet added
to the existing "Opening a pull request" section — no new heading, no script, no gate.

## Why this does not close the issue

#1359 offers two fixes and states the trade-off itself. The second — branch protection with
`required_status_checks.strict = true` — forces a rebase per merge during a wave of PRs landing
against one branch. That is a policy call, not a documentation one; it is an open decision and is
deliberately untouched here. The issue stays open for it.

The new text also deliberately does not state whether `develop-v2` is protected. That premise is
exactly what the open decision would flip, and a rule that cites it would go stale the day it lands.
The guidance holds either way.

## Premises re-derived at source, not relayed

- `CONTRIBUTING.md` at `efc68c52` has zero hits for `mergeable|mergeStateStatus|conflict|rollup`,
  so the gap the issue describes is real and still open.
- `gh pr view <N> --json mergeable,mergeStateStatus` returns both fields on this box's gh — run
  against PR #1341, it answered rather than erroring.

## What was run

- `make lint-docs-voice` — rc 0 over 41 prose docs, its own self-test firing first
- `make lint-md` — rc 0, 48 files, 0 errors
- `make lint-topology` — rc 0, seven self-test controls firing first
- lane-guard, **with a positive control**: an unowned `dashboard/` file staged alone was REFUSED
  (rc 1, naming it); `CONTRIBUTING.md` staged alone PASSED (rc 0). No `.lane-override` was present
  before or after, so none was consumed.
- `git rev-parse origin/develop-v2` before the commit and after the push — unmoved at `efc68c52`.

## What was NOT run, and what is NOT established

- `make test` and `make lint-sh` were not run. The diff is one Markdown file and touches no shell,
  Python or JS surface; the three gates that actually read prose docs were run instead.
- **The `16 of 16 checks SUCCESS` figure in the new text is RELAYED from this issue's body, not
  re-derived by me.** PR #1341 has since merged and now reports `mergeable: UNKNOWN`, so its
  historical rollup is not recoverable. The sentence attributes the figure to the issue rather than
  asserting it flatly, which is why it is phrased that way.
- Whether this is universal GitHub behaviour or particular to this repo's check configuration is
  still unestablished, as the issue says. The wording claims only that a conflicting PR *can* report
  a full green rollup — not that the rollup is always wrong.

## Lane note

`CONTRIBUTING.md` is outside this lane's standing paths. It is granted per-file and per-item for
this issue and lapses on this PR's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127BCXAYf9tZNfKMSvuPzRu
