### PR TITLE
fix(ci): #1746 the five gates that cost nothing stop queueing behind three downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,6 @@ jobs:
           export UV_INSTALL_DIR="$HOME/.local/bin"
           curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
-      - name: Lint JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo), docs voice, operator strings, topology classes, file budget
-        # Single source of truth: the Makefile targets. Tools run via npx/uvx/docker (preinstalled).
-        run: make lint-js lint-yaml lint-md lint-proto lint-toml lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity
+      - name: Lint docs voice, operator strings, topology classes, file budget, trivy parity, then JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo)
+        # Single source of truth: the Makefile targets. REPO-LOCAL GATES FIRST (#1746): the five bash ones cost under 6s between them, while the five after them fetch via npx/uvx/docker and have eaten the whole 15-minute timeout on a slow registry.
+        run: make lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity lint-js lint-yaml lint-md lint-proto lint-toml


### PR DESCRIPTION
Closes #1746 — hand-close, since keywords are inert on `develop-v2`.

## The defect

`lint-surfaces` runs ten gates as **one shell step**, and every gate that fetches a tool over the network sat at the **front** of it. On run `33820131896` the three `npx --yes` downloads took **3m21s, 4m22s and 7m01s**, ate the whole `timeout-minutes: 15`, and the job was `cancelled` before it ever reached `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget` and `lint-trivy-parity` — which together took **under 6 seconds** in that same run.

Nothing was wrong with the repo. The registry episode is one sample and will pass. **The structure that turned it into a cancelled gate is permanent and is in the file:** the repo's cheapest gates were transitively dependent on npm latency, for no reason other than statement order inside one `run:`.

## The change

Five repo-local `bash` gates first; the five that fetch (`npx` biome, `uvx` yamllint, `npx` markdownlint, `docker` buf, `npx` taplo) after them. The reason is recorded on the comment line that was already there, so the next reader does not have to re-derive it.

## What this does NOT do — read this before approving

**It does not stop the cancellation.** A slow registry still burns the timeout, the job still reports `cancelled`, the check is still not green and the PR is still not mergeable. What changes is **which** gates get to run and report before that happens: the five that could have caught a real defect now execute, in about six seconds, instead of never being reached.

That is a smaller claim than "#1746 is fixed", and it is the honest one. The remaining half is the download cost itself — cache or pin the npx tools, or split the step so one slow linter cannot cancel the others. **Both add lines**, and `.github/workflows/ci.yml` is at **512 against a recorded ceiling of 513**, with #1738 about to consume the last one. So neither is free, and **#1746 stays OPEN** for that half rather than being closed by this PR. I would rather leave the issue open and accurate than close it on a partial fix.

I also did not take the fourth option in the issue (raise `timeout-minutes`). My own issue ranked it last because it makes the symptom rarer and leaves the coupling, and quietly doing the thing I ranked worst is not a decision I should make on my own.

## Budget

**Line-neutral by construction: three lines replaced by three. 512 before, 512 after.** `.yamllint` has `line-length: disable`, so the longer comment line costs nothing. No tsv edit, and the row is untouched.

## Shared-file disclosure

`.github/workflows/ci.yml` is a **named-file grant** to the currency lane, not ownership, and the grant text says to announce before staging it. **There is no controller session in this window** — the control seat reads role files and panes — so this paragraph and the NOW line in `roles/currency.md` are the announcement. No other workflow file is touched.

**Note the merge-order interaction with #1738**, which also touches this file: #1738 adds `fetch-depth: 0` at the checkout step (line ~499) and this touches the step's `name`/comment/`run` lines (~510-512). Different hunks, far enough apart that they should not conflict textually, but whichever merges second should be re-checked rather than assumed clean.

## What was run

- `make lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity` **in the new order, rc 0**, self-tests included.
- `wc -l` before and after: **512 / 512**.
- No doc names `lint-surfaces` or the target order, so no doc update is owed — checked with two different instruments and a firing control, not one grep.

**NOT run:** the actual CI job on a slow registry. There is no way to stage that, and I am not claiming the improvement was observed end to end — the durations above are from the cancelled run's own log, and the reordering argument is from the file.

## Over-engineering pass (done by hand on this diff, findings kept rather than hidden)

The diff is three lines, so the question is not "is there too much machinery" but "does each of the three earn its place".

1. **The `run:` line — kept, and it is the whole fix.** Nothing simpler achieves anything: any real remedy other than reordering adds lines, and there is one line of headroom about to be spent by #1738.
2. **The comment line — kept, and it got LONGER.** That is the finding worth stating. The issue's own root cause is that nothing at the site said the order mattered, so a future edit that alphabetised the targets or appended a new npx gate at the front would silently undo this with no reviewer able to see it. A short comment would not carry the numbers that make the argument checkable. The cost is a 230-character line; `.yamllint` disables `line-length`, and the alternative — a correct fix with no reason recorded next to it — is the exact defect being fixed.
3. **The `name:` line — kept, but this is the marginal one and I will not pretend otherwise.** It is cosmetic: it changes what appears in the job log, nothing else. It also silently omitted `lint-trivy-parity` before, which this corrects. A reviewer who thinks a step name should not enumerate ten targets at all has a fair point, and the smaller diff (leave the name alone, let it be stale) was a real option I rejected — a name that lists the surfaces in an order the step no longer runs them in is a small lie in a file whose whole problem was an unstated ordering.

**Rejected as over-engineering:** splitting the step into two, adding a tool cache, and adding a `continue-on-error` matrix. Each is a defensible fix to the download cost and each adds lines to a file with no room. They belong to the half of #1746 that stays open, not to a three-line ordering fix smuggling in machinery.

**Nothing was added that the issue did not ask for.** No new step, no new job, no new dependency, no version bump.
