### PR TITLE
refactor(dashboard): #1732 one writer for the control requests spool

### DIFF
--- a/dashboard/mining_dashboard/service/control_service.py
+++ b/dashboard/mining_dashboard/service/control_service.py
@@ -19,6 +19,7 @@ import time
 import uuid
 
 from mining_dashboard.config import config
+from mining_dashboard.service import request_spool
 
 logger = logging.getLogger("ControlService")
 
@@ -319,11 +320,7 @@ def submit(action, cfg=None, actor="", intent_id=None, version=None, confirm=Non
         request["version"] = version
     if confirm is not None:
         request["confirm"] = confirm
-    tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
-    with open(tmp, "w") as f:
-        json.dump(request, f)
-    os.replace(tmp, os.path.join(config.CONTROL_REQUESTS_DIR, f"{rid}.json"))
-    return rid
+    return request_spool.write(request)
 
 
 def submit_worker_apply(worker, changes, actor="", intent_id=None):
@@ -340,11 +337,7 @@ def submit_worker_apply(worker, changes, actor="", intent_id=None):
         "worker": worker,
         "changes": changes,
     }
-    tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
-    with open(tmp, "w") as f:
-        json.dump(request, f)
-    os.replace(tmp, os.path.join(config.CONTROL_REQUESTS_DIR, f"{rid}.json"))
-    return rid
+    return request_spool.write(request)
 
 
 def submit_worker_upgrade(worker, version, actor="", intent_id=None):
@@ -361,11 +354,7 @@ def submit_worker_upgrade(worker, version, actor="", intent_id=None):
         "worker": worker,
         "version": version,
     }
-    tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
-    with open(tmp, "w") as f:
-        json.dump(request, f)
-    os.replace(tmp, os.path.join(config.CONTROL_REQUESTS_DIR, f"{rid}.json"))
-    return rid
+    return request_spool.write(request)
 
 
 # The config keys the Worker Inspect editor may change — the exact writable allowlist the rig's

--- a/dashboard/mining_dashboard/service/diagnostics_service.py
+++ b/dashboard/mining_dashboard/service/diagnostics_service.py
@@ -14,12 +14,10 @@ round-trip; deciding whether a WELL-FORMED name may be read is the host's, and i
 back as a "rejected" result the panel shows verbatim.
 """
 
-import json
-import os
 import re
 import uuid
 
-from mining_dashboard.config import config
+from mining_dashboard.service import request_spool
 
 # Compose service names: the charset docker-compose itself allows. Not an allowlist — a shape
 # check. Anything passing this still has to survive the host's membership test.
@@ -36,22 +34,9 @@ def valid_container(name) -> bool:
     return isinstance(name, str) and bool(_CONTAINER_RE.match(name))
 
 
-def _spool(request: dict) -> str:
-    """Atomic write into the requests spool: temp + rename, so the host runner never reads a
-    half-written file. The same four lines appear in control_service.submit* — folding all four
-    into one writer is a worthwhile change and a different one; it is filed, not done here,
-    because control_service.py has no line budget left to receive it."""
-    rid = request["id"]
-    tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
-    with open(tmp, "w") as f:
-        json.dump(request, f)
-    os.replace(tmp, os.path.join(config.CONTROL_REQUESTS_DIR, f"{rid}.json"))
-    return rid
-
-
 def submit_diag_doctor(actor: str = "") -> str:
     """Spool a `doctor --json` request (#913). Takes no operator input at all."""
-    return _spool({"id": str(uuid.uuid4()), "action": "diag-doctor", "actor": actor})
+    return request_spool.write({"id": str(uuid.uuid4()), "action": "diag-doctor", "actor": actor})
 
 
 def submit_diag_logs(container: str, lines: int, actor: str = "") -> str:
@@ -60,7 +45,7 @@ def submit_diag_logs(container: str, lines: int, actor: str = "") -> str:
     ``lines`` is a REQUEST, not a bound: the host clamps it to its own cap and falls back to that
     cap on anything non-numeric, so a tampered intent can at most ask for what the host was
     already willing to give."""
-    return _spool(
+    return request_spool.write(
         {
             "id": str(uuid.uuid4()),
             "action": "diag-logs",

--- a/dashboard/mining_dashboard/service/request_spool.py
+++ b/dashboard/mining_dashboard/service/request_spool.py
@@ -1,0 +1,40 @@
+"""One writer for the control-channel requests spool (#1732).
+
+WHY THIS MODULE EXISTS: the temp-then-rename below is a correctness shape, not a convenience.
+The host runner watches `CONTROL_REQUESTS_DIR` and reads whatever it finds there, so a request
+written in place would be readable while still half-written. Writing to a dotted temp name and
+`os.replace`-ing it onto the real name makes the request appear atomically, fully formed or not
+at all. That property was being maintained in four separate places — three in `control_service`
+and one in `diagnostics_service` — which is three chances for the next intent type to get it
+subtly wrong.
+
+WHY IT IS ITS OWN MODULE RATHER THAN A HELPER IN `control_service`: that file sits at its 414-line
+budget ceiling with no headroom, and the budget gate refuses a raise on a non-exempt row. The ruled
+shape for a zero-headroom file that must receive a line is to split into a new rowless module and
+keep the old row, so the writer lands here and `control_service.py` gets smaller instead of larger.
+
+`config` is referenced through the module object on every call, never bound at import time. The
+service tests patch `CONTROL_REQUESTS_DIR` onto that shared object; a `from ... import
+CONTROL_REQUESTS_DIR` here would read the import-time value and every one of those patches would
+silently stop taking effect, which is the failure that leaves a test green while asserting nothing.
+"""
+
+import json
+import os
+
+from mining_dashboard.config import config
+
+
+def write(request: dict) -> str:
+    """Write one control intent into the requests spool atomically. Returns the request id.
+
+    ``request`` must already carry its ``id``: the id becomes the host-side filename and the
+    runner rejects anything that is not a UUID, so minting it is the caller's business — this
+    writer does not invent one, because a request whose id was chosen here could not be returned
+    to the caller before the file appeared."""
+    rid = request["id"]
+    tmp = os.path.join(config.CONTROL_REQUESTS_DIR, f".{rid}.tmp")
+    with open(tmp, "w") as f:
+        json.dump(request, f)
+    os.replace(tmp, os.path.join(config.CONTROL_REQUESTS_DIR, f"{rid}.json"))
+    return rid

--- a/dashboard/tests/service/test_request_spool.py
+++ b/dashboard/tests/service/test_request_spool.py
@@ -1,0 +1,48 @@
+"""The shared requests-spool writer (#1732).
+
+These assert the property the four duplicated copies existed to maintain, which no test asserted
+directly before: the request becomes visible under its final name ATOMICALLY, and the dotted temp
+file it was staged through does not survive. The callers' own tests cover what each intent CARRIES;
+this covers how it LANDS."""
+
+import json
+
+import pytest
+
+from mining_dashboard.service import request_spool
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    """Patch the attribute on the shared config object, not an import-time binding — the same
+    shape every control test uses, and the reason `request_spool` reads it per call."""
+    monkeypatch.setattr(request_spool.config, "CONTROL_REQUESTS_DIR", str(tmp_path))
+    return tmp_path
+
+
+class TestWrite:
+    def test_lands_under_the_id_as_its_filename(self, spool):
+        rid = request_spool.write({"id": "abc", "action": "diag-doctor"})
+        assert rid == "abc"
+        assert json.loads((spool / "abc.json").read_text()) == {
+            "id": "abc",
+            "action": "diag-doctor",
+        }
+
+    def test_no_temp_file_survives_a_successful_write(self, spool):
+        request_spool.write({"id": "abc", "action": "diag-doctor"})
+        # The dotted temp is the staging name. A leftover would be read by nothing, but its
+        # presence would mean the rename did not happen and the visible file is a second write.
+        assert [p.name for p in spool.iterdir()] == ["abc.json"]
+
+    def test_an_unwritable_spool_raises_rather_than_dropping_the_request(self, monkeypatch):
+        monkeypatch.setattr(request_spool.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")
+        with pytest.raises(OSError):
+            request_spool.write({"id": "abc", "action": "diag-doctor"})
+
+    def test_a_request_without_an_id_raises_before_writing_anything(self, spool):
+        # The id is the caller's to mint; this writer must not invent one and must not leave a
+        # half-named artefact behind when it is missing.
+        with pytest.raises(KeyError):
+            request_spool.write({"action": "diag-doctor"})
+        assert list(spool.iterdir()) == []

--- a/dashboard/tests/web/test_diagnostics_views.py
+++ b/dashboard/tests/web/test_diagnostics_views.py
@@ -10,7 +10,7 @@ import json
 
 import pytest
 
-from mining_dashboard.service import control_service, diagnostics_service
+from mining_dashboard.service import control_service, diagnostics_service, request_spool
 from mining_dashboard.service.storage_service import StateManager
 from mining_dashboard.web.server import create_app
 
@@ -81,9 +81,7 @@ class TestDiagDoctor:
         assert spooled(spool)["actor"] == ""
 
     async def test_a_spool_failure_is_a_500_that_names_no_path(self, diag_client, monkeypatch):
-        monkeypatch.setattr(
-            diagnostics_service.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests"
-        )
+        monkeypatch.setattr(request_spool.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")
         resp = await diag_client.post("/api/control/diag-doctor", headers=CONTROL_HEADERS)
         assert resp.status == 500
         assert "nonexistent" not in json.dumps(await resp.json())
@@ -198,9 +196,7 @@ class TestDiagLogs:
         assert spooled(spool)["lines"] == 10_000
 
     async def test_a_spool_failure_is_a_500_that_names_no_path(self, diag_client, monkeypatch):
-        monkeypatch.setattr(
-            diagnostics_service.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests"
-        )
+        monkeypatch.setattr(request_spool.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")
         resp = await diag_client.post(
             "/api/control/diag-logs", headers=CONTROL_HEADERS, json={"container": "tor"}
         )


### PR DESCRIPTION
The atomic temp-then-rename that puts a control intent into the requests
spool was written out four times: control_service.submit, submit_worker_apply,
submit_worker_upgrade, and diagnostics_service._spool. It is a correctness
shape, not repetition — it is what stops the host runner reading a
half-written request — so it was being maintained in four places.

Now one writer in a new service/request_spool.py, with the four callers
reduced to a call each. The four copies were byte-identical in behaviour
(verified against origin/develop-v2), so the extraction changes no caller's
semantics, and the writer keeps _spool's `(request: dict) -> str` signature.

WHY A NEW MODULE: control_service.py sat at 414/414 with no headroom and the
budget gate refuses a raise on a non-exempt row. Per the w101 ruling, a
zero-headroom file that must receive a line gets SPLIT into a new rowless
module with the old row kept. The extraction is a net reduction:
control_service.py 414 -> 403, and the 414 row is deliberately NOT lowered —
lowering it to match would spend the headroom this bought. request_spool.py
is 40 lines and its test 48, both under 400, so neither takes a budget row.

request_spool reads config.CONTROL_REQUESTS_DIR through the module object on
every call rather than binding it at import. The service tests patch that
attribute on the shared config object; an import-time binding would read the
old value and leave those tests green while asserting nothing.

diagnostics_service no longer imports config (its only use was the spool
write), so the two spool-failure tests now patch request_spool.config — the
module that actually does the read. That repoint is forced, not stylistic:
diagnostics_service.config no longer exists. test_server.py's spool-failure
tests keep naming control_service.config, which is the same shared object and
the module their route actually goes through.

Tests: tests/service/test_request_spool.py asserts what the four copies
existed to guarantee and no test asserted directly — the request lands under
its id and no dotted temp file survives — plus an unwritable spool raising
rather than dropping the request, and a missing id raising before anything is
written.

Not done: the wizard's separate _spool_write_text family is a different
spool (the installer's, not the control channel's) and is untouched. The new
module is not enrolled in the annotation-coverage guard, matching the
precedent of diagnostics_service.py — PINNED is an explicit opt-in list, not
a whole-tree sweep.

Verified on this tree, rebased onto a3b723bd: make lint rc=0 (all 13 targets);
make test-dashboard rc=0, 2511 passed, coverage 97.40%. request_spool.py,
control_service.py and diagnostics_service.py are each at 100% statement
coverage, so every changed line is covered.

## The over-engineering pass (done by hand, on merits)

What I checked and what it found. Two of these are the reason this PR differs from the branch as
it was first pushed.

1. **Were the four copies actually identical?** An extraction is only safe if the copies it folds
   together agreed. Diffed all four against `origin/develop-v2`: same temp name, same `json.dump`,
   same `os.replace`, same return. No caller loses or gains behaviour. **Faithful.**
2. **Did the moved code lose anything?** It did. `diagnostics_service._spool` was
   `(request: dict) -> str`; the extracted `write` was unannotated. **Fixed** — the writer now
   carries the signature the code it replaces had.
3. **Is there a test that patches the name I deleted?** This is the failure that leaves a test
   green while asserting nothing. Swept for `setattr(diagnostics_service, ...)` and any surviving
   `_spool` reference: **zero sites**. The `_spool_*` family in `wizard.py` is the installer's
   spool, a different mechanism, untouched.
4. **Are the pruned imports really unused?** `os` and `json` are still used elsewhere in
   `control_service.py` (lines 61, 260, 283, 384-386), so those imports stay. `config` has **zero**
   remaining uses in `diagnostics_service.py`, so dropping it is correct.
5. **Does the new module owe a budget row or a guard entry?** Neither. 40 lines and 48 are both
   under 400, and `PINNED` is an explicit opt-in list — `diagnostics_service.py` (shipped in #1736)
   is not in it either.

## What I did not do

- I did not lower the `control_service.py` 414 row to its new 403. That is deliberate; lowering it
  spends the headroom the split bought.
- The new module is not enrolled in the annotation-coverage guard. That matches precedent, but it
  is a choice, not a gate result — flagging it so a reviewer can overrule it.
- No shell or host-side change, so there is no rig evidence here and none is owed.

## Evidence

Run on `9750534a`, rebased onto `a3b723bd` (the branch was cut before #1741 merged; rebasing makes
this the narrow review case):

- `make lint` **rc 0** — all 13 targets, `lint-sh` included.
- `make test-dashboard` **rc 0**, **2511 passed**, coverage **97.40%**.
- `request_spool.py` 10 statements / 0 missed, `control_service.py` and `diagnostics_service.py`
  also 100% — every changed line sits in a 100%-covered module, so patch coverage is 100%.

`Closes #1732` does not fire on this base — **#1732 needs closing by hand after merge.**

**MERGE-READY: not yet — this needs a non-author PASS. I am the author; I do not merge it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAzEyAYaaUPqbrrxY8wmgM
