### PR TITLE
test(integration): #1748 ELEMENT_SHAPE_UNKNOWN reads its own premise out of the schema

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -767,7 +767,13 @@ element for the screen to read, and a list element's path ends in `[]`, which no
 match, so all four of the schema's arrays sat outside that guarantee — three of them carrying
 secrets the masked-config pass covers by path. Checking that pass's own path list against this
 file's classification is what turned up `xvb.standby.source`, which the screen now reaches; the
-check itself is not yet mechanical here. It also guards the other direction: a sha256 digest, a non-secret flag value, the
+check itself is not yet mechanical here. Two of those arrays hold objects, and the row for them
+asserts nothing, because an empty reference gives no element to probe — so that emptiness is now
+read from the schema rather than stated
+([#1748](https://github.com/p2pool-starter-stack/pithead/issues/1748)). Populate one and the row
+fails and asks for a reclassification; before, it went on reporting that the reference carried no
+element, and an element under a name the screen does not carry reddened nothing at all. It also
+guards the other direction: a sha256 digest, a non-secret flag value, the
 reserved IP ranges and a HAProxy timestamp must survive, because an artifact with its image pins or
 its port map stripped is useless for the triage it exists for. That timestamp is not a hypothetical
 near-miss: HAProxy's `DD/Mon/YYYY:HH:MM:SS` reads as an IPv6 address, because a four-digit year

--- a/tests/integration/selftest-redact.sh
+++ b/tests/integration/selftest-redact.sh
@@ -218,9 +218,10 @@ SCREEN = re.compile(r"(password|passwd|secret|token|login|username|user|key|wall
 
 # An ARRAY is classified on its own account, whatever its name and whether the reference
 # populates it (#1723). Two blind spots meet: an empty list yields no element to screen, and a
-# scalar element's path ends in "[]", which no `$`-anchored suffix can match. All four arrays in
-# the schema ship empty, three of them carrying secrets render_masked_config masks.
-ARRAY = object()
+# scalar element's path ends in "[]", which no `$`-anchored suffix can match.
+# The list is yielded WHOLE rather than as a sentinel, so its LENGTH reaches the classifier as a
+# measurement (#1748) — ELEMENT_SHAPE_UNKNOWN's premise is that the reference carries no element,
+# and that had been a sentence in the output rather than something read from the document.
 
 
 def walk(node, path=""):
@@ -228,7 +229,7 @@ def walk(node, path=""):
         for k, v in node.items():
             yield from walk(v, f"{path}.{k}" if path else k)
     elif isinstance(node, list):
-        yield path + "[]", ARRAY
+        yield path + "[]", node
         for v in node:
             yield from walk(v, path + "[]")
     else:
@@ -236,8 +237,9 @@ def walk(node, path=""):
 
 
 for path, value in walk(json.load(open(sys.argv[1], encoding="utf-8"))):
-    if value is ARRAY:
+    if isinstance(value, list):
         print(path)
+        print("@@%s %d" % (path, len(value)))  # the array's length, for the entry condition below
     elif isinstance(value, str) and SCREEN.search(path.split(".")[-1]):
         print(path)
 # The invariant above, MECHANICALLY (#1590): it shipped as a comment and was already false once,
@@ -258,7 +260,8 @@ PY
 )"
 # Violations are prefixed, so one python run reports both the population and the invariant.
 VOCAB_BAD="$(printf '%s\n' "$SCREENED" | sed -n 's/^!!//p')"
-SCREENED="$(printf '%s\n' "$SCREENED" | grep -v '^!!')"
+ARRAY_LEN="$(printf '%s\n' "$SCREENED" | sed -n 's/^@@//p')"
+SCREENED="$(printf '%s\n' "$SCREENED" | grep -v '^@@' | grep -v '^!!')"
 [ -n "$SCREENED" ] || it_fail "screen over config.reference.json returns fields" "empty population"
 if [ -n "$VOCAB_BAD" ]; then
     it_fail "redact()'s two suffix vocabularies agree, and the screen covers them" "$VOCAB_BAD"
@@ -311,10 +314,18 @@ for field in $SCREENED; do
         assert_contains "KNOWN GAP ($gap_ref) — $field is NOT redacted by the STREAM filter" "$out" "$SENTINEL"
         continue
     fi
-    # No assertion is possible against an empty object array, and a passing row here would read as
-    # coverage it does not have. The classification requirement above is what this list buys.
+    # No assertion is possible against an EMPTY object array, and a passing row here would read as
+    # coverage it does not have. That emptiness is the bucket's whole premise, so it is READ from
+    # the schema (#1748): asserted, the row went on printing it over a reference that had gained
+    # an element, and an element named outside the screen's vocabulary reds nothing else either.
     if in_list "$field" "$ELEMENT_SHAPE_UNKNOWN"; then
-        it_warn "NOT MEASURED (#1723): $field is an array of objects and the reference carries no element — its .token entries are covered by render_masked_config and by tier 1, not by this filter."
+        elems="$(printf '%s\n' "$ARRAY_LEN" | awk -v f="$field" '$1 == f { print $2; exit }')"
+        if [ "$elems" = "0" ]; then
+            it_warn "NOT MEASURED (#1723): $field is an array of objects and the reference carries 0 elements, read from the schema — its .token entries are covered by render_masked_config and by tier 1, not by this filter."
+        else
+            it_fail "$field is in ELEMENT_SHAPE_UNKNOWN and the reference carries no element" \
+                "the reference carries ${elems:-no measured count} — this bucket asserts nothing BECAUSE there was no element to probe, so reclassify $field against what its element actually holds"
+        fi
         continue
     fi
     assert_contains "$field survives redaction" "$out" "$SENTINEL"


### PR DESCRIPTION
Fixes half 2 of #1748, and the checkable part of half 1, with one mechanism: the walk yields the
list itself instead of a sentinel, so its LENGTH reaches the classifier as a measurement.
`ELEMENT_SHAPE_UNKNOWN` membership then carries a checked entry condition — a member whose array has
gained an element FAILS and asks for a reclassification, where before the row printed a sentence
about a document it never read.

`selftest-redact.sh` 385 -> 396 lines, under `TARGET_LINES=400`, so no budget row and no
registration (`Makefile:29` globs `selftest*.sh`).

## The load-bearing arm — re-derived on this head, not relayed

An element under a name the screen's vocabulary does not carry. This is the case the pre-existing
drift alarm cannot see: that alarm fires on the ELEMENT path, and a non-screened name produces none.
Reference armed with `jq`, read back, restored and confirmed byte-identical by `sha256sum` after
each leg (`4975afde…65cec6c` before and after).

```
armed: workers.list = [{"name": "w1"}]   len=1   (read back from the file)

HEAD b7655224 .................. 58 passed, 1 failed
    x workers.list[] is in ELEMENT_SHAPE_UNKNOWN and the reference carries no element
origin/develop-v2, SAME armed reference ... 58 passed, 0 failed   <- nothing caught it
```

The remaining arms — per-field isolation on `dashboard.workers`, a `token`-named element reddening
the drift alarm as well, and a broken length lookup failing CLOSED with both rows red — are on the
issue and are RELAYED from the previous session, not re-derived here.

Both arrays read 0 elements from the schema today, so the warn still fires and still says so.

## What was RUN, at b7655224

| check | result |
|---|---|
| `make test-integration-selftest` | rc 0 — all 21 selftests green; `selftest-redact` 58/0, `selftest-skip-accounting` 76/0, `selftest` 214/0 |
| `shfmt -i 4 -d` over the Makefile's exact glob | rc 0 |
| `make lint-md` | 0 errors over 46 files |
| `make lint-docs-voice` | OK — 41 prose docs |
| `make lint-file-budget` | OK, run with the files TRACKED (the ratchet is blind to an untracked file, #1486) |
| `make lint-sh` (whole glob) | **NOT OBTAINED — say so rather than imply it** |
| `shellcheck-real 0.11.0 --severity=warning` on the changed file, from the repo root | rc 0, with an SC2154 control firing rc 1 |

`selftest-skip-accounting` matters here because this change moves a skip that leaves through a bare
`it_warn`.

**On the missing `make lint-sh`.** It was started twice — once by the previous session, once by me —
and both runs were swept at roughly six minutes (exit 144); background work on this box is reaped
silently, so the whole-glob verdict is not something I can honestly claim. What I ran instead is this
lane's documented substitute for the serialized OOM path: the CI-pinned `shellcheck 0.11.0` over the
one shell file this branch changes, plus `shfmt -i 4 -d` over the Makefile's exact glob. The clean
was controlled — an injected SC2154 reds the same invocation — and a targeted glob's known failure
mode here is INVENTING SC2034s, not hiding real findings. CI runs the whole glob on this PR; treat
that as the binding verdict.

## Ponytail over-engineering review — run off disk on this diff

**Declined: replacing the in-band `@@<path> <len>` channel with a second `jq` read of
`config.reference.json`.** It is simpler on its face and removes a marker. It was declined because
it would rest the row's premise on a SECOND read of the document, which can drift from the read that
produced the classification; one read, one classification. The collision risk the in-band form
actually carries was measured rather than reasoned: no key in `config.reference.json` contains `@` or
whitespace, and `!!` already occupies this same channel above it for the vocabulary invariant.

**Kept: the fail-closed branch when no length is found.** An absent measurement reds rather than
warns, which is the direction this file's whole premise runs in.

Nothing was added beyond the one mechanism.

## What this does NOT do

The residual half of #1748 stands, so the issue stays OPEN on merge. An EMPTY array's element shape
— scalar or object — is still not derivable from the reference, so nothing yet stops a new SCALAR
array of secrets being put in the bucket that asserts nothing. The masker's own `jq` distinguishes
the two shapes (an object-element array gets `.token` replaced; a scalar-element array has the whole
element replaced), which makes `selftest-redact-paths.sh` the natural home for that check rather than
this file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StSphsxhuptMS8Zv8ybUYX
