### PR TITLE
fix(gate): #1739 an unresolvable base ref is fatal in CI, not a note nobody reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,11 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      split or shrink the file so the addition fits under a ceiling that stays put or drops —
      see issue #1258 for the worked example, where a security test that outgrew its file moved
      into its own — and note that two same-wave merges can each pass alone and fail together, so
-     re-run `make lint` after merging onto the tip. Generated
+     re-run `make lint` after merging onto the tip. The ratchet half is fatal in CI when it
+     cannot run at all: a job that resolves none of the base-ref candidates has lost its
+     `fetch-depth: 0`, which is a misconfigured job rather than a clean tree, so the gate
+     fails there instead of printing a note into a log nobody reads (issue #1739). A local
+     checkout without those refs still gets the note and still passes. Generated
      code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
      the script — and so is the shipped `pithead` artifact itself: it is generated, and the gate
      governs its `lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it.

--- a/scripts/lint-file-budget-selftest.sh
+++ b/scripts/lint-file-budget-selftest.sh
@@ -281,6 +281,48 @@ self_test() {
     expect "control: a new row stating the file's real count on first appearance passes" 0 "$rc"
     rm -rf "$tmp5"
 
+    # #1739 — the resolve-failure arm: FATAL under GITHUB_ACTIONS, a NOTE outside it. Its own repo,
+    # on a branch named neither develop nor develop-v2 and with no remotes, so resolve_base_ref
+    # finds none of its four candidates — the shape a depth-1 CI checkout has. Every other fixture
+    # in this file is `git init -b develop`, so the bare local `develop` always resolves and none
+    # of them ever reach this arm; that is why it needs a repo of its own to be exercised at all.
+    local tmp6
+    tmp6=$(mktemp -d)
+    git -C "$tmp6" init -q -b probe
+    git -C "$tmp6" config user.email test@example.invalid
+    git -C "$tmp6" config user.name test
+    mkdir -p "$tmp6/$(dirname "$BUDGET_FILE")"
+    seq 1 500 >"$tmp6/budgeted.sh"
+    printf '# test budget\nbudgeted.sh\t500\n' >"$tmp6/$BUDGET_FILE"
+    git -C "$tmp6" add -A && git -C "$tmp6" commit -q -m no-base-refs
+    rc=0
+    (cd "$tmp6" && [ -z "$(resolve_base_ref)" ]) || rc=1
+    expect "calibration: this fixture really does resolve NO base ref" 0 "$rc"
+    rc=0
+    (cd "$tmp6" && export GITHUB_ACTIONS=true && run_gate) >"$out" 2>&1 || rc=$?
+    expect "an unresolvable base ref is FATAL under GITHUB_ACTIONS (#1739)" 1 "$rc"
+    if grep -q "no base ref .* resolvable under GITHUB_ACTIONS" "$out"; then
+        echo "  self-test ok: names the unresolvable base ref and the remedy"
+    else
+        echo "  self-test FAIL: did not name the unresolvable base ref"
+        st_fail=1
+    fi
+
+    # NEGATIVE CONTROL, and the `unset` in it is load-bearing: this self-test itself runs IN CI,
+    # where GITHUB_ACTIONS is already true in the environment. Inheriting it would redden this
+    # case there while it passed locally, and — worse — a case that cannot produce the OTHER
+    # answer never shows the arm discriminates on the variable rather than on the missing refs.
+    rc=0
+    (cd "$tmp6" && unset GITHUB_ACTIONS && run_gate) >"$out" 2>&1 || rc=$?
+    expect "control: the same fixture outside CI still PASSES, with the NOTE" 0 "$rc"
+    if grep -q "NOTE — no base ref" "$out"; then
+        echo "  self-test ok: the local skip still says why it skipped"
+    else
+        echo "  self-test FAIL: the local skip lost its NOTE"
+        st_fail=1
+    fi
+    rm -rf "$tmp6"
+
     rc=0
     (
         cd "$tmp" || exit 90

--- a/scripts/lint-file-budget.sh
+++ b/scripts/lint-file-budget.sh
@@ -248,6 +248,20 @@ check_monotonic() {
         # It DID happen in CI — on every pull_request run, until lint-surfaces was given
         # fetch-depth: 0 (#1452, #1608). A depth-1 checkout resolves none of the four candidates,
         # so the ratchet skipped here while the gate went on to print "file budget OK".
+        #
+        # In CI that is a misconfigured job, never a clean tree, so there it is FATAL (#1739). A
+        # stderr NOTE inside a job whose other output is voluminous is not a signal anyone reads,
+        # so without this arm the ratchet un-arms silently the moment fetch-depth: 0 is lost again
+        # — a reflow, a checkout-action bump that changes defaults, a copied job block — and the
+        # run that skipped is indistinguishable from a run that checked. Outside CI the NOTE
+        # stays: a local checkout legitimately may not carry the base branch refs.
+        if [ "${GITHUB_ACTIONS:-}" = true ]; then
+            echo "file-budget: FAIL — no base ref (origin/develop-v2, develop-v2, origin/develop" \
+                "or develop) resolvable under GITHUB_ACTIONS. The monotonic-ceiling check cannot" \
+                "run, and a job that resolves no base ref at all is misconfigured rather than" \
+                "clean: restore fetch-depth: 0 on this job (#1452, #1739)."
+            return 1
+        fi
         echo "file-budget: NOTE — no base ref (origin/develop-v2, develop-v2, origin/develop or" \
             "develop) resolvable; skipping the monotonic-ceiling check. A checkout without the base" \
             "branch refs does this; in CI it means the job has lost its fetch-depth: 0 (#1452)." >&2


### PR DESCRIPTION
Fixes #1739 — hand-close, `Closes` is inert on `develop-v2`.

## What was wrong

#1738 gave `lint-surfaces` `fetch-depth: 0` so `resolve_base_ref` finds the base and the monotonic ratchet runs on every pull-request run. That is the right fix, and it left the gate exactly one deleted line from the defect it had just closed: `check_monotonic`'s resolve-failure arm returned 0 unconditionally, behind a stderr NOTE inside a job whose other output is voluminous.

If a later edit loses `fetch-depth: 0` — a reflow, a checkout-action bump that changes defaults, a copied job block — the ratchet goes quiet again, CI prints `file budget OK`, and **nothing distinguishes that run from a real pass.** That is the same fail-open shape as #1431, #1432 and #1452.

## What changed

Under `GITHUB_ACTIONS` the arm now returns 1: a job that resolves none of the four candidates is a misconfigured job, not a clean tree, and it should say so in the exit code. The message names the remedy (`restore fetch-depth: 0`). Outside CI the NOTE and the pass both stay — a local checkout legitimately may not carry the base branch refs.

The failure line goes to stdout like every other `file-budget: FAIL —` in this gate, so it lands above `See CONTRIBUTING.md — file budget gate.` rather than in a stream the summary does not reach.

## The part that needed doing, and why it needed a sixth fixture

The arm has to be exercised, or it is untested code in the one file in this repo whose whole purpose is being tested. #1739 called this out and it is the reason this is not a one-liner.

Every existing fixture in `lint-file-budget-selftest.sh` is `git init -q -b develop`, so the bare local `develop` candidate resolves in all of them and none ever reaches this arm. The new `tmp6` fixture is on a branch named neither `develop` nor `develop-v2`, with no remotes — the shape a depth-1 CI checkout has. Four cases:

| case | asserts |
|---|---|
| calibration | the fixture really does resolve NO base ref (`[ -z "$(resolve_base_ref)" ]`) |
| the fix | `GITHUB_ACTIONS=true` → rc 1 |
| — | the message names the unresolvable base ref and the remedy |
| **negative control** | same fixture, `GITHUB_ACTIONS` **unset** → rc 0, and the NOTE is still on stderr |

**The `unset GITHUB_ACTIONS` in that control is load-bearing, and is the part worth reviewing.** This self-test itself runs in CI, where `GITHUB_ACTIONS` is already `true` in the environment. Without the `unset`, the control would inherit that value, redden in CI while passing locally, and — worse — never show that the arm discriminates on the variable rather than on the missing refs.

## What was run

**Self-test, both legs, 36/36, rc 0.** The second leg matters: it runs the whole file with `GITHUB_ACTIONS=true` in the ambient environment, which is how CI runs it, and confirms the existing fixtures still never reach the new arm.

```
env -u GITHUB_ACTIONS bash scripts/lint-file-budget-selftest.sh   → rc=0, 36 ok, 0 FAIL
GITHUB_ACTIONS=true    bash scripts/lint-file-budget-selftest.sh   → rc=0, 36 ok, 0 FAIL
```

**Mutation-proved**, in a throwaway `git clone --shared` (never the working checkout), each mutation's application confirmed by grepping content before the run, with the unmutated clone as the M0 control:

| # | mutation | result |
|---|---|---|
| M0 | none (control) | 36 ok, 0 FAIL, rc 0 — the harness works in the clone |
| M1 | the whole `GITHUB_ACTIONS` arm deleted (i.e. the pre-fix code) | rc 1 — **only** `an unresolvable base ref is FATAL under GITHUB_ACTIONS` and its message assertion redden |
| M2 | `if [ "${GITHUB_ACTIONS:-}" = true ]` → `if true` (arm always fires) | rc 1 — **only** the negative control and its NOTE assertion redden |

M1 is the regression firing; M2 is what shows the case discriminates on the variable rather than on the missing refs. Each killed a different pair of assertions, so neither is one measurement printed twice.

**Gates, all rc 0 locally:** `lint-file-budget` (against this repo), `lint-md`, `lint-operator-strings`, `lint-topology`, `lint-docs-voice`. `shellcheck -x` on both changed scripts: rc 0, no findings — it ran only after another session's hold on `~/.shellcheck-serialize.lock` cleared, and the result quoted here is from the captured file, not predicted.

**Line budget:** `lint-file-budget.sh` 347 → 365, `lint-file-budget-selftest.sh` 311 → 353. Both stay under the 400 target, so neither needs a ceiling row and `docs/dev/file-budget.tsv` is unchanged.

## Shared files, under a one-shot `.lane-override`

Three files in this commit are in no role's `.paths`:

- `scripts/lint-file-budget.sh` — the w101 grant to `currency` said *"expires on merge"*, and #1738 merged at 05:16:33Z as `b452eeb2`. Rather than ride an expired line, it was removed from `roles/currency.paths` and recorded EXPIRED there.
- `scripts/lint-file-budget-selftest.sh` — never granted to any role.
- `CONTRIBUTING.md` — in no path **this lane** owns, and not in `_shared.paths` (only `docs/` is). **CORRECTED after review:** an earlier version of this line said *"in no `.paths`"*, which is false — `CONTRIBUTING.md` is an uncommented line in the `tests` lane's path list under a live controller grant for another issue's docs half. The guard's decision is per-role and it refused correctly here, but the old wording would have told the next reader nobody holds that file. See the correction comment below; the `tests` lane has been told directly.

**Arming readback, proven before the commit rather than discovered at commit time.** With all three staged and no marker present, the guard refused, naming all three:

```
lane-guard: role currency does not own these staged paths:
  CONTRIBUTING.md
  scripts/lint-file-budget-selftest.sh
  scripts/lint-file-budget.sh
… rc=1
```

Then, on the commit itself:

```
lane-guard: OVERRIDE present — allowing out-of-lane files for role currency:
  CONTRIBUTING.md
  scripts/lint-file-budget-selftest.sh
  scripts/lint-file-budget.sh
lane-guard: override CONSUMED (one-shot) — touch it again for the next commit.
```

The hatch admits **every** out-of-lane file in the commit, not only the ones intended, so the allow-list above is the readback that matters: it names three and only three. `.lane-override` was confirmed gone afterwards (`ls` reports no such file) — worth stating because this lane has seen the marker survive a `git rebase --continue` **unconsumed**, since a rebase commit never runs the `pre-commit` hook.

## Docs

`CONTRIBUTING.md`'s file-budget paragraph gains one sentence: the ratchet half is fatal in CI when it cannot run at all, and a local checkout without those refs still gets the note and still passes. A contributor who hits the new red needs to know it is about the job's checkout, not about their file sizes.

## What this does NOT do, and what I did not check

- **It does not detect a `fetch-depth: 0` that is present but ineffective.** It fires when no candidate resolves at all. A shallow-but-not-depth-1 checkout that happens to contain one of the four refs would still pass, and would still ratchet against whatever it found.
- **No workflow file is touched.** #1739's blast-radius claim was **re-derived here, not relayed**: `grep -rn lint-file-budget .github/workflows/` finds it at `ci.yml:513` and nowhere else, in the `lint-surfaces` job, which carries `fetch-depth: 0` at `ci.yml:499`. No workflow runs the aggregate `make lint` (the only `make lint` string in `.github/workflows/` is a comment at `ci.yml:442`), so the fatal arm cannot redden any job but that one — and that one has the refs it needs.
- The gate's own failure text points at *"CONTRIBUTING.md — file budget gate"*, and CONTRIBUTING.md has no section by that name; the material is inside the `make lint` bullet. Noticed, not changed — out of scope for this fix, and no issue filed for it yet.

## Over-engineering pass (ponytail), done by hand — findings recorded, not hidden

**Kept, and why each is not decoration:**

- *The environment condition rather than a plain `return 1`.* An unconditional fatal would break a local checkout that legitimately has no base branch refs. The CI-only shape is what #1739 asked for, and the negative control is what pins it.
- *A sixth fixture repo.* Every existing fixture is `git init -b develop` **by construction** — that is what the cases they exist for depend on. Making one of them resolve nothing would break those cases. A separate repo is the minimum, not an addition.
- *The calibration case.* One line. Without it, a fixture that accidentally resolved a ref would fail the fatal case and pass the control, and the diagnosis would be ambiguous rather than obvious.

**Two findings I am recording rather than acting on:**

1. **The two `grep -q` message assertions are not independently killed by M1 or M2.** Each mutation reddens the rc assertion and its message assertion together, so on this evidence the message checks add no discrimination. They are kept anyway because they discriminate against a mutation class these two do not produce — something *else* in the gate failing the fixture, which an rc-only assertion would read as this arm firing. That is a claim about a mutation I did not run, and it is stated as such.
2. **The `CONTRIBUTING.md` addition is five lines where two would carry the behaviour.** The extra length is the local-checkout exception, which is the half a contributor hitting the new red actually needs. Trimmable if a reviewer disagrees; I judged the exception worth the lines.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJ126JuJEYTihuWtRB3MyS

