### PR TITLE
test(dashboard): #1731 the diag picker's container list is held to the host's allowlist

### DIFF
--- a/dashboard/mining_dashboard/web/static/diagview.mjs
+++ b/dashboard/mining_dashboard/web/static/diagview.mjs
@@ -12,7 +12,10 @@
 // redactor is keyed to the launch-line leak class and the wallet daemons are the two whose
 // ordinary output most easily carries key material outside it. If this list ever drifts from the
 // host's, the host refuses and the panel shows that refusal verbatim rather than reinterpreting
-// it. Publishing the list from the host so the two CANNOT drift is filed as a follow-up.
+// it. Publishing the list from the host so the two CANNOT drift is still open as #1731 — both
+// shapes it proposes need a host-side change. Until then a drift test in
+// tests/frontend/diagview.test.mjs holds this list to the host's by exact membership, so a
+// divergence reds in CI rather than reaching an operator as a service the host then refuses.
 
 import { pollResult } from "./configview.mjs";
 import { Component, html } from "./preact.mjs";

--- a/dashboard/tests/frontend/diagview.test.mjs
+++ b/dashboard/tests/frontend/diagview.test.mjs
@@ -10,6 +10,7 @@
 // Run with Node's built-in test runner:
 //     node --test dashboard/tests/frontend/*.test.mjs
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import {
@@ -150,6 +151,33 @@ test("the idle card offers both actions and every container the host allowlists"
   assert.match(out, /Run health check/);
   assert.match(out, /Show recent log/);
   for (const c of DIAG_CONTAINERS) assert.match(out, new RegExp(`<option value="${c}"`));
+});
+
+test("the picker's container list has not drifted from the host's allowlist (#1731)", () => {
+  // DIAG_CONTAINERS is a second copy of the host's PITHEAD_DIAG_CONTAINERS and this test is the
+  // only thing holding them together. Drift is not a security hole — the host still decides, and
+  // its refusal reaches the panel verbatim — but it offers an operator a service the host will
+  // refuse, or hides one it would serve, and both read as a dashboard bug.
+  //
+  // Read from the built `pithead` rather than lib/pithead/46a-control-diagnostics.sh, matching the
+  // editable/confirm drift tests in test_control_service.py. lint-pithead-parity is what makes the
+  // built file a faithful stand-in for the slice it was concatenated from.
+  const pithead = readFileSync(new URL("../../../pithead", import.meta.url), "utf8");
+  const m = /readonly PITHEAD_DIAG_CONTAINERS="([^"]*)"/.exec(pithead);
+  assert.ok(m, "could not find PITHEAD_DIAG_CONTAINERS in pithead");
+  const hostList = m[1].split(/\s+/).filter(Boolean);
+  // The deepEqual below would also fail on an empty list, so this guard is here for its MESSAGE,
+  // not for the detection: it names the shape of the failure instead of printing a nine-element
+  // array against an empty one. It is reachable only when the regex matched an empty capture —
+  // the no-match case is already taken by the assertion above — so it does not say "the regex
+  // stopped matching", which would be false in the one case that can reach it.
+  assert.ok(
+    hostList.length > 0,
+    "the host allowlist parsed as empty — PITHEAD_DIAG_CONTAINERS was emptied, or the regex no longer captures its value",
+  );
+  // Membership, not order: the host tests the requested name for exact membership in a
+  // whitespace-separated list, so a reordering there is harmless and must not red this.
+  assert.deepEqual([...DIAG_CONTAINERS].sort(), [...hostList].sort());
 });
 
 test("the picker offers neither wallet daemon — the host refuses both", () => {


### PR DESCRIPTION
The Service Diagnostics picker carries its own copy of the container list and
the host's PITHEAD_DIAG_CONTAINERS is the authority. Nothing held them
together, so they could drift: the dashboard would offer a service the host
then refuses, or omit one it would serve. Neither is a security hole — the
host still decides and its refusal reaches the panel verbatim — but the first
reads to an operator as a dashboard bug.

A drift test in tests/frontend/diagview.test.mjs now compares the two by exact
membership, so a divergence reds in CI instead of reaching an operator. It
reads the built `pithead`, matching the editable/confirm drift tests in
test_control_service.py; lint-pithead-parity is what makes the built file a
faithful stand-in for the slice it came from. Membership and not order,
because the host's own check is an exact-membership test over a
whitespace-separated list and a reordering there is harmless.

THIS DOES NOT CLOSE #1731 AND THE ISSUE SHOULD STAY OPEN. #1731 asks for the
host to PUBLISH its list so the second copy stops existing, and both shapes it
proposes — the doctor result carrying the allowlist, or a `diag-containers`
verb — need a change in lib/pithead/46a-control-diagnostics.sh, which this
lane cannot make. What is fixed here is the harm the duplication causes, not
the duplication. The issue's own note that this is not urgent still holds, and
the publication decision it defers is untouched.

This test cannot replace the wallet-daemon test beside it. A name added to
BOTH lists at once leaves them in perfect agreement and this test stays green
— the same gap test_env_key_perimeter.py documents for the editable/confirm
allowlists. That test asserts the host list's CONTENT; this one asserts only
that the copies agree.

Controls, each seeded separately because node:assert short-circuits and only
the first seeded row would redden:
  A. a container dropped from DIAG_CONTAINERS -> FAILS (13 pass / 1 fail)
  B. `wallet-rpc` added to DIAG_CONTAINERS   -> FAILS (12 pass / 2 fail; the
     second failure is the wallet-daemon test, which is how that test shows it
     is still load-bearing rather than made redundant by this one)
  C. the regex renamed as a shell-side rename would leave it -> FAILS with its
     own named reason, `could not find PITHEAD_DIAG_CONTAINERS in pithead`
Each seed was reverted by file copy and confirmed by sha256, never by
git checkout, and the suite returned to 14 pass / 0 fail after each.

Verified on this tree: make lint rc=0 (all 13 targets); make test-frontend
rc=0, 530 passed. make test-dashboard was NOT re-run: no Python file changed,
so it would measure the same program.

## Why a guard test rather than the fix the issue asks for

#1731 lists three shapes, and every one of them needs `lib/pithead/46a-control-diagnostics.sh`:
the doctor result carrying the allowlist, a `diag-containers` verb, or including it in the masked
config. That file is outside this lane. So the choice was between shipping nothing and closing the
harm from the side I own.

I think the guard is the better answer to the *drift* half regardless of who could reach the host
file: it costs no verb, couples the picker to nothing, and catches a divergence at merge rather
than surfacing it to an operator at runtime. It does not remove the second copy, which is the half
#1731 is actually about — so **the issue stays open**, and the publication decision it defers is
untouched and unprejudiced.

## What I did not do

- I did not change the request path. The issue is explicit that it should keep shape-checking and
  letting the host refuse, and that `test_a_wellformed_but_unlisted_container_still_spools` asserts
  exactly that. Untouched.
- I did not key the test on the slice file. It reads the built `pithead`, matching the existing
  drift tests; `lint-pithead-parity` covers the gap between them. Keying on the slice would catch a
  drift one step earlier and would be a defensible reviewer request.
- I did not re-run `make test-dashboard`. No Python file changed, so it would measure the same
  program. CI runs it anyway.
- The `assert.ok(m, ...)` and empty-list guards inside the test are proven to fire (control C).

## The over-engineering pass (done by hand, on merits)

The gate asked, so here is what the pass actually found rather than a note that it happened.

1. **The empty-list guard's message was wrong.** It said "the regex likely stopped matching", but
   the no-match case is already taken by the `assert.ok(m, ...)` above it — the only way to reach
   the length guard is a regex that matched an EMPTY capture, i.e. the shell constant was emptied.
   The message named a cause that cannot be the cause. **Fixed**, and the comment now says the
   guard is there for its message rather than for the detection, since `deepEqual` would fail on an
   empty list regardless.
2. **Does `.sort()` corrupt the export?** `[...DIAG_CONTAINERS].sort()` spreads into a new array
   first, so the module's exported constant is not reordered under later tests in the same process.
   Checked, not assumed.
3. **Is the second spread redundant?** `[...hostList].sort()` — `hostList` is already a fresh array
   from `split().filter()`. Kept for symmetry with the other side and as insurance against a later
   edit that reads `hostList` after the comparison. Noting it rather than hiding it.
4. **Should this replace the wallet-daemon test?** No, and control B is the measurement rather than
   the opinion: seeding `wallet-rpc` reds BOTH tests, and the case where a name is added to both
   lists at once reds only that one. Distinct claims.

## Evidence

- `make lint` **rc 0** — all 13 targets.
- `make test-frontend` **rc 0**, **530 passed**.
- Three seeded controls, each run separately, each red on the right test with the right message;
  each revert confirmed by sha256 and the suite returned to 14 pass / 0 fail.

`Closes #1731` is deliberately absent — see above, this does not close it.

**MERGE-READY: not yet — needs a non-author PASS. I am the author; I do not merge it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAzEyAYaaUPqbrrxY8wmgM
