### PR TITLE
test(stack): #1740 every PASS label is held against a reviewed set, not two named lines

### DIFF
--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -213,3 +213,114 @@ echo "== unit: scheduled-run watch self-test (#1377) =="
 # FAILED is reported and exits 0 (a finding), while a sweep it could not read exits 1 (UNCHECKED).
 bash "$ROOT/scripts/scheduled-run-watch.sh" --self-test >/dev/null 2>&1
 assert_rc "scheduled-run watch self-test passes" "$?" "0"
+
+echo "== unit: verdict-line determinism — every PASS label, not two named lines (#1740) =="
+# The two rows above pin #1709's two nondeterministic PASS lines BY NAME, and nothing looks for a
+# third — N grew from one to two by discovery, so the multiset proof still rests on an enumeration
+# no instrument can show is complete. A PASS verdict line is exactly `  <glyph> <label>` (lib.sh's
+# ok() prints its first argument and nothing else), so a value can only reach one through the
+# LABEL. That makes the whole set checkable statically, in one pass, with no sampling — which
+# matters twice over. Two samples miss a value that changes only SOMETIMES: #1709's own heartbeat
+# line read clean across two samples that happened to land on the same second. And the domains most
+# likely to carry a measurement cannot be sampled in isolation at all — test-spool-audit.sh is a
+# deliberate consumer of another domain's $C and refuses a standalone source, so there is nothing
+# to run twice.
+#
+# So hold the set of PASS labels that interpolate ANYTHING against a reviewed expectation. Keyed on
+# the interpolated NAME, not the label prose: rewording a label is routine and must not red the
+# suite, while a genuinely new interpolation must. `bad` is excluded — its label prints only on the
+# failure path, which no multiset proof compares.
+vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interpolated name
+    awk '
+    {
+        stripped = $0
+        sub(/^[ \t]+/, "", stripped)
+        # Heredoc BODY is data, not code. Without this the fixture written a few lines below —
+        # which has to contain an emitter call to be a control at all — is scanned as if it were
+        # source, and the sweep reports its name against a file that never emits it. `<<<` is a
+        # here-STRING and opens nothing.
+        if (hd != "") { if (stripped == hd) hd = ""; next }
+        if (match($0, /<<-?[ \t]*[\047"]?[A-Za-z_][A-Za-z0-9_]*[\047"]?/) && $0 !~ /<<</) {
+            tag = substr($0, RSTART, RLENGTH)
+            sub(/^<<-?[ \t]*/, "", tag)
+            gsub(/[\047"]/, "", tag)
+            hd = tag
+            next
+        }
+        if (stripped ~ /^#/) next
+        if (!match($0, /(^|[^A-Za-z0-9_])(ok|assert_eq|assert_contains|assert_not_contains|assert_rc)[ \t]+"/)) next
+        rest = substr($0, RSTART + RLENGTH)
+        label = ""
+        n = length(rest)
+        for (j = 1; j <= n; j++) {
+            c = substr(rest, j, 1)
+            if (c == "\\") { j++; continue }
+            if (c == "\"") break
+            label = label c
+        }
+        f = FILENAME
+        sub(/^.*\//, "", f)
+        while (match(label, /\$\{?[A-Za-z_][A-Za-z0-9_]*|\$\(|`/)) {
+            tok = substr(label, RSTART, RLENGTH)
+            label = substr(label, RSTART + RLENGTH)
+            if (tok == "$(" || tok == "`") { print f "|$(cmd)"; continue }
+            gsub(/[${]/, "", tok)
+            print f "|" tok
+        }
+    }
+    ' "$@" | sort -u
+}
+# Every entry below was read at its call site and is a loop variable over a fixed list, a count
+# derived from the tree, or a value parsed out of a repo file — the same on every run of a given
+# tree. The four that are NOT run-invariant are called out in #1740: test-appliance-os-update.sh's
+# RIS/RIJ are absolute paths that differ per WORKTREE, and test-secrets.sh's mem/host_ram_mb come
+# from /proc/meminfo MemTotal, so they differ per BOX. Both are stable across two runs in one place,
+# which is exactly why sampling never found them.
+vd_expected="$(
+    cat <<'VDEXP'
+test-appliance-boot.sh|ph
+test-appliance-identity-boot.sh|cli_pages
+test-appliance-identity-boot.sh|u
+test-appliance-identity.sh|f
+test-appliance-os-update.sh|RIJ
+test-appliance-os-update.sh|RIS
+test-config.sh|bad_port
+test-config.sh|checked
+test-config.sh|core_checked
+test-control-core.sh|reowned
+test-doctor.sh|ip
+test-release.sh|comp
+test-release.sh|pin_rel
+test-release.sh|svc
+test-render-quadlet.sh|f
+test-secrets.sh|ev
+test-secrets.sh|host_ram_mb
+test-secrets.sh|mem
+test-spool-audit.sh|audit_lines
+test-spool-audit.sh|audit_size
+test-tor-network.sh|v
+test-unit-helpers.sh|t_human
+test-unit-helpers.sh|t_name
+test-unit-helpers.sh|t_val
+VDEXP
+)"
+assert_eq "every PASS label that interpolates a value is one the suite has reviewed" \
+    "$(vd_interp_names "$ROOT/tests/stack/lib.sh" "$ROOT"/tests/stack/test-*.sh)" "$vd_expected"
+
+# The row above is an equality over a set, so a sweep that silently stopped matching would report
+# an empty actual against a non-empty expectation and fail loudly — but it would fail naming the
+# wrong cause. These three drive the extractor over a file written for the purpose, so each
+# property that the row depends on is asserted separately and a break says which one went.
+vd_seed="$SANDBOX/vd-interp-control"
+mkdir -p "$vd_seed"
+cat >"$vd_seed/test-vd-seed.sh" <<'VDSEED'
+ok "a label carrying a brand new interpolation $vd_fresh_name"
+ok "an escaped \$PWD is prose in a label, not an interpolation"
+bad "a bad-only label naming $vd_failure_only"
+VDSEED
+vd_ctl="$(vd_interp_names "$vd_seed/test-vd-seed.sh")"
+assert_contains "the sweep reports a new interpolated PASS label (firing control)" "$vd_ctl" "vd_fresh_name"
+assert_not_contains "an escaped dollar in a label is not read as interpolation" "$vd_ctl" "PWD"
+assert_not_contains "a bad-only label is not held to the PASS-line rule" "$vd_ctl" "vd_failure_only"
+unset -f vd_interp_names
+unset vd_expected vd_seed vd_ctl


### PR DESCRIPTION
Closes #1740.

## What was wrong

`test-harness-tooling.sh` pins #1709's two nondeterministic PASS lines **by name**, and nothing looks for a third. N grew from one to two by discovery, so the multiset proof still rested on an enumeration no instrument could show was complete.

Two reasons sampling was never going to close it:

- **Two samples miss a value that changes only sometimes.** #1709's own heartbeat line read clean across two samples that happened to land on the same second.
- **The domains most likely to carry a measurement cannot be sampled in isolation at all.** `test-spool-audit.sh` is a deliberate consumer of another domain's `$C` and refuses a standalone source — there is nothing to run twice.

## What makes the whole set statically checkable

`lib.sh`'s `ok()` prints its **first argument and nothing else**, so a PASS verdict line is exactly `  <glyph> <label>`. A value can therefore only reach a PASS line through the **label**. That turns the question from "sample until you are convinced" into a single pass over the source with no sampling at all.

So the new row holds the set of PASS labels that interpolate **anything** against a reviewed expectation, keyed on the interpolated **name** rather than the label prose: rewording a label is routine and must not red the suite, while a genuinely new interpolation must. `bad` is excluded — its label prints only on the failure path, which no multiset proof compares.

## What was RUN

- **Full `bash tests/stack/run.sh` at this head: `pithead tests: 3200 passed, 0 failed`, rc 0.** The section really executed — the log carries `== unit: verdict-line determinism — every PASS label, not two named lines (#1740) ==` with both of its rows green, **including the firing control**. A green total is not evidence the new section ran; this is.
- **The extractor was cross-checked against an independent Python implementation: 24/24 agreement.**
- **Three separate controls, not one.** The main row is an equality over a set, so a sweep that silently stopped matching would fail loudly but name the wrong cause. Each property it depends on is therefore asserted on its own against a purpose-written fixture: a brand-new interpolation IS reported (firing control), an escaped `\$PWD` is NOT read as interpolation, and a `bad`-only label is NOT held to the PASS-line rule.
- **Rebased onto `7442399f` (`c1d49b0f`), and the rebase is proven content-neutral the right way:** `diff <(git diff OLDBASE OLDHEAD) <(git diff NEWBASE NEWHEAD)` -> **0 lines**. Patches, not trees — across a base that moved, the trees MUST differ and a tree comparison would report a false positive.

## Two things found on the way, worth keeping

- **`ok()` prints only its first argument**, so a nondeterministic PASS line can *only* come from the label. That is what makes the static approach sound rather than convenient.
- **Four of the 24 reviewed entries are not run-invariant** — `test-appliance-os-update.sh`'s `RIS`/`RIJ` are absolute paths that differ per **worktree**, and `test-secrets.sh`'s `mem`/`host_ram_mb` come from `/proc/meminfo` `MemTotal`, so they differ per **box**. Both are stable across two runs in one place, which is exactly why sampling never found them. The row is unaffected because it keys on the interpolated **name**, never the value.

## What this does NOT cover, and the cost it imposes

- **`test_compose.sh` is a SECOND verdict vocabulary** — its own `echo "  ✓"` plus a `fails` counter — and `run.sh` never sources it. Out of scope here, and not covered by anything else either. Said rather than left to be discovered.
- **This row reds when a lane adds a legitimately new interpolated PASS label.** That is the point of it, but it is a real cost on every other lane, so it should be said plainly: the fix is to add one `<basename>|<name>` line to the reviewed set in `test-harness-tooling.sh`, not to reword the label around the check.

## Over-engineering pass

Run on this diff. The awk extractor is dense, but each branch in it exists for a named failure: the heredoc skip is there because without it the control fixture — which has to contain an emitter call to be a control at all — gets scanned as source and reports its own seeded name against a file that never emits it; the `<<<` exclusion is there because a here-string opens no heredoc; the escape handling is there because `\$PWD` in a label is prose. The reviewed set is a quoted heredoc so no entry can ever expand, and it sits inside the very file the sweep scans. Nothing here is speculative flexibility. **Lean already. Ship.**

## Lane

`tests/stack/` only, in this lane's `.paths`. One file, additive.
