### PR TITLE
test(dashboard): #1732 the spool writer's atomicity is asserted, not just claimed

### DIFF
--- a/dashboard/tests/service/test_request_spool.py
+++ b/dashboard/tests/service/test_request_spool.py
@@ -6,6 +6,7 @@ file it was staged through does not survive. The callers' own tests cover what e
 this covers how it LANDS."""
 
 import json
+import os
 
 import pytest
 
@@ -34,6 +35,27 @@ class TestWrite:
         # The dotted temp is the staging name. A leftover would be read by nothing, but its
         # presence would mean the rename did not happen and the visible file is a second write.
         assert [p.name for p in spool.iterdir()] == ["abc.json"]
+
+    def test_the_visible_name_is_only_ever_created_by_a_rename(self, spool, monkeypatch):
+        # THE ATOMICITY PROPERTY, and the reason the cleanup test above is not enough: a direct
+        # in-place write leaves exactly ["abc.json"] too, so that test cannot tell the two shapes
+        # apart. What distinguishes them is that the name the host runner watches for is only ever
+        # brought into existence by a rename, so the runner can never observe a partial request.
+        #
+        # This matters more now than it did as four copies: one writer means a single future edit
+        # removes the property for every intent type at once. Without this assertion that edit
+        # leaves the suite green.
+        seen = []
+        real_replace = os.replace
+
+        def recording_replace(src, dst):
+            seen.append((os.path.basename(src), os.path.basename(dst), os.path.exists(dst)))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", recording_replace)
+        request_spool.write({"id": "abc", "action": "diag-doctor"})
+        # Staged under the dotted temp, and the final name did not exist before the rename made it.
+        assert seen == [(".abc.tmp", "abc.json", False)]
 
     def test_an_unwritable_spool_raises_rather_than_dropping_the_request(self, monkeypatch):
         monkeypatch.setattr(request_spool.config, "CONTROL_REQUESTS_DIR", "/nonexistent/requests")


### PR DESCRIPTION
#1732's four assertions guard temp-file cleanup, not atomicity — the one
property the shared writer exists for is the one property none of them can
see. A direct in-place write lands `abc.json` under its id, leaves exactly
["abc.json"], raises on an unwritable spool and raises on a missing id: all
four stay green.

Found by the non-author pass on PR #1754 with a mutation battery — a direct
in-place write SURVIVED 183/183 — and re-derived here rather than relayed.

It matters more after the consolidation than before it. Four copies meant an
edit removing atomicity had to be made four times; one writer means it is made
once, silently, for every intent type at once, with the suite green.

test_the_visible_name_is_only_ever_created_by_a_rename records os.replace's
arguments and asserts the final name did not exist before the rename created
it, so the property asserted is the one the host runner depends on: the name
it watches for is only ever brought into existence atomically.

WHY THIS IS A SEPARATE PR. It was written as an amendment to #1754, but #1754
merged at 9750534a while the amended head was 799beffc, so the test did not
land — verified at source with `git show origin/develop-v2:` rather than
inferred from the merge. This carries only the stranded test; no product code
changed, and the module it tests is develop-v2's as merged.

Control, run against the MERGED module on this branch: re-seeding the direct
in-place write gives 1 failed / 4 passed, failing exactly this test and
nothing else, so it discriminates the shape rather than merely covering the
line. The seeded module was restored by file copy and confirmed by sha256,
never by git checkout.

Verified on this tree: tests/service/test_request_spool.py 5 passed. The test
file is 70 lines and stays rowless.

## The over-engineering pass (by hand, on merits)

- **Does the assertion test the mechanism or just call it?** It asserts `os.replace` was called with
  the dotted temp as source and the final name as destination, **and** that the destination did not
  exist at that moment. The last clause is the one that makes it about atomicity rather than about
  a rename having happened somewhere.
- **Could it pass for the wrong reason?** The control answers this rather than an argument: the only
  seeded shape that removes atomicity reds this test and only this test.
- **Is patching `os.replace` globally safe here?** It is monkeypatched for the duration of one test
  and restored by pytest; the recorder calls through to the real `os.replace`, so the write still
  happens and the other four assertions are unaffected.
- **Does it duplicate `test_no_temp_file_survives_a_successful_write`?** No — that test is exactly
  the one proven unable to see this, which is why this PR exists. They fail on different shapes.

## What I did not do

- I did not re-run the full suite or all 13 lint targets on this branch. The change is one test file
  added to a tree that is otherwise `develop-v2` as merged; I ran the module's own tests, `lint-py`
  and `lint-file-budget`. CI settles the rest.
- I did not touch product code. `request_spool.py` here is develop-v2's, byte-for-byte.

`Closes #1732` is inert on this base, and #1732 is already closed by #1754's merge in any case.

**MERGE-READY: not yet — needs a non-author PASS. I am the author; I do not merge it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAzEyAYaaUPqbrrxY8wmgM
