### PR TITLE
test(os): #1651 a reboot in the KVM harness is observed by boot id, never assumed after a fixed sleep

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -154,6 +154,30 @@ _wait_ssh() { # $1 seconds — the definition of "not bricked"
     done
     return 1
 }
+_boot_id() { _ssh cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n' | grep .; } # rc 1 when unreadable
+# A reboot is OBSERVED, never assumed (#1651): wait for a boot id DIFFERENT from $1. `sleep 10; _wait_ssh` reconnected
+# to the still-running old boot whenever the shutdown outlasted the sleep (or the reboot command never landed) and
+# read the OLD marker as the verdict. Reports how many probes the old boot answered, so a near-miss is visible.
+_wait_new_boot() { # $1 = boot id before the reboot, $2 = seconds
+    local deadline=$(($(date +%s) + $2)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" now stale=0
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        now=$(_boot_id)
+        [ -n "$now" ] && [ "$now" != "$1" ] && break
+        [ "$now" = "$1" ] && stale=$((stale + 1))
+        sleep 5
+    done
+    [ "$stale" -eq 0 ] || info "the old boot $1 answered $stale probe(s) after the reboot command before going down"
+    [ -n "$now" ] && [ "$now" != "$1" ] && return 0
+    info "no new boot within $2 s — boot id ${now:-unreadable}, was $1"
+    return 1
+}
+_reboot_wait() { # $1 = the command that reboots the guest, $2 = seconds to wait for the new boot
+    local before
+    before=$(_boot_id) || info "could not read the boot id before '$1' — a reconnect and a reboot would look alike"
+    [ -n "$before" ] || return 1
+    _ssh "$1" >/dev/null 2>&1 || true # the session dies with the reboot
+    _wait_new_boot "$before" "$2"
+}
 # Classify why _wait_ssh gave up, using only signals that do NOT need a working SSH session — the
 # guest either isn't running, isn't the one we're still probing, or is running and refusing the
 # connection (sshd not up yet, or genuinely dead) vs. not answering the network at all. $1 is the
@@ -501,9 +525,7 @@ phase_boot() {
     id_before=$(_ssh cat /etc/machine-id)
     jd_before=$(_ssh 'ls /var/log/journal | wc -l' | tr -d '\r\n ')
     if [ -n "$id_before" ]; then
-        _ssh reboot >/dev/null 2>&1 || true
-        sleep 10
-        if _wait_ssh 240; then
+        if _reboot_wait reboot 240; then
             id_after=$(_ssh cat /etc/machine-id)
             [ -n "$id_after" ] && [ "$id_before" = "$id_after" ] && ok "machine-id stable across a reboot ($id_before)" ||
                 bad "machine-id changed across a reboot (before: $id_before, after: ${id_after:-none})"
@@ -627,9 +649,7 @@ phase_update() {
         return
     }
     ok "v2 installed into the spare slot"
-    _ssh "$(_boot_spare_cmd)" || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait "$(_boot_spare_cmd)" 300 || {
         bad "guest never returned after booting the spare slot"
         return
     }
@@ -638,9 +658,7 @@ phase_update() {
         bad "expected v2 in the spare slot, got '$marker'"
         return
     }
-    _ssh reboot || true # uncommitted -> the bootloader must fall back on its own
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || { # uncommitted -> the bootloader must fall back on its own
         bad "guest never returned after the no-commit reboot"
         return
     }
@@ -655,9 +673,7 @@ phase_update() {
         bad "the second v2 install failed on the guest"
         return
     }
-    _ssh "$(_boot_spare_cmd)" || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait "$(_boot_spare_cmd)" 300 || {
         bad "guest never returned after the second install"
         return
     }
@@ -666,9 +682,7 @@ phase_update() {
         return
     }
     ok "committed the booted update"
-    _ssh reboot || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || {
         bad "guest never returned after the post-commit reboot"
         return
     }
@@ -711,9 +725,7 @@ phase_update() {
     # and everything after belongs to the boot leg 4 actually runs against.
     local serial_mark
     serial_mark=$(wc -c <"$SERIAL" 2>/dev/null | tr -d ' ')
-    _ssh "$(_rollback_cmd)" || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait "$(_rollback_cmd)" 300 || {
         bad "guest never returned after an operator rollback"
         return
     }
@@ -2254,9 +2266,7 @@ phase_provision() {
     # pithead-boot's own loader running on a provisioned machine (#798).
     _ssh "rm -f /data/pithead/data/.loaded-*.sha" 2>/dev/null ||
         bad "could not drop the digest records before the reboot"
-    _ssh reboot 2>/dev/null || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || {
         bad "guest never returned from the reboot"
         return
     }
@@ -2438,9 +2448,7 @@ phase_provision() {
         bad "no migration-pending marker after installing a data_migration bundle"
         return
     fi
-    _ssh reboot || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || {
         bad "guest never returned after booting the migration bundle"
         return
     }
@@ -2854,9 +2862,7 @@ phase_rig() {
 
     # ---- reboot: pithead-boot owns a rig now, and commits its slot -------------------------
     info "reboot leg — the rig must come back mining, and commit its own slot"
-    _ssh reboot 2>/dev/null || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || {
         bad "the rig never returned from the reboot"
         return
     }
@@ -2917,9 +2923,7 @@ phase_rig() {
         return
     }
     ok "v2 installed into the rig's spare slot"
-    _ssh "$(_boot_spare_cmd)" || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait "$(_boot_spare_cmd)" 300 || {
         bad "the rig never returned after booting the spare slot"
         return
     }
@@ -2964,9 +2968,7 @@ phase_rig() {
         ;;
     *) bad "the rig never self-committed the updated slot — grubenv: ${genv2:-unreadable}" ;;
     esac
-    _ssh reboot || true
-    sleep 10
-    _wait_ssh 300 || {
+    _reboot_wait reboot 300 || {
         bad "the rig never returned after the post-commit reboot"
         return
     }
@@ -3055,10 +3057,12 @@ phase_fault() {
         bad "re-staging the bundle before the commit test failed"
         return
     }
+    local before
+    before=$(_boot_id) || bad "could not read the boot id before the install — a reconnect and a reboot would look alike"
+    [ -n "$before" ] || return
     out=$(_ssh "$(_install_and_boot_cmd /data/update.bundle) 2>&1" || true)
     [ -n "$out" ] && info "install output: $(printf '%s' "$out" | tail -3 | tr '\n' ' ' | cut -c1-160)"
-    sleep 10
-    _wait_ssh 300 || {
+    _wait_new_boot "$before" 300 || {
         bad "guest never returned after installing v2"
         return
     }
@@ -3085,9 +3089,7 @@ phase_fault() {
     # be able to put the previous version back on demand — not only wait for an automatic fallback.
     info "operator-initiated rollback"
     marker=$(_marker)
-    _ssh "$(_rollback_cmd)" >/dev/null 2>&1 || true
-    sleep 10
-    if _wait_ssh 300; then
+    if _reboot_wait "$(_rollback_cmd)" 300; then
         local after
         after=$(_marker)
         if [ -n "$after" ] && [ "$after" != "$marker" ]; then
@@ -3230,9 +3232,7 @@ phase_reset() {
 
     # The real command an operator runs — not a reimplementation of it (factory_reset() in
     # `pithead`). It arms the ESP marker and reboots; the ssh connection drops with the reboot.
-    _ssh "cd /data/pithead && ./pithead factory-reset -y" >/dev/null 2>&1 || true
-    sleep 10
-    if _wait_ssh 300; then
+    if _reboot_wait "cd /data/pithead && ./pithead factory-reset -y" 300; then
         ok "guest returned after the factory-reset reboot"
     else
         bad "guest never returned after factory-reset — BRICKED"

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -159,7 +159,7 @@ _boot_id() { _ssh cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n'
 # to the still-running old boot whenever the shutdown outlasted the sleep (or the reboot command never landed) and
 # read the OLD marker as the verdict. Reports how many probes the old boot answered, so a near-miss is visible.
 _wait_new_boot() { # $1 = boot id before the reboot, $2 = seconds
-    local deadline=$(($(date +%s) + $2)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" now= stale=0
+    local deadline=$(($(date +%s) + $2)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" now='' stale=0
     while [ "$(date +%s)" -lt "$deadline" ]; do
         now=$(_boot_id)
         [ -n "$now" ] && [ "$now" != "$1" ] && break

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -159,7 +159,7 @@ _boot_id() { _ssh cat /proc/sys/kernel/random/boot_id 2>/dev/null | tr -d '\r\n'
 # to the still-running old boot whenever the shutdown outlasted the sleep (or the reboot command never landed) and
 # read the OLD marker as the verdict. Reports how many probes the old boot answered, so a near-miss is visible.
 _wait_new_boot() { # $1 = boot id before the reboot, $2 = seconds
-    local deadline=$(($(date +%s) + $2)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" now stale=0
+    local deadline=$(($(date +%s) + $2)) SSH_TIMEOUT="${SSH_PROBE_TIMEOUT:-20}" now= stale=0
     while [ "$(date +%s)" -lt "$deadline" ]; do
         now=$(_boot_id)
         [ -n "$now" ] && [ "$now" != "$1" ] && break
@@ -912,7 +912,7 @@ PYEOF
 # (os-update-test-base); RAUC signature verification still runs for real against the slot
 # keyring, so the bad-signature refusal is genuine, not simulated.
 phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-boot>
-    local good_bundle="$1" serial_mark="${2:-0}" marker
+    local good_bundle="$1" serial_mark="${2:-0}" marker before
     info "leg 4 — dashboard OS-update action end-to-end (provision, then check/download/verify/install/reboot)"
     if ! _wizard_provision_capture "$serial_mark"; then
         bad "leg 4: could not provision the stack through the wizard (${WIZ_FAIL_REASON:-no dashboard, no control channel})"
@@ -1121,9 +1121,9 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     marker=$(_ssh cat /etc/pithead-test-marker)
     [ "$marker" = "v1" ] && ok "leg 4: nothing auto-rebooted — still on v1 until the operator says so" ||
         bad "leg 4: expected to still be on v1 before the reboot intent, got '$marker'"
-    _os_step '{"action":"reboot"}' 30 >/dev/null 2>&1 || true # the machine goes away mid-poll
-    sleep 15
-    _wait_ssh 420 || {
+    before=$(_boot_id) || info "could not read the boot id before the reboot intent — a reconnect and a reboot would look alike"
+    [ -n "$before" ] && _os_step '{"action":"reboot"}' 30 >/dev/null 2>&1 || true # the machine goes away mid-poll; no id, no reboot
+    [ -n "$before" ] && _wait_new_boot "$before" 420 || {
         bad "leg 4: guest never returned after the dashboard reboot intent"
         kill "$srv_pid" 2>/dev/null
         rm -rf "$srv"


### PR DESCRIPTION
## What

Every reboot leg in `tests/os/run.sh` was `reboot; sleep 10; _wait_ssh`, and `_wait_ssh` only waits for `ssh true`. If the guest's shutdown outlasts the sleep, or the reboot command never lands, the harness reconnects to the still-running OLD boot and reads its marker as the verdict. That is the shape of the one red in the 09-04 battery on the frozen tip.

Three helpers replace it. `_boot_id` reads `/proc/sys/kernel/random/boot_id`. `_wait_new_boot <before> <secs>` polls until the id DIFFERS from `before`, counts how many probes the old boot answered after the command (a near-miss is now visible in the log), and fails at the deadline naming the id that stayed. `_reboot_wait <cmd> <secs>` records the id, issues the command, and waits; it refuses (rc 1, with a line saying why) when the id cannot be read before the command, because then a reconnect and a reboot would look alike. All 15 reboot legs whose verdict is read over SSH use it: 13 through `_reboot_wait`, and two that cannot (the fault-phase install-and-boot site, which must keep the install command's captured output, and leg 4's dashboard-driven reboot, where `_os_step` owns the command) record the id themselves and call `_wait_new_boot`. The two media-phase reboots are deliberately untouched: each already observes the new boot by a console banner on a truncated serial log before it waits for SSH. Leg 4 was the fifteenth, found independently by both non-author passes; it took `sleep 15`, which is what a `sleep 10` sweep passes over. Second commit; line-neutral.

`tests/os/` is outside the IMAGE FREEZE. Nothing under `tests/` is COPYed into the rootfs (`os/rootfs/Dockerfile`), so the image a battery on this tip builds differs from the frozen tip's only by the stamped commit.

## Why now (#1651)

- The battery on the frozen tip (`BUILD_COMMIT` `b4d818ec038954108fa86fe6cc36cb79d661469b`) ended `os harness: 188 passed, 1 failed`; the one red is the rig phase's update leg at `run.sh:2928`, `expected v2 in the rig's spare slot, got 'v1'`. Re-derived this session from the evidence dir's log, not relayed.
- A rig-only rerun on the SAME tree with the old harness plus an external 5-s probe (boot id, marker, RAUC booted slot, grubenv) was rc 0 with 0 reds; the probe recorded a different boot id after every reboot (four ids across three reboots) and read `v2` on slot B with `B_OK=1`. Neither hypothesis (reconnect race vs a slot-B rollback) reproduced; the failed run's guest is gone, so its cause is unrecoverable. Re-derived from that run's `probe.log` this session.
- The standing directive on this lane is that a green rerun with no cause named is not accepted. This change makes the race impossible by construction and instruments the near-miss, and a third run on this harness follows (below).

## What was RUN (this session)

- `bash -n tests/os/run.sh`: ok. `shfmt -i 4 -d`: clean. `bash scripts/lint-file-budget.sh`: OK. The file is 3423 lines, its ceiling exactly; the change is line-neutral.
- `_wait_new_boot` now declares `now=` (second commit): the reviewer reproduced `now: unbound variable` under `set -u` for a deadline that never enters the loop, unreachable from every site but free to fix; `_wait_new_boot old-id 0` now returns 1 cleanly.
- Four offline controls against the committed helper text with a fake `_ssh` (a guest that answers the OLD id for N probes after `reboot`, then a NEW one):
  - old boot answers 2 probes, then a new id: rc 0, and the log line `the old boot old-id answered 2 probe(s) after the reboot command before going down`
  - instant shutdown: rc 0, no stale line
  - never reboots, 12 s deadline: rc 1, `no new boot within 12 s — boot id old-id, was old-id`
  - boot id unreadable before the command: rc 1, `could not read the boot id before 'reboot' — a reconnect and a reboot would look alike`
- Leg-4 shape control with a fake guest and a fake `_os_step`: unreadable id, no reboot issued and the failure block fires; old boot never goes down, rc 1; reboot observed, the leg proceeds.
- NOT run locally: `make lint-sh`. The previous session ran it for seven minutes and lost the verdict to a pipeline's rc; a re-run here contends with the KVM run for memory. CI's lint-sh job is the gate; this PR is not MERGE-READY until it is green.
- Run 3, the rig phase on THIS harness (first commit, tree clean): `run.sh rc=0`, `os harness: 21 passed, 0 failed`, zero reds; the helper's own line `the old boot … answered 1 probe(s) after the reboot command before going down` printed on BOTH rig reboots, so the old boot is still answering SSH after the reboot command on this bench and the race is real, not theoretical. An independent 5-s probe saw four boot ids across three reboots and `v2` only after slot B's own id. Full readings on #1651. The second commit changes no line the rig phase executes (leg 4 is in the update phase; `now=` changes nothing on a reachable path), so run 3 stands for the helpers; I did not rerun it.

## Over-engineering pass (by hand: the review hook keys off a dead branch from this lane's cwd and cannot see this diff)

- One helper composed of two, not two per site. Inlining record/issue/wait at every site was available and rejected: about 40 extra lines against a file at its ceiling, and 14 copies of the same guard.
- No new flag or env var: the probe timeout reuses `SSH_PROBE_TIMEOUT`, the variable `_wait_ssh` already uses.
- Every site keeps its deadline (240, 300 or 420 s); only what the deadline waits FOR changed.
- New failure mode, named by the reviewer: the pre-read is one unretried probe, so a transient SSH blip at that instant now reds a leg the old code would have carried through. That is the direction a harness should fail in (a false red gets investigated, a false green ships); not changed.

## Not done

- No `--phase all` on this harness yet. That is the gating battery, which runs after this merges, on the tip it produces.
- The 09-04 red's cause stays unknown. What this change guarantees is that the harness can no longer produce that false red, and that a real slot-B rollback now reads as `boot id changed, marker v1` instead of the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
