### PR TITLE
docs(release): #1765 the release server's linter installs read the pins instead of copying them

### DIFF
--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -119,10 +119,13 @@ comparing.
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs jq curl git tar make
 
-# shellcheck + shfmt, read from the Makefile pins instead of copied.
-# Run from the repo root - clone it there first if the box has just been reimaged.
+# shellcheck + shfmt, read from the Makefile pins instead of copied. This block reads the repo,
+# so it needs a checkout and runs from its root. The two guards say that if it is not, rather than
+# letting an empty version build a URL that 404s and an install path that does not exist.
 SC=$(make -s print-shellcheck-version)
 SF=$(make -s print-shfmt-version)
+: "${SC:?not in a checkout - run this block from the repo root}"
+: "${SF:?not in a checkout - run this block from the repo root}"
 curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v$SC/shellcheck-v$SC.linux.x86_64.tar.xz" | tar -xJ -C /tmp
 sudo install -m 0755 "/tmp/shellcheck-v$SC/shellcheck" /usr/local/bin/shellcheck
 sudo curl -fsSL -o /usr/local/bin/shfmt "https://github.com/mvdan/sh/releases/download/v$SF/shfmt_v${SF}_linux_amd64"

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -108,20 +108,24 @@ missing tool rather than dying mid-gate. Restore them with the same pinned versi
 and reformat differently, so a version skew would fail `make lint` on the box for diffs the merge
 gate never saw. Both pins live in the `Makefile` — `SHELLCHECK_VERSION` and `SHFMT_VERSION` — and
 each is what `ci.yml` installs and what `make lint-sh` refuses to run without;
-`make -s print-shellcheck-version` and `make -s print-shfmt-version` print them, so the versions
-below are copies and those commands are the source. One wrinkle worth knowing when you check by
-hand: `shfmt --version` prints a leading `v` on the upstream release builds (`v3.13.1`) while some
-distro builds print a bare number, so the gate strips it before comparing.
+`make -s print-shellcheck-version` and `make -s print-shfmt-version` print them, and the block below
+calls those commands rather than copying what they print, so it cannot go stale against the pins.
+One wrinkle worth knowing when you check by hand: `shfmt --version` prints a leading `v` on the
+upstream release builds while some distro builds print a bare number, so the gate strips it before
+comparing.
 
 ```bash
 # node 20 (brings npx) + the basics the harness also needs
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-sudo apt-get install -y nodejs jq curl git tar
+sudo apt-get install -y nodejs jq curl git tar make
 
-# shellcheck 0.11.0 (= make -s print-shellcheck-version) + shfmt 3.13.1 (= make -s print-shfmt-version)
-curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz | tar -xJ -C /tmp
-sudo install -m 0755 /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
-sudo curl -fsSL -o /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
+# shellcheck + shfmt, read from the Makefile pins instead of copied.
+# Run from the repo root - clone it there first if the box has just been reimaged.
+SC=$(make -s print-shellcheck-version)
+SF=$(make -s print-shfmt-version)
+curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v$SC/shellcheck-v$SC.linux.x86_64.tar.xz" | tar -xJ -C /tmp
+sudo install -m 0755 "/tmp/shellcheck-v$SC/shellcheck" /usr/local/bin/shellcheck
+sudo curl -fsSL -o /usr/local/bin/shfmt "https://github.com/mvdan/sh/releases/download/v$SF/shfmt_v${SF}_linux_amd64"
 sudo chmod 0755 /usr/local/bin/shfmt
 
 # uv 0.10.10 (pinned installer; brings uvx, and adds ~/.local/bin to PATH)

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -119,9 +119,10 @@ comparing.
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 sudo apt-get install -y nodejs jq curl git tar make
 
-# shellcheck + shfmt, read from the Makefile pins instead of copied. This block reads the repo,
-# so it needs a checkout and runs from its root. The two guards say that if it is not, rather than
-# letting an empty version build a URL that 404s and an install path that does not exist.
+# shellcheck + shfmt, read from the Makefile pins instead of copied. This block reads the repo, so
+# it needs a checkout and runs from its root. If it does not, the two guards name that as the cause.
+# Run as a script they also stop it; pasted into an interactive shell they do not, so what follows
+# is a 404 you can interpret rather than one you cannot.
 SC=$(make -s print-shellcheck-version)
 SF=$(make -s print-shfmt-version)
 : "${SC:?not in a checkout - run this block from the repo root}"


### PR DESCRIPTION
Fixes #1765 by hand — `Closes` is inert on `develop-v2`, so the issue gets closed with the merge sha.

## What was wrong

`docs/dev/release-server.md` names `make -s print-shellcheck-version` and `make -s print-shfmt-version`
as the source of truth for the two linter pins, and then four lines later pastes the versions in as
literals: `0.11.0` three times and `3.13.1` twice, in the block an operator copies onto a reimaged
release box. Nothing checked those copies against the Makefile.

**#1688 changed what a stale copy costs.** `make lint-sh` now refuses any `shfmt` but the pinned one.
On the next bump `SHFMT_VERSION` and `ci.yml`'s sha256 fail loudly, and this doc stays silent — so a
box provisioned from a stale copy installs the wrong linter and hard-fails `make release`'s blocking
lint gate. On the release box. During a release. Reading as the linter's fault rather than the doc's.

This lane's canonical shape — a version that is only PRINTED is not CHECKED — one layer out, in the docs.

## What changed

The install block calls the two commands and rebuilds both download URLs from what they print, the
same construction `ci.yml:428-436` already uses (same `SC=` / `SF=` variable names, same URL shape).
`make` joins the `apt-get install` line because the block now needs it, and the comment says to run
from the repo root.

One file, 14 insertions, 10 deletions. Docs only, no code, no workflow.

## Proven, not assumed

Measured at this PR's tree, not relayed:

- `make -s print-shellcheck-version` prints `0.11.0`; `make -s print-shfmt-version` prints `3.13.1`.
  Both **bare, no `v` prefix** — which is what makes the `v$SC` / `v$SF` in the URLs correct.
- The three strings the block now rebuilds are **byte-identical** to the three literals they replace.
  Diffed, not eyeballed: rebuilt values against `git show <base>:docs/dev/release-server.md` piped
  through `grep -oE`, sorted, `diff` clean.
  - `https://github.com/koalaman/shellcheck/releases/download/v$SC/shellcheck-v$SC.linux.x86_64.tar.xz`
  - `/tmp/shellcheck-v$SC/shellcheck`
  - `https://github.com/mvdan/sh/releases/download/v$SF/shfmt_v${SF}_linux_amd64`
- `make lint-md`, `make lint-docs-voice`, `make lint-operator-strings`, `make lint-file-budget`: all rc 0.
  `make lint-sh` was **not** run locally; CI is the lint gate for this PR. This change adds no shell
  file and edits no shell file — the only shell it touches is inside a fenced block in a Markdown doc,
  which `lint-sh` does not read.
- Lane-guard fired on the commit and **allowed** it, which is what proves `docs/`'s `_shared` grant is
  live rather than merely believed. One file staged, so this is a permission check, not a narrowness control.

## Design pass — what I attacked, and what survived

- **The block now needs a checkout and `make`; the old one needed neither.** Real dependency, and the
  honest cost of deriving. Addressed both ways: `make` added to the apt line, and the comment says to
  run from the repo root. **CORRECTED after the delta review:** this bullet also said the comment tells
  you "to clone first on a fresh reimage". It no longer does — `a2ff62ed` deliberately removed that
  clause, and `grep -i clone` over the doc at `d10e2ded` returns nothing (the same grep at `f446f916`
  returns line 123, so the instrument is not dead). The page already presumes a checkout
  (the readiness command above it passes `--dir pithead`).
- **What if a print target is deleted?** `SC` goes empty, the URL 404s under `curl -f`, and
  `sudo install /tmp/shellcheck-v/shellcheck` dies on a missing path. It fails loudly; it does not
  quietly install nothing.
- **`make -s` output pollution.** `-s` implies `--no-print-directory`, and `ci.yml` already stakes
  every PR's lint job on this exact capture — so the doc is now no more fragile than the gate itself.
  Verified empirically here anyway: clean single-token output.
- **A sha256 beside each download was considered and not added.** **CORRECTED after review:** this is
  a non-change, not a decision — the base block has no sha256 either, so there was nothing here to
  veto. Stated only as a reason not to add one later without thinking: `ci.yml`'s hashes are each
  tied to one tarball, so pasting them here would reintroduce the exact staleness this PR removes,
  one layer down.
- **Not fixed here, same shape:** the `uv 0.10.10` line below has no single source of truth to derive
  from — `ci.yml` itself copies that literal four times. **CORRECTED after review: the reason I first
  gave for leaving it was false, though the conclusion stands.** I wrote that adding a `uv` Makefile
  variable is "outside a docs-only fix under the image freeze". The image freeze covers `os/`,
  `tests/os/`, `lib/pithead/`, `pithead`, `build/`, the compose file and `VERSION`; `Makefile` is in
  none of them. It is a serialized shared file that needs a one-shot `.lane-override`, which is a
  cost, not a prohibition. **Scope was always the real reason** — this is a docs fix for one stale
  copy, and giving `uv` a pin variable is a separate change across `Makefile` and four `ci.yml`
  lines. A correct conclusion resting on a false premise gives no tell, which is why it is corrected
  in place rather than quietly dropped.

## Over-engineering pass (ponytail gate)

Ran by hand on this diff; findings recorded rather than deferred.

- **Is deriving heavier than just correcting the literals?** Correcting them is one line and stale
  again at the next bump — that is the defect, not the symptom. Deriving is the smaller change over
  the life of the file.
- **Simpler shape considered and rejected:** a single `eval "$(make -s print-pins)"` reading one new
  combined target. It removes one line here and adds a Makefile target — a code change, under the
  image freeze, to save a line in a doc. Not worth it.
- **The comment.** Borderline, kept: the precondition it states — run from a checkout's root — is
  a real dependency this change introduces, and it is the one thing a reader on a fresh box needs.
  **CORRECTED after the delta review:** this said "two-line comment" and "(repo root, clone first)".
  Both are stale at `d10e2ded` — the comment is now **four** lines and says nothing about cloning.
- **Nothing else was touched.** The paragraph reflow above the block repairs a line break this edit
  created; it changes no wording.

## Freeze compliance

Touches nothing in `os/`, `tests/os/`, `lib/pithead/`, `pithead`, `build/`, compose or `VERSION`.

Rebased onto `origin/develop-v2` at `ef3942d0`.

## Review round 1 — findings taken, head moved

`lane-reviewer-05` PASSed at `f446f916` and re-derived the byte-identity claim by an independent
route: it built each string individually rather than sorted-diffing the set (a sorted diff can be
satisfied by the multiset while one string is wrong), confirmed both pins are 7 bytes with `od -c`
so `v$SC` / `v$SF` yield exactly one `v`, and fired a wrong-pin control.

It raised one SHOULD-FIX, which is now taken. **Head is `d10e2ded`** — two commits, the fix and a
correction to my own measurement of it:

**This change introduces exactly one new failure mode and it failed with the least informative
message available.** Outside a checkout, `SC=$(make -s print-shellcheck-version)` swallows make's
failure, `SC` is empty, and the operator gets a 404 on a version-less URL plus an install error on a
path that does not exist — neither naming the cause. Two `: "${SC:?...}"` guards fix that.

Measured in both shell modes rather than reasoned about, because the colon form's stopping behaviour
differs between them:

| case | result |
|---|---|
| non-interactive bash, outside a checkout | guard names the cause, rc 1, **next line never runs** |
| interactive bash reading the lines on stdin (a paste into an ssh session), outside a checkout | guard names the cause, **the shell survives and the next line runs** with an empty `SC`, so the curl still 404s |
| control, from the repo root | both guards silent, `SC=0.11.0` / `SF=3.13.1` pass through, rc 0 |

**CORRECTED, and the commit message of `a2ff62ed` overstates this — read `d10e2ded` with it.** My
first interactive test used `bash -i -c '<string>'` and recorded that the guard stops the block. It
does not. A `-c` command string exits after the string regardless of `-i`, so that fixture never
exercised interactivity and passed for the wrong reason. Bash documents `${var:?word}` as exiting a
*non-interactive* shell only. **In a pasted block the guard explains the 404 rather than preventing
it** — which is still the change worth making, but it is a smaller claim than the one I first wrote,
and the doc comment has been reworded to say the smaller thing.

`:?` is still the right form, for a stronger reason than I originally gave — the reviewer's, not
mine: the explicit `|| { echo; exit 1; }` alternative would log an operator out of the box they just
ssh'd into. Neither form both halts a paste and keeps the session. And make's own error still prints
first, naming *which* precondition failed (no make, no target, wrong directory), so the doubled
output is two messages saying different useful things rather than one saying the wrong thing.

The first attempt at the passing control also ran from the wrong cwd and failed for that reason
rather than a real one; it is re-run from the repo root, which is what makes it a control rather
than a second copy of the firing case. Two broken fixtures in one review round, both of which
produced a result that looked like a finding.

## For whoever merges

**Set the squash body explicitly — do not accept GitHub's default.** It composes the squash message
from the constituent commit messages, and `a2ff62ed`'s message carries the retracted `bash -i -c`
measurement that `d10e2ded` exists to correct. Accepting the default lands that retracted claim in
`develop-v2`'s history as fact. Raised by the delta reviewer, and it is the one merge-time hazard here.

**`Closes` is inert on `develop-v2`** — hand-close #1765 with the merge sha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jqhjbL6yAu4GmLaKV6gTv

