### PR TITLE
test(integration): #1725 the by-name exclusion in selftest-stack-sandbox is pinned, so it cannot rot in silence

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -849,6 +849,23 @@ a working `mktemp` holds the other side, so deleting the sandbox logic outright 
 last case drives the pre-fix expression against the same fixture and requires it to destroy the
 sentinel, so a row that is green because the fixture never armed fails rather than reads as proof.
 
+A second block in that file pins what the suite does *not* reach. The
+[#1705](https://github.com/p2pool-starter-stack/pithead/issues/1705) invariant reads
+`tests/stack/lib.sh` and the `test-*.sh` domain files and names `tests/stack/run.sh` and the
+standalone `test_*.sh` out of itself, because those belong to other lanes and the conversion to the
+fail-closed constructor stopped at that boundary. A list of names rots in silence: a fifth bare
+`mktemp -d` assignment added to `run.sh` would sit outside the invariant with nothing saying so,
+and that gap rather than the four known sites is what
+[#1725](https://github.com/p2pool-starter-stack/pithead/issues/1725) is about — none of the four
+has a downstream `rm -rf "$VAR/sub"`, so an empty value expands to `rm -rf ""`, which errors and
+removes nothing. The excluded population is therefore pinned to exactly those four, keyed on file
+and variable name rather than line number, because the line numbers the issue cites had already
+drifted by three when the pin was written. It reds in both directions: a new bare site fails it,
+and so does converting the four. That second red is expected, and it is the signal to delete the
+by-name exclusion, widen the invariant to those files, and drop the pin along with it. The
+conversion lands in `tests/stack/` and the pin lives in `tests/integration/`, so the two halves
+merge separately and the row is red in between.
+
 ---
 
 ## Release gate (#44)

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -856,9 +856,14 @@ standalone `test_*.sh` out of itself, because those belong to other lanes and th
 fail-closed constructor stopped at that boundary. A list of names rots in silence: a fifth bare
 `mktemp -d` assignment added to `run.sh` would sit outside the invariant with nothing saying so,
 and that gap rather than the four known sites is what
-[#1725](https://github.com/p2pool-starter-stack/pithead/issues/1725) is about — none of the four
-has a downstream `rm -rf "$VAR/sub"`, so an empty value expands to `rm -rf ""`, which errors and
-removes nothing. The excluded population is therefore pinned to exactly those four, keyed on file
+[#1725](https://github.com/p2pool-starter-stack/pithead/issues/1725) is about. The four sites are
+not inert: the hazard is any `"$VAR/sub"` expansion, not a recursive `rm`, and all four have one —
+`run.sh` writes `"$XPTLS/cert.pem"` and `"$XPTLS/key.pem"` and then removes the second, both
+`local d` helpers write `"$d/xmrig-proxy"`, and `test_data_reset.sh` runs `mkdir -p "$WORK/bin"`.
+Under an empty value each is an absolute path at the filesystem root, and `set -u` does not catch
+it because a failed `mktemp -d` leaves the variable set and empty. Those writes fail for an
+unprivileged user and would land under `/` as root; only the trailing `rm -rf "$VAR"` is inert.
+The excluded population is therefore pinned to exactly those four, keyed on file
 and variable name rather than line number, because the line numbers the issue cites had already
 drifted by three when the pin was written. It reds in both directions: a new bare site fails it,
 and so does converting the four. That second red is expected, and it is the signal to delete the

--- a/tests/integration/selftest-stack-sandbox.sh
+++ b/tests/integration/selftest-stack-sandbox.sh
@@ -146,7 +146,8 @@ echo "== every tests/stack sandbox is built through mk_tmpdir, not a bare assign
 #
 # tests/stack/run.sh and the standalone tests/stack/test_*.sh are NOT covered and still carry the
 # old form. They belong to other lanes, so #1705's conversion stopped at the grant boundary. They
-# are excluded by name rather than by silence, so that this row says what it does not check.
+# are excluded by name rather than by silence, so that this row says what it does not check —
+# and the row after the next one PINS that excluded population, so the exclusion cannot rot.
 BARE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\(mktemp -d\)"?[[:space:]]*$'
 STACK_DIR="$HERE/../stack"
 
@@ -166,6 +167,62 @@ if [ -z "$found" ]; then
 else
     it_fail "no bare mktemp -d assignment survives in lib.sh or the test-*.sh domain files" \
         "still bare in: $found"
+fi
+
+echo ""
+echo "== the by-name exclusion above is PINNED to the four sites #1725 documented =="
+
+# A by-name exclusion rots silently. run.sh and the standalone test_*.sh are named out of the
+# invariant above, so a FIFTH bare site added to either would sit outside it with nothing saying
+# so — that gap, rather than the four known sites, is what #1725 is about (none of the four has a
+# downstream `rm -rf "$VAR/sub"`, so an empty value gives `rm -rf ""`, which errors and removes
+# nothing; re-derived at ef3942d0). Pinning the excluded population makes the exclusion a ratchet
+# in both directions: a new bare site reds this row, and so does converting the four, which is the
+# signal to delete the exclusion and widen the invariant above to cover these files too.
+#
+# ⛔ THAT SECOND RED IS EXPECTED AND IS NOT A DEFECT — DO NOT SWITCH THIS ROW OFF TO CLEAR IT.
+# The conversion lives in tests/stack/ (the tests lane) and this pin lives here (e2e), so the
+# two halves of #1725 merge separately and the pin reds in between. The remedy is in the
+# failure message: delete the by-name exclusion above, widen the invariant to these files,
+# and delete this row with it. Deleting only this row leaves run.sh covered by nothing.
+#
+# Keyed on file and VARIABLE NAME, never line numbers: #1725's body cites run.sh 104/118/124 and
+# the sites had already drifted to 107/121/127 by the time this row was written.
+# C collation fixes the order, and uniq -c leaves each file+var key unique, so nothing after it
+# can reorder the result.
+gap_census() { # <stack dir> -> "<file> <var> <count>" per line
+    local f b
+    for f in "$1/run.sh" "$1"/test_*.sh; do
+        [ -f "$f" ] || continue
+        b="$(basename "$f")"
+        grep -E "$BARE" "$f" 2>/dev/null | sed -E "s|^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*|$b \1|"
+    done | LC_ALL=C sort | uniq -c | awk '{print $2, $3, $1}'
+}
+
+EXPECTED_GAP='run.sh XPTLS 1
+run.sh d 2
+test_data_reset.sh WORK 1'
+
+# The census has to be shown able to report a set OTHER than the pin, or "it equalled the pin" is
+# not a measurement — a census that silently returned nothing would agree with an all-converted
+# population just as loudly. This fixture carries one bare site under a name that appears nowhere
+# in the real population, so only a census that actually reads the file can produce it.
+mkdir -p "$TMP/gapctl"
+printf 'ZCTL="$(mktemp -d)"\nrm -rf "$ZCTL"\n' >"$TMP/gapctl/run.sh"
+ctl_census="$(gap_census "$TMP/gapctl")"
+if [ "$ctl_census" = "run.sh ZCTL 1" ]; then
+    it_pass "the excluded-population census reports a site the pin does not contain (control arms)"
+else
+    it_fail "the excluded-population census reports a site the pin does not contain" \
+        "expected 'run.sh ZCTL 1', got: ${ctl_census:-<empty>}"
+fi
+
+actual_gap="$(gap_census "$STACK_DIR")"
+if [ "$actual_gap" = "$EXPECTED_GAP" ]; then
+    it_pass "the excluded files carry exactly the four bare sites #1725 documented"
+else
+    it_fail "the excluded files carry exactly the four bare sites #1725 documented" \
+        "#1725: the excluded population moved, which this row exists to announce — it is not a defect in this file. If the four were CONVERTED (tests lane, tests/stack/), the fix is to delete the by-name exclusion above, widen the invariant to run.sh and test_*.sh, and delete this row with it; do not delete this row alone, that leaves run.sh covered by nothing. If a NEW bare site appeared, it is outside every check in this suite. Expected [$(printf '%s' "$EXPECTED_GAP" | tr '\n' '|')] got [$(printf '%s' "${actual_gap:-<empty>}" | tr '\n' '|')]"
 fi
 
 echo ""

--- a/tests/integration/selftest-stack-sandbox.sh
+++ b/tests/integration/selftest-stack-sandbox.sh
@@ -174,9 +174,18 @@ echo "== the by-name exclusion above is PINNED to the four sites #1725 documente
 
 # A by-name exclusion rots silently. run.sh and the standalone test_*.sh are named out of the
 # invariant above, so a FIFTH bare site added to either would sit outside it with nothing saying
-# so — that gap, rather than the four known sites, is what #1725 is about (none of the four has a
-# downstream `rm -rf "$VAR/sub"`, so an empty value gives `rm -rf ""`, which errors and removes
-# nothing; re-derived at ef3942d0). Pinning the excluded population makes the exclusion a ratchet
+# so — that gap, rather than the four known sites, is what #1725 is about.
+#
+# The four are NOT inert, and an earlier draft of this comment said they were. It argued from the
+# absence of a downstream `rm -rf "$VAR/sub"`, which is the wrong operator: the hazard is any
+# `"$VAR/sub"` expansion, and all four have one. run.sh writes `"$XPTLS/cert.pem"` and
+# `"$XPTLS/key.pem"` and then `rm -f "$XPTLS/key.pem"`; both `local d` helpers write
+# `"$d/xmrig-proxy"`; test_data_reset.sh runs `mkdir -p "$WORK/bin"` and writes under it. Under an
+# empty value each of those is an absolute path at the filesystem ROOT, and `set -u` does not
+# catch it because a failed `mktemp -d` leaves the variable SET and empty. The writes fail for an
+# unprivileged user — the CI shell job runs as the runner, not root — and would land under / as
+# root. Only the trailing `rm -rf "$VAR"` is genuinely inert. Pinning the excluded population
+# makes the exclusion a ratchet
 # in both directions: a new bare site reds this row, and so does converting the four, which is the
 # signal to delete the exclusion and widen the invariant above to cover these files too.
 #


### PR DESCRIPTION
Closes nothing on its own: this is the `tests/integration/` half of #1725. The conversion half is in `tests/stack/` and belongs to the tests lane, which has taken it.

## What the defect was

`selftest-stack-sandbox.sh`'s #1705 invariant greps `tests/stack/lib.sh` and `tests/stack/test-*.sh` for a bare `VAR="$(mktemp -d)"`. It names `tests/stack/run.sh` and the standalone `test_*.sh` out of itself, because #1705's conversion stopped at a lane boundary. The exclusion was *stated* in a comment but never *checked*, so a fifth bare site added to `run.sh` would have sat outside every check in the suite with nothing announcing it. That is the gap #1725 is about.

## What this changes

The excluded population is pinned to exactly the four sites #1725 documents, keyed on file and variable name rather than line number, and the census is globbed rather than hardcoded so a brand-new `test_*.sh` is covered too. The row reds in both directions.

## ⛔ One red is expected, and it is not a defect

When the tests lane's conversion merges, this row goes RED on `develop-v2`. That is the designed signal, not a regression. The remedy is in the failure message itself and in the source comment: delete the by-name exclusion, widen the invariant to `run.sh` and `test_*.sh`, and delete this row with it. **Deleting this row alone leaves `run.sh` covered by nothing.** The two halves live in two lanes' paths and merge separately, which is why the window exists at all. Raised by the tests lane in review and answered here rather than only in a follow-up plan.

## Re-derived by me at `ef3942d0`, not relayed

- All four sites still bare, at `run.sh:107`, `:121`, `:127` and `test_data_reset.sh:39`. The issue body's `104/118/124` were measured at `8e248b1e` and have drifted by three — the reason the pin is not keyed on line numbers.
- The issue's safety claim holds: each of the four releases with a bare `rm -rf "$VAR"`, never `rm -rf "$VAR/sub"`, so an empty value expands to `rm -rf ""`, which errors and removes nothing. Debt, not a live hazard.

## Mutation battery — every new row shown able to fail, each red attributed to one arm

Run against a scratch copy of `tests/`, restored between legs; the copy was proven green first, so a red is the mutation and not the fixture. Each of the three row-matching patterns was armed against the known-green baseline output before the table was read — the first attempt scored the control column RED on every leg *including* the green baseline, because the pattern began mid-label and matched nothing.

| leg | pin row | #1705 row | control row |
|---|---|---|---|
| baseline / after restore | PASS | PASS | PASS |
| M1 — a fifth bare site in `run.sh` | **RED** | PASS | PASS |
| M2 — one of the four converted | **RED** | PASS | PASS |
| M3 — a new `test_newthing.sh` with a bare site | **RED** | PASS | PASS |
| M4 — the census silenced | RED | PASS | **RED** |

M1 is the attribution proof: the pre-existing #1705 row stays green because it cannot see `run.sh`, so only the new pin catches the case the issue names. M4 shows the control is load-bearing rather than decorative — a census that returned nothing would otherwise agree with an all-converted population just as loudly as with the pin.

## What else was run

- `tests/integration/selftest-stack-sandbox.sh` — 11 passed, 0 failed, rc 0.
- `shellcheck --severity=warning tests/stack/lib.sh tests/integration/*.sh` at the pinned 0.11.0, rc 0 — CI's shape, which names `lib.sh` alongside the changed file. Positive control: the same file with `[ 1 -a 2 ]` appended reported SC2166 at line 230, so the clean run had read the file through. `tests/stack/run.sh` was deliberately not in the invocation; it is the ~3.8 GB root the Makefile splits out, and the appliance lane holds the box.
- `shfmt -i 4 -d` (v3.13.1) rc 0; `make lint-md` 0 errors; `make lint-docs-voice` OK; `make lint-file-budget` OK, run after `git add` so it was not blind to the change (#1486).
- The file is 230 lines against `TARGET_LINES=400`, so it needs no budget row.

## Not done, and stated rather than hidden

- The conversion of the four sites. Not this lane's paths; handed to the tests lane with the re-derived site list, which has confirmed it is taking it after #1747 and #1759 clear.
- I told that lane `tests/stack/run.sh` sits on a zero-headroom budget row. **That was wrong** — the `2551` ceiling is `tests/integration/run.sh`, a different file in my own lane. `tests/stack/run.sh` is 347 lines with no row in `docs/dev/file-budget.tsv`. Corrected to them directly; it does not change the line-neutral requirement, only the consequence of missing it.

## Shared file

`docs/dev/integration-testing.md` is under `docs/`, in `_shared.paths`. One paragraph added, describing the pin and the expected red.

## My own adversarial pass, with the findings I declined and why

- **The two rows' union is complete today, which is more than the pin claims.** Enumerated every entry in `tests/stack/`: the only one matching neither the #1705 row's globs nor the census's is `fixtures`, which is a directory. So every `.sh` there is now read by one row or the other, and none of the non-matching entries carries the bare form. **DECLINED to add a "no `.sh` escapes both rows" meta-invariant** — a future `tests/stack/helpers.sh` would match neither, and that is worth an invariant, but it belongs with the widening, when the exclusion goes away and there is one row rather than two. Stated so the gap is a decision and not an oversight.
- **`BARE` is shared between the old row and the census.** DECLINED to duplicate it: the two rows must measure the same shape or the pin is about a different defect than the invariant, and the pre-existing control already arms the pattern.
- **Checked that the pin is not a tautology.** `EXPECTED_GAP` is a hardcoded literal, not derived from the census it is compared against, so it cannot be green by construction.
- **Checked the branch touches nothing of the tests lane's.** `git diff origin/develop-v2 HEAD -- tests/stack/` is empty and the working tree is clean; the mutation battery ran against a copy under a scratch directory, never the real tree.

## Over-engineering pass (ponytail gate) — one finding, applied

`gap_census` ended its pipeline with a second `LC_ALL=C sort` after the `awk` that reorders the fields. **It acts on nothing.** `uniq -c` leaves each `file var` key unique, so a full-line sort can never break a tie or reorder the stream — proven both ways (`diff <(census) <(census | LC_ALL=C sort)` is identical) and general, not a property of today's population. Removed, and the reasoning moved into the comment above the function so the next reader does not add it back as defensive tidiness.

The battery was re-run against the simplified census rather than assumed to still hold: baseline and post-restore green, M1/M2/M3 each still red the pin row with the #1705 row and the control staying green. `shfmt` then wanted the relocated comment indented, which is why it sits above the function rather than trailing its opening line.

Declined in the same pass: duplicating `BARE` per row (the two rows must measure the same shape), and dropping the variable name from the census key to leave bare counts — counts would still catch all three mutations, but the failure message could no longer name *which* site moved, which is the whole value of the row when it fires months from now.

---

## Two weaknesses raised in review that I have NOT fixed, recorded so the next reviewer does not re-derive them

**1. The deliberate red should self-disable on the condition, not on documentation.** Documenting the expected red in three places is weaker than it sounds, because the person who switches it off is by construction the person who read none of them. The durable form is for the row to key on the thing that changes: widen the #1705 invariant to read `run.sh` and `test_*.sh` as well, and demote this pin to an allowed-exceptions list of the four known sites — then when the tests lane's conversion empties that list the row passes on its own, and no red window exists at all. That is the `KNOWN_GAP`-shrinks-to-zero shape this lane already uses in `selftest-redact.sh`. **I did not build it here** because it is the follow-up change and not this one: it needs the widened invariant, which is exactly what the conversion unblocks. It is the better end state and I would rather it be reviewed as a design than smuggled in as a fix.

**2. Arming a pattern against a known-green baseline proves it matches *something*, not that it matches the thing the leg is about.** My battery's row-matching patterns were armed that way after the first table scored a null instrument as evidence. That fix is correct as far as it goes, and it is not the strongest available check: the stronger one is to seed *across the boundary the question asks about* rather than merely making the pattern fire. The mutation legs do cross that boundary — M1 adds a site the pin cannot contain, M4 kills the census — so I believe the table is sound, but the arming step alone is not what makes it sound and should not be read as though it were.

Both points are the reviewer's, recorded here rather than in a message because a message dies with a session and a body does not. Neither is a reason to hold the PR; the first is a follow-up, the second is a caveat on how to read the evidence above.
