### PR TITLE
test(stack): #1767 the PASS-label sweep sees positional interpolation

### DIFF
--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -260,7 +260,7 @@ vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interp
         }
         f = FILENAME
         sub(/^.*\//, "", f)
-        while (match(label, /\$\{?[A-Za-z_][A-Za-z0-9_]*|\$\(|`/)) {
+        while (match(label, /\$\{?[A-Za-z_][A-Za-z0-9_]*|\$\{?[0-9]+|\$[@*#]|\$\(|`/)) {
             tok = substr(label, RSTART, RLENGTH)
             label = substr(label, RSTART + RLENGTH)
             if (tok == "$(" || tok == "`") { print f "|$(cmd)"; continue }
@@ -276,24 +276,48 @@ vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interp
 # RIS/RIJ are absolute paths that differ per WORKTREE, and test-secrets.sh's mem/host_ram_mb come
 # from /proc/meminfo MemTotal, so they differ per BOX. Both are stable across two runs in one place,
 # which is exactly why sampling never found them.
+#
+# THE NUMBERED ENTRIES ARE A DIFFERENT CLASS AND CARRY A DIFFERENT PROOF (#1767). A label built from
+# a POSITIONAL is a WRAPPER's label: what actually prints is whatever its callers pass, which this
+# file cannot see. So the sweep flags the wrapper and the review has to go to the callers. Done
+# mechanically at the commit that added these rows — every call of the eight wrappers, with
+# backslash continuations joined, argument extracted by a shell-grammar parser rather than by eye:
+# 55 calls, 54 passing a bare string literal, and one passing `${ev}` from
+# test-control-editable-allowlist.sh's loop over 25 spelled-out event names. That one is a loop
+# variable over a fixed list, so the whole class is run-invariant today.
+#   * `lib.sh|1` is not a call site at all — it is assert_eq/assert_contains/assert_not_contains/
+#     assert_rc forwarding their own <label> parameter to ok(). Every label in the suite funnels
+#     through it, so it is listed for completeness and says nothing about any one domain.
+# WHAT THIS ROW STILL DOES NOT PROVE: it pins the SET of interpolating labels, not the VALUES. A new
+# caller handing one of these wrappers a measured value keeps the set identical and the row green —
+# the caller audit above is a point-in-time reading, not a standing instrument. Re-run it when a
+# wrapper gains callers; that is the residual #1740 could not close and this row does not either.
 vd_expected="$(
     cat <<'VDEXP'
+lib.sh|1
 test-appliance-boot.sh|ph
 test-appliance-identity-boot.sh|cli_pages
 test-appliance-identity-boot.sh|u
+test-appliance-identity.sh|1
 test-appliance-identity.sh|f
 test-appliance-os-update.sh|RIJ
 test-appliance-os-update.sh|RIS
+test-config.sh|2
 test-config.sh|bad_port
 test-config.sh|checked
 test-config.sh|core_checked
+test-control-add-only-ssrf.sh|2
+test-control-add-only-ssrf.sh|3
 test-control-core.sh|reowned
 test-control-diagnostics.sh|_c
+test-control-editable-allowlist.sh|1
 test-doctor.sh|ip
 test-release.sh|comp
 test-release.sh|pin_rel
 test-release.sh|svc
 test-render-quadlet.sh|f
+test-rig-worker.sh|3
+test-secrets-masking.sh|1
 test-secrets.sh|ev
 test-secrets.sh|host_ram_mb
 test-secrets.sh|mem
@@ -317,11 +341,18 @@ mkdir -p "$vd_seed"
 cat >"$vd_seed/test-vd-seed.sh" <<'VDSEED'
 ok "a label carrying a brand new interpolation $vd_fresh_name"
 ok "an escaped \$PWD is prose in a label, not an interpolation"
+ok "a wrapper label built from a positional $1 and a braced one ${2}"
+ok "a label splicing all of its arguments $@"
 bad "a bad-only label naming $vd_failure_only"
 VDSEED
 vd_ctl="$(vd_interp_names "$vd_seed/test-vd-seed.sh")"
 assert_contains "the sweep reports a new interpolated PASS label (firing control)" "$vd_ctl" "vd_fresh_name"
 assert_not_contains "an escaped dollar in a label is not read as interpolation" "$vd_ctl" "PWD"
 assert_not_contains "a bad-only label is not held to the PASS-line rule" "$vd_ctl" "vd_failure_only"
+# #1767: the positional and special-parameter alternations are the two this extractor did NOT have.
+# Assert them separately from the $VAR row above, so a break says which class stopped matching.
+assert_contains "the sweep reports a positional interpolation (#1767 firing control)" "$vd_ctl" "|1"
+assert_contains "the sweep reports a braced positional too" "$vd_ctl" "|2"
+assert_contains "the sweep reports \$@, which splices every argument" "$vd_ctl" "|@"
 unset -f vd_interp_names
 unset vd_expected vd_seed vd_ctl

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -280,11 +280,16 @@ vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interp
 # THE NUMBERED ENTRIES ARE A DIFFERENT CLASS AND CARRY A DIFFERENT PROOF (#1767). A label built from
 # a POSITIONAL is a WRAPPER's label: what actually prints is whatever its callers pass, which this
 # file cannot see. So the sweep flags the wrapper and the review has to go to the callers. Done
-# mechanically at the commit that added these rows — every call of the eight wrappers, with
-# backslash continuations joined, argument extracted by a shell-grammar parser rather than by eye:
-# 55 calls, 54 passing a bare string literal, and one passing `${ev}` from
-# test-control-editable-allowlist.sh's loop over 25 spelled-out event names. That one is a loop
-# variable over a fixed list, so the whole class is run-invariant today.
+# mechanically — every call of the ELEVEN wrappers, with backslash continuations joined, argument
+# extracted by a shell-grammar parser rather than by eye: 73 calls, 72 passing a bare string
+# literal, and one passing `${ev}` from test-control-editable-allowlist.sh's loop over 25
+# spelled-out event names. That one is a loop variable over a fixed list, so the whole class is
+# run-invariant today.
+#   * COUNT THE WRAPPERS, NOT THE ROWS. The first pass said "eight wrappers, 55 calls" because it
+#     counted ROWS: a row is <file>|<index>, so test-config.sh|2 collapses three wrappers and
+#     test-rig-worker.sh|3 collapses three more. Eleven and 73 are the numbers the imperative below
+#     is about; auditing eight misses three. The verdict held at the wider scope, the sentence
+#     supporting it did not.
 #   * `lib.sh|1` is not a call site at all — it is assert_eq/assert_contains/assert_not_contains/
 #     assert_rc forwarding their own <label> parameter to ok(). Every label in the suite funnels
 #     through it, so it is listed for completeness and says nothing about any one domain.
@@ -292,9 +297,9 @@ vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interp
 # caller handing one of these wrappers a measured value keeps the set identical and the row green —
 # the caller audit above is a point-in-time reading, not a standing instrument. Re-run it when a
 # wrapper gains callers; that is the residual #1740 could not close and this row does not either.
-# AND the special-parameter class is wider than its control: the alternation takes $@, $* and $#,
-# but no label in tests/stack uses $* or $#, so only $@ has a live site and a seed. Those two
-# branches are covered by construction, not by a firing control — seed them if a label adopts one.
+# The special-parameter class has no live site beyond $@ — no label in tests/stack uses $* or $#.
+# They are seeded anyway, below, so all three characters have a control that can fail rather than
+# two branches that pass by construction.
 vd_expected="$(
     cat <<'VDEXP'
 lib.sh|1
@@ -346,6 +351,7 @@ ok "a label carrying a brand new interpolation $vd_fresh_name"
 ok "an escaped \$PWD is prose in a label, not an interpolation"
 ok "a wrapper label built from a positional $1 and a braced one ${2}"
 ok "a label splicing all of its arguments $@"
+ok "a label naming $* and $# — no live site, seeded so the branch has a control"
 bad "a bad-only label naming $vd_failure_only"
 VDSEED
 vd_ctl="$(vd_interp_names "$vd_seed/test-vd-seed.sh")"
@@ -357,5 +363,7 @@ assert_not_contains "a bad-only label is not held to the PASS-line rule" "$vd_ct
 assert_contains "the sweep reports a positional interpolation (#1767 firing control)" "$vd_ctl" "|1"
 assert_contains "the sweep reports a braced positional too" "$vd_ctl" "|2"
 assert_contains "the sweep reports \$@, which splices every argument" "$vd_ctl" "|@"
+assert_contains "the sweep reports \$*, the other splicing parameter" "$vd_ctl" "|*"
+assert_contains "the sweep reports \$#, the argument count" "$vd_ctl" "|#"
 unset -f vd_interp_names
 unset vd_expected vd_seed vd_ctl

--- a/tests/stack/test-harness-tooling.sh
+++ b/tests/stack/test-harness-tooling.sh
@@ -292,6 +292,9 @@ vd_interp_names() { # <file...> -> "<basename>|<name>", once per distinct interp
 # caller handing one of these wrappers a measured value keeps the set identical and the row green —
 # the caller audit above is a point-in-time reading, not a standing instrument. Re-run it when a
 # wrapper gains callers; that is the residual #1740 could not close and this row does not either.
+# AND the special-parameter class is wider than its control: the alternation takes $@, $* and $#,
+# but no label in tests/stack uses $* or $#, so only $@ has a live site and a seed. Those two
+# branches are covered by construction, not by a firing control — seed them if a label adopts one.
 vd_expected="$(
     cat <<'VDEXP'
 lib.sh|1


### PR DESCRIPTION
## What this changes

`vd_interp_names()` in `tests/stack/test-harness-tooling.sh` pins the set of PASS labels that carry a
shell interpolation. Its extractor matched `$NAME`, `${NAME}`, `$(cmd)` and backticks — but **not
positionals or special parameters**, so a label built from `$1` or `$@` read as literal prose and the
row said nothing about it. This widens the alternation to `${?N` and `$[@*#]`, adds the eight rows the
widened sweep then finds, and seeds three firing controls for the new classes.

## Proven — each instrument with the control that fired

**1. The widening is load-bearing (controlled pair, same seed, same worktree).** The extractor function
was lifted from each revision and run against the identical five-line seed:

| extractor | rows emitted |
|---|---|
| `develop-v2` (base) | `\|vd_fresh_name` only |
| this branch (head) | `\|@`, `\|1`, `\|2`, `\|vd_fresh_name` |

So the three new assertions fail on the base and pass on the head — the change is what makes them
green, not something else in the file. The two negative assertions still hold on the head: an escaped
`\$PWD` is not reported, and a `bad`-only label is not held to the PASS-line rule.

**2. The eight new expected rows are a SET, not a floor.** Ran the head extractor over the real file
set the assertion uses (`tests/stack/lib.sh` plus `tests/stack/test-*.sh`) and diffed it against the
`vd_expected` heredoc: **33 rows both sides, `diff` empty**. Not "the rows I added are present" —
byte-identical in both directions, so an extra row would have shown too.

**3. The `lib.sh|1` row is the four `assert_*` wrappers forwarding their own `<label>` parameter**, not
a domain call site. Verified by grepping `lib.sh` for every line calling `ok` with an interpolated
first argument: exactly `assert_eq`, `assert_contains`, `assert_not_contains`, `assert_rc`.

**4. Wrap width held.** Max *comment*-line length in the file is **102 on the base and 102 on the
head**, zero lines over 110 — the check this lane uses because max *line* length is dominated by long
`printf` data lines and hides a comment-reflow regression. `bash -n` rc 0, `shfmt -d` clean.

## Not proven — said rather than hidden

- **The full stack suite was not run on this branch.** The evidence above exercises the assertion's own
  instrument against the assertion's own file set, which is the part this diff changes; `Shell tests`
  in CI is the gate for the rest. The box's heavy-job slot is held elsewhere.
- **The caller audit behind the row comment is point-in-time.** The row pins the SET of interpolating
  labels, never their VALUES: a new caller handing one of these wrappers a *measured* value keeps the
  set identical and the row green. The comment says so, and says the audit must be re-run when a
  wrapper gains callers.
- **Two of the three special parameters have no live site.** The alternation takes `$@`, `$*` and `$#`;
  no label in `tests/stack` uses `$*` or `$#`, so only `$@` has a seed and a firing control. Those two
  branches are covered by construction, and the second commit here says that in the file rather than
  letting three branches read as three proven ones.
- **The file has no row in `docs/dev/file-budget.tsv`** — it is under the 400 target, so the gate has not
  recorded it and this diff costs nothing there. It is closer to the target than it was. (No line count
  is quoted here on purpose: the first draft said "358 lines", which the very next commit made false.)

## Correcting the issue as filed

Recorded because the issue will be read again, and both of its stated premises are wrong in ways that
did not move its verdict:

- **The site list in #1767 is a FLOOR, not a set.** It names six labels in six files; the widened sweep
  finds **eight names across seven files** — `lib.sh`, `test-control-add-only-ssrf.sh` and
  `test-rig-worker.sh` are not in the issue.
- **"Every caller passes a string literal" is FALSE.** A mechanical audit of all 55 calls of the eight
  wrappers — continuations joined, arguments parsed by shell grammar rather than by eye — found
  `roundtrip_key "TELEGRAM_EVENT ${ev}"`. It is still run-invariant, because `${ev}` is a loop variable
  over 25 spelled-out event names, so the issue's conclusion survives while its premise does not.

Closes #1767 (`Closes` is inert on `develop-v2` — hand-close on merge).

