### PR TITLE
docs(contributing): #1766 the file budget gate gets the section its refusal names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,30 +51,8 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      generic class, not a trace of whoever's actual box; `tests/` and `docs/` are an accepted
      exemption boundary for illustrative/fixture content, and each class also carries a small,
      explicit value-level allowlist — see the script's own header — never a per-file exemption
-     comment), `lint-file-budget` (the file-budget ratchet, issue #1105 Phase 0 — a new tracked
-     file has a hard ceiling of 800 lines, target 400; an existing offender's current line count
-     is its personal ceiling in `docs/dev/file-budget.tsv`, and a PR may not grow it past that —
-     ceilings only ever move down, and the gate rejects a budget edit that raises one. A
-     deliberate, justified addition to a budgeted file therefore has exactly one legal path:
-     split or shrink the file so the addition fits under a ceiling that stays put or drops —
-     see issue #1258 for the worked example, where a security test that outgrew its file moved
-     into its own — and note that two same-wave merges can each pass alone and fail together, so
-     re-run `make lint` after merging onto the tip. The ratchet half is fatal in CI when it
-     cannot run at all: a job that resolves none of the base-ref candidates has lost its
-     `fetch-depth: 0`, which is a misconfigured job rather than a clean tree, so the gate
-     fails there instead of printing a note into a log nobody reads (issue #1739). A local
-     checkout without those refs still gets the note and still passes. Generated
-     code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in
-     the script — and so is the shipped `pithead` artifact itself: it is generated, and the gate
-     governs its `lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it.
-     One row was exempt from the ceilings-only-move-down half, and only that half:
-     `lib/pithead/99-remainder.sh` measured how much of that generated artifact Phase 2 had not
-     split out yet, not the size of a file anyone writes. Without that, `pithead`'s own exemption
-     became a freeze — the CLI could not gain a line, because the row refused to rise and the file
-     refused to grow past it (issue #1464). That row has retired, and not by reaching the 400
-     target: Phase 2 split the remainder out completely, so the file was deleted at 949 lines and
-     nothing in `docs/dev/file-budget.tsv` names it now. `monotonic_exempt()` in the script still
-     carries the arm and the reasoning behind it),
+     comment), `lint-file-budget` (the file-budget ratchet, issue #1105 Phase 0 — see
+     [File budget gate](#file-budget-gate) below),
      `lint-pithead-parity` (the shipped `pithead` must be exactly what `lib/pithead/*.sh`
      concatenate to: edit a slice, run `scripts/build-pithead.sh`, and commit both — issue #1105
      Phase 2), `lint-trivy-parity` (the CVE
@@ -107,6 +85,35 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
 5. Update the docs in [`docs/`](docs/) (and the README, if relevant) for any
    user-facing change. To see what the suites cover, `make test-inventory` writes a
    generated (git-ignored) inventory you can read locally.
+
+### File budget gate
+
+The file-budget ratchet (issue #1105 Phase 0). A new tracked file has a hard ceiling of 800 lines, target
+400; an existing offender's current line count is its personal ceiling in `docs/dev/file-budget.tsv`, and a
+PR may not grow it past that — ceilings only ever move down, and the gate rejects a budget edit that raises
+one.
+
+A deliberate, justified addition to a budgeted file therefore has exactly one legal path: split or shrink
+the file so the addition fits under a ceiling that stays put or drops — see issue #1258 for the worked
+example, where a security test that outgrew its file moved into its own — and note that two same-wave merges
+can each pass alone and fail together, so re-run `make lint` after merging onto the tip.
+
+The ratchet half is fatal in CI when it cannot run at all: a job that resolves none of the base-ref
+candidates has lost its `fetch-depth: 0`, which is a misconfigured job rather than a clean tree, so the gate
+fails there instead of printing a note into a log nobody reads (issue #1739). A local checkout without those
+refs still gets the note and still passes.
+
+Generated code, vendored files, data/config, and prose docs are exempt by glob — see `is_exempt()` in the
+script — and so is the shipped `pithead` artifact itself: it is generated, and the gate governs its
+`lib/pithead/*.sh` sources instead, now that Phase 2 has begun splitting it.
+
+One row was exempt from the ceilings-only-move-down half, and only that half: `lib/pithead/99-remainder.sh`
+measured how much of that generated artifact Phase 2 had not split out yet, not the size of a file anyone
+writes. Without that, `pithead`'s own exemption became a freeze — the CLI could not gain a line, because the
+row refused to rise and the file refused to grow past it (issue #1464). That row has retired, and not by
+reaching the 400 target: Phase 2 split the remainder out completely, so the file was deleted at 949 lines
+and nothing in `docs/dev/file-budget.tsv` names it now. `monotonic_exempt()` in the script still carries the
+arm and the reasoning behind it.
 
 ### The two lanes, and what that means for CI config
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ runs `ruff` (plus a few hygiene hooks) on your changed files. If you change depe
      exemption boundary for illustrative/fixture content, and each class also carries a small,
      explicit value-level allowlist — see the script's own header — never a per-file exemption
      comment), `lint-file-budget` (the file-budget ratchet, issue #1105 Phase 0 — see
-     [File budget gate](#file-budget-gate) below),
+     [File budget gate](#file-budget-gate)),
      `lint-pithead-parity` (the shipped `pithead` must be exactly what `lib/pithead/*.sh`
      concatenate to: edit a slice, run `scripts/build-pithead.sh`, and commit both — issue #1105
      Phase 2), `lint-trivy-parity` (the CVE


### PR DESCRIPTION
## What this changes

`scripts/lint-file-budget.sh:203` prints **"See CONTRIBUTING.md — file budget gate."** at the moment the
gate refuses a commit, and `CONTRIBUTING.md` had no such section. The material existed — roughly 24 lines
covering the ratchet, the ceilings, the CI fatality and the exemptions — but it sat unheaded inside a
single bullet of the lint-surface list under `## Development workflow`. A reader who searches for the
section name finds nothing and concludes the docs are missing rather than that the pointer is stale, at
the one moment they are blocked and least able to go hunting.

This lifts that material into its own **`### File budget gate`** section, a sibling of
`### The two lanes …` under the same `## Development workflow` heading, and shrinks the bullet to a
pointer at the new anchor.

## Why the restructure rather than the one-liner

The issue offered two one-line fixes. Neither was available as written:

- **"Give `CONTRIBUTING.md:54` a real `### File budget gate` heading."** That line is *inside a numbered
  list item*, five spaces of continuation indent deep. A `###` cannot go there without ending the list
  and orphaning steps 4 and 5. The heading has to live outside the list, which means the prose has to
  move — a restructure, not a heading.
- **"Change the message to name the section that actually exists."** That edits
  `scripts/lint-file-budget.sh`, which is not this lane's to touch.

So the section is placed after the numbered list, and the bullet keeps its parallel one-line shape
alongside the other lint surfaces.

## Proven

- **The prose is unchanged.** Word-multiset compare of the lifted text against the new section differs by
  exactly six tokens, all of them the wrapper punctuation becoming a sentence: `` `lint-file-budget` (the
  file-budget ratchet, issue #1105 Phase 0 — a new tracked file`` → `The file-budget ratchet (issue #1105
  Phase 0). A new tracked file`, and a closing `it),` → `it.`. **No content word was added, removed or
  changed** — the diff is `{(the, 0, ``lint-file-budget``, a, issue, it),, ratchet,, —}` out and
  `{(issue, 0)., A, The, it., ratchet}` in.
- **Structure**: headings are now `## Development workflow` → `### File budget gate` (new) →
  `### The two lanes, and what that means for CI config`. The list itself is untouched.
- **Wrap width held**: max line length in the file is **110 before and 110 after**, and the longest new
  line is 108.
- **`make lint-md` rc 0** over 46 files; **`make lint-docs-voice` rc 0** over 41 prose docs, with its
  own `--self-test` passing first (an empty enumeration is refused rather than read as a clean scan).
- The anchor resolves: `### File budget gate` generates `#file-budget-gate`, which is what the bullet
  links to.

## The issue named one stale pointer; there were two

`tests/integration/selftest-compose-profiles.sh:6` already read *"see CONTRIBUTING.md's
**file-budget-gate** entry"* — citing the exact anchor slug this section creates, for a section that did
not exist. That file belongs to another lane and is **untouched here**; its sentence simply becomes true.
Recorded because it shows the pointer had been assumed real from more than one place.

## Not done — said rather than hidden

- **`scripts/lint-file-budget.sh` is not touched.** It is not in this lane's paths. Its `:203` message now
  resolves; its `:336` generated comment (`… and CONTRIBUTING.md for the gate.`) names no section, so it
  was never wrong, only vague, and it is left alone.
- **No shellcheck was run.** Another lane holds the box for the RC battery, so CI is the lint gate for
  this branch — which costs nothing here, since the diff is one Markdown file.
- **This is a prose doc, exempt from the file budget by glob**, so the restructure moves no ceiling.

## The over-engineering pass found one thing, and it shipped

`see [File budget gate](#file-budget-gate) **below**` carried a position claim the anchor already makes
unnecessary, and one that goes stale the moment either section moves — the same class as any rule citing
a line number in another file. The link is the durable half; the word is gone (`c1cb658a`).

Closes #1766 (`Closes` is inert on `develop-v2` — hand-close on merge).
