### PR TITLE
test(integration): #1471 wait the #185 history row to terminal before asserting it

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -549,6 +549,29 @@ first hardware run to exercise the wait hit precisely that
 self-test that covers the settle now runs the real wait rather than a silent stub, because a stub
 that prints nothing cannot see this class at all.
 
+The same leg then asserts that the change reached the dashboard's `#185` per-worker history, and
+that readback needed a settle of its own
+([#1471](https://github.com/p2pool-starter-stack/pithead/issues/1471)). The two surfaces converge
+at different moments, and the harness used to argue that they did not. The argument's first half
+holds: the reconcile step does run before the enriched-feed merge, on the same poll. Its second
+half does not, because both of those read a rig file that RigForge writes at the *start* of a
+control-apply, before it has decided the outcome at all. The terminal status goes to a second file
+at the end, after the apply, an xmrig restart and a bounded wait for the miner to come back, and
+the reconciler cannot move the row off `accepted` until it has read that one. Settling on the
+config therefore ends at the start of that window rather than after it, and reading the row there
+raced it by up to ninety seconds. The claim survived because the only two keys that ever reached it
+are on the fast path, where the window is too small to see.
+
+The row is now waited to a terminal status before it is read, on the same ninety-second bound the
+window itself has. Terminal rather than `applied`, which is what keeps the assertion honest in both
+directions: a rig that genuinely rejected a change publishes its terminal row at once, so the leg
+reds on the real status instead of spending the whole bound on a verdict already known, and a row
+that never settles stays `accepted` and reds as well. The one answer the wait must never invent is
+`applied` for a row nobody has confirmed. Terminal is written as the complement of `accepted` and
+"no row yet", not as a list of the six outcomes the rig can report today, so a status added
+upstream reads as terminal and gets named by the assertion rather than timing out and being
+reported as a row that never settled.
+
 ### The abort-safe unwind
 
 Every leg above restores what it changed when it finishes. That covers a leg that *fails*; it does

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -559,8 +559,10 @@ control-apply, before it has decided the outcome at all. The terminal status goe
 at the end, after the apply, an xmrig restart and a bounded wait for the miner to come back, and
 the reconciler cannot move the row off `accepted` until it has read that one. Settling on the
 config therefore ends at the start of that window rather than after it, and reading the row there
-raced it by up to ninety seconds. The claim survived because the only two keys that ever reached it
-are on the fast path, where the window is too small to see.
+raced it by up to ninety seconds. The claim survived because two of the three keys that reach that
+assertion, `max_temp_c` and `watchdog_interval_min`, are on RigForge's restart-free fast path, where
+the window is too small to see. The third, `DONATION`, is off that list and takes the full path —
+which is where the ninety-second bound comes from, and where a hardware run would have hit this.
 
 The row is now waited to a terminal status before it is read, on the same ninety-second bound the
 window itself has. Terminal rather than `applied`, which is what keeps the assertion honest in both

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -13,10 +13,21 @@
 #       (worker_config_store.py:reconcile_worker_config_status, #579/#604) — step 3a in that poll,
 #       strictly BEFORE the enriched-feed merge at step 3b.
 # So observing the feed converge to the requested max_temp_c is proof the requested key (the only
-# key in a max_temp_c change) is what changed, and the #185 history row for that change_id is
-# already reconciled to "applied" by the time run.sh reads it back — no direct rig dial needed
-# (IT_RIG_TOKEN/RIG_HOST bench flags aren't always set: the live-box case uses the baseline's own
-# workers.list[] descriptor without them), and no reliance on the dial-time result ever changing.
+# key in a max_temp_c change) is what changed — no direct rig dial needed (IT_RIG_TOKEN/RIG_HOST
+# bench flags aren't always set: the live-box case uses the baseline's own workers.list[]
+# descriptor without them), and no reliance on the dial-time result ever changing.
+#
+# ⛔ WHAT IT DOES NOT PROVE, AND THIS MODULE USED TO CLAIM IT DID (#1471): that the #185 history
+# row for that change_id is terminal by the time a caller reads it back. The (a)/(b) ordering
+# above is real — 3a does run before 3b, and both surfaces come off one poll — but both are
+# downstream of a rig file written BEFORE the rig has decided the outcome at all. RigForge commits
+# the new config at the START of a control-apply (_control_commit's `mv -f`) and writes the
+# terminal status.json only at the END, after the apply, an xmrig restart and a `_wait_miner_live`
+# bounded at 20 tries x 3s; the reconciler cannot move the row off "accepted" until it has read
+# that second file, which costs up to one further UPDATE_INTERVAL. A settle on the readback
+# surface therefore ends at the START of that gap, not after it. The claim survived because the
+# only two keys that ever reached it are on the fast path, where the gap is too small to see.
+# Callers asserting on the row go through _settle_history_row below, which waits for it.
 # Fails loudly (leaves status/ckeys at their dial-time "accepted"/empty) on a real
 # rejected/failed/timeout, exactly like a "the change never actually happened" bug would.
 #
@@ -30,7 +41,8 @@
 # report the change before calling it applied. Only the readback surface differs, so that arrives as
 # a predicate: max_temp_c has live telemetry in the enriched feed's watchdog stats (the only
 # writable key that does), while the keys added by #1236 read the rig's own reported config. Both
-# ride the same per-rig poll tick, so the reasoning above holds either way.
+# ride the same per-rig poll tick, so the readback half of the reasoning above holds either way —
+# and neither of them says anything about the history row, which is why that has its own settle.
 _settle_worker_apply() { # <ckeys-on-success> <wait-desc> <dial-result-json> <predicate-cmd...>
     local key="$1" desc="$2" res="$3" status ckeys change_id
     shift 3
@@ -55,4 +67,45 @@ _settle_worker_apply_maxt() { # <rig> <want-max_temp_c> <dial-result-json> -> "<
     _settle_worker_apply max_temp_c \
         "the rig to report max_temp_c=$2 applied (RigForge #344 async apply, #1309)" \
         "$3" _pred_feed_maxt "$1" "$2"
+}
+
+# One #185 history row, by change_id and never "the newest row" (#579/#604's reconciler keys on
+# the id, and a concurrent change would otherwise be read as this one's outcome).
+#
+# `_worker_detail` is the caller's, exactly like the readback predicates above: it is defined in
+# rigforge-writable-keys.sh and is in scope for every caller by the time these run, because run.sh
+# sources both modules before any leg executes.
+_history_row_status() { # <rig> <change_id> -> that row's status, or empty when there is no row
+    _worker_detail "$1" | jq -r --arg c "$2" \
+        'first(.history[]? | select(.change_id == $c)) | .status // empty' 2>/dev/null
+}
+
+# Terminal is stated as the COMPLEMENT of the non-terminal pair, not as an allowlist of #1009's
+# six names, and the direction matters: a status this harness has never seen must read as terminal
+# and let the caller's assert_eq name it. An allowlist would turn a newly added rig status into a
+# 90s timeout reported as "the row never settled" — the wrong diagnosis, and one that costs the
+# full bound to reach. Empty is non-terminal because there is no row yet, not because it is stuck.
+_pred_history_row_terminal() { # <rig> <change_id>
+    case "$(_history_row_status "$1" "$2")" in
+    "" | accepted) return 1 ;;
+    *) return 0 ;;
+    esac
+}
+
+# Wait that row to terminal, then report it (#1471). Waiting for TERMINAL rather than for
+# "applied" is what keeps the caller's assertion honest in both directions: a rig that genuinely
+# rejected or failed the change publishes a terminal row at once, so this returns that status and
+# the caller reds immediately instead of burning the bound on a verdict already known; a row that
+# never settles stays "accepted" and reds too. The one answer it must never invent is "applied"
+# for a row nobody has confirmed — which is what reading the row unwaited did, across a window of
+# up to ~90s (_wait_miner_live + one UPDATE_INTERVAL), and why the bound here is that same 90s.
+#
+# The `>&2` is this module's #1454 discipline, for the same reason: stdout is the return value and
+# wait_for opens with an it_step banner on stdout. The wait's rc is deliberately NOT guarded: the
+# read below runs either way (run.sh:20 — "NOT -e: we deliberately continue-on-error"), and on a
+# timeout reporting the status the row is STUCK at is what lets the caller's assert_eq name it.
+_settle_history_row() { # <rig> <change_id> -> the row's terminal status, or what it is stuck at
+    wait_for 90 5 "the #185 history row for $2 to reach a terminal status (#1471)" \
+        _pred_history_row_terminal "$1" "$2" >&2
+    _history_row_status "$1" "$2"
 }

--- a/tests/integration/rigforge-apply-settle.sh
+++ b/tests/integration/rigforge-apply-settle.sh
@@ -25,8 +25,11 @@
 # terminal status.json only at the END, after the apply, an xmrig restart and a `_wait_miner_live`
 # bounded at 20 tries x 3s; the reconciler cannot move the row off "accepted" until it has read
 # that second file, which costs up to one further UPDATE_INTERVAL. A settle on the readback
-# surface therefore ends at the START of that gap, not after it. The claim survived because the
-# only two keys that ever reached it are on the fast path, where the gap is too small to see.
+# surface therefore ends at the START of that gap, not after it. The claim survived because two of
+# the three keys that reach the row, max_temp_c and watchdog_interval_min, are on RigForge's
+# restart-free fast path (CONTROL_FAST_PATH_KEYS, rigforge.sh:4203 at v1.16.0), where the gap is
+# too small to see. The third, DONATION, is off that list and takes the full path — which is where
+# the 90s bound below comes from, and where a hardware run would have hit this.
 # Callers asserting on the row go through _settle_history_row below, which waits for it.
 # Fails loudly (leaves status/ckeys at their dial-time "accepted"/empty) on a real
 # rejected/failed/timeout, exactly like a "the change never actually happened" bug would.

--- a/tests/integration/rigforge-writable-keys.sh
+++ b/tests/integration/rigforge-writable-keys.sh
@@ -14,10 +14,12 @@
 # derive a probe from it, and assert the rig's OWN reported value changed and was restored — no new
 # env var, no direct rig dial, no new port, and no reliance on a record of what we last pushed.
 #
-# The settle reasoning is rigforge-apply-settle.sh's, unchanged: `.rig_config` rides the same
-# per-rig poll tick as the enriched feed (data_service step 3b), which runs strictly AFTER the #185
-# history reconcile (step 3a), so seeing the rig report the new value also means that change_id's
-# history row is already terminal.
+# The settle reasoning is rigforge-apply-settle.sh's: `.rig_config` rides the same per-rig poll
+# tick as the enriched feed (data_service step 3b), which runs strictly AFTER the #185 history
+# reconcile (step 3a). That ordering is real, but it does NOT make the row terminal by the time
+# the readback lands — the rig publishes its config before it has decided the outcome, so the
+# settle ends at the start of that gap (#1471, derived in full on that module). The history
+# assertion below therefore waits for the row itself, through _settle_history_row.
 #
 # Sourced by run.sh, which supplies wait_for (lib.sh), the assert_* helpers, rx/quote_arg, and
 # _worker_apply. Every function here is drivable standalone against stubs — that is the tier the
@@ -77,10 +79,11 @@ _writable_key_round_trip() { # <rig> <key> <orig-json> <probe-json>
     IFS='|' read -r status ckeys change_id <<<"$(_settle_worker_apply_key "$rig" "$key" "$probe" "$res")"
     assert_eq "$key edit applied on the rig (#1236)" "$status" "applied"
     assert_contains "the rig's own config confirms $key changed (#1236)" "$ckeys" "$key"
-    # Matched by change_id, not "the newest row" — #579/#604's reconciler, as the #513 leg does.
-    assert_eq "$key worker-apply recorded in the per-worker history (#185/#1236)" \
-        "$(_worker_detail "$rig" | jq -r --arg c "$change_id" \
-            'first(.history[]? | select(.change_id == $c)) | .status // empty' 2>/dev/null)" "applied"
+    # Matched by change_id, not "the newest row" — #579/#604's reconciler, as the #513 leg does —
+    # and waited to terminal first, because the settle above returns before the rig has published
+    # its outcome (#1471). Read unwaited, this raced a window of up to ~90s.
+    assert_eq "$key worker-apply recorded in the per-worker history (#185/#1236/#1471)" \
+        "$(_settle_history_row "$rig" "$change_id")" "applied"
     it_step "reverting $key $probe -> $orig…"
     res="$(_worker_apply "$rig" "$(jq -nc --arg k "$key" --argjson v "$orig" '{($k): $v}')")"
     IFS='|' read -r status _ _ <<<"$(_settle_worker_apply_key "$rig" "$key" "$orig" "$res")"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -2281,9 +2281,9 @@ run_rigforge_control() {
         IFS='|' read -r status ckeys change_id <<<"$(_settle_worker_apply_maxt "$rig" "$new_maxt" "$res")"
         assert_eq "Worker Inspect edit applied on the rig (#513)" "$status" "applied"
         assert_contains "the rig's /status confirms max_temp_c changed (#513)" "$ckeys" "max_temp_c"
-        # Matched by change_id, not "the newest row" — #579/#604's reconciler (rigforge-apply-settle.sh).
-        assert_eq "worker-apply recorded in the per-worker history (#185)" \
-            "$(_worker_detail "$rig" | jq -r --arg c "$change_id" 'first(.history[]? | select(.change_id==$c)) | .status // empty' 2>/dev/null)" "applied"
+        # By change_id, not "the newest row", and WAITED to terminal: the rig publishes its config
+        # before it decides the outcome, so reading the row straight after the settle raced it (#1471).
+        assert_eq "worker-apply recorded in the per-worker history (#185/#1471)" "$(_settle_history_row "$rig" "$change_id")" "applied"
         it_step "reverting max_temp_c $new_maxt -> $orig_maxt…"
         res="$(_worker_apply "$rig" "{\"max_temp_c\":$orig_maxt}")"
         IFS='|' read -r status _ _ <<<"$(_settle_worker_apply_maxt "$rig" "$orig_maxt" "$res")"

--- a/tests/integration/selftest-rigforge-apply-settle.sh
+++ b/tests/integration/selftest-rigforge-apply-settle.sh
@@ -37,6 +37,104 @@ assert_eq "the settle's stdout is the result and nothing else" "$out" "applied|m
 err="$(_settle_worker_apply max_temp_c "the rig to report max_temp_c=101 applied" "$res" _pred_settles_now 2>&1 >/dev/null)"
 assert_contains "the progress banner is redirected, not deleted" "$err" "waiting for the rig to report max_temp_c=101 applied"
 
+echo "== _history_row_status: the row is read by change_id, never 'the newest' (#1471) =="
+# _worker_detail is the CALLER's, injected exactly like the readback predicates this module already
+# takes as arguments; these cases supply it directly rather than through a rig or a server.
+# The wanted row is deliberately NOT first, and the ordering is the whole case: with c-mine first
+# a `first(.history[]?)` mutation — matching the newest row instead of the change_id — returns it
+# anyway, and this assertion goes green against the very defect it names. The status values differ
+# too, so the mutation is caught on the VALUE and not only on the row's absence.
+STUB_HIST='[{"change_id":"c-newer","status":"failed"},{"change_id":"c-mine","status":"applied"}]'
+_worker_detail() { printf '{"history":%s}' "$STUB_HIST"; }
+assert_eq "the row for THIS change_id is read, not the newest one" \
+    "$(_history_row_status r c-mine)" "applied"
+assert_eq "a change_id with no row of its own reads back empty" \
+    "$(_history_row_status r c-absent)" ""
+STUB_HIST='null'
+assert_eq "a detail body carrying no history at all reads back empty, not an error" \
+    "$(_history_row_status r c-mine)" ""
+
+echo "== _pred_history_row_terminal: terminal is the COMPLEMENT of accepted/absent (#1471) =="
+STUB_HIST='[{"change_id":"c1","status":"accepted"}]'
+_pred_history_row_terminal r c1
+assert_eq "a still-'accepted' row is NOT terminal — that is the whole point of waiting" "$?" "1"
+STUB_HIST='[]'
+_pred_history_row_terminal r c1
+assert_eq "no row yet is NOT terminal" "$?" "1"
+STUB_HIST='[{"change_id":"c1","status":"applied"}]'
+_pred_history_row_terminal r c1
+assert_eq "'applied' is terminal" "$?" "0"
+STUB_HIST='[{"change_id":"c1","status":"rejected"}]'
+_pred_history_row_terminal r c1
+assert_eq "'rejected' is terminal — a real refusal must not burn the 90s bound" "$?" "0"
+# The complement form, asserted rather than assumed. #1009's vocabulary is six names TODAY, and the
+# allowlist spelling of this predicate passes every case above while turning a newly added rig
+# status into a 90s timeout reported as "the row never settled" — the wrong diagnosis, reached at
+# the most expensive possible price. This is the case that kills that spelling.
+STUB_HIST='[{"change_id":"c1","status":"quarantined"}]'
+_pred_history_row_terminal r c1
+assert_eq "a status this harness has never seen reads as terminal, not as 'keep waiting'" "$?" "0"
+
+echo "== _settle_history_row: wait_for's banner must not reach the RESULT (#1454, #1471) =="
+# The same trap as the settle above and for the same reason — this function's stdout is its return
+# value, and the real wait_for opens with an it_step banner on stdout. Run with the GENUINE wait_for
+# against a row that is already terminal, so it costs nothing: drop the `>&2` in
+# rigforge-apply-settle.sh and this capture gains the banner as its first line.
+STUB_HIST='[{"change_id":"c-t","status":"applied"}]'
+assert_eq "the settle's stdout is the row status and nothing else" \
+    "$(_settle_history_row r c-t)" "applied"
+
+echo "== _settle_history_row: a row that goes terminal LATE is waited for (#1471) =="
+# THE mutation-kill for #1471, and it drives the genuine lib.sh wait_for. Delete the wait from
+# _settle_history_row and this reads "accepted" — which is exactly the race the issue documents:
+# RigForge commits the new config at the START of a control-apply and writes the terminal status
+# only at the END, after the miner restart, so the row is still "accepted" when the config settle
+# that precedes this returns.
+#
+# The read counter is a FILE, not a shell variable, and that is load-bearing rather than a style
+# choice: the call under test is captured with `$(...)`, so a stub counting into a variable would
+# lose every increment to the command-substitution subshell and report "converged on the first
+# read" — passing against BOTH the waited and the unwaited form, proving nothing. (The same lesson
+# APPLY_LOG carries in selftest-rigforge-writable-keys.sh.)
+TICKS="$(mktemp)"
+trap 'rm -f "$TICKS"' EXIT
+printf '1' >"$TICKS"
+_worker_detail() { # "accepted" on the first read, "applied" from the second onwards
+    local n
+    n="$(cat "$TICKS")"
+    printf '%s' $((n + 1)) >"$TICKS"
+    if [ "$n" -ge 2 ]; then
+        printf '{"history":[{"change_id":"c-late","status":"applied"}]}'
+    else
+        printf '{"history":[{"change_id":"c-late","status":"accepted"}]}'
+    fi
+}
+assert_eq "a row still 'accepted' at settle time is waited to its terminal status" \
+    "$(_settle_history_row r c-late)" "applied"
+# Second conjunct, a DIFFERENT mechanism on purpose: the status assertion alone would also pass a
+# function that read the row once and got lucky on ordering. The unwaited form reads exactly twice
+# (predicate never runs; one read for the result); the waited form re-reads after the interval.
+assert_num_ge "the wait re-read the row rather than settling on one look" "$(cat "$TICKS")" "3"
+# What this case does NOT discriminate, said so it is not read as covering more than it does: a
+# predicate that treats "accepted" as TERMINAL passes both assertions above. It returns on the
+# first read, and the result read is then the second — the one that converges — so the status
+# comes back "applied" for the wrong reason and the tick count still reaches 3. That mutation is
+# owned by the "a still-'accepted' row is NOT terminal" case in the block above; delete that case
+# and nothing here replaces it. Converging on the third read instead would cover it twice at the
+# price of a second real interval, which is not worth paying for a mutation already killed.
+
+echo "== _settle_history_row: a row that never settles must not read as 'applied' (#1471) =="
+# The other half, stubbed rather than real so it costs nothing — the 90s bound is the function's
+# point, not something to spend here. What must hold is that a timeout reports what the row is
+# STUCK at: not empty, which would report a missing row for what is really an unsettled one, and
+# never "applied", which would be #1471's false pass with extra steps. The section below re-stubs
+# wait_for for its own case, so this stub does not reach it.
+STUB_HIST='[{"change_id":"c-stuck","status":"accepted"}]'
+_worker_detail() { printf '{"history":%s}' "$STUB_HIST"; }
+wait_for() { return 1; }
+assert_eq "a timed-out settle reports the status the row is stuck at, so the caller can name it" \
+    "$(_settle_history_row r c-stuck)" "accepted"
+
 echo "== _settle_worker_apply_maxt: RigForge #344 async apply (#1309) =="
 # This is the load-bearing mutation-kill: if the "accepted is terminal" bug (#1309) were
 # reintroduced — treating status verbatim instead of polling for it to settle — this would still


### PR DESCRIPTION
Closes nothing on its own — hand-close #1471 with the merge sha (`Closes` is inert on `develop-v2`).

## The defect

The rig-apply legs settle on the rig's own reported config, then assert the dashboard's `#185` history row for that `change_id` is `applied`. The settle finishes before that row can be terminal, so the assertion was racing a window of up to ~90s.

Both modules carried the ordering claim that made it look safe, and its first half is true — the reconcile (step 3a) does run before the enriched-feed merge (step 3b), on the same poll. The second half does not follow. Both of those read a rig file RigForge writes at the **start** of a control-apply (`_control_commit`'s `mv -f`); the terminal `status.json` is written at the **end**, after the apply, an xmrig restart and `_wait_miner_live` (20 tries × 3s), and the reconciler cannot move the row off `accepted` until it has read that second file. Settling on the config ends at the start of that gap rather than after it. It never bit visibly because two of the three keys that reach it — `max_temp_c` and `watchdog_interval_min` — are on RigForge's restart-free fast path, where the gap is small. The third, `DONATION`, is off `CONTROL_FAST_PATH_KEYS` (`rigforge.sh:4203`, re-derived at the GA-baked `v1.16.0`) and takes the full apply plus `_wait_miner_live`, which is where the ~90s bound this PR budgets for comes from.

Derivation credit: the analysis on the issue, by the lane that filed it. I re-derived the pithead half at `origin/develop-v2` before building on it; the RigForge line numbers I have **relayed**, not re-derived — `rigforge.sh` is the other repo and I did not open it.

## Enumerated the class — the issue names one site, there are two

```
tests/integration/rigforge-writable-keys.sh:80-83   the #1236 writable-key legs   <- the issue
tests/integration/run.sh:2284-2286                  the #513 max_temp_c leg       <- same shape
```

`run.sh:2462-2467` (#517) reads the *newest* row and already accepts `rolled_back|accepted`, so it is deliberately tolerant of a non-terminal row and is left alone. The permanently-`accepted` case there is #1702, a different class.

## Why the issue's third option, not its recommended one

Accepting `applied|accepted` would retire the only end-to-end check that the `#579`/`#604` reconciler works, and would go permanently green against a genuinely stuck row. Instead `_settle_history_row` waits the row to a **terminal** status and the callers still assert `applied`.

Terminal rather than `applied` is what keeps the assertion honest in both directions: a rig that genuinely rejected the change publishes its terminal row at once, so the leg reds on the real status instead of spending the whole bound on a verdict already known; a row that never settles stays `accepted` and reds as well. The one answer it must never invent is `applied` for a row nobody confirmed.

Terminal is written as the **complement** of `accepted`/absent rather than as an allowlist of `#1009`'s six names, so a status added upstream reads as terminal and gets named by the assertion instead of timing out and being reported as a row that never settled.

## Mutation battery — every new row shown able to fail, each red attributed

Against a scratch copy of `tests/`, restored between legs, each mutation read back from disk to prove it landed before the leg ran. Baseline green first, so a red is the mutation and not the fixture.

| leg | mutation | result |
|---|---|---|
| M0 | baseline | **19 passed, 0 failed**, rc 0 |
| M1 | the wait deleted — read the row once, as the pre-#1471 code did | red: *waited to its terminal status* + *the wait re-read the row* |
| M2 | `>&2` dropped (the #1454 stream discipline) | red: *stdout is the row status and nothing else* + the above |
| M3 | terminal as an allowlist of #1009's six names | red: *a status this harness has never seen reads as terminal* |
| M4 | `accepted` treated as terminal (the #1309 bug class, one level up) | red: *a still-'accepted' row is NOT terminal* |
| M5 | the row matched by newest instead of by `change_id` | red: *the row for THIS change_id is read, not the newest one* + the empty case |

M1 is the one that matters: it restores the pre-fix behaviour exactly, and it reds. It runs the **genuine** `lib.sh` `wait_for`, not a stub — the stub cases cover the logic, and a stub that returns instantly cannot see whether the wait is there at all.

### The battery found two defects in my own test, both fixed here

Both are the passes-for-the-wrong-reason class, and both were invisible in a green run:

1. **The M5 fixture had the wanted row FIRST**, so `first(.history[]?)` returned it anyway and the case named *"the row for THIS change_id is read, not the newest one"* went green against the very mutation it names. Only the unrelated empty-row case caught M5. The wanted row is now second and the two rows carry different statuses, so the mutation is caught on the value.
2. **The late-convergence case does not discriminate M4.** Its stub converges on the second read, which is also the result read, so a predicate treating `accepted` as terminal returns early and still comes back `applied`. The mutation is killed by the predicate case instead. That is now written into the file naming the case that owns it, so deleting that case cannot quietly open a hole this one looks like it covers. Converging on the third read would cover it twice at the price of a second real 5s interval — declined, for a mutation already killed.

## What else was run

- `make test-integration-selftest` — **rc 0**; 214 passed in `selftest.sh` plus 21 standalone files, **0 failed anywhere**. `selftest-rigforge-apply-settle` 19/0 and `selftest-rigforge-writable-keys` 57/0 both cover files this PR changes.
- `shellcheck` 0.11.0 `--severity=warning` rc 0 over exactly the four changed shell files. Positive control: the same invocation on a copy with one undefined lowercase reference reported SC2154 and rc 1, so the clean run had read the files through.
- `shfmt -i 4 -d` rc 0; `bash -n` rc 0 on all four; `make lint-md` 0 errors; `make lint-docs-voice` OK; `make lint-file-budget` OK, run **after** `git add` so it was not blind to the change (#1486).
- **CI's full-glob shellcheck is the authoritative gate here and I deferred to it deliberately**: the appliance lane holds the box for the gating battery, MemAvailable was 6.7 GiB, and the whole-glob run is the ~4.9 GB job the serialize lock exists for. A partial glob can invent findings; it cannot hide one in a file it did read.

## Budget

`tests/integration/run.sh` is on a **zero-headroom** row (2551/2551) and the change there is line-neutral: 3 lines out, 3 in, verified on the diff. The other three shell files are 114 / 215 / 173 lines against `TARGET_LINES=400` and need no row.

## Shared file

`docs/dev/integration-testing.md` is under `docs/`, in `_shared.paths` — one subsection added under "Settling an apply that comes back `accepted`", correcting the ordering claim the harness used to make and describing the new wait.

## Not done, stated rather than hidden

- **The leg has not been run on hardware.** It needs a borrowed rig, and `rigforge-writable-keys.sh` states that its proofs live at the stub self-test tier rather than the bench. That is where this one is.
- **The RigForge-side line numbers are relayed from the issue, not re-derived.** They are load-bearing for the *explanation*, not for the fix: the fix is correct if the row is ever non-terminal at readback, which the stub cases demonstrate directly.
- I did not audit the `control-upgrade` path, matching the scope of the issue's own analysis.

## Over-engineering pass (ponytail gate) — one finding, applied

`_settle_history_row` ended its wait with `|| true`, and I had written seven comment lines defending it. Re-reading that off disk is what made it a finding: **the guard does nothing under this harness's own shell options.** `run.sh:20` is `set -uo pipefail` with an explicit "NOT -e: we deliberately continue-on-error to collect the whole matrix", so a failed wait already falls through to the read below, and the function's rc comes from that read either way. It was guarding a hypothetical the codebase rules out, in a comment longer than the code. Removed, and the seven lines cut to four that say what the unguarded rc actually means.

Needing a long defence for a construct that changes no behaviour was the tell, so it is worth naming as a shape and not only as this instance.

**The battery caught its own staleness on the re-run.** M1 and M2 anchor on the exact text of that line, so after the cut both legs reported `MUTATION DID NOT LAND` and refused to run, rather than silently exercising an unmutated file and reporting its green as a surviving mutation. Anchors re-pinned; the table above **is** the re-run — baseline 19/0, all five red with the same attribution. Also re-verified after the cut: `make test-integration-selftest` rc 0 with zero failures anywhere, `shfmt -i 4 -d` rc 0, `shellcheck` rc 0.

Declined in the same pass: collapsing the three helpers into two. `_history_row_status` has two real call sites (the predicate, and the settle's result read), and `wait_for` takes a command rather than an expression, so the predicate cannot be folded into the call. Three is the minimal decomposition that duplicates nothing.

## My own adversarial pass, with the findings I declined and why

- **The new helpers live in `rigforge-apply-settle.sh` but call `_worker_detail`, which is defined in `rigforge-writable-keys.sh` — a module sourced *after* it.** It works (bash resolves at call time, and both are sourced before any leg runs), but it is a backwards dependency and the module's own idiom is to take the readback surface as an injected predicate. **DECLINED to inject a getter**: there is no per-key variation — both legs read the same endpoint — so injection would be indirection with one implementation. The dependency is declared in the header instead, the same way the module already declares `wait_for` as the caller's.
- **The 90s bound is a sum of two upstream values the harness cannot read.** It is `_wait_miner_live` (20 × 3s) plus one `UPDATE_INTERVAL` (30s default), and a rig with a raised `CONTROL_LIVE_TRIES` would exceed it. **DECLINED to make it configurable**: the harness has no read on the rig's value, and an env var it sets nowhere is the `IT_RIG_POOLS_PROBE` shape this lane already carries one of. Recorded as a known bound rather than hidden.
- **A stuck row now costs 90s per key instead of failing instantly.** Worst case across the #513 leg and the two #1236 keys is ~270s added to a gate run — but only in the case where the product is already broken, which is the case worth spending time on. Stated so nobody reads a slower red as a regression.
- **`_history_row_status` is called twice per settle** — once inside the predicate, once for the result. **DECLINED to cache**: `wait_for` takes a predicate command, so threading the value out would need a global, and the saving is one `curl` against a local port after the wait has already succeeded.
- **Checked the change is not a no-op at the call sites.** The old inline `jq` and the new helper use the same expression; I normalised `select(.change_id==$c)` to the spaced spelling the other module already used. Same semantics, and the M5 leg proves the `change_id` match is still load-bearing.
- **Checked the branch carries nothing of my other open PR.** `git diff origin/develop-v2` names exactly these five files; `selftest-stack-sandbox.sh` and the #1725 docs paragraph (PR #1781) do not appear. `selftest-stack-sandbox` reports 9/0 here rather than 11/0 for that reason — this branch is off `develop-v2`, which does not carry that pin.



---

## Delta `0086050a` -> `c03dcf6c` — the non-author RETURN, applied

The non-author pass returned this PR at `0086050a` on one finding: the sentence *"the only two keys that ever reached it are on the fast path"* is false. It was the one claim in this PR I relayed rather than re-derived, and the relayed half was the wrong half.

**Re-derived by me, in the RigForge repo rather than from the issue.** `CONTROL_FAST_PATH_KEYS="watchdog_interval_min max_temp_c"` (`rigforge.sh:4203` at tag `v1.16.0`, the version baked for GA), and `_control_fast_path_eligible()` returns 1 if any key in the change is off that list. **Three** keys reach `_settle_history_row`, not two:

| key | call site | path |
|---|---|---|
| `max_temp_c` | `run.sh:2286` | fast |
| `watchdog_interval_min` | `rigforge-writable-keys.sh:158` -> `:86` | fast |
| `DONATION` | `rigforge-writable-keys.sh:144` -> `:86` | **slow** |

Both #1236 keys are driven unconditionally by the same function (`run_rigforge_writable_keys`, `rigforge-writable-keys.sh:120`), so any run that reaches the fast-path keys reaches `DONATION` too. The slow path is `_control_do_apply` -> `_wait_miner_live` (20 × 3s) plus one `UPDATE_INTERVAL` — which is exactly the ~90s this PR budgets for. **The bound and the sentence contradicted each other, and the bound was right.**

Corrected in three places, wording only, no behaviour change: `tests/integration/rigforge-apply-settle.sh` (module header), `docs/dev/integration-testing.md` (the settle subsection), and the paragraph near the top of this body. Also folded from the same review: the #517 range is `run.sh:2462-2467`, not `2461-2466` — `2461` is the tail of the comment and the `it_fail` arm runs to `2467`.

**One figure in this body was wrong when the reviewer measured it and is right now, which is worth saying rather than leaving to read as though it always was.** The "114 / 215 / 173" line counts were **111** / 215 / 173 at `0086050a`; the reviewer caught it. The three comment lines added here bring `rigforge-apply-settle.sh` to 114, so the line reads true at `c03dcf6c`. All three are under `TARGET_LINES=400` and carry no budget row. `run.sh` is untouched by this delta and stays 2551/2551.

**What I did NOT run for this delta.** CI is the only test gate while the appliance lane holds the shared box, so: no selftest run, no `make lint*`, no `shellcheck`, no `shfmt`. Verified locally instead — `bash -n` on the changed shell file rc 0; both new blocks inside the files' own 100-column comment/prose wrap (measured, not assumed); the banned-word pattern lifted from `scripts/lint-docs-voice.sh` run over the added prose with a positive control that fired on a seeded string. Everything else is CI's to say, and the previous head's full local evidence is unchanged by a comment reflow.

**Base movement.** The base moved `691dec1d` -> `418d50f7` under this PR. `git merge-tree --write-tree origin/develop-v2 HEAD` is rc 0, no conflict; the only base-side file that intersects this diff is `docs/dev/integration-testing.md`, whose #1781 hunk sits ~290 lines away from this one.
