### PR TITLE
test(stack): #1725 the last four bare mktemp -d sites build through the constructor

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -849,27 +849,34 @@ a working `mktemp` holds the other side, so deleting the sandbox logic outright 
 last case drives the pre-fix expression against the same fixture and requires it to destroy the
 sentinel, so a row that is green because the fixture never armed fails rather than reads as proof.
 
-A second block in that file pins what the suite does *not* reach. The
+A second block in that file holds the invariant that keeps the constructor honest. The
 [#1705](https://github.com/p2pool-starter-stack/pithead/issues/1705) invariant reads
-`tests/stack/lib.sh` and the `test-*.sh` domain files and names `tests/stack/run.sh` and the
-standalone `test_*.sh` out of itself, because those belong to other lanes and the conversion to the
-fail-closed constructor stopped at that boundary. A list of names rots in silence: a fifth bare
-`mktemp -d` assignment added to `run.sh` would sit outside the invariant with nothing saying so,
-and that gap rather than the four known sites is what
-[#1725](https://github.com/p2pool-starter-stack/pithead/issues/1725) is about. The four sites are
-not inert: the hazard is any `"$VAR/sub"` expansion, not a recursive `rm`, and all four have one —
+`tests/stack/lib.sh` and the `test-*.sh` domain files, and for a while it named `tests/stack/run.sh`
+and the standalone `test_*.sh` out of itself, because those belonged to other lanes and the
+conversion to the fail-closed constructor stopped at that boundary. A list of names rots in
+silence: a fifth bare `mktemp -d` assignment added to `run.sh` would have sat outside the invariant
+with nothing saying so, and that gap rather than the four known sites is what
+[#1725](https://github.com/p2pool-starter-stack/pithead/issues/1725) was about. The four sites were
+not inert: the hazard is any `"$VAR/sub"` expansion, not a recursive `rm`, and all four had one —
 `run.sh` writes `"$XPTLS/cert.pem"` and `"$XPTLS/key.pem"` and then removes the second, both
 `local d` helpers write `"$d/xmrig-proxy"`, and `test_data_reset.sh` runs `mkdir -p "$WORK/bin"`.
 Under an empty value each is an absolute path at the filesystem root, and `set -u` does not catch
 it because a failed `mktemp -d` leaves the variable set and empty. Those writes fail for an
 unprivileged user and would land under `/` as root; only the trailing `rm -rf "$VAR"` is inert.
-The excluded population is therefore pinned to exactly those four, keyed on file
-and variable name rather than line number, because the line numbers the issue cites had already
-drifted by three when the pin was written. It reds in both directions: a new bare site fails it,
-and so does converting the four. That second red is expected, and it is the signal to delete the
-by-name exclusion, widen the invariant to those files, and drop the pin along with it. The
-conversion lands in `tests/stack/` and the pin lives in `tests/integration/`, so the two halves
-merge separately and the row is red in between.
+While that gap stood it was pinned to exactly those four, keyed on file and variable name rather
+than line number, because the line numbers the issue cites had already drifted by three when the
+pin was written. The pin reds in both directions: a new bare site fails it, and so does converting
+the four. #1725 converted them, so the second red is the signal the pin was built to give, and the
+by-name exclusion, the pin, and the split between the two halves are gone together. Both halves land
+in one merge, because neither order keeps the branch green on its own: converting first empties the
+pin, and widening first makes the invariant's own match set non-empty against sites that are still
+bare. The glob now covers `lib.sh`, `run.sh` and both test-file spellings, which is every suite file
+under `tests/stack`; the one file outside it, `fixtures/rauc-info/capture.sh`, is a capture helper
+the suite does not source and is named in the code rather than left implied. What replaces the pin
+is a file-set control: the invariant asserts that its own list resolves and reaches `run.sh` and
+`test_data_reset.sh` before it reads an absence of matches as evidence, and refuses rather than
+records when it does not, because a glob that quietly stopped matching would report the same clean
+result as a fully converted tree.
 
 ---
 

--- a/tests/integration/selftest-stack-sandbox.sh
+++ b/tests/integration/selftest-stack-sandbox.sh
@@ -144,10 +144,15 @@ echo "== every tests/stack sandbox is built through mk_tmpdir, not a bare assign
 # guarded expression, never as a bare `VAR=$(mktemp -d)` whose failure leaves VAR set-but-empty
 # for a later `rm -rf "$VAR/store"` to expand against /store.
 #
-# tests/stack/run.sh and the standalone tests/stack/test_*.sh are NOT covered and still carry the
-# old form. They belong to other lanes, so #1705's conversion stopped at the grant boundary. They
-# are excluded by name rather than by silence, so that this row says what it does not check —
-# and the row after the next one PINS that excluded population, so the exclusion cannot rot.
+# #1705's conversion stopped at a grant boundary: tests/stack/run.sh and the standalone
+# tests/stack/test_*.sh belonged to another lane and kept the old form, so this row named them out
+# of itself and a second row PINNED that excluded population against the four known sites, keeping
+# the exclusion from rotting. #1725 converted those four, so both halves are gone: the glob below
+# covers every file the constructor reaches, and the pin has nothing left to hold. That pin reddens
+# on exactly this change, which is why the two halves cannot merge one at a time — they land here
+# together or the row is red in between. The glob is lib.sh, run.sh and both test-file spellings,
+# which today is every .sh under tests/stack except fixtures/rauc-info/capture.sh — a capture
+# helper the suite does not source, named here so the one file outside is stated, not implied.
 BARE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*="?\$\(mktemp -d\)"?[[:space:]]*$'
 STACK_DIR="$HERE/../stack"
 
@@ -161,77 +166,38 @@ else
         "it matched nothing, so the absence checked below proves nothing"
 fi
 
-found=$(grep -El "$BARE" "$STACK_DIR/lib.sh" "$STACK_DIR"/test-*.sh 2>/dev/null | tr '\n' ' ')
+# Every entry goes through the same existence filter, the two fixed names included. Seeding those
+# in unconditionally would make the check below a tautology — it would read back the list it had
+# just been handed, and a stack directory missing run.sh entirely would still report it as covered.
+COVERED=()
+for f in "$STACK_DIR/lib.sh" "$STACK_DIR/run.sh" "$STACK_DIR"/test-*.sh "$STACK_DIR"/test_*.sh; do
+    [ -f "$f" ] && COVERED+=("$f")
+done
+
+# The deleted pin was not only a pin: it was the only thing proving this row read real files. With
+# it gone, a file set that resolved to nothing would report the same clean absence as a fully
+# converted tree. So the set is measured before the absence below is read as evidence, and this
+# refuses rather than records — a vacuous invariant row is worse than no row, it reads as proof.
+covered_names=" ${COVERED[*]##*/} "
+missing=""
+for want in lib.sh run.sh test_data_reset.sh; do
+    case "$covered_names" in *" $want "*) ;; *) missing="$missing $want" ;; esac
+done
+if [ "${#COVERED[@]}" -ge 4 ] && [ -z "$missing" ]; then
+    it_pass "the invariant's file set resolves and reaches run.sh and test_*.sh (control arms)"
+else
+    it_fail "the invariant's file set resolves and reaches run.sh and test_*.sh" \
+        "the absence below would be vacuous — ${#COVERED[@]} files, missing:${missing:- none}"
+    echo "selftest-stack-sandbox: $IT_PASS passed, $IT_FAIL failed"
+    exit 1
+fi
+
+found=$(grep -El "$BARE" "${COVERED[@]}" 2>/dev/null | tr '\n' ' ')
 if [ -z "$found" ]; then
-    it_pass "no bare mktemp -d assignment survives in lib.sh or the test-*.sh domain files"
+    it_pass "no bare mktemp -d assignment survives in any tests/stack suite file"
 else
-    it_fail "no bare mktemp -d assignment survives in lib.sh or the test-*.sh domain files" \
+    it_fail "no bare mktemp -d assignment survives in any tests/stack suite file" \
         "still bare in: $found"
-fi
-
-echo ""
-echo "== the by-name exclusion above is PINNED to the four sites #1725 documented =="
-
-# A by-name exclusion rots silently. run.sh and the standalone test_*.sh are named out of the
-# invariant above, so a FIFTH bare site added to either would sit outside it with nothing saying
-# so — that gap, rather than the four known sites, is what #1725 is about.
-#
-# The four are NOT inert, and an earlier draft of this comment said they were. It argued from the
-# absence of a downstream `rm -rf "$VAR/sub"`, which is the wrong operator: the hazard is any
-# `"$VAR/sub"` expansion, and all four have one. run.sh writes `"$XPTLS/cert.pem"` and
-# `"$XPTLS/key.pem"` and then `rm -f "$XPTLS/key.pem"`; both `local d` helpers write
-# `"$d/xmrig-proxy"`; test_data_reset.sh runs `mkdir -p "$WORK/bin"` and writes under it. Under an
-# empty value each of those is an absolute path at the filesystem ROOT, and `set -u` does not
-# catch it because a failed `mktemp -d` leaves the variable SET and empty. The writes fail for an
-# unprivileged user — the CI shell job runs as the runner, not root — and would land under / as
-# root. Only the trailing `rm -rf "$VAR"` is genuinely inert. Pinning the excluded population
-# makes the exclusion a ratchet
-# in both directions: a new bare site reds this row, and so does converting the four, which is the
-# signal to delete the exclusion and widen the invariant above to cover these files too.
-#
-# ⛔ THAT SECOND RED IS EXPECTED AND IS NOT A DEFECT — DO NOT SWITCH THIS ROW OFF TO CLEAR IT.
-# The conversion lives in tests/stack/ (the tests lane) and this pin lives here (e2e), so the
-# two halves of #1725 merge separately and the pin reds in between. The remedy is in the
-# failure message: delete the by-name exclusion above, widen the invariant to these files,
-# and delete this row with it. Deleting only this row leaves run.sh covered by nothing.
-#
-# Keyed on file and VARIABLE NAME, never line numbers: #1725's body cites run.sh 104/118/124 and
-# the sites had already drifted to 107/121/127 by the time this row was written.
-# C collation fixes the order, and uniq -c leaves each file+var key unique, so nothing after it
-# can reorder the result.
-gap_census() { # <stack dir> -> "<file> <var> <count>" per line
-    local f b
-    for f in "$1/run.sh" "$1"/test_*.sh; do
-        [ -f "$f" ] || continue
-        b="$(basename "$f")"
-        grep -E "$BARE" "$f" 2>/dev/null | sed -E "s|^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*|$b \1|"
-    done | LC_ALL=C sort | uniq -c | awk '{print $2, $3, $1}'
-}
-
-EXPECTED_GAP='run.sh XPTLS 1
-run.sh d 2
-test_data_reset.sh WORK 1'
-
-# The census has to be shown able to report a set OTHER than the pin, or "it equalled the pin" is
-# not a measurement — a census that silently returned nothing would agree with an all-converted
-# population just as loudly. This fixture carries one bare site under a name that appears nowhere
-# in the real population, so only a census that actually reads the file can produce it.
-mkdir -p "$TMP/gapctl"
-printf 'ZCTL="$(mktemp -d)"\nrm -rf "$ZCTL"\n' >"$TMP/gapctl/run.sh"
-ctl_census="$(gap_census "$TMP/gapctl")"
-if [ "$ctl_census" = "run.sh ZCTL 1" ]; then
-    it_pass "the excluded-population census reports a site the pin does not contain (control arms)"
-else
-    it_fail "the excluded-population census reports a site the pin does not contain" \
-        "expected 'run.sh ZCTL 1', got: ${ctl_census:-<empty>}"
-fi
-
-actual_gap="$(gap_census "$STACK_DIR")"
-if [ "$actual_gap" = "$EXPECTED_GAP" ]; then
-    it_pass "the excluded files carry exactly the four bare sites #1725 documented"
-else
-    it_fail "the excluded files carry exactly the four bare sites #1725 documented" \
-        "#1725: the excluded population moved, which this row exists to announce — it is not a defect in this file. If the four were CONVERTED (tests lane, tests/stack/), the fix is to delete the by-name exclusion above, widen the invariant to run.sh and test_*.sh, and delete this row with it; do not delete this row alone, that leaves run.sh covered by nothing. If a NEW bare site appeared, it is outside every check in this suite. Expected [$(printf '%s' "$EXPECTED_GAP" | tr '\n' '|')] got [$(printf '%s' "${actual_gap:-<empty>}" | tr '\n' '|')]"
 fi
 
 echo ""

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -104,7 +104,7 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-monero-tari.sh" && domain_ran test-mo
 XP_ENTRY="$ROOT/build/xmrig-proxy/entrypoint.sh"
 xp_argv() { # <password value> -> the argv the wrapper would exec
     local d
-    d="$(mktemp -d)"
+    mk_tmpdir d
     printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
     chmod +x "$d/xmrig-proxy"
     PATH="$d:$PATH" PROXY_STRATUM_PASSWORD="$1" sh "$XP_ENTRY" --http-no-restricted --donate-level=0
@@ -118,13 +118,13 @@ assert_eq "xmrig-proxy entrypoint: set password appends --access-password (#152)
 # mount (PROXY_TLS_MOUNT overrides the fixed /tls so the suite can use a temp dir).
 xp_tls_argv() { # <PROXY_STRATUM_TLS value> <tls dir>
     local d
-    d="$(mktemp -d)"
+    mk_tmpdir d
     printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
     chmod +x "$d/xmrig-proxy"
     PATH="$d:$PATH" PROXY_STRATUM_PASSWORD='' PROXY_STRATUM_TLS="$1" PROXY_TLS_MOUNT="$2" sh "$XP_ENTRY" -b 0.0.0.0:3333
     rm -rf "$d"
 }
-XPTLS="$(mktemp -d)"
+mk_tmpdir XPTLS
 printf 'cert' >"$XPTLS/cert.pem"
 printf 'key' >"$XPTLS/key.pem"
 assert_eq "xmrig-proxy entrypoint: TLS on + keypair appends the cert flags (#261)" \

--- a/tests/stack/test_data_reset.sh
+++ b/tests/stack/test_data_reset.sh
@@ -36,7 +36,7 @@ for tool in mkfs.ext4 e2fsck mke2fs debugfs; do
     }
 done
 
-WORK="$(mktemp -d)"
+mk_tmpdir WORK
 # One trap, both dirs: bash traps replace rather than stack, so a bare "$WORK" trap here would
 # silently disarm lib.sh's cleanup of $SANDBOX and leak a temp dir per run.
 trap 'rm -rf "$WORK" "${SANDBOX:-}"' EXIT


### PR DESCRIPTION
## What this changes

#1721 closed #1705 for every `tests/stack/test-*.sh` domain file and `lib.sh`: they build their
sandboxes through one fail-closed constructor, `mk_tmpdir`. **Four sites sat outside that PR's grant**
and are named out of the invariant in `tests/integration/selftest-stack-sandbox.sh`. This converts
them:

| site | was | now |
|---|---|---|
| `tests/stack/run.sh:107` (`xp_argv`) | `d="$(mktemp -d)"` | `mk_tmpdir d` |
| `tests/stack/run.sh:121` (`xp_tls_argv`) | `d="$(mktemp -d)"` | `mk_tmpdir d` |
| `tests/stack/run.sh:127` | `XPTLS="$(mktemp -d)"` | `mk_tmpdir XPTLS` |
| `tests/stack/test_data_reset.sh:39` | `WORK="$(mktemp -d)"` | `mk_tmpdir WORK` |

One-for-one and **line-neutral**: `run.sh` is 350 lines either side of the diff, `test_data_reset.sh`
is 127. Zero bare `mktemp -d` remains in either file. *(This body said 347 before the rebase. That was
the pre-#1781 base; the new base adds three lines to `run.sh` far below every hunk. The sites are still
at `:107`, `:121`, `:127` and `:39`, re-derived at this head.)*

## Rebased onto the current tip

The merge sweep found the recorded pass had been taken over a base that no longer exists — #1781 merged
after this branch's merge-base, so the green was green about a tree that was gone. Rebased onto the
current tip. **The patch is byte-identical across the move:** `diff` of `git diff OLDBASE OLDHEAD`
against `git diff NEWBASE NEWHEAD` differs only in the blob `index` line, which is the new base's three
added lines in `run.sh`. The same instrument against a deliberately different patch returns non-zero, so
it discriminates. Trees are the wrong instrument across a moved base — a rebase holds the *patch* fixed,
never the tree.

## Proven — both suites, and the refusal measured in each of its two scopes

**1. The two suites that execute these files. ⚠ TAKEN AT THE SUPERSEDED BASE — do not lean on them.**

- `tests/stack/run.sh` — **rc 0, `pithead tests: 3304 passed, 0 failed`**, zero `^  ✗` lines.
- `tests/stack/test_data_reset.sh` — **rc 0, `data-reset real-image tests: 7 passed, 0 failed`**.

Both were measured before the rebase, on the pre-#1781 base, and **the row count is stale by
construction**: the new base sources one more domain file into `run.sh`, so 3304 is not what a run at
this head would print. They are kept rather than deleted because they remain a true record of the
conversion's own effect — zero failures, no `^  ✗` — but **neither is a measurement of this head**. I
have not re-run either: another lane holds the box for the RC battery and this window's rule is that CI
is the only test gate. `Shell tests` at this head is the figure that counts.

The second run is not redundant. **`run.sh` does not source `test_data_reset.sh`** — it is invoked
standalone from `Makefile:18` and `ci.yml:449`, and the string `test_data_reset` does not appear in the
3304-row log at all. Running only the first would have left the fourth site unexercised while reading
as full coverage.

**2. The refusal behaves differently in the two scopes, and only one of them is a hard stop.** Measured
rather than reasoned, with a positive control first (real `mktemp`, both shapes return real
directories — so the fixture works):

| shape | sites | with `mktemp` stubbed to fail |
|---|---|---|
| top-level assignment | `run.sh:127`, `test_data_reset.sh:39` | refusal on stderr, the line after **does not run**, rc 1 — a hard stop |
| inside `$( )` | `run.sh:107`, `run.sh:121` | refusal on stderr, the function body **does not continue**, but the OUTER shell carries on with an empty result |

So for the two helper sites the conversion buys a **loud refusal plus a failed assertion**, not a
halted run — `mk_tmpdir`'s `exit` ends the command substitution's subshell, which is the very limit
`lib.sh`'s own header describes. That is still strictly better than the bare form, which continued
silently with an empty `d`. **Saying it because "fail-closed" would be the wrong word for half of this
diff.**

*(The first version of this fixture proved nothing: arming the stub before sourcing `lib.sh` killed the
run at the `source` line, because sourcing `lib.sh` itself calls `mk_tmpdir _sbx`. Both legs "passed"
by dying early. The measurement above arms the stub after sourcing.)*

`bash -n` rc 0 on both files, `shfmt -d` clean on both.

## The four sites were not inert — and e2e found that first

The issue argues these are debt rather than the #1705 hazard, because none has a downstream
`rm -rf "$VAR/sub"` and `rm -rf ""` removes nothing. That is true of the **deletions** and not of the
**writes**. With an empty value these sites write `/xmrig-proxy` (twice, then `chmod +x` it),
`/cert.pem`, `/key.pem`, `/bin/mount`, `/bin/umount` and `/payload.txt`. They fail with `EACCES` for an
unprivileged user and would land under `/` as root.

**Credit where it belongs: PR #1781 states this already**, in its `docs/dev/integration-testing.md`
addition — "the hazard is any `"$VAR/sub"` expansion, not a recursive `rm`, and all four have one". I
re-derived it independently before reading that PR, which is corroboration, not a second discovery.
The only thing my enumeration adds is the two `test_data_reset.sh` sites beyond the `mkdir -p` #1781
names: `cat >"$WORK/bin/mount"` and `printf … >"$WORK/payload.txt"`, the latter carrying the suite's
literal sentinel payload string.

## Both halves ride on this branch now — they cannot land separately

This PR previously carried only the conversion, on the reasoning that widening the invariant was e2e's
to do. **The review found that wrong, and it is the reason this branch changed shape.** The conversion
empties #1781's census, so merging this half first leaves `Shell tests` red on `develop-v2` — and the
opposite order is red too, because widening the invariant *before* the conversion lands makes `found`
non-empty and fails that row instead. **There is no sequence of two separate merges that keeps
`develop-v2` green.** So the second commit does exactly what #1781's own failure message prescribes:
delete the by-name exclusion, widen the invariant to `run.sh` and the standalone `test_*.sh`, and drop
the pin along with it.

**Cross-lane, disclosed:** `tests/integration/selftest-stack-sandbox.sh` is the e2e lane's file and this
commit reaches into it under a one-shot `.lane-override` naming it. **That lane is running, reached the
same conclusion independently from the file itself, prepared the pin removal, and recorded its consent
for this branch to carry it** — this commit takes their prepared version essentially verbatim: the
widened glob, the rewritten exclusion paragraph, the deleted pin.

Their wording is better than my first draft on the point that matters. It **names the one file left
outside the glob** — `tests/stack/fixtures/rauc-info/capture.sh`, a capture helper the suite does not
source, which still carries a bare site. My draft's row read "anywhere in `tests/stack`", which
overclaimed by exactly that file. Corrected by adopting theirs.

`docs/dev/integration-testing.md` described the pin block in detail and would have been left false by
the cut — it said the two halves "merge separately and the row is red in between", which is wrong in
substance now that both orders red. Rewritten to match; it is shared rather than owned, and the e2e
lane owns that paragraph and may correct it. **e2e should review the file-set control below — it is the
one part not in their brief.**

### What replaces the pin, and why something had to

That census was not only a pin: it was the only thing proving the row read real files. Deleting it and
widening the glob would have left an absence check with no evidence that its own file set resolves. So
the invariant now builds its list through an existence filter, and asserts that the list resolves and
still names `lib.sh`, `run.sh` and `test_data_reset.sh` before any absence of matches is read as
evidence. A failed file-set control **exits** rather than recording, because a vacuous invariant row is
worse than no row — it reads as proof.

**An earlier draft of that control was a tautology, and the negative control is what caught it.** It
seeded `lib.sh` and `run.sh` into the list unconditionally and then asserted their names were present —
reading back the list it had just been handed — so a stack directory missing `run.sh` entirely still
reported it as covered. Every entry now goes through the same existence filter.

### Proven for the second commit, in this worktree at this head

- The selftest is **10 passed, 0 failed, rc 0**.
- **Negative control A** — `run.sh` restored to its pre-conversion form: the invariant row **fails and
  names `run.sh`**. That is what shows the widened glob *reads* the newly covered file rather than
  merely listing it.
- **Negative control B** — a stack directory holding only `lib.sh`: the file-set control **fails, naming
  both `run.sh` and `test_data_reset.sh` missing**, and the run stops before the invariant row. In the
  tautological draft it went vacuously green at exactly that point.
- The census itself, lifted verbatim and driven over both trees: **exactly the pinned three keys at the
  current base, empty at this head**, with its fixture control reporting a name the pin does not carry —
  the base leg is what makes the head leg a measurement.

Both negative controls run a copied harness over a fixture stack directory, so nothing in the worktree
was mutated; the one file touched for an unrelated guard control was restored and checked byte-identical
against `HEAD`.

## Not proven — said rather than hidden

- **No shellcheck**, and **no suite run at this head**. Another lane holds the box for the RC battery,
  so `make lint-sh`, any tree-wide shellcheck, and both suites are off for this window; CI's
  `Shell tests` is the lint gate and the test gate. The second commit's selftest is grep-only and was
  run locally; nothing else was.
- **The second commit's shellcheck is unmeasured.** It adds a bash array and a `case`; `bash -n` is rc 0
  but SC over `tests/integration/*.sh` has not been run here. Read the `Shell tests` shellcheck step.
- **The root-write hazard is a source reading plus a path-expansion check, not an executed root run.** I
  confirmed `"$WORK/bin/mount"` expands to `/bin/mount` under an empty `WORK`; I did not run any of this
  as root, and will not.
- **Neither file has a row in `docs/dev/file-budget.tsv`**, so this moves no ceiling. The issue's
  "`run.sh` sits on a zero-headroom budget row" is about a **different file** — the 2551 row is
  `tests/integration/run.sh`.
- The issue's line numbers (`:104`, `:118`, `:124`) had drifted by three; the sites are at `:107`,
  `:121`, `:127`. #1781 had already noticed the drift and keyed its pin on file and variable name
  instead.

## The over-engineering pass found one thing, and it shipped

The code diff is four one-line conversions — nothing to trim there. What the pass caught was the
**commit message**, which stated the write-hazard correction without crediting #1781. A squash merge
makes that message permanent, so it would have read as this lane's discovery forever. Fixed by a
message-only amend at the then-head `733e1976`, tree sha identical either side (`29ebd226…`). That
commit is now `5edbfcad` after the rebase — the amend record stands, but the staleness note above
governs what the 3304/0 and 7/0 still measure.

Closes #1725 (`Closes` is inert on `develop-v2` — hand-close on merge).

