### PR TITLE
test(os): #1651 the floor-fallback leg observes its reboot by boot id, so the old boot cannot pass the wait

### DIFF
--- a/tests/os/data-floor-fallback-leg.sh
+++ b/tests/os/data-floor-fallback-leg.sh
@@ -58,14 +58,16 @@ _floor_state() {
 }
 
 # Reboot into the just-installed slot and wait until the guest is back on the slot carrying marker
-# $1 with its boot gate PASSED (the commit line in this boot's journal). SSH answers on the failing
-# slot too, while it loads images and tries to bring the stack up, so the marker is what tells the
-# two apart. $2 = seconds: a failed `up` reboots within minutes, a gate that loops 90 rounds
-# takes ~15 min, and the fallback boot then re-loads images — allow for all three.
+# $1 with its boot gate PASSED (the commit line in this boot's journal). The reboot is OBSERVED
+# before anything is polled (#1651): the boot that issued it still carries marker $1 and a
+# committed line in its own journal, so a probe it answered while shutting down satisfied the
+# predicate off the OLD boot — and `-b -1` in the caller then named the wrong boot. SSH answers
+# on the failing slot too, while it loads images and tries to bring the stack up, so the marker
+# is what tells the two apart. $2 = seconds: a failed `up` reboots within minutes, a gate that
+# loops 90 rounds takes ~15 min, and the fallback boot then re-loads images — allow for all three.
 _floor_fallback_wait() {
     local deadline=$(($(date +%s) + $2)) got
-    _ssh reboot || true
-    sleep 10
+    _reboot_wait reboot "$2" || return 1
     while [ "$(date +%s)" -lt "$deadline" ]; do
         got=$(SSH_TIMEOUT=20 _ssh "cat /etc/pithead-test-marker 2>/dev/null; journalctl -u pithead-boot -b 2>/dev/null | grep -c 'booted slot committed'" 2>/dev/null | tr -d '\r' | tr '\n' ' ')
         case "$got" in "$1 "[1-9]*) return 0 ;; esac


### PR DESCRIPTION
## What

`tests/os/data-floor-fallback-leg.sh` — `_floor_fallback_wait` now observes the reboot by boot id (`_reboot_wait`, the #1778 helper) before it polls for the fallback slot. One function, +8/−6 lines, no product bytes: `tests/` is not COPYed into the rootfs, so this is outside the image freeze.

## Why

Gating battery run 4 (`BUILD_COMMIT 670c33e9`, `--phase all`) went red on ONE row, in the floor-fallback leg:

> ✗ the previous boot's journal has no 'slot left uncommitted' line — either the 99.0.0 slot committed, or the journal did not persist

Read from the live guest before the harness tore it down (persistent journal, `journalctl --list-boots`): the 99.0.0 slot's boot IS in the list, 13 s long, WITH the gate line (`slot left uncommitted so A/B fallback stays armed`), and the three rows around the ✗ (restored floor, restore line on the console, re-install at the restored floor) all ran against the live fallback boot. So the product did what #1393 says. What the row's instrument could not see: `-b -1` from the boot the harness was talking to.

The helper did `_ssh reboot; sleep 10` and then polled for `marker == vmig` AND a `booted slot committed` line in `-b`. The boot that ISSUES the reboot satisfies both — it is the migration leg's committed slot — so any probe it answered while shutting down returned 0 before the guest went down, and `-b -1` on that boot is the boot BEFORE the migration commit, which has no uncommitted line. Same class as #1778, in the one file #1778 did not touch.

## What was RUN

- `bash -n` and `shfmt -i 4 -d` on the file: clean. Line count 198 → 200; the file has no tsv row (under 400).
- Offline control, `_ssh` stubbed with file-backed state, three reboot shapes, helper extracted from `origin/develop-v2` (old) and this branch (new), `_reboot_wait`/`_wait_new_boot`/`_boot_id` extracted verbatim from `run.sh`:

| scenario | old helper | new helper |
|---|---|---|
| A — the old boot never goes down | rc 0 after 1 probe, ON THE OLD BOOT (false green) | rc 1 at the deadline (honest) |
| B — the reboot lands before the first probe | rc 0 on the fallback boot | rc 0 on the fallback boot |
| C — the old boot answers 2 probes, then the 99.0.0 boot, then the fallback | rc 0 after 1 probe, ON THE OLD BOOT (false green) | rc 0 after 9 probes on the fallback boot; info line `the old boot … answered 2 probe(s)` |

Scenario B is the positive control that the fixed helper still passes the honest case; C is the shape the battery hit.

## What was NOT run

- The KVM leg itself. It runs next as `tests/os/run.sh --phase provision --keep` on the same `os/` bytes once this merges and the box is quiet, and that run is where the other hypothesis is settled: the fallback boot in run 4 has NO entry in the persistent boot list (nothing between the 99.0.0 boot's last line and the negative control's boot, ~7 min), i.e. its journal never reached `/data/pithead/journal`. If the fallback boot IS listed on the kept guest, this race was the whole cause; if it is NOT, that is a separate `os/` finding and gets its own issue. The `-b -1` row is left as it is on purpose, and NOT because it discriminates: after this fix the wait lands on the fallback boot, whose `-b -1` is the 99.0.0 boot, and run 4 already shows that boot's journal persisted with the gate line — so the row goes green whether or not the fallback boot's own journal reached `/data`, and only a red there would say anything (about the 99.0.0 boot, not the fallback boot). It stays because it is #1393's assertion and the defect was in the wait; changing what it asks in the same PR would leave the next battery's green unable to say which change bought it. The boot-list read on the kept guest is the discriminator. (Corrected after the reviewer's pass — the first body called the row the instrument.)
- `make lint-sh`: the gating chain holds the shellcheck serialisation lock until it exits. CI's shell job is the check.

## Over-engineering pass (by hand — the PR gate reads the wrong branch from this lane's cwd)

Two lines of code replaced by one call into an existing helper. Alternatives considered: converting both callers to capture the fallback boot id and key the `-b -1` row on it — rejected above, on purpose; adding a `sleep` before `_reboot_wait` — nothing to wait for, the helper's first act is to read the boot id from the still-running boot; passing `_reboot_wait` 300 s instead of `$2` (the reviewer's suggestion, truer to the other call sites) — rejected for THIS PR so it stays a one-mechanism change; the two deadlines share `$2`, which is immaterial at the call sites' 1800 s and worth a comment line on the next touch of the file.

Known trade-off, shared with the 14 sites #1778 converted (scenario D in the reviewer's terms): if the boot id is unreadable BEFORE the reboot, `_reboot_wait` returns 1 without sending the command, the helper returns 1 at once, and the caller's message says "did not come back within 30 min" — a wrong reason for a right refusal. Not fixed here.

Evidence dir on the bench host: `~/battery-1651-20260904T215352Z` (`battery.log`, `guest-journal/`).
