### PR TITLE
test(os): #1651 the media abort leg keeps its console and names what it saw when the cancel line is missing

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -2712,14 +2712,14 @@ phase_media() {
     _ssh reboot >/dev/null 2>&1 || true
     wait_serial "staged configuration differs from the running one" 180 || bad "no diff banner on the abort leg"
     # Pull the medium mid-countdown — the deliberate physical act that cancels a pending change.
-    _detach_media_stick
-    # Full expected text, matching the apply leg's own precision above (#1061): a bare
-    # "cancelled" would also match unrelated boot noise, and it is exactly the console's own
-    # wording that went missing when this issue was filed — the weak match could not have told
-    # "the right line appeared" from "some other word did".
+    _detach_media_stick || info "detach-device returned rc $? — the guest may still see the stick"
+    # Full expected text (#1061): a bare "cancelled" would also match boot noise. On a miss, keep this
+    # boot's console (no-clobber, as cleanup does) and quote the channel's last line, so the red carries it.
     wait_serial "Media configuration channel: cancelled" 90 &&
-        ok "removing the media mid-countdown cancels the change, and says so on the console" ||
-        bad "no cancellation confirmation ever appeared on the console after the media was pulled"
+        ok "removing the media mid-countdown cancels the change, and says so on the console" || {
+        [ -f "$SERIAL.failed" ] || cp "$SERIAL" "$SERIAL.failed" 2>/dev/null
+        bad "no cancellation confirmation on the console within 90 s of the pull — the channel's last line: '$(grep -o 'Media configuration channel: .*' "$SERIAL" | tail -1)'; console kept at $SERIAL.failed"
+    }
     _wait_ssh 180 || {
         bad "guest never came back after the cancelled change"
         return


### PR DESCRIPTION
## What

Run 4 of the #1651 gating battery (`BUILD_COMMIT 670c33e9`, verdict on the issue at 00:05Z) reddened `tests/os/run.sh`'s media abort-leg row — *no cancellation confirmation ever appeared on the console after the media was pulled* — once in three `--phase all` runs on byte-identical `os/`, with the rows either side of it green (the diff banner appeared; the change was not applied). Nothing survived to say why: the harness truncates the console before the next boot, the leg deletes its stick, and later phases overwrite the disk.

This makes the row carry its own evidence next time, in the same eight lines of `phase_media`:

1. `_detach_media_stick`'s return code is reported with an `info` line instead of being discarded. A failed hot-unplug is one of the two ways to reach this red, and the harness could not see it.
2. On a miss, this boot's console is kept at `$SERIAL.failed`, no-clobber, the same contract `cleanup()` already honours for the end-of-run copy.
3. The red quotes the media channel's last console line. `cancelled` arriving late, `applied`, `could not write` and nothing-at-all are the four shapes; the quote tells them apart without a rerun.

Line-neutral: `run.sh` is 3423 lines before and after (its `file-budget.tsv` row is 3423, at the line count, so any growth would have needed a ceiling change). No product bytes: `tests/` is not copied into the image, so the freeze is untouched.

## What was RUN (by me, this worktree at `7dae676f` + this commit)

- `bash -n tests/os/run.sh` → clean. `shfmt -i 4 -d tests/os/run.sh` (the Makefile's flags, pinned 3.13.1 = local) → no diff. `awk 'END{print NR+0}'` → 3423.
- Offline control of the new branch, on the exact 8-line snippet extracted from the file by content, with `wait_serial`, `_detach_media_stick`, `ok`/`bad`/`info` stubbed and a synthetic console:
  - **A, fires:** detach rc 3 + wait miss + console ending in the `applied` line → `INFO: detach-device returned rc 3 …`, `BAD: … the channel's last line: 'Media configuration channel: applied. Continuing boot with the new configuration.'; console kept at …/serial.log.failed`, the copy exists, `FAIL=1`.
  - **B, no-clobber:** a pre-existing `.failed` holding `PRIOR` survives the miss unchanged.
  - **C, positive control:** wait hit + detach rc 0 → the `ok` row, no copy, `FAIL=0`.
  - A first attempt over-extracted by one line (the next block's `|| {` opener) and hit a syntax error at end-of-file after the snippet had run; that run was discarded and the control re-run on the 8-line snippet with `bash -n` clean first.

## What was NOT run, and why

- **`make lint-sh` / shellcheck: not run here.** The #1651 discriminating rerun on the bench holds `~/.shellcheck-serialize.lock` for its whole KVM leg, and shellcheck beside a 16 GiB guest is the OOM path; CI's shell job is the shellcheck evidence for this PR.
- **No KVM run of the changed leg.** The rerun in flight uses the lane tree at `7dae676f` (old wording). If this merges before the full `--phase all` gate, that run carries it; the change alters no verdict, only what a miss reports.
- **Docs:** `docs/dev/appliance-release.md` § the battery already says the harness keeps the guest console at `/tmp/pithead-os-serial.log.failed` on failure; still true and now true one row earlier, so no doc change. The house-voice pass therefore had nothing to read.

## Over-engineering pass (by hand — the PR gate keys off the wrong branch from this lane's cwd, disclosed)

Pure evidence capture; the assertion and its 90 s window are unchanged. Alternatives considered and rejected: widening the window (hides a slow countdown, the product prints within ~2 s of the pull); a shared helper for "keep console + quote last line" (one caller today; `cleanup()` and this site share a contract, not code); placing the copy in `failure-evidence.sh` (that file sits at its own ceiling and this is a single site). Eight lines in, eight out; two comment lines shortened to pay for the brace block.

Merge rule: needs a recorded non-author PASS; the `fixes` lane or the control seat merges. `Closes` is inert on `develop-v2`: #1651 stays open — this is one instrument for it, not its fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
