### PR TITLE
test(os): #1651 the media-abort miss quotes the console without its CR and keeps only a non-empty console

### DIFF
--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -2717,8 +2717,8 @@ phase_media() {
     # boot's console (no-clobber, as cleanup does) and quote the channel's last line, so the red carries it.
     wait_serial "Media configuration channel: cancelled" 90 &&
         ok "removing the media mid-countdown cancels the change, and says so on the console" || {
-        [ -f "$SERIAL.failed" ] || cp "$SERIAL" "$SERIAL.failed" 2>/dev/null
-        bad "no cancellation confirmation on the console within 90 s of the pull — the channel's last line: '$(grep -o 'Media configuration channel: .*' "$SERIAL" | tail -1)'; console kept at $SERIAL.failed"
+        [ -f "$SERIAL.failed" ] || [ ! -s "$SERIAL" ] || cp "$SERIAL" "$SERIAL.failed" 2>/dev/null
+        bad "no cancellation confirmation on the console within 90 s of the pull — the channel's last line: '$(tr -d '\r' 2>/dev/null <"$SERIAL" | grep -o 'Media configuration channel: .*' | tail -1)'; console kept at $SERIAL.failed"
     }
     _wait_ssh 180 || {
         bad "guest never came back after the cancelled change"


### PR DESCRIPTION
## What

The two non-blocking findings from the review of #1787, folded into the same two lines of `phase_media`'s abort-leg miss block:

1. **B (the higher-ranked):** the red quotes the media channel's last console line, read raw from `$SERIAL`. The virsh serial file is CRLF, so the quote ended in a carriage return; on a terminal that returns the cursor to column 0 and the rest of the message overwrites the quote. The one line the red exists to show was scrambled on every miss it served. The line now goes through `tr -d '\r'` first, the file's own convention (25 sites, one of them earlier in `phase_media`), and a missing file is silenced (`2>/dev/null` is placed before `<"$SERIAL"` because redirections apply left to right).
2. **A:** the at-miss console keep copied a zero-byte serial file, and an empty `.failed` would then suppress a later phase's keep (no-clobber). The copy now takes the same `[ -s "$SERIAL" ]` guard `cleanup()` uses.

Line-neutral: `run.sh` is 3423 before and after; its `file-budget.tsv` row is 3423, zero headroom, so the long line stays long (no continuation). No product bytes: `tests/` is not copied into the image, the freeze is untouched.

## What was RUN (by me, worktree at `2604b7a9` + this commit)

- `bash -n tests/os/run.sh` → clean. `shfmt -d tests/os/run.sh` (pinned 3.13.1 = local) → no diff. `awk 'END{print NR+0}'` → 3423. `scripts/lint-file-budget.sh` on the staged file → OK.
- Controls on the file's own two lines (`sed -n '2720,2721p'`, sourced with `bad` stubbed), against the OLD block extracted the same way from `origin/develop-v2`:
  - **CRLF fixture, the one the #1787 control lacked:** old block's quoted text contains 1 CR; new block's contains 0, and the quote reads `'Media configuration channel: applying'`.
  - **LF-only fixture:** old and new quotes identical, which is why the earlier control could not see the defect.
  - **Empty serial file:** old block leaves a 0-byte `.failed`; new block leaves none. **Non-empty file:** new block still copies it (100 B).
  - **Missing file:** old block writes 58 bytes to stderr; new block writes 0.

## What was NOT run, and why

- **`make lint-sh` / shellcheck: not run here.** The #1651 discriminating rerun holds `~/.shellcheck-serialize.lock` for its KVM leg and shellcheck beside a 16 GiB guest is the OOM path; CI's shell job is the shellcheck evidence.
- **No KVM run of the changed leg.** The discriminator in flight runs the lane tree at `7dae676f`; the full `--phase all` gate is launched after a pull, so it carries this if it has merged by then. The change alters no verdict, only what a miss reports.
- **Docs:** nothing in `docs/` describes the quoted line; no doc change.

## Over-engineering pass (by hand, disclosed as in #1787)

Two in-line edits, no helper: one caller for the quote, and the guard is a copy of the contract `cleanup()` already states. Wrapping the 233-character line (207 before this change) for tidiness was rejected on purpose: a continuation is a new line and the budget gate reds.

Merge rule: needs a recorded non-author PASS; the `fixes` lane or the control seat merges. #1651 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ

