### PR TITLE
refactor(dashboard): #1361 xvbview renders the shared StatCard, not a private twin

### DIFF
--- a/dashboard/mining_dashboard/web/static/xvbview.mjs
+++ b/dashboard/mining_dashboard/web/static/xvbview.mjs
@@ -4,17 +4,8 @@
 import { EstTable } from "./esttable.mjs";
 import { coinFiat, fmtHashrate, formatFiat, formatXmr } from "./logic.mjs";
 import { html } from "./preact.mjs";
+import { StatCard } from "./statcards.mjs";
 import { computeXvbTier, xvbDecisionRows } from "./xvblogic.mjs";
-
-// --- Small shared pieces (local copies of components.mjs's private helpers; see components.mjs
-// for the shared convention — kept private there too, so each caller gets its own small copy
-// rather than a shared export, following workerview.mjs's InfoCard precedent) ---------------
-
-const StatCard = ({ label, value, cls, span, title }) => html`
-    <div class=${"stat-card" + (span ? " col-span-2" : "")} title=${title || ""}>
-        <h5>${label}</h5>
-        <p class=${cls || ""}>${value}</p>
-    </div>`;
 
 // XvB tier decision block (#872, study-final): the analytical tool a miner decides with. Every
 // donor tier gets a block — the two net verdicts (what XvB says, and what the study says) as

--- a/dashboard/tests/frontend/statcards.test.mjs
+++ b/dashboard/tests/frontend/statcards.test.mjs
@@ -6,6 +6,7 @@
 // Only the pure pieces live here; the components themselves are exercised through the rendered
 // app in components.test.mjs, which is the lowest tier that proves they are actually wired up.
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { nodeLocation } from "../../mining_dashboard/web/static/statcards.mjs";
@@ -22,4 +23,38 @@ test("nodeLocation never guesses Local when the payload does not say (#1040)", (
   for (const missing of [undefined, null, "", 0, "true", 1]) {
     assert.equal(nodeLocation(missing), "—", `${JSON.stringify(missing)} must not read as a location`);
   }
+});
+
+// --- No module may keep a private copy of a shared primitive (#1361) ------------------------
+//
+// xvbview.mjs carried a `const StatCard` byte-identical to the export above, justified in-file by
+// a `workerview.mjs` InfoCard precedent that did not apply. Nothing caught it and nothing here
+// could have: identical copies render identically, so no assertion over rendered output can tell
+// them apart — which is why this law is enforced over the SOURCE. It proves the text (no sibling
+// module re-declares one of these names) and NOT the behaviour (it cannot tell you a caller
+// actually uses the import it holds). The names are read out of statcards.mjs itself, so a
+// primitive added there is covered without editing this test.
+const STATIC_DIR = new URL("../../mining_dashboard/web/static/", import.meta.url);
+// `export` is part of the pattern: a sibling that re-declares AND exports a shared primitive is
+// the same defect, and a bare `^(?:const|...)` alternation would step straight over it.
+const DECL = "(?:export\\s+)?(?:const|let|var|function|class)";
+
+test("no module keeps a private copy of a shared stat-card primitive (#1361)", () => {
+  const shared = readFileSync(new URL("statcards.mjs", STATIC_DIR), "utf8");
+  const EXPORTED = /^export\s+(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/gm;
+  const names = [...shared.matchAll(EXPORTED)].map((m) => m[1]);
+  // Anti-false-pass: a reformat that stopped the pattern matching would leave the sweep below
+  // vacuously clean, which reads exactly like compliance. Add a name here when you export one.
+  assert.deepEqual(names.sort(), ["MoreStats", "StatCard", "TariStatus", "nodeLocation"].sort());
+
+  const offenders = [];
+  for (const file of readdirSync(STATIC_DIR).filter((f) => f.endsWith(".mjs") && f !== "statcards.mjs")) {
+    const body = readFileSync(new URL(file, STATIC_DIR), "utf8");
+    for (const name of names) {
+      if (new RegExp(`^${DECL}\\s+${name}\\b`, "m").test(body)) {
+        offenders.push(`${file} declares its own ${name}`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `import these from statcards.mjs instead of re-declaring them`);
 });


### PR DESCRIPTION
`xvbview.mjs` held a `const StatCard` byte-identical to `statcards.mjs`'s export (227 bytes each,
differing only in the leading `export`), with six live usages. Nothing rendered wrong and nothing
could — identical copies render identically, which is exactly why the first edit to the shared one
would have stopped applying to the XvB block silently.

The in-file comment justifying the copy cited two premises and both are false: it said
`components.mjs` keeps these helpers private (line 40 imports them from `statcards.mjs`), and it
cited `workerview.mjs`'s `InfoCard` as precedent (`InfoCard` is unexported and unique to its module —
the opposite case). The comment is what let the duplicate survive being read, so it goes with the
copy rather than being corrected.

## Where the guard lives, and why not next door

In `statcards.test.mjs`, not `xvbview.test.mjs`. The latter sits at its 431-line budget ceiling with
zero headroom — row and actual both re-measured at this head — and the law belongs to the shared
component anyway. `statcards.test.mjs` is 60 lines and carries no budget row; under 400 it needs
none, and adding one would itself fail the gate.

The test reads the exported names out of `statcards.mjs` at runtime, so a primitive added there is
covered without editing the test. It carries an anti-false-pass assertion pinning the name list: a
reformat that stopped the extraction pattern matching would otherwise leave the sweep vacuously
clean, which reads exactly like compliance.

The declaration pattern matches an optional leading `export`. A sibling that re-declares **and**
exports one of these primitives is the same defect, and the bare
`^(?:const|let|var|function|class)` form stepped straight over it.

## What the guard proves, and what it does not

It is a SOURCE-level law over top-level declarations. It proves no sibling module re-declares one of
these names. **It cannot prove a caller uses the import it holds**, and it does not see an indented
or nested declaration. That is not a shortcut taken for convenience: no assertion over rendered
output can discriminate between two identical components, so source is the only instrument here that
can produce the other answer.

## What was RUN

This lane is under the burst window's CI-ONLY rule — another lane holds the shared build box and
1-minute load was above 3 — so **no local test or lint run was performed. CI is the gate for this
PR.** What I did run locally, all of it cheap and non-contending:

- `node --check` on the edited test file: rc 0.
- Widened-pattern sweep over the whole `static/` tree at this head: the only match was the copy this
  commit removes. **Fired both ways first** — an `export`-prefixed and a bare re-declaration were
  each seeded into scratchpad copies and the pattern caught both, so the clean sweep is a fired
  instrument rather than an unarmed one.
- Budget verification: `xvbview.test.mjs` row 431 / actual 431; `statcards.test.mjs` 60, rowless.
- Rebased onto the current `develop-v2` tip with the explicit `--onto` form (base had moved; the
  branch was cut at `125e6eb9`). Verified the change survived by comparing normalised
  `format-patch` output before and after — byte-identical — with a one-line tamper control that
  fired.

**Not run, say so if you quote this:** the frontend suite (`make test-frontend`), `make lint`, and
every other local target. I have not observed this test pass. CI's `Frontend logic tests (node
--test)` and `Lint per-surface` jobs are the first execution.

Refs #1361 — `Closes` is inert on `develop-v2`; hand-close with the merge sha.
