### PR TITLE
fix(ci): #1789 #1788 the shell gate's cap fits its real range, and a failed uv download fails its own step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         # Curl the pinned installer (same posture as hadolint below); avoids a mutable-tag action.
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"   # deterministic install dir (runners may set CARGO_HOME)
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # download then run, never a pipe: the pipeline's status is sh's, which is 0 on empty input, so a failed download passed this step (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Dashboard tests + coverage gate (emits coverage.xml)
         run: make test-dashboard
@@ -364,7 +364,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"   # deterministic install dir (runners may set CARGO_HOME)
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: ruff check + format --check (config in dashboard/pyproject.toml + root ruff.toml)
         # Single source of truth: the Makefile `lint-py` target, which runs ruff via uv from the
@@ -406,7 +406,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Audit workflows (injection, token scope, self-hosted-runner risks)
         run: uvx zizmor@1.25.2 --offline .github/workflows/
@@ -415,7 +415,7 @@ jobs:
     name: Shell tests (shellcheck + pithead suite)
     if: github.event_name != 'schedule' # scheduled runs are the CVE sweep — build-images only (#833)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25 # 11-15 min is this job's honest range on develop-v2 (73 runs: 633-902 s, 21 within 60 s of the old 900 s cap) and two runs were cancelled AT it (#1789)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -506,7 +506,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Lint docs voice, operator strings, topology classes, file budget, trivy parity, then JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo)
         # Single source of truth: the Makefile targets. REPO-LOCAL GATES FIRST (#1746): the five bash ones cost under 6s between them, while the five after them fetch via npx/uvx/docker and have eaten the whole 15-minute timeout on a slow registry.


### PR DESCRIPTION
Two defects in `.github/workflows/ci.yml`, both the same class: the check reports something other
than the state of the code. Addresses #1789 and #1788 — both hand-closed with the merge sha, since
`Closes` is inert on `develop-v2`.

## #1789 — the Shell tests job's cap sits inside its own range

`Shell tests (shellcheck + pithead suite)` had `timeout-minutes: 15`. A timed-out job is reported as
`cancelled`, which `gh pr checks` buckets under `fail`, so a green diff reads as broken.

Measured by me at `418d50f7` over the last 96 `ci.yml` runs, from per-step `started_at`/`completed_at`
in `gh api repos/:owner/:repo/actions/runs/<id>/jobs`:

| | |
|---|---|
| Shell-tests jobs on `develop-v2` branches (>= 600 s) | 73 |
| range | **633 s - 902 s**, against a 900 s cap |
| mean | 799 s |
| finished within 60 s of the cap | 21 of 73 |
| cancelled AT the cap | 2 |

The queue asked for the slow step. There is no anomalous one: `Run pithead test suite` is **73%** of
the job (mean 581 s) and `Lint pithead, build/* + dashboard/ container scripts, and test scripts`
is **17%** (mean 133 s). Everything else — checkout, the pinned shellcheck/shfmt install, and the
five suites after the pithead one — is under 90 s combined.

Two things eat the margin, and neither is something a code change fixes here:

- **The same branch, minutes apart, runs at different speeds.** `fix/1651-reboot-boot-id` took 828 s
  at 21:13Z and 745 s at 21:39Z; `fix/1725-stack-sandbox-exclusion-pin` took 678 s at 22:55Z and
  869 s at 23:13Z.
- **The shellcheck+shfmt step is growing.** Mean by half-day: 122 s (09-03 PM) -> 128 s (09-04 AM)
  -> 149 s (09-04 PM) -> 157 s (09-05 AM). More shell to lint; +29% in two days.

So the cap moves to 25 min. 1500 s is 66% above the worst run observed, and a job that reaches it is
a genuine hang rather than a slow runner. **I did not take the issue's alternative** of splitting
`Run integration harness self-test` into its own job: it adds a required check name, which is
branch-protection surgery and not a lane's, and it would not help — that step is 11-22 s, nowhere
near where the time goes.

## #1788 — the pinned uv install passes when its download fails

Four byte-identical sites (`:58` dashboard, `:367` lint-py, `:409` zizmor, `:509` lint) ran
`curl -LsSf ... | sh` with no step-level `shell:` key, so the runner's default `bash -e {0}` applies
*without* `pipefail`. The pipeline's status is `sh`'s, and `sh` on empty input exits 0.

**I measured the candidate fixes against a stand-in curl that exits 35 with no output, run as script
files under `bash -e` — and the obvious one-liner does not work:**

| shape | failed download | successful download |
|---|---|---|
| `curl ... \| sh` (today) | **rc 0 — the defect, reproduced** | rc 0 |
| `curl ... -o F && sh F` | **rc 0 — still broken** | rc 0 |
| `curl ... -o F; sh F` (**shipped**) | rc 35 | rc 0 |
| `set -o pipefail; curl ... \| sh` | rc 35 | rc 0 |

`&&` fails because `set -e` is suppressed for a command in an `&&` list that is not the last one: the
list returns non-zero, nothing exits, and the `echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"` line after
it ends the block at 0. The successful-download column is the positive control — none of the four
shapes is simply always-failing.

I shipped the `;` form over `pipefail` because it never feeds a truncated download into `sh` at all,
and because the same file's pinned shellcheck/shfmt install already uses download-to-file.

**The positive control for the shipped shape is this PR's own CI run:** all four jobs call `uv` or
`uvx` in the step immediately after the install, so a broken install reddens them by name.

## Line budget

`.github/workflows/ci.yml` is at its recorded ceiling of 513 lines, and `scripts/lint-file-budget.sh`
rejects any edit that raises a ceiling. Both fixes are therefore **line-neutral** — which is why the
reasoning rides in inline comments rather than on comment lines, and why each install site is one
line rather than a `shell: bash` key or a `set -o pipefail` line.

## Lane

`.github/workflows/ci.yml` is a named-file grant to `currency` in `roles/currency.paths` (controller,
2026-08-23), so **no `.lane-override` was used**. #1788's body states the file is in nobody's
`.paths`; that is not true of this lane. Armed, with the control fired:

- `ci.yml` staged alone -> `lane-guard.sh` rc **0**
- ungranted sibling `release-gate.yml` staged -> rc **1**, naming the file (reverted immediately; the
  working tree carries only `ci.yml`)

## Not done

- **No local test run of any kind.** The window makes CI the only gate while the appliance lane holds
  the build box for the RC battery: no `make lint`, no `make test`, no `make lint-sh`, no shellcheck,
  no KVM, no container. The YAML was parsed with `yaml.safe_load` (the job's `timeout-minutes` reads
  back as int 25; zero `| sh` steps remain) and the shell shapes were measured with the fixture
  above. Everything else is CI's to say.
- **`develop`'s copy of `ci.yml` carries the same four `| sh` sites and is not changed here** —
  `develop` is frozen. #1789 does not bite there: its Shell-tests job runs 348-425 s.
- No retry hardening (`curl --retry`); #1788 names it as separate and optional.
- I did not separate runner-speed variance from suite growth. Both are visibly present and the fix is
  the same either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEuaDRUCNNn2NTxCeunbMB
