### PR TITLE
test(stack): #1771 the TTL-window row waits on the write, not on a fixed budget

### DIFF
--- a/tests/stack/test-control-backup.sh
+++ b/tests/stack/test-control-backup.sh
@@ -104,11 +104,20 @@ export CONTROL_BACKUP_KIT_TTL_S=3
 printf '{"id":"%s","action":"backup","actor":"admin"}\n' "$bid2" >"$BKC/req2.json"
 run_sourced "$SANDBOX" control_process_request "$BKC/req2.json" "$BKC" >/dev/null 2>&1 &
 bg_pid=$!
-sleep 0.5 # well inside the 3s TTL — the stubbed child + write are effectively instant
-mid_pass="$(jq -r '.passphrase // "null"' "$BKC/results/$bid2.json" 2>/dev/null)"
-{ [ -n "$mid_pass" ] && [ "$mid_pass" != "null" ]; } &&
+# The mid-flight read races the background write, so it waits on the condition rather than on a
+# fixed budget; why a tick budget is wrong is #1495's lesson and lives on wait_while_alive itself.
+# What is specific to this row: when the old `sleep 0.5` lost, jq read a result file that was not
+# there yet and the row redded with `got: null`, the exact text a real TTL defect prints. The
+# writer cannot exit before it redacts (lib/pithead/45-control-backup.sh), so it outlives the
+# window by construction and a give-up means it published nothing at all.
+bkc_kit_published() { # #1495: see wait_while_alive in lib.sh
+    mid_pass="$(jq -r '.passphrase // "null"' "$BKC/results/$bid2.json" 2>/dev/null)"
+    [ -n "$mid_pass" ] && [ "$mid_pass" != "null" ]
+}
+wait_while_alive "$bg_pid" bkc_kit_published &&
     ok "the passphrase IS present while inside the TTL window" ||
-    bad "the passphrase IS present while inside the TTL window" "got: $mid_pass"
+    bad "the passphrase IS present while inside the TTL window" \
+        "got: ${mid_pass:-none} — the writer exited without publishing one: a broken write, not a slow box"
 assert_eq "the kit's passphrase is exactly what the child received (same secret both ends)" \
     "$mid_pass" "$(cat "$PASS_LOG")"
 wait "$bg_pid"
@@ -118,6 +127,7 @@ assert_eq "the passphrase is null once the TTL elapses" \
     ok "the archive file itself is untouched by the redaction" ||
     bad "the archive file itself is untouched by the redaction" "missing"
 unset bg_pid mid_pass
+unset -f bkc_kit_published
 
 echo "== control channel: backup verb — failure and throttle (#908) =="
 rm -f "$BKC/staged/.backup-stamp" # bid2 above already claimed the 10-minute throttle


### PR DESCRIPTION
## What was wrong

The backup-kit TTL stanza in `tests/stack/test-control-backup.sh` read the mid-flight result through
a fixed `sleep 0.5` racing an unbounded background write.

The comment defending it reasoned about the wrong end of the window. The risk was never that the wait
overruns the TTL — it was that `control_process_request` had not yet written `results/<id>.json` when
the read happened. When the race was lost, `jq` on a missing file yields `null`, and the row reds with
`got: null`, **which is exactly what a genuine defect in the TTL logic prints**. That is what made this
expensive rather than merely annoying: a flake in the control-channel domain that is indistinguishable
from a regression is one the next lane to touch that code has to disprove.

## The fix is the instrument this suite already has

`wait_while_alive` in `tests/stack/lib.sh` was built for #1495 against precisely this shape — its own
comment names the fixed tick budget that reddened the #1342 mergemine-lock test under concurrent runs.
It bounds on the holder still being **alive** rather than on a tick count a loaded box does not owe.
The call site follows `test-lifecycle.sh`'s established pattern: a predicate function beside the call,
and `unset -f` beside the stanza's existing `unset`.

Two properties make the new bound honest rather than merely longer:

- **The predicate assigns `mid_pass` itself** instead of returning a verdict the caller then re-reads.
  There is no second read that could land after the redaction, so the value asserted is the value the
  check passed on.
- **The writer cannot exit before it has redacted**, so it outlives the window by construction.
  Re-derived at source in `lib/pithead/45-control-backup.sh` rather than taken from the test's own
  comment: `control_write_result` publishes the passphrase, then the in-band
  `sleep "${CONTROL_BACKUP_KIT_TTL_S}"` runs, then the `jq` redaction, then the function returns.

Together those mean a give-up from `wait_while_alive` is a writer that published **nothing at all** — a
broken write rather than a slow box — and the failure text now says so instead of reporting a bare
`got: null`.

## The draft that would have reintroduced the defect

My first version was a fixed poll of forty 0.05s ticks with its own deadline, and it was wrong in a way
worth recording because it looks like a fix. Each tick forks a `jq`, so the real wall time is the sleep
budget **plus** the fork cost, which under load can pass the TTL — at which point the redaction has
already run and the row reds for the original reason, just later. That is the tick-budget shape #1495
ruled against, and noticing it is what sent me to `lib.sh` instead of writing a wall-clock deadline.

## The over-engineering pass

Three findings, all applied.

- **A dead initialiser.** `mid_pass="null"` never survived to be read: `wait_while_alive` invokes the
  predicate before its first liveness test, so the variable is always assigned before anything reads
  it, and `${mid_pass:-none}` already covers the unset case in the failure text.
- **The comment restated a rationale that already exists.** The "why not a tick budget" argument lives
  on `wait_while_alive` itself in `lib.sh`. The comment now points there and keeps only what is
  specific to this row — that a lost race here prints the same text as a real TTL defect, and that the
  writer outlives the window.
- **An `if/then/else` departed from the surrounding idiom.** This file, and this very row before the
  change, use `&& ok || bad`. It went back to that form.

**One candidate was examined and deliberately KEPT:** the `[ -n "$mid_pass" ]` conjunct looks redundant
beside `// "null"`, and is not. `jq` on a file that does not exist yet prints nothing at all, so without
that conjunct an empty value would satisfy `!= "null"` and the row would pass for the worst reason
available — the precise failure the fix exists to remove.

## Proven, and not

- **`bash -n` rc 0.** That is the whole local check.
- **Comment width did not regress:** widest comment line is unchanged between the base and this head,
  measured separately on each rather than as a diff, with a control (a file in the same directory that
  reports a different figure) to show the instrument discriminates.
- **No budget impact.** `tests/stack/test-control-backup.sh` has no row in `docs/dev/file-budget.tsv`
  and sits far under the target, so this moves no ceiling.
- **Not run: no suite, no shellcheck, no shfmt, no bench.** The appliance lane holds the box for the RC
  battery and CI is this window's only test gate, so the `Shell tests` job is the execution.
- **What CI green will and will not prove.** It proves the row still passes. It does **not** by itself
  prove the row still discriminates — I could not run a negative control locally. The give-up path is
  not unproven, though: `wait_while_alive`'s own unit rows in `tests/stack/test-harness-tooling.sh`
  already cover a holder that exits without ever satisfying its check, and cover the fixed-budget shape
  giving up on a delayed-but-live holder. What is new here is only the predicate.

Closes #1771 (`Closes` is inert on `develop-v2` — hand-close on merge).
