### PR TITLE
fix(dashboard): #1696 the worker-config store refuses a bind sqlite cannot encode

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,6 +138,18 @@ The stack's defaults:
   row, and the later detection was DROPPED. The same escaping settles the `host-edit` and
   `control.log` identifiers by construction instead of by reading the call sites — those carry no
   `:` and every out-of-band id does, so a rig cannot mint one however it names itself.
+  Nor can either source stop the poll step that detects them (#1696). Both read strings the device
+  picks — its change id, the reason beside it, its own worker name — and a rig's JSON may legally
+  carry a lone surrogate, which sqlite refuses to store. That refusal is a `ValueError` rather than
+  a database error, so it used to travel through the store's fail-closed handlers and end the step:
+  an unauthenticated device on the LAN could halt out-of-band detection with one character. Each
+  rig-chosen string is now checked before it is bound, and each caller answers in its own
+  direction. An unstorable change id reads as one this dashboard never sent, so the rig is flagged
+  rather than excused — the opposite direction from a read error, and deliberately so, since
+  treating it as already-known would have let a rig opt out of being audited. An unstorable reason
+  is dropped while the outcome beside it is still recorded. One case is disclosed rather than
+  fixed: a rig whose worker NAME is unstorable is not drift-checked at all for as long as it keeps
+  that name, because a name the database cannot hold is one no later poll can compare against.
   The `host-edit` and mirrored `control.log` rows are not attacker-controllable and are not capped.
 
 ### Telegram control commands (#338)

--- a/dashboard/mining_dashboard/service/audit_service.py
+++ b/dashboard/mining_dashboard/service/audit_service.py
@@ -82,12 +82,15 @@ def _escape_id_part(part):
     is inside ``_SAFE_CHARS``, so an escaped id survives ``_clean`` verbatim.
 
     ``errors="surrogatepass"`` for the same reason ``clean_event_id``'s digest uses it, and it is
-    load-bearing on one half specifically. A rig's JSON can carry U+D800 and ``json.loads`` hands it
+    load-bearing on BOTH parts now. A rig's JSON can carry U+D800 and ``json.loads`` hands it
     back as a lone surrogate, which ``quote``'s default strict UTF-8 encode REFUSES — a raise inside
-    the poll loop, where the old bare join never encoded anything at all. Measured per position: a
-    surrogate in the WORKER NAME reaches here and is escaped to ``%ED%A0%80``; one in a
-    ``change_id`` never arrives, because ``worker_config_change_known`` passes it to sqlite first
-    and sqlite refuses it. That upstream raise predates this and is #1696, not this function's."""
+    the poll loop, where the old bare join never encoded anything at all. A surrogate in the WORKER
+    NAME reaches here and is escaped to ``%ED%A0%80``. One in a ``change_id`` used to stop short of
+    this function on an upstream raise inside ``worker_config_change_known``, which ended the poll
+    step; #1696 fixed that, and the fix routes the value HERE instead — an id sqlite could never
+    have written reads as a change this dashboard never sent, so the rig is flagged and its
+    change_id is escaped like any other part. This escape now carries the position it was
+    previously only argued to cover."""
     return quote(str(part), safe="", errors="surrogatepass").replace("~", "%7E").replace("-", "%2D")
 
 

--- a/dashboard/mining_dashboard/service/worker_config_store.py
+++ b/dashboard/mining_dashboard/service/worker_config_store.py
@@ -48,6 +48,31 @@ _RECONCILE_TERMINAL = ("applied", "rejected", "rolled_back", "failed", "noop", "
 _SELECT_CHANGE = "SELECT change_id, ts, status, changes, reason, type FROM worker_config"
 
 
+# A rig names its own ``change_id``, ``reason`` and worker ``name`` on the unauthenticated enriched
+# feed, and ``json.loads`` hands a lone surrogate (U+D800) straight back as a ``str``. sqlite3
+# encodes a TEXT parameter as strict UTF-8 and raises ``UnicodeEncodeError`` on one — a
+# ``ValueError``, NOT a ``sqlite3.Error``, so it walks through every fail-closed handler in this
+# file and out through the caller's ``asyncio.to_thread``, aborting the poll step rather than being
+# handled (#1696). Refusing the bind up front lets each method answer its OWN contract, which is
+# the part a uniform fix gets wrong: widening every ``except`` to the same tuple would route this
+# input into ``worker_config_change_known``'s deliberate fail-OPEN and hand a rogue rig a way to
+# opt out of being audited by putting one character in its ``change_id``.
+#
+# The encode is sqlite's own operation rather than a charset test that could disagree with it. The
+# verdict accumulates instead of returning from inside the handler, which keeps this predicate's
+# ``False`` an ANSWER about the input rather than an error path hidden in a success type.
+def _bindable(*values: object) -> bool:
+    """Whether sqlite3 can bind every string in ``values`` as a TEXT parameter (#1696)."""
+    ok = True
+    for value in values:
+        if isinstance(value, str):
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError:
+                ok = False
+    return ok
+
+
 def _shaped(row: sqlite3.Row) -> dict:
     """One ``worker_config`` row as the rest of the app reads it: ``changes`` parsed back to a
     dict (unparseable JSON reads as ``{}`` rather than raising), credentials stripped out of it,
@@ -179,9 +204,19 @@ class WorkerConfigStoreMixin:
         duplicate report for the same ``change_id``. ``status`` is recorded as-is: it becomes the
         row's outcome verbatim, and the frontend's ``STATUS_META`` already renders every member of
         this vocabulary (``workerview.mjs``).
+
+        Both rig-chosen fields go through ``_bindable`` (#1696), in the two directions their own
+        roles ask for. A ``change_id`` sqlite cannot bind could match no row anyway — nothing
+        non-encodable was ever written — so it returns. A ``reason`` it cannot bind is recorded as
+        ``None`` instead of refusing the call: ``reason`` is display prose beside the outcome, and
+        the terminal ``status`` is the thing this exists to catch up. Refusing on the prose would
+        strand the row on ``accepted`` for as long as the rig kept resending it, which is the very
+        state #579 was written to clear.
         """
-        if status not in _RECONCILE_TERMINAL or not change_id:
+        if status not in _RECONCILE_TERMINAL or not change_id or not _bindable(change_id):
             return
+        if not _bindable(reason):
+            reason = None
         try:
             with self._db_lock:
                 if not self._conn:
@@ -252,8 +287,15 @@ class WorkerConfigStoreMixin:
         `EXPLAIN QUERY PLAN`, and `_reconcile_worker_config` calls this once per reporting rig per
         poll. What the two genuinely must share is the ROW SHAPE, and only the reads that return a
         row have that in common; ``_SELECT_CHANGE`` is where they share it.
+
+        A ``change_id`` sqlite cannot bind answers ``False``, and that is the CORRECT answer rather
+        than this method's fail-open direction applied to a new input (#1696).
+        ``add_worker_config_version`` is the only writer to this table and its own bind of the same
+        value would have raised, so a non-encodable id has never been a row here and "never spooled
+        by this dashboard" is the true answer. The rig is then flagged for an out-of-band edit, which is
+        what a terminal report for a change this dashboard never sent IS.
         """
-        if not change_id:
+        if not change_id or not _bindable(change_id):
             return False
         try:
             with self._db_lock:
@@ -294,9 +336,16 @@ class WorkerConfigStoreMixin:
         accuses nobody. A missed detection is a poll's delay — the next poll compares against the
         same stored row, because a failed write leaves it unchanged — whereas a false accusation is
         a permanent audit row naming an operator's rig for something it did not do.
+
+        ``worker`` is the one field here a rig still chooses freely — ``meta`` arrives through
+        ``parse_config_meta``, whose ``_token`` charset a lone surrogate cannot match — so it is the
+        member checked by ``_bindable`` (#1696). A name sqlite cannot bind says nothing, in the same
+        closed direction: a name we cannot store is one we cannot compare against. That cost is
+        disclosed and is NOT the poll's delay above — a rig naming itself with a lone surrogate goes
+        unchecked for drift for as long as it keeps that name.
         """
         revision = (meta or {}).get("revision")
-        if not worker or not revision:
+        if not worker or not revision or not _bindable(worker):
             return None
         last_change_id = meta.get("last_change_id")
         try:

--- a/dashboard/tests/service/test_worker_change_audit.py
+++ b/dashboard/tests/service/test_worker_change_audit.py
@@ -314,12 +314,14 @@ class TestRowIdsSeparateOneDetectionFromAnother:
         """The id is now BUILT in the poll loop rather than only cleaned at the sink, which puts an
         encode where there was none, and nothing upstream rejects a lone surrogate in a worker name.
 
-        The WORKER NAME is the position deliberately: measured per position, a surrogate
-        ``change_id`` never reaches the escape at all — ``worker_config_change_known`` hands it to
-        sqlite first and sqlite refuses it — a separate pre-existing raise on this path, filed as
-        #1696, and not what this test is about. Written against the reachable half, this goes RED without
-        ``errors="surrogatepass"``; written against the other it would have gone red for sqlite's
-        reason and proved nothing about the escape."""
+        The WORKER NAME was the position deliberately: when this was written a surrogate
+        ``change_id`` never reached the escape at all — ``worker_config_change_known`` handed it to
+        sqlite first and sqlite refused it, a separate raise on this path filed as #1696. Written
+        against the reachable half, this goes RED without ``errors="surrogatepass"``; written
+        against the other it would have gone red for sqlite's reason and proved nothing about the
+        escape. #1696 has since landed and a surrogate ``change_id`` DOES now reach the escape, so
+        the reasoning is kept in the past tense rather than deleted: it is what makes the choice of
+        position here a measurement rather than an arbitrary pick."""
         svc, sm = _svc()
         try:
             _rig_edit(svc, "\ud800", "chg1")

--- a/dashboard/tests/service/test_worker_config_surrogates.py
+++ b/dashboard/tests/service/test_worker_config_surrogates.py
@@ -1,0 +1,204 @@
+"""The lone-surrogate binds on the unauthenticated worker feed (#1696).
+
+A new module for the same reason ``test_worker_revision.py`` is one: ``test_storage_worker.py``,
+where these three methods are otherwise tested, sits at its recorded file-budget ceiling (451/451).
+The subject is the same store, so the tests-ROOT ``state_manager`` fixture from
+``dashboard/tests/conftest.py`` serves here unchanged.
+
+The file is named for a defect CLASS rather than a method because that is what it is: one input
+class reaching three separate binds. A rig chooses ``change_id``, its own worker ``name`` and
+``reason`` on the enriched read feed; ``json.loads`` hands a lone surrogate back verbatim; sqlite3
+encodes a TEXT parameter as strict UTF-8 and raises ``UnicodeEncodeError``. That is a ``ValueError``
+and NOT a ``sqlite3.Error``, so it walked through every fail-closed handler in the store and out
+through the caller's ``asyncio.to_thread``, aborting the poll step — an unauthenticated LAN device
+stopping a step of the poll with one character.
+
+Three binds were swept and left alone, each for a reason rather than by omission:
+``revision`` and ``last_change_id`` reach ``note_worker_revision`` only through
+``parse_config_meta``, whose ``_TOKEN_RE`` charset a surrogate cannot match; and the two readers
+``get_worker_config_change`` and ``get_worker_revision_drift`` take a route-supplied worker name
+beside an already-tokenised id. What is NOT swept here is every other table this worker name
+reaches outside this store — that is a wider question than this issue.
+
+Every hostile case below is paired with a control, because "did not raise" is the weakest
+assertion there is: ``TestTheSurrogateIsGenuinelyHostile`` proves the fixture value really does
+break a bind on THIS connection, so a green run here is the guard working rather than a value that
+was never dangerous in the first place.
+"""
+
+import pytest
+
+from mining_dashboard.service import worker_config_store
+
+# A lone high surrogate: legal inside a JSON string, handed back verbatim by ``json.loads``, and
+# refused by every strict UTF-8 encoder — including the one sqlite3 uses on a TEXT parameter.
+SURROGATE = "\ud800"
+
+
+def _meta(revision, last_change_id=None):
+    """The fields ``note_worker_revision`` reads, in the shape ``parse_config_meta`` returns."""
+    return {
+        "revision": revision,
+        "last_change_id": last_change_id,
+        "changed_at": None,
+        "source": None,
+    }
+
+
+class TestTheSurrogateIsGenuinelyHostile:
+    """POSITIVE CONTROL for every class below, and the reason they are worth reading.
+
+    An absence assertion is satisfied by any mechanism at all, including the fixture never having
+    been dangerous. Both halves are asserted: the value still breaks a real bind on this exact
+    connection, and it is TRUTHY — every guarded method here already returns early on a falsy
+    argument, so an empty hostile fixture would turn each test below into a test of that branch.
+    """
+
+    def test_a_bare_bind_of_it_still_raises(self, state_manager):
+        with state_manager._db_lock, pytest.raises(UnicodeEncodeError):
+            state_manager._conn.execute("SELECT ?", (SURROGATE,))
+
+    def test_it_is_not_falsy(self):
+        assert SURROGATE
+
+
+class TestChangeIdBind:
+    """Site 1 — ``worker_config_change_known``, the bind this issue reports."""
+
+    def test_a_surrogate_change_id_does_not_abort_the_poll(self, state_manager):
+        assert state_manager.worker_config_change_known(SURROGATE) is False
+
+    def test_it_answers_false_rather_than_the_fail_open_true(self, state_manager):
+        """The DIRECTION is the load-bearing half here, not the absence of the raise.
+
+        This method fails OPEN on a ``sqlite3.Error`` — ``True`` means "this dashboard spooled that
+        change", which SUPPRESSES the out-of-band rig-edit audit row. Folding the encode failure
+        into that same handler, which is what widening every ``except`` to one tuple would have
+        done, hands a rogue rig an opt-out from being audited for the price of one character.
+
+        ``False`` is also the true answer, and this test grounds that claim rather than
+        asserting it: ``add_worker_config_version`` is the only writer to ``worker_config``, its
+        own bind refuses the same value, and so no non-encodable id has ever been a row here.
+        """
+        state_manager.add_worker_config_version("rig1", SURROGATE, "accepted", {}, None)
+        assert state_manager.get_worker_config_history("rig1") == []
+        assert state_manager.worker_config_change_known(SURROGATE) is False
+
+    def test_the_fail_open_direction_still_holds_for_a_db_error(self, state_manager):
+        # CONTROL on the narrowing: the #530 behaviour this sits beside must be untouched. A DB
+        # hiccup must still not manufacture a false rig-edit report.
+        with state_manager._db_lock:
+            state_manager._conn.execute("DROP TABLE worker_config")
+        assert state_manager.worker_config_change_known("cid-1") is True
+
+    def test_a_clean_change_id_is_unaffected(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid-1", "accepted", {}, None)
+        assert state_manager.worker_config_change_known("cid-1") is True
+
+
+class TestWorkerNameBind:
+    """Site 2 — the rig-chosen worker NAME in ``note_worker_revision``.
+
+    Not the path the issue reports and not reachable through ``parse_worker_control_status`` at
+    all. ``note_revision_drift`` runs BEFORE the caller's terminal-control-status guard, so this
+    bind is reached on every poll of any rig serving a valid ``revision`` — no control block and no
+    terminal outcome needed.
+    """
+
+    def test_a_surrogate_worker_name_does_not_abort_the_poll(self, state_manager):
+        assert state_manager.note_worker_revision(SURROGATE, _meta("aaa")) is None
+
+    def test_it_stays_silent_on_the_move_it_could_not_store(self, state_manager):
+        """The disclosed cost, asserted rather than left to a docstring.
+
+        A name we cannot store is one we cannot compare against, so a rig naming itself with a
+        surrogate is never checked for drift. That is permanent for as long as it keeps the name,
+        and it is NOT the one-poll delay this method's ordinary closed-failure note describes —
+        stating it as such would be the milder claim rather than the true one.
+        """
+        state_manager.note_worker_revision(SURROGATE, _meta("aaa"))
+        assert state_manager.note_worker_revision(SURROGATE, _meta("bbb")) is None
+
+    def test_a_clean_name_still_detects_the_same_move(self, state_manager):
+        # CONTROL: the identical two-poll sequence under an encodable name. Without it the pair
+        # above reads exactly the same against a method that had stopped detecting anything.
+        state_manager.note_worker_revision("rig1", _meta("aaa"))
+        assert state_manager.note_worker_revision("rig1", _meta("bbb")) == {
+            "worker": "rig1",
+            "before": "aaa",
+            "after": "bbb",
+        }
+
+
+class TestReasonBind:
+    """Site 3 — ``reason`` in ``reconcile_worker_config_status``, which neither the issue nor its
+    recon comment names.
+
+    Reachable only once the rig holds a real ``change_id`` of ours, which it comes by honestly: we
+    sent it the change. It can then echo that id back with a terminal status and a lone surrogate
+    in the free-prose ``reason``, and the bind is the same abort as site 1.
+    """
+
+    def _seed(self, state_manager):
+        state_manager.add_worker_config_version("rig1", "cid-1", "accepted", {}, None)
+
+    def _row(self, state_manager):
+        rows = state_manager.get_worker_config_history("rig1")
+        assert len(rows) == 1
+        return rows[0]
+
+    def test_a_surrogate_reason_does_not_abort_the_poll(self, state_manager):
+        self._seed(state_manager)
+        state_manager.reconcile_worker_config_status("cid-1", "applied", SURROGATE)
+        assert self._row(state_manager)["status"] == "applied"
+
+    def test_the_prose_is_dropped_and_the_outcome_is_not(self, state_manager):
+        """The direction this site turns on, and it is not the same one as site 1.
+
+        ``reason`` is display prose beside the outcome; ``status`` is the terminal outcome the
+        reconciler exists to catch up. Refusing the whole call over the prose would strand the row
+        on ``accepted`` for as long as the rig kept resending it — the exact state #579 was written
+        to clear, reintroduced by the fix for a different defect.
+        """
+        self._seed(state_manager)
+        state_manager.reconcile_worker_config_status("cid-1", "applied", SURROGATE)
+        assert self._row(state_manager)["reason"] is None
+
+    def test_a_clean_reason_is_still_recorded_verbatim(self, state_manager):
+        # CONTROL: the drop is specific to the value sqlite refuses, not a reason field that quietly
+        # stopped being written at all.
+        self._seed(state_manager)
+        state_manager.reconcile_worker_config_status("cid-1", "applied", "rig said so")
+        assert self._row(state_manager)["reason"] == "rig said so"
+
+    def test_a_surrogate_change_id_reconciles_nothing_and_does_not_raise(self, state_manager):
+        # The other field on this call, in its own direction: an id nothing could have written
+        # matches no row, so the seeded row stays exactly as it was.
+        self._seed(state_manager)
+        state_manager.reconcile_worker_config_status(SURROGATE, "applied", None)
+        assert self._row(state_manager)["status"] == "accepted"
+
+
+class TestTheBindablePredicate:
+    """``_bindable`` itself — the one place the three sites share, so its own edges are worth
+    holding rather than inferring from the three callers above."""
+
+    def test_a_plain_string_is_bindable(self):
+        assert worker_config_store._bindable("cid-1") is True
+
+    def test_a_lone_surrogate_is_not(self):
+        assert worker_config_store._bindable(SURROGATE) is False
+
+    def test_non_strings_are_left_to_the_bind_itself(self):
+        # ``reason`` is optional and ``change_id`` can arrive as None. The predicate answers about
+        # the strings it is handed and takes no position on any other type.
+        assert worker_config_store._bindable(None, 7, b"bytes") is True
+
+    def test_one_bad_value_among_good_ones_is_still_caught(self):
+        # The verdict accumulates rather than returning from inside the handler, so this is the
+        # shape that would break first: a later clean value must not overwrite an earlier refusal.
+        assert worker_config_store._bindable("cid-1", SURROGATE, "rig1") is False
+        assert worker_config_store._bindable(SURROGATE, "cid-1") is False
+
+    def test_no_argument_at_all_is_bindable(self):
+        assert worker_config_store._bindable() is True

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -11,6 +11,7 @@ dashboard/mining_dashboard/service/data_service.py	1454
 dashboard/mining_dashboard/service/egress.py	424
 dashboard/mining_dashboard/service/storage_service.py	1358
 dashboard/mining_dashboard/service/telegram_commands.py	1023
+dashboard/mining_dashboard/service/worker_config_store.py	448
 dashboard/mining_dashboard/sim/donation_model.py	539
 dashboard/mining_dashboard/web/infra_views.py	507
 dashboard/mining_dashboard/web/server.py	645


### PR DESCRIPTION
Closes #1696 — inert on `develop-v2`, so hand-close with the merge sha.

## The defect

A rig names its own `change_id`, `reason` and worker `name` on the unauthenticated enriched read
feed. `json.loads` hands a lone surrogate (U+D800) back verbatim; sqlite3 encodes a TEXT parameter
as strict UTF-8 and raises `UnicodeEncodeError`. That is a `ValueError` and **not** a
`sqlite3.Error`, so it walked through every fail-closed handler in `worker_config_store` and out
through the caller's `asyncio.to_thread`, ending the poll step — an unauthenticated LAN device
stopping out-of-band change detection with one character.

## Three reachable binds, not the one reported

The issue asked for a sweep rather than a patch of the single call. The sweep found three:

| bind | how a rig reaches it | direction |
|---|---|---|
| `worker_config_change_known(change_id)` | the reported path | **`False`** |
| `note_worker_revision(worker)` | the rig-chosen NAME, through `note_revision_drift`, which runs BEFORE the terminal-control-status guard — so it fires on every poll of any rig serving a valid `revision` | `None`, closed |
| `reconcile_worker_config_status(reason)` | free prose echoed back beside a real change_id of ours | prose dropped, outcome kept |

The `reason` bind is named by neither the issue nor its recon comment. It needs the rig to hold a
real change_id first, which it comes by honestly: we sent it the change.

## Why the direction is per method, not one widened `except`

Adding `UnicodeEncodeError` to every handler is the tidy fix and it introduces a second defect.
`worker_config_change_known` fails **OPEN** by contract — `True` means "this dashboard spooled that
change", which SUPPRESSES the out-of-band rig-edit audit row. Routing this input there would hand a
rogue rig an opt-out from being audited for the price of one character.

It answers `False` instead, and that is the *true* answer rather than a hedge in the other
direction: `add_worker_config_version` is the only writer to `worker_config`, its own bind refuses
the same value, so no non-encodable id has ever been a row there. The rig is flagged, which is what
a terminal report for a change we never sent is.

`reconcile_worker_config_status` drops the unstorable prose and still records the terminal status,
because refusing the whole call would strand the row on `accepted` for as long as the rig kept
resending it — the exact state #579 exists to clear.

## Swept and deliberately NOT changed

- `revision` / `last_change_id` reach the store only through `parse_config_meta`, whose `_TOKEN_RE`
  (`^[A-Za-z0-9._-]+$`) a lone surrogate cannot match. The obvious next-two-sites guess is wrong.
- `get_worker_config_change` and `get_worker_revision_drift` take a route-supplied worker name
  beside an already-tokenised id.
- **Not swept:** every other table the worker name reaches outside this store. Wider than #1696.

## Does answering `False` just move the abort downstream?

No, and this was the check the design turned on. `False` sends the poll into the rig-edit audit
write. That path is already surrogate-safe: `_escape_id_part` uses `errors="surrogatepass"`,
`clean_event_id`'s digest does too, and `_clean` strips the surrogate from `actor`/`keys`. The new
rows are bounded by the existing shared `_RIG_EDIT_CAP_PER_HOUR` (#724), so this adds no unbounded
write capability — a rig rotating distinct surrogate ids spends the same budget as one rotating
distinct ordinary ids.

## Two prose sites went false on this commit

Found by the over-engineering pass, not by any gate; neither goes red, so both would have survived
as false text. `audit_service._escape_id_part`'s docstring and one test docstring in
`test_worker_change_audit.py` each stated that a surrogate `change_id` never reaches the escape
*because of this defect*, each naming #1696 by number. It reaches it now. Both corrected in place,
the test one in past tense because the reasoning is what makes its choice of position a measurement.

## Shared-file disclosures

- `SECURITY.md` (`_shared.paths` CLASS 2, operator ruling): the out-of-band bullet gains the new
  property and the one disclosed limitation.
- `docs/dev/file-budget.tsv` (CLASS 1): **one new row**, `worker_config_store.py 448`. The file was
  399 and crossed the 400 target, so gate rule 1 requires a ceiling. Hand-curated, not regenerated.
  Resolve any conflict by regenerating on your own lane, never by taking a side.

## What was RUN, and what was not

**No local test or lint target was run.** A concurrent long-running job held this machine's shared
build capacity for the whole of this change, so CI was the only test gate available to it.
What I ran locally: `python3 -m py_compile` on all four Python files (rc 0), `wc -l` against every
budget row touched, and the topology detector on this body.

**CI is the first execution of the new tests.** I have not observed them pass. The direction
arguments above are derived at source; the `UnicodeEncodeError` itself is the issue's own
measurement, not mine.

One thing I could not settle locally and flag for the reviewer: `_bindable` accumulates its verdict
rather than returning from inside the `except`, so it creates no failure return through either door
`annotation_gate._failure_returns` watches. That is deliberate — I could not run the annotation
suite to learn whether a `-> bool` returning `False` from a handler would have needed a signed
`_UNJUDGED_AND_READ` entry, and the accumulating shape is correct under either answer. If CI shows
it would not have mattered, the early-return form reads slightly better.

## Tier

Tier 1 (`dashboard/tests/service/test_worker_config_surrogates.py`, 204 lines, no budget row) — the
store is exercised directly against the real fixture, which is where this behaviour is honest.
Every hostile case is paired with a control, and `TestTheSurrogateIsGenuinelyHostile` pins that the
fixture value really does break a bind on that connection, so a green run is the guard working
rather than a value that was never dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcHCQa59LmHJg75K5reeaM
