### PR TITLE
fix(inventory): #1420 the aggregate counters get floors, not a zero test

### DIFF
--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -300,7 +300,8 @@ Every scenario, at every tier, holds to the same rules.
   hashing on the box; all artifacts pass a redactor.
 - Reproducible. The live run records a manifest (stack `VERSION`, git rev, image digests).
 - Test code is real code. The same lint (shellcheck) and coverage gate apply to the tests
-  themselves, and the inventory generator fails CI if it stops enumerating a suite.
+  themselves, and the inventory generator fails CI if a suite stops enumerating or shrinks past
+  its floor.
 - An assertion reads its haystack directly, never through a pipe. `grep -q` exits at its first
   match, so under `pipefail` the writer's broken pipe becomes the pipeline's exit status and the
   match is thrown away: a directive that was present read as missing, and — in the direction

--- a/tests/inventory.sh
+++ b/tests/inventory.sh
@@ -69,15 +69,16 @@ n_mini=$(grep -cE 'log "scenario [0-9]' tests/integration/mini-stack/run-mini-st
 total=$((n_py_dash + n_py_fake + n_node + n_stack + n_selftest + n_scen + n_mini))
 
 # --- drift gate -----------------------------------------------------------
-# The gathering above is grep-based, so a suite that moves, renames, or changes shape
-# enumerates as zero without erroring. Fail loudly instead of emitting an inventory that
-# silently under-counts — CI runs this on every PR (#981).
-# ponytail: zero-count is the only drift detectable since #414 untracked the generated file;
-# per-suite freshness would need the file back under git and its merge conflicts with it.
-for c in n_py_dash n_py_fake n_node n_stack n_selftest n_scen n_axes n_mini; do
-    if [ "${!c:-0}" -eq 0 ]; then # :-0 — grep -c on a deleted file emits nothing, not 0
-        echo "inventory drift: $c counted 0 tests — a suite moved or its shape changed;" \
-            "update the matching pattern in tests/inventory.sh" >&2
+# The gathering above is grep-based, so a suite that moves, renames or changes shape enumerates
+# as zero — or, just as quietly, as a handful — without erroring. CI runs this on every PR (#981).
+# These are FLOORS, not emptiness tests (#1420): a counter falling from hundreds to one passes a
+# zero check, the very defect min_expected fixes further down this same file. Each floor is about
+# half of today's count, so ordinary churn never reaches it; never lower one to pass a real drop.
+for pair in n_py_dash:1200 n_py_fake:12 n_node:250 n_stack:180 n_selftest:80 n_scen:8 n_axes:10 n_mini:6; do
+    c=${pair%%:*} f=${pair##*:} # :-0 — grep -c on a deleted file emits nothing, not 0
+    if [ "${!c:-0}" -lt "$f" ]; then
+        echo "inventory drift: $c counted ${!c:-0}, floor $f — at 0 its pattern stopped matching;" \
+            "above 0 a suite moved or shrank. Fix it, or lower this floor in tests/inventory.sh" >&2
         exit 1
     fi
 done


### PR DESCRIPTION
## What this fixes

The eight aggregate counters in `tests/inventory.sh` were each tested against zero, so any of them could fall from hundreds to one and pass. #1420 filed that as the sharper half of a complaint: the file had **already** fixed the identical defect one guard over — `check_source_agreement`'s `min_expected` is a floor precisely because a fallback condition of "the set is empty" is defeated by a single survivor — and the two sat in one file disagreeing. A reader who checks whether this file thinks about zero-versus-floor found the answer yes, and it was true of only one of them.

Parts 1 and 3 of the issue shipped earlier and cite it in their own comments. This is part 2, the remainder.

The comment claiming `zero-count is the only drift detectable` went with the change — it was the statement of the defect, not a description of the gate. `docs/dev/testing-strategy.md` carried the same claim and is corrected in the same commit.

## The floors, and why these numbers

Each is roughly half of today's measured count: generous, so ordinary churn never reaches one and a firing means a layer collapsed rather than that somebody forgot to bump a number.

| counter | today | floor |
|---|---|---|
| `n_py_dash` | 2180 | 1200 |
| `n_node` | 489 | 250 |
| `n_stack` | 340 | 180 |
| `n_selftest` | 159 | 80 |
| `n_py_fake` | 31 | 12 |
| `n_axes` | 22 | 10 |
| `n_scen` | 15 | 8 |
| `n_mini` | 13 | 6 |

Not a blanket percentage, because the two shapes differ: the large shell counters glob whole directories, so the churn they must tolerate is a *retired file*, while the small ones move a row at a time and a floor set close would red on an ordinary edit.

## Proven by me, in this worktree

- **Counts measured, not estimated** — 2180/31/489/340/159/15/22/13, on a tree whose `tests/inventory.sh` I confirmed byte-identical to `origin/develop-v2` with `cmp` before measuring.
- **Mutation battery, each mutation verified applied before its run.** Every counter at floor-1 reds with a message naming *that* counter and its floor; every counter at exactly its floor passes silently. Both directions, so the instrument has been shown able to give either answer rather than only one.
- **Edge:** an unset counter under `set -u` reds through the `:-0` default instead of crashing — that default is the reason the original comment gave, and the rewrite preserves it.
- **Non-regression:** a counter at 0 still reds. The old gate's only case is inside the new one.
- **Control:** the unmutated tree passes rc 0 with empty stderr.
- **Budget:** the file lands at exactly 400 lines. At or below the 400 target it needs no `file-budget.tsv` row, so this adds no ceiling to a file the split exists to keep small. Verified the rule at source: an over-target file with no row is a hard FAIL in `scripts/lint-file-budget.sh`.
- **Wrap width:** max comment-line length is 100 at base and 100 at head, with zero comment lines over 100 either side.
- `bash -n` rc 0. Docs voice lint rc 0, and I seeded a banned word into a tracked doc to confirm the linter can fail before trusting its clean result.

## Not run by me

No shell suite, no shellcheck, no shfmt, no bench. CI is the only test gate while the appliance lane holds the box. The `for pair in ...` line is 106 characters; five code lines in this file already exceed 100 and the longest is 133, so this is within existing practice, but shfmt and shellcheck are CI's to confirm, not mine.

## Over-engineering pass

Run on my own diff, as the gate requires. Three alternatives considered, none adopted, and I am recording that the pass found nothing to cut rather than implying it found nothing to look at:

1. **A `case` block or an associative array instead of `name:floor` pairs** — the `case` costs nine lines, the array costs two and a bash-4 dependency this file does not otherwise carry. The pair string keeps each floor adjacent to the counter it guards, and under a one-line budget it is the only form that fits.
2. **Inlining `${pair##*:}` instead of binding `f`** — it is used three times, including in the operator-facing message.
3. **Hoisting the floors to constants at the top** — separates each number from the loop that reads it, for no gain.

I did **not** touch `total` on the gather line, which sums seven of the eight counters and omits `n_axes`. I checked before assuming it was a bug: axis values are already reported parenthetically beside the scenario count, so including them would double-count that dimension. Deliberate, left alone.

## Gap I did not close

**There is no permanent test for this gate.** Nothing under `tests/integration/` references `tests/inventory.sh` — I swept for it, and the other `inventory` hits in the tree are the appliance disk inventory, unrelated. My battery is evidence recorded here, not coverage that runs on the next PR. Closing that properly means a new self-test file, which is a larger change than the wind-down ranking supports right now, so I am naming the gap rather than quietly leaving it or widening this diff into it.

## Lane notes

`tests/inventory.sh` is owned outright by this lane, so no `.lane-override` was needed. `docs/dev/testing-strategy.md` is in `_shared.paths` — disclosed here, not overridden.

`Closes` is inert on `develop-v2`, so this does not close #1420. Note the issue carries `do-not-close` ("the merge did NOT meet acceptance; read the newest comment before closing") — whether the gap above clears that bar is the merger's call, not mine, and I would leave it open for the missing self-test.
