### PR TITLE
test(integration): #1796 the file-set control counts spellings, not filenames

### DIFF
--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -898,10 +898,14 @@ pin, and widening first makes the invariant's own match set non-empty against si
 bare. The glob now covers `lib.sh`, `run.sh` and both test-file spellings, which is every suite file
 under `tests/stack`; the one file outside it, `fixtures/rauc-info/capture.sh`, is a capture helper
 the suite does not source and is named in the code rather than left implied. What replaces the pin
-is a file-set control: the invariant asserts that its own list resolves and reaches `run.sh` and
-`test_data_reset.sh` before it reads an absence of matches as evidence, and refuses rather than
-records when it does not, because a glob that quietly stopped matching would report the same clean
-result as a fully converted tree.
+is a file-set control: the invariant asserts that each of its four spellings — `lib.sh`, `run.sh`,
+`test-*.sh` and `test_*.sh` — matches at least one file before it reads an absence of matches as
+evidence, and refuses rather than records when one does not, because a glob that quietly stopped
+matching would report the same clean result as a fully converted tree. Counting matches per spelling
+rather than naming files is what lets the refusal say which spelling failed. The first form asserted
+`test_data_reset.sh` by name, which put one lane's filename inside another lane's assertion and gave
+the same red whether that file had been renamed or the whole spelling had drained away
+([#1796](https://github.com/p2pool-starter-stack/pithead/issues/1796)).
 
 ---
 

--- a/tests/integration/selftest-stack-sandbox.sh
+++ b/tests/integration/selftest-stack-sandbox.sh
@@ -169,25 +169,40 @@ fi
 # Every entry goes through the same existence filter, the two fixed names included. Seeding those
 # in unconditionally would make the check below a tautology — it would read back the list it had
 # just been handed, and a stack directory missing run.sh entirely would still report it as covered.
+#
+# The set is built per SPELLING, not per filename. The deleted pin was not only a pin: it was the
+# only thing proving this row read real files, and with it gone a file set that resolved to nothing
+# would report the same clean absence as a fully converted tree. So the set is measured before the
+# absence below is read as evidence, and this refuses rather than records — a vacuous invariant row
+# is worse than no row, it reads as proof. Counting each spelling's matches is what lets the refusal
+# name the spelling that failed. The first form asserted three filenames instead, which put another
+# lane's test_data_reset.sh inside this lane's assertion and emitted the same red whether that one
+# file had been renamed or the whole test_*.sh spelling had drained away — two failures, one
+# message (#1796).
+#
+# The spellings are quoted in the list deliberately: unquoted, test-*.sh and test_*.sh would glob
+# against the working directory at this line rather than against $STACK_DIR below, and the control
+# would quietly stop meaning what it says.
 COVERED=()
-for f in "$STACK_DIR/lib.sh" "$STACK_DIR/run.sh" "$STACK_DIR"/test-*.sh "$STACK_DIR"/test_*.sh; do
-    [ -f "$f" ] && COVERED+=("$f")
+missing=""
+for spelling in "lib.sh" "run.sh" "test-*.sh" "test_*.sh"; do
+    n=0
+    # shellcheck disable=SC2086  # $spelling is a glob; quoting it would defeat the match
+    for f in "$STACK_DIR"/$spelling; do
+        [ -f "$f" ] || continue
+        COVERED+=("$f")
+        n=$((n + 1))
+    done
+    [ "$n" -gt 0 ] || missing="$missing $spelling"
 done
 
-# The deleted pin was not only a pin: it was the only thing proving this row read real files. With
-# it gone, a file set that resolved to nothing would report the same clean absence as a fully
-# converted tree. So the set is measured before the absence below is read as evidence, and this
-# refuses rather than records — a vacuous invariant row is worse than no row, it reads as proof.
-covered_names=" ${COVERED[*]##*/} "
-missing=""
-for want in lib.sh run.sh test_data_reset.sh; do
-    case "$covered_names" in *" $want "*) ;; *) missing="$missing $want" ;; esac
-done
-if [ "${#COVERED[@]}" -ge 4 ] && [ -z "$missing" ]; then
-    it_pass "the invariant's file set resolves and reaches run.sh and test_*.sh (control arms)"
+# All four spellings matching means COVERED holds at least four entries, so the empty-expansion
+# guard the grep below needs is implied by this refusal rather than asserted separately beside it.
+if [ -z "$missing" ]; then
+    it_pass "the invariant's file set resolves for every spelling (control arms)"
 else
-    it_fail "the invariant's file set resolves and reaches run.sh and test_*.sh" \
-        "the absence below would be vacuous — ${#COVERED[@]} files, missing:${missing:- none}"
+    it_fail "the invariant's file set resolves for every spelling" \
+        "the absence below would be vacuous — ${#COVERED[@]} files, unmatched:$missing"
     echo "selftest-stack-sandbox: $IT_PASS passed, $IT_FAIL failed"
     exit 1
 fi


### PR DESCRIPTION
Closes #1796 — hand-close on merge; `Closes` does not fire on `develop-v2`.

## What changed

`tests/integration/selftest-stack-sandbox.sh`'s file-set control proved its glob had resolved by
asserting three **filenames** were present. One of them, `test_data_reset.sh`, belongs to the tests
lane and was there only as a witness that the `test_*.sh` spelling resolved at all — one lane's
filename inside another lane's assertion.

It fails closed, so this was rot rather than a false green. The defect is that the red
*misdescribes* what happened: rename that one file and the row reports the file set would be
vacuous, when the set resolved fine and a single name moved.

The assertion is now per **spelling** — `lib.sh`, `run.sh`, `test-*.sh`, `test_*.sh` each must match
at least one file — so a refusal names the spelling that failed. Counting in the loop also retires
the `-ge 4` magic floor (with all four spellings required, `COVERED` holds at least four entries by
construction, so the guard against expanding empty into `grep -El` is implied) and the
`covered_names` space-joined string match.

## What was RUN, and what was not

**Not run locally, and this is the important caveat:** no selftest run, no `shellcheck`, no `shfmt`.
The burst window's rule is that CI is the only test gate while the appliance lane holds the box for
the #1651 battery, and it still holds it. **CI is a real gate for this file** — `ci.yml:474` runs every
`tests/integration/selftest*.sh`, and this one exits non-zero on failure by its own accounting
(`[ "$IT_FAIL" -eq 0 ] || exit 1`, plus an explicit `exit 1` on the refusal path above). Worth being
exact, because I had it recorded wrong and checked it rather than quoting my own note: the invocation
is plain `bash "$t"` and the script sets `set -uo pipefail` with **no** `-e`, so the gate is the
script's own exit status, not errexit. The Shell tests job lints `tests/integration/*.sh`. I am
relying on both rather than on a local green.

**Measured by me, last cycle, at the logic level** (posted in full on the issue): both control blocks
extracted verbatim into standalone scripts and run against seven fabricated `STACK_DIR` trees. The
loop shipped here is byte-identical to the one measured, apart from comment spacing; the refusal
condition is the simplification the issue specifies.

| tree | OLD (per-filename) | NEW (per-spelling) |
|---|---|---|
| all four spellings present | PASS, 4 files | PASS, 4 files |
| no `test-*.sh` member | PASS, 4 files | FAIL — unmatched: `test-*.sh` |
| witness renamed, all spellings resolve | FAIL — missing: `test_data_reset.sh` | PASS, 4 files |
| no `test_*.sh` member | FAIL — missing: `test_data_reset.sh` | FAIL — unmatched: `test_*.sh` |
| no `lib.sh` | FAIL — missing: `lib.sh test_data_reset.sh` | FAIL — unmatched: `lib.sh` |
| empty directory | FAIL — 0 files | FAIL — unmatched: all four |
| no `run.sh` | FAIL — missing: `run.sh test_data_reset.sh` | FAIL — unmatched: `run.sh` |

Row 3 is the rot. Row 4 is the sharper version: the old control emits the **same** red whether the
witness was renamed or the entire `test_*.sh` spelling vanished — two different failures, one
message.

## SC2086, the question the issue left open

`$spelling` is a variable holding a glob, expanded unquoted on purpose, so SC2086 is the correct
code — the previous form globbed with a *literal*, which triggers nothing. Settled by precedent
rather than by running the linter: `tests/integration/run.sh:474` and
`tests/integration/selftest-e2e-phases.sh:136` both carry `# shellcheck disable=SC2086` in this
position, and both are linted by the same `--severity=warning` invocation as this file
(`Makefile:93-96`). I have **not** confirmed against the pinned 0.11.0 binary; if CI disagrees, that
is the finding.

## Caveat the replacement buys

Per-spelling trades a coupling to one filename for a coupling to each spelling class being
non-empty. Measured against `develop-v2`: `tests/stack` holds 60 `test-*.sh` and 5 `test_*.sh`, so
neither class is near empty, and draining one would be a deliberate and visible act whose red then
names it. Stated, not a reason to redesign.

## Shared-file disclosure

`docs/dev/integration-testing.md` described this control by the filename that is no longer asserted,
so its closing sentence is corrected here. `docs/` is in `_shared.paths` and needs no
`.lane-override`; flagging it because the file is shared. No other file references the retired
mechanism — swept for `covered_names` and `-ge 4`, both now zero repo-wide.

## The over-engineering pass

Run on my own diff, as the PR gate requires. It found no scaffolding to remove — the block is twelve
lines and the counter is the simplest form that lets a refusal name a spelling. It did surface one
thing worth stating rather than changing: the quotes around `"test-*.sh"` and `"test_*.sh"` in the
`for` list are load-bearing. Unquoted, they would glob against the working directory at that line
instead of against `$STACK_DIR`, so a tidy-up removing them would change what the control means
without changing what it looks like. That is now a comment in the file.

## Review

I am the author and the owner of `tests/integration/`, so this needs a **recorded non-author PASS**
at the current head plus green CI, and someone other than me to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01591uDrSa5f1w39aDUaTBhc
