### PR TITLE
test(stack): #1777 the #1213 verb-leak sweep catches the imperative, not only the executable

### DIFF
--- a/lib/pithead/20-doctor-install-checks.sh
+++ b/lib/pithead/20-doctor-install-checks.sh
@@ -82,7 +82,7 @@ check_control_units() {
     if [[ "$_name" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -L "$_parent/current" ]; then
         _live=$(cd "$_parent/current" 2>/dev/null && pwd -P)
         if [ -n "$_live" ] && [ "$_live" != "$here" ]; then
-            dr_info "This is not the live install — '$_parent/current' points at $_live. Run doctor there to check its control channel."
+            dr_info "This is not the live install — '$_parent/current' points at $_live. Run doctor there to check its control channel." # appliance-unreachable: the DIY versioned layout only -- the guard above needs basename pithead-vX.Y.Z AND a sibling `current` symlink, and the appliance's /opt/pithead install creates neither
             return 0
         fi
     fi

--- a/pithead
+++ b/pithead
@@ -4928,7 +4928,7 @@ check_control_units() {
     if [[ "$_name" =~ ^pithead-v[0-9]+\.[0-9]+\.[0-9]+$ ]] && [ -L "$_parent/current" ]; then
         _live=$(cd "$_parent/current" 2>/dev/null && pwd -P)
         if [ -n "$_live" ] && [ "$_live" != "$here" ]; then
-            dr_info "This is not the live install — '$_parent/current' points at $_live. Run doctor there to check its control channel."
+            dr_info "This is not the live install — '$_parent/current' points at $_live. Run doctor there to check its control channel." # appliance-unreachable: the DIY versioned layout only -- the guard above needs basename pithead-vX.Y.Z AND a sibling `current` symlink, and the appliance's /opt/pithead install creates neither
             return 0
         fi
     fi

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -288,8 +288,8 @@ echo "== unit: doctor's remedial strings are surface-aware (#1213) =="
 # Doctor's verdicts reach the dashboard verbatim now that the diagnostics verbs ship them
 # (control_diag_doctor runs `doctor --json`; doctor_json emits every message as {status, message}),
 # so a remedial string naming a CLI verb is a dead end on an appliance, which has no shell. Two
-# instruments, because either one alone passes for the wrong reason: the switch has to actually
-# FLIP, and no verdict may be left behind it.
+# instruments, because either alone passes for the wrong reason: the switch has to actually FLIP,
+# and no verdict may be left behind it.
 #
 # 1. The mechanism. Argument one is the DIY/host wording, argument two the appliance's; each side
 #    must print its own and NOT the other's -- asserting only that the right text appears would
@@ -309,23 +309,20 @@ for _s in fail warn info; do
     esac
 done
 
-# 2. The #1776 site, named because the sweep below could not see it. Its verdict prescribed two
-#    host-only remedies ("Move the data here" and the verb as the bare quoted word 'apply'), and
-#    the literal alternation carries `\./pithead ` but no token for that quoting -- so the sweep
-#    returned 0 matches over a site it fully covers, and #1213 closed with this string still plain.
-#    Read off the SHIPPED artifact, the same instrument the sweep uses, so a lib/ edit that never
-#    reaches `pithead` cannot pass this.
+# 2. The #1776 site, named because the sweep below could not see it: its verdict prescribed two
+#    host-only remedies ("Move the data here" and the verb as the bare quoted word 'apply'), which
+#    the sweep's alternation had no token for until #1777 widened it. Read off the SHIPPED
+#    artifact, the same instrument the sweep uses, so a lib/ edit that never reaches it cannot pass.
 #
-#    AND THIS BLOCK IS NOW THE SITE'S ONLY VERB GUARD. Converting it to dr_warn_surface takes it
+#    AND THIS BLOCK IS NOW THE SITE'S ONLY VERB GUARD. Converting it to dr_warn_surface took it
 #    OUT of block 3's sweep by construction -- that sweep's site pattern is `dr_warn "`, which a
-#    `dr_warn_surface "` call does not match, and the exclusion is deliberate because a host
-#    argument is SUPPOSED to keep its verb. So the single literal in _dd_pred_verb is all that
-#    stands behind the appliance side of this one verdict. Widen it here, not there.
+#    `dr_warn_surface "` call does not match, deliberately, because a host argument is SUPPOSED to
+#    keep its verb. The single literal in _dd_pred_verb is all that stands behind the appliance
+#    side of this verdict. Widen it here, not there.
 #
-#    THE CONTROL IS NOT OPTIONAL. Both assertions below are ABSENCE claims over a grep, and an
-#    absence claim goes green when the needle simply stops matching -- rename the message and this
-#    passes forever while proving nothing. So the same two predicates run against a synthetic
-#    PRE-FIX line first and must FAIL there.
+#    THE CONTROL IS NOT OPTIONAL. Both assertions below are ABSENCE claims over a grep, and one
+#    goes green when the needle merely stops matching -- rename the message and this passes forever
+#    proving nothing. So the same two predicates run against a synthetic PRE-FIX line and must fire.
 _dd_pred_plain() { case "$1" in *dr_warn_surface*) return 1 ;; *) return 0 ;; esac }
 _dd_pred_verb() { case "$1" in *"run 'apply'"*) return 0 ;; *) return 1 ;; esac }
 _dd_seed="            dr_warn \"Data dir from .env not found: X=Y — a relocated/copied install re-syncs from scratch. Move the data here, or set the data_dir in config.json and run 'apply'.\""
@@ -348,9 +345,9 @@ else
     # The host side KEEPS the verb by design (it is the DIY wording); only the appliance side must
     # not. Take the second quoted argument, the way the helper's own contract orders them.
     _dd_appl=$(printf '%s' "$_dd_line" | awk -F'"' '{print $4}')
-    # ...and prove the field EXISTS before reading an absence out of it. On the pre-fix shape --
-    # one quoted argument -- $4 is the empty string, _dd_pred_verb "" returns rc 1, and the row
-    # below would print ok having examined nothing. Only its sibling reds that case today.
+    # ...and prove the field EXISTS before reading an absence out of it: on the pre-fix shape (one
+    # quoted argument) $4 is empty, _dd_pred_verb "" returns rc 1, and the row below would print ok
+    # having examined nothing. Only its sibling reds that case today.
     if [ -z "$_dd_appl" ]; then
         bad "the data-dir verdict's appliance wording names no host verb (#1776)" "no second quoted argument on: $_dd_line"
     elif _dd_pred_verb "$_dd_appl"; then
@@ -360,10 +357,9 @@ else
     fi
 
     # The appliance wording NAMES which of these dirs the dashboard can repoint, so it is a claim
-    # about CONTROL_DASHBOARD_CONFIRM_KEYS -- and the first draft of it ("no dashboard control
-    # relocates a data directory") was false for four of the five keys the check fires on. Derive
-    # both sets from the shipped artifact rather than restating them, so an allowlist change reds
-    # HERE and names the string to rewrite, instead of leaving an operator a remedy they lack.
+    # about CONTROL_DASHBOARD_CONFIRM_KEYS -- and its first draft ("no dashboard control relocates a
+    # data directory") was false for four of the five keys the check fires on. Derive both sets from
+    # the shipped artifact, so an allowlist change reds HERE and names the string to rewrite.
     _dd_in_set() { case " $2 " in *" $1 "*) return 0 ;; *) return 1 ;; esac }
     _dd_repointable() {
         local _k _out=''
@@ -376,8 +372,8 @@ else
     # strictly REDUNDANT, its pass condition being exactly what the CANNOT row asserts, so it could
     # never red alone. This closes what those rows cannot see -- a second `for var in ..._DATA_DIR;
     # do` above missing_data_dirs would feed them, through head -1, a set the shipped code no longer
-    # uses, every row still green. The awk keeps a narrower gap: a trailing comment after its
-    # closing quote makes it over-read. Wrong input, no wrong output today, so NAMED not guarded.
+    # uses, every row green. The awk gap is narrower: a trailing comment after its closing quote
+    # makes it over-read. Wrong input, no wrong output today, so NAMED not guarded.
     assert_eq "the data-dir key list comes from exactly one site (#1776)" "$(printf '%s\n' "$_dd_sites" | grep -c .)" "1"
     _dd_conf=$(awk "/^CONTROL_DASHBOARD_CONFIRM_KEYS='/{f=1} f{print} f && /'[[:space:]]*\$/{exit}" "$STACK" |
         tr -d "\n'" | sed "s/^CONTROL_DASHBOARD_CONFIRM_KEYS=//;s/  */ /g;s/^ //")
@@ -400,29 +396,33 @@ else
 fi
 
 # 3. Totality over the SHIPPED artifact. The SITES are enumerated mechanically out of the built
-#    `pithead` rather than from a list kept by hand -- a hand list is blind to the site nobody
-#    remembered, and this sweep found nine of those. A PLAIN dr_fail/dr_warn/dr_info literal is one
-#    with no appliance side at all, so if it names a CLI verb an appliance operator is told to run
-#    it. `dr_*_surface` calls do not match the pattern: their host argument is supposed to keep the
-#    verb. The one exemption carries its reason in the source line itself.
+#    `pithead`, not a hand list -- a hand list is blind to the site nobody remembered, and this
+#    sweep found nine of those. A PLAIN dr_fail/dr_warn/dr_info literal has no appliance side, so
+#    naming a CLI verb there tells an appliance operator to run it; `dr_*_surface` calls do not
+#    match, their host argument keeping its verb by design. An exemption states its reason inline.
 #
-#    KNOW WHAT THIS DOES NOT COVER. The site enumeration is mechanical; the NEEDLE list below is
-#    not. It catches the verb forms doctor uses today, so a verdict phrased with a token nobody
-#    listed -- a `systemctl` this file never learned, a new console noun -- passes it clean. A green
-#    result here means "none of the KNOWN verb forms leaked", never "no verb leaked". Extend the
-#    alternation when doctor learns a new way to tell someone to do something.
+#    #1777 WIDENED THE ALTERNATION TO THE IMPERATIVE, not just the executable form: it carried
+#    `\./pithead ` but no token for a verb written as a bare or quoted word, so it returned 0 over
+#    #1776's site, which it fully covers. Over the artifact the widened branch adds exactly one
+#    site -- the "Run doctor there" info below -- and that one takes the marker, not a conversion.
 #
-#    AND IT IS LITERAL-ONLY, which is the blind spot extending the alternation does NOT close. The
-#    site pattern needs a quoted message on the same line, so a verdict whose text arrives in a
-#    VARIABLE can never be reached by any needle: 05-doctor-checks.sh:111 (dr_warn "$(head -n 1
-#    ...)", appliance-only by construction, text from the hugepages helper) and
-#    21-doctor-stack-checks.sh:261 (dr_fail "${verdict#fail:}"). Both are unguarded here and cannot
-#    be guarded here — read them by hand. A THIRD, 20-doctor-install-checks.sh:28, LEFT this list
-#    rather than being fixed here: #1772 made it dr_warn_surface, which the site pattern does not
-#    match, so its guard is behavioural now and lives in test-doctor-exposure.sh.
-dr_verb_leaks=$(grep -nE '(dr_fail|dr_warn|dr_info) "' "$STACK" |
-    grep -E "\./pithead |docker compose |docker pull |docker-compose-v2|Start the Docker daemon|sudo |systemctl|git pull" |
-    grep -v "appliance-unreachable" || true)
+#    WHICH LEAVES THE CONTROL AS THE ONLY THING VALIDATING THE WIDENING: with that marker in place
+#    the new branch has NO live target, so its 0 is what a needle matching nothing also prints. The
+#    seed is the pre-marker text, run through _dr_leaks -- the helper the sweep itself calls, never
+#    a second spelling of it, which would be mutated in lockstep with nothing.
+#
+#    STILL NOT COVERED: the needle list is hand-kept, so a verdict using a token nobody listed
+#    passes clean -- green means "none of the KNOWN forms leaked", never "no verb leaked". And it
+#    is LITERAL-ONLY: a message arriving in a VARIABLE is beyond any needle -- read
+#    05-doctor-checks.sh:111 and 21-doctor-stack-checks.sh:261 by hand. A THIRD site left this list
+#    when #1772 made the stratum-exposure warn a dr_warn_surface; it is test-doctor-exposure.sh's.
+_dr_leaks() { grep -nE '(dr_fail|dr_warn|dr_info) "' | grep -E "\./pithead |docker compose |docker pull |docker-compose-v2|Start the Docker daemon|sudo |systemctl|git pull|([Rr]e-?)?[Rr]un '?(\./pithead )?(apply|setup|up|down|restart|doctor|status|logs)'?" | grep -v "appliance-unreachable" || true; }
+if [ -z "$(printf '%s\n' '    dr_info "This is not the live install -- X/current points at Y. Run doctor there to check its control channel."' | _dr_leaks)" ]; then
+    bad "control: the sweep catches an imperative naming a bare pithead verb (#1777)" "the widened alternation cannot fire; the 0 below is not evidence"
+else
+    ok "control: the sweep catches an imperative naming a bare pithead verb (#1777)"
+fi
+dr_verb_leaks=$(_dr_leaks <"$STACK")
 assert_eq "no plain doctor verdict still names a CLI verb (#1213)" \
     "$(printf '%s' "$dr_verb_leaks" | grep -c . || true)" "0"
 [ -n "$dr_verb_leaks" ] && printf '    leaked: %s\n' "$dr_verb_leaks" | head -12 || true


### PR DESCRIPTION
Closes #1777 (inert on `develop-v2` — hand-closed on merge).

The #1213 verb-leak sweep in `tests/stack/run.sh` enumerates its SITES mechanically out of the
built `pithead`, but matches them against a hand-written alternation. That alternation carried
`\./pithead ` and had no token for a verb written as a bare or quoted word, so it returned 0
matches over #1776's site — a plain `dr_warn` literal it fully covers — and #1213 closed with
that string still naming a host remedy.

## What changed

1. **The alternation now catches the imperative, not only the executable.** New branch:
   `([Rr]e-?)?[Rr]un '?(\./pithead )?(apply|setup|up|down|restart|doctor|status|logs)'?`.
2. **`lib/pithead/20-doctor-install-checks.sh`'s "Run doctor there" info takes the
   `appliance-unreachable` marker**, with its reason on the same line, the way
   `05-doctor-checks.sh:142` already does. That verdict is gated on the DIY versioned layout —
   basename `pithead-vX.Y.Z` AND a sibling `current` symlink — and the appliance's `/opt/pithead`
   install creates neither, so it is unreachable there by construction rather than a conversion
   candidate.
3. **The sweep's site pattern, needle and exemption filter are now ONE helper, `_dr_leaks`,** which
   both the law and the control call. A control that re-spells the grep is mutated in lockstep with
   nothing; this one cannot drift from what it validates.
4. **A seeded control**, because after item 2 the widened branch has NO live target: its 0 is
   indistinguishable from a needle that matches nothing at all.

## Why the control is not optional here

RUN BY ME, four legs, one variable moved between the first two:

| leg | input | needle | result |
|---|---|---|---|
| 1 | seeded pre-marker text | widened | **fires** (1 hit) |
| 2 | seeded pre-marker text | pre-#1777 | **empty** |
| 3 | shipped `pithead` | widened | empty — the sweep's green |
| 4 | shipped `pithead`, my marker stripped | widened | **fires**, naming the real site |

Leg 2 is the differential: the same seed against the same instrument with only the alternation
moved, which is what rules out "the seed fires for some other reason". Leg 4 shows leg 3's green is
caused by the marker rather than by a dead needle. Leg 1 alone would have proved neither.

Also re-derived: the pre-#1777 needle's ONLY hit over the artifact is `05-doctor-checks.sh:142`,
which already carries the marker — so the sweep was green before and is green after, and the
difference is entirely in what it is now able to see.

## Line budget

`tests/stack/run.sh` was 440 against a 440 ceiling with zero headroom, and ceilings only go down.
The new helper, control and comments were paid for by compressing seven comment blocks this lane
wrote for #1776/#1772 — per-edit deltas -2, -1, -1 and four at 0, then +4 for the block-3 rewrite.
**Final: 440 lines, exactly the ceiling; `docs/dev/file-budget.tsv` is UNTOUCHED.**
`lib/pithead/20-doctor-install-checks.sh` is line-neutral (a trailing comment) and has no budget row.

## Folded in

The re-pass nit deferred into this item: block 3's comment named
`20-doctor-install-checks.sh:28` as a bare historical locator, which at the current head is neither
the call nor the right line. It now names the site by what it IS — the stratum-exposure warn that
#1772 converted to `dr_warn_surface` — so a reader cannot mistake a gravestone for a live pointer.

## Scope

The doctor-surface class is closed at #1772 and #1776; this makes the instrument able to say so.
#1769 is a different surface (the raw apply log) and is not touched here.

## RUN BY ME at this head

- `bash tests/stack/run.sh` — **rc 0, `pithead tests: 3346 passed, 0 failed`**, zero `✗` marks in the
  whole log. The new control row is at log line 3699, immediately above the sweep row it validates
  (3700), so the control is proven to have EXECUTED and not merely to exist in the file.
- `make lint-sh` — **rc 0**, run under `flock ~/.lint-sh-manual.lock`, never the shellcheck-serialize
  lock. Pins read from the Makefile itself: shfmt **v3.13.1**, shellcheck **0.11.0**, so this is that
  gate's result and not some other tool's.
- `make lint-file-budget`, `lint-pithead-parity`, `lint-topology`, `lint-docs-voice`, `lint-md` — all rc 0
- the four control legs above
- `~/dev/fleet/lane-guard.sh` — rc 0 on this change staged alone, with a FIRED negative control: a
  one-byte edit to `lib/pithead/14-local-miner.sh`, a sibling in the same directory, returns rc 1
  "Another role owns this code". A near-miss sibling rather than a distant file, so the rc 0 means
  "granted", not "the guard waves everything through". Probe file restored; worktree clean.
- `python3 ~/code/pithead-topography/detect-topology.py` over this body — clean. Its control was this
  same text plus a seeded rig hostname, which returned an ADVISORY; the seeded IP and `user@host` did
  not fire, so the control shows the detector reading THIS draft and reaching a non-clean verdict, and
  does not establish coverage of every class.

## NOT run by me / ASSUMED

- I did NOT re-run the suite at `origin/develop-v2` to produce a before/after row count, so I make no
  delta claim: 3346 is this head's figure, and the 3336 in pull 1813's record was a different tree.
- No bench, no KVM, no image build. No dashboard or integration tier — this change is tier 1 only.
- No doc update is owed and none is shipped: I grepped `docs/` for the sweep, the marker and #1213
  and no prose doc describes this instrument or carries a count my change moves. Saying so rather
  than shipping a doc edit to satisfy the bar.

## Over-engineering pass (run by me, no command exists for it)

Four things I checked for being more machinery than the problem needs, and one cost I am
accepting rather than hiding:

- **`_dr_leaks` earns its line.** It replaces a 3-line pipeline with 1, so it is a net
  simplification even before the control needs it — and the control is the reason it must exist,
  since a control that re-spells the grep is mutated in lockstep with nothing.
- **The marker, not a `dr_info_surface` conversion.** Converting would add an appliance wording for
  a verdict no appliance operator can reach, which is a second string to keep true for no reader.
- **The verb list stays the full pithead set**, not narrowed to the two verbs that hit today.
  Narrowing to the known hit is what the issue names as the thing to avoid.
- **The comment block shrank.** Block 3's prose is 21 lines against a 10-line instrument, which is
  the one place a reviewer could reasonably push back; it is carrying the blind-spot disclosure,
  and I paid for the new material by cutting elsewhere rather than adding.

**The cost I am accepting, named because a reviewer should get to veto it:** `down`, `up`, `status`
and `logs` are ordinary English words, so a future verdict phrased "…will run down its buffer"
would match and red this row falsely. I kept them because the alternative is fitting the needle to
today's two hits. The failure is in the safe direction — the sweep prints the offending line, and
the fix is a marker or a reword, not a silent miss — but it is a real maintenance cost and it is
mine to have chosen.

## Returned once, and what the red actually was

CI reddened `Lint per-surface` at `7b233398` on `lint-operator-strings`. **My defect**, and a gap I
own: I ran the lint targets individually and did not run `make lint`, so I never ran that one.

The marker I added carried `(#1777)`, and it sits in a trailing comment on the same line as the
`dr_info` call. `scripts/lint-operator-strings.sh` selects lines by call shape and then greps the
**whole line** for `#[0-9]+`, so an issue number in a comment is indistinguishable from one in
operator text — even though the linter's own failure message says "comments keep them".

**Fix: drop `(#1777)` from the marker, leave the marker where it is.** That matches the only
existing precedent, `lib/pithead/05-doctor-checks.sh:142`, whose marker carries a reason and no
issue reference, which is why it has never tripped this.

**The fix that looks right and is not:** moving the comment to its own line, which is what the
linter's message invites. `_dr_leaks` ends in a line-based `grep -v "appliance-unreachable"`, so the
marker suppresses a site only while it shares the call's line. Moving it trades a lint red for a
**sweep** red — and that one reads like a real leak. Caught by the reviewer, who reasoned it from
the line-based `grep -v`; **I then MEASURED it rather than leaving it as agreed reasoning**, because
two passes converging is two opinions and neither of us had run it. Moved the marker onto its own
line in a scratch copy of the artifact and ran the sweep: **1 hit, naming the real site**, against
**0** over the real artifact with the marker in place. One variable moved, paired control, so the
claim is now a measurement.

Reproduced both ways locally: `make lint-operator-strings` names exactly that one line before the
change and passes after. All four control legs re-run on the rebuilt artifact and are unchanged.

**Not fixed here, and not filed:** the linter cannot distinguish a trailing comment from operator
text. `scripts/lint-operator-strings.sh` is in no lane's `.paths` I hold, the milestone that could
carry a tooling fix is frozen, and an issue with no active milestone is in no queue whatever its
label says — so filing it would make it invisible rather than tracked. Recorded here, where the next
person to add a marker will hit it.
