### PR TITLE
fix(os): #1817 a rig's journal reclaim tolerates the persistent bind, and the bind stands down on a rig

### DIFF
--- a/lib/pithead/14-local-miner.sh
+++ b/lib/pithead/14-local-miner.sh
@@ -326,8 +326,22 @@ rig_minimize_writes() {
     # overrides a drop-in.
     printf '[Journal]\nStorage=volatile\nRuntimeMaxUse=32M\n' >"$dropin/zz-rig-volatile.conf" 2>/dev/null || return 0
     [ -d "$journal" ] || return 0
-    rm -rf "${journal:?}"
+    # Restart FIRST: journald holds the persistent files under $journal open, and a bind there
+    # cannot come off while it does (umount: target is busy). Volatile, it writes under /run and
+    # holds nothing here. (Before #1817 the restart came after the reclaim, which worked only
+    # because unlinking an open file is allowed — taking a mount off is not.)
     systemctl restart systemd-journald >/dev/null 2>&1 || true
+    # #1817: a first boot binds the persistent journal home onto this path before the role is
+    # known (pithead-journal-persist), so the reclaim meets a MOUNTPOINT. `rm -rf` on one empties
+    # it — through the bind, onto /data — and then fails on the mountpoint itself. Take the bind
+    # off first, so what is reclaimed is the overlay's own directory and nothing on /data is
+    # touched. Every step is best-effort: this is a stick-wear optimisation, nothing downstream
+    # reads its result, and the one caller that matters runs under errexit (pithead-boot's
+    # `local-miner`) — a cleanup that cannot complete must never leave a slot uncommitted.
+    if mountpoint -q "$journal" 2>/dev/null; then
+        umount "$journal" 2>/dev/null || true
+    fi
+    rm -rf "${journal:?}" || warn "The journal directory could not be reclaimed; journald is volatile for this boot anyway."
     log "Rig write minimization: the journal is in memory for this boot — the root may be the stick the miner runs from."
 }
 
@@ -336,7 +350,11 @@ provision_rig_miner() {
         warn "This machine is marked as a rig, but its settings are missing — install it again from the stick to choose a role."
         return 1
     fi
-    rig_minimize_writes
+    # `|| true` on purpose (#1817): the minimization is best-effort by construction, and this
+    # function is called BARE from the boot path (pithead-boot -> `pithead local-miner`, errexit
+    # armed) but under `|| true` from the wizard — a failure inside it passed first boot and
+    # killed every boot after, which is the one signature a full gate is needed to see.
+    rig_minimize_writes || true
     render_rig_miner_config || return 1
     if rigforge_setup_run; then
         log "The rig is mining: $(jq -r '.worker // "this machine"' "$PWD/rig.json" 2>/dev/null) -> $(jq -r '.pool // "no pool recorded"' "$PWD/rig.json" 2>/dev/null)."

--- a/lib/pithead/14-local-miner.sh
+++ b/lib/pithead/14-local-miner.sh
@@ -340,6 +340,12 @@ rig_minimize_writes() {
     # `local-miner`) — a cleanup that cannot complete must never leave a slot uncommitted.
     if mountpoint -q "$journal" 2>/dev/null; then
         umount "$journal" 2>/dev/null || true
+        # A bind that did not come off is left alone: `rm -rf` through it would empty the
+        # persistent home on /data, the one thing this block promises not to do.
+        if mountpoint -q "$journal" 2>/dev/null; then
+            warn "The journal bind is still up, so nothing is reclaimed; journald is volatile for this boot anyway."
+            return 0
+        fi
     fi
     rm -rf "${journal:?}" || warn "The journal directory could not be reclaimed; journald is volatile for this boot anyway."
     log "Rig write minimization: the journal is in memory for this boot — the root may be the stick the miner runs from."

--- a/os/overlay/pithead-journal-persist
+++ b/os/overlay/pithead-journal-persist
@@ -18,6 +18,20 @@ set -eu
 
 DATA_DIR="${PITHEAD_JOURNAL_DATA_DIR:-/data/pithead/journal}"
 TARGET="${PITHEAD_JOURNAL_TARGET:-/var/log/journal}"
+ROLE_FILE="${PITHEAD_MACHINE_ROLE_FILE:-/data/pithead/machine-role}"
+
+# A rig has nothing to persist (#1817): its journal is volatile BY DESIGN — the root may be
+# the stick it mines from — and `pithead local-miner` reclaims /var/log/journal on every boot
+# on its way to flipping journald volatile. With the persistent home bound onto that path the
+# reclaim met a mountpoint, `rm -rf` failed on it, and pithead's errexit turned the failure into
+# a boot verb that exited non-zero: the rig booted mining and never committed its slot. Same
+# marker as pithead-boot's role fork, read the same way; RequiresMountsFor=/data means it is
+# readable by now. A machine with no marker yet (first boot) still binds — the wizard's rig leg
+# takes that bind off itself before reclaiming (rig_minimize_writes).
+if [ -f "$ROLE_FILE" ] && [ "$(tr -d '[:space:]' <"$ROLE_FILE")" = "rig" ]; then
+    echo "pithead-journal-persist: this machine is a rig — its journal is volatile, nothing to bind"
+    exit 0
+fi
 
 mkdir -p "$DATA_DIR"
 # Same owner+mode systemd-tmpfiles gives /var/log/journal itself (root:systemd-journal, setgid

--- a/pithead
+++ b/pithead
@@ -3581,6 +3581,12 @@ rig_minimize_writes() {
     # `local-miner`) — a cleanup that cannot complete must never leave a slot uncommitted.
     if mountpoint -q "$journal" 2>/dev/null; then
         umount "$journal" 2>/dev/null || true
+        # A bind that did not come off is left alone: `rm -rf` through it would empty the
+        # persistent home on /data, the one thing this block promises not to do.
+        if mountpoint -q "$journal" 2>/dev/null; then
+            warn "The journal bind is still up, so nothing is reclaimed; journald is volatile for this boot anyway."
+            return 0
+        fi
     fi
     rm -rf "${journal:?}" || warn "The journal directory could not be reclaimed; journald is volatile for this boot anyway."
     log "Rig write minimization: the journal is in memory for this boot — the root may be the stick the miner runs from."

--- a/pithead
+++ b/pithead
@@ -3567,8 +3567,22 @@ rig_minimize_writes() {
     # overrides a drop-in.
     printf '[Journal]\nStorage=volatile\nRuntimeMaxUse=32M\n' >"$dropin/zz-rig-volatile.conf" 2>/dev/null || return 0
     [ -d "$journal" ] || return 0
-    rm -rf "${journal:?}"
+    # Restart FIRST: journald holds the persistent files under $journal open, and a bind there
+    # cannot come off while it does (umount: target is busy). Volatile, it writes under /run and
+    # holds nothing here. (Before #1817 the restart came after the reclaim, which worked only
+    # because unlinking an open file is allowed — taking a mount off is not.)
     systemctl restart systemd-journald >/dev/null 2>&1 || true
+    # #1817: a first boot binds the persistent journal home onto this path before the role is
+    # known (pithead-journal-persist), so the reclaim meets a MOUNTPOINT. `rm -rf` on one empties
+    # it — through the bind, onto /data — and then fails on the mountpoint itself. Take the bind
+    # off first, so what is reclaimed is the overlay's own directory and nothing on /data is
+    # touched. Every step is best-effort: this is a stick-wear optimisation, nothing downstream
+    # reads its result, and the one caller that matters runs under errexit (pithead-boot's
+    # `local-miner`) — a cleanup that cannot complete must never leave a slot uncommitted.
+    if mountpoint -q "$journal" 2>/dev/null; then
+        umount "$journal" 2>/dev/null || true
+    fi
+    rm -rf "${journal:?}" || warn "The journal directory could not be reclaimed; journald is volatile for this boot anyway."
     log "Rig write minimization: the journal is in memory for this boot — the root may be the stick the miner runs from."
 }
 
@@ -3577,7 +3591,11 @@ provision_rig_miner() {
         warn "This machine is marked as a rig, but its settings are missing — install it again from the stick to choose a role."
         return 1
     fi
-    rig_minimize_writes
+    # `|| true` on purpose (#1817): the minimization is best-effort by construction, and this
+    # function is called BARE from the boot path (pithead-boot -> `pithead local-miner`, errexit
+    # armed) but under `|| true` from the wizard — a failure inside it passed first boot and
+    # killed every boot after, which is the one signature a full gate is needed to see.
+    rig_minimize_writes || true
     render_rig_miner_config || return 1
     if rigforge_setup_run; then
         log "The rig is mining: $(jq -r '.worker // "this machine"' "$PWD/rig.json" 2>/dev/null) -> $(jq -r '.pool // "no pool recorded"' "$PWD/rig.json" 2>/dev/null)."

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -172,6 +172,66 @@ assert_rc "re-run (the leg fires every boot) -> rc 0" "$?" "0"
 assert_eq "the config is re-derived, not repaired" "$(jq -r '.pools[0].url' "$RIGL/rigforge/config.json")" "pithead.local:3333"
 assert_eq "the stratum password lands as the pool pass" "$(jq -r '.pools[0].pass' "$RIGL/rigforge/config.json")" "s3cret"
 assert_not_contains "already volatile -> journald is not restarted again" "$(cat "$RF_LOG")" "restart systemd-journald"
+# #1817: a first boot binds the persistent journal home onto this path before the role is
+# known (pithead-journal-persist), so the reclaim meets a MOUNTPOINT. The bind comes off
+# first — after journald has let go of the files under it, which is why the restart moves
+# ahead of the umount — and only then is the directory reclaimed.
+cat >"$RIGL/bin/mountpoint" <<EOF
+#!/usr/bin/env bash
+[ -f "$RIGL/bound" ] && exit 0
+exit 1
+EOF
+cat >"$RIGL/bin/umount" <<EOF
+#!/usr/bin/env bash
+echo "umount:\$*" >>"\${RF_LOG:?}"
+rm -f "$RIGL/bound"
+EOF
+chmod +x "$RIGL/bin/mountpoint" "$RIGL/bin/umount"
+mkdir -p "$RIGL/journal/abc"
+touch "$RIGL/bound"
+: >"$RF_LOG"
+rigl_out=$(run_rig provision_local_miner 2>&1)
+assert_rc "a bound journal path -> rc 0" "$?" "0"
+assert_eq "journald lets go first, then the bind comes off, then the miner is set up" \
+    "$(grep -o 'systemctl:restart systemd-journald\|umount:[^ ]*\|rigforge:setup' "$RF_LOG" | tr '\n' ' ')" \
+    "systemctl:restart systemd-journald umount:$RIGL/journal rigforge:setup "
+[ -d "$RIGL/journal" ] && bad "the directory under the bind is reclaimed" "still there" ||
+    ok "the directory under the bind is reclaimed"
+# A reclaim that cannot complete must not take the boot verb down: pithead-boot calls
+# `pithead local-miner` BARE under the CLI's errexit, while the wizard calls the same leg under
+# `|| true` — a failure inside the minimization passed first boot and killed every boot after
+# (the #1651 gate, BUILD_COMMIT 4fb4943a: the rig booted mining and never committed its slot).
+# Driven under errexit for real, with a control that the runner is armed; rm is stubbed to
+# refuse the journal path with the exact text the mountpoint case prints.
+run_rig_errexit() { (
+    cd "$RIGL" || exit 99
+    export PITHEAD_APPLIANCE=1 PATH="$RIGL/bin:$PATH"
+    source "$STACK"
+    "$@"
+); }
+_errexit_probe() {
+    false
+    echo survived
+}
+assert_not_contains "control: the errexit runner is armed" "$(run_rig_errexit _errexit_probe 2>/dev/null)" "survived"
+cat >"$RIGL/bin/rm" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+    [ "\$a" = "$RIGL/journal" ] && { echo "rm: cannot remove '\$a': Device or resource busy" >&2; exit 1; }
+done
+exec /bin/rm "\$@"
+EOF
+chmod +x "$RIGL/bin/rm"
+mkdir -p "$RIGL/journal/abc"
+touch "$RIGL/bound"
+: >"$RF_LOG"
+rigl_out=$(run_rig_errexit provision_local_miner 2>&1)
+assert_rc "a reclaim that cannot complete does not take the boot verb down (errexit armed)" "$?" "0"
+assert_contains "the miner is still set up behind it" "$(cat "$RF_LOG")" "rigforge:setup appliance=1"
+assert_contains "the console says the journal was not reclaimed" "$rigl_out" "could not be reclaimed"
+rm -f "$RIGL/bin/rm" "$RIGL/bin/mountpoint" "$RIGL/bin/umount" "$RIGL/bound"
+rm -rf "$RIGL/journal"
+unset -f run_rig_errexit _errexit_probe
 # No prebuilt (a wiped workspace): the operator gets told why the console is silent for minutes.
 rm -rf "$RIGL/rigforge/data/worker/xmrig"
 rigl_out=$(run_rig provision_local_miner 2>&1)

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -176,16 +176,8 @@ assert_not_contains "already volatile -> journald is not restarted again" "$(cat
 # known (pithead-journal-persist), so the reclaim meets a MOUNTPOINT. The bind comes off
 # first — after journald has let go of the files under it, which is why the restart moves
 # ahead of the umount — and only then is the directory reclaimed.
-cat >"$RIGL/bin/mountpoint" <<EOF
-#!/usr/bin/env bash
-[ -f "$RIGL/bound" ] && exit 0
-exit 1
-EOF
-cat >"$RIGL/bin/umount" <<EOF
-#!/usr/bin/env bash
-echo "umount:\$*" >>"\${RF_LOG:?}"
-rm -f "$RIGL/bound"
-EOF
+printf '#!/usr/bin/env bash\n[ -f "%s/bound" ] && exit 0\nexit 1\n' "$RIGL" >"$RIGL/bin/mountpoint"
+printf '#!/usr/bin/env bash\necho "umount:$*" >>"${RF_LOG:?}"\nrm -f "%s/bound"\n' "$RIGL" >"$RIGL/bin/umount"
 chmod +x "$RIGL/bin/mountpoint" "$RIGL/bin/umount"
 mkdir -p "$RIGL/journal/abc"
 touch "$RIGL/bound"
@@ -201,8 +193,8 @@ assert_eq "journald lets go first, then the bind comes off, then the miner is se
 # `pithead local-miner` BARE under the CLI's errexit, while the wizard calls the same leg under
 # `|| true` — a failure inside the minimization passed first boot and killed every boot after
 # (the #1651 gate, BUILD_COMMIT 4fb4943a: the rig booted mining and never committed its slot).
-# Driven under errexit for real, with a control that the runner is armed; rm is stubbed to
-# refuse the journal path with the exact text the mountpoint case prints.
+# Driven under errexit for real. The armed-runner control is an ABSENCE row, paired with the
+# positive rows after it (rc 0 + console text); rm is stubbed to refuse the path as a mountpoint does.
 run_rig_errexit() { (
     cd "$RIGL" || exit 99
     export PITHEAD_APPLIANCE=1 PATH="$RIGL/bin:$PATH"
@@ -230,6 +222,14 @@ rigl_out=$(run_rig_errexit provision_local_miner 2>&1)
 assert_rc "a reclaim that cannot complete does not take the boot verb down (errexit armed)" "$?" "0"
 assert_contains "the miner is still set up behind it" "$(cat "$RF_LOG")" "rigforge:setup appliance=1"
 assert_contains "the console says the journal was not reclaimed" "$rigl_out" "could not be reclaimed"
+# Review (#1817): a bind that will not come off is LEFT ALONE — `rm -rf` through it would empty the
+# persistent home on /data. Real rm here, so a reclaim that reached it would empty the directory.
+printf '#!/usr/bin/env bash\necho "umount:$*" >>"${RF_LOG:?}"\nexit 32\n' >"$RIGL/bin/umount"
+rm -f "$RIGL/bin/rm" && mkdir -p "$RIGL/journal/abc" && touch "$RIGL/bound" && : >"$RF_LOG"
+rigl_out=$(run_rig_errexit provision_local_miner 2>&1)
+assert_rc "umount fails (busy) -> the verb still completes" "$?" "0"
+[ -d "$RIGL/journal/abc" ] && ok "a bind still up is not reclaimed through" || bad "a bind still up is not reclaimed through" "emptied"
+assert_contains "the console says the bind is still up" "$rigl_out" "bind is still up"
 rm -f "$RIGL/bin/rm" "$RIGL/bin/mountpoint" "$RIGL/bin/umount" "$RIGL/bound"
 rm -rf "$RIGL/journal"
 unset -f run_rig_errexit _errexit_probe

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -206,6 +206,7 @@ assert_eq "journald lets go first, then the bind comes off, then the miner is se
 run_rig_errexit() { (
     cd "$RIGL" || exit 99
     export PITHEAD_APPLIANCE=1 PATH="$RIGL/bin:$PATH"
+    # shellcheck disable=SC1090
     source "$STACK"
     "$@"
 ); }

--- a/tests/stack/test_firstboot_journal.sh
+++ b/tests/stack/test_firstboot_journal.sh
@@ -75,6 +75,35 @@ out=$(PATH="$JP/bin:$PATH" PITHEAD_JOURNAL_DATA_DIR="$DATA_DIR" PITHEAD_JOURNAL_
 assert_eq "already mounted -> mount is not called again" "$(cat "$MOUNT_LOG")" ""
 assert_contains "the script says it is already bound" "$out" "already the persistent mount"
 
+# A rig stands down (#1817): its journal is volatile by design, and `pithead local-miner`
+# reclaims /var/log/journal on every boot — a bind there turned the reclaim into an rm on a
+# mountpoint, and under errexit the rig's boot verb died on it. The marker is the same file
+# pithead-boot forks on, read the same way (whitespace-tolerant, the exact word).
+echo "== unit: pithead-journal-persist stands down on a rig — the marker, not the bind (#1817) =="
+ROLE_FILE="$JP/machine-role"
+: >"$MOUNT_LOG"
+rm -f "$JP/already-mounted"
+printf 'rig\n' >"$ROLE_FILE"
+out=$(PATH="$JP/bin:$PATH" PITHEAD_JOURNAL_DATA_DIR="$DATA_DIR" PITHEAD_JOURNAL_TARGET="$TARGET" \
+    PITHEAD_MACHINE_ROLE_FILE="$ROLE_FILE" sh "$SCRIPT" 2>&1)
+assert_rc "rig marker -> rc 0 (the unit must not fail the early boot transaction)" "$?" "0"
+assert_eq "rig marker -> mount is never called" "$(cat "$MOUNT_LOG")" ""
+assert_contains "the script says why it stood down" "$out" "is a rig"
+# Sibling controls: a coordinator marker and a near-miss both still bind — the fork is on the
+# exact word, as in pithead-boot, and an absent marker (first boot) binds too.
+for role in pithead rigs; do
+    : >"$MOUNT_LOG"
+    printf '%s\n' "$role" >"$ROLE_FILE"
+    PATH="$JP/bin:$PATH" PITHEAD_JOURNAL_DATA_DIR="$DATA_DIR" PITHEAD_JOURNAL_TARGET="$TARGET" \
+        PITHEAD_MACHINE_ROLE_FILE="$ROLE_FILE" sh "$SCRIPT" >/dev/null 2>&1
+    assert_contains "marker '$role' still binds" "$(cat "$MOUNT_LOG")" "--bind $DATA_DIR $TARGET"
+done
+: >"$MOUNT_LOG"
+rm -f "$ROLE_FILE"
+PATH="$JP/bin:$PATH" PITHEAD_JOURNAL_DATA_DIR="$DATA_DIR" PITHEAD_JOURNAL_TARGET="$TARGET" \
+    PITHEAD_MACHINE_ROLE_FILE="$ROLE_FILE" sh "$SCRIPT" >/dev/null 2>&1
+assert_contains "no marker yet (first boot) still binds" "$(cat "$MOUNT_LOG")" "--bind $DATA_DIR $TARGET"
+
 echo "== unit: load_baked_images narrates a FINISH, not just a start, per archive (#1030) =="
 # Without this, a journal that survives a reset (the fix above) still shows only "Loading..."
 # for an archive that was interrupted mid-write and a truncated load is indistinguishable from


### PR DESCRIPTION
Fixes #1817 (hand-close on merge — `Closes` is inert on `develop-v2`). Found by the #1651 gate on `BUILD_COMMIT 4fb4943a` (187/7, all seven reds one failure); on-image proof and the retraction of my earlier "runs after the miner start" sentence are on #1651.

**What broke.** #1792 made the persistent-journal bind win `/var/log/journal` on every boot. The rig role's write minimization assumed a plain directory there: `rm -rf` emptied it through the bind (onto `/data`) and then failed on the mountpoint (`Device or resource busy`). The wizard calls that leg under `|| true`, so first boot mined; `pithead-boot` runs `./pithead local-miner` bare under the CLI's errexit, so every later boot exited 1, `fail_boot`, slot uncommitted, miner never set up. The failure also erased its own journal.

**Both halves, as the seat's directive shaped them:**

(a) `os/overlay/pithead-journal-persist` reads `/data/pithead/machine-role` — the marker `pithead-boot` forks on, read the same way (whitespace-stripped, the exact word) — and exits 0 without binding when it says `rig`. `After=var.mount` and everything else from #1791 stay. Override for tier 1: `PITHEAD_MACHINE_ROLE_FILE`.

(b) `rig_minimize_writes` (`lib/pithead/14-local-miner.sh`, `pithead` regenerated): the journald restart moves BEFORE the reclaim — journald holds the persistent files under the path open, and a bind cannot come off while it does — then the bind is taken off if the path is a mountpoint, then the directory is reclaimed best-effort (`|| warn`). The call site becomes `rig_minimize_writes || true`.

**Which half the battery row exercises.** The rig reboot row (`tests/os/run.sh` § rig, "pithead-boot owns a provisioned rig's boot" + the self-commit row) exercises (a): on a provisioned rig's boot there is no bind, so the reclaim meets a plain directory as before #1792. (b) is what a rig's FIRST boot exercises — the bind is up before the role is known — and that boot already passed under the wizard's `|| true`, so the battery cannot discriminate (b); tier 1 does, under errexit, with fired controls (table below).

**Half (b) proven on-image, on the UNFIXED image's failed rig boot** (kept `--phase rig` guest of `4fb4943a`, after its phase ended; evidence dir `~/battery-1791-rigdiag-20260905T061417Z/guest-experiment-b-*.txt` on the build box), in the fix's order with the naive orders as controls:

| step | rc |
|---|---|
| control: `umount /var/log/journal` while journald is still persistent | 32, `target is busy` — the directive's "umount first" alone would not have fixed it |
| control: `rm -rf /var/log/journal` on the mountpoint | 1, `Device or resource busy` |
| `systemctl restart systemd-journald` (the volatile drop-in was already there) | 0; journald's open fds under the path go 1 → 0 |
| then `umount` | 0, no longer a mountpoint |
| then `rm -rf` | 0, gone |
| then `./pithead local-miner` exactly as `pithead-boot` calls it | 0; `xmrig` active, process running |

**Tests, tier 1 (run: `tests/stack/run.sh` in the branch worktree, and the journal domain standalone — counts below).** Full suite on this branch before the shfmt-only reformat of the rig-miner fragment: `pithead tests: 3352 passed, 0 failed`, rc 0; after it, the journal domain 17/0 and the rig-miner fragment 90/0 again via the mini-runner. CI runs the whole suite over the pushed tree.
- `test_firstboot_journal.sh` (+6 rows): rig marker → rc 0, `mount` never called, the script says why; sibling controls `pithead`, near-miss `rigs`, and NO marker all still bind.
- `test-appliance-rig-miner.sh` (+8 rows): a bound path → the call log reads `restart journald, umount <path>, rigforge setup` in that order and the directory is gone; an errexit-ARMED runner (with a control row proving it is armed) drives `provision_local_miner` with `rm` stubbed to refuse the journal path exactly as the mountpoint case does → rc 0, RigForge setup still ran, the console says the journal was not reclaimed.

**Mutation battery** (detached checkout of this commit, each mutant proven applied by `git diff --numstat`, restored by checkout; the fixed tree is 90/0 on the rig-miner fragment and 17/0 on the journal domain):

| mutant | rows reddened |
|---|---|
| M2 restart moved back after the rm | the order row |
| M3 umount block dropped | the order row (same instrument as M2 — one axis) |
| M4 `\|\| warn` on the rm dropped (call site still `\|\| true`) | "the console says the journal was not reclaimed" |
| M5 overlay role check dropped | "mount is never called", "says why it stood down" |
| M6 errexit runner disarmed | the control row — the control can fail |
| M7 BOTH guards dropped | the rc row, the setup row, the console row — the rc row can fail |
| **M1 call-site `\|\| true` dropped alone** | **SURVIVES, by construction**: every step inside the function is now guarded, so nothing reaches the call site non-zero. It is defence against the next unguarded line (this bug's exact signature: passes first boot, kills every boot after) and is NOT proven by a row. Said here rather than hidden. |

**Over-engineering pass, by hand** (the ponytail gate keys off the pinned shell cwd's branch here, not this worktree's — disclosed): the diff is two guarded lines plus a reorder in one function, a 12-line early exit in one script, and rows. No new file, no new helper. Adjacent merges considered: folding the role check into the `.service` as `ConditionPathExists`/`ConditionFileNotEmpty` was available and rejected — systemd conditions cannot test a file's CONTENT, and the marker's value is what forks; a `machine_role()`-style helper shared with the CLI was rejected because the overlay is `#!/bin/sh` and never sources the CLI (same reason `pithead-boot` open-codes the read).

**Not done / not touched:** no `verify-image` row (the file sits at its 400-line bar with no budget row; the archive-vs-tree check with `PITHEAD_EXPECT_COMMIT` already proves the image carries the tree's script; the tier-1 rows prove the script). No prose doc names the reclaim or the bind; the comments in both files carry the record. `CHANGELOG.md` untouched (as #1792). `tests/os/verify-image.sh` count stays 103. Image-bytes change: **new freeze tip on merge; the full gate reruns**, and the reviewer lane's design finding on #1817 (whether `pithead-boot:308` should `fail_boot` at all, given the liveness gate below it) is filed there, not taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ


---

## Review round 1 (ephemeral reviewer, RETURN at the first head) — both items taken

**Blocking, SC1090:** the new `source "$STACK"` inside `run_rig_errexit()` carries the line-above directive (house shape for a source inside a function). Shellcheck through the box's wrapper fired on the old text (rc 1) and passes on the new (rc 0). At that head CI's `Shell tests` stopped in step 4, so steps 5–11 SKIPPED and CI had proven nothing about the suite; the rerun at the current head is that proof.

**Finding 2, taken — a bind that will not come off is left alone.** `rig_minimize_writes` re-tests `mountpoint -q "$journal"` after the `umount`; still mounted → `warn` + `return 0`, and `rm -rf` never runs through the bind onto /data. Proof, run not intended: the rig-miner fragment is 93/0 on the fix; the mutant that drops the re-check (proven applied by `git diff --numstat`) reddens exactly two rows — `a bind still up is not reclaimed through` (the directory under the bind survives) and `the console says the bind is still up` — with the stubbed `rm` REMOVED first so the real `rm` would have emptied the directory. The third new row (`umount fails (busy) -> the verb still completes`, rc 0) survives that mutant by design: the verb completes either way; it is the positive leg the reviewer asked for beside the absence row, and the comment above the errexit runner now says so.

**Budget:** `tests/stack/test-appliance-rig-miner.sh` is at exactly 400 lines — the bar is `TARGET_LINES=400` in `scripts/lint-file-budget.sh` (a row IFF over it), which is also the sourcing for the `verify-image.sh` sentence above. To stay there the `mountpoint`/`umount` stub heredocs became one-line `printf`s; `lint-file-budget` OK, no row. `lint-pithead-parity` OK; `shfmt -i 4 -d` clean.

**Rebase:** onto the pull 1818 merge (it regenerates `pithead` too); `scripts/build-pithead.sh` re-run; the patch outside `pithead` was byte-identical to the pre-rebase patch (confirmed independently by the `fixes` lane against each side's own merge-base).

**Not done:** no full-suite local rerun after finding 2 (fragment only); CI at the current head is the whole-suite proof. Merge is non-author — `fixes` holds it on steps 5–11 `success` plus a reviewer PASS naming the current head.
