### PR TITLE
fix(dashboard): #1769 an appliance operator is not shown host remedies it cannot reach

### DIFF
--- a/dashboard/mining_dashboard/web/static/applyfailure.mjs
+++ b/dashboard/mining_dashboard/web/static/applyfailure.mjs
@@ -1,0 +1,67 @@
+// What a failed apply tells the operator (#1769).
+//
+// Its own module rather than more of configview.mjs: that file sits at its recorded budget ceiling
+// with no headroom, and this is a self-contained concern — one host result in, display text out,
+// with no fetching, sequencing or state of its own. The same split osverdict.mjs took out of
+// osupdate.mjs.
+//
+// The defect: the host writes `tail -c 2000` of the raw `apply` log into the result's `error`
+// field (43-control-approval-and-preview.sh), server.py returns the result dict to the browser
+// unfiltered, and this card rendered that tail bare. An apply log names host CLI verbs — "Run
+// './pithead setup' first", "then re-run './pithead apply'" — and an appliance operator has no
+// shell to run them in. #1213 settled the rule for doctor's messages: an appliance is told what it
+// can actually reach, and the wording NEVER invents a remedy. This is that rule on a surface
+// #1213's sweep cannot see, because the text never passes through dr_* at all.
+//
+// The tail is KEPT on both branches. It is real diagnostic detail and dropping it would trade one
+// bad outcome for another. What changes on an appliance is that it is labelled as the machine's
+// own log instead of being left to read as instructions, and that the sentences around it name
+// only surfaces on this page: the form above, and the Service diagnostics card beside it.
+//
+// The host branch is unchanged, deliberately. A host operator has a shell, so
+// `config.json.bak-control` is a path they can act on, and naming it is the useful thing to do.
+//
+// KNOWN RESIDUAL. The caller's signal is `state.os_update`, which is the presence of a file only
+// an appliance's host writes (config.py OS_UPDATE_STATE_PATH). It is the only appliance tell
+// build_state carries — checked against the whole payload, not assumed — but it is a signal about
+// that FILE, not about the hardware. An appliance whose host has not written it yet reads as a
+// non-appliance and gets the host wording, so #1769 survives in that window. Same fail-direction
+// as the header's OS-update control, which simply does not render in it. Closing it properly
+// needs an explicit appliance flag in build_state, which is a bigger change than this bug.
+import { html } from "./preact.mjs";
+
+// The backup path is a host filesystem path. It is the right thing to show someone with a shell
+// and a dead end for someone without one, so it is the sentence that has to branch.
+function backupLine(result, appliance) {
+  if (appliance) {
+    return html`<p class="status-bad">Apply failed. Your change was saved but is not running, and
+        the previous configuration is kept on this machine.</p>`;
+  }
+  return html`<p class="status-bad">Apply failed. The previous config is kept at
+      <code>${result.backup || "config.json.bak-control"}</code> on the host.</p>`;
+}
+
+// On an appliance the log needs a frame, because its imperatives are addressed to someone at a
+// shell prompt and the reader is not that person. It names no remedy of its own beyond the two
+// surfaces this page actually has.
+function logCaption(appliance) {
+  if (!appliance) return null;
+  return html`<p class="text-muted text-xs">Below is this machine's own log from the failed
+      apply. It is diagnostic detail: any commands it names run on the machine itself and cannot
+      be run from here. Correct the change in the form above and save again; Service diagnostics
+      on this page can run the health check and show a recent log for each service.</p>`;
+}
+
+// The whole failed arm of the Configuration card's result state.
+//
+// Returned as a plain array of children rather than one `html` template: every root here is an
+// interpolation, with no literal tag for htm to anchor on, and a child array is a shape both
+// Preact and the tests' render probe handle without that question arising at all. A null entry
+// (no log, or the host branch's absent caption) is dropped by both, as it is anywhere else.
+export function applyFailure(result, appliance) {
+  return [
+    backupLine(result, appliance),
+    logCaption(appliance),
+    result.error ? html`<pre class="config-error-tail">${result.error}</pre>` : null,
+  ];
+}

--- a/dashboard/mining_dashboard/web/static/components.mjs
+++ b/dashboard/mining_dashboard/web/static/components.mjs
@@ -1041,7 +1041,7 @@ function DashboardView({
         <${AdvancedHint} ui=${ui} onView=${onView} onDismissHint=${onDismissHint} />
         ${
           configView
-            ? html`<div class="card-stack"><${ConfigView} /><${BackupPanel} enabled=${state.control_enabled} /><${DiagnosticsPanel} enabled=${state.control_enabled} /><${SecurityPanel} /></div>`
+            ? html`<div class="card-stack"><${ConfigView} appliance=${!!state.os_update} /><${BackupPanel} enabled=${state.control_enabled} /><${DiagnosticsPanel} enabled=${state.control_enabled} /><${SecurityPanel} /></div>`
             : null
         }
         ${

--- a/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/dashboard/mining_dashboard/web/static/configview.mjs
@@ -21,6 +21,7 @@
 // sentinels, render blank with a keep-hint, and an untouched or re-blanked secret keeps its
 // sentinel — "blank means keep" survives the model change.
 
+import { applyFailure } from "./applyfailure.mjs";
 import {
   buildSections,
   isSecretSentinel,
@@ -442,9 +443,7 @@ export class ConfigView extends Component {
           ${
             ok
               ? html`<p class="status-ok">Changes applied — only the affected containers were recreated.</p>`
-              : html`<p class="status-bad">Apply failed. The previous config is kept at
-                  <code>${result.backup || "config.json.bak-control"}</code> on the host.</p>
-                  ${result.error ? html`<pre class="config-error-tail">${result.error}</pre>` : null}`
+              : applyFailure(result, this.props.appliance)
           }
           <button class="btn-toggle" onClick=${() => this.load()}>Back to the form</button>
       </div>`;

--- a/dashboard/tests/frontend/applyfailure.test.mjs
+++ b/dashboard/tests/frontend/applyfailure.test.mjs
@@ -1,0 +1,147 @@
+// The failed-apply wording an appliance operator reads (#1769).
+//
+// The defect: the host puts `tail -c 2000` of the raw `apply` log into the control result's
+// `error` field, server.py returns that dict to the browser unfiltered, and the Configuration
+// card rendered the tail bare beneath a sentence naming a host filesystem path. An appliance has
+// no shell, so both the path and the log's imperatives are dead ends. #1213 settled the rule for
+// doctor's messages; this is the same rule on a surface #1213's dr_* sweep is structurally blind
+// to, because the text never passes through dr_*.
+//
+// Its own file rather than more of configview.test.mjs: that file is at its recorded budget
+// ceiling with no headroom, and this is a distinct defect class. It reuses the sibling render
+// probe (helpers/render.mjs) rather than duplicating one.
+//
+// WHAT THIS FILE DOES NOT COVER, so nobody reads it as more than it is:
+//   - The App -> ConfigView prop hop (`appliance=${!!state.os_update}`, components.mjs:1044) is
+//     verified by reading, not by a test: ConfigView's first paint through App is always its
+//     loading card, so this render probe cannot reach the failed state that way. The test below
+//     that pins the undefined-prop degradation is what stands in for it.
+//   - Escaping. The probe does not escape, so an assertion about it would pass or fail for a
+//     reason unrelated to what it names (the same call osverdict.test.mjs makes).
+//   - That no CLI verb reaches an appliance at all. That is FALSE by design and asserted false
+//     below: the log tail is kept verbatim on both branches, because it is real diagnostic detail
+//     and #1769 is a wording problem, not a redaction one.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/*.test.mjs
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { applyFailure } from "../../mining_dashboard/web/static/applyfailure.mjs";
+import { ConfigView } from "../../mining_dashboard/web/static/configview.mjs";
+import { DiagnosticsPanel } from "../../mining_dashboard/web/static/diagview.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// A faithful failed-commit result: `backup` as 43-control-approval-and-preview.sh writes it, and
+// an `error` tail carrying the two host-CLI imperatives #1769 names, verbatim from
+// 40-apply-and-render.sh:131 and :289 with `$0` expanded as the operator would see it.
+const BACKUP = "/opt/pithead/config.json.bak-control";
+const TAIL = [
+  "==> Rendering .env",
+  "ERROR: Stack is not fully provisioned. Run './pithead setup' first.",
+  "WARN: Fix the cause shown above, then re-run './pithead apply' (it will retry the recreate).",
+].join("\n");
+const RESULT = { status: "failed", error: TAIL, backup: BACKUP };
+
+const host = () => renderToString(applyFailure(RESULT, false));
+const appliance = () => renderToString(applyFailure(RESULT, true));
+
+// --- the host branch, which is also the control for the appliance branch's absence -------------
+
+// This test is load-bearing twice over. It pins that a shelled operator still gets the path they
+// can act on, and it is the FIRING CONTROL for the assertion below: the same needle, through the
+// same instrument, found here and absent there. Without it, "the path is absent on an appliance"
+// could be satisfied by a render that produced nothing at all.
+test("a host operator is still told where the previous config was kept", () => {
+  const out = host();
+  assert.match(out, /Apply failed\./);
+  assert.match(out, /previous config is kept at/);
+  assert.ok(out.includes(BACKUP), "the host branch must name the backup path");
+  assert.ok(out.includes("on the host"));
+});
+
+test("an appliance operator is never pointed at a host path they cannot reach", () => {
+  const out = appliance();
+  // Non-empty and saying the right thing FIRST, so the absence below cannot be an empty render.
+  assert.ok(out.length > 0);
+  assert.match(out, /Apply failed\./);
+  assert.match(out, /previous configuration is kept on this machine/);
+  // The needle the control above proved this instrument can find.
+  assert.ok(!out.includes(BACKUP), "the appliance branch must not name a host path");
+  assert.doesNotMatch(out, /config\.json\.bak-control/);
+  assert.doesNotMatch(out, /on the host/);
+});
+
+// --- the constraint #1769 states explicitly: wording, not redaction ----------------------------
+
+test("the apply log survives verbatim on both branches", () => {
+  // Suppressing the tail would trade one bad outcome for another — it is the only diagnostic
+  // detail either operator gets. Asserted on BOTH branches so a later "fix" that scrubs the log
+  // reddens here rather than passing as an improvement.
+  for (const out of [host(), appliance()]) {
+    assert.ok(out.includes("Stack is not fully provisioned"));
+    assert.ok(out.includes("./pithead setup"));
+    assert.ok(out.includes("./pithead apply"));
+  }
+});
+
+test("the appliance branch frames the log instead of leaving it to read as instructions", () => {
+  const out = appliance();
+  assert.match(out, /this machine's own log from the failed\s+apply/);
+  assert.match(out, /cannot\s+be run from here/);
+  // It names only surfaces this page actually has: the form above and the Service diagnostics
+  // card rendered beside it in the same card-stack. #1213's rule is that it invents no remedy.
+  assert.match(out, /Correct the change in the form above and save again/);
+  assert.match(out, /Service diagnostics/);
+});
+
+// Finding B of this change's over-engineering pass: the caption names another component's card by
+// its heading, and cross-file prose goes stale with nothing red. Pin the two together so renaming
+// that card fails here instead of leaving the appliance pointed at a surface that no longer exists.
+test("the surface the caption names is the heading Service diagnostics actually renders", () => {
+  const panel = renderToString(new DiagnosticsPanel({ enabled: false }).render());
+  assert.match(panel, /<h3>Service diagnostics<\/h3>/);
+  assert.ok(renderToString(applyFailure(RESULT, true)).includes("Service diagnostics"));
+});
+
+// --- the prop is load-bearing, and its absence is silent ---------------------------------------
+
+test("a dropped appliance prop degrades to the host wording, not to a blank card", () => {
+  // The failure mode of the App -> ConfigView hop this file cannot otherwise reach: if the prop
+  // is ever removed, `this.props.appliance` is undefined and #1769 returns with nothing red. Pin
+  // it so the next reader knows the prop carries the whole fix.
+  const out = renderToString(applyFailure(RESULT, undefined));
+  assert.ok(out.includes(BACKUP));
+  assert.equal(out, host());
+});
+
+// --- the wiring inside ConfigView --------------------------------------------------------------
+
+// Proves the failed arm of ConfigView's `done` state actually consults this.props.appliance,
+// which the module-level tests above cannot see.
+function doneCard(props) {
+  const view = new ConfigView(props);
+  view.state = { ...view.state, phase: "done", result: RESULT };
+  return renderToString(view.render());
+}
+
+test("ConfigView's failed result routes through the appliance-aware wording", () => {
+  const onAppliance = doneCard({ appliance: true });
+  assert.match(onAppliance, /previous configuration is kept on this machine/);
+  assert.ok(!onAppliance.includes(BACKUP));
+  const onHost = doneCard({ appliance: false });
+  assert.ok(onHost.includes(BACKUP));
+  // Both still offer the way back to the form, so neither branch lost the card's own control.
+  assert.match(onAppliance, /Back to the form/);
+  assert.match(onHost, /Back to the form/);
+});
+
+test("an applied result is untouched by #1769 on either branch", () => {
+  for (const props of [{ appliance: true }, { appliance: false }]) {
+    const view = new ConfigView(props);
+    view.state = { ...view.state, phase: "done", result: { status: "applied" } };
+    const out = renderToString(view.render());
+    assert.match(out, /Changes applied/);
+    assert.doesNotMatch(out, /Apply failed/);
+  }
+});

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1048,6 +1048,12 @@ records its action as `commit-confirmed`, so a confirm-gated apply reads distinc
 ordinary commit in the log. The container cannot forge results,
 alter a staged config between preview and commit, or rewrite the audit log. A failed apply keeps
 the previous config at `config.json.bak-control` and surfaces pithead's error in the view.
+On an appliance that view is worded differently
+([#1769](https://github.com/p2pool-starter-stack/pithead/issues/1769)): the operator has no
+shell, so it says the backup was kept without naming a host path they cannot reach, and it
+labels pithead's error as the machine's own apply log rather than leaving its `./pithead`
+commands to read as instructions. The log itself is shown either way — it is the only
+diagnostic detail either operator gets.
 Operational details:
 [Operations › Editing config from the dashboard](operations.md#editing-config-from-the-dashboard).
 


### PR DESCRIPTION
Closes #1769.

## The defect, re-derived at source

Every link read in the code, none observed in a running UI (see "What I did not do"):

1. `lib/pithead/43-control-approval-and-preview.sh:364` writes `tail -c 2000` of the raw `apply` log into the failed result's `error`, alongside `backup`.
2. `control_service.wait_result` returns that dict untouched (`return res`).
3. `web/server.py:196` spreads it to the browser: `web.json_response({"id": rid, **res})`.
4. `configview.mjs` rendered `result.error` bare in a `<pre>`, under a sentence naming `config.json.bak-control` "on the host".

So an appliance operator reads `Run './pithead setup' first.` and `Fix the cause shown above, then re-run './pithead apply'` (both verbatim from `40-apply-and-render.sh:131` and `:289`) with no shell to run them in, plus a host path they cannot reach. #1213 settled the rule for doctor's messages; its sweep is keyed to `dr_*` and this text never passes through `dr_*`, so that sweep is structurally blind to this surface and always will be.

## The fix

The wording branches on `state.os_update` — the appliance tell the client already uses (`osupdate.mjs`, `components.mjs`). On an appliance:

- the backup sentence says the previous configuration is kept **without naming a host path**;
- the log tail is **captioned** as the machine's own apply log, diagnostic detail rather than instructions;
- the caption names only surfaces that page actually has — the form above, and the Service diagnostics card rendered beside it in the same card-stack.

**The tail is kept on both branches.** #1769 is explicit that this is a wording problem, not a redaction one, and the tail is the only diagnostic detail either operator gets. A test asserts the tail — `./pithead setup` and `./pithead apply` included — survives on both branches, so a later "fix" that scrubs the log reds instead of passing as an improvement.

**The host branch is byte-unchanged.** A shelled operator still gets the actionable path.

### Why the client, and not a filter in `server.py`

Because a server-side filter at `:196` would miss the common case. `handle_control_commit` waits `CONTROL_WAIT_S` (30s) inline; a failing `apply` is a full container recreate and routinely runs longer, so it 202s and the client polls `/api/control/result` — `server.py:441`, a different handler that returns the whole dict. `configview.mjs` `commit()` -> `poll()` -> `setState({phase: "done", result})` puts both routes through the *same* render branch. Fixing the render covers both; fixing `:196` would have covered only the fast failure and left the slow one — the likelier one — showing the old text.

## Why new files rather than edits

`configview.mjs` (591) and `configview.test.mjs` (492) both sit at their recorded ceilings with **zero** headroom. `applyfailure.mjs` (67) and `applyfailure.test.mjs` (147) are new, both under the 400 target, so **neither takes a budget row** and `file-budget.tsv` is untouched. `configview.mjs` ends at 590/591 and `components.mjs` at 1137/1177. This is the split `osverdict.mjs` took out of `osupdate.mjs`, for the same stated reason; the new test file reuses the sibling `helpers/render.mjs` probe rather than duplicating one.

## Over-engineering pass (done on merits — the local gate verifies nothing)

Two real findings, both fixed in this branch before it was pushed:

- **A.** My first draft asserted `doesNotMatch(/ssh|console|terminal/i)` on the appliance caption. `console access` is #1213's **own approved** appliance remedy, used at eight sites in `06-doctor.sh` for exactly the case where no dashboard surface exists. The assertion would have redded a correct future edit. Removed.
- **B.** The caption names another component's card by its heading, and cross-file prose goes stale with nothing red. Added a test pinning the caption's "Service diagnostics" against the `<h3>` `DiagnosticsPanel` actually renders (`diagview.mjs:145`).

## Known residual, recorded in the module

`state.os_update` is a signal about a **host-written file**, not about the hardware. It is the only appliance tell `build_state` carries — checked against the whole payload rather than assumed — but an appliance whose host has not written `os-update-state.json` yet reads as a non-appliance and gets the host wording, so #1769 survives in that window. Same fail-direction as the header's OS-update control, which simply does not render in it. Closing it properly needs an explicit appliance flag in `build_state`: a bigger change than this bug, and not one to start during a freeze.

## Scope this does NOT cover

- **The host half.** `lib/pithead/43-control-approval-and-preview.sh` still emits a raw tail, and `40-apply-and-render.sh` still writes CLI imperatives into it. Both are under the image freeze and are not this lane's paths, so this fixes what the operator reads, not what the host writes.
- **RETRACTED, and corrected here rather than quietly rewritten.** This body first said the other two `**res` passthroughs were "`server.py:173` preview, `:364` os-update" and carried the same raw-tail shape. **`:364` is `handle_worker_apply`, not os-update, and it carries no raw tail at all** — `46-control-worker-ops.sh` has zero `tail -c` calls; its errors are messages. Re-derived after opening this PR. The class is real but its members are these:
  - Raw `tail -c 2000` writers: `43-...:284` (preview), `43-...:364` (commit — the one fixed here), `44-...:388` (upgrade/lifecycle), `45-...:76` (backup).
  - They reach the browser via `server.py:173` (preview), `:196` (commit), and — the one I had missed — **`handle_control_result` at `server.py:441`, `web.json_response(res)`, which returns the whole dict for anything that 202'd.** That is how the upgrade and backup tails get out.
  - Rendered by `configview.mjs`'s UpgradeControl (which also names a host backup path) and `backupview.mjs:124`.

  I did **not** widen this PR to cover them: it is mid-CI with a recorded shape, each surface needs its own honest wording, and the window is a wind-down. Flagging it for the reviewer to rule on rather than deciding it myself — happy to file it as a follow-up issue.
- **The App -> ConfigView prop hop.** `appliance=${!!state.os_update}` at `components.mjs:1044` is verified by reading, not by a test: ConfigView's first paint through App is always its loading card, so the render probe cannot reach the failed state that way. A test pins the failure mode instead — dropping the prop degrades to the host wording, which is #1769 returning with nothing red.

## What was RUN, and what was not

**Nothing was run locally.** This lane is under a CI-only rule for the duration of the #1651 release-gate battery: no `make test*`, no `make lint*`, no node runs. So `node --test`, `biome check` and `lint-file-budget` are unverified by me and CI is the first gate they meet. Two consequences I handled statically instead, and which a reviewer should still check:

- `applyFailure` returns a plain **array** of children rather than one `html` template, because every root would have been an interpolation with no literal tag for htm to anchor on. `renderToString` handles arrays explicitly and Preact takes array children, so this removes the one shape I could not settle without running it.
- The `applyfailure.mjs` import was moved above the `configlogic.mjs` block to keep the file's alphabetical order, because `make lint-js` runs `biome check .`, which includes the organize-imports assist. Max line length 99 against biome's 100.

`docs/dashboard.md` is updated in the same commit (shared `docs/` path, disclosed per lane policy). `docs/operations.md:270` was checked and left alone: it describes what the host keeps, which is still true.

**Not MERGE-READY.** Needs a recorded non-author pass; I am the author and do not merge my own. Note for whoever sequences it: `dashboard/` is image bytes, so merging moves the tip the next gate builds from — this is ready when the seat wants it, not necessarily now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcHCQa59LmHJg75K5reeaM