### PR TITLE
test(os): #1651 a failed leg-4 install keeps the guest's own account before the harness returns

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -242,6 +242,11 @@ Two harness rules worth knowing before you lose an afternoon to them:
 - On failure it keeps the guest console at `/tmp/pithead-os-serial.log.failed`. Read it
   first. `/dev/console` is whichever `console=` came **last** on the kernel cmdline, so
   check which one you are reading before concluding a component is silent.
+- A failed dashboard-driven install (update phase, leg 4) also keeps the guest's own
+  account at `/tmp/pithead-os-serial.log.leg4-install`: the boot journal's rauc and
+  OS-install lines, `rauc status`, disk and memory, and any OOM kill. The runner deletes
+  its install log on failure and the dashboard result carries only rauc's last line, so
+  this file is the only place the cause survives.
 
 ## The automated battery
 

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -243,10 +243,11 @@ Two harness rules worth knowing before you lose an afternoon to them:
   first. `/dev/console` is whichever `console=` came **last** on the kernel cmdline, so
   check which one you are reading before concluding a component is silent.
 - A failed dashboard-driven install (update phase, leg 4) also keeps the guest's own
-  account at `/tmp/pithead-os-serial.log.leg4-install`: the boot journal's rauc and
-  OS-install lines, `rauc status`, disk and memory, and any OOM kill. The runner deletes
-  its install log on failure and the dashboard result carries only rauc's last line, so
-  this file is the only place the cause survives.
+  account at `/tmp/pithead-os-serial.log.leg4-install`: the root runner's own journal
+  (`pithead-control.service`, where its "OS install failed" warning and log tail land),
+  the boot journal's rauc and OS-install lines, `rauc status`, disk and memory, and any
+  OOM kill. The runner deletes its install log on failure and the dashboard result
+  carries only rauc's last line, so this file is the only place the cause survives.
 
 ## The automated battery
 

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -246,8 +246,10 @@ Two harness rules worth knowing before you lose an afternoon to them:
   account at `/tmp/pithead-os-serial.log.leg4-install`: the root runner's own journal
   (`pithead-control.service`, where its "OS install failed" warning and log tail land),
   the boot journal's rauc and OS-install lines, `rauc status`, disk and memory, and any
-  OOM kill. The runner deletes its install log on failure and the dashboard result
-  carries only rauc's last line, so this file is the only place the cause survives.
+  OOM kill. It reads the current boot only: if the install took the guest down, the
+  serial log above spans the reboot. The runner deletes its install log on failure and
+  the dashboard result carries at most rauc's last error line, or nothing, so this file
+  is the only place the cause survives.
 
 ## The automated battery
 

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1103,7 +1103,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         bad "leg 4: install did not complete (got: $(printf '%s' "$out" | cut -c1-200))"
         # The runner deletes .install.log on a failed install and the result carries only a whitelisted last line
         # (#1651: one gate red said "[ERROR] rauc install failed", guest gone) — keep the guest's own account.
-        _ssh "{ journalctl -b -o short-iso --no-pager | grep -aiE 'rauc|os.install|os-update' | tail -300; echo '== rauc status'; rauc status; echo '== df'; df -h /data /tmp; echo '== free'; free -m; echo '== oom'; dmesg | grep -aiE 'oom|killed process'; } 2>&1" >"$SERIAL.leg4-install" || true
+        SSH_TIMEOUT=120 _ssh "{ echo '== pithead-control.service (the root runner)'; journalctl -b -u pithead-control.service -o short-iso --no-pager -n 200; echo '== journal rauc/os-install lines'; journalctl -b -o short-iso --no-pager | grep -aiE 'rauc|os.install|os-update' | tail -300; echo '== rauc status'; rauc status; echo '== df'; df -h /data /tmp; echo '== free'; free -m; echo '== oom'; dmesg | grep -aiE 'oom|killed process'; } 2>&1" >"$SERIAL.leg4-install" || true
         info "install diagnostics kept at $SERIAL.leg4-install"
         _leg4_srv_stop
         return

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -1104,7 +1104,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         # The runner deletes .install.log on a failed install and the result carries only a whitelisted last line
         # (#1651: one gate red said "[ERROR] rauc install failed", guest gone) — keep the guest's own account.
         SSH_TIMEOUT=120 _ssh "{ echo '== pithead-control.service (the root runner)'; journalctl -b -u pithead-control.service -o short-iso --no-pager -n 200; echo '== journal rauc/os-install lines'; journalctl -b -o short-iso --no-pager | grep -aiE 'rauc|os.install|os-update' | tail -300; echo '== rauc status'; rauc status; echo '== df'; df -h /data /tmp; echo '== free'; free -m; echo '== oom'; dmesg | grep -aiE 'oom|killed process'; } 2>&1" >"$SERIAL.leg4-install" || true
-        info "install diagnostics kept at $SERIAL.leg4-install"
+        [ -s "$SERIAL.leg4-install" ] && info "install diagnostics kept at $SERIAL.leg4-install" || info "install diagnostics capture came back EMPTY (guest unreachable, or the 120 s cap hit) — read $SERIAL.failed"
         _leg4_srv_stop
         return
     fi

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -911,6 +911,10 @@ PYEOF
 # bundle download are pointed at a bench-local server through the root-owned test seam
 # (os-update-test-base); RAUC signature verification still runs for real against the slot
 # keyring, so the bad-signature refusal is genuine, not simulated.
+_leg4_srv_stop() { # the bench release server and its dir, torn down at every leg-4 exit; reads the caller's locals
+    kill "$srv_pid" 2>/dev/null
+    rm -rf "$srv"
+}
 phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-boot>
     local good_bundle="$1" serial_mark="${2:-0}" marker before
     info "leg 4 — dashboard OS-update action end-to-end (provision, then check/download/verify/install/reboot)"
@@ -973,8 +977,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     fi
     _ssh "printf 'http://$host_addr:$port' > /data/pithead/os-update-test-base" || {
         bad "leg 4: could not plant the update-server seam on the guest"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     }
 
@@ -994,14 +997,12 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     local aged
     if ! aged=$(aged_version "${tag#v}"); then
         bad "leg 4: cannot age the running version ${tag#v} — nothing sorts below it (tests/os/aged-version.sh)"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     fi
     if ! _ssh "printf '%s\n' '$aged' > /data/pithead/VERSION"; then
         bad "leg 4: could not age the guest's running version to $aged"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     fi
 
@@ -1013,8 +1014,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         ok "leg 4: check derived the published release ($tag, $(printf '%s' "$out" | jq -r '.size') bytes)"
     else
         bad "leg 4: check did not derive the release (got: $(printf '%s' "$out" | cut -c1-200))"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     fi
 
@@ -1093,8 +1093,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         ok "leg 4: the good bundle verifies (signature + compatible + version)"
     else
         bad "leg 4: the good bundle failed verify (got: $(printf '%s' "$out" | cut -c1-200))"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     fi
     out=$(_os_step '{"action":"install"}' 900)
@@ -1102,8 +1101,11 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
         ok "leg 4: install wrote the spare slot through the dashboard action"
     else
         bad "leg 4: install did not complete (got: $(printf '%s' "$out" | cut -c1-200))"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        # The runner deletes .install.log on a failed install and the result carries only a whitelisted last line
+        # (#1651: one gate red said "[ERROR] rauc install failed", guest gone) — keep the guest's own account.
+        _ssh "{ journalctl -b -o short-iso --no-pager | grep -aiE 'rauc|os.install|os-update' | tail -300; echo '== rauc status'; rauc status; echo '== df'; df -h /data /tmp; echo '== free'; free -m; echo '== oom'; dmesg | grep -aiE 'oom|killed process'; } 2>&1" >"$SERIAL.leg4-install" || true
+        info "install diagnostics kept at $SERIAL.leg4-install"
+        _leg4_srv_stop
         return
     fi
     if [ "$(_ssh "jq -r '.to' /data/pithead/data/os-update/in-flight.json" 2>/dev/null)" = "${tag#v}" ]; then
@@ -1125,8 +1127,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     [ -n "$before" ] && _os_step '{"action":"reboot"}' 30 >/dev/null 2>&1 || true # the machine goes away mid-poll; no id, no reboot
     [ -n "$before" ] && _wait_new_boot "$before" 420 || {
         bad "leg 4: guest never returned after the dashboard reboot intent"
-        kill "$srv_pid" 2>/dev/null
-        rm -rf "$srv"
+        _leg4_srv_stop
         return
     }
     marker=$(_ssh cat /etc/pithead-test-marker)
@@ -1151,8 +1152,7 @@ phase_update_dashboard() { # <good-bundle-path> <serial-byte-offset-before-this-
     else
         bad "leg 4: /api/state does not carry the updated verdict — the banner would never show"
     fi
-    kill "$srv_pid" 2>/dev/null
-    rm -rf "$srv"
+    _leg4_srv_stop
 }
 
 phase_install() {


### PR DESCRIPTION
## What

A failed dashboard-driven install (update phase, leg 4) now keeps the guest's own account before the harness returns: the root runner's own unit journal (`pithead-control.service`, 200 lines), the boot journal's rauc and OS-install lines, `rauc status`, `/data` and `/tmp` usage, memory, and any OOM kill, at `/tmp/pithead-os-serial.log.leg4-install`. The capture's ssh is capped at 120 s so it cannot hold the harness, and an empty capture is reported as empty rather than as kept. Docs: one bullet under the harness rules in `docs/dev/appliance-release.md`.

## Why

The #1651 gate on the freeze tip (BUILD_COMMIT bc685eeb) went 187/1. The one red was leg 4's install: the dashboard result said `[ERROR] rauc install failed` and nothing else. The runner deletes `.install.log` on failure and the container-visible result carries only a whitelist-extracted last line (`48-os-update-verbs.sh`), and `--phase all` destroyed the guest before anyone could read its journal. The cause is still not established; this PR makes the next red name it.

Re-derived, not relayed: the runner bounds only the lock wait (`PITHEAD_EX_LOCK_TIMEOUT`), never `rauc install` itself, so a timeout hypothesis is out.

## What was RUN

- `bash -n`, `shfmt -i 4 -d` (clean, rc 0), `shellcheck --severity=warning tests/os/run.sh` (the Makefile's severity; rc 0), `make lint-docs-voice` (OK).
- Line-neutral: `tests/os/run.sh` stays at its 3423 ceiling. The eight identical release-server teardown pairs (`kill "$srv_pid"; rm -rf "$srv"`) fold into `_leg4_srv_stop`, which reads the caller's locals by bash's dynamic scope.
- Local control of the remote command string on the bench host: 175 KB captured, and a permission error from `dmesg` landed IN the capture, proving the `2>&1` wrapping.
- `sudo tests/os/run.sh --phase update --keep` on this tree (image bytes identical to bc685eeb: `git diff bc685eeb..HEAD -- os/ dashboard/ lib/pithead/ pithead build/ docker-compose*.yml VERSION` is empty): rc 0, every leg 4 row green, so the capture path was NOT exercised by a real failure this run. The kept guest's journal gave the success baseline: the slot write took 3m14s and systemd accounted rauc.service at a 6.9 GB memory peak in the 16 GB guest.


## Head moved after the first review pass (two commits on top of the reviewed 90522db0)

- **The runner unit, verified at source, not relayed:** `lib/pithead/50-control-runner-provisioning.sh:113-121` writes `pithead-control.service` as `Type=oneshot`, `User=root`, `ExecStart` only, no `Standard*` redirection, so the runner's `warn "OS install failed (rc=…); log tail: …"` (`48-os-update-verbs.sh:306`) lands in the journal under that unit. The capture now reads `journalctl -b -u pithead-control.service -n 200` explicitly, ahead of the pattern grep. It carries the runner's 500-byte log TAIL, not the deleted install log.
- **Cannot stall the harness:** `_ssh` defaults to `timeout 5400`; `_os_step … 900` can return with rauc still `installing`, and nothing in the tree wraps a `rauc` call in a timeout, so `rauc status` could have held the harness 90 minutes. The capture call is prefixed `SSH_TIMEOUT=120`. Measured here: the prefix reaches the function (`T=5 f` prints 5); the reviewer measured separately that it does not persist after the call.
- **An empty capture says so:** the `info` is gated on `[ -s "$SERIAL.leg4-install" ]` (the file's own precedent at the console copy), otherwise it points at `$SERIAL.failed`.
- **Not done, and forced:** the capture is one 477-character line (base max 302). `tests/os/run.sh` sits at exactly its 3423 ceiling and `shfmt` expands every line-saving shape (one-line function bodies, semicolon lists), so splitting the string costs a line the budget has not got. Nothing gates line length; the reviewer checked. The capture reads the current boot only; the serial log spans a reboot.
- **Run on the final head:** `bash -n`, `shfmt -d`, `shellcheck --severity=warning` (rc 0 each), `make lint-docs-voice` OK, line count 3423 = ceiling, image-path diff to the freeze tip `bc685eeb` EMPTY (the same filter fires on the previous merge as its control). The capture script was run locally through `bash -c` as a parse control; no red has exercised it on a guest.

## Not done

- No red has run through the new capture yet; its first real exercise is the next gate red.
- The gate itself is not re-run here.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this worktree)

Pure move for the teardown: added ∖ removed = one helper definition; every one of the eight sites becomes a one-line call. Adjacent merge considered and rejected: folding the capture into `_leg4_srv_stop` would run a 300-line journal read on every leg-4 exit, including the seven that are not the install; the capture stays at the one site whose failure loses its evidence.

Closes #none — #1651 stays open until the gate is green on a named tree.

