### PR TITLE
feat(os): #1826 repin RIGFORGE_REF to RigForge v1.17.0

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -571,20 +571,19 @@ How it stays safe:
   against its prefill, table mode only ever emits a key you changed. The change record never gets
   a chance to hold the value either way — it strips the password and the TLS fingerprint out
   before writing, and strips them again out of every read.
-  **Editing a pool entry is a different story, and it is not fully solved yet.** RigForge deletes
-  `pass` and `tls-fingerprint` before serving its enriched feed (`rigforge.sh`'s
-  `_api_config_json`), so on a stock rig `pools` reaches this dashboard with no password key at
-  all — no `{__secret__: true}` sentinel, nothing for the editor to recognise as "a credential
-  lives here." (The sentinel and the scrub chain that removes a stray one before it reaches the
-  rig do exist and do fire, but only for a rig running an older or patched build that still serves
-  `pass`.) **Edit a pool entry's URL or any other field on a stock rig, in either mode, and the
-  submitted entry carries no password — RigForge accepts it: a missing `pass` defaults to the
-  literal string `x` (`parse_config`), and `_control_commit` replaces the array wholesale, so the
-  rig starts running with password `x`, silently.** Fixing this needs a change on the RigForge
-  side — a marker for "a password is set" that `_control_commit` can honour when an incoming entry
-  omits `pass` — tracked as rigforge#415; this dashboard's sentinel machinery becomes the real
-  defence once that lands. Until then, re-supply a pool's password whenever you edit anything else
-  on that pool.
+  **Editing a pool entry keeps its password, with one exception.** RigForge serves a stored
+  `pass` or `tls-fingerprint` as the `{__secret__: true}` sentinel and never the value
+  (`rigforge.sh`'s `_api_config_json`, rigforge#415, in the build this appliance bakes); a pool that
+  stores no password arrives with no `pass` key at all, so "not set" stays distinguishable from
+  "set but hidden". The editor keeps the sentinel in its prefill, the scrub chain drops it again
+  before the request reaches the rig, and `_control_commit` restores the stored value for an
+  incoming entry that omits `pass` or carries the sentinel — matched on the entry's `url` and
+  `user`. **Change a pool's URL or its user and that match finds nothing: the entry commits as a
+  brand-new pool with no password, which `parse_config` defaults to the literal string `x`, and the
+  rig starts running with password `x`, silently.** Re-supply the password whenever you change a
+  pool's URL or user; editing any other field on the pool keeps it. A rig on a RigForge build older
+  than 1.17.0 still deletes `pass` outright before serving it, and there every pool edit needs the
+  password re-supplied.
 
 RigForge keeps no config history on the rig, so Pithead owns it: every change the dashboard applies is
 recorded with its keys, outcome, and time. The editor prefills from the rig's own current writable

--- a/docs/dev/integration-testing.md
+++ b/docs/dev/integration-testing.md
@@ -512,13 +512,15 @@ loudly without its prerequisite:
 - **Three writable keys are deliberately never driven, and this is a decision rather than a gap.**
   `autotune` would start a real tuning run — it moves hashrate and thermals and may not settle
   inside the leg. `watchdog` would remove thermal protection from a rig mining at its temperature
-  ceiling. `pools` cannot be round-tripped from the rig's own reading at all: RigForge strips `pass`
-  and `tls-fingerprint` before serving the config, and the dashboard strips them again, so the value
-  that comes back is lossy — and `pass` is the stack's stratum password
+  ceiling. `pools` cannot be round-tripped from the rig's own reading at all: RigForge serves a
+  stored `pass` or `tls-fingerprint` as the `{"__secret__": true}` marker and never the value, and
+  the dashboard drops the marker again on the way back, so the value that comes back is lossy — and
+  `pass` is the stack's stratum password
   ([#113](https://github.com/p2pool-starter-stack/pithead/issues/113)), which the proxy rejects a
-  login without. Worse, the harness cannot tell "this rig has no password" from "this rig's password
-  was stripped on the way to me": both arrive as `{"url": …}`. Writing that back would silently
-  strand a borrowed miner.
+  login without. The marker does let the harness tell "this rig has no password" (no `pass` key)
+  from "a password is stored here", but RigForge restores a stored password only for an entry whose
+  `url` and `user` still match what the rig holds, and a probe moves the URL. Writing the rig's own
+  reading back under a probe would silently strand a borrowed miner on password `x`.
 - `pools`, the operator-supplied route (the repoint-your-hashrate key): because the rig's own
   reading cannot be written back, the restore target is the dashboard's record of what *it* last
   pushed (`GET /api/worker`'s `.last_applied.pools`), which is un-stripped, and the probe is

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -186,7 +186,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image
 # build because nothing can be installed later — apt cannot run on the read-only root, and even
 # a rw-remount install leaves its /etc state (alternatives, ld.so.cache) on the volatile overlay
-# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.16.0 release
+# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.17.0 release
 # (by commit, not tag name, so a moved tag cannot change the bake); bump it release by release.
 # v1.16.0 is the floor for the HugePages pool ceiling: hugepages_pool_ceiling_mb (rigforge#398,
 # filed from #1103) is absent from v1.15.1's tree entirely, and declaring it into one fails OPEN —
@@ -204,7 +204,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=4ce29b3daf063fd1b45e050649e93aa9592618e1
+ARG RIGFORGE_REF=efd23e440ce8a160a9251f59f0ebcc5faa7ad4f1
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \

--- a/tests/integration/fakes/contract/v1/PROVENANCE
+++ b/tests/integration/fakes/contract/v1/PROVENANCE
@@ -1,2 +1,2 @@
-ref=4ce29b3daf063fd1b45e050649e93aa9592618e1
-version=1.16.0
+ref=efd23e440ce8a160a9251f59f0ebcc5faa7ad4f1
+version=1.17.0

--- a/tests/integration/fakes/contract/v1/feed.json
+++ b/tests/integration/fakes/contract/v1/feed.json
@@ -24,6 +24,9 @@
       "max_temp_c": 85,
       "pools": [
         {
+          "pass": {
+            "__secret__": true
+          },
           "url": "h:3333"
         }
       ],

--- a/tests/integration/fakes/fake_worker_api.py
+++ b/tests/integration/fakes/fake_worker_api.py
@@ -83,12 +83,13 @@ _RIGFORGE_BLOCK = {
         "strikes": 0,
     },
     # The rig's EFFECTIVE writable config (rigforge#253), what Worker Inspect prefills from (#1235).
-    # Exactly the six writable keys, and `pools` carries only what the producer leaves after its own
-    # `del(.pass, ."tls-fingerprint")` — a contract-shaped body cannot contain a credential, which
-    # is why the credential-strip defence is proven at tier 1 against a deliberately hostile body
-    # and not here. Testing it here too would be the same behaviour at two tiers.
+    # Exactly the six writable keys. `pools[].pass` is the {"__secret__": true} marker: since the
+    # ref PROVENANCE names, the producer serves a STORED pool password as that marker and omits the
+    # key when none is stored (rigforge#415), so a contract-shaped body still never carries a
+    # credential. The credential-strip defence is proven at tier 1 against a deliberately hostile
+    # body and not here; testing it here too would be the same behaviour at two tiers.
     "config": {
-        "pools": [{"url": "itest-proxy:3333"}],
+        "pools": [{"url": "itest-proxy:3333", "pass": {"__secret__": True}}],
         "DONATION": 1,
         "autotune": "disabled",
         "watchdog": "enabled",

--- a/tests/integration/fakes/test_contract.py
+++ b/tests/integration/fakes/test_contract.py
@@ -403,9 +403,9 @@ def test_worker_config_prefill_parses_over_the_wire():
     with FakeWorkerApi(auth="none") as fake:
         payload = _probe_worker(fake, auth="none")
     cfg = parse_rigforge(payload)["config"]
-    # Exactly the writable keys, with the rig's own values — not our record of what we last pushed.
+    # Exactly the writable keys, with the rig's own values; pools[].pass is the producer's {"__secret__": true} marker, kept as-is (rigforge#415, #1548).
     assert cfg == {
-        "pools": [{"url": "itest-proxy:3333"}],
+        "pools": [{"url": "itest-proxy:3333", "pass": {"__secret__": True}}],
         "DONATION": 1,
         "autotune": "disabled",
         "watchdog": "enabled",


### PR DESCRIPTION
**Pins RigForge `v1.17.0` — the annotated tag's target commit, re-derived two ways (`gh api repos/p2pool-starter-stack/rigforge/commits/v1.17.0` and `git ls-remote --tags` `^{}` row agree; equals rigforge `main`; `VERSION` at that ref reads `1.17.0`). The Dockerfile fetches `archive/<sha>.tar.gz`, a git archive by commit, so the RigForge GitHub Release still being a DRAFT does not block the bake.** Closes nothing on `develop-v2`; #1826 is hand-closed after the gate.

## Why (#1826)

Operator ruling relayed by the control seat (2026-09-05T17:15Z): RigForge's next release is cut first and repinned into the appliance BEFORE the 2.0.0 soak image. The #1651 gate on the `develop-v2` tip `f5a8f32d` went GREEN (194/0, comment 5553782068) and is the v1.16.0 baseline; the soak image is built from the repinned tree after its own full gate.

## What moves, and why each file is in the diff

- `os/rootfs/Dockerfile` — `ARG RIGFORGE_REF` and the comment naming the release. `tests/os/verify-image.sh` needs NO edit: `rigforge_ref_matches` (`tests/os/verify-image.sh:28-33`) reads the ARG out of the Dockerfile and compares it to the baked `/opt/rigforge/RIGFORGE_REF` record.
- `tests/integration/fakes/contract/v1/feed.json`, `PROVENANCE` — re-copied from the producer at the pinned ref. RigForge's fixture gained `pools[].pass: {"__secret__": true}` since v1.16.0 (rigforge#415); `control-status.json` is byte-identical at v1.16.0 and at v1.17.0 (the repin script re-copied it and `git diff` shows no change), so the `/status` vocabulary re-check the Dockerfile comment asks for is satisfied by bytes.
- `tests/integration/fakes/fake_worker_api.py` — the fake's served config carries the same key, or `test_fake_matches_the_vendored_wire_contract` (key-set equality both ways) reds.
- `tests/integration/fakes/test_contract.py` — the prefill-over-the-wire expected literal now carries the marker: `parse_rigforge` passes it through unchanged, which is what the editor relies on to recognise and never resend it (#1548).

Consumer side, checked before calling this pin-only: the dashboard already treats a nested `{"__secret__": true}` in `pools[].pass` as a masked token it never held (#1548, #1543). `xmrig_client.py:174`'s "a stock feed never does" stays TRUE after the repin: v1.17.0's `_api_config_json` (`rigforge.sh:5333`) masks a `pass` only when a non-empty string is STORED and still deletes it otherwise, and `config.minimal.json` stores none — the vendored fixture carries the marker because its source config sets `"pass": "secret"` (rigforge `tests/run.sh:9745`), not because a stock feed serves it. (Reviewer pass 1 finding 1; an earlier body said the opposite.). RigForge's `util/proposed-grub.sh` gained the #410 clamp below the lines `14-local-miner.sh` and `test_appliance_hugepages.sh` cite, so those citations still hold. `PITHEAD_RIGFORGE_POOL_CEILING_FLOOR=1.16.0` is a floor, not the pin.

## Shared / out-of-lane files — `.lane-override`, disclosed

The four files under `tests/integration/fakes/` are the `e2e` lane's path; that lane is wound down. They ride here under the one-shot override because the pin cannot merge without them (two contract guards red, one of them FAILS in CI by design when the producer disagrees). `docs/dev/file-budget.tsv` is NOT touched: the placeholder head had grown `test_contract.py` to 453 over its 451 ceiling (its "lint-file-budget clean" claim was WRONG; the gate FAILS there), and the ratchet refuses a raised row, so the two added comment lines are folded into the existing one and the file stays at 451. No serialized shared file is touched.

## What was RUN (in the repin worktree at this head, the v1.17.0 commit)

- `make test-fakes`: 31 passed, 0 skipped — `test_vendored_contract_bytes_match_the_producer_at_the_baked_ref` RAN against the producer at the v1.17.0 ref (not skipped).
- `make lint-py`, `make lint-file-budget`, `make lint-topology`: clean.
- Negative control at THIS head, mutation restored after (tree clean): `PROVENANCE` ref moved back to the v1.16.0 pin → `test_vendored_contract_ref_line_agrees_with_the_baked_pin` FAILED (see the run line below). The fake-without-the-new-key control was run at the placeholder head (`303cbbc6`): 2 FAILED, 28 passed — the fake did not change between that head and this one, so it is relayed from that run, not re-run here.

NOT run: `make lint-sh` (no shell file changed), the docker e2e suite `tests/integration/run.sh` (CI runs it; the fake's served config is what changed), and the KVM battery — image bytes move, so the freeze tip moves on merge and the FULL gate runs on the merged tip per the seat's directive. A red on a RigForge-related rig row there is the new release misbehaving on the appliance and goes on the RigForge tag first.

## Over-engineering pass (by hand — the PR-gate hook keys off the pinned shell cwd's branch, not this worktree's, and checks nothing)

Every file in the diff has a guard that reds without it; nothing else was added. Rejected: loosening the key-set guard to tolerate a missing `pass` (the both-ways equality IS the file's thesis), and having the fake strip the marker (it would pin a shape no rig sends). One follow-up NOT here: the 2.0.0 CHANGELOG on `release/2.0.0-prep` (#1774) should name the RigForge bump once the version is known — a serialized shared file on another branch.




## Docs delta (reviewer pass 1, finding 2)

The repin falsified two prose sites the diff did not touch, both written against v1.16.0's unconditional `del(.pass, ."tls-fingerprint")` (`rigforge.sh:4955` at the old pin). Corrected at source, re-derived from `rigforge.sh` at `efd23e44` and rigforge `tests/run.sh:7992-7993,8016`:

- `docs/dashboard.md` § Worker Inspect, "Editing a pool entry": the named function now masks a stored credential rather than deleting it; `_control_commit` restores it for an entry that omits `pass` or carries the sentinel, matched on `url`+`user` (`rigforge.sh:4392` `pkey`); the "until then, re-supply on every edit" imperative narrows to "re-supply when you change a pool's URL or user" (a moved URL commits as a brand-new pool, `pass` absent, `parse_config` defaults it to `x`). A pre-1.17.0 rig keeps the old behaviour and the old advice, and the passage says so.
- `docs/dev/integration-testing.md` § Rig legs, `pools`: the harness CAN now tell "no password" (no key) from "stored" (marker); the restore still cannot write the rig's reading back because the probe moves the URL, so the `.last_applied.pools` restore target is unchanged.

Lints at this head, run by me in the branch worktree: `lint-docs-voice` self-test OK, `lint-md` 0 errors over 47 files, `lint-file-budget` OK (no tsv change). Topology detector: clean over the ADDED lines; per-file hit counts on each doc are identical at base `5ce19927` and at this head (the file-level hits pre-exist this PR and sit on lines it never touched).
