### PR TITLE
fix(dashboard): #1830 the wizard opens on Pithead + RigForge, and the select IS the miner switch

### DIFF
--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -752,8 +752,8 @@ export class WizardApp extends Component {
             change later.<//>
             <${Field} label="Mine on this machine too?">
                 <select value=${String(v("localMiner") ?? false)} onChange=${on("localMiner")}>
-                    <option value="false">No — this box only coordinates the miners (default)</option>
-                    <option value="true">Yes — this machine also mines with its own CPU (built-in RigForge)</option>
+                    <option value="false">No — this box only coordinates the miners</option>
+                    <option value="true">Yes — this machine also mines with its own CPU (built-in RigForge, default)</option>
                 </select>
             <//>
             ${

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -260,10 +260,9 @@ export class WizardApp extends Component {
     jsonText: "",
     jsonError: "",
     authMode: "auto", // auto | set | none — travels beside the config (see wizard.py submit)
-    // What this machine IS — the first disclosure, above the disk. pithead | both | rig.
-    // "both" rides the existing local_miner switch; "rig" collapses the form to three answers
-    // that travel beside the config exactly like authMode does.
-    role: "pithead",
+    // What this machine IS, asked above the disk. ONLY "rig" is stored — it is the one answer
+    // that carries no config; the two coordinators are read back out of one (see renderSetup).
+    role: "",
     rigPool: "",
     rigWorker: "",
     rigPassword: "",
@@ -372,13 +371,12 @@ export class WizardApp extends Component {
   };
 
   // The role reshapes the page the way the disk choice does. "Both" IS the existing
-  // local_miner switch — the role presets it and the switch below stays live; back to plain
-  // Pithead resets it to the documented default so the submitted config is byte-for-byte
-  // today's. The rig role never touches the config at all.
+  // local_miner switch: picking it turns that switch on, plain Pithead turns it off, and the
+  // switch below stays live either way. Neither is stored; a rig never touches the config.
   setRole = (e) => {
     const role = e.target.value;
     const cfg = this.state.cfg;
-    const next = { role, cfg };
+    const next = { role: role === "rig" ? "rig" : "", cfg };
     if (role !== "rig") {
       pathSet(cfg, "local_miner.enabled", role === "both");
       // "usb" only exists for rigs — a coordinator switching back must re-pick a real disk.
@@ -598,7 +596,9 @@ export class WizardApp extends Component {
     const remoteMonero = v("moneroMode") === "remote";
     const remoteTari = v("tariMode") === "remote";
     const { installer, disks, chosen, confirm, wipe, dataWiped } = this.state;
-    const rig = this.state.role === "rig";
+    // The select is stored for a rig and read out of the config for the two coordinators.
+    const role = this.state.role || (v("localMiner") ? "both" : "pithead");
+    const rig = role === "rig";
     // Keep-everything reinstall: the machine's settings, wallets, login and chains all survive,
     // so there is nothing to ask — the config half of the page would collect answers the
     // machine will ignore (its preserved config wins). Only the disk half renders.
@@ -643,7 +643,7 @@ export class WizardApp extends Component {
         <${Err}>${error}<//>
         <form onSubmit=${this.submit}>
             <${Field} label="What is this machine?">
-                <select value=${this.state.role} onChange=${this.setRole}>
+                <select value=${role} onChange=${this.setRole}>
                     <option value="pithead">Pithead</option>
                     <option value="both">Pithead + RigForge</option>
                     <option value="rig">RigForge</option>

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -229,10 +229,10 @@ async def auth(request: web.Request) -> web.Response:
 
 
 async def wizard_state(request: web.Request) -> web.Response:
-    """Everything the SPA needs to render: which flow, the effective config (defaults with the
-    last attempt merged over them — a rejected config comes back for editing rather than making
-    someone retype a 95-character address), the reference for type coercion, the host's error,
-    and the disk inventory in installer mode."""
+    """Everything the SPA needs to render: which flow, the effective config (the defaults with a
+    previous configuration merged over them — a pre-seed, a reinstall pre-fill or a rejected
+    submission, each of which WINS WHOLE; a machine that has never been configured gets this
+    page's own default instead), the reference, the host's error, and the disk inventory."""
     if not _authed(request):
         return web.json_response({"error": "unauthenticated"}, status=401)
     ref = _reference()
@@ -243,7 +243,7 @@ async def wizard_state(request: web.Request) -> web.Response:
             "stage": stage,
             # Kept for the field's original meaning; `stage` is what the client renders from.
             "mode": "installer" if installer_mode() else "setup",
-            "config": _deep_merge(ref, _last_attempt()),
+            "config": _deep_merge(ref, _last_attempt() or {"local_miner": {"enabled": True}}),
             "reference": ref,
             "error": _spool_read("error.txt"),
             "disks": _disks(),

--- a/dashboard/tests/frontend/wizard.test.mjs
+++ b/dashboard/tests/frontend/wizard.test.mjs
@@ -400,7 +400,7 @@ test("submit validates IN PLACE: no view swap, the button narrates, the server m
   restore();
 });
 
-test("the mine-on-this-box choice is a labeled select naming RigForge, default No", async () => {
+test("the mine-on-this-box choice is a labeled select naming RigForge, default Yes", async () => {
   const { inst, restore } = await appOn([stateFor("setup")]);
   const out = renderToString(inst.render());
   assert.match(out, /Mine on this machine too\?/);

--- a/dashboard/tests/frontend/wizardrole.test.mjs
+++ b/dashboard/tests/frontend/wizardrole.test.mjs
@@ -1,0 +1,82 @@
+// The setup wizard's role select (mining_dashboard/web/static/wizard.mjs): what an unconfigured
+// machine opens on (#1830), and the single fact it shares with the built-in-miner switch
+// (#1831). A sibling of wizard.test.mjs rather than more rows inside it: that file sits at its
+// recorded ceiling in docs/dev/file-budget.tsv, and ceilings only go down.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { WizardApp } from "../../mining_dashboard/web/static/wizard.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// The published reference as a real machine has it: config.reference.json carries
+// local_miner.enabled and documents it OFF (#593), which is what the CLI wizard keeps.
+const REF = {
+  monero: { wallet_address: "", prune: true },
+  p2pool: { pool: "mini" },
+  local_miner: { enabled: false },
+};
+const cfgFor = (enabled) => ({
+  monero: { wallet_address: "", prune: true },
+  p2pool: { pool: "mini" },
+  local_miner: { enabled },
+});
+
+// A mounted wizard sitting on a given config. The server round trip is deliberately not driven
+// here — loadState's own behaviour is asserted in wizard.test.mjs, and what the SERVER publishes
+// for an unconfigured machine is pinned at its own tier in tests/web/test_wizard_role.py.
+function appOn(cfg) {
+  const inst = new WizardApp({});
+  inst.setState = (patch) =>
+    Object.assign(inst.state, typeof patch === "function" ? patch(inst.state) : patch);
+  Object.assign(inst.state, {
+    stage: "setup",
+    cfg,
+    reference: REF,
+    jsonText: JSON.stringify(cfg, null, 2),
+  });
+  return inst;
+}
+
+test("a machine whose config has the miner on opens on Pithead + RigForge (#1830)", () => {
+  const out = renderToString(appOn(cfgFor(true)).render());
+  assert.match(out, /<select value="both"/); // the select
+  assert.match(out, /Nothing to install/); // the switch's own Yes note — the same fact
+});
+
+test("a machine whose config keeps the miner off opens on Pithead (#1830 control)", () => {
+  // The control that shows the row above can say something else. It is also the real case: a
+  // pre-seed, a reinstall pre-fill and a rejected submission all arrive with their own config
+  // and win whole over the page's default (tests/web/test_wizard_role.py pins that half).
+  const out = renderToString(appOn(cfgFor(false)).render());
+  assert.match(out, /<select value="pithead"/);
+  assert.doesNotMatch(out, /Nothing to install/);
+});
+
+test("the miner switch moves the role select, and so does the JSON pane (#1831)", () => {
+  const inst = appOn(cfgFor(false));
+  // The switch is the plain field edit the rendered <select> is bound to (FIELDS.localMiner).
+  inst.edit("local_miner.enabled")({ target: { value: "true" } });
+  assert.match(renderToString(inst.render()), /<select value="both"/);
+  inst.edit("local_miner.enabled")({ target: { value: "false" } });
+  assert.match(renderToString(inst.render()), /<select value="pithead"/);
+  // Hand-edited JSON wins the same way, because it is the same one fact.
+  inst.editJson({ target: { value: JSON.stringify(cfgFor(true)) } });
+  assert.match(renderToString(inst.render()), /<select value="both"/);
+});
+
+test("picking rig IS stored, and outranks whatever the config's miner switch says (#1831)", () => {
+  // A rig carries no config at all, so it is the one answer that cannot be read out of one.
+  const inst = appOn(cfgFor(true));
+  inst.setRole({ target: { value: "rig" } });
+  assert.equal(inst.state.role, "rig");
+  assert.match(renderToString(inst.render()), /<select value="rig"/);
+  assert.equal(inst.state.cfg.local_miner.enabled, true); // untouched: a rig never edits config
+  // Back to a coordinator: nothing is stored, and the config answers again.
+  inst.setRole({ target: { value: "pithead" } });
+  assert.equal(inst.state.role, "");
+  assert.equal(inst.state.cfg.local_miner.enabled, false);
+  assert.match(renderToString(inst.render()), /<select value="pithead"/);
+});

--- a/dashboard/tests/frontend/wizardrole.test.mjs
+++ b/dashboard/tests/frontend/wizardrole.test.mjs
@@ -61,19 +61,22 @@ test("the (default) marker names the option an unconfigured machine opens on (#1
   // wizard.test.mjs asserts option text that survives moving the marker back, so a straight
   // revert of the fix ships green (measured by the non-author reviewer at this head).
   const out = renderToString(appOn(cfgFor(true)).render());
-  // Structure, not wording: read each option of THIS select and ask which one carries a default
-  // marker. Matching prose literals was BOTH too narrow and too brittle — it missed a marker
-  // duplicated onto No in the comma form, and it red on a pure reword of either label. Both
-  // needles are unique to their option; four other markers elsewhere on the page are why this is
-  // per-option rather than a page-wide count.
-  const label = (needle) => {
-    const m = out.match(new RegExp(`<option [^>]*>([^<]*${needle}[^<]*)<`));
-    assert.ok(m, `no rendered option matched ${needle}`); // a clean failure, not a TypeError
-    return m[1];
-  };
-  assert.match(label("also mines"), /\bdefault\b/);
+  // Structure, and keyed by VALUE rather than by prose: scope to this one select, then ask of
+  // each option what its value attribute is. Keying on label literals pinned the marker one
+  // indirection short of the thing — it stayed green when the two options' value attributes were
+  // swapped, and when the select's own binding was inverted, each of which puts the marker on
+  // the option the operator does not get, which is #1830 verbatim.
+  const sel = out.match(
+    /Mine on this machine too\?[\s\S]*?<select value="([^"]*)"([\s\S]*?)<\/select>/,
+  );
+  assert.ok(sel, "the mine-on-this-machine select did not render");
+  const opt = Object.fromEntries(
+    [...sel[2].matchAll(/<option value="([^"]*)"[^>]*>([^<]*)</g)].map((m) => [m[1], m[2]]),
+  );
+  assert.equal(sel[1], "true"); // the option an unconfigured machine actually opens on
+  assert.match(opt.true, /\bdefault\b/);
   // The load-bearing half: matching on Yes alone still passes if the marker is re-added to No.
-  assert.doesNotMatch(label("only coordinates"), /\bdefault\b/);
+  assert.doesNotMatch(opt.false, /\bdefault\b/);
 });
 
 test("the miner switch moves the role select, and so does the JSON pane (#1831)", () => {

--- a/dashboard/tests/frontend/wizardrole.test.mjs
+++ b/dashboard/tests/frontend/wizardrole.test.mjs
@@ -55,6 +55,17 @@ test("a machine whose config keeps the miner off opens on Pithead (#1830 control
   assert.doesNotMatch(out, /Nothing to install/);
 });
 
+test("the (default) marker names the option an unconfigured machine opens on (#1830)", () => {
+  // wizard.py:246 publishes local_miner.enabled true for a machine with no previous config, so
+  // the marker belongs on Yes. Nothing else on this page pins any marker's POSITION: the row in
+  // wizard.test.mjs asserts option text that survives moving the marker back, so a straight
+  // revert of the fix ships green (measured by the non-author reviewer at this head).
+  const out = renderToString(appOn(cfgFor(true)).render());
+  assert.match(out, /Yes — this machine also mines[^<]*, default\)/);
+  // The load-bearing half: matching on Yes alone still passes if the marker is re-added to No.
+  assert.doesNotMatch(out, /coordinates the miners \(default\)/);
+});
+
 test("the miner switch moves the role select, and so does the JSON pane (#1831)", () => {
   const inst = appOn(cfgFor(false));
   // The switch is the plain field edit the rendered <select> is bound to (FIELDS.localMiner).

--- a/dashboard/tests/frontend/wizardrole.test.mjs
+++ b/dashboard/tests/frontend/wizardrole.test.mjs
@@ -61,9 +61,19 @@ test("the (default) marker names the option an unconfigured machine opens on (#1
   // wizard.test.mjs asserts option text that survives moving the marker back, so a straight
   // revert of the fix ships green (measured by the non-author reviewer at this head).
   const out = renderToString(appOn(cfgFor(true)).render());
-  assert.match(out, /Yes — this machine also mines[^<]*, default\)/);
+  // Structure, not wording: read each option of THIS select and ask which one carries a default
+  // marker. Matching prose literals was BOTH too narrow and too brittle — it missed a marker
+  // duplicated onto No in the comma form, and it red on a pure reword of either label. Both
+  // needles are unique to their option; four other markers elsewhere on the page are why this is
+  // per-option rather than a page-wide count.
+  const label = (needle) => {
+    const m = out.match(new RegExp(`<option [^>]*>([^<]*${needle}[^<]*)<`));
+    assert.ok(m, `no rendered option matched ${needle}`); // a clean failure, not a TypeError
+    return m[1];
+  };
+  assert.match(label("also mines"), /\bdefault\b/);
   // The load-bearing half: matching on Yes alone still passes if the marker is re-added to No.
-  assert.doesNotMatch(out, /coordinates the miners \(default\)/);
+  assert.doesNotMatch(label("only coordinates"), /\bdefault\b/);
 });
 
 test("the miner switch moves the role select, and so does the JSON pane (#1831)", () => {

--- a/dashboard/tests/web/test_wizard_role.py
+++ b/dashboard/tests/web/test_wizard_role.py
@@ -1,0 +1,73 @@
+"""What the wizard server publishes as an unconfigured machine's starting point (#1830).
+
+A sibling of ``test_wizard.py`` rather than more rows inside it: that file sits at its recorded
+ceiling in ``docs/dev/file-budget.tsv``, and ceilings only go down. Its ``spool``/``client``
+fixtures are module-local, so this module carries its own copies.
+
+The half the operator SEES — the role select reading these back — is pinned where the dashboard
+tests its frontend: ``node --test`` over ``tests/frontend/wizardrole.test.mjs``.
+"""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    # The published reference as a real machine has it: local_miner is a documented key and it
+    # is documented OFF (#593). Without it here BOTH rows below could pass on a missing key.
+    sd.joinpath("config.reference.json").write_text(
+        json.dumps(
+            {
+                "monero": {"wallet_address": "", "mode": "local", "prune": True},
+                "p2pool": {"pool": "mini"},
+                "local_miner": {"enabled": False},
+            }
+        )
+    )
+    return sd
+
+
+@pytest.fixture
+async def client(spool):
+    c = TestClient(TestServer(wizard.make_app(exit_fn=lambda code: None)))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def _state(client):
+    await client.post("/auth", data={"token": "pit-X7KM2Q"}, allow_redirects=False)  # noqa: S106
+    return await (await client.get("/api/wizard-state")).json()
+
+
+async def test_an_unconfigured_machine_starts_with_the_built_in_miner_on(client):
+    # The page's own default, not the product's: the role select opens on "Pithead + RigForge",
+    # and that role IS this switch. The reference it is published beside still reads off, which
+    # is what the CLI wizard and every existing install keep.
+    s = await _state(client)
+    assert s["config"]["local_miner"]["enabled"] is True
+    assert s["reference"]["local_miner"]["enabled"] is False
+
+
+async def test_a_configuration_that_already_exists_wins_whole_over_that_default(client, spool):
+    # The control, and the reason the default does not merge UNDERNEATH a previous config: an
+    # operator pre-seed (12-firstboot-wizard.sh:162), the reinstall pre-fill read off the target
+    # disk (10-installer-preseed.sh:220) and a rejected submission all arrive as
+    # last-attempt.json, and strip_defaults drops local_miner entirely when it is off. Layered
+    # under one of those, this page would read a deliberate Pithead-only machine as
+    # "Pithead + RigForge" and switch its miner on behind the operator.
+    spool.joinpath("last-attempt.json").write_text(
+        json.dumps({"monero": {"wallet_address": "4KEEP"}})
+    )
+    s = await _state(client)
+    assert s["config"]["local_miner"]["enabled"] is False
+    assert s["config"]["monero"]["wallet_address"] == "4KEEP"

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -136,8 +136,8 @@ the machine gets a dashboard at all.
 
 | Choice | What it produces |
 |---|---|
-| **Pithead** (default) | A coordinator: p2pool, xmrig-proxy, Tor and the dashboard, plus the Monero and Tari nodes for whichever of the two you keep on this machine (the setup page asks). Does not mine itself unless you turn on the built-in miner. |
-| **Pithead + RigForge** | The same coordinator, plus a built-in miner on this machine's own CPU, pointed at its own pool. Same as turning on "Mine with this machine's CPU" below. |
+| **Pithead** | A coordinator: p2pool, xmrig-proxy, Tor and the dashboard, plus the Monero and Tari nodes for whichever of the two you keep on this machine (the setup page asks). Does not mine itself unless you turn on the built-in miner. |
+| **Pithead + RigForge** (default) | The same coordinator, plus a built-in miner on this machine's own CPU, pointed at its own pool. It is the same switch as "Mine on this machine too?" below, pre-answered — most people who put one machine on this image want it to mine as well as coordinate. Pick **Pithead** for a box that should only coordinate. |
 | **RigForge** | A rig: just the miner, pointed at a Pithead you already have running. No coordinator, no containers, no chains, no dashboard. |
 
 Picking **RigForge** collapses the rest of the page to three questions — the pool address
@@ -213,7 +213,7 @@ Then a handful of choices, all with sensible defaults:
 | Telegram bot | — | Optional. Alerts and status commands; needs both the token and the chat id. |
 | Monero node | run it here | Point at a node you already run. It has to be on your own network — a private address (10.x, 172.16–31.x, 192.168.x) or one reached over a VPN — because the machine only lets the mining containers dial private ranges; everything else goes through Tor. |
 | Tari node | run it here | Same, over a network you trust, and the same private-address requirement. Pointing Tari elsewhere is the single biggest saving on a small disk: it takes about 200 GB out of the budget. |
-| Mine with this machine's CPU | off | On if this box should mine as well as coordinate. Nothing to install: the image carries its own [RigForge](https://github.com/p2pool-starter-stack/rigforge) miner, pointed at this machine's own pool. It starts by itself once the stack is up, comes back on every boot, and appears in the dashboard's Workers view. The box is tuned for hashrate either way — the CPU governor and the HugePages reservation are set on every boot whether or not this switch is on. |
+| Mine on this machine too? | on | Off if this box should only coordinate — it is the same answer as the **Pithead** role above. Nothing to install: the image carries its own [RigForge](https://github.com/p2pool-starter-stack/rigforge) miner, pointed at this machine's own pool. It starts by itself once the stack is up, comes back on every boot, and appears in the dashboard's Workers view. The box is tuned for hashrate either way — the CPU governor and the HugePages reservation are set on every boot whether or not this switch is on. |
 | First sync | private over Tor | Faster over the open internet if days of syncing is too slow; it uses Tor afterwards either way. |
 | Dashboard login | generate one for me | Or choose your own password. "No login" is offered but leaves the dashboard — payout addresses, hashrate — open to anyone on your network; never combine it with the Tor onion. It also leaves the machine **unconfigurable from the dashboard** — editing settings can change the payout address, so that stays behind a login — and on a machine with no shell that is permanent: changing it means a factory reset and setting up again. |
 

--- a/docs/dev/appliance-wizard.md
+++ b/docs/dev/appliance-wizard.md
@@ -79,8 +79,8 @@ reshapes to the answer the same way the disk choice already reshapes the form:
 
 | Role | The form | What lands |
 |---|---|---|
-| Pithead | today's flow, byte for byte — the default, and the regression bar | `config.json` (the whole contract above) |
-| Pithead + RigForge | Pithead's form with the mine-on-this-machine switch preset to Yes. The role IS `local_miner.enabled` — the switch below stays live, and flipping it back submits today's config unchanged | `config.json` with `local_miner.enabled: true`; the boot contract's step 5 starts the miner |
+| Pithead | today's flow, byte for byte — the regression bar | `config.json` (the whole contract above) |
+| Pithead + RigForge | the default. Pithead's form, opening with the mine-on-this-machine switch already on. The role IS `local_miner.enabled` — the select and the switch are two views of ONE value, so moving either moves the other, and choosing Pithead submits today's config unchanged | `config.json` with `local_miner.enabled: true`; the boot contract's step 5 starts the miner |
 | RigForge | collapses to a pool address, a worker name and an optional stratum password. The pool field opens pre-filled when the host found a Pithead answering `pithead.local:3333` — dialed HOST-side and published to the spool as `rig-defaults.json`, the way the disk inventory travels, failing open to an empty field. The disk section gains **Run from this USB stick** as a first-class target: a rig holds almost no state, so the stick can BE the system — no erase, no commitment on machines whose disks belong to something else. The card shows the worker name and where it points; a rig has no dashboard and no login | `machine-role` + `rig.json` (below) |
 
 Validation-before-erase, the keep semantics, the card-then-ack gate, self-power-off and the


### PR DESCRIPTION
Closes #1830. Closes #1831. One change to how one control works, so one PR — the issues ask for
that explicitly.

## What changed

The setup wizard's role select now opens on **Pithead + RigForge**, and the two coordinator
answers are read back out of the config instead of being stored beside it. The select, the
"Mine on this machine too?" switch and the JSON pane are three views of `local_miner.enabled`
and cannot disagree.

- `wizard.mjs` — the select's value is `this.state.role || (v("localMiner") ? "both" : "pithead")`.
  Only `rig` is stored, because a rig carries no config at all and nothing else can express it;
  `setRole` stores nothing for either coordinator answer.
- `wizard.py` — `wizard_state` publishes `_deep_merge(ref, _last_attempt() or {"local_miner":
  {"enabled": True}})`. `config.reference.json` is untouched: the documented default stays off for
  the CLI wizard and every existing install.
- `docs/appliance.md` — "(default)" moves to the **Pithead + RigForge** row; the settings table's
  built-in-miner row moves to `on` and now quotes the label the page actually uses (it said
  "Mine with this machine's CPU"; the page says "Mine on this machine too?").

## The one design decision, and why it went this way

The default could have been layered *under* the last attempt. It must not be. `last-attempt.json`
is the channel for **three** different things, every one of which has to win whole:

| Channel | Writer |
|---|---|
| operator pre-seed from the medium | `lib/pithead/12-firstboot-wizard.sh:162` |
| reinstall pre-fill read off the target disk | `lib/pithead/10-installer-preseed.sh:220` (`prefill_from_previous_install`) |
| a rejected or previous submission | `dashboard/mining_dashboard/wizard.py:474` |

`strip_defaults` drops `local_miner` entirely when it is off, so a config from any of those three
that means "Pithead only" says so by **absence**. Merged underneath, this page's default would
have read a deliberate Pithead-only machine as "Pithead + RigForge" and switched its miner on
behind the operator on a reinstall. `_last_attempt() or {...}` makes that impossible by
construction, and the second server row below is the control that pins it.

## The audit the issue asked for

- **Server-side role fallbacks: there are none to fix.** `role` is read in exactly three places
  (`wizard.py:413`, `:451`, `:551`) and every one tests for `rig`. Absent `role` means
  "coordinator", and what a coordinator mines is `local_miner.enabled` in the config it submits —
  there is no second statement of the default to keep in step.
- **Restore-at-setup** goes through `/submit-restore` and never reads the published config. The
  restored config wins, unchanged.
- **Pre-seed and the reinstall pre-fill** are two of the three `last-attempt.json` channels above,
  so both win whole, by the decision above.
- **KVM provision rows: unaffected, and I checked every one.** Each `/submit` in `tests/os/run.sh`
  (`:780`, `:1255`, `:1574`, `:1678`, `:2012`, `:2787`, `:3176`) posts form **fields**, which go
  through `build_config`, not the published config — so none of them can see this default. `:2012`
  already names `local_miner=true` for the Both leg and `:2787` is the rig leg. The one row that
  reads `/api/wizard-state` is the reinstall pre-fill check at `:1422`, and it runs with a
  last-attempt present, so the default is suppressed there.

## Known gap, named rather than hidden

**The no-JS form path keeps today's behaviour.** `build_config` (`wizard.py:311`) sets
`local_miner` only when the submitted form says so, so a client that posts raw fields without
reading the published config — the KVM harness's curl, a text browser — still provisions without
the built-in miner. That is defensible on its own terms (an explicit field submission is an
explicit answer) and I deliberately did not change it: it would flip four provisioning legs of the
gating KVM battery to run a miner, which is not something to slip into this PR.

## Both new test files are SIBLINGS, because the budget gate leaves no room

`dashboard/tests/frontend/wizard.test.mjs` (765/765) and `dashboard/tests/web/test_wizard.py`
(974/974) are both AT their recorded ceilings, and ceilings only ever go down — so the rows go in
`tests/frontend/wizardrole.test.mjs` (82 lines) and `tests/web/test_wizard_role.py` (73), each
under the 400-line target and so needing no budget row. Neither production file grew either:
`wizard.mjs` is 889/889 and `wizard.py` 674/674 after this change, same as before it.
`docs/dev/file-budget.tsv` is therefore **not touched at all**.

## What was RUN

- `node --test dashboard/tests/frontend/` — **543 pass, 0 fail** (4 new).
- `uv run --locked --extra test python -m pytest` over `dashboard/` — **green, 97% total**, gate 80%.
- `bash tests/inventory.sh` — rc 0 (the CI drift gate; both new files are picked up by its globs).
- **`make lint`: 12 of the 13 targets green, `lint-sh` NOT RUN — and I am naming it rather than
  reporting a green.** Under `flock ~/.lint-sh-manual.lock` it died twice with
  `shellcheck: exceeded the 6G cgroup cap` (Error 137) — the #1206 class on this box, not a
  finding about this branch: the diff contains **no shell file at all**. I then ran the
  Makefile's own `lint:` list minus that one target —
  `lint-py lint-js lint-yaml lint-md lint-docs-voice lint-operator-strings lint-topology
  lint-file-budget lint-pithead-parity lint-trivy-parity lint-proto lint-toml` — **rc 0**,
  `lint-file-budget`'s own self-tests firing among them. CI's shellcheck is the authority here.
- `make test-patch-coverage` — **rc 0, and it is the vacuous shape (#1000), which its guard caught
  correctly**: `No lines with coverage information in this diff`, then
  `all 1 changed file(s) under the measured tree are present in coverage.xml`. The reason is real
  rather than a broken measurement — the only changed Python line is a value line inside a
  multi-line dict literal, plus a docstring, and coverage.py records neither as a statement. The
  statement they belong to is covered: `wizard.py`'s missing-line list does not name it.
- **Mutation battery — 4 mutations, 4 distinct redden-sets, no vacuous row.** Each printed the
  substitution it made, each proved it applied (the file's sha256 MOVED), and each file was
  restored and its sha256 re-checked afterwards:

  | Mutation | Reddens |
  |---|---|
  | server default removed (`_last_attempt() or {...}` -> `_last_attempt()`) | server row 1 only — row 2 stays green, which is what shows the instrument can read a `False` |
  | the select stops reading the config (`\|\| (v("localMiner") ? …)` -> `\|\| "pithead"`) | frontend rows 1 and 3 |
  | the select answers `"both"` regardless | frontend rows 2, 3 and 4 |
  | `setRole` stores nothing at all | frontend row 4 only |

  The third exists only so that row 2 — the Pithead control — is not a row that has never been
  shown able to fail.
- `~/dev/fleet/lane-guard.sh` **rc 0** on the staged paths, **with a firing control**: staging a
  one-byte change to `lib/pithead/14-local-miner.sh` alongside them returned **rc 1** naming that
  file and only that file, so the rc 0 means "granted", not "the guard waves everything through".
  The control file was restored and its sha256 re-checked.

## Over-engineering pass (the branch gate's, run by hand)

No changes came out of it. The derivation is one expression reusing the existing `v()` accessor —
no new method; `wizard.py` gains no constant and no helper; the three comment blocks rewritten in
`wizard.mjs` had each become FALSE ("the role presets it", "byte-for-byte today's"), so they are
repair, not scope. Six test rows for a two-line change is the one thing worth defending, and each
row is pinned by a distinct mutation above. **Two duplications stand deliberately**: each new test
file carries a small local harness (a 3-line `setState` stub; a `spool`/`client` fixture pair)
because the sibling files own theirs module-locally and are at their ceilings, so exporting from
them is not available.

## Disclosures

- `docs/appliance.md` is in `_shared.paths` — no lane owns `docs/`; disclosed here as the law asks.
- **No CHANGELOG entry.** `develop-v2`'s CHANGELOG has no `[Unreleased]` section: the `## [2.0.0]`
  section lives in the open release-prep pull 1774, so a competing section here would collide with
  it. This change is one more commit that section was written without, which is already the open
  finding in #1822.
- The new frontend file carries its own three-line harness rather than importing
  `wizard.test.mjs`'s: that file's helpers are module-local, and its shared `REF` object literal
  is mutated in place by earlier tests through `pathSet`, so a fixture built from it would carry a
  previous test's `local_miner`.
