### PR TITLE
fix(os): #1836 an appliance rig mints its control token, serves the sister feed and pins control to its coordinator

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -145,9 +145,16 @@ Picking **RigForge** collapses the rest of the page to three questions — the p
 addresses, runs no node, and serves nothing to log into. If a Pithead already answers on the
 network at `pithead.local:3333`, its address is filled in for you; otherwise enter it by hand
 from that machine's own "Point miners at" line. Confirming shows a summary card with the worker
-name and where it mines — **not a login**, because a rig has none. It appears in that Pithead's
-dashboard, under Workers, once it connects; from then on its own console is the only place to
-look at it, the same way you would watch any other machine on the network.
+name, where it mines, this machine's address and a **control token** — **not a login**, because
+a rig has none. The token is shown once and never again: a rig serves no page after this, so copy
+it now. It is what lets that Pithead adopt the rig: in its dashboard, under Workers, the adopt
+form takes this rig's address, control port `8082` and the token. Until you do that, the rig
+still mines and still appears under Workers once it connects, but its row reads as an API error,
+because the token guards every API on the rig — the miner's own included, so nothing else on the
+network can read or change it. From then on its own console is the only place to look at it, the
+same way you would watch any other machine on the network. A rig pointed at a pool with no
+IPv4 address (an onion address, say) keeps the token and the read-only feed but runs with
+control off, since RigForge refuses a writable path it cannot pin to one source.
 
 **Pithead + RigForge** asks every coordinator question below, unchanged, and adds the built-in
 miner on top. The two mining workloads on that one box do not compete for HugePages: the

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -52,6 +52,7 @@ dashboard/tests/web/test_worker_detail_meta.py	425
 dashboard/tests/web/test_xvb_views.py	1243
 .github/workflows/ci.yml	513
 lib/pithead/12-firstboot-wizard.sh	556
+lib/pithead/14-local-miner.sh	414
 lib/pithead/28-parse-and-validate-config.sh	485
 lib/pithead/33-render-env.sh	494
 lib/pithead/39-describe-change.sh	428
@@ -76,6 +77,7 @@ tests/stack/test-appliance-identity.sh	483
 tests/stack/test-appliance-media.sh	409
 tests/stack/test-appliance-os-update.sh	457
 tests/stack/test-appliance-os-update-verbs.sh	454
+tests/stack/test-appliance-rig-miner.sh	466
 tests/stack/test-backup.sh	523
 tests/stack/test-cli.sh	410
 tests/stack/test_compose.sh	462

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -281,14 +281,18 @@ who can sniff or MITM the mining LAN and capture the token can push config to yo
 mining LAN isolated from untrusted devices, and treat the token as a secret (it lives only in the
 owner-only `config.json`/`.env`, never in the dashboard container).
 
-NOTE: a rig provisioned by the appliance (the installer's RigForge choice) ships with control
-**off**. Its rendered RigForge config carries the `pools` entry — pool, worker name, stratum
-password — and nothing else: no `control` flag, no `ACCESS_TOKEN`. The appliance's built-in
-miner ships without control the same way. Such a rig mines and reports like any other, but
-Worker Inspect's config push and the [one-click rig upgrade](#one-click-rig-upgrade) cannot
-reach it. To make it editable, enable control on the rig itself (RigForge's `control` flag plus
-an `ACCESS_TOKEN`), then add its `host` + `token` entry to `workers.list[]` here, like any
-other rig.
+NOTE: a rig provisioned by the appliance (the setup page's RigForge choice) ships with control
+**on**, pinned to the Pithead it was pointed at. Its rendered RigForge config carries the `pools`
+entry — pool, worker name, stratum password — plus an `ACCESS_TOKEN` minted at setup, `api:
+enabled` and `control: enabled` with `api_allow_from` set to that Pithead's IPv4 address.
+`control_upgrade` stays off: an appliance rig updates through its own signed image, never through
+RigForge's upgrade path. The token is shown once, on the setup page's rig card, beside the rig's
+address. Until you adopt the rig — paste both into Worker Inspect's adopt form, or add its
+`host` + `token` entry to `workers.list[]` by hand — the dashboard's probe is refused (the feed
+wants the token) and the rig's row reads as an API error, though it mines all the while. A rig
+pointed at a pool with no IPv4 address (an onion address) renders with control off and the feed
+on. The appliance's built-in miner (the **Pithead + RigForge** choice) still ships without
+control: it sits on the same machine as the dashboard.
 
 Entries are matched by `name` — the rig's stratum worker name (the part before any `+` suffix).
 On a name miss the dashboard falls back to matching by the rig's connecting IP against an

--- a/lib/pithead/12-firstboot-wizard.sh
+++ b/lib/pithead/12-firstboot-wizard.sh
@@ -287,14 +287,14 @@ firstboot_wizard() {
             fi
             if [ "$rrc" -eq 0 ]; then
                 log "Rig settings accepted."
-                local rig_worker rig_pool
+                local rig_worker rig_pool rig_token
                 rig_worker=$(jq -r '.worker // ""' "$PWD/rig.json" 2>/dev/null)
                 rig_pool=$(jq -r '.pool // ""' "$PWD/rig.json" 2>/dev/null)
-                # The rig's card: the worker name and where it points. No dashboard, no login —
-                # a rig serves neither, so there is nothing to save; the same ack still gates
-                # the erase on the installation medium.
-                jq -n --arg w "$rig_worker" --arg s "stratum+tcp://$rig_pool" \
-                    '{role: "rig", worker: $w, stratum: $s}' >"$spool/handoff.json"
+                rig_token=$(rig_access_token) || rig_token="" # empty here = the render leg refuses below
+                # The rig's card: worker, pool, the control token (#1836 — minted once, shown ONCE: a rig serves
+                # no page after this) and this box's address for the adopt form. No login. The same ack still gates the erase.
+                jq -n --arg w "$rig_worker" --arg s "stratum+tcp://$rig_pool" --arg t "$rig_token" --arg a "$(hostname -I 2>/dev/null | awk '{print $1}')" \
+                    '{role: "rig", worker: $w, stratum: $s, token: $t, address: $a}' >"$spool/handoff.json"
                 chown 1000:1000 "$spool/handoff.json" 2>/dev/null || true
                 local hwait=0
                 while [ ! -f "$spool/handoff-ack" ] && [ "$hwait" -lt 600 ]; do

--- a/lib/pithead/14-local-miner.sh
+++ b/lib/pithead/14-local-miner.sh
@@ -286,21 +286,64 @@ provision_local_miner() {
 # miner. So it rides the SAME leg the Both role rides, sourced from rig.json instead of
 # config.json — one invocation contract, one prebuilt, one appliance mode.
 
+# The rig's control token (#1836): 32 hex, minted once and kept in rig.json beside the answers
+# it belongs to, so the config rebuilt at every boot carries the token the operator pasted into
+# the coordinator's adopt form. The token is this function's ONLY stdout — callers capture it.
+rig_access_token() {
+    local tok tmp="$PWD/.rig.json.tmp"
+    tok=$(jq -r '.access_token // ""' "$PWD/rig.json" 2>/dev/null)
+    if ! [[ "$tok" =~ ^[0-9a-f]{32}$ ]]; then
+        tok=$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
+        [[ "$tok" =~ ^[0-9a-f]{32}$ ]] || return 1
+        if ! { jq --arg t "$tok" '. + {access_token: $t}' "$PWD/rig.json" >"$tmp" 2>/dev/null &&
+            chmod 600 "$tmp" && mv -f "$tmp" "$PWD/rig.json"; }; then
+            rm -f "$tmp"
+            return 1
+        fi
+    fi
+    printf '%s' "$tok"
+}
+
+# The coordinator's address for RigForge's api_allow_from pin: rig.json's pool host resolved to
+# ONE IPv4. RigForge takes an address or CIDR there, never a name, and binds its API ports on
+# IPv4. Prints nothing when the host has no IPv4 — an onion pool, a name mDNS does not answer —
+# and the caller leaves control OFF rather than guess: RigForge refuses control without the pin.
+rig_coordinator_ip() {
+    local host
+    host=$(jq -r '.pool // ""' "$PWD/rig.json" 2>/dev/null)
+    host=${host%:*}
+    host=${host#\[}
+    host=${host%\]}
+    [ -n "$host" ] || return 0
+    getent ahostsv4 "$host" 2>/dev/null | awk '$1 ~ /^[0-9]+(\.[0-9]+){3}$/ { print $1; exit }'
+}
+
 # RigForge's config for a rig, derived from rig.json exactly the way the Both role's is derived
-# from config.json — rebuilt every boot, never repaired. Three values and no more: the pool the
-# operator gave, the worker name that labels this rig at that pool (RigForge's pools[].user,
-# which falls back to the hostname when empty), and the stratum password when one was set.
-# No hugepages_reserve_extra_mb: there is no stack on this machine to leave headroom for, so
-# RigForge sizes the HugePages pool for the miner alone.
+# from config.json — rebuilt every boot, never repaired. The pool the operator gave, the worker
+# name that labels this rig there (RigForge's pools[].user, the hostname when empty), the stratum
+# password when one was set — and, #1836, the rig's own token on every API, the read-only sister
+# feed the coordinator probes, and the writable control path pinned to the coordinator's address,
+# which is what lets the Workers view adopt this rig instead of showing "API error". Without the
+# token XMRig's own API stood open on the LAN. control_upgrade stays off: an appliance rig updates
+# through its own A/B bundle, never through RigForge's upgrade path. No hugepages_reserve_extra_mb:
+# there is no stack on this machine to leave headroom for, so RigForge sizes the pool for the miner.
 render_rig_miner_config() {
-    local dir
+    local dir tok allow
     dir=$(rigforge_dir)
     if [ ! -d "$dir" ]; then
         warn "This machine is a rig, but there is no RigForge tree at $dir — this image does not carry the miner."
         return 1
     fi
-    jq '{pools: [({url: .pool, user: (.worker // "")}
-        + (if (.stratum_password // "") == "" then {} else {pass: .stratum_password} end))]}' \
+    tok=$(rig_access_token) || {
+        warn "Could not mint or keep the rig's control token in rig.json — the miner was not configured."
+        return 1
+    }
+    allow=$(rig_coordinator_ip)
+    [ -n "$allow" ] || warn "The rig's control API stays off: the pool host does not resolve to an IPv4 address to pin it to. The read-only feed still serves, token required."
+    jq --arg tok "$tok" --arg allow "$allow" '{pools: [({url: .pool, user: (.worker // "")}
+        + (if (.stratum_password // "") == "" then {} else {pass: .stratum_password} end))],
+        ACCESS_TOKEN: $tok, api: "enabled"}
+        + (if $allow == "" then {} else {control: "enabled", api_allow_from: $allow} end)' \
         "$PWD/rig.json" >"$dir/config.json" 2>/dev/null || return 1
     chmod 600 "$dir/config.json" 2>/dev/null || true
 }

--- a/pithead
+++ b/pithead
@@ -2905,14 +2905,14 @@ firstboot_wizard() {
             fi
             if [ "$rrc" -eq 0 ]; then
                 log "Rig settings accepted."
-                local rig_worker rig_pool
+                local rig_worker rig_pool rig_token
                 rig_worker=$(jq -r '.worker // ""' "$PWD/rig.json" 2>/dev/null)
                 rig_pool=$(jq -r '.pool // ""' "$PWD/rig.json" 2>/dev/null)
-                # The rig's card: the worker name and where it points. No dashboard, no login —
-                # a rig serves neither, so there is nothing to save; the same ack still gates
-                # the erase on the installation medium.
-                jq -n --arg w "$rig_worker" --arg s "stratum+tcp://$rig_pool" \
-                    '{role: "rig", worker: $w, stratum: $s}' >"$spool/handoff.json"
+                rig_token=$(rig_access_token) || rig_token="" # empty here = the render leg refuses below
+                # The rig's card: worker, pool, the control token (#1836 — minted once, shown ONCE: a rig serves
+                # no page after this) and this box's address for the adopt form. No login. The same ack still gates the erase.
+                jq -n --arg w "$rig_worker" --arg s "stratum+tcp://$rig_pool" --arg t "$rig_token" --arg a "$(hostname -I 2>/dev/null | awk '{print $1}')" \
+                    '{role: "rig", worker: $w, stratum: $s, token: $t, address: $a}' >"$spool/handoff.json"
                 chown 1000:1000 "$spool/handoff.json" 2>/dev/null || true
                 local hwait=0
                 while [ ! -f "$spool/handoff-ack" ] && [ "$hwait" -lt 600 ]; do
@@ -3527,21 +3527,64 @@ provision_local_miner() {
 # miner. So it rides the SAME leg the Both role rides, sourced from rig.json instead of
 # config.json — one invocation contract, one prebuilt, one appliance mode.
 
+# The rig's control token (#1836): 32 hex, minted once and kept in rig.json beside the answers
+# it belongs to, so the config rebuilt at every boot carries the token the operator pasted into
+# the coordinator's adopt form. The token is this function's ONLY stdout — callers capture it.
+rig_access_token() {
+    local tok tmp="$PWD/.rig.json.tmp"
+    tok=$(jq -r '.access_token // ""' "$PWD/rig.json" 2>/dev/null)
+    if ! [[ "$tok" =~ ^[0-9a-f]{32}$ ]]; then
+        tok=$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
+        [[ "$tok" =~ ^[0-9a-f]{32}$ ]] || return 1
+        if ! { jq --arg t "$tok" '. + {access_token: $t}' "$PWD/rig.json" >"$tmp" 2>/dev/null &&
+            chmod 600 "$tmp" && mv -f "$tmp" "$PWD/rig.json"; }; then
+            rm -f "$tmp"
+            return 1
+        fi
+    fi
+    printf '%s' "$tok"
+}
+
+# The coordinator's address for RigForge's api_allow_from pin: rig.json's pool host resolved to
+# ONE IPv4. RigForge takes an address or CIDR there, never a name, and binds its API ports on
+# IPv4. Prints nothing when the host has no IPv4 — an onion pool, a name mDNS does not answer —
+# and the caller leaves control OFF rather than guess: RigForge refuses control without the pin.
+rig_coordinator_ip() {
+    local host
+    host=$(jq -r '.pool // ""' "$PWD/rig.json" 2>/dev/null)
+    host=${host%:*}
+    host=${host#\[}
+    host=${host%\]}
+    [ -n "$host" ] || return 0
+    getent ahostsv4 "$host" 2>/dev/null | awk '$1 ~ /^[0-9]+(\.[0-9]+){3}$/ { print $1; exit }'
+}
+
 # RigForge's config for a rig, derived from rig.json exactly the way the Both role's is derived
-# from config.json — rebuilt every boot, never repaired. Three values and no more: the pool the
-# operator gave, the worker name that labels this rig at that pool (RigForge's pools[].user,
-# which falls back to the hostname when empty), and the stratum password when one was set.
-# No hugepages_reserve_extra_mb: there is no stack on this machine to leave headroom for, so
-# RigForge sizes the HugePages pool for the miner alone.
+# from config.json — rebuilt every boot, never repaired. The pool the operator gave, the worker
+# name that labels this rig there (RigForge's pools[].user, the hostname when empty), the stratum
+# password when one was set — and, #1836, the rig's own token on every API, the read-only sister
+# feed the coordinator probes, and the writable control path pinned to the coordinator's address,
+# which is what lets the Workers view adopt this rig instead of showing "API error". Without the
+# token XMRig's own API stood open on the LAN. control_upgrade stays off: an appliance rig updates
+# through its own A/B bundle, never through RigForge's upgrade path. No hugepages_reserve_extra_mb:
+# there is no stack on this machine to leave headroom for, so RigForge sizes the pool for the miner.
 render_rig_miner_config() {
-    local dir
+    local dir tok allow
     dir=$(rigforge_dir)
     if [ ! -d "$dir" ]; then
         warn "This machine is a rig, but there is no RigForge tree at $dir — this image does not carry the miner."
         return 1
     fi
-    jq '{pools: [({url: .pool, user: (.worker // "")}
-        + (if (.stratum_password // "") == "" then {} else {pass: .stratum_password} end))]}' \
+    tok=$(rig_access_token) || {
+        warn "Could not mint or keep the rig's control token in rig.json — the miner was not configured."
+        return 1
+    }
+    allow=$(rig_coordinator_ip)
+    [ -n "$allow" ] || warn "The rig's control API stays off: the pool host does not resolve to an IPv4 address to pin it to. The read-only feed still serves, token required."
+    jq --arg tok "$tok" --arg allow "$allow" '{pools: [({url: .pool, user: (.worker // "")}
+        + (if (.stratum_password // "") == "" then {} else {pass: .stratum_password} end))],
+        ACCESS_TOKEN: $tok, api: "enabled"}
+        + (if $allow == "" then {} else {control: "enabled", api_allow_from: $allow} end)' \
         "$PWD/rig.json" >"$dir/config.json" 2>/dev/null || return 1
     chmod 600 "$dir/config.json" 2>/dev/null || true
 }

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -2730,15 +2730,23 @@ phase_media() {
     rm -f "$stick2"
 }
 
+_rig_mining_up() { # <tries>, 10 s apart — 0 once the xmrig unit is active with its process up
+    local n=0
+    while [ "$n" -lt "$1" ]; do
+        _ssh "systemctl is-active --quiet xmrig && pgrep -x xmrig >/dev/null" && return 0
+        sleep 10
+        n=$((n + 1))
+    done
+    return 1
+}
+
 phase_rig() {
     info "phase: rig (the OTHER machine this image installs — mines instead of coordinating)"
     # One image, two machines. Every other phase proves the coordinator; this one proves that
-    # answering "RigForge" on the same page produces a box with no stack at all, that it mines
-    # from the baked binary without compiling or reaching the network, and — the part that makes
-    # it a fleet member rather than a toy — that it takes an A/B update exactly like a
-    # coordinator does. A rig has no dashboard to complain through, so a rig that silently never
-    # starts is invisible to everything except an assertion like this one.
-    local img token jar body scode marker
+    # answering "RigForge" produces a box with no stack at all, mining the baked binary without
+    # compiling or reaching the network, that takes an A/B update exactly like a coordinator. A
+    # rig has no dashboard to complain through, so one that never starts is invisible otherwise.
+    local img token jar body scode marker card card_tok rtok pcode ptries=0
 
     img=$(_build_image v1) || {
         bad "image build failed (/tmp/os-fault-build.log)"
@@ -2777,12 +2785,10 @@ phase_rig() {
         return
     }
 
-    # The pool: the guest's OWN sshd. The host-side gate dials the address before it commits anything, and a
-    # KVM guest has no Pithead on its LAN to dial — so this stands in for one. It is a real TCP listener and
-    # nothing more, which is exactly what the gate checks; what it deliberately does NOT prove is an accepted
-    # share, the same limit the coordinator's local-miner leg documents. XMRig will dial it, get no stratum
-    # and retry forever, and that is the point: the miner must come up and STAY up on a pool that does not
-    # answer, or a rig whose coordinator is late would fail its own boot and roll its slot back.
+    # The pool: the guest's OWN sshd — a KVM guest has no Pithead on its LAN, and the host-side gate only
+    # dials a TCP listener before committing. It deliberately does NOT prove an accepted share (the same
+    # limit the coordinator's local-miner leg documents). XMRig dials it, gets no stratum and retries
+    # forever, which is the point: the miner must come up and STAY up on a pool that does not answer.
     body="role=rig&rig_pool=127.0.0.1:22&rig_worker=kvm-rig"
     scode=$(curl -sSk -b "$jar" --data "$body" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
     [ "$scode" = "200" ] || {
@@ -2793,9 +2799,8 @@ phase_rig() {
     ok "rig role submitted through the wizard"
     tries=0
     while [ "$tries" -lt 24 ]; do
-        if curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null | grep -q '"worker"'; then
-            break
-        fi
+        card=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null)
+        case "$card" in *'"worker"'*) break ;; esac
         sleep 5
         tries=$((tries + 1))
     done
@@ -2804,26 +2809,16 @@ phase_rig() {
         rm -f "$jar"
         return
     }
-    # A rig's card carries the worker and where it points — and NO login, because a rig has none.
-    if curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null | grep -q '"password"'; then
-        bad "the rig card published a dashboard password — a rig serves no dashboard"
-    else
-        ok "the rig card is worker + pool, with no login (a rig has none)"
-    fi
+    case "$card" in
+    *'"password"'*) bad "the rig card published a dashboard password — a rig serves no dashboard" ;;
+    *) ok "the rig card is worker + pool, with no login (a rig has none)" ;;
+    esac
+    card_tok=$(printf '%s' "$card" | jq -r '.token // ""' 2>/dev/null)
     curl -sSk -b "$jar" -X POST "https://$ip/handoff-ack" -o /dev/null 2>/dev/null || true
     rm -f "$jar"
 
     # ---- the machine that came out: a rig, not a small coordinator ------------------------
-    local mtries=0 miner_up=0
-    while [ "$mtries" -lt 36 ]; do
-        if _ssh "systemctl is-active --quiet xmrig && pgrep -x xmrig >/dev/null"; then
-            miner_up=1
-            break
-        fi
-        sleep 10
-        mtries=$((mtries + 1))
-    done
-    if [ "$miner_up" -eq 1 ]; then
+    if _rig_mining_up 36; then
         ok "the rig mines (xmrig unit active, process running) with no reboot in between"
     else
         bad "the rig never started mining (unit: $(_ssh 'systemctl is-active xmrig' 2>/dev/null || echo unknown))"
@@ -2839,6 +2834,29 @@ phase_rig() {
     else
         bad "the rig's miner config does not match its answers ($(_ssh "jq -c '.pools' /data/rigforge/config.json 2>/dev/null" | cut -c1-100))"
     fi
+    # #1836: the rig's token guards every API, the sister feed the coordinator probes exists, and the
+    # writable control path is pinned to the pool host — 127.0.0.1 here, so the guest probes itself over
+    # loopback and this host, an unpinned source, is dropped (loopback answering proves the port is alive).
+    rtok=$(_ssh "jq -r '.ACCESS_TOKEN // \"\"' /data/rigforge/config.json" | tr -d '\r')
+    [[ "$rtok" =~ ^[0-9a-f]{32}$ ]] && ok "the miner's config carries a minted 32-hex control token" || bad "no control token in the rig's config (got '${rtok:0:8}')"
+    [ -n "$card_tok" ] && [ "$card_tok" = "$rtok" ] && ok "the rig card showed the SAME token the miner enforces" || bad "the card's token ('${card_tok:0:8}') is not the miner's ('${rtok:0:8}')"
+    _ssh "jq -e '.api == \"enabled\" and .control == \"enabled\" and .api_allow_from == \"127.0.0.1\" and (has(\"control_upgrade\") | not)' /data/rigforge/config.json >/dev/null" &&
+        ok "sister API + control enabled, pinned to the pool host; control_upgrade untouched" ||
+        bad "the rig's API keys are not what #1836 renders: $(_ssh "jq -c 'del(.pools, .ACCESS_TOKEN)' /data/rigforge/config.json" | cut -c1-120)"
+    _rig_http() { _ssh "curl -s -m 5 -o /dev/null -w '%{http_code}' $*" 2>/dev/null | tr -d '\r'; }
+    while [ "$ptries" -lt 12 ] && [ "$(_rig_http -H "'Authorization: Bearer $rtok'" http://127.0.0.1:8081/1/summary)" != "200" ]; do
+        sleep 5
+        ptries=$((ptries + 1))
+    done
+    [ "$ptries" -lt 12 ] && ok "the sister feed answers 200 with the token" || bad "the sister feed never answered 200 with the token"
+    pcode=$(_rig_http http://127.0.0.1:8081/1/summary)
+    [ "$pcode" = "401" ] && ok "the sister feed refuses without the token (401)" || bad "the sister feed answered '${pcode}' without a token"
+    pcode=$(_rig_http http://127.0.0.1:8080/1/summary)
+    case "$pcode" in 401 | 403) ok "XMRig's own API is closed without the token ($pcode)" ;; *) bad "XMRig's API on 8080 answered '${pcode}' with no token — still open on the LAN" ;; esac
+    pcode=$(_rig_http http://127.0.0.1:8082/)
+    [ -n "$pcode" ] && [ "$pcode" != "000" ] && ok "the control port listens (loopback answers $pcode)" || bad "the control port does not answer even on loopback ('${pcode}')"
+    pcode=$(curl -s -m 5 -o /dev/null -w '%{http_code}' "http://$ip:8082/" 2>/dev/null)
+    [ "${pcode:-000}" = "000" ] && ok "the control port is unreachable from an unpinned source (this host)" || bad "the control port answered '$pcode' from an unpinned source"
     # THE assertion of this phase: no stack. Not a stopped stack, not a held one — none started.
     local names
     names=$(_ssh "podman ps -a --format '{{.Names}}'" 2>/dev/null | tr -d '\r' | tr '\n' ' ')
@@ -2866,16 +2884,7 @@ phase_rig() {
         bad "the rig never returned from the reboot"
         return
     }
-    local mtries2=0 miner_back=0
-    while [ "$mtries2" -lt 24 ]; do
-        if _ssh "systemctl is-active --quiet xmrig && pgrep -x xmrig >/dev/null"; then
-            miner_back=1
-            break
-        fi
-        sleep 10
-        mtries2=$((mtries2 + 1))
-    done
-    [ "$miner_back" -eq 1 ] &&
+    _rig_mining_up 24 &&
         ok "the rig returned mining with no hands on it (its unit lives in /run and died with the reboot)" ||
         bad "the rig did not return after the reboot — its runtime unit was never re-rendered"
     # WHICH unit owns the boot is the whole R4 fork: the wizard's window is closed by rig.json,
@@ -2937,16 +2946,7 @@ phase_rig() {
     [ "$(_ssh 'cat /data/pithead/machine-role' | tr -d '\r\n')" = "rig" ] &&
         ok "the role survived the slot swap (it lives on /data, not in the image)" ||
         bad "the updated slot lost the rig role"
-    local mtries3=0 miner_v2=0
-    while [ "$mtries3" -lt 24 ]; do
-        if _ssh "systemctl is-active --quiet xmrig && pgrep -x xmrig >/dev/null"; then
-            miner_v2=1
-            break
-        fi
-        sleep 10
-        mtries3=$((mtries3 + 1))
-    done
-    [ "$miner_v2" -eq 1 ] && ok "the rig mines again on the updated slot" ||
+    _rig_mining_up 24 && ok "the rig mines again on the updated slot" ||
         bad "the rig stopped mining after the A/B update"
     # No harness mark-good: the boot that just brought the miner up must have COMMITTED — a rig commits on the
     # miner running, the same event this leg just waited for. That coupling is also why an "uncommitted

--- a/tests/stack/test-appliance-rig-miner.sh
+++ b/tests/stack/test-appliance-rig-miner.sh
@@ -398,3 +398,69 @@ assert_contains "missing tree is named" "$lmp_out" "no RigForge tree"
 unset RF_LOG PITHEAD_RIGFORGE_DIR
 rm -rf "$LMP"
 unset LMP lmp_out
+
+echo "== unit: the rig's control token and its APIs — minted once, pinned to the coordinator (#1836) =="
+# A rig used to render pools and nothing else, which left XMRig's API open on the LAN and the
+# coordinator's Workers view on "API error". Now: one token minted into rig.json (stable across
+# the rebuild every boot), the read-only sister feed on, and the writable control path pinned to
+# the pool host's IPv4 — or OFF when there is none, because RigForge refuses control unpinned.
+# getent is a PATH stub: the resolver answers deterministically, and what it answers is the case.
+mk_tmpdir RTSB
+mkdir -p "$RTSB/rigforge" "$RTSB/bin"
+cat >"$RTSB/bin/getent" <<'EOF'
+#!/bin/bash
+case "$1 $2" in
+"ahostsv4 coordinator.lan") printf '192.168.7.20    STREAM coordinator.lan\n192.168.7.20    DGRAM\n' ;;
+"ahostsv4 fd00::20") printf '10.9.9.9        STREAM\n' ;;
+*) exit 2 ;;
+esac
+EOF
+chmod +x "$RTSB/bin/getent"
+printf '{"pool":"coordinator.lan:3333","worker":"shed-3","stratum_password":"pw"}' >"$RTSB/rig.json"
+run_rt() { PITHEAD_RIGFORGE_DIR="$RTSB/rigforge" PATH="$RTSB/bin:$PATH" run_sourced "$RTSB" "$@"; }
+rt_tok=$(run_rt rig_access_token 2>/dev/null)
+assert_rc "minting a token -> rc 0" "$?" "0"
+[[ "$rt_tok" =~ ^[0-9a-f]{32}$ ]] && ok "the token is 32 lowercase hex" || bad "the token is not 32 hex: '$rt_tok'"
+assert_eq "the token is kept in rig.json" "$(jq -r '.access_token' "$RTSB/rig.json")" "$rt_tok"
+assert_eq "rig.json stays owner-only after the rewrite" "$(stat -c '%a' "$RTSB/rig.json")" "600"
+assert_eq "the answers beside it are untouched" "$(jq -r '.pool + " " + .worker + " " + .stratum_password' "$RTSB/rig.json")" "coordinator.lan:3333 shed-3 pw"
+assert_eq "a second call returns the SAME token (stable across the per-boot rebuild)" "$(run_rt rig_access_token 2>/dev/null)" "$rt_tok"
+assert_eq "no temp file left beside rig.json" "$(find "$RTSB" -maxdepth 1 -name '.rig.json*' | wc -l | tr -d ' ')" "0"
+jq '.access_token = "short"' "$RTSB/rig.json" >"$RTSB/r.tmp" && mv -f "$RTSB/r.tmp" "$RTSB/rig.json"
+rt_tok2=$(run_rt rig_access_token 2>/dev/null)
+[[ "$rt_tok2" =~ ^[0-9a-f]{32}$ ]] && [ "$rt_tok2" != "$rt_tok" ] && ok "a malformed token is re-minted, never served" || bad "a malformed token survived: '$rt_tok2'"
+assert_eq "the pool host resolves to ONE IPv4 for the pin" "$(run_rt rig_coordinator_ip)" "192.168.7.20"
+rt_out=$(run_rt render_rig_miner_config 2>&1)
+assert_rc "render with a resolvable coordinator -> rc 0" "$?" "0"
+assert_eq "ACCESS_TOKEN in the miner's config is the rig.json token" "$(jq -r '.ACCESS_TOKEN' "$RTSB/rigforge/config.json")" "$rt_tok2"
+assert_eq "the sister API is on" "$(jq -r '.api' "$RTSB/rigforge/config.json")" "enabled"
+assert_eq "control is on, pinned to the coordinator's IPv4" "$(jq -r '.control + " " + .api_allow_from' "$RTSB/rigforge/config.json")" "enabled 192.168.7.20"
+assert_eq "control_upgrade is left at RigForge's default (off) — no key written" "$(jq -r 'has("control_upgrade")' "$RTSB/rigforge/config.json")" "false"
+assert_eq "the pools entry is unchanged: url, user, pass" "$(jq -c '.pools' "$RTSB/rigforge/config.json")" '[{"url":"coordinator.lan:3333","user":"shed-3","pass":"pw"}]'
+assert_eq "the miner's config stays owner-only" "$(stat -c '%a' "$RTSB/rigforge/config.json")" "600"
+assert_not_contains "the token is never logged" "$rt_out" "$rt_tok2"
+# No IPv4 for the pool host (an onion, a name mDNS does not answer): the feed stays on behind the
+# token, control stays OFF and the log says so — RigForge would refuse an unpinned control anyway.
+printf '{"pool":"abcdefghij.onion:3333","worker":"shed-3","access_token":"%s"}' "$rt_tok2" >"$RTSB/rig.json"
+assert_eq "an unresolvable host -> no pin" "$(run_rt rig_coordinator_ip)" ""
+rt_out=$(run_rt render_rig_miner_config 2>&1)
+assert_rc "render with no pin -> still rc 0 (the miner must come up)" "$?" "0"
+assert_eq "no pin -> control key absent, api_allow_from absent, feed still on" "$(jq -r '[(has("control") | tostring), (has("api_allow_from") | tostring), .api, .ACCESS_TOKEN] | join(" ")' "$RTSB/rigforge/config.json")" "false false enabled $rt_tok2"
+assert_contains "no pin is said out loud" "$rt_out" "control API stays off"
+assert_not_contains "the token is never logged (no-pin path)" "$rt_out" "$rt_tok2"
+# A bracketed IPv6 pool host is unwrapped before the lookup: the stub only answers the bare form.
+printf '{"pool":"[fd00::20]:3333","worker":"shed-3"}' >"$RTSB/rig.json"
+assert_eq "a bracketed IPv6 pool host is looked up unwrapped" "$(run_rt rig_coordinator_ip)" "10.9.9.9"
+# rig.json that cannot be rewritten: no token can be kept, so the miner is NOT configured (rc 1).
+# Root ignores directory modes, so the case runs only where the mode can refuse.
+if [ "$(id -u)" != 0 ]; then
+    printf '{"pool":"coordinator.lan:3333","worker":"shed-3"}' >"$RTSB/rig.json"
+    chmod 500 "$RTSB"
+    rt_out=$(run_rt render_rig_miner_config 2>&1)
+    assert_rc "a token that cannot be kept -> rc 1" "$?" "1"
+    chmod 700 "$RTSB"
+    assert_contains "the refusal names the token" "$rt_out" "control token"
+fi
+rm -rf "$RTSB"
+unset RTSB rt_tok rt_tok2 rt_out
+unset -f run_rt


### PR DESCRIPTION
## What the operator saw

A rig provisioned from the setup page (RigForge role) mines at once, but the coordinator's Workers table shows it as "API error", and nothing on the rig card lets the operator adopt it. Its RigForge config carried `pools` only, so RigForge ran with its defaults: no token, XMRig's own API open on the LAN, no sister feed on 8081, no control on 8082. This is the **config half** of #1836; the card half (rendering the token on the wizard's rig card) is the fixes lane's, against the spool contract below.

## What changes

- **`lib/pithead/14-local-miner.sh`** (appliance lane): `render_rig_miner_config` now renders `ACCESS_TOKEN` (32 hex, minted once by the new `rig_access_token` and kept in `rig.json`, so the config rebuilt at every boot carries the same token the operator pasted into the adopt form), `api: enabled`, and `control: enabled` + `api_allow_from` pinned to the pool host's IPv4 (new `rig_coordinator_ip`, `getent ahostsv4`; brackets stripped from an IPv6 literal). No IPv4 for the pool host (an onion address, a name mDNS does not answer) renders the feed on behind the token and control OFF with a warn, because RigForge refuses an unpinned writable path. `control_upgrade` is not written (RigForge default off). The token is never logged. A `rig.json` that cannot be rewritten refuses the render (rc 1) so the miner does not come up half-configured.
- **`lib/pithead/12-firstboot-wizard.sh`** (in nobody's `.paths`; the seat directive assigns the spool write to this lane, shipped through the one-shot `.lane-override`, line-neutral at the pinned 556): the rig card's `handoff.json` gains `token` (from `rig_access_token`, before the card is shown) and `address` (this box's first IPv4 from `hostname -I`, may be `""`). Spool contract agreed with the fixes lane in its pane: `{role:"rig", worker, stratum, token, address}`; `control_port` deliberately NOT in the spool (RigForge's default, a second source would go stale). **Card half: treat an empty `token` like an empty `address`** (it is empty only when `rig.json` could not be rewritten, in which case the render leg refuses and the rig does not mine).
- **`tests/os/run.sh`** (line-neutral at the pinned 3423; the three identical mining-wait loops became one `_rig_mining_up` helper): the rig phase gains the #1836 rows — token minted and equal to the card's; `api`/`control`/`api_allow_from` as rendered; 8081 answers 200 with the token and 401 without (from inside the guest, since the pin is 127.0.0.1 there); 8080 closed without the token; 8082 answers on loopback (the positive control) and is unreachable from the host, an unpinned source.
- **`tests/stack/test-appliance-rig-miner.sh`** (+66 lines, new tsv row at its true count 466): tier-1 for both helpers and the renderer, with a `getent` PATH stub — mint/stability/re-mint of a malformed token, owner-only modes, the rendered keys on the pinned path, the no-pin path, the bracketed-IPv6 unwrap, and the cannot-keep refusal (skipped as root, whom directory modes do not refuse).
- **`docs/appliance.md`, `docs/workers.md`**: the rig card now carries a token shown once; the workers NOTE that said an appliance rig ships with control off is rewritten.
- **`docs/dev/file-budget.tsv`**: two rows ADDED at true counts (`14-local-miner.sh` 414, the test 466); no other row touched — a full `--generate` would also lower nine rows on files other lanes are editing, which was available and rejected.
- `pithead` rebuilt from the slices (parity clean).

## What was RUN

- `bash tests/stack/run.sh`: `pithead tests: 3387 passed, 0 failed` (rc 0, 21:02Z; the new section runs its 30 rows green; log kept locally).
- `make lint-sh` (shellcheck + shfmt, under the manual lock): rc 0 (shellcheck + shfmt over `pithead`, `tests/os/*.sh`, `tests/stack/run.sh` and the rest of the Makefile list).
- `scripts/build-pithead.sh --check`: parity OK. `scripts/lint-file-budget.sh`: OK. `make lint-docs-voice`: OK (41 docs). `tests/inventory.sh`: rc 0, the domain lists 8 sections. `shfmt -d` on the four shell files: clean.
- Mutation controls on the tier-1 rows: **NOT run** (context bar hit; a full-suite mutation pass is ~13 min). What stands in: the same instrument reads BOTH answers within the section — the pinned path asserts `control`/`api_allow_from` PRESENT and the no-pin path asserts them ABSENT on the same reader — so the enumeration has been shown able to say the other thing. Successor or reviewer: revert the `ACCESS_TOKEN: $tok, api: "enabled"` clause in the jq and expect the ACCESS_TOKEN/api/control rows to redden.
- KVM `--phase rig` on this branch's tree: LAUNCHED detached at push time as `~/battery-phase-chain.sh ~/battery-1836-rig-<ts> ~/dev/appliance-1836 rig` (build → mkimage --dev → verify-image --test → `run.sh --phase rig`, ~30 min); the verdict is read from `battery.rc` + `battery.log` in that dir and posted here by the successor BEFORE the non-author merge. Until it is posted, treat the rig-phase rows as UNPROVEN on a guest.

## Over-engineering pass (by hand; the ponytail gate keys off the wrong branch from this worktree)

The diff adds two helpers and extends one renderer; each helper has one caller in the product plus the card writer. Available and rejected: moving the rig leg into its own slice to keep `14-local-miner.sh` under 400 lines (a pure move plus this change in one cut, against the wind-down ruling that sizes the diff to the fix; the new tsv row is the documented cost). Also rejected: a per-rig `control_port` in the spool (see above).

## Not done here

- The wizard CARD (fixes lane, per the seat directive). Until it lands the token is in the spool but not on the page.
- The Workers-table wording ("not adopted" instead of "API error") the issue calls a separate follow-up.
- The CHANGELOG line for #1836 belongs on `release/2.0.0-prep` with the other 2.0.0 notes (the branch that carries the `[2.0.0]` section); it goes in at the prep rebase after the gate.
- No support-bundle change: the rig's RigForge `config.json` is not collected by `pithead support-bundle` (checked `07-support-bundle.sh`), and RigForge's own outputs mask `ACCESS_TOKEN`.

Closes-by-hand #1836 (config half) on merge; `Closes` is inert on `develop-v2`.
