### PR TITLE
fix(wizard): #1835 a rig running from the USB stick is never told the disk is being copied

### DIFF
--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -464,16 +464,16 @@ async def submit(request: web.Request) -> web.Response:
 
 async def submit_restore(request: web.Request) -> web.Response:
     """Restore-at-setup (#909, #786 sub-issue B): an uploaded encrypted backup archive + its
-    emergency-kit passphrase, in place of the config form. This server only asks — the archive
-    and passphrase cross the SAME spool the rest of the wizard uses, and the HOST decrypts,
-    validates and extracts (firstboot_consume_restore, reusing stack_restore's own machinery).
-    A rejected archive falls back to the form with the reason, exactly like a rejected config;
-    the passphrase is written once and the host deletes it immediately either way."""
+    emergency-kit passphrase, in place of the config form. This server only asks — both cross the
+    SAME spool the rest of the wizard uses, and the HOST decrypts, validates and extracts
+    (firstboot_consume_restore). The passphrase is written once, deleted immediately either way."""
     if not _authed(request):
         raise web.HTTPFound("/")
     # aiohttp enforces client_max_size (set in make_app) itself, answering 413 before this
     # body even finishes reading — no try/except needed to turn that into a response.
     form = await request.post()
+    # Restated like /submit (#1835): a restore installs to a DISK — the gate below refuses "usb".
+    _spool_write_text("stick", "0")
     upload = form.get("archive")
     if not isinstance(upload, web.FileField):
         return web.json_response({"error": "choose a backup archive to upload"}, status=400)

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -147,9 +147,8 @@ def _data_wiped() -> dict:
 def wizard_stage() -> str:
     """Which step this machine is actually on, decided by the SPOOL — never by the client.
 
-    A page refresh must not walk backwards into an editable form after a config was accepted,
-    and the client cannot know the difference on its own: a bench session refreshed during
-    provisioning and was handed the setup form again, as if nothing had been submitted.
+    A page refresh must not walk back into an editable form after a config was accepted, and the
+    client cannot know that alone: a bench session refreshed mid-provision got the setup form back.
 
     handoff    credentials published, waiting for the operator to save them
     done       provisioning under way (or finished) — nothing left to edit
@@ -161,9 +160,9 @@ def wizard_stage() -> str:
     if _spool_read("installed") is not None or _spool_read("installing") is not None:
         return "installing"
     if _spool_read("applied") is not None or _spool_read("handoff-ack") is not None:
-        # Same ack, two meanings: on the installation medium it releases the INSTALL (the page
-        # then shows the switch-off steps), on an installed machine it releases provisioning.
-        return "installing" if installer_mode() else "done"
+        # Same ack, two meanings: on the medium it releases the INSTALL, on an installed
+        # machine provisioning. A stick run installs nothing, so it is "done" too (#1835).
+        return "installing" if installer_mode() and _spool_read("stick") is None else "done"
     if installer_mode():
         return "installer"
     return "setup"
@@ -370,12 +369,10 @@ def _gate_install_request(form: dict) -> str | None:
 
 
 def _submit_rig(form: dict) -> web.Response:
-    """The RigForge role's submission: no pithead config at all — a pool address, a worker
-    name, an optional stratum password, on their own spool channel. The coordinator flow stays
-    byte-for-byte untouched because nothing here goes near config.json; the HOST dials the
-    pool and owns everything after. On the installation medium the disk gates are the same as
-    every other role, with one extra first-class target: "usb" means run from this stick —
-    nothing is erased, so no gates apply to it."""
+    """The RigForge role's submission: no pithead config at all — a pool address, a worker name,
+    an optional stratum password, on their own spool channel. The coordinator flow stays
+    byte-for-byte untouched because nothing goes near config.json; the HOST dials the pool. On the
+    medium the disk gates match every other role, bar one target: "usb" runs from the stick."""
     pool = str(form.get("rig_pool", "")).strip()
     host, _, port = pool.rpartition(":")
     if not host or not port.isdigit():
@@ -383,7 +380,8 @@ def _submit_rig(form: dict) -> web.Response:
             {"error": "enter the pool address as host:port — a Pithead answers on port 3333"},
             status=400,
         )
-    if installer_mode() and str(form.get("disk", "")).strip() != "usb":
+    stick = installer_mode() and str(form.get("disk", "")).strip() == "usb"
+    if installer_mode() and not stick:
         err = _gate_install_request(form)
         if err:
             return web.json_response({"error": err}, status=400)
@@ -395,7 +393,9 @@ def _submit_rig(form: dict) -> web.Response:
     if password:
         rig["stratum_password"] = password
     _spool_clear_error()
-    # The role rides beside the request so /status can narrate honestly after it is consumed.
+    # Role AND medium ride beside it: a stick run copies nothing, so nothing may narrate that.
+    if stick:
+        _spool_write_text("stick", "1")
     _spool_write_text("role", "rig")
     _spool_write_text("rig-request.json", json.dumps(rig))
     return web.json_response({"status": "accepted"})
@@ -523,7 +523,7 @@ async def handoff_ack(request: web.Request) -> web.Response:
 
 
 async def status(request: web.Request) -> web.Response:
-    if installer_mode():
+    if installer_mode() and _spool_read("stick") is None:
         if _spool_read("installed") is not None:
             return web.Response(
                 text="Installed — the machine is switching itself off. "

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -162,7 +162,7 @@ def wizard_stage() -> str:
     if _spool_read("applied") is not None or _spool_read("handoff-ack") is not None:
         # Same ack, two meanings: on the medium it releases the INSTALL, on an installed
         # machine provisioning. A stick run installs nothing, so it is "done" too (#1835).
-        return "installing" if installer_mode() and _spool_read("stick") is None else "done"
+        return "installing" if installer_mode() and _spool_read("stick") != "1" else "done"
     if installer_mode():
         return "installer"
     return "setup"
@@ -393,9 +393,7 @@ def _submit_rig(form: dict) -> web.Response:
     if password:
         rig["stratum_password"] = password
     _spool_clear_error()
-    # Role AND medium ride beside it: a stick run copies nothing, so nothing may narrate that.
-    if stick:
-        _spool_write_text("stick", "1")
+    # The role rides beside the request so /status can narrate honestly after it is consumed.
     _spool_write_text("role", "rig")
     _spool_write_text("rig-request.json", json.dumps(rig))
     return web.json_response({"status": "accepted"})
@@ -405,6 +403,8 @@ async def submit(request: web.Request) -> web.Response:
     if not _authed(request):
         raise web.HTTPFound("/")
     form = await request.post()
+    # Restated per SUBMISSION (#1835): a stale stick choice must not mute the install narration.
+    _spool_write_text("stick", "1" if str(form.get("disk", "")).strip() == "usb" else "0")
     raw = str(form.get("config", "")).strip()
     ref = _reference()
     # Keep-everything reinstall: the preserved config wins, so the submission carries NO config
@@ -523,7 +523,7 @@ async def handoff_ack(request: web.Request) -> web.Response:
 
 
 async def status(request: web.Request) -> web.Response:
-    if installer_mode() and _spool_read("stick") is None:
+    if installer_mode() and _spool_read("stick") != "1":
         if _spool_read("installed") is not None:
             return web.Response(
                 text="Installed — the machine is switching itself off. "

--- a/dashboard/tests/web/test_wizard_stick.py
+++ b/dashboard/tests/web/test_wizard_stick.py
@@ -58,26 +58,49 @@ async def _status(client):
 # --- the marker ------------------------------------------------------------------------------
 
 
-async def test_the_stick_marker_is_written_only_when_the_stick_is_the_target(client, installer):
-    """disk=usb records the choice beside the request; a real install records no such thing."""
+async def test_the_marker_is_a_per_submission_fact_not_a_one_way_write(client, installer):
+    """Every submission RESTATES the medium. A one-way write is the whole bug in mirror image: a
+    stick choice left by an earlier attempt would mute the install narration on a later real
+    install. Nothing here clears the marker by hand — if it did, the second half could not fail."""
     await _auth(client)
     assert (await client.post("/submit", data={**RIG, "disk": "usb"})).status == 200
     assert (installer / "stick").read_text() == "1"
     assert json.loads((installer / "rig-request.json").read_text()) == {"pool": "10.0.0.5:3333"}
 
-    (installer / "stick").unlink()
     r = await client.post(
         "/submit", data={**RIG, "disk": "nvme0n1", "confirm": "nvme0n1", "wipe": "all"}
     )
     assert r.status == 200
-    assert not (installer / "stick").exists()
+    assert (installer / "stick").read_text() == "0"
 
 
-async def test_a_rig_off_the_medium_writes_no_marker(client, spool):
-    """Not on the installation medium at all: there is no medium to run from."""
+async def test_a_retarget_after_a_failed_stick_attempt_gets_the_install_narration_back(
+    client, installer
+):
+    """The reachable sequence, in one boot: the stick attempt is rejected by the host, the operator
+    retargets to the internal disk, and the real install must narrate as a real install — including
+    the remove-the-stick instruction, which the frontend gates on the "Installed" prefix."""
+    await _auth(client)
+    await client.post("/submit", data={**RIG, "disk": "usb"})
+    # The host fails the dial and drops the request; the page returns to the form with the error.
+    (installer / "error.txt").write_text("pool unreachable")
+    (installer / "rig-request.json").unlink()
+
+    await client.post(
+        "/submit", data={**RIG, "disk": "nvme0n1", "confirm": "nvme0n1", "wipe": "all"}
+    )
+    assert "Copying the system to the disk" in await _status(client)
+    (installer / "installed").write_text("1")
+    body = await _status(client)
+    assert body.startswith("Installed")
+    assert "remove the USB stick" in body
+
+
+async def test_a_rig_off_the_medium_leaves_the_marker_inert(client, spool):
+    """Not on the installation medium: the marker is written but can never read as a stick run."""
     await _auth(client)
     assert (await client.post("/submit", data=RIG)).status == 200
-    assert not (spool / "stick").exists()
+    assert (spool / "stick").read_text() == "0"
 
 
 # --- /status ---------------------------------------------------------------------------------

--- a/dashboard/tests/web/test_wizard_stick.py
+++ b/dashboard/tests/web/test_wizard_stick.py
@@ -12,11 +12,27 @@ A new file rather than rows in test_wizard.py: that file is at its file-budget c
 import json
 
 import pytest
+from aiohttp import FormData
 from aiohttp.test_utils import TestClient, TestServer
 
 from mining_dashboard import wizard
 
 RIG = {"role": "rig", "rig_pool": "10.0.0.5:3333"}
+
+
+def _archive_form(**extra):
+    """A restore submission: the archive is a FILE, so this door is multipart, not urlencoded."""
+    form = FormData()
+    form.add_field(
+        "archive",
+        b"Salted__fixture-ciphertext",
+        filename="backup.tar.gz.enc",
+        content_type="application/octet-stream",
+    )
+    form.add_field("passphrase", "hunter2")  # noqa: S106 — a fixture, not a secret
+    for k, v in extra.items():
+        form.add_field(k, v)
+    return form
 
 
 @pytest.fixture
@@ -165,3 +181,60 @@ async def test_an_applied_disk_install_is_still_installing(client, installer):
     )
     (installer / "applied").write_text("1")
     assert wizard.wizard_stage() == "installing"
+
+
+async def test_a_restore_after_a_stick_attempt_gets_the_install_narration_back(client, installer):
+    """The SECOND install door. /submit is the choke point for every ROLE, not for every INSTALL:
+    /submit-restore reaches the same _gate_install_request. Stick attempt, host refuses, operator
+    toggles "Restore from a backup" and picks the internal disk — a real install, which must
+    narrate as one. Before the fix the marker kept the "1" the stick attempt left."""
+    await _auth(client)
+    await client.post("/submit", data={**RIG, "disk": "usb"})
+    assert (installer / "stick").read_text() == "1"
+    # The host fails the dial and drops the request; the page returns to the form with the error.
+    (installer / "error.txt").write_text("pool unreachable")
+    (installer / "rig-request.json").unlink()
+
+    r = await client.post(
+        "/submit-restore", data=_archive_form(disk="nvme0n1", confirm="nvme0n1", wipe="all")
+    )
+    assert r.status == 200
+    assert (installer / "stick").read_text() == "0"
+    assert "Copying the system to the disk" in await _status(client)
+    (installer / "installed").write_text("1")
+    body = await _status(client)
+    assert body.startswith("Installed")
+    assert "remove the USB stick" in body
+    assert wizard.wizard_stage() == "installing"
+
+
+async def test_a_stale_marker_from_another_machine_does_not_mute_a_first_action_restore(
+    client, installer
+):
+    """The variant that needs no pivot inside one session: nothing on the host clears $spool/stick,
+    so a stick carried to a second machine boots with the first machine's "1" still on it. Restore
+    is the operator's FIRST action here — /submit is never reached, so only this door can restate
+    it."""
+    (installer / "stick").write_text("1")
+    await _auth(client)
+
+    r = await client.post(
+        "/submit-restore", data=_archive_form(disk="nvme0n1", confirm="nvme0n1", wipe="keep")
+    )
+    assert r.status == 200
+    assert (installer / "stick").read_text() == "0"
+    assert "Copying the system to the disk" in await _status(client)
+
+
+async def test_a_refused_restore_still_leaves_the_marker_true_of_a_disk_install(client, installer):
+    """Narrowness: the restate sits ahead of the archive and disk gates on purpose. A restore that
+    the gate refuses has still chosen a disk, never the stick, so "0" is the honest reading — and
+    the refusal itself must survive the extra write."""
+    (installer / "stick").write_text("1")
+    await _auth(client)
+
+    r = await client.post("/submit-restore", data=_archive_form(disk="sdz", confirm="sdz"))
+    assert r.status == 400
+    assert (await r.json())["error"] == "choose a disk from the list"
+    assert (installer / "stick").read_text() == "0"
+    assert not (installer / "restore-archive").exists()

--- a/dashboard/tests/web/test_wizard_stick.py
+++ b/dashboard/tests/web/test_wizard_stick.py
@@ -1,0 +1,144 @@
+"""Run-from-USB narration: a rig set up to RUN FROM the stick is never shown the installer's
+"Copying the system to the disk…" (#1835).
+
+Nothing is copied to any disk on that path — the rig is provisioned in place and starts mining
+— so both things the page can read must agree: /status and the stage the frontend polls. A
+sibling assertion pins the DISK-install path in every case, because a fix that merely deleted
+the install narration would pass a one-sided test while breaking the path that needs it.
+
+A new file rather than rows in test_wizard.py: that file is at its file-budget ceiling.
+"""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+RIG = {"role": "rig", "rig_pool": "10.0.0.5:3333"}
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    return sd
+
+
+@pytest.fixture
+def installer(spool):
+    """The host booted from removable media and published a disk inventory."""
+    spool.joinpath("disks.tsv").write_text("nvme0n1\t931.5G\tSamsung SSD 990\tS6P1NF0T\tempty\n")
+    return spool
+
+
+@pytest.fixture
+async def client(spool):
+    c = TestClient(TestServer(wizard.make_app(exit_fn=lambda code: None)))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def _auth(client):
+    return await client.post(
+        "/auth",
+        data={"token": "pit-X7KM2Q"},  # noqa: S106 — the fixture's token, not a secret
+        allow_redirects=False,
+    )
+
+
+async def _status(client):
+    return await (await client.get("/status")).text()
+
+
+# --- the marker ------------------------------------------------------------------------------
+
+
+async def test_the_stick_marker_is_written_only_when_the_stick_is_the_target(client, installer):
+    """disk=usb records the choice beside the request; a real install records no such thing."""
+    await _auth(client)
+    assert (await client.post("/submit", data={**RIG, "disk": "usb"})).status == 200
+    assert (installer / "stick").read_text() == "1"
+    assert json.loads((installer / "rig-request.json").read_text()) == {"pool": "10.0.0.5:3333"}
+
+    (installer / "stick").unlink()
+    r = await client.post(
+        "/submit", data={**RIG, "disk": "nvme0n1", "confirm": "nvme0n1", "wipe": "all"}
+    )
+    assert r.status == 200
+    assert not (installer / "stick").exists()
+
+
+async def test_a_rig_off_the_medium_writes_no_marker(client, spool):
+    """Not on the installation medium at all: there is no medium to run from."""
+    await _auth(client)
+    assert (await client.post("/submit", data=RIG)).status == 200
+    assert not (spool / "stick").exists()
+
+
+# --- /status ---------------------------------------------------------------------------------
+
+
+async def test_a_stick_run_is_never_told_the_system_is_being_copied(client, installer):
+    """The reported bug: the page sat on the install text while the rig was already mining."""
+    await _auth(client)
+    await client.post("/submit", data={**RIG, "disk": "usb"})
+
+    # Before the host applies: waiting, not copying.
+    body = await _status(client)
+    assert "Copying" not in body
+    assert "Waiting" in body
+
+    # After it applies: the in-place rig text, which says where the machine actually went.
+    (installer / "applied").write_text("1")
+    body = await _status(client)
+    assert "Copying" not in body
+    assert "Rig settings saved" in body
+    assert "Workers view" in body
+
+
+async def test_a_disk_install_is_still_told_the_system_is_being_copied(client, installer):
+    """The sibling that makes the assertion above narrow: the install path is untouched."""
+    await _auth(client)
+    await client.post(
+        "/submit", data={**RIG, "disk": "nvme0n1", "confirm": "nvme0n1", "wipe": "all"}
+    )
+    assert "Copying the system to the disk" in await _status(client)
+
+    (installer / "installed").write_text("1")
+    assert "switching itself off" in await _status(client)
+
+
+async def test_a_stick_run_still_surfaces_a_host_rejection(client, installer):
+    """Taking the in-place branch must not cost the stick path its error narration."""
+    await _auth(client)
+    await client.post("/submit", data={**RIG, "disk": "usb"})
+    (installer / "error.txt").write_text("pool unreachable")
+    body = await _status(client)
+    assert "Copying" not in body
+    assert "Rejected: pool unreachable" in body
+
+
+# --- the stage the frontend polls ------------------------------------------------------------
+
+
+async def test_an_applied_stick_run_is_done_not_installing(client, installer):
+    """wizard_stage drives the Installing card, so it has to agree with /status."""
+    await _auth(client)
+    await client.post("/submit", data={**RIG, "disk": "usb"})
+    (installer / "applied").write_text("1")
+    assert wizard.wizard_stage() == "done"
+
+
+async def test_an_applied_disk_install_is_still_installing(client, installer):
+    """The sibling: without the marker the same spool state is an install."""
+    await _auth(client)
+    await client.post(
+        "/submit", data={**RIG, "disk": "nvme0n1", "confirm": "nvme0n1", "wipe": "all"}
+    )
+    (installer / "applied").write_text("1")
+    assert wizard.wizard_stage() == "installing"

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -172,6 +172,8 @@ A rig has one more choice: **run from this USB stick**. Nothing is written to an
 of the erase questions below apply — the machine mines from the stick and stops when you unplug
 it. The page says the rig's settings are saved and that it appears in your Pithead's Workers
 view once it connects. It never shows the install progress, because nothing is being installed.
+Choosing a disk on a later attempt — including through **Restore from a backup** — puts the
+install progress back, so a machine that really is being installed always says so.
 
 A disk that already holds a Pithead install is the exception, and the page asks what to do
 with what is on it:

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -168,6 +168,11 @@ Each disk is listed with its model, size and serial number. The USB stick you bo
 never offered. Nothing is preselected — you choose deliberately, because **installing erases
 the disk**.
 
+A rig has one more choice: **run from this USB stick**. Nothing is written to any disk, so none
+of the erase questions below apply — the machine mines from the stick and stops when you unplug
+it. The page says the rig's settings are saved and that it appears in your Pithead's Workers
+view once it connects. It never shows the install progress, because nothing is being installed.
+
 A disk that already holds a Pithead install is the exception, and the page asks what to do
 with what is on it:
 


### PR DESCRIPTION
Fixes the run-from-USB narration reported in #1835: a rig set up with "Run from this USB stick"
sat on **"Installing — Copying the system to the disk…"** while it was already mining. Nothing is
copied to any disk on that path.

## Two readers said it, not one

The issue names `status()`. Fixing only that would have left the bug on screen.

- `status()` branched on `installer_mode()` **first** and returned the copy text unconditionally.
  The in-place provision writes `applied` + `role`, which are only consulted in the branch below.
- `wizard_stage()` — which drives the frontend's `Installing` card — returned `"installing"` for an
  applied config whenever `installer_mode()` was true. **The card renders off the stage, not off
  `/status`**, so the page would have kept showing it however honest `/status` became.

`_submit_rig` now records the choice beside the request (a `stick` spool marker when
`disk == "usb"`), and both readers consult it. **The frontend needs no change:** `wizard.mjs:295`
already maps a server stage of `done` to its done view, so the `Installing` card can no longer
render for a stick run — which is also why `wizard.mjs` (889/889) did not have to move.

## What was RUN

- **The tests were run against the UNFIXED module, and 4 of the 7 FAIL there** — exactly the four
  stick-path rows. That is the control: a test written after a fix is otherwise green by
  construction.
- **The other three pass on both sides, deliberately.** They pin the disk-install path — it still
  says "Copying", still reaches the switch-off text, and a rig off the medium still writes no
  marker. A fix that merely deleted the install narration would pass a one-sided test; these are
  the siblings that make the assertion narrow.
- `dashboard/tests/web`: **676 passed**, no regressions.
- `lint-py`, `lint-yaml`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`,
  `lint-file-budget`, `lint-pithead-parity`, `lint-toml`: **all rc 0.**

## Budgets

`wizard.py` is **674 against a 674 ceiling with zero headroom**, so the change is line-neutral: the
marker write and the two guard clauses are paid for by compressing prose **in the two functions
being changed**, not by raiding unrelated docstrings. An earlier draft added a `_stick_run()`
helper; two call sites do not earn a function and it cost six lines, so it was inlined.

Tests go in a **new sibling file** (`test_wizard_stick.py`, 144 lines) because `test_wizard.py` is
at 974/974. It needs no budget row, and `docs/dev/file-budget.tsv` is **byte-unchanged**.

## Over-engineering pass

Run before opening this, as the gate requires. Nothing found to cut — see the inlined helper above,
which was the one thing this could have carried and does not. No new module, no new endpoint, no
frontend change, and the fix reuses the spool channel the wizard already owns.

## Gaps named

- **A refresh in the window between accepting a stick submit and the host writing `applied` still
  shows the setup form**, because `wizard_stage()` falls through to `"installer"`. That window is
  pre-existing and identical for a disk install, so it is out of this fix's scope — but it is the
  same class as the walk-backwards case `wizard_stage`'s own docstring warns about, and it is worth
  a follow-up issue rather than a silent widening here.
- `docs/appliance.md` had **no run-from-USB section** — the option is named once in passing. The
  sentence went into "The disk", where a reader actually meets the choice.
- `Closes` is inert on `develop-v2` — #1835 needs hand-closing after merge.

## Merge

I authored this; I do not merge it. Reviewer pass, then the appliance lane merges.
