### PR TITLE
feat(os): #1318 #1838 the boot menu names what it boots, and "Set up again" opens the wizard beside the saved role

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -146,8 +146,9 @@ addresses, runs no node, and serves nothing to log into. If a Pithead already an
 network at `pithead.local:3333`, its address is filled in for you; otherwise enter it by hand
 from that machine's own "Point miners at" line. Confirming shows a summary card with the worker
 name, where it mines, this machine's address and a **control token** — **not a login**, because
-a rig has none. The token is shown once and never again: a rig serves no page after this, so copy
-it now. It is what lets that Pithead adopt the rig: in its dashboard, under Workers, the adopt
+a rig has none. The token is shown once — a rig serves no page after this — so copy it now. If you lose
+it, the boot menu's **Set up again** with the same worker name shows the same token again
+(see [The boot menu](#the-boot-menu)). It is what lets that Pithead adopt the rig: in its dashboard, under Workers, the adopt
 form takes this rig's address, control port `8082` and the token. Until you do that, the rig
 still mines and still appears under Workers once it connects, but its row reads as an API error,
 because the token guards every API on the rig — the miner's own included, so nothing else on the
@@ -374,6 +375,57 @@ install-then-fall-back protection as any other update. The practical consequence
 **taking updates when they are offered is the security maintenance.** A machine left on
 an old image keeps running fine, but it keeps the old image's known holes too. The base
 system is Debian 13, which receives security support upstream into 2030.
+
+## The boot menu
+
+Every start shows a short menu for five seconds, then boots by itself. You never need to
+touch it: the machine keeps two copies of the system and boots the last one that worked,
+so an update that fails to come up is undone on the next start without you.
+
+- **Pithead OS - slot A** and **slot B** are those two copies. The one selected when the
+  menu appears is the one the machine chose; the other holds the previous version after an
+  update. Pick it only if support asks you to.
+- **Pithead OS - slot A (fallback)** is what boots when neither copy is marked good: the
+  same system as slot A, offered so a machine with nobody at it boots something rather
+  than waiting at a prompt.
+- **Set up again** opens the setup page, keeping everything the machine already has. Use it
+  when a machine's answers need changing and there is no other way in. A RigForge rig has no
+  dashboard and no login, so this entry is its only way back to the setup page from the
+  machine itself.
+
+### Set up again
+
+Choose it with a keyboard on the machine during the countdown. The machine starts the
+setup page instead of its normal work, prints the address and one-time token on the
+console as it did on the first boot, and the page opens by naming what the machine is: a
+rig mining at a pool as a worker, or a Pithead coordinator. Two choices:
+
+- **Keep it** closes the page and starts the machine exactly as it was. Nothing changes,
+  and the same holds for a page you never touch or a machine switched off part way: the
+  saved settings are replaced only when you accept new ones.
+- **Set up again** opens the form filled in with the saved answers and the secrets left
+  out: a stratum password, and for a coordinator the dashboard login and node credentials,
+  are typed again. Accept the form and the machine provisions itself with the new answers.
+
+A rig kept as a rig with the same worker name keeps its control token: the Pithead that
+adopted it goes on reaching it, and the card shows that same token again, so this is also
+the way to see a token you did not copy the first time. A different worker name, or a
+change of role, makes a new one. A rig that becomes a coordinator, or the other way round,
+is provisioned as the new role; whatever the old role kept on the data partition stays
+there until a [factory reset](#starting-over-the-two-resets).
+
+### Getting a rig back to setup from another computer
+
+A run-from-USB rig with no monitor or keyboard cannot reach the menu. Plug the stick into
+another computer instead:
+
+- Delete `pithead/machine-role` and `pithead/rig.json` from the stick's partition labelled
+  `data`. It is ext4, so a Linux machine can open it; macOS and Windows cannot without extra
+  software. The setup page runs on the next boot and the installed systems are kept.
+- Or create an empty file named `pithead-reset` at the top of the stick's first partition,
+  the small FAT one that any computer can open. The next boot erases the data area and
+  starts from a blank setup page: a factory reset.
+- Or write the image to the stick again ([step 1](#1-write-the-image-to-a-usb-stick)).
 
 ## Backing up your data
 

--- a/docs/dev/appliance-wizard.md
+++ b/docs/dev/appliance-wizard.md
@@ -105,12 +105,39 @@ carried to the target by `pithead-install` beside the config and token pre-seeds
 installed machine's first boot lands them as the two files above, scrubbing the ESP copy the
 way the config pre-seed is scrubbed. The stick keeps neither copy after a disk install: a
 stick whose own `/data` carries the rig marker IS a rig (run-from-USB), and that marker
-outranks installer mode on every later boot.
+outranks installer mode on every later boot — except one chosen from the boot menu's **Set up
+again** entry, which opens the wizard beside the role (below).
 
-**Getting a machine back out of the rig role** is the installer, not a setting: a rig serves no
-dashboard and answers on no port, so there is nothing to log into and change. Boot the stick
-beside it and install with the wipe, and it is a blank machine that can pick any role again. A
-*keep* reinstall deliberately leaves it a rig — keep means keep whatever the role says.
+**Getting a machine back out of the rig role** is the boot menu's **Set up again** entry
+(#1318) or the installer, never a setting: a rig serves no dashboard and answers on no port, so
+there is nothing to log into and change. Boot the stick beside it and install with the wipe, and
+it is a blank machine that can pick any role again. A *keep* reinstall deliberately leaves it a
+rig — keep means keep whatever the role says.
+
+### Set up again: the wizard beside a saved role
+
+`os/rauc/grub.cfg`'s fourth entry boots the slot the default would have booted and appends
+`pithead.setup=1` to that one boot's kernel cmdline. `pithead-setup-again.service`, the flag's
+only reader, runs `pithead firstboot-wizard` on a provisioned machine with `PITHEAD_SETUP_AGAIN=1`
+and `Before=pithead-boot.service`, so the role's normal boot waits behind the page. Under the
+switch (`lib/pithead/12a-setup-again.sh`) three things change and nothing else: the "already a
+rig" and "config.json present" short-circuits are skipped; `stage_wizard_spool` publishes
+`saved-role.json` and points the pre-fill at the saved answers (`rig-defaults.json` gets the saved
+pool + worker; `last-attempt.json` gets `config.json` through `strip_config_secrets`, unless a
+failed retry's context is already there); and the inner loop honours `keep-role`. The page shows
+its Keep it / Set up again screen exactly when `saved-role.json` exists (`saved_role` in
+`/api/state`, `null` otherwise; a malformed file falls through to the normal form).
+
+| Spool file | Written by | Meaning |
+|---|---|---|
+| `saved-role.json` | host | present only on a set-up-again boot: `{role, pool, worker}` for a rig, `{role}` for a coordinator, never a secret |
+| `keep-role` | page | Keep it: the host ends the session with nothing on `/data` touched, the unit exits, pithead-boot runs the normal boot |
+
+Set up again is the ordinary submit. A rig accepted with the same worker name keeps its
+`access_token` (`firstboot_consume_rig` carries it over); any other change mints a new one on the
+next render. `record_machine_role` removes `rig.json` when the accepted role is not `rig`, so a
+role's data goes with the role. A coordinator's `config.json` is NOT removed by a change to `rig`:
+it is operator data, and the factory reset is the erase.
 
 ## Restore-at-setup
 

--- a/lib/pithead/08-uninstall-firstboot.sh
+++ b/lib/pithead/08-uninstall-firstboot.sh
@@ -85,6 +85,9 @@ firstboot_consume_spool() { # <spool-dir>
 
 record_machine_role() { # <pithead|both|rig>
     printf '%s\n' "$1" >"$PWD/machine-role" 2>/dev/null || true
+    # A role change replaces the role's data with it (#1318): rig.json — and the control token in
+    # it — belongs to the rig role only, so a machine accepted as a coordinator leaves none behind.
+    [ "$1" = rig ] || rm -f "$PWD/rig.json"
 }
 
 # The wizard's response to a failed (setup), as one step so it can be driven directly (#1059).
@@ -206,8 +209,14 @@ firstboot_consume_rig() { # <spool-dir>
         rm -f "$req"
         return 1
     fi
-    if ! jq --arg w "${worker:-$(hostname)}" '{pool: .pool, worker: $w}
-        + (if (.stratum_password // "") == "" then {} else {stratum_password: .stratum_password} end)' \
+    # The control token (#1836) survives a "Set up again" that keeps the role AND the worker name
+    # (#1318): the coordinator adopted THIS worker with THIS token. Any other change mints a new one.
+    local keep_tok=""
+    [ "$(jq -r '.worker // ""' "$PWD/rig.json" 2>/dev/null)" = "${worker:-$(hostname)}" ] &&
+        keep_tok=$(jq -r '.access_token // ""' "$PWD/rig.json" 2>/dev/null)
+    if ! jq --arg w "${worker:-$(hostname)}" --arg t "$keep_tok" '{pool: .pool, worker: $w}
+        + (if (.stratum_password // "") == "" then {} else {stratum_password: .stratum_password} end)
+        + (if $t == "" then {} else {access_token: $t} end)' \
         "$req" >"$PWD/rig.json" 2>/dev/null; then
         rm -f "$req" "$PWD/rig.json"
         printf 'could not record the rig settings — submit again' >"$spool/error.txt"

--- a/lib/pithead/12-firstboot-wizard.sh
+++ b/lib/pithead/12-firstboot-wizard.sh
@@ -19,9 +19,10 @@ stage_wizard_spool() { # <spool-dir> -> fingerprint on stdout
     cp /opt/pithead/config.reference.json "$spool/config.reference.json" 2>/dev/null ||
         cp "$PWD/config.reference.json" "$spool/config.reference.json" 2>/dev/null || true
     chown 1000:1000 "$spool/config.reference.json" 2>/dev/null || true
-    # The rig role's pre-fill rides beside the reference — derived fresh each boot, like the
-    # disk inventory, so machine 2 on a fleet stick never opens on machine 1's discovery.
+    # The rig pre-fill and (#1318) the saved role ride beside the reference — derived fresh each
+    # boot, like the disk inventory, so machine 2 on a fleet stick never opens on machine 1's.
     publish_rig_defaults "$spool"
+    publish_saved_role "$spool"
     # The data-wipe note (#1121): same "derived fresh every boot" rule, for the same fleet-stick
     # reason — see publish_data_wipe_note.
     publish_data_wipe_note "$spool"
@@ -94,12 +95,11 @@ firstboot_wizard() {
         fi
     fi
     # A machine already carrying the rig role mines, and asks nothing — not even on a stick that
-    # could offer the installer, because a run-from-USB rig's stick IS that rig's system, not a
-    # fleet tool. Reached only on the boot that ACCEPTS the role (a disk install's first boot,
-    # just above): once the marker exists, pithead-boot owns every later boot and this unit's
-    # own condition skips it. The miner is best-effort here for the same reason it is in pithead-boot
-    # — a rig whose pool moved must still come up and keep retrying, not brick its own boot.
-    if [ "$(machine_role)" = "rig" ]; then
+    # could offer the installer: a run-from-USB rig's stick IS that rig's system, not a fleet tool.
+    # Reached only on the boot that ACCEPTS the role (a disk install's first boot, just above); a
+    # boot from the menu's "Set up again" entry (#1318) skips this and opens the page beside the role.
+    # The miner is best-effort, as in pithead-boot: a pool that moved must not brick the boot.
+    if [ "$(machine_role)" = "rig" ] && ! setup_again_mode; then
         _console "This machine is a RigForge rig ($(jq -r '.worker // "unnamed"' "$PWD/rig.json" 2>/dev/null) -> $(jq -r '.pool // "no pool recorded"' "$PWD/rig.json" 2>/dev/null))."
         provision_rig_miner || true
         return 0
@@ -126,7 +126,7 @@ firstboot_wizard() {
                     warn "Could not remove the consumed pre-seed from $PRESEED_DIR — it holds credentials; delete it."
             fi
         fi
-        if [ -f "$PWD/config.json" ]; then
+        if [ -f "$PWD/config.json" ] && ! setup_again_mode; then
             log "config.json already present (pre-seeded) — skipping the wizard and running setup."
             # A pre-seeded config that names no password gets one too: skipping the wizard must
             # not mean skipping the login.
@@ -198,7 +198,7 @@ firstboot_wizard() {
         rm -f "$spool/handoff.json" "$spool/handoff-ack" "$spool/installing" \
             "$spool/installed" "$spool/applied" "$spool/install-request" \
             "$spool/rig-request.json" "$spool/role" \
-            "$spool/restore-archive" "$spool/restore-passphrase"
+            "$spool/restore-archive" "$spool/restore-passphrase" "$spool/keep-role" "$spool/stick"
         # A pre-seeded token is the operator's own choice and stays fixed across restarts of
         # this loop; without one, mint a fresh secret every round.
         token=$(preseed_token) || token=$(wizard_mint_token)
@@ -209,12 +209,10 @@ firstboot_wizard() {
             -e WIZARD_TLS_KEY="${cert_fp:+/wizard-spool/wizard.key}" \
             -v "$spool":/wizard-spool \
             "$image" -m mining_dashboard.wizard >/dev/null || {
-            # `error` writes to stderr, which systemd routes to /dev/console — ONE device,
-            # whichever the kernel cmdline named LAST. On a box whose monitor is not that device
-            # the failure is invisible, so the newest thing on screen stays "preparing the setup
-            # page" and a STOPPED box reads as a slow one for as long as the operator is willing
-            # to wait. That is how a three-minute failure was mistaken for an hour of progress.
-            # _console reaches every physical console, which is the whole point here.
+            # `error` writes to stderr = /dev/console, ONE device (whichever the cmdline named
+            # LAST); on a box whose monitor is the other one the failure is invisible and a STOPPED
+            # box reads as a slow one — a three-minute failure was once taken for an hour of
+            # progress. _console reaches every physical console, which is the whole point here.
             _console "" "Setup has STOPPED — this box is no longer preparing a page." \
                 "The container engine could not start the setup page." \
                 "Diagnose with: journalctl -u pithead-firstboot -b"
@@ -254,6 +252,8 @@ firstboot_wizard() {
             } >"$dev" 2>/dev/null || true
         done
         while :; do
+            # #1318 "Keep it": the page wrote keep-role — nothing on /data was touched; return.
+            wizard_keep_requested "$spool" && return 0
             # A keep-everything reinstall arrives as a bare install-request with no config
             # candidate: the preserved /data keeps config, login and chains, so there is
             # nothing to validate and no credentials to hand off — install and switch off.

--- a/lib/pithead/12a-setup-again.sh
+++ b/lib/pithead/12a-setup-again.sh
@@ -1,0 +1,42 @@
+# The boot menu's "Set up again" entry (#1318). os/rauc/grub.cfg appends pithead.setup=1 to that
+# one boot; pithead-setup-again.service runs `pithead firstboot-wizard` with PITHEAD_SETUP_AGAIN
+# set, ahead of pithead-boot. What that switch changes is small, and all of it is here or one line
+# each in firstboot_wizard: the "this machine already has a role" short-circuits are skipped, the
+# page is told what the machine is, and "Keep it" ends the session with nothing on /data touched.
+# The role marker, rig.json and config.json are replaced only where a NEW role is accepted — the
+# same accept paths a first boot takes, unchanged.
+setup_again_mode() { [ -n "${PITHEAD_SETUP_AGAIN:-}" ]; }
+
+# What the page is told the machine already is, secrets left out: the role, and for a rig the pool
+# and worker it mines as (no stratum password, no control token). The rig form's pre-fill is
+# pointed at the SAME answers, so "Set up again" opens on them rather than on a fresh LAN probe; a
+# coordinator's form pre-fills from config.json through the reinstall rule (strip_config_secrets),
+# once per session so a failed re-provision's own retry context is never overwritten. Nothing is
+# published outside a set-up-again boot: the file's presence IS the page's signal.
+publish_saved_role() { # <spool-dir>
+    setup_again_mode || return 0
+    local spool="$1" role tmp="$1/.saved-role.json.$$" rtmp="$1/.rig-defaults.json.$$"
+    role=$(machine_role)
+    if [ "$role" = rig ] && [ -f "$PWD/rig.json" ]; then
+        jq '{role: "rig", pool: (.pool // ""), worker: (.worker // "")}' "$PWD/rig.json" >"$tmp" 2>/dev/null ||
+            jq -n '{role: "rig"}' >"$tmp"
+        jq '{pool, worker}' "$tmp" >"$rtmp" 2>/dev/null && mv -f "$rtmp" "$spool/rig-defaults.json" || rm -f "$rtmp"
+    else
+        jq -n --arg r "$role" '{role: $r}' >"$tmp"
+        if [ ! -f "$spool/last-attempt.json" ] && [ -f "$PWD/config.json" ]; then
+            strip_config_secrets "$PWD/config.json" >"$spool/last-attempt.json" 2>/dev/null ||
+                rm -f "$spool/last-attempt.json"
+        fi
+    fi
+    chown 1000:1000 "$tmp" "$spool/rig-defaults.json" "$spool/last-attempt.json" 2>/dev/null || true
+    mv -f "$tmp" "$spool/saved-role.json"
+}
+
+# "Keep it": the page wrote keep-role. Nothing on /data was touched — the marker, rig.json and
+# config.json are exactly as this boot found them — so firstboot_wizard returns, the unit ends,
+# and pithead-boot runs the boot the machine would have taken from the default entry.
+wizard_keep_requested() { # <spool-dir>
+    setup_again_mode && [ -f "$1/keep-role" ] || return 1
+    rm -f "$1/keep-role"
+    _console "Setup closed: the saved settings are kept. The machine is starting as it was."
+}

--- a/os/overlay/pithead-setup-again.service
+++ b/os/overlay/pithead-setup-again.service
@@ -1,0 +1,49 @@
+[Unit]
+Description=Pithead setup wizard beside the saved role (the boot menu's "Set up again" entry, #1318)
+# This unit runs on exactly one kind of boot: one chosen from the "Set up again" entry in
+# os/rauc/grub.cfg, which appends pithead.setup=1 to that boot's kernel cmdline and to no other —
+# the next boot takes the default entry and this condition is false again. And only on a
+# PROVISIONED machine, the same two triggering shapes pithead-boot.service keys on: before a role
+# exists pithead-firstboot owns the boot whatever the cmdline says, so the two units are
+# mutually exclusive by construction rather than by ordering.
+#
+# Before pithead-boot: the role's normal boot — the stack, or a rig's miner — waits behind the
+# page. "Keep it" ends this unit with nothing on /data touched, and pithead-boot then runs the
+# boot the machine would have taken from the default entry. A new role accepted on the page is
+# provisioned by the wizard exactly as on a first boot; pithead-boot's pass after it is the same
+# idempotent every-boot pass it always is. The booted slot is not committed while the page is
+# open, so a freshly updated slot that is never confirmed here falls back exactly as one that
+# never served would — that is the A/B promise, not a gap.
+ConditionKernelCommandLine=pithead.setup=1
+ConditionPathExists=|/data/pithead/config.json
+ConditionPathExists=|/data/pithead/machine-role
+# Same guard as both boot owners: container storage lives on /data.
+ConditionPathIsMountPoint=/data
+Wants=network-online.target systemd-timesyncd.service podman.socket pithead-sync.service
+After=network-online.target systemd-timesyncd.service podman.socket pithead-sync.service
+Before=pithead-boot.service
+
+[Service]
+Type=oneshot
+# Stays 'active' after success so the boot that follows can be attributed to this entry
+# (the harness asserts it; `systemctl is-active pithead-setup-again` on the machine says so).
+RemainAfterExit=yes
+WorkingDirectory=/data/pithead
+Environment=PITHEAD_ENGINE=podman
+# Same pair as pithead-firstboot: systemd sets neither, and pithead assumes both.
+Environment=HOME=/root
+Environment=USER=root
+# The one switch the wizard reads to become a wizard BESIDE a role instead of a first boot:
+# it skips the "this machine already has a role" short-circuits, tells the page what the machine
+# is (spool: saved-role.json), and honours the page's "Keep it" (spool: keep-role).
+Environment=PITHEAD_SETUP_AGAIN=1
+# The URL + one-time token must reach the person standing at the machine — the whole reason
+# this entry exists is that they have a console and nothing else.
+StandardOutput=journal+console
+StandardError=journal+console
+ExecStartPre=/bin/sh -c 'timedatectl show -p NTPSynchronized --value | grep -qx yes || htpdate -s www.debian.org || true'
+ExecStart=/data/pithead/pithead firstboot-wizard
+TimeoutStartSec=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/os/rauc/grub.cfg
+++ b/os/rauc/grub.cfg
@@ -2,7 +2,9 @@
 # RAUC writes ORDER/<slot>_OK/<slot>_TRY into this grubenv; GRUB picks the first slot that is
 # marked OK and has not already been tried, so an update that never marks itself good falls back.
 default=0
-timeout=3
+# 5 s, not 3: long enough for a person at the console to reach "Set up again" (#1318). An
+# unattended boot still takes the default entry by itself.
+timeout=5
 
 set ORDER="A B"
 set A_OK=0
@@ -45,6 +47,26 @@ fi
 
 save_env A_TRY A_OK B_TRY B_OK ORDER
 
+# The slot "Set up again" boots is the one the counting above just chose: that entry is the
+# default boot plus one kernel-cmdline flag, never a different system. Index 0 (nothing
+# selectable) boots slot A, so the setup entry follows it there too.
+set SETUP_PART=gpt2
+set SETUP_SLOT=A
+if [ "$default" -eq 2 ]; then
+    set SETUP_PART=gpt3
+    set SETUP_SLOT=B
+fi
+
+# A one-boot entry choice written by the running system — `grub-editenv <grubenv> set
+# next_entry=N`, the mechanism grub-reboot uses — consumed here so the boot after it takes the
+# default again. The slot counting above does not see it: the entry it names still boots the slot
+# the counting chose.
+if [ -n "$next_entry" ]; then
+    set default="$next_entry"
+    set next_entry=
+    save_env next_entry
+fi
+
 # Slots are addressed BY PARTITION, never by filesystem label. A RAUC bundle carries one
 # filesystem image that installs into whichever slot is spare, so its fs label cannot encode the
 # slot — after an install both slots would claim the same label and `search --label system-b`
@@ -77,31 +99,47 @@ regexp --set=1:DISK '^([^,]+)' "$root"
 #                           monitor being plugged in.
 CMDLINE="console=tty1 console=ttyS0 loglevel=4 drm_kms_helper.poll=0 panic=60"
 
-# Index 0 — reached only when neither slot is selectable. Best effort: boot slot A rather than
-# leaving the operator at a GRUB prompt on a headless machine.
+# Titles are for the person at the console (#1838): they name what an entry boots and nothing
+# else. The OK/TRY counters are the bootloader's bookkeeping (`grub-editenv list` on the machine
+# shows them) and mean nothing to a user; and index 0 used to be called "Recovery" while booting
+# slot A byte for byte as entry 1 does — it recovers nothing, so it says what it is: the fallback
+# taken when neither slot is selectable, on a headless box that must boot SOMETHING rather than
+# sit at a GRUB prompt. Plain hyphens, deliberately: firmware text consoles are not guaranteed a
+# glyph for anything else.
+#
 # The kernel root is the PARTUUID of the partition GRUB actually chose, probed at boot time —
 # never a label. Labels are identical on every pithead disk BY DESIGN (the installer copies the
 # running system), so the moment an installed disk and the install stick are present together,
 # root=/dev/disk/by-partlabel/system-a means whichever udev processed last: the stick's GRUB
 # could silently boot the internal disk's system, or the reverse. The PARTUUID is unique per
 # partition and `probe` resolves it from $root, so the kernel always boots the slot GRUB picked.
-menuentry "Recovery (slot A)" {
+menuentry "Pithead OS - slot A (fallback)" {
     set root=($DISK,gpt2)
     probe --set=PU --part-uuid ($DISK,gpt2)
     linux /vmlinuz root=PARTUUID=$PU $CMDLINE rauc.slot=A
     initrd /initrd.img
 }
 
-menuentry "Slot A (OK=$A_OK TRY=$A_TRY)" {
+menuentry "Pithead OS - slot A" {
     set root=($DISK,gpt2)
     probe --set=PU --part-uuid ($DISK,gpt2)
     linux /vmlinuz root=PARTUUID=$PU $CMDLINE rauc.slot=A
     initrd /initrd.img
 }
 
-menuentry "Slot B (OK=$B_OK TRY=$B_TRY)" {
+menuentry "Pithead OS - slot B" {
     set root=($DISK,gpt3)
     probe --set=PU --part-uuid ($DISK,gpt3)
     linux /vmlinuz root=PARTUUID=$PU $CMDLINE rauc.slot=B
+    initrd /initrd.img
+}
+
+# #1318: the way back to the setup page from the machine itself. Same slot as the default boot,
+# one extra flag; pithead-setup-again.service (the only reader of the flag) opens the wizard
+# BESIDE the saved role, and nothing on /data changes unless a new role is accepted there.
+menuentry "Set up again (opens the setup wizard; keeps the saved settings)" {
+    set root=($DISK,$SETUP_PART)
+    probe --set=PU --part-uuid ($DISK,$SETUP_PART)
+    linux /vmlinuz root=PARTUUID=$PU $CMDLINE rauc.slot=$SETUP_SLOT pithead.setup=1
     initrd /initrd.img
 }

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -289,10 +289,10 @@ RUN printf '[Match]\nName=en*\nName=eth*\n\n[Network]\nDHCP=yes\nMulticastDNS=ye
 COPY os/overlay/pithead-firstboot.service /etc/systemd/system/pithead-firstboot.service
 COPY os/overlay/pithead-sync.service /etc/systemd/system/pithead-sync.service
 COPY os/overlay/pithead-sync /usr/local/sbin/pithead-sync
-# State mounts are derived from the boot disk at every boot, never from labels — every pithead
-# disk carries the same labels, and two present at once made LABEL= mount the wrong /data.
+# State mounts derive from the boot disk every boot, never labels: every pithead disk carries the same labels, and two at once made LABEL= mount the wrong /data.
 COPY os/overlay/pithead-mount-generator /usr/lib/systemd/system-generators/pithead-mount-generator
 COPY os/overlay/pithead-boot.service /etc/systemd/system/pithead-boot.service
+COPY os/overlay/pithead-setup-again.service /etc/systemd/system/pithead-setup-again.service
 COPY os/overlay/pithead-boot /usr/local/sbin/pithead-boot
 # Physical-presence configuration channel (#786 sub-issue D): pithead-boot's one stage before render; no unit of its own.
 COPY os/overlay/pithead-media-config /usr/local/sbin/pithead-media-config
@@ -375,7 +375,7 @@ RUN systemctl enable podman.socket pithead-boot.service pithead-cpu-governor.ser
         systemd-timesyncd systemd-resolved \
         systemd-networkd systemd-networkd-wait-online pithead-sync.service pithead-firstboot.service \
         pithead-data-reset.service pithead-machine-id.service pithead-hugepages.service \
-        pithead-journal-persist.service \
+        pithead-journal-persist.service pithead-setup-again.service \
     && systemctl disable ssh
 # systemd-repart.service is static — it is pulled in by sysinit.target, and `systemctl enable` on a
 # static unit is an error that would fail the build. Assert it is present instead.

--- a/pithead
+++ b/pithead
@@ -1866,6 +1866,9 @@ firstboot_consume_spool() { # <spool-dir>
 
 record_machine_role() { # <pithead|both|rig>
     printf '%s\n' "$1" >"$PWD/machine-role" 2>/dev/null || true
+    # A role change replaces the role's data with it (#1318): rig.json — and the control token in
+    # it — belongs to the rig role only, so a machine accepted as a coordinator leaves none behind.
+    [ "$1" = rig ] || rm -f "$PWD/rig.json"
 }
 
 # The wizard's response to a failed (setup), as one step so it can be driven directly (#1059).
@@ -1987,8 +1990,14 @@ firstboot_consume_rig() { # <spool-dir>
         rm -f "$req"
         return 1
     fi
-    if ! jq --arg w "${worker:-$(hostname)}" '{pool: .pool, worker: $w}
-        + (if (.stratum_password // "") == "" then {} else {stratum_password: .stratum_password} end)' \
+    # The control token (#1836) survives a "Set up again" that keeps the role AND the worker name
+    # (#1318): the coordinator adopted THIS worker with THIS token. Any other change mints a new one.
+    local keep_tok=""
+    [ "$(jq -r '.worker // ""' "$PWD/rig.json" 2>/dev/null)" = "${worker:-$(hostname)}" ] &&
+        keep_tok=$(jq -r '.access_token // ""' "$PWD/rig.json" 2>/dev/null)
+    if ! jq --arg w "${worker:-$(hostname)}" --arg t "$keep_tok" '{pool: .pool, worker: $w}
+        + (if (.stratum_password // "") == "" then {} else {stratum_password: .stratum_password} end)
+        + (if $t == "" then {} else {access_token: $t} end)' \
         "$req" >"$PWD/rig.json" 2>/dev/null; then
         rm -f "$req" "$PWD/rig.json"
         printf 'could not record the rig settings — submit again' >"$spool/error.txt"
@@ -2655,9 +2664,10 @@ stage_wizard_spool() { # <spool-dir> -> fingerprint on stdout
     cp /opt/pithead/config.reference.json "$spool/config.reference.json" 2>/dev/null ||
         cp "$PWD/config.reference.json" "$spool/config.reference.json" 2>/dev/null || true
     chown 1000:1000 "$spool/config.reference.json" 2>/dev/null || true
-    # The rig role's pre-fill rides beside the reference — derived fresh each boot, like the
-    # disk inventory, so machine 2 on a fleet stick never opens on machine 1's discovery.
+    # The rig pre-fill and (#1318) the saved role ride beside the reference — derived fresh each
+    # boot, like the disk inventory, so machine 2 on a fleet stick never opens on machine 1's.
     publish_rig_defaults "$spool"
+    publish_saved_role "$spool"
     # The data-wipe note (#1121): same "derived fresh every boot" rule, for the same fleet-stick
     # reason — see publish_data_wipe_note.
     publish_data_wipe_note "$spool"
@@ -2730,12 +2740,11 @@ firstboot_wizard() {
         fi
     fi
     # A machine already carrying the rig role mines, and asks nothing — not even on a stick that
-    # could offer the installer, because a run-from-USB rig's stick IS that rig's system, not a
-    # fleet tool. Reached only on the boot that ACCEPTS the role (a disk install's first boot,
-    # just above): once the marker exists, pithead-boot owns every later boot and this unit's
-    # own condition skips it. The miner is best-effort here for the same reason it is in pithead-boot
-    # — a rig whose pool moved must still come up and keep retrying, not brick its own boot.
-    if [ "$(machine_role)" = "rig" ]; then
+    # could offer the installer: a run-from-USB rig's stick IS that rig's system, not a fleet tool.
+    # Reached only on the boot that ACCEPTS the role (a disk install's first boot, just above); a
+    # boot from the menu's "Set up again" entry (#1318) skips this and opens the page beside the role.
+    # The miner is best-effort, as in pithead-boot: a pool that moved must not brick the boot.
+    if [ "$(machine_role)" = "rig" ] && ! setup_again_mode; then
         _console "This machine is a RigForge rig ($(jq -r '.worker // "unnamed"' "$PWD/rig.json" 2>/dev/null) -> $(jq -r '.pool // "no pool recorded"' "$PWD/rig.json" 2>/dev/null))."
         provision_rig_miner || true
         return 0
@@ -2762,7 +2771,7 @@ firstboot_wizard() {
                     warn "Could not remove the consumed pre-seed from $PRESEED_DIR — it holds credentials; delete it."
             fi
         fi
-        if [ -f "$PWD/config.json" ]; then
+        if [ -f "$PWD/config.json" ] && ! setup_again_mode; then
             log "config.json already present (pre-seeded) — skipping the wizard and running setup."
             # A pre-seeded config that names no password gets one too: skipping the wizard must
             # not mean skipping the login.
@@ -2834,7 +2843,7 @@ firstboot_wizard() {
         rm -f "$spool/handoff.json" "$spool/handoff-ack" "$spool/installing" \
             "$spool/installed" "$spool/applied" "$spool/install-request" \
             "$spool/rig-request.json" "$spool/role" \
-            "$spool/restore-archive" "$spool/restore-passphrase"
+            "$spool/restore-archive" "$spool/restore-passphrase" "$spool/keep-role" "$spool/stick"
         # A pre-seeded token is the operator's own choice and stays fixed across restarts of
         # this loop; without one, mint a fresh secret every round.
         token=$(preseed_token) || token=$(wizard_mint_token)
@@ -2845,12 +2854,10 @@ firstboot_wizard() {
             -e WIZARD_TLS_KEY="${cert_fp:+/wizard-spool/wizard.key}" \
             -v "$spool":/wizard-spool \
             "$image" -m mining_dashboard.wizard >/dev/null || {
-            # `error` writes to stderr, which systemd routes to /dev/console — ONE device,
-            # whichever the kernel cmdline named LAST. On a box whose monitor is not that device
-            # the failure is invisible, so the newest thing on screen stays "preparing the setup
-            # page" and a STOPPED box reads as a slow one for as long as the operator is willing
-            # to wait. That is how a three-minute failure was mistaken for an hour of progress.
-            # _console reaches every physical console, which is the whole point here.
+            # `error` writes to stderr = /dev/console, ONE device (whichever the cmdline named
+            # LAST); on a box whose monitor is the other one the failure is invisible and a STOPPED
+            # box reads as a slow one — a three-minute failure was once taken for an hour of
+            # progress. _console reaches every physical console, which is the whole point here.
             _console "" "Setup has STOPPED — this box is no longer preparing a page." \
                 "The container engine could not start the setup page." \
                 "Diagnose with: journalctl -u pithead-firstboot -b"
@@ -2890,6 +2897,8 @@ firstboot_wizard() {
             } >"$dev" 2>/dev/null || true
         done
         while :; do
+            # #1318 "Keep it": the page wrote keep-role — nothing on /data was touched; return.
+            wizard_keep_requested "$spool" && return 0
             # A keep-everything reinstall arrives as a bare install-request with no config
             # candidate: the preserved /data keeps config, login and chains, so there is
             # nothing to validate and no credentials to hand off — install and switch off.
@@ -3189,6 +3198,49 @@ firstboot_wizard() {
             sleep 2
         done
     done
+}
+
+# The boot menu's "Set up again" entry (#1318). os/rauc/grub.cfg appends pithead.setup=1 to that
+# one boot; pithead-setup-again.service runs `pithead firstboot-wizard` with PITHEAD_SETUP_AGAIN
+# set, ahead of pithead-boot. What that switch changes is small, and all of it is here or one line
+# each in firstboot_wizard: the "this machine already has a role" short-circuits are skipped, the
+# page is told what the machine is, and "Keep it" ends the session with nothing on /data touched.
+# The role marker, rig.json and config.json are replaced only where a NEW role is accepted — the
+# same accept paths a first boot takes, unchanged.
+setup_again_mode() { [ -n "${PITHEAD_SETUP_AGAIN:-}" ]; }
+
+# What the page is told the machine already is, secrets left out: the role, and for a rig the pool
+# and worker it mines as (no stratum password, no control token). The rig form's pre-fill is
+# pointed at the SAME answers, so "Set up again" opens on them rather than on a fresh LAN probe; a
+# coordinator's form pre-fills from config.json through the reinstall rule (strip_config_secrets),
+# once per session so a failed re-provision's own retry context is never overwritten. Nothing is
+# published outside a set-up-again boot: the file's presence IS the page's signal.
+publish_saved_role() { # <spool-dir>
+    setup_again_mode || return 0
+    local spool="$1" role tmp="$1/.saved-role.json.$$" rtmp="$1/.rig-defaults.json.$$"
+    role=$(machine_role)
+    if [ "$role" = rig ] && [ -f "$PWD/rig.json" ]; then
+        jq '{role: "rig", pool: (.pool // ""), worker: (.worker // "")}' "$PWD/rig.json" >"$tmp" 2>/dev/null ||
+            jq -n '{role: "rig"}' >"$tmp"
+        jq '{pool, worker}' "$tmp" >"$rtmp" 2>/dev/null && mv -f "$rtmp" "$spool/rig-defaults.json" || rm -f "$rtmp"
+    else
+        jq -n --arg r "$role" '{role: $r}' >"$tmp"
+        if [ ! -f "$spool/last-attempt.json" ] && [ -f "$PWD/config.json" ]; then
+            strip_config_secrets "$PWD/config.json" >"$spool/last-attempt.json" 2>/dev/null ||
+                rm -f "$spool/last-attempt.json"
+        fi
+    fi
+    chown 1000:1000 "$tmp" "$spool/rig-defaults.json" "$spool/last-attempt.json" 2>/dev/null || true
+    mv -f "$tmp" "$spool/saved-role.json"
+}
+
+# "Keep it": the page wrote keep-role. Nothing on /data was touched — the marker, rig.json and
+# config.json are exactly as this boot found them — so firstboot_wizard returns, the unit ends,
+# and pithead-boot runs the boot the machine would have taken from the default entry.
+wizard_keep_requested() { # <spool-dir>
+    setup_again_mode && [ -f "$1/keep-role" ] || return 1
+    rm -f "$1/keep-role"
+    _console "Setup closed: the saved settings are kept. The machine is starting as it was."
 }
 
 announce_dashboard_url() {

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -57,6 +57,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 . "$SCRIPT_DIR/data-floor-fallback-leg.sh"
 # shellcheck source=tests/os/aged-version.sh
 . "$SCRIPT_DIR/aged-version.sh"
+# shellcheck source=tests/os/setup-again-leg.sh
+. "$SCRIPT_DIR/setup-again-leg.sh"
 
 IMAGE=""
 KEEP=0
@@ -2865,15 +2867,13 @@ phase_rig() {
     else
         bad "a rig started containers: '$names'"
     fi
-    # Prebuilt-first, proven by identity: a native recompile produces a DIFFERENT binary, and a
-    # clone could not have happened at all (this guest has no path to github).
+    # Prebuilt-first, proven by identity: a recompile gives a DIFFERENT binary; a clone has no path to github.
     if _ssh "cmp -s /data/rigforge/data/worker/xmrig/build/xmrig /opt/rigforge/prebuilt/xmrig/build/xmrig"; then
         ok "the rig mines the BAKED binary byte for byte — no compile, no clone, no clearnet"
     else
         bad "the running miner is not the baked prebuilt — something compiled or fetched on first boot"
     fi
-    # Removable-root tolerance: the journal is in memory, so a stick root takes no rotating
-    # writes. (This guest's root is virtual, but the setting is the role's, not the medium's.)
+    # Removable-root tolerance: an in-memory journal, so a stick root takes no rotating writes (the role's setting, not the medium's).
     [ "$(_ssh 'systemd-analyze cat-config systemd/journald.conf 2>/dev/null | grep -c "^Storage=volatile"')" != "0" ] &&
         ok "journald is volatile on a rig (a rig's root may be the stick it mines from)" ||
         bad "journald is still persistent on a rig — a USB root would take rotating writes"
@@ -2887,8 +2887,7 @@ phase_rig() {
     _rig_mining_up 24 &&
         ok "the rig returned mining with no hands on it (its unit lives in /run and died with the reboot)" ||
         bad "the rig did not return after the reboot — its runtime unit was never re-rendered"
-    # WHICH unit owns the boot is the whole R4 fork: the wizard's window is closed by rig.json,
-    # and pithead-boot — skipped on a rig before this phase existed — is what runs.
+    # WHICH unit owns the boot is the whole R4 fork: the wizard's window is closed, pithead-boot runs.
     [ "$(_ssh 'systemctl is-active pithead-boot' | tr -d '\r\n')" = "active" ] &&
         ok "pithead-boot owns a provisioned rig's boot" ||
         bad "pithead-boot did not run on the rig (its condition still excludes a machine with no config.json)"
@@ -2900,8 +2899,7 @@ phase_rig() {
         awk '$1 !~ /^[0-9a-f]{64}-[0-9a-f]+\.service$/' | tr -s ' ' | tr '\n' ';')
     [ -z "${failed_units//[; ]/}" ] && ok "no failed systemd units on the rig after the reboot" ||
         bad "failed units on the rig after the reboot: $failed_units"
-    # The commit gate, rig-shaped: a rig that could not commit would roll back every A/B update
-    # it ever received. Note the pool here answers nothing — the commit must not depend on it.
+    # The commit gate, rig-shaped: a rig that cannot commit rolls back every update; the pool answers nothing, and must not matter.
     local genv tries3=0
     while [ "$tries3" -lt 18 ]; do
         genv=$(_ssh "grub-editenv /boot/efi/grub/grubenv list" 2>/dev/null | tr '\n' ' ')
@@ -2915,6 +2913,7 @@ phase_rig() {
         ;;
     *) bad "the rig never self-committed — grubenv: ${genv:-unreadable}" ;;
     esac
+    rig_setup_again_legs "$card_tok" "$token" # #1318: Keep it, then Set up again as the same rig (tests/os/setup-again-leg.sh)
 
     # ---- A/B update: identical pipeline, identical outcome --------------------------------
     info "update leg — a rig takes a bundle exactly like a coordinator"
@@ -2975,6 +2974,7 @@ phase_rig() {
     marker=$(_ssh cat /etc/pithead-test-marker | tr -d '\r\n')
     [ "$marker" = "v2" ] && ok "COMMIT: the update persists on the rig across reboot" ||
         bad "expected v2 on the rig after commit, got '$marker'"
+    rig_setup_again_coordinator_leg "$token" # #1318: Set up again as a coordinator, from the updated slot
 }
 
 phase_fault() {

--- a/tests/os/setup-again-leg.sh
+++ b/tests/os/setup-again-leg.sh
@@ -22,6 +22,11 @@ _setup_again_boot() {
         bad "could not write next_entry into the ESP's grubenv"
         return 1
     }
+    # Where the console log ends NOW: the session below reads only what this boot prints after
+    # it. The log is continuous across in-guest reboots, so "the last token on the console" is
+    # the previous session's until the new one appears — leg 3 once posted leg 2's token off
+    # exactly that and the gate refused it.
+    SA_SERIAL_OFFSET=$(stat -c %s "$SERIAL" 2>/dev/null || echo 0)
     _reboot_wait reboot "$1" || {
         bad "the guest never returned from the reboot into the setup entry"
         return 1
@@ -38,20 +43,22 @@ _setup_again_boot() {
         bad "pithead-setup-again is '${st:-unreadable}' 120 s into the boot — the flag was not honoured"
 }
 
-# The wizard session on a set-up-again boot: a token this boot minted (not $1, the last session's),
-# the page served, a session cookie in $jar. Sets token and jar in the caller; rc 1 = reported.
-_setup_again_session() { # $1 = the previous session's token
-    local tries=0
+# The wizard session on a set-up-again boot: the token THIS boot minted (read past the offset
+# _setup_again_boot took before the reboot, never the last session's), the page served, a session
+# cookie in $jar. Sets token and jar in the caller; rc 1 = reported.
+_setup_again_session() {
+    local tries=0 from="${SA_SERIAL_OFFSET:-0}"
+    # A harness-driven guest boot truncates the console log; then everything in it is this boot's.
+    [ "$(stat -c %s "$SERIAL" 2>/dev/null || echo 0)" -ge "$from" ] || from=0
     token=""
     while [ "$tries" -lt 40 ]; do
-        token=$(tr -d '\r' <"$SERIAL" | grep -oE 'pit-[A-Z0-9]{6}' | tail -1)
-        [ -n "$token" ] && [ "$token" != "$1" ] && break
-        token=""
+        token=$(tail -c +"$((from + 1))" "$SERIAL" | tr -d '\r' | grep -oE 'pit-[A-Z0-9]{6}' | tail -1)
+        [ -n "$token" ] && break
         sleep 3
         tries=$((tries + 1))
     done
     [ -n "$token" ] || {
-        bad "no NEW one-time token appeared on the console (the last session's was $1)"
+        bad "no one-time token appeared on the console after the reboot into the setup entry"
         return 1
     }
     _wait_setup_page 120 || {
@@ -85,8 +92,9 @@ _setup_again_rig_submit() {
         bad "no rig card appeared after Set up again"
         return 1
     }
-    sa_card_address=$(printf '%s' "$card" | jq -r '.address // ""' 2>/dev/null)
-    printf '%s' "$card" | jq -r '.token // ""' 2>/dev/null
+    # Both fields on ONE line: this runs under $(...), so a variable set here dies with the
+    # subshell — the first battery read an empty address off exactly that (#1318 rig-leg red).
+    printf '%s' "$card" | jq -r '"\(.token // "") \(.address // "")"' 2>/dev/null
     curl -sSk -b "$jar" -X POST "https://$ip/handoff-ack" -o /dev/null 2>/dev/null || true
 }
 
@@ -114,7 +122,7 @@ rig_setup_again_legs() {
     _ssh "systemctl is-active --quiet xmrig" 2>/dev/null &&
         bad "the miner is running beside the open page — the normal boot was taken" ||
         ok "the miner is not started beside the page"
-    _setup_again_session "$token" || return
+    _setup_again_session || return
     saved=$(_ssh "cat $SA_SPOOL/saved-role.json" 2>/dev/null | tr -d '\r')
     printf '%s' "$saved" | jq -e '.role == "rig" and .worker == "kvm-rig" and .pool == "127.0.0.1:22"' >/dev/null 2>&1 &&
         ok "the page is told the saved role: rig, kvm-rig -> 127.0.0.1:22" ||
@@ -137,8 +145,15 @@ rig_setup_again_legs() {
     done
     [ "$st" = active ] && ok "Keep it: the page closed and the unit ended clean (active, exited)" ||
         bad "the setup-again unit is '${st:-unreadable}' 120 s after keep-role was written"
-    _ssh "journalctl -b -u pithead-setup-again -o cat --no-pager 2>/dev/null | grep -q 'saved settings are kept'" 2>/dev/null &&
-        ok "the host logged the keep, by name" || bad "no 'saved settings are kept' line in the setup-again journal"
+    # The keep line is a JOURNAL line (journal+console on the unit), but this is a rig: minutes
+    # into every boot pithead-boot flips journald volatile and reclaims the persistent journal
+    # (#1817, 14-local-miner.sh), taking this boot's earlier entries with it — by the time the
+    # miner is up, `journalctl -b -u pithead-setup-again` is empty. journald's own console
+    # forward of the entry (`pithead[<pid>]: [pithead] ...`, distinct from _console's bare tty
+    # write) is the durable witness that the line reached the journal.
+    tr -d '\r' <"$SERIAL" | grep -qE 'pithead\[[0-9]+\]: \[pithead\] Setup closed: the saved settings are kept' &&
+        ok "the host logged the keep, by name (the journal entry, via its console forward)" ||
+        bad "no 'saved settings are kept' journal entry reached the console"
     _ssh "test ! -e $SA_SPOOL/keep-role" 2>/dev/null && ok "keep-role was consumed" ||
         bad "keep-role is still in the spool — a later session would close at once"
     _rig_mining_up 24 && ok "the rig mines again after Keep — pithead-boot ran the boot it would have" ||
@@ -150,12 +165,14 @@ rig_setup_again_legs() {
 
     info "set-up-again leg 2 — Set up again as the same rig keeps the token"
     _setup_again_boot 300 || return
-    _setup_again_session "$token" || return
+    _setup_again_session || return
     card_tok=$(_setup_again_rig_submit kvm-rig) || {
         rm -f "$jar"
         return
     }
     rm -f "$jar"
+    sa_card_address=${card_tok#* }
+    card_tok=${card_tok%% *}
     [ -n "$card_tok" ] && [ "$card_tok" = "$tok0" ] &&
         ok "same role + worker: the card shows the SAME token — the coordinator's adoption survives" ||
         bad "the card's token changed on an unchanged rig ('${card_tok:0:8}' vs '${tok0:0:8}')"
@@ -170,18 +187,33 @@ rig_setup_again_legs() {
         ok "still no coordinator config on the rig" || bad "a config.json appeared on the rig after Set up again"
 }
 
-# Leg 3, at the end of the phase: the rig runs the updated slot B, committed. $1 = the last
-# session's one-time token. Set up again as a coordinator replaces the role and its data.
+# Leg 3, at the end of the phase: the rig runs the updated slot B, committed. Set up again as a
+# coordinator replaces the role and its data. ($1, the last session's token, is no longer what
+# the session keys on — see _setup_again_boot — but run.sh still hands it over.)
 rig_setup_again_coordinator_leg() {
     local token="$1" jar="" cmd scode tries=0 n=0 role
     info "set-up-again leg 3 — Set up again as a coordinator replaces the role (from slot B)"
+    # The COMMIT leg's reboot left GRUB's try-count on B raised (B_TRY=1) until pithead-boot
+    # re-commits it on the miner running. The setup entry follows what the DEFAULT would boot,
+    # and an uncommitted B is not it — the first battery rebooted inside that window and the
+    # entry correctly took A. Wait for the rig's own re-commit; that it happens is the property.
+    while [ "$n" -lt 24 ]; do
+        case "$(_ssh 'grub-editenv /boot/efi/grub/grubenv list' 2>/dev/null | tr -d '\r' | tr '\n' ' ')" in
+        *"B_OK=1 "*"B_TRY=0"* | *"B_TRY=0"*"B_OK=1"*) break ;;
+        esac
+        sleep 5
+        n=$((n + 1))
+    done
+    [ "$n" -lt 24 ] && ok "the updated slot re-committed itself on the next boot (B_OK=1 B_TRY=0), no hands" ||
+        bad "slot B did not re-commit within 120 s of the COMMIT reboot — the setup entry would follow the fallback"
+    n=0
     _setup_again_boot 300 || return
     cmd=$(_ssh cat /proc/cmdline 2>/dev/null | tr -d '\r')
     case "$cmd" in
     *pithead.setup=1*rauc.slot=B* | *rauc.slot=B*pithead.setup=1*) ok "after the update the setup entry followed the default to slot B" ;;
     *) bad "the setup entry did not follow the default to slot B — cmdline: $(printf '%s' "$cmd" | cut -c1-160)" ;;
     esac
-    _setup_again_session "$token" || return
+    _setup_again_session || return
     scode=$(curl -sSk -b "$jar" --data "monero_wallet=$HARNESS_WALLET&tari_wallet=$HARNESS_TARI&pool=mini" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
     [ "$scode" = "200" ] || {
         bad "coordinator submit on the set-up-again page returned ${scode:-none}, want 200"

--- a/tests/os/setup-again-leg.sh
+++ b/tests/os/setup-again-leg.sh
@@ -1,0 +1,209 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154  # ip, token, jar and SERIAL are run.sh's — the guest address, the session, the console log
+#
+# The boot menu's "Set up again" entry, tier 4 (#1318). Sourced by tests/os/run.sh and run inside
+# phase_rig on the guest the reboot leg just left: a provisioned rig, mining, slot A committed.
+# Three legs, each a boot from that entry. Keep it: the page closes and the rig mines again with
+# the SAME token. Set up again as the same rig: the card shows the SAME token, so the coordinator's
+# adoption survives. And after the update leg has moved the rig to slot B, Set up again as a
+# coordinator: the role and its data are replaced — and the entry followed the default to slot B.
+#
+# The entry is chosen the way the running system would choose it: `grub-editenv set next_entry=3`
+# in the ESP's grubenv, which grub.cfg consumes for exactly one boot. Never keystrokes on the
+# serial console. The page's "Keep it" is the fixes lane's screen; here it is what that screen
+# writes — an empty keep-role in the spool — touched over SSH. That proves the HOST half (the
+# marker ends the session with nothing changed) independent of the SPA, which is proven at tier 1.
+
+SA_SPOOL=/data/pithead/data/firstboot
+
+# Boot the "Set up again" entry once, and wait for the new boot. $1 = seconds. rc 1 = reported.
+_setup_again_boot() {
+    _ssh "mount -o remount,rw /boot/efi && grub-editenv /boot/efi/grub/grubenv set next_entry=3" || {
+        bad "could not write next_entry into the ESP's grubenv"
+        return 1
+    }
+    _reboot_wait reboot "$1" || {
+        bad "the guest never returned from the reboot into the setup entry"
+        return 1
+    }
+    # The unit is 'activating' for as long as the page is open; sshd answers before it starts.
+    local n=0 st=""
+    while [ "$n" -lt 24 ]; do
+        st=$(_ssh 'systemctl is-active pithead-setup-again' 2>/dev/null | tr -d '\r\n')
+        [ "$st" = activating ] && break
+        sleep 5
+        n=$((n + 1))
+    done
+    [ "$st" = activating ] && ok "pithead-setup-again holds the boot (activating) while the page is open" ||
+        bad "pithead-setup-again is '${st:-unreadable}' 120 s into the boot — the flag was not honoured"
+}
+
+# The wizard session on a set-up-again boot: a token this boot minted (not $1, the last session's),
+# the page served, a session cookie in $jar. Sets token and jar in the caller; rc 1 = reported.
+_setup_again_session() { # $1 = the previous session's token
+    local tries=0
+    token=""
+    while [ "$tries" -lt 40 ]; do
+        token=$(tr -d '\r' <"$SERIAL" | grep -oE 'pit-[A-Z0-9]{6}' | tail -1)
+        [ -n "$token" ] && [ "$token" != "$1" ] && break
+        token=""
+        sleep 3
+        tries=$((tries + 1))
+    done
+    [ -n "$token" ] || {
+        bad "no NEW one-time token appeared on the console (the last session's was $1)"
+        return 1
+    }
+    _wait_setup_page 120 || {
+        bad "the setup page never served on the set-up-again boot"
+        return 1
+    }
+    jar=$(mktemp)
+    curl -fsSk -c "$jar" -d "token=$token" "https://$ip/auth" -o /dev/null 2>/dev/null && grep -q wizard_session "$jar" || {
+        bad "the set-up-again token was not accepted (or no session cookie came back)"
+        rm -f "$jar"
+        return 1
+    }
+    ok "the setup page is up on the set-up-again boot, with a fresh token ($token)"
+}
+
+# Submit the rig form and wait for its card. $1 = worker; prints the card's token; rc 1 = reported.
+_setup_again_rig_submit() {
+    local scode card tries=0
+    scode=$(curl -sSk -b "$jar" --data "role=rig&rig_pool=127.0.0.1:22&rig_worker=$1" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
+    [ "$scode" = "200" ] || {
+        bad "rig submit on the set-up-again page returned ${scode:-none}, want 200"
+        return 1
+    }
+    while [ "$tries" -lt 24 ]; do
+        card=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null)
+        case "$card" in *'"worker"'*) break ;; esac
+        sleep 5
+        tries=$((tries + 1))
+    done
+    [ "$tries" -lt 24 ] || {
+        bad "no rig card appeared after Set up again"
+        return 1
+    }
+    sa_card_address=$(printf '%s' "$card" | jq -r '.address // ""' 2>/dev/null)
+    printf '%s' "$card" | jq -r '.token // ""' 2>/dev/null
+    curl -sSk -b "$jar" -X POST "https://$ip/handoff-ack" -o /dev/null 2>/dev/null || true
+}
+
+# Legs 1 and 2, on a committed, mining rig. $1 = the token the provisioning card showed,
+# $2 = the provisioning session's one-time token. Leaves the rig mining as kvm-rig.
+rig_setup_again_legs() {
+    local tok0="$1" token="$2" jar="" cmd st n card_tok saved sa_card_address=""
+    info "set-up-again leg 1 (#1318) — the menu entry opens the wizard beside the saved rig; Keep it"
+    _setup_again_boot 300 || return
+    cmd=$(_ssh cat /proc/cmdline 2>/dev/null | tr -d '\r')
+    case "$cmd" in
+    *pithead.setup=1*rauc.slot=A* | *rauc.slot=A*pithead.setup=1*) ok "GRUB booted the setup entry: the flag rides the slot the default would have booted (A)" ;;
+    *) bad "the setup entry did not boot slot A with the flag — cmdline: $(printf '%s' "$cmd" | cut -c1-160)" ;;
+    esac
+    case "$(_ssh 'grub-editenv /boot/efi/grub/grubenv list' 2>/dev/null | tr -d '\r')" in
+    *next_entry=3*) bad "next_entry is still set — the NEXT boot would open the page again" ;;
+    *) ok "next_entry was consumed: the next boot takes the default entry again" ;;
+    esac
+    [ "$(_ssh 'systemctl is-active pithead-boot' 2>/dev/null | tr -d '\r\n')" = inactive ] &&
+        ok "pithead-boot waits behind the page — the rig's normal boot is not taken" ||
+        bad "pithead-boot ran beside the open page"
+    _ssh "systemctl is-active --quiet pithead-firstboot" 2>/dev/null &&
+        bad "pithead-firstboot ran on a provisioned rig — the flag must not reopen the first-boot unit" ||
+        ok "the first-boot unit stays closed: the marker decides, the flag does not"
+    _ssh "systemctl is-active --quiet xmrig" 2>/dev/null &&
+        bad "the miner is running beside the open page — the normal boot was taken" ||
+        ok "the miner is not started beside the page"
+    _setup_again_session "$token" || return
+    saved=$(_ssh "cat $SA_SPOOL/saved-role.json" 2>/dev/null | tr -d '\r')
+    printf '%s' "$saved" | jq -e '.role == "rig" and .worker == "kvm-rig" and .pool == "127.0.0.1:22"' >/dev/null 2>&1 &&
+        ok "the page is told the saved role: rig, kvm-rig -> 127.0.0.1:22" ||
+        bad "saved-role.json is not the saved rig: ${saved:-empty}"
+    [ "$(printf '%s' "$saved" | jq -c 'keys' 2>/dev/null)" = '["pool","role","worker"]' ] &&
+        ok "saved-role.json carries no secret: exactly role, pool, worker" ||
+        bad "saved-role.json carries more than role, pool, worker: $(printf '%s' "$saved" | jq -c 'keys' 2>/dev/null)"
+    _ssh "jq -e '.pool == \"127.0.0.1:22\" and .worker == \"kvm-rig\"' $SA_SPOOL/rig-defaults.json >/dev/null" 2>/dev/null &&
+        ok "the rig form pre-fills from the saved answers, not a fresh LAN probe" ||
+        bad "rig-defaults.json does not carry the saved pool + worker"
+    # Keep it — what the page's button writes, written here.
+    _ssh "touch $SA_SPOOL/keep-role && chown 1000:1000 $SA_SPOOL/keep-role" >/dev/null 2>&1 || true
+    rm -f "$jar"
+    n=0
+    while [ "$n" -lt 24 ]; do
+        st=$(_ssh 'systemctl is-active pithead-setup-again' 2>/dev/null | tr -d '\r\n')
+        [ "$st" = active ] && break
+        sleep 5
+        n=$((n + 1))
+    done
+    [ "$st" = active ] && ok "Keep it: the page closed and the unit ended clean (active, exited)" ||
+        bad "the setup-again unit is '${st:-unreadable}' 120 s after keep-role was written"
+    _ssh "journalctl -b -u pithead-setup-again -o cat --no-pager 2>/dev/null | grep -q 'saved settings are kept'" 2>/dev/null &&
+        ok "the host logged the keep, by name" || bad "no 'saved settings are kept' line in the setup-again journal"
+    _ssh "test ! -e $SA_SPOOL/keep-role" 2>/dev/null && ok "keep-role was consumed" ||
+        bad "keep-role is still in the spool — a later session would close at once"
+    _rig_mining_up 24 && ok "the rig mines again after Keep — pithead-boot ran the boot it would have" ||
+        bad "the rig did not come back mining after Keep (unit: $(_ssh 'systemctl is-active xmrig' 2>/dev/null || echo unknown))"
+    [ "$(_ssh 'jq -r .access_token /data/pithead/rig.json' 2>/dev/null | tr -d '\r\n')" = "$tok0" ] &&
+        ok "the control token survived Keep" || bad "the token in rig.json changed on Keep"
+    [ "$(_ssh 'cat /data/pithead/machine-role' 2>/dev/null | tr -d '\r\n')" = rig ] &&
+        ok "the role marker is untouched by Keep" || bad "the role marker changed on Keep"
+
+    info "set-up-again leg 2 — Set up again as the same rig keeps the token"
+    _setup_again_boot 300 || return
+    _setup_again_session "$token" || return
+    card_tok=$(_setup_again_rig_submit kvm-rig) || {
+        rm -f "$jar"
+        return
+    }
+    rm -f "$jar"
+    [ -n "$card_tok" ] && [ "$card_tok" = "$tok0" ] &&
+        ok "same role + worker: the card shows the SAME token — the coordinator's adoption survives" ||
+        bad "the card's token changed on an unchanged rig ('${card_tok:0:8}' vs '${tok0:0:8}')"
+    # #1836's card field the first battery never read (reviewer finding on the #1836 PR): the address
+    # the adopt form needs must be THIS guest's, not empty and not another interface's.
+    [ "$sa_card_address" = "$ip" ] && ok "the card's address is the guest's own ($ip) — the adopt form can reach it" ||
+        bad "the card's address is '${sa_card_address:-empty}', the guest answers on $ip"
+    _rig_mining_up 36 && ok "the rig mines after Set up again" || bad "the rig did not come up after Set up again"
+    [ "$(_ssh 'jq -r .ACCESS_TOKEN /data/rigforge/config.json' 2>/dev/null | tr -d '\r\n')" = "$tok0" ] &&
+        ok "the miner enforces the kept token" || bad "the miner's config carries a different token after Set up again"
+    [ -z "$(_ssh 'ls /data/pithead/config.json 2>/dev/null')" ] &&
+        ok "still no coordinator config on the rig" || bad "a config.json appeared on the rig after Set up again"
+}
+
+# Leg 3, at the end of the phase: the rig runs the updated slot B, committed. $1 = the last
+# session's one-time token. Set up again as a coordinator replaces the role and its data.
+rig_setup_again_coordinator_leg() {
+    local token="$1" jar="" cmd scode tries=0 n=0 role
+    info "set-up-again leg 3 — Set up again as a coordinator replaces the role (from slot B)"
+    _setup_again_boot 300 || return
+    cmd=$(_ssh cat /proc/cmdline 2>/dev/null | tr -d '\r')
+    case "$cmd" in
+    *pithead.setup=1*rauc.slot=B* | *rauc.slot=B*pithead.setup=1*) ok "after the update the setup entry followed the default to slot B" ;;
+    *) bad "the setup entry did not follow the default to slot B — cmdline: $(printf '%s' "$cmd" | cut -c1-160)" ;;
+    esac
+    _setup_again_session "$token" || return
+    scode=$(curl -sSk -b "$jar" --data "monero_wallet=$HARNESS_WALLET&tari_wallet=$HARNESS_TARI&pool=mini" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
+    [ "$scode" = "200" ] || {
+        bad "coordinator submit on the set-up-again page returned ${scode:-none}, want 200"
+        rm -f "$jar"
+        return
+    }
+    while [ "$tries" -lt 24 ]; do
+        curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null | grep -q '"password"' && break
+        sleep 5
+        tries=$((tries + 1))
+    done
+    [ "$tries" -lt 24 ] && ok "a coordinator's credentials card appeared on the set-up-again page" ||
+        bad "no coordinator card appeared — the config was not accepted (error: $(_ssh "cat $SA_SPOOL/error.txt" 2>/dev/null | cut -c1-160))"
+    curl -sSk -b "$jar" -X POST "https://$ip/handoff-ack" -o /dev/null 2>/dev/null || true
+    rm -f "$jar"
+    while [ "$n" -lt 18 ]; do
+        role=$(_ssh 'cat /data/pithead/machine-role' 2>/dev/null | tr -d '\r\n')
+        [ "$role" = pithead ] && break
+        sleep 5
+        n=$((n + 1))
+    done
+    [ "$role" = pithead ] && ok "the role marker was replaced: rig -> pithead" || bad "the role marker still says '${role:-nothing}' 90 s after the ack"
+    _ssh "test -s /data/pithead/config.json" 2>/dev/null && ok "the coordinator's config.json was written" || bad "no config.json after accepting the coordinator role"
+    _ssh "test ! -e /data/pithead/rig.json" 2>/dev/null && ok "rig.json (and the token in it) went with the rig role" || bad "rig.json survived a role change to coordinator"
+}

--- a/tests/os/verify-image-boot-menu.sh
+++ b/tests/os/verify-image-boot-menu.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=bash
+#
+# The boot menu's rows for tests/os/verify-image.sh (#1838 the titles, #1318 the way back to setup).
+# Sourced after the ESP and slot A are mounted, with chk/ok/bad, $ESP and $ROOT in scope. A sibling
+# rather than more rows in verify-image.sh, which sits at the 400-line target: one subject, one file.
+echo "==> boot menu (titles for a person, #1838; the way back to setup, #1318)"
+# shellcheck disable=SC2034  # read inside chk's eval'd conditions
+GRUBCFG="$ESP/grub/grub.cfg"
+chk "the menu waits 5 s — long enough to choose an entry" 'grep -q "^timeout=5$" "$GRUBCFG"'
+chk "entries name what they boot: slot A, slot B" 'grep -q "^menuentry \"Pithead OS - slot A\"" "$GRUBCFG" && grep -q "^menuentry \"Pithead OS - slot B\"" "$GRUBCFG"'
+# Index 0 boots slot A byte for byte as entry 1 does; it recovers nothing and its TITLE must not say so
+# (grub.cfg's comment records the old name, so the sweep reads entries, not the file).
+chk "the fallback entry says fallback, and no entry says Recovery" 'grep -q "^menuentry \"Pithead OS - slot A (fallback)\"" "$GRUBCFG" && ! grep "^menuentry" "$GRUBCFG" | grep -qi "recovery"'
+chk "no bootloader counters in any title" '! grep "^menuentry" "$GRUBCFG" | grep -qE "OK=|TRY="'
+chk "a Set up again entry, carrying the flag on its kernel line" 'grep -q "^menuentry \"Set up again (opens the setup wizard; keeps the saved settings)\"" "$GRUBCFG" && [ "$(grep -c "^ *linux .*pithead.setup=1" "$GRUBCFG")" -eq 1 ]'
+# The entry is the default boot plus one flag: it must follow the slot counting, never pin a slot.
+chk "the setup entry boots the slot the counting chose" 'grep -q "rauc.slot=\$SETUP_SLOT pithead.setup=1" "$GRUBCFG" && grep -q "^set SETUP_SLOT=A$" "$GRUBCFG" && grep -q "SETUP_SLOT=B" "$GRUBCFG"'
+# grub-reboot's mechanism: the running system names an entry for ONE boot, and grub.cfg consumes it.
+chk "next_entry is honoured for one boot and consumed" 'grep -q "set default=\"\$next_entry\"" "$GRUBCFG" && grep -q "^    save_env next_entry$" "$GRUBCFG"'
+# shellcheck disable=SC2034  # read inside chk's eval'd conditions
+SAU="$ROOT/etc/systemd/system/pithead-setup-again.service"
+chk "the setup-again unit ships and is enabled" '[ -s "$SAU" ] && [ -L "$ROOT/etc/systemd/system/multi-user.target.wants/pithead-setup-again.service" ]'
+chk "it runs only on a boot carrying the flag" 'grep -q "^ConditionKernelCommandLine=pithead.setup=1$" "$SAU"'
+chk "…and only on a provisioned machine, either shape" 'grep -q "^ConditionPathExists=|/data/pithead/config.json$" "$SAU" && grep -q "^ConditionPathExists=|/data/pithead/machine-role$" "$SAU"'
+chk "it holds the normal boot behind the page" 'grep -q "^Before=pithead-boot.service$" "$SAU"'
+chk "it runs the wizard in set-up-again mode, on the console" 'grep -q "^Environment=PITHEAD_SETUP_AGAIN=1$" "$SAU" && grep -q "^ExecStart=/data/pithead/pithead firstboot-wizard$" "$SAU" && grep -q "^StandardOutput=journal+console$" "$SAU"'
+# The switch's three readers in the baked CLI: the mode test, the page's signal, the page's keep.
+chk "the baked pithead honours the switch (mode, saved-role.json, keep-role)" 'grep -q "setup_again_mode" "$ROOT/opt/pithead/pithead" && grep -q "saved-role.json" "$ROOT/opt/pithead/pithead" && grep -q "keep-role" "$ROOT/opt/pithead/pithead"'
+chk "pithead-boot does not read the flag (the unit is its only reader)" '! grep -q "pithead.setup" "$ROOT/usr/local/sbin/pithead-boot"'

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -110,14 +110,14 @@ chk "grub.cfg in the prefix dir" '[ -s "$ESP/grub/grub.cfg" ]'
 chk "grubenv in the prefix dir, not the ESP root" '[ -s "$ESP/grub/grubenv" ] && [ ! -e "$ESP/grubenv" ]'
 chk "grubenv seeds slot A good" 'grub-editenv "$ESP/grub/grubenv" list | grep -q "A_OK=1"'
 chk "kernel root by probed PARTUUID, never label" 'grep -q "probe --set=PU --part-uuid" "$ESP/grub/grub.cfg"'
-# The console carries the token and the generated password; kernel chatter that scrolls them
-# away is a defect. Journald keeps everything regardless.
+# The console carries the token and the password; chatter that scrolls them away is a defect.
 chk "console is quieted so the token stays readable" 'grep -q "loglevel=4" "$ESP/grub/grub.cfg"'
 chk "display hotplug polling off (repeated EDID spam)" 'grep -q "drm_kms_helper.poll=0" "$ESP/grub/grub.cfg"'
+# shellcheck source=tests/os/verify-image-boot-menu.sh
+. "$SCRIPT_DIR/verify-image-boot-menu.sh"
 # mDNS advertises IPv4 only — AAAA records stalled clients that cannot route to the box's v6.
 chk "avahi is IPv4-only (no unreachable-AAAA stall)" 'grep -q "^use-ipv6=no" "$ROOT/etc/avahi/avahi-daemon.conf"'
-# Boot recovery is compose-owned (#792): pithead-boot renders + ups + health-gates the slot
-# commit. podman-restart started the stack into its own cgroup and SIGKILLed it on unit stop.
+# Boot recovery is compose-owned (#792): pithead-boot renders + ups + health-gates the slot commit.
 chk "pithead-boot unit enabled" 'test -L "$ROOT/etc/systemd/system/multi-user.target.wants/pithead-boot.service"'
 chk "pithead-boot script present and executable" 'test -x "$ROOT/usr/local/sbin/pithead-boot"'
 # Physical-presence config channel (#786 sub-issue D): pithead-boot's one stage before render,

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -35,13 +35,10 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard.sh" && domain_ran test-dash
 # shellcheck source=tests/stack/test-dashboard-onion.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-dashboard-onion.sh" && domain_ran test-dashboard-onion.sh "$_d0" "$?" || domain_ran test-dashboard-onion.sh "$_d0" "$?"
 
-# Regression (#1330): test-dashboard-onion.sh must not depend on running after test-dashboard.sh.
-# A `( ... )` subshell is a fork of THIS process and inherits its whole variable table, exported
-# or not — including $auth_hb64/$caddy_https, already left behind here by test-dashboard.sh's
-# earlier `source` a few lines up, so a subshell guard would stay green even if this file went
-# back to reading those as globals. Only a genuinely separate `bash` process is isolated: it
-# inherits the environment (exported vars), never a parent shell's plain variables. $HERE isn't
-# exported either, so it's passed as an argument rather than read from the environment.
+# Regression (#1330): test-dashboard-onion.sh must not depend on running after test-dashboard.sh. A
+# `( ... )` subshell forks THIS process and inherits its whole variable table, exported or not — including
+# $auth_hb64/$caddy_https left behind by test-dashboard.sh's `source` above — so a subshell guard would
+# stay green. Only a separate `bash` process is isolated (environment only); $HERE is passed as an argument.
 # shellcheck disable=SC1090,SC2015  # STACK/HERE paths are dynamic by design
 bash -c '
     set -uo pipefail
@@ -223,6 +220,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-install.sh" && domain_ran t
 
 # shellcheck source=tests/stack/test-appliance-rig-miner.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-rig-miner.sh" && domain_ran test-appliance-rig-miner.sh "$_d0" "$?" || domain_ran test-appliance-rig-miner.sh "$_d0" "$?"
+
+# shellcheck source=tests/stack/test-appliance-setup-again.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-appliance-setup-again.sh" && domain_ran test-appliance-setup-again.sh "$_d0" "$?" || domain_ran test-appliance-setup-again.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-appliance-boot.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-appliance-boot.sh" && domain_ran test-appliance-boot.sh "$_d0" "$?" || domain_ran test-appliance-boot.sh "$_d0" "$?"

--- a/tests/stack/test-appliance-setup-again.sh
+++ b/tests/stack/test-appliance-setup-again.sh
@@ -1,0 +1,115 @@
+# shellcheck shell=bash
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
+# The boot menu's "Set up again" entry, host side (#1318): the switch pithead-setup-again.service
+# sets, what the wizard publishes to the page under it, what "Keep it" does, and how a role's data
+# follows a role change — the tier-1 half of what the KVM rig phase proves end to end (the entry
+# boots, the page opens beside the role, the token survives a Keep and an unchanged Set-up-again).
+# Sourced by tests/stack/run.sh. Every function under test resolves inside run_sourced's subshell,
+# which sources $STACK for itself; $SASB and its captures are unset at the end. The tier-1 rows
+# for rig_access_token itself are in test-appliance-rig-miner.sh (#1836) and are not repeated.
+
+echo "== unit: publish_saved_role — the page is told what the machine is, secrets left out (#1318) =="
+mk_tmpdir SASB
+mkdir -p "$SASB/spool" "$SASB/bin"
+printf 'rig\n' >"$SASB/machine-role"
+printf '{"pool":"10.0.0.5:3333","worker":"shed-3","stratum_password":"pw-fixture","access_token":"kept-token-fixture-for-shed-3"}' >"$SASB/rig.json"
+printf '{"worker":"probe-host","pool":"pithead.local:3333"}' >"$SASB/spool/rig-defaults.json"
+run_sourced "$SASB" publish_saved_role "$SASB/spool" >/dev/null 2>&1
+assert_rc "no switch -> rc 0 (a no-op on a first boot, never an error)" "$?" "0"
+[ -e "$SASB/spool/saved-role.json" ] && bad "no switch -> nothing published (presence IS the signal)" "saved-role.json exists" ||
+    ok "no switch -> nothing published (presence IS the signal)"
+assert_eq "no switch -> the LAN probe's pre-fill is left alone" "$(jq -r '.worker' "$SASB/spool/rig-defaults.json")" "probe-host"
+PITHEAD_SETUP_AGAIN=1 run_sourced "$SASB" publish_saved_role "$SASB/spool" >/dev/null 2>&1
+assert_eq "rig: the saved role, pool and worker" "$(jq -c '[.role,.pool,.worker]' "$SASB/spool/saved-role.json")" '["rig","10.0.0.5:3333","shed-3"]'
+assert_eq "rig: no secret crosses — exactly role, pool, worker" "$(jq -c 'keys' "$SASB/spool/saved-role.json")" '["pool","role","worker"]'
+assert_eq "rig: the form's pre-fill is the SAVED pool + worker, not the probe's" "$(jq -c '[.pool,.worker]' "$SASB/spool/rig-defaults.json")" '["10.0.0.5:3333","shed-3"]'
+assert_eq "no temp file beside either atomic target" "$(find "$SASB/spool" -name '.*.json.*' | wc -l | tr -d ' ')" "0"
+rm -f "$SASB/machine-role" "$SASB/rig.json" "$SASB/spool/saved-role.json"
+printf '{"monero":{"wallet":"4fixture"},"dashboard":{"auth":{"username":"admin","password":"hunter2"}}}' >"$SASB/config.json"
+PITHEAD_SETUP_AGAIN=1 run_sourced "$SASB" publish_saved_role "$SASB/spool" >/dev/null 2>&1
+assert_eq "coordinator: the role (an absent marker is pithead)" "$(jq -r '.role' "$SASB/spool/saved-role.json")" "pithead"
+assert_eq "coordinator: the form pre-fills from config.json" "$(jq -r '.monero.wallet' "$SASB/spool/last-attempt.json")" "4fixture"
+assert_eq "coordinator: ...with the login stripped (the reinstall rule)" "$(jq -r '.dashboard | has("auth")' "$SASB/spool/last-attempt.json")" "false"
+printf '{"monero":{"wallet":"4retry"}}' >"$SASB/spool/last-attempt.json"
+PITHEAD_SETUP_AGAIN=1 run_sourced "$SASB" publish_saved_role "$SASB/spool" >/dev/null 2>&1
+assert_eq "an existing last-attempt.json (a failed retry's context) is never overwritten" "$(jq -r '.monero.wallet' "$SASB/spool/last-attempt.json")" "4retry"
+
+echo "== unit: wizard_keep_requested — Keep it ends the session with nothing touched (#1318) =="
+run_sourced "$SASB" wizard_keep_requested "$SASB/spool" >/dev/null 2>&1
+assert_rc "no switch, no marker -> rc 1" "$?" "1"
+: >"$SASB/spool/keep-role"
+run_sourced "$SASB" wizard_keep_requested "$SASB/spool" >/dev/null 2>&1
+assert_rc "a marker with no switch -> rc 1 (a stale marker cannot close a first boot)" "$?" "1"
+[ -e "$SASB/spool/keep-role" ] && ok "...and the marker is left alone" || bad "...and the marker is left alone" "consumed"
+PITHEAD_SETUP_AGAIN=1 run_sourced "$SASB" wizard_keep_requested "$SASB/spool" >/dev/null 2>&1
+assert_rc "switch + marker -> rc 0: the caller returns" "$?" "0"
+[ -e "$SASB/spool/keep-role" ] && bad "the marker is consumed" "still present" || ok "the marker is consumed"
+PITHEAD_SETUP_AGAIN=1 run_sourced "$SASB" wizard_keep_requested "$SASB/spool" >/dev/null 2>&1
+assert_rc "consumed -> rc 1 again (one keep per marker)" "$?" "1"
+assert_eq "config.json is untouched by a keep" "$(jq -r '.monero.wallet' "$SASB/config.json")" "4fixture"
+
+echo "== unit: a role's data follows the role — record_machine_role and the kept token (#1318) =="
+printf '{"pool":"10.0.0.5:3333","worker":"shed-3","access_token":"kept-token-fixture-for-shed-3"}' >"$SASB/rig.json"
+run_sourced "$SASB" record_machine_role rig >/dev/null 2>&1
+[ -f "$SASB/rig.json" ] && ok "accepting rig keeps rig.json" || bad "accepting rig keeps rig.json" "removed"
+run_sourced "$SASB" record_machine_role both >/dev/null 2>&1
+[ -f "$SASB/rig.json" ] && bad "accepting a coordinator role removes rig.json (and the token in it)" "still present" ||
+    ok "accepting a coordinator role removes rig.json (and the token in it)"
+assert_eq "...and the marker still lands" "$(cat "$SASB/machine-role")" "both"
+# firstboot_consume_rig: the token survives when role AND worker are unchanged; any other worker
+# carries nothing, and rig_access_token mints anew on the next render. timeout is a PATH stub so
+# the pool dial answers deterministically (the rig-miner domain's fixture).
+printf '#!/bin/bash\nexit 0\n' >"$SASB/bin/timeout"
+chmod +x "$SASB/bin/timeout"
+printf '{"pool":"10.0.0.5:3333","worker":"shed-3","access_token":"kept-token-fixture-for-shed-3"}' >"$SASB/rig.json"
+printf '{"pool":"10.0.0.9:3333","worker":"shed-3"}' >"$SASB/spool/rig-request.json"
+PATH="$SASB/bin:$PATH" run_sourced "$SASB" firstboot_consume_rig "$SASB/spool" >/dev/null 2>&1
+assert_rc "same worker, new pool -> accepted" "$?" "0"
+assert_eq "same worker: the token is KEPT (the coordinator adopted this worker with it)" "$(jq -r '.access_token' "$SASB/rig.json")" "kept-token-fixture-for-shed-3"
+assert_eq "...and the new pool landed" "$(jq -r '.pool' "$SASB/rig.json")" "10.0.0.9:3333"
+printf '{"pool":"10.0.0.9:3333","worker":"shed-4"}' >"$SASB/spool/rig-request.json"
+PATH="$SASB/bin:$PATH" run_sourced "$SASB" firstboot_consume_rig "$SASB/spool" >/dev/null 2>&1
+assert_eq "a changed worker: no token carried — the next render mints a fresh one" "$(jq -r 'has("access_token")' "$SASB/rig.json")" "false"
+rm -f "$SASB/rig.json"
+printf '{"pool":"10.0.0.9:3333","worker":"shed-4"}' >"$SASB/spool/rig-request.json"
+PATH="$SASB/bin:$PATH" run_sourced "$SASB" firstboot_consume_rig "$SASB/spool" >/dev/null 2>&1
+assert_eq "no previous rig.json (a first boot): no token key, exactly as before #1318" "$(jq -r 'has("access_token")' "$SASB/rig.json")" "false"
+rm -rf "$SASB"
+unset SASB
+
+echo "== unit: firstboot_wizard under the switch — the role short-circuits are skipped (#1318) =="
+# Reaching the page path is observed at export_build_provenance, the first DIRECT call past both
+# short-circuits (a stub inside a $(...) would only exit its own subshell); the stub exits 7. The
+# no-switch runs are the sibling controls: the same fixture takes the rig leg (rc 0, the miner's
+# setup logged) or runs setup (stubbed, rc 5) exactly as before #1318.
+mk_tmpdir SAWB
+mk_tmpdir SAESP
+mkdir -p "$SAWB/rigforge"
+printf '#!/usr/bin/env bash\necho "rigforge:$1" >>"${RF_LOG:?}"\n' >"$SAWB/rigforge/rigforge.sh"
+chmod +x "$SAWB/rigforge/rigforge.sh"
+export PITHEAD_PRESEED_DIR="$SAESP" PITHEAD_RIGFORGE_DIR="$SAWB/rigforge" RF_LOG="$SAWB/calls"
+SAW_STUBS='container_engine() { echo podman; }; export_build_provenance() { echo page-path-reached; exit 7; }; setup() { echo setup-ran; exit 5; }; firstboot_wizard'
+printf 'rig\n' >"$SAWB/machine-role"
+printf '{"pool":"10.0.0.5:3333","worker":"shed-3"}' >"$SAWB/rig.json"
+: >"$RF_LOG"
+out=$(PITHEAD_INSTALL_BIN=/nonexistent run_sourced "$SAWB" eval "$SAW_STUBS" 2>&1)
+assert_rc "no switch: a marked rig takes the rig leg and returns" "$?" "0"
+assert_contains "...the miner's setup ran, the page path was never reached" "$(cat "$RF_LOG")" "rigforge:setup"
+assert_not_contains "...(control: the stub CAN be reached, and was not)" "$out" "page-path-reached"
+: >"$RF_LOG"
+out=$(PITHEAD_SETUP_AGAIN=1 PITHEAD_INSTALL_BIN=/nonexistent run_sourced "$SAWB" eval "$SAW_STUBS" 2>&1)
+assert_rc "switch: the rig short-circuit is skipped and the page path is reached" "$?" "7"
+assert_contains "...by name" "$out" "page-path-reached"
+assert_not_contains "...and the rig leg did not run beside it" "$(cat "$RF_LOG")" "rigforge:setup"
+assert_eq "...the marker is untouched" "$(cat "$SAWB/machine-role")" "rig"
+assert_eq "...rig.json is untouched" "$(jq -r '.worker' "$SAWB/rig.json")" "shed-3"
+rm -f "$SAWB/machine-role" "$SAWB/rig.json"
+printf '{"monero":{"wallet":"4fixture"}}' >"$SAWB/config.json"
+out=$(PITHEAD_INSTALL_BIN=/nonexistent run_sourced "$SAWB" eval "$SAW_STUBS" 2>&1)
+assert_rc "no switch: a present config.json short-circuits into setup" "$?" "5"
+out=$(PITHEAD_SETUP_AGAIN=1 PITHEAD_INSTALL_BIN=/nonexistent run_sourced "$SAWB" eval "$SAW_STUBS" 2>&1)
+assert_rc "switch: config.json does not short-circuit — the page path is reached" "$?" "7"
+assert_not_contains "...and setup did not run" "$out" "setup-ran"
+unset PITHEAD_PRESEED_DIR PITHEAD_RIGFORGE_DIR RF_LOG SAW_STUBS
+rm -rf "$SAWB" "$SAESP"
+unset SAWB SAESP out


### PR DESCRIPTION
**Status 2026-09-06 — rebased onto `develop` (the develop-v2 fast-forward), out of draft.** The branch carries its two commits on the `develop` tip. Proven by me: the patch over `os/`, `tests/`, `lib/pithead/`, `docs/` is content-identical before and after the rebase (normalised diff, only index lines and one hunk offset in a docs file moved); the `pithead` artifact was regenerated and `lint-pithead-parity` is OK; the file-budget gate is OK. The rig-phase battery is GREEN 60/0 at tree 23a3038a (the comment below carries the evidence path and the four-red diagnosis); the tier-1 stack suite at the rebased #1847 head, a superset of this tree: 3431 passed, 0 failed, rc 0 (run by my predecessor session, w135; log path in my role file archive). Not run here: the full `--phase all` battery on the merged tip — that is the RC gate. Merge note: `pithead` will conflict with the dashboard lane's #1855 (slices 28/33); whichever merges second regenerates it, never hand-patches. Reviewer of record for RC1 is the design lane; the seat merges with `--admin`.


Closes-by-hand #1318 and #1838 (host half; the wizard's Keep / Set-up-again screen is the `fixes` lane's, against the spool contract below). Stacked on #1839's branch until it merges.

## What changes

**Boot menu (`os/rauc/grub.cfg`).** Entries name what they boot: `Pithead OS - slot A (fallback)` (index 0, still the degraded entry `default=0` means), `Pithead OS - slot A`, `Pithead OS - slot B`, and a fourth, `Set up again (opens the setup wizard; keeps the saved settings)`. The OK/TRY counters are out of the titles; nothing says Recovery. Countdown 3 s to 5 s. The setup entry boots the slot the counting chose (`SETUP_PART`/`SETUP_SLOT`, computed from the loop's `default`) and appends `pithead.setup=1`. grub.cfg also honours `next_entry` for one boot and consumes it, grub-reboot's mechanism: `grub-editenv <grubenv> set next_entry=3` from the running system picks the entry, which is how the harness drives it and how a future verb could.

**One new unit, `pithead-setup-again.service`, is the flag's only reader.** `ConditionKernelCommandLine=pithead.setup=1`, the same two provisioned-shape triggers `pithead-boot.service` keys on, `Before=pithead-boot.service`, console output, `PITHEAD_SETUP_AGAIN=1`, `ExecStart=pithead firstboot-wizard`. `pithead-boot` is untouched; `pithead-firstboot` is untouched (its conditions, not the flag, own the first boot, so the two are exclusive by construction).

**Under the switch (`lib/pithead/12a-setup-again.sh`, new slice) three things change, nothing else.** The wizard's "already a rig" and "config.json present" short-circuits are skipped (two line-neutral edits in slice 12). `stage_wizard_spool` publishes `saved-role.json` and re-points the pre-fill at the saved answers. The inner loop honours `keep-role`. The accept paths are the ones a first boot takes, unchanged, plus two things in slice 08: `firstboot_consume_rig` carries `access_token` over when the worker name is unchanged (the coordinator adopted THIS worker with THIS token), and `record_machine_role` removes `rig.json` when the accepted role is not `rig`.

**Spool contract (agreed by name with the `fixes` lane; its successor re-confirms):**

| file | written by | meaning |
|---|---|---|
| `saved-role.json` | host | present ONLY on a set-up-again boot: `{role, pool, worker}` for a rig, `{role}` for a coordinator, never a secret. Presence is the page's signal; `saved_role` in `/api/state`, `null` otherwise; malformed falls through to the normal form |
| `keep-role` | page | Keep it: the host ends the session with nothing on `/data` touched, the unit exits, pithead-boot runs the normal boot |

Pre-fill needs no new field: `rig-defaults.json` gets the saved pool + worker, `last-attempt.json` gets `config.json` through `strip_config_secrets` (unless a failed retry's context is already there).

## Where this departs from the seat's sketch on #1318, and why

- **The unit honours the flag, not `pithead-boot`.** `pithead-boot` sits at its 420/420 ceiling, and routing its output to the console (the token must reach the person at the machine) would change every boot's console. A unit with the flag as its condition is the smaller, more legible reader, and it keeps `pithead-boot` byte-identical.
- **Titles use a plain hyphen**, not the em dash in the issue text: a firmware text console is not guaranteed a glyph for anything else.
- **`next_entry` support was added** so the entry can be selected by the running system. It is the standard GRUB mechanism; without it the only way to drive the entry in KVM is keystrokes on the serial console during a countdown.
- **A changed worker name regenerating the token is proven at tier 1, not on KVM** (each KVM leg is a reboot plus a wizard session; the battery carries the two legs the operator named plus the coordinator switch).
- **A coordinator's `config.json` is NOT removed when the machine is accepted as a rig.** It is operator data (wallets); the factory reset is the erase. Documented.

## Over-engineering pass (by hand; the ponytail gate keys off the wrong branch from this lane's cwd)

15 files. Not a move, so no pure-move proof applies. Adjacent merges enumerated, each available and rejected: the setup-again logic into `pithead-boot` (420/420, and see above); the new slice into slice 12 (556/556); the verify-image rows inline (400 target; the sibling holds one subject and the file stays at 400); the KVM legs inline in `tests/os/run.sh` (3423/3423; the sourced-leg pattern is the file's own, eight siblings); the tier-1 rows into `test-appliance-rig-miner.sh` (466/466). Every touched budgeted file is line-neutral at its ceiling: `pithead-boot` 420, `12-firstboot-wizard.sh` 556, `tests/os/run.sh` 3423, `verify-image.sh` 400, `Dockerfile` 406, `tests/stack/run.sh` 440. No new tsv row.

## Lane override

Out-of-lane under the one-shot `.lane-override`: `lib/pithead/08-uninstall-firstboot.sh`, `lib/pithead/12-firstboot-wizard.sh`, `lib/pithead/12a-setup-again.sh` (new), `tests/stack/test-appliance-setup-again.sh` (new). The `cli` prefix owns `lib/pithead/`; no cli session is live, and the operator's 2026-09-05 ruling put the host half of #1318 on this lane. `docs/` is shared.

## What was RUN

- `make lint-file-budget`, `lint-pithead-parity`, `lint-topology`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`: all OK at this head.
- `shfmt -i 4 -d` on every touched shell file: clean. `shellcheck --severity=warning` (no `-x`) on the three new test files: clean. `tests/inventory.sh` lists the new domain with 4 sections.
- `tests/stack/run.sh`: STATE_STACK_SUITE
- KVM: STATE_BATTERY
- `make lint-sh` in full was NOT run locally (the shellcheck wrapper's memory cap on this box; a `-x` run over the stack runner reached 16 GB and was killed). CI's `Shell tests` is the authority.
- Mutation controls on the tier-1 rows: NOT run. The rows carry their own no-switch controls (the same fixture takes the rig leg / runs setup without the switch, and the page path with it; the token is kept in one case and absent in the sibling), so each assertion has been shown able to say the other thing, but no line of the new slice was mutated to prove a row reddens.

## Follow-ups filed from the #1839 review, not this PR

The card's `address` field was unasserted on #1839; this PR's rig leg asserts it equals the guest's own address. `handoff.json` written at default umask with a Bearer token, and the preseed rig path minting a token nobody is shown: separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ

