### PR TITLE
test(os): #1846 the KVM provision leg submits the browser body and asserts a generated password on the card

### DIFF
--- a/tests/os/provision-browser-submit.sh
+++ b/tests/os/provision-browser-submit.sh
@@ -9,10 +9,13 @@
 # path the operator actually took — and the one that refused on Both — never ran through the
 # gate. A sibling, not rows in run.sh, which sits at its 3423-line ceiling.
 #
-# $1 ip, $2 authenticated cookie jar -> prints the HTTP status of /submit (or a short reason
-# when the page never served a config), the same contract the inline curl had.
-provision_browser_submit() { # <ip> <jar>
-    local ip="$1" jar="$2" served cfg
+# $1 ip, $2 authenticated cookie jar, then any extra form fields (`disk=vda`, `wipe=data` — the
+# installer's disk half rides beside the config) -> prints the HTTP status of /submit (or a short
+# reason when the page never served a config), the same contract the inline curl had.
+provision_browser_submit() { # <ip> <jar> [field=value]...
+    local ip="$1" jar="$2" served cfg extra=()
+    shift 2
+    for f in "$@"; do extra+=(--data-urlencode "$f"); done
     served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/state" 2>/dev/null | jq -c '.config // empty' 2>/dev/null)
     [ -n "$served" ] || {
         printf 'no-served-config'
@@ -25,7 +28,7 @@ provision_browser_submit() { # <ip> <jar>
         printf 'jq-failed'
         return 1
     }
-    curl -sSk -b "$jar" --data-urlencode "config=$cfg" --data-urlencode "auth_mode=auto" \
+    curl -sSk -b "$jar" --data-urlencode "config=$cfg" --data-urlencode "auth_mode=auto" "${extra[@]}" \
         "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null
 }
 

--- a/tests/os/provision-browser-submit.sh
+++ b/tests/os/provision-browser-submit.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+#
+# The browser-shaped wizard submit for phase_provision (#1846). Sourced by tests/os/run.sh.
+# What a person's browser sends is not the no-JS field form: wizard.mjs takes the page's own
+# served config (/api/state .config — the reference merged with the last attempt), sets the
+# operator's answers on the same paths the page uses, and POSTs it whole as `config=<JSON>`
+# beside `auth_mode=auto` (the recommended "generate a strong password for me"). The old leg
+# posted `monero_wallet=…&pool=…`, which build_config() turns into a config server-side, so the
+# path the operator actually took — and the one that refused on Both — never ran through the
+# gate. A sibling, not rows in run.sh, which sits at its 3423-line ceiling.
+#
+# $1 ip, $2 authenticated cookie jar -> prints the HTTP status of /submit (or a short reason
+# when the page never served a config), the same contract the inline curl had.
+provision_browser_submit() { # <ip> <jar>
+    local ip="$1" jar="$2" served cfg
+    served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/state" 2>/dev/null | jq -c '.config // empty' 2>/dev/null)
+    [ -n "$served" ] || {
+        printf 'no-served-config'
+        return 1
+    }
+    # The four answers the Both role gives on the page, on the page's own paths (wizard.mjs
+    # FIELDS: monero.wallet_address, tari.wallet_address, p2pool.pool, local_miner.enabled).
+    cfg=$(printf '%s' "$served" | jq -c --arg m "$HARNESS_WALLET" --arg t "$HARNESS_TARI" \
+        '.monero.wallet_address = $m | .tari.wallet_address = $t | .p2pool.pool = "mini" | .local_miner.enabled = true') || {
+        printf 'jq-failed'
+        return 1
+    }
+    curl -sSk -b "$jar" --data-urlencode "config=$cfg" --data-urlencode "auth_mode=auto" \
+        "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null
+}
+
+# The page's own error line, for a red that names the refusal instead of a timeout. Empty when
+# the page shows none (or cannot be reached).
+provision_page_error() { # <ip> <jar>
+    curl -sSk -b "$2" -m 5 "https://$1/api/state" 2>/dev/null | jq -r '.error // ""' 2>/dev/null
+}

--- a/tests/os/reinstall-prefill-submit-leg.sh
+++ b/tests/os/reinstall-prefill-submit-leg.sh
@@ -1,0 +1,95 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154  # ip is run.sh's: the guest address _wait_dhcp_ip assigns, a global there
+#
+# The reinstall pre-fill submit leg (#1846). Sourced by tests/os/run.sh and run LAST in
+# phase_install, when nothing after it needs the target disk. The operator's path that refused:
+# the installer booted over a disk that already holds a Pithead install, so the host publishes
+# the previous machine's answers as the page's pre-fill (#794, prefill_from_previous_install), and
+# the browser then submits that pre-fill whole beside "Generate a strong password for me"
+# (auth_mode=auto) and a wipe mode. The host validates the candidate BEFORE it generates a
+# password and before it touches the disk, so a pre-fill that carries a switch needing a login
+# (dashboard.control.enabled) with the login stripped is refused on the operator's own answers.
+# The fresh-disk provision leg cannot see this: its candidate carries no dashboard block at all.
+#
+# NON-DESTRUCTIVE BY CONSTRUCTION. The card is published before the erase and the erase is
+# released only by the acknowledgement, which this leg never sends; the host then hands the form
+# back ("Credentials were never confirmed — nothing was installed"). A refusal installs nothing
+# either. The disk is the same after the leg as before it, whichever way the row goes.
+#
+# $1 = a disk holding a provisioned install (the reinstall leg's target); $DISK still holds the
+# installer image the restore leg booted from; ip/SERIAL/VM/HARNESS_WALLET from run.sh.
+phase_install_prefill_submit_leg() { # <target-disk>
+    local target_disk="$1" token="" tries=0 jar served scode handoff="" page_err=""
+    info "pre-fill submit leg (#1846) — the previous machine's answers, submitted as a browser does"
+    _ssh "systemctl poweroff" 2>/dev/null || true
+    sleep 8
+    vm_destroy
+    : >"$SERIAL"
+    kvm_preflight || exit 1 # #1059: never boot a 16 GiB guest the host cannot back
+    virt-install --name "$VM" --memory 16384 --vcpus 4 --cpu host-passthrough \
+        --osinfo debian12 \
+        --boot uefi,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
+        --import \
+        --disk "path=$DISK,format=raw,bus=usb,removable=on,boot.order=1" \
+        --disk "path=$target_disk,format=raw,bus=virtio,boot.order=2" \
+        --network network=default,model=virtio --graphics none \
+        --serial "file,path=$SERIAL" --noautoconsole >/dev/null 2>&1 || {
+        bad "pre-fill submit leg: virt-install failed for the installer boot"
+        return
+    }
+    _wait_dhcp_ip 120
+    _wait_ssh 240 || {
+        bad "pre-fill submit leg: installer guest never answered SSH"
+        return
+    }
+    while [ -z "$token" ] && [ "$tries" -lt 40 ]; do
+        token=$(tr -d '\r' <"$SERIAL" | grep -oE 'pit-[A-Z0-9]{6}' | tail -1)
+        [ -n "$token" ] || sleep 3
+        tries=$((tries + 1))
+    done
+    [ -n "$token" ] && _wait_setup_page 180 || {
+        bad "pre-fill submit leg: the installer wizard never served its gate"
+        return
+    }
+    jar=$(mktemp)
+    curl -fsSk -c "$jar" -d "token=$token" "https://$ip/auth" -o /dev/null 2>/dev/null &&
+        grep -q "wizard_session" "$jar" || {
+        bad "pre-fill submit leg: wizard auth failed"
+        rm -f "$jar"
+        return
+    }
+    # Fixture-works control: the page must be OFFERING the previous install's answers, or the
+    # candidate below is a blank form and the row cannot reach the #1846 path.
+    served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/state" 2>/dev/null | jq -r '.config.monero.wallet_address // ""' 2>/dev/null)
+    case "$served" in
+    "${HARNESS_WALLET:0:8}"*) ok "pre-fill submit leg: the page offers the previous install's answers (pre-fill armed)" ;;
+    *)
+        bad "pre-fill submit leg: pre-fill NOT armed, the leg cannot reach the #1846 path (served wallet: ${served:-none})"
+        rm -f "$jar"
+        return
+        ;;
+    esac
+    # What the browser sends on this page: the served pre-fill whole, auth_mode=auto, the disk
+    # retyped, and a wipe mode other than keep (keep never carries a config across).
+    scode=$(provision_browser_submit "$ip" "$jar" "disk=vda" "confirm=vda" "wipe=data")
+    [ "$scode" = "200" ] || {
+        bad "pre-fill submit leg: submit did not return 200 (got ${scode:-none})"
+        rm -f "$jar"
+        return
+    }
+    tries=0
+    while [ "$tries" -lt 24 ]; do
+        handoff=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null)
+        printf '%s' "$handoff" | grep -q '"password"' && break
+        page_err=$(provision_page_error "$ip" "$jar")
+        [ -z "$page_err" ] || break
+        sleep 5
+        tries=$((tries + 1))
+    done
+    rm -f "$jar" # never acknowledged: the ack is what releases the erase
+    if printf '%s' "$handoff" | jq -r '.password // ""' 2>/dev/null | grep -qE '^[A-Za-z0-9]{32}$'; then
+        ok "pre-fill submit leg: the previous answers validated and the card carries a generated password (#1846)"
+    else
+        bad "pre-fill submit leg: no generated password for the pre-filled answers${page_err:+ — the page says: $page_err}${page_err:-" (no card, no error, ${tries}x5s)"}"
+    fi
+}

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -59,6 +59,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 . "$SCRIPT_DIR/aged-version.sh"
 # shellcheck source=tests/os/provision-browser-submit.sh
 . "$SCRIPT_DIR/provision-browser-submit.sh"
+# shellcheck source=tests/os/reinstall-prefill-submit-leg.sh
+. "$SCRIPT_DIR/reinstall-prefill-submit-leg.sh"
 # shellcheck source=tests/os/setup-again-leg.sh
 . "$SCRIPT_DIR/setup-again-leg.sh"
 
@@ -1944,18 +1946,16 @@ phase_install() {
         [ -n "$new_onion" ] && [ -n "$tor_hostname" ] && break
         sleep 15
     done
-    # .env is itself an archive member that load_preserved_state replays verbatim whenever it is
-    # already non-empty (pithead:6155-6166) — new_onion == orig_onion here proves only that the
-    # CONFIG FILE made the round trip, which holds even if the Tor data dir (the actual onion
-    # PRIVATE KEYS) was dropped from the backup: the stale address string rides along in .env while
-    # Tor silently mints a fresh, unrelated hidden service underneath it (#1090). The only
-    # comparison that proves the keys themselves came back is against Tor's OWN hostname file,
-    # sourced from the restored key material rather than from the archived config.
+    # .env is an archive member load_preserved_state replays verbatim when non-empty (pithead:6155-6166),
+    # so new_onion == orig_onion proves only that the CONFIG FILE made the round trip — true even when
+    # the Tor data dir (the onion PRIVATE KEYS) was dropped and Tor mints a fresh service underneath
+    # (#1090). Only Tor's OWN hostname file, from the restored key material, proves the keys came back.
     if [ -n "$new_onion" ] && [ -n "$tor_hostname" ] && [ "$new_onion" = "$orig_onion" ] && [ "$tor_hostname" = "$orig_onion" ]; then
         ok "restore leg: restored machine kept the ORIGINAL Tor identity, not a regenerated one"
     else
         bad "restore leg: onion identity not restored (.env: $orig_onion -> ${new_onion:-none}, Tor's own hostname: ${tor_hostname:-none})"
     fi
+    phase_install_prefill_submit_leg "$target_disk" # #1846, last: nothing after it needs the disk
     rm -f "$target_disk" "$restore_archive" "$restore_target"
 }
 

--- a/tests/os/run.sh
+++ b/tests/os/run.sh
@@ -57,6 +57,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 . "$SCRIPT_DIR/data-floor-fallback-leg.sh"
 # shellcheck source=tests/os/aged-version.sh
 . "$SCRIPT_DIR/aged-version.sh"
+# shellcheck source=tests/os/provision-browser-submit.sh
+. "$SCRIPT_DIR/provision-browser-submit.sh"
 # shellcheck source=tests/os/setup-again-leg.sh
 . "$SCRIPT_DIR/setup-again-leg.sh"
 
@@ -1959,7 +1961,7 @@ phase_install() {
 
 phase_provision() {
     info "phase: provision (wizard HTTP submit -> setup -> stack containers up)"
-    local img token jar body scode
+    local img token jar scode
 
     img=$(_build_image v1) || {
         bad "image build failed (/tmp/os-fault-build.log)"
@@ -1990,10 +1992,9 @@ phase_provision() {
     }
 
     jar=$(mktemp)
-    # https, and PROVE the cookie landed: auth against :80 once hit the new TLS redirect, whose
-    # 301 carries no cookie — curl -f called that success, the jar stayed empty, and the
-    # unauthenticated submit's redirect then ALSO read as success. Two phantom green checks in a
-    # row while nothing was written. Status codes and the jar are asserted now, not inferred.
+    # https, and PROVE the cookie landed: auth against :80 once hit the TLS redirect, whose 301
+    # carries no cookie — curl -f called that success, the jar stayed empty, and the unauthenticated
+    # submit's redirect ALSO read as success. Status codes and the jar are asserted, not inferred.
     curl -fsSk -c "$jar" -d "token=$token" "https://$ip/auth" -o /dev/null 2>/dev/null || {
         bad "token was not accepted"
         rm -f "$jar"
@@ -2004,27 +2005,19 @@ phase_provision() {
         rm -f "$jar"
         return
     }
-    # Minimal honest config: a checksum-valid primary Monero address (see HARNESS_WALLET — the
-    # old dummy crash-looped p2pool, #829). Tari's gate is deliberately format-free host-side
-    # and p2pool tolerates a bad merge-mine address, so a labelled dummy stays obviously fake.
-    # Everything else keeps its default — which is itself part of what this proves.
-    # local_miner=true: the Both role (#796) — the same submit must also light the built-in
-    # RigForge worker, asserted in the local-miner leg below.
-    body="monero_wallet=$HARNESS_WALLET&tari_wallet=$HARNESS_TARI&pool=mini&local_miner=true"
-    scode=$(curl -sSk -b "$jar" --data "$body" "https://$ip/submit" -o /dev/null -w '%{http_code}' 2>/dev/null)
+    # The browser's body (#1846): served config + HARNESS_WALLET (#829) + a dummy Tari address +
+    # local_miner on (Both, #796; the local-miner leg asserts it) + auth_mode=auto — see the sibling.
+    scode=$(provision_browser_submit "$ip" "$jar")
     [ "$scode" = "200" ] || {
         bad "config submit did not return 200 (got ${scode:-none} — a 30x means the session was not accepted)"
         rm -f "$jar"
         return
     }
-    # The jar lives on: the handoff below is authenticated too, and a real operator's session
-    # does not end at submit. (Deleting it here made the handoff poll silently unauthenticated,
-    # which read as "the appliance never published credentials" — it had.)
+    # The jar lives on: the handoff below is authenticated too (deleting it here once made the poll silently unauthenticated).
     ok "config submitted through the wizard"
-    # The credentials handoff: the host publishes the generated login and HOLDS provisioning
-    # until it is acknowledged — the page goes dark afterwards, so the card must come first.
-    # The login is kept: the OS-update presence check below drives the authenticated state API.
-    local handoff_body=""
+    # The credentials handoff: the host publishes the generated login and HOLDS provisioning until
+    # it is acknowledged (the page goes dark after). The login is kept for the OS-update check below.
+    local handoff_body="" page_err=""
     tries=0
     while [ "$tries" -lt 24 ]; do
         handoff_body=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/handoff" 2>/dev/null)
@@ -2032,14 +2025,21 @@ phase_provision() {
             ok "generated credentials published to the page"
             break
         fi
+        page_err=$(provision_page_error "$ip" "$jar")
+        [ -z "$page_err" ] || break # the host refused: say what it said, not that it timed out
         sleep 5
         tries=$((tries + 1))
     done
-    [ "$tries" -lt 24 ] || {
-        bad "no credentials handoff appeared on the page"
+    [ "$tries" -lt 24 ] && [ -z "$page_err" ] || {
+        bad "no credentials handoff appeared on the page${page_err:+ — the page says: $page_err}"
         rm -f "$jar"
         return
     }
+    if printf '%s' "$handoff_body" | jq -r '.password // ""' | grep -qE '^[A-Za-z0-9]{32}$'; then
+        ok "the card carries a generated 32-character password (auth_mode=auto, #1846)"
+    else
+        bad "the card's password is not a generated one: $(printf '%s' "$handoff_body" | jq -c '.password // null')"
+    fi
     scode=$(curl -sSk -b "$jar" -X POST "https://$ip/handoff-ack" -o /dev/null -w '%{http_code}' 2>/dev/null)
     [ "$scode" = "200" ] || {
         bad "handoff acknowledgement did not return 200 (got ${scode:-none})"


### PR DESCRIPTION
**Status 2026-09-06 — re-stacked onto the rebased #1844 (`git rebase --onto`), base `develop`, out of draft.** Proven by me: the branch is exactly its own two commits over #1844's head; their patch is content-identical to the pre-rebase one except one line that was a local, unpushed shellcheck directive in `tests/os/reinstall-prefill-submit-leg.sh` (now pushed with it); `lint-pithead-parity` OK; file-budget gate OK. Tier-1 stack suite at this head: 3431 passed, 0 failed, rc 0 (run by my predecessor session, w135; log path in my role file archive). Not run here: this branch's own KVM legs on the rebased tree — they ride the full `--phase all` battery on the merged tip, the RC gate. Merges after #1844.


The KVM half of #1846 (the fix is the `fixes` lane's PR #1852, `strip_config_secrets` in slice 10). Stacked on #1844's branch until it merges; hand-close is theirs, not this PR's.

**Second commit, after the fixes lane found the mechanism: the bug is not on a fresh disk.** A clean first browser attempt carries no dashboard block at all (`strip_defaults` drops the reference-equal `auth.password ""` and `control.enabled false`), so the fresh-disk provision leg below goes green on the tip and discriminates nothing. The refusal lives on the REINSTALL path: the installer booted over a disk that already holds an install publishes the previous answers as the page's pre-fill (#794), the strip removes the login but leaves `dashboard.control.enabled` standing, and the host's first validation refuses the operator's own answers before it ever generates a password. So this PR now carries a leg on that path too.

## What changes

**A final leg in `phase_install` (`tests/os/reinstall-prefill-submit-leg.sh`), on the operator's path.** After the restore leg, with the reinstall leg's target disk still holding a provisioned install: power the guest off, boot the installer over that disk (the same virt-install shape the restore leg uses), read the token, auth, and FIRST prove the fixture works — the page's served config carries the previous install's wallet, so the pre-fill is armed and the candidate is the operator's answers, not a blank form (without that row a green here would prove nothing). Then submit exactly what the browser submits on that page: the served config whole as `config=<JSON>`, `auth_mode=auto`, `disk=vda`, `confirm=vda`, `wipe=data` (keep never carries a config across). Poll the handoff and the page's error line together; assert a 32-alphanumeric generated password on the card. **The leg never acknowledges the card**: the host publishes the card before the erase and releases the erase only on the ack, so a green leaves the disk untouched (the host hands the form back after its 600 s wait) and a red installs nothing either. It runs last because that wait belongs to no later leg. Expected on the tip: RED with `the page says: dashboard.control.enabled is true but dashboard.auth.password is empty …`; on #1852: GREEN.

**`phase_provision` submits what a browser submits.** The leg posted `monero_wallet=…&tari_wallet=…&pool=mini&local_miner=true` — the no-JavaScript field form, which `build_config()` turns into a config server-side. A person's browser does something else (`wizard.mjs` submit): it takes the page's served config (`/api/state .config`, the reference merged with the last attempt), sets the operator's answers on the page's own paths, and POSTs the whole thing as `config=<JSON>` beside `auth_mode=auto`, the recommended "generate a strong password for me". That path — the one the operator took, and the one that refused on Pithead + RigForge — had never run through the gate for any role. The leg now does exactly that: fetch the served config with the session jar, set `monero.wallet_address`, `tari.wallet_address`, `p2pool.pool=mini`, `local_miner.enabled=true` (the same four the page sets for the Both role), post it url-encoded with `auth_mode=auto`.

**Two new rows, one sharper red.** After the handoff appears, the leg asserts the card's password is a generated one: 32 alphanumerics, the shape `generate_node_password` produces. While waiting for the handoff it polls the page's own error line and breaks out the moment the host refuses, so the red names the refusal (`the page says: dashboard.control.enabled is true but …`) instead of reporting a two-minute timeout.

**A sourced sibling, `tests/os/provision-browser-submit.sh`.** `run.sh` sits at its 3423-line ceiling; the submit helper and the error reader live beside it (the file's own pattern: `data-floor-fallback-leg.sh`, `aged-version.sh`), and the leg's edit is line-neutral — seven comment lines in the leg were compressed to pay for the rows.

## What each leg is expected to do

- Pre-fill submit leg (install phase): **RED on the tip** at the operator's refusal, its firing control; **GREEN on #1852**.
- Fresh-disk provision leg: green on both — it proves the browser body and the generated password on a first install, the path every new machine takes, and stays as the gate row for that.

## Coverage moved, not lost

The no-JS form path keeps its coverage where it is honest: `dashboard/tests/web/test_wizard.py` covers `build_config()` and `auth_mode` at the server. The KVM battery now proves the path people use.

## Over-engineering pass (by hand; the ponytail gate keys off the wrong branch from this lane's cwd)

Three files. Adjacent merges enumerated: the pre-fill leg inline in `phase_install` (rejected: 3423/3423, and the phase is already 800 lines); the pre-fill leg into the provision-submit sibling (rejected: one is a submit helper, the other a whole guest leg with its own boot); running the pre-fill submit at the existing pre-fill-verdict point instead of last (rejected: that point precedes the wipe legs, and the host's 600 s unacknowledged-card wait would overlap them); the helper inline in `phase_provision` (rejected: `run.sh` is at 3423/3423 and the helper is 14 lines of code); the helper into `data-floor-fallback-leg.sh` (rejected: that file is one subject, the /data-floor fallback, and this is another); a second provisioning leg carrying the browser body beside the old form (rejected: a full extra provisioning per battery for a fallback path the server tests cover). A separate `provision_page_error` reader rather than inlining the curl twice: one call site today, kept because the same read belongs in the local-miner and rig legs' waits and is the one line a reviewer will want to reuse.

## What was RUN

- `shfmt -i 4 -d` on both files: clean. `bash -n tests/os/run.sh`: ok. `make lint-file-budget`: OK, `run.sh` at 3423/3423, the sibling is a new unbudgeted file.
- `shellcheck --severity=warning -x` on the sibling: QUEUED — the wrapper serialises on the lock the running #1318 battery holds; CI's `Shell tests` is the authority.
- The pinned gitleaks image over this commit alone: no leaks found.
- KVM: NOT RUN YET. The bench is under the #1318 battery; when it frees, `--phase install` and `--phase provision` run on this branch (tip behaviour, expected RED at the pre-fill leg) and on this branch rebased over #1852 (expected GREEN), and both verdicts land here with `BUILD_COMMIT`. Until then this PR stays a draft.
- Tier 1 for the mechanism is #1852's (`test-appliance-install.sh` rows on `strip_config_secrets`); this PR adds no tier-1 rows, the two siblings read a live wizard.
- Not testable at tier 1: the helper reads a live wizard; its only honest tier is the guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ

