### PR TITLE
fix(installer): #1846 the reinstall pre-fill drops the login but keeps the switches that need it

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -195,8 +195,11 @@ On either fresh start, the page opens with the previous install's answers alread
 wallet addresses, node locations, pool tier — read from the disk you are about to wipe, so you
 only change what you came to change. Its secrets never make the trip: the dashboard login,
 node passwords, view keys, worker tokens and alert credentials are left out, and anything the
-machine generates for itself is generated anew. If the old configuration cannot be read, the
-page opens blank.
+machine generates for itself is generated anew. The two switches that need that login come
+back at their defaults for the same reason: config editing from the dashboard, which the
+machine turns on again for you once a password exists, and publishing the dashboard as a Tor
+onion, which you tick again if you want it. If the old configuration cannot be read, the page
+opens blank.
 
 Type the disk's name to confirm.
 

--- a/lib/pithead/10-installer-preseed.sh
+++ b/lib/pithead/10-installer-preseed.sh
@@ -178,12 +178,23 @@ publish_disk_inventory() { # <spool-dir>
 # the fixed paths cannot reach), alert credentials, the ssh key. Wallet addresses, node modes
 # and hosts, the pool tier stay: those are the answers the operator came back for, and none of
 # them is a secret. Errs toward stripping more — a lost convenience beats a leaked credential.
+#
+# The two ENABLEMENTS go with the login, and that is the half this was missing (#1846). The
+# validator fails closed on dashboard.control.enabled and on dashboard.onion.enabled whenever
+# the password is empty — deliberately, since both are reachable control surfaces. Deleting the
+# login while leaving either switch on therefore publishes a pre-fill that CANNOT be submitted:
+# the page offers it back, "Generate a strong password for me" leaves the password empty because
+# the HOST generates one only AFTER the candidate has validated, and the first validation refuses
+# the operator's own answers. Dropping control.enabled costs nothing — apply_appliance_defaults
+# puts it back on any appliance whose password is non-empty. onion.enabled the operator re-ticks,
+# which is the same trade the paragraph above already makes.
 # rc non-zero when the file is not a usable config object; callers treat that as "no pre-fill".
 strip_config_secrets() { # <config-file> -> stripped JSON on stdout
     jq -e --argjson paths "$CONTROL_SECRET_PATHS" '
         delpaths($paths)
         | del(.dashboard.auth, .dashboard.workers, .workers, .telegram,
-              .healthchecks, .notifications, .ssh, .tari.spend_public_key)' "$1" 2>/dev/null
+              .healthchecks, .notifications, .ssh, .tari.spend_public_key,
+              .dashboard.control.enabled, .dashboard.onion.enabled)' "$1" 2>/dev/null
 }
 
 # Reinstall pre-fill (#794). When the offered targets include exactly one disk that already

--- a/pithead
+++ b/pithead
@@ -2375,12 +2375,23 @@ publish_disk_inventory() { # <spool-dir>
 # the fixed paths cannot reach), alert credentials, the ssh key. Wallet addresses, node modes
 # and hosts, the pool tier stay: those are the answers the operator came back for, and none of
 # them is a secret. Errs toward stripping more — a lost convenience beats a leaked credential.
+#
+# The two ENABLEMENTS go with the login, and that is the half this was missing (#1846). The
+# validator fails closed on dashboard.control.enabled and on dashboard.onion.enabled whenever
+# the password is empty — deliberately, since both are reachable control surfaces. Deleting the
+# login while leaving either switch on therefore publishes a pre-fill that CANNOT be submitted:
+# the page offers it back, "Generate a strong password for me" leaves the password empty because
+# the HOST generates one only AFTER the candidate has validated, and the first validation refuses
+# the operator's own answers. Dropping control.enabled costs nothing — apply_appliance_defaults
+# puts it back on any appliance whose password is non-empty. onion.enabled the operator re-ticks,
+# which is the same trade the paragraph above already makes.
 # rc non-zero when the file is not a usable config object; callers treat that as "no pre-fill".
 strip_config_secrets() { # <config-file> -> stripped JSON on stdout
     jq -e --argjson paths "$CONTROL_SECRET_PATHS" '
         delpaths($paths)
         | del(.dashboard.auth, .dashboard.workers, .workers, .telegram,
-              .healthchecks, .notifications, .ssh, .tari.spend_public_key)' "$1" 2>/dev/null
+              .healthchecks, .notifications, .ssh, .tari.spend_public_key,
+              .dashboard.control.enabled, .dashboard.onion.enabled)' "$1" 2>/dev/null
 }
 
 # Reinstall pre-fill (#794). When the offered targets include exactly one disk that already

--- a/tests/stack/test-appliance-install.sh
+++ b/tests/stack/test-appliance-install.sh
@@ -276,6 +276,8 @@ cat >"$SCS/prev.json" <<'PREV'
   "p2pool": {"pool": "main", "stratum_password": "LEAK-stratum"},
   "dashboard": {"timezone": "Europe/Berlin",
                 "auth": {"username": "LEAK-dashuser", "password": "LEAK-dashpw"},
+                "control": {"enabled": true},
+                "onion": {"enabled": true, "client_auth": true},
                 "workers": [{"name": "w0", "host": "h", "token": "LEAK-oldworker"}]},
   "workers": {"api_auth": true, "api_token": "LEAK-apitoken",
               "list": [{"name": "rig1", "host": "rig1.lan", "token": "LEAK-workertoken"}]},
@@ -294,6 +296,16 @@ assert_eq "remote node mode survives" "$(printf '%s' "$stripped" | jq -r '.tari.
 assert_eq "remote node host survives" "$(printf '%s' "$stripped" | jq -r '.tari.remote.host')" "tari.lan"
 assert_eq "pool tier survives" "$(printf '%s' "$stripped" | jq -r '.p2pool.pool')" "main"
 assert_eq "timezone survives" "$(printf '%s' "$stripped" | jq -r '.dashboard.timezone')" "Europe/Berlin"
+# Secret-free is not the same as SUBMITTABLE (#1846). parse_and_validate_config fails closed on
+# dashboard.control.enabled (:455) and dashboard.onion.enabled (:432) whenever the password is
+# empty — and this strip is what empties it. Leaving either switch on published a pre-fill the
+# page offers back and the first validation then refuses, which is how "Generate a strong
+# password for me" became unusable on a reinstall: the HOST generates one only AFTER validation.
+assert_eq "control.enabled goes with the login it needs" "$(printf '%s' "$stripped" | jq -r '.dashboard.control.enabled // "absent"')" "absent"
+assert_eq "onion.enabled goes with the login it needs" "$(printf '%s' "$stripped" | jq -r '.dashboard.onion.enabled // "absent"')" "absent"
+# The sibling that keeps the two above narrow: a dashboard answer that depends on NO credential is
+# still carried over, so this is not "strip the whole dashboard block and call it safe".
+assert_eq "client_auth, which needs no login, survives" "$(printf '%s' "$stripped" | jq -r '.dashboard.onion.client_auth')" "true"
 # Not-a-config shapes are refused, not partially stripped: rc != 0 means "no pre-fill".
 printf 'not json at all' >"$SCS/garbage.json"
 if run_sourced "$SANDBOX" strip_config_secrets "$SCS/garbage.json" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #1846 (hand-close — `Closes` is inert on `develop-v2`).

## The mechanism: candidate (a)'s outcome, reached by a source (a) did not consider

`strip_config_secrets` (`lib/pithead/10-installer-preseed.sh`) is what a previous install's `config.json` passes through before the setup page may show any of it — the #794 reinstall pre-fill. It deletes `.dashboard.auth` and **left `.dashboard.control.enabled` and `.dashboard.onion.enabled` standing.** Those are exactly the two switches `parse_and_validate_config` fails closed on when the password is empty (`28-parse-and-validate-config.sh:455` and `:432`).

So the pre-fill it published was invalid **by construction**:

1. reinstall over a `pithead-with-data` disk arms `prefill_from_previous_install`;
2. the strip removes the login and keeps the switch, and publishes the remainder as `last-attempt.json`;
3. `/api/wizard-state` serves `_deep_merge(reference, last_attempt)`, so the page carries `control.enabled: true` with an empty password;
4. **"Generate a strong password for me" never touches the password** — the HOST generates one, and only *after* the candidate has validated;
5. `strip_defaults` drops the empty password (it equals the reference) and keeps `control.enabled: true` (it does not), so the submitted candidate is the exact pair the validator refuses;
6. `firstboot_consume_spool`'s **first** validation refuses the operator's own answers.

Typing a password by hand supplied the missing half, which is why the operator's workaround worked.

## What was RUN

**A controlled pair over one variable — the tree.** Same script, same fixture, driving `wizard.py`'s own `_deep_merge` and `strip_defaults` rather than a re-spelling of them, so the page half is the real page half:

| | unfixed tree | this branch |
|---|---|---|
| pre-fill published | `{"control":{"enabled":true}}` | `{"control":{}}` |
| candidate submitted | `dashboard.control.enabled: true` beside an empty password | **no `dashboard.control` / `dashboard.onion` key** (in this fixture that leaves no `dashboard` block at all, but the criterion is the KEY: a fixture with a non-default `dashboard.timezone` would still carry a `dashboard` block on the fixed leg) |
| `firstboot_consume_spool` | **rc 1** | **rc 0** |
| `error.txt` | **240 bytes, byte-identical to the string the operator quoted, `son).` prefix included** | not written |

**The onion leg is the same class and also reproduces** — `dashboard.onion.enabled` against the `:432` rule, also rc 1, also 240 bytes — and the same jq clause fixes it. That is why both are dropped rather than only the reported one: shipping the fix for one while leaving its identical sibling live is a worse outcome than one extra key in a `del`. **The sharper argument for keeping the onion half in this PR:** `:434` imposes a 16-character floor, so an operator following the documented workaround with a hand-typed 8-character password clears `:455` and is then refused by `:434` with a *different* message. A control-only fix ships a second, less legible wall directly behind the first one.

**Tier 1, each row with its own firing control.** The rows go where this function's coverage already lives (`unit: strip_config_secrets`). That fixture carried **no `dashboard.control` or `dashboard.onion` key at all**, which is why `no secret of ANY class survives` is green and blind to this — secret-free is not the same as submittable. Against the unfixed tree, using the fixture extracted mechanically from the test file itself, the three new rows read `control.enabled=true`, `onion.enabled=true`, `client_auth=true`; on this branch `absent`, `absent`, `true`. The two pre-existing assertions (`LEAK-` count 0, timezone) are unchanged on both sides, so the fixture addition disturbs nothing.

**Gates at the head:** `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget`, `lint-pithead-parity`, `lint-trivy-parity`, `lint-yaml` each rc 0. `shfmt -i 4 -d` clean at the gate's own pin, v3.13.1 from `make -s print-shfmt-version`, over `pithead` and both changed shell files. `lane-guard.sh` rc 0 on the staged set with a near-miss control staged in `os/` returning rc 1. `pithead` rebuilt with `scripts/build-pithead.sh` and co-committed.

## What was NOT run, and what is assumed

- **`tests/stack/run.sh` has NOT been run locally on this branch.** The appliance lane holds this box until ~00:25Z for its KVM battery's pre-flight (a concurrent heavy job reds it), and I am respecting that. CI runs it here; I will post the local result when the hold lifts. The per-row firing control above WAS run — it needs only `jq` and a sourced `pithead`.
- **`make lint-sh` was not run** — rc 137 on this box is pre-existing (shellcheck killed at the local 6G cap, #1206) and CI's uncapped run is the authority.
- **ASSUMED, and it is the only one:** that the operator's install was a reinstall over a disk whose state is `pithead-with-data`, which is what arms `prefill_from_previous_install`. I cannot close that without the machine; issue item 1 (the journal) is the operator's and the appliance lane is holding the ask. Everything else above is measured.
- **A claim I am retracting before it travels:** I first argued the 240-byte width *pinned* `firstboot_consume_spool` as the refusing site. It does not — three scrapes use `tail -c 240`. The width excludes `setup`'s and the post-validate's `tail -c 300`, which is what ruled out the issue's candidate (c); **the reproduction pins the site.**

## Disclosures

- **The fix is in `lib/pithead/10-installer-preseed.sh`, which is NOT among the five slices the seat's 22:30Z directive granted** (12, 26, 27, 28, 08). Those were aimed at the mechanisms the issue guessed, and the real one is elsewhere. This lane owns 10 by a standing bare line, so no hatch was needed — flagging it so the seat can correct the reading.
- `tests/stack/test-appliance-install.sh` is the tests lane's by prefix; granted for #1846 only, expiring on this merge (`ask-tests-20260905T224553Z`). The file lands at 398 lines, under the 400-line target, so it still needs no budget row. The granter also corrected the 240-byte claim above.
- `docs/appliance.md` is `_shared.paths`. One sentence, in the paragraph that already describes the pre-fill.
- Image bytes: this touches `lib/pithead/` and `pithead`, so it rides the freeze move the seat put #1846 on.

## Over-engineering pass

One jq clause and two keys. The alternatives I rejected: deleting `.dashboard.control` and `.dashboard.onion` whole (over-strips — `client_auth` needs no credential and is asserted to survive); fixing only the reported `control` key and filing the onion separately (ships a known-broken identical sibling); and moving `ensure_appliance_dashboard_password` ahead of the first validation (that would validate something other than what the operator submitted, and is wrong for `auth_mode=none`). No new files, no new helpers, no refactor. The comment is long because the *why* is the part that rots.

The appliance lane's #1847 carries the KVM half — a provision leg with the browser body and `auth_mode=auto` — and will run it against the tip and against this branch back to back.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7txeRNDQmj5b4Wsx33mCF

## Corrections after the non-author pass

The reviewer's pass (comment 5555388117) is a PASS on substance; these are its corrections and additions, applied here rather than left in the thread. The first is a **retraction of my own claim**.

1. **RETRACTED: "none of the three the issue guessed".** That overstated it, and the heading above is corrected. Candidate (a) *as stated* is exactly what happens; what is refuted is its parenthetical provenance. Verified by construction: `apply_appliance_defaults` fires only with a non-empty password, so a `control.enabled: true` arriving from there implies a password `strip_defaults` keeps. Candidates (b) and (c) are refuted outright.
2. **The fix is complete for its class, which I understated.** Only two `[ -z "$dash_pw" ]` guards exist in the whole validator — `:431` and `:454` — and both are now covered. The reviewer enumerated every empty-credential rule and found no third orphan.
3. **The `del` was already a companion-key pattern.** It strips `tari.spend_public_key` beside `tari.view_key`, so adding `control` beside `onion` extends an established shape rather than inventing one.
4. **Two extra discriminators on the 240-byte figure**, both the reviewer's: `[ERROR] ` plus the message is 235 bytes, so `tail -c 240` carries exactly the 5 characters of the prior line the operator quoted (`son).`), where a 300-byte scrape would have carried 65; and `$0` renders `bash` under `bash -c`, where `setup`'s in-process validation would render pithead's own. Candidate (c) is excluded twice over.

Standing caveat, unchanged from the body above and from my role file: the 240-byte width **narrows the family and does not pin the site** — three scrapes use `tail -c 240`. The end-to-end repro is what pins it.
