### PR TITLE
feat(wizard): #1836 the rig card shows the control token once, beside the address to adopt it at

### DIFF
--- a/dashboard/mining_dashboard/web/static/rigcardlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/rigcardlogic.mjs
@@ -4,8 +4,11 @@
 // two of those five are legitimately empty at the moment the page renders it:
 //
 //   token   — rig_access_token could not mint or keep one. The card is written BEFORE the miner is
-//             configured, so the wizard shows this state first and 14-local-miner.sh's render leg
-//             refuses afterwards; the operator sees the card either way.
+//             configured, so the wizard shows this state first. What happens next DIVERGES, which
+//             is why the note promises neither half: run from the stick, render_rig_miner_config
+//             returns 1 and rigforge_setup_run never runs, so the machine does not even mine; on
+//             the installer path the target mints its own token and mines, but nothing prints that
+//             token after provisioning, so its console cannot tell the operator what to paste.
 //   address — hostname -I answered nothing, because the box has no IPv4 lease yet.
 //
 // A label with a blank beside it is the one thing this card must never show, so an empty value
@@ -39,8 +42,8 @@ export function rigCardFields(handoff) {
 export function rigCardNote(handoff) {
   if (!handoff.token) {
     return (
-      "This machine has no control token, so your Pithead cannot adopt it — its console says why. " +
-      "It still mines, and appears by this name in the Workers view."
+      "This machine could not create its control token. There is nothing to copy here, and no " +
+      "Pithead can adopt this rig until it has one — set this machine up again."
     );
   }
   const adopt = handoff.address

--- a/dashboard/mining_dashboard/web/static/rigcardlogic.mjs
+++ b/dashboard/mining_dashboard/web/static/rigcardlogic.mjs
@@ -1,0 +1,59 @@
+// The rig handoff card's contents, kept DOM-free so node --test covers the two states nobody can
+// produce by hand (issue #1836). The host publishes the card as
+// {role, worker, stratum, token, address} — lib/pithead/12-firstboot-wizard.sh's rig handoff — and
+// two of those five are legitimately empty at the moment the page renders it:
+//
+//   token   — rig_access_token could not mint or keep one. The card is written BEFORE the miner is
+//             configured, so the wizard shows this state first and 14-local-miner.sh's render leg
+//             refuses afterwards; the operator sees the card either way.
+//   address — hostname -I answered nothing, because the box has no IPv4 lease yet.
+//
+// A label with a blank beside it is the one thing this card must never show, so an empty value
+// drops its own row and the note says what is missing instead. Worker and pool stay unconditional:
+// they were on the card before the token existed, and their emptiness is the host's own business.
+
+import { DEFAULT_CONTROL_PORT } from "./workeradoptlogic.mjs";
+
+/**
+ * The card's rows, in the order they render. The view owns the markup; this owns only which rows
+ * exist, which is what makes the address and token branches testable without a DOM.
+ */
+export function rigCardFields(handoff) {
+  const fields = [
+    { label: "Worker name", value: handoff.worker },
+    { label: "Mines toward", value: handoff.stratum },
+  ];
+  if (handoff.address) {
+    fields.push({ label: "This machine's address", value: handoff.address });
+  }
+  if (handoff.token) {
+    fields.push({ label: "Control token", value: handoff.token });
+  }
+  return fields;
+}
+
+/**
+ * The note under the rows. Before the token existed this said "no login — nothing to save"; there
+ * is now exactly one thing to save, and this page is the only place it is ever shown.
+ */
+export function rigCardNote(handoff) {
+  if (!handoff.token) {
+    return (
+      "This machine has no control token, so your Pithead cannot adopt it — its console says why. " +
+      "It still mines, and appears by this name in the Workers view."
+    );
+  }
+  const adopt = handoff.address
+    ? "takes this rig's address, control port " + DEFAULT_CONTROL_PORT + " and the token."
+    : "takes this rig's address, control port " +
+      DEFAULT_CONTROL_PORT +
+      " and the token — this machine has no address on the network yet, so read it from its " +
+      "console once it is up.";
+  return (
+    "The token is not a login — a rig has none. It is shown once and never again: this machine " +
+    "serves no page after this, so copy it now. Your Pithead's Workers → Adopt form " +
+    adopt +
+    " Until you adopt it the rig still mines and appears by this name in the Workers view, though " +
+    "its row reads as an API error."
+  );
+}

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -17,6 +17,7 @@ import {
   telegramPairReady,
 } from "./configsync.mjs";
 import { Component, html, render } from "./preact.mjs";
+import { rigCardFields, rigCardNote } from "./rigcardlogic.mjs";
 
 // The simple questions, each bound to its config path. Conditional blocks name the field that
 // gates them; option lists carry the same guidance the docs give. This is deliberately a
@@ -208,10 +209,8 @@ export const Done = ({ status, handoff, installer, stick, rig, onAck }) => html`
       handoff && handoff.role === "rig"
         ? html`<h3>Check this rig</h3>
             <p>This is what the machine will be.</p>
-            <${Field} label="Worker name"><code class="wizard-mono">${handoff.worker}</code><//>
-            <${Field} label="Mines toward"><code class="wizard-mono">${handoff.stratum}</code><//>
-            <${Note}>A rig has no dashboard and no login — nothing to save. It appears by this
-            name in the Pithead's Workers view.<//>
+            ${rigCardFields(handoff).map((f) => html`<${Field} label=${f.label}><code class="wizard-mono">${f.value}</code><//>`)}
+            <${Note}>${rigCardNote(handoff)}<//>
             <button type="button" onClick=${onAck}>
                 ${installer && !stick ? "Looks right — erase the disk and install" : "Looks right — save it"}</button>`
         : handoff

--- a/dashboard/tests/frontend/rigcardlogic.test.mjs
+++ b/dashboard/tests/frontend/rigcardlogic.test.mjs
@@ -105,11 +105,16 @@ test("rigCardNote: with no address, it says to read the address off the console"
 
 test("rigCardNote: with no token, it never tells the operator to paste one", () => {
   const note = rigCardNote({ ...FULL, token: "" });
-  assert.match(note, /cannot adopt it/);
-  assert.match(note, /still mines/);
+  assert.match(note, /could not create its control token/);
+  assert.match(note, /no Pithead can adopt this rig/);
   assert.doesNotMatch(note, /Adopt form/);
   assert.doesNotMatch(note, /control port/);
   assert.doesNotMatch(note, /shown once/);
+  // Both halves of the pre-review wording were false, on OPPOSITE paths: run from the stick the
+  // machine does not mine at all, and on the installer path nothing ever prints the token. The
+  // note must promise neither, so these two pin the retracted claims rather than the new ones.
+  assert.doesNotMatch(note, /still mines/);
+  assert.doesNotMatch(note, /console says why/);
 });
 
 test("rigCardNote: the pre-token wording is gone from every case", () => {
@@ -146,6 +151,6 @@ test("rendered: an unminted token puts no empty 'Control token' row on the card"
   );
   assert.doesNotMatch(card, /Control token/);
   assert.doesNotMatch(card, /Workers → Adopt/);
-  assert.match(card, /cannot adopt it/);
+  assert.match(card, /could not create its control token/);
   assert.match(card, /This machine's address/); // the address it DOES have still shows
 });

--- a/dashboard/tests/frontend/rigcardlogic.test.mjs
+++ b/dashboard/tests/frontend/rigcardlogic.test.mjs
@@ -1,0 +1,151 @@
+// Unit tests for the rig handoff card's contents (issue #1836):
+// mining_dashboard/web/static/rigcardlogic.mjs — which rows the card shows, and the note that
+// replaced "no login — nothing to save" now that there is a token to save.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// Mutation-kill notes: the two "missing" cases are the point of the module. Dropping either guard
+// in rigCardFields puts a labelled row with a blank value on the card, which the row-count and
+// label assertions catch; dropping either branch in rigCardNote leaves the operator being told to
+// paste something that does not exist, which the phrase assertions catch in both directions — each
+// case asserts what its note MUST say and what it must NOT.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { html } from "../../mining_dashboard/web/static/preact.mjs";
+import {
+  rigCardFields,
+  rigCardNote,
+} from "../../mining_dashboard/web/static/rigcardlogic.mjs";
+import { Done } from "../../mining_dashboard/web/static/wizard.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// The shape lib/pithead/12-firstboot-wizard.sh publishes for role=rig. The token keeps the real
+// 32-hex shape but is all zeros on purpose: gitleaks scans every pushed ref and reads its config
+// from the checked-out one, so a plausible literal here reds the secret scan on every OTHER branch
+// until an allowlist entry for it has merged. Nothing on the card depends on the characters.
+const FULL = {
+  role: "rig",
+  worker: "rig-01",
+  stratum: "stratum+tcp://pithead.example:3333",
+  token: "00000000000000000000000000000000",
+  address: "10.0.0.9",
+};
+const labels = (h) => rigCardFields(h).map((f) => f.label);
+
+// --- rigCardFields --------------------------------------------------------------------------
+
+test("rigCardFields: a complete handoff shows all four rows, worker and pool first", () => {
+  assert.deepEqual(labels(FULL), [
+    "Worker name",
+    "Mines toward",
+    "This machine's address",
+    "Control token",
+  ]);
+  assert.deepEqual(
+    rigCardFields(FULL).map((f) => f.value),
+    [FULL.worker, FULL.stratum, FULL.address, FULL.token],
+  );
+});
+
+test("rigCardFields: no IPv4 lease yet drops the address row rather than blanking it", () => {
+  const fields = rigCardFields({ ...FULL, address: "" });
+  assert.deepEqual(labels({ ...FULL, address: "" }), [
+    "Worker name",
+    "Mines toward",
+    "Control token",
+  ]);
+  assert.ok(fields.every((f) => f.value !== ""));
+});
+
+test("rigCardFields: an unminted token drops the token row rather than blanking it", () => {
+  const fields = rigCardFields({ ...FULL, token: "" });
+  assert.deepEqual(labels({ ...FULL, token: "" }), [
+    "Worker name",
+    "Mines toward",
+    "This machine's address",
+  ]);
+  assert.ok(fields.every((f) => f.value !== ""));
+});
+
+test("rigCardFields: both missing leaves only the two rows the card always had", () => {
+  assert.deepEqual(labels({ ...FULL, token: "", address: "" }), ["Worker name", "Mines toward"]);
+});
+
+test("rigCardFields: worker and pool are unconditional — an empty one still gets its row", () => {
+  // Deliberate asymmetry: these two predate the token and the host decides what they hold, so the
+  // card does not start hiding them. Only the rows this change added are conditional.
+  assert.deepEqual(labels({ ...FULL, worker: "", stratum: "" }), [
+    "Worker name",
+    "Mines toward",
+    "This machine's address",
+    "Control token",
+  ]);
+});
+
+// --- rigCardNote ----------------------------------------------------------------------------
+
+test("rigCardNote: with a token and an address, it points at the adopt form and the port", () => {
+  const note = rigCardNote(FULL);
+  assert.match(note, /Workers → Adopt/);
+  assert.match(note, /control port 8082/);
+  assert.match(note, /shown once and never again/);
+  assert.doesNotMatch(note, /no address on the network yet/);
+});
+
+test("rigCardNote: with no address, it says to read the address off the console", () => {
+  const note = rigCardNote({ ...FULL, address: "" });
+  assert.match(note, /no address on the network yet/);
+  assert.match(note, /console once it is up/);
+  // Still the adopt instruction — the token is real, only the address is not known yet.
+  assert.match(note, /Workers → Adopt/);
+  assert.match(note, /control port 8082/);
+});
+
+test("rigCardNote: with no token, it never tells the operator to paste one", () => {
+  const note = rigCardNote({ ...FULL, token: "" });
+  assert.match(note, /cannot adopt it/);
+  assert.match(note, /still mines/);
+  assert.doesNotMatch(note, /Adopt form/);
+  assert.doesNotMatch(note, /control port/);
+  assert.doesNotMatch(note, /shown once/);
+});
+
+test("rigCardNote: the pre-token wording is gone from every case", () => {
+  // The old note said a rig has "nothing to save". It now has exactly one thing to save, so that
+  // sentence must not survive in any branch.
+  for (const h of [FULL, { ...FULL, address: "" }, { ...FULL, token: "" }]) {
+    assert.doesNotMatch(rigCardNote(h), /nothing to save/);
+  }
+});
+
+// --- the card as the wizard actually renders it -----------------------------------------------
+//
+// The rows above are decided here but WIRED in wizard.mjs's Done view, so the logic assertions
+// alone cannot tell a correct field list from one the view drops on the floor. These two rows
+// close that gap. They live in this file rather than beside the other Done probes because
+// wizard.test.mjs sits at its file-budget ceiling with no headroom.
+
+test("rendered: a complete handoff puts the address and the token on the card", () => {
+  const card = renderToString(
+    html`<${Done} status="" handoff=${FULL} installer=${false} stick=${false} onAck=${() => {}} />`,
+  );
+  assert.match(card, /This machine's address/);
+  assert.match(card, /10\.0\.0\.9/);
+  assert.match(card, /Control token/);
+  assert.match(card, new RegExp(FULL.token));
+  assert.match(card, /Workers → Adopt/);
+  assert.doesNotMatch(card, /nothing to save/);
+});
+
+test("rendered: an unminted token puts no empty 'Control token' row on the card", () => {
+  const card = renderToString(
+    html`<${Done} status="" handoff=${{ ...FULL, token: "" }} installer=${false} stick=${false}
+      onAck=${() => {}} />`,
+  );
+  assert.doesNotMatch(card, /Control token/);
+  assert.doesNotMatch(card, /Workers → Adopt/);
+  assert.match(card, /cannot adopt it/);
+  assert.match(card, /This machine's address/); // the address it DOES have still shows
+});

--- a/dashboard/tests/frontend/wizard.test.mjs
+++ b/dashboard/tests/frontend/wizard.test.mjs
@@ -528,7 +528,7 @@ test("an empty pool address is stopped client-side with a named reason", async (
   restore();
 });
 
-test("the rig card shows the worker and where it points — no credentials, no login", () => {
+test("the rig card with no token and no address is worker and pool only — no login", () => {
   const handoff = { role: "rig", worker: "shed-3", stratum: "stratum+tcp://pithead.local:3333" };
   const card = renderToString(
     html`<${Done} status="" handoff=${handoff} installer=${true} stick=${false} onAck=${() => {}} />`,

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -158,7 +158,7 @@ control off, since RigForge refuses a writable path it cannot pin to one source.
 Where the machine cannot fill a line in, the card leaves that line out rather than
 showing a blank beside its label: with no IPv4 address yet it tells you to read the
 address off the console once the machine is up, and on the rare failure to mint a token
-it says the rig cannot be adopted and that its console gives the reason.
+it says the rig cannot be adopted until it has one, and to set the machine up again.
 
 **Pithead + RigForge** asks every coordinator question below, unchanged, and adds the built-in
 miner on top. The two mining workloads on that one box do not compete for HugePages: the

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -155,6 +155,10 @@ network can read or change it. From then on its own console is the only place to
 same way you would watch any other machine on the network. A rig pointed at a pool with no
 IPv4 address (an onion address, say) keeps the token and the read-only feed but runs with
 control off, since RigForge refuses a writable path it cannot pin to one source.
+Where the machine cannot fill a line in, the card leaves that line out rather than
+showing a blank beside its label: with no IPv4 address yet it tells you to read the
+address off the console once the machine is up, and on the rare failure to mint a token
+it says the rig cannot be adopted and that its console gives the reason.
 
 **Pithead + RigForge** asks every coordinator question below, unchanged, and adds the built-in
 miner on top. The two mining workloads on that one box do not compete for HugePages: the


### PR DESCRIPTION
Closes the card half of #1836. The host half — minting the token, enabling the sister feed and pinning control — is already on `develop-v2`; this is the page that shows the operator what was minted.

## What was wrong

The rig handoff card ended at worker and pool, under a note saying a rig has "no login — nothing to save". That stopped being true when the host began minting a rig access token: there is now exactly one thing to save, and this card is the only place it is ever shown — minted once, kept in `rig.json`, and a rig serves no page after this.

So a provisioned appliance rig could not be adopted at all. Its Workers row reads as an API error, and nothing on screen said what to paste or where. `docs/appliance.md` and `docs/workers.md` already described a card with the token on it; the prose was ahead of the code.

## What this does

The card renders the token and this machine's address beside worker and pool, and the note points at the coordinator's Workers → Adopt form with the control port, matching the wording the docs already carry.

Which rows the card shows moves into a new DOM-free module, `rigcardlogic.mjs`, because two of the five fields the host publishes are legitimately empty and neither state can be produced by hand:

- **`token`** — `rig_access_token` could not mint or keep one. The card is written **before** the miner is configured (`12-firstboot-wizard.sh:296` publishes the handoff; `14-local-miner.sh`'s render leg refuses afterwards), so the wizard shows this state first.
- **`address`** — `hostname -I` answered nothing, because the box has no IPv4 lease yet.

A blank beside a label is the one thing this card must never show, so an empty value drops its own row and the note says what is missing instead. Worker and pool stay unconditional: they predate the token, and an empty one is the host's business rather than the card's.

The control port is read from `workeradoptlogic.mjs`'s `DEFAULT_CONTROL_PORT` rather than written as a second literal. It is the same fact as the adopt form's own default, the wizard serves the same static tree, and that module imports nothing.

## What was RUN, at this head

- `node --test` on the new file: **11 passed, 0 failed**.
- `make test-frontend`, the whole suite: **555 passed, 0 failed**.
- **Mutation battery, with a firing control per row.** Every mutation is proven applied by a moved `sha256`, and the file is restored byte-identically after each:

  | mutation | reds |
  |---|---|
  | address guard removed | the no-lease rows (2, 4) — a labelled row with a blank value |
  | token guard removed | rows 3, 4 **and 11** |
  | no-token note branch disabled | rows 8 **and 11** |
  | **the view's own field list truncated in `wizard.mjs`** | **rows 10 and 11** |

  **Row 10 is the wiring-only probe; row 11 is mixed** — its first assertion is an absence, which pure-logic mutations also trip. My first version of this table claimed rows 10 and 11 were wiring-only and that only the fourth mutation reached them; the reviewer re-derived it and was right, and the table above is the corrected attribution.
- Non-shell lint battery **rc 0** — py, js, yaml, md, docs-voice, operator-strings, topology, file-budget, pithead-parity, trivy-parity, proto, toml. js, md, file-budget, docs-voice and operator-strings re-run **after the rebase**, at this head.
- `lane-guard` **rc 0**, with a near-miss control: a sibling under `lib/pithead/` staged alone returns **rc 1**, so the rc 0 is a grant rather than a guard waving everything through.

## NOT run

`tests/stack/run.sh` and the dashboard pytest suite. The appliance lane holds this box for a KVM battery pre-flight until ~00:25Z; CI covers both, and I have not quoted either as green.

## Disclosed

- **`docs/appliance.md` is in `_shared.paths`.** One paragraph, in the rig-role section, covering only the two absent-value branches. The rest of that section already described the token and needed no change. The `dashboard` lane also holds a grant on `docs/` this round — this hunk is in the rig-role prose, away from its Tari and backup work.
- **`wizard.mjs` is at its file-budget ceiling (889).** This change leaves it at **888**: folding the field list into the new module removes more lines from the view than the import and the note add, so no line had to be bought elsewhere. The tests are in a new sibling file (148 lines) because `wizard.test.mjs` is at 765/765 with no headroom — which is also why the two render probes live beside the logic rows instead of next to the other `Done` probes.
- **A gap this card cannot close.** The host leaves RigForge's control path **off** when the pool host does not resolve to an IPv4 address, and that fact is not in the handoff spool, so the note still names the adopt form. `docs/appliance.md` already documents the behaviour. Raised with the appliance lane, who owns that half; adding a field to the spool is a contract change, not mine to make unilaterally.
- The existing rendered rig-card probe in `wizard.test.mjs` uses a handoff with no token and no address, so it now exercises the both-missing branch and still passes unchanged.

## Assumed, not proven

Nothing beyond the agreed spool contract: that the host publishes `{role, worker, stratum, token, address}` for `role=rig`. I re-derived that at `12-firstboot-wizard.sh:296-297` on `develop-v2` rather than taking it from the handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7txeRNDQmj5b4Wsx33mCF

## Fixes after the non-author RETURN

Both blockers were real, both were outside what I asked the reviewer to look at, and both are fixed at head `dd220508`.

1. **`Secret scan (gitleaks)` was red, this branch caused it, and my first fix was the wrong remedy.** The finding is `generic-api-key` at `rigcardlogic.test.mjs:29` — the fixture control token — on commit `d53ac22f`. I first allowlisted the literal in `.gitleaks.toml`, following the precedent four lines above it from this same test family. That greened **this** PR and left every other open PR red, which is the half the precedent hides:

   **gitleaks scans every ref in the CI clone (`fetch-depth: 0` fetches them all), but reads its config from the checked-out ref only.** An allowlist entry living on an in-flight branch therefore protects that branch's own PR and nothing else, while the flagged commit reddens every other ref until the entry merges. Measured, not reasoned, with one variable moved: same all-refs clone, config from `develop-v2` -> 1 leak; config from this branch -> no leaks. The `dashboard` lane hit the same red from the other side and derived the same mechanism independently.

   **So this branch retires the realistic fixture instead** — the fix `ef31a865` already chose when the wizard password fixture was in this exact position. The token keeps its real 32-hex shape but is all zeros, which the rule does not flag, and nothing on the card depends on the characters; the comment above it says why, so it is not restored by the next reader. **The `.gitleaks.toml` commit is dropped and this branch no longer touches that file.** History was rewritten (`--force-with-lease`) because the scan reads history: an added commit would have left `d53ac22f` reachable and the red in place. Verified with the old tip as the fired control on the same clone: 1 leak -> 0. **My "non-shell lint battery rc 0" was true and never covered this — gitleaks is not part of `make lint`.**
2. **The no-token note asserted two things that are not true**, and on opposite paths: run from the stick, `render_rig_miner_config` returns 1 and `rigforge_setup_run` never runs, so the machine does not mine; on the installer path it does mine but nothing prints the token afterwards, so its console cannot say why. The note now promises neither — it says the machine could not create its token, there is nothing to copy, and no Pithead can adopt the rig until it has one. **Two assertions pin the retracted claims** (`/still mines/` and `/console says why/` must NOT appear) so the wording cannot drift back.

Also from the RETURN: I had **under-disclosed `wizard.test.mjs:531`**. Its fixture has neither token nor address, so it silently covers the both-missing branch while being titled "no credentials, no login" — anyone adding a token to match that title would have deleted the only rendered coverage of that case. The title now says what the fixture is. Line-neutral: the file stays at 765/765.

**`.lane-override` NO LONGER USED — the commit that needed it is gone.** Dropping the `.gitleaks.toml` change leaves this branch touching only files in its own lane, so nothing here needs the hatch and no marker exists in the tree. Kept because it cost real time: **running `lane-guard.sh` by hand to pre-check a commit CONSUMES the one-shot override**, so the marker has to be touched and the commit made with no manual guard run in between — the pre-commit hook is the gate.
