### PR TITLE
feat(dashboard): #1853 the header shows the .onion URL when the dashboard is on Tor

### DIFF
--- a/dashboard/mining_dashboard/web/header.py
+++ b/dashboard/mining_dashboard/web/header.py
@@ -1,0 +1,78 @@
+"""The header's address block: what this machine is called, and how to reach it.
+
+The header names the machine as hostname-then-IP and, when the dashboard is published as a Tor
+hidden service, carries its ``.onion`` URL underneath (#1853). Both are *ways in* rather than
+status readings, which is why they sit together here instead of among ``views.py``'s metric
+formatting.
+
+The three ``DASHBOARD_ONION_*`` values are read in this module rather than in
+``config/config.py`` for two reasons that happen to agree. Nothing else in the dashboard consumes
+them, so a module-level constant would be indirection for one caller; and ``version.py`` already
+establishes the injectable-``env`` reader for a presentation value, which lets a test pass a dict
+instead of mutating process state. (``config/config.py`` is also at its recorded file-budget
+ceiling, and that ratchet only moves down — see ``docs/dev/file-budget.tsv``.)
+
+Nothing here ever emits client-authorisation key material. The dashboard container is not given
+it: ``docker-compose.yml`` passes the enabled flag, the address and the client-auth *boolean*,
+and the keys stay host-side behind ``pithead onion-client-key``.
+"""
+
+import os
+
+from mining_dashboard.helper.utils import detect_host_ipv4, is_ip_address
+
+# pithead writes the literal "placeholder" into .env when the onion has not been provisioned yet
+# (lib/pithead/29-preserved-state-and-dirs.sh), so "enabled" on its own never means "reachable".
+# The host's own `dashboard_onion_status` (lib/pithead/04-status.sh) makes exactly these two
+# checks before it prints a URL, and this mirrors it rather than inventing a second rule.
+_UNPROVISIONED = "placeholder"
+
+
+def host_display_addr(host):
+    """The numeric IP to show *beside* the configured host in the header, or ``None`` (Issue #119).
+
+    The configured ``dashboard.host`` is often a hostname that won't resolve from another machine
+    on the LAN (flaky mDNS/``.local``, no DNS entry), so we surface the host's primary IP next to
+    it as a fallback way in. Returns ``None`` — meaning "show the host alone" — when there's
+    nothing useful to add: the host is already an IP, the address can't be determined, or it just
+    duplicates the host.
+    """
+    if is_ip_address(host):
+        return None
+    addr = detect_host_ipv4()
+    if not addr or addr == host:
+        return None
+    return addr
+
+
+def dashboard_onion(env=None):
+    """The dashboard's ``.onion`` way in for the header, or ``None`` when there isn't one (#1853).
+
+    Answers ``{"url", "client_auth"}`` only when the onion is both **enabled and provisioned** —
+    the same pair of conditions the host applies before `pithead status` prints the line. An
+    onion that is switched on but has no address yet is not a way in, so it renders as nothing at
+    all rather than as an empty row the operator would read as breakage.
+
+    ``client_auth`` is a boolean and never more than that: with client authorisation on, the URL
+    alone does not open, and the *reason* is what the header has to say. The key that would open
+    it is deliberately not in this container's environment, so this function could not leak it
+    even if it tried to.
+
+    The address is required to end in ``.onion``. That is a sanity check against a status word
+    reaching the header, not v3 address validation — a stricter rule would silently hide a real
+    address the day the address format changes, and hiding is the failure that looks like Tor
+    being broken.
+    """
+    env = os.environ if env is None else env
+    if env.get("DASHBOARD_ONION_ENABLED", "").strip().lower() != "true":
+        return None
+    address = env.get("DASHBOARD_ONION_ADDRESS", "").strip()
+    if not address or address == _UNPROVISIONED or not address.endswith(".onion"):
+        return None
+    return {
+        # The full URL, assembled here so the client renders one pasteable string and cannot
+        # build a broken one. http:// matches the host's own line: the hidden service supplies
+        # the encryption and authentication that TLS would, and Tor Browser expects this form.
+        "url": f"http://{address}",
+        "client_auth": env.get("DASHBOARD_ONION_CLIENT_AUTH", "").strip().lower() == "true",
+    }

--- a/dashboard/mining_dashboard/web/static/components.mjs
+++ b/dashboard/mining_dashboard/web/static/components.mjs
@@ -34,6 +34,7 @@ import {
   WORKER_COLUMNS,
 } from "./logic.mjs";
 import { MineCartTrain } from "./minecart.mjs";
+import { OnionUrl } from "./onionurl.mjs";
 import { OsUpdateControl, OsVerdictBanner } from "./osupdate.mjs";
 import { Component, Fragment, html } from "./preact.mjs";
 import { SecurityPanel } from "./securityview.mjs";
@@ -154,6 +155,7 @@ function Header({ state }) {
                         }
                     </div>
                     <div class="brand-host font-mono text-muted">${state.host_ip}${state.host_addr ? html`<span class="brand-host-at">@</span>${state.host_addr}` : null}</div>
+                    <${OnionUrl} onion=${state.dashboard_onion} />
                 </div>
             </div>
             <div class="text-small mt-2">

--- a/dashboard/mining_dashboard/web/static/onionurl.mjs
+++ b/dashboard/mining_dashboard/web/static/onionurl.mjs
@@ -1,0 +1,66 @@
+// The dashboard's Tor way in, rendered under the header's hostname/IP line (#1853).
+//
+// The server decides whether there IS one: state.dashboard_onion is {url, client_auth} only when
+// the onion is both enabled and provisioned (mining_dashboard/web/header.py). This file renders
+// what it is handed and infers nothing — no onion means no block at all, not an empty row, which
+// on the appliance is the difference between "Tor is off" and "Tor is broken".
+//
+// The URL is never elided. A v3 onion address is 56 characters of base32 with no redundancy, so a
+// tidy-looking truncation produces a string that does not open — and the whole product here is
+// that someone can copy it to a phone, which is the only way in on a machine with no shell.
+//
+// Reuses .brand-host (the host line's own size, spacing and overflow-wrap: anywhere) and the
+// generic .btn-range control rather than introducing header-only CSS.
+
+import { Component, html } from "./preact.mjs";
+
+// Copy `text`, answering true only if the clipboard actually took it. The clipboard is passed in
+// rather than reached for: it is absent in the test renderer, and undefined on any page not
+// served in a secure context — where the button has to degrade to "select it by hand" instead of
+// throwing. A false answer leaves the label alone, so the operator is never told it copied when
+// nothing reached the clipboard.
+export async function copyText(text, clipboard) {
+  try {
+    if (!clipboard || typeof clipboard.writeText !== "function") return false;
+    await clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class OnionUrl extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { copied: false };
+  }
+
+  async copy() {
+    const ok = await copyText(this.props.onion.url, globalThis.navigator?.clipboard);
+    this.setState({ copied: ok });
+  }
+
+  render({ onion }, { copied }) {
+    if (!onion) return null;
+    return html`
+      <div class="brand-host text-muted">
+        <span class="font-mono">${onion.url}</span>
+        <button type="button" class="btn-range btn-reset" onClick=${() => this.copy()}>
+          ${copied ? "Copied" : "Copy"}
+        </button>
+        ${
+          // Client authorisation on means the URL alone does not open — Tor Browser answers with
+          // a generic failure that reads as "the onion is down". Saying so here is the whole
+          // point; the key itself is host-side and never reaches this container.
+          onion.client_auth
+            ? html`<div>
+                Client authorisation is on — this address only opens for a browser holding your
+                client key. Get the key with
+                <span class="font-mono">pithead onion-client-key</span> on the machine.
+              </div>`
+            : null
+        }
+      </div>
+    `;
+  }
+}

--- a/dashboard/mining_dashboard/web/static/onionurl.mjs
+++ b/dashboard/mining_dashboard/web/static/onionurl.mjs
@@ -45,18 +45,28 @@ export class OnionUrl extends Component {
     return html`
       <div class="brand-host text-muted">
         <span class="font-mono">${onion.url}</span>
-        <button type="button" class="btn-range btn-reset" onClick=${() => this.copy()}>
+        <button
+          type="button"
+          class="btn-range btn-reset"
+          aria-live="polite"
+          onClick=${() => this.copy()}
+        >
           ${copied ? "Copied" : "Copy"}
         </button>
         ${
           // Client authorisation on means the URL alone does not open — Tor Browser answers with
           // a generic failure that reads as "the onion is down". Saying so here is the whole
           // point; the key itself is host-side and never reaches this container.
+          //
+          // The ${" "} before the <span> is load-bearing and the repo has 13 other sites of it:
+          // htm strips a whitespace run CONTAINING A NEWLINE from both ends of every static text
+          // chunk, so a line break before a tag deletes the space and the words run together. A
+          // field is pushed as its own child and never goes through that regex.
           onion.client_auth
             ? html`<div>
                 Client authorisation is on — this address only opens for a browser holding your
-                client key. Get the key with
-                <span class="font-mono">pithead onion-client-key</span> on the machine.
+                client key. On a machine you can log in to,${" "}
+                <span class="font-mono">pithead onion-client-key</span> prints it.
               </div>`
             : null
         }

--- a/dashboard/mining_dashboard/web/static/onionurl.mjs
+++ b/dashboard/mining_dashboard/web/static/onionurl.mjs
@@ -3,16 +3,28 @@
 // The server decides whether there IS one: state.dashboard_onion is {url, client_auth} only when
 // the onion is both enabled and provisioned (mining_dashboard/web/header.py). This file renders
 // what it is handed and infers nothing — no onion means no block at all, not an empty row, which
-// on the appliance is the difference between "Tor is off" and "Tor is broken".
+// is the difference between "Tor is off" and "Tor is broken".
+//
+// WHERE THIS RENDERS TODAY: the Compose stack, which passes DASHBOARD_ONION_ENABLED, _ADDRESS and
+// _CLIENT_AUTH into the dashboard container (docker-compose.yml). The appliance runs podman
+// quadlets, and its dashboard unit is written with none of the three
+// (lib/pithead/36-quadlet-units.sh), so there the server sends no onion and this block is absent.
+// That gap is #1896 — until it lands, no prose here promises an appliance operator this surface.
 //
 // The URL is never elided. A v3 onion address is 56 characters of base32 with no redundancy, so a
 // tidy-looking truncation produces a string that does not open — and the whole product here is
-// that someone can copy it to a phone, which is the only way in on a machine with no shell.
+// that someone can copy it to a phone instead of reading it off a terminal.
 //
-// Reuses .brand-host (the host line's own size, spacing and overflow-wrap: anywhere) and the
-// generic .btn-range control rather than introducing header-only CSS.
+// Reuses .brand-host (the host line's own size, spacing and overflow-wrap: anywhere), .text-muted,
+// and the generic .btn-range control paired with .btn-reset, which is what supplies the 8px before
+// the button (dashboard.css) — no header-only CSS is introduced.
 
 import { Component, html } from "./preact.mjs";
+
+// How long the copy confirmation stays up. It has to come down: the confirmation lives in a live
+// region, and a live region announces a CHANGE to its content. A control that reads "Copied" from
+// the first copy onwards announces once per page load and is silent for every copy after it.
+export const CLEAR_MS = 4000;
 
 // Copy `text`, answering true only if the clipboard actually took it. The clipboard is passed in
 // rather than reached for: it is absent in the test renderer, and undefined on any page not
@@ -33,26 +45,36 @@ export class OnionUrl extends Component {
   constructor(props) {
     super(props);
     this.state = { copied: false };
+    this.clearTimer = null;
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.clearTimer);
   }
 
   async copy() {
     const ok = await copyText(this.props.onion.url, globalThis.navigator?.clipboard);
+    // A copy that failed takes the standing confirmation down with it rather than leaving the
+    // previous one to read as this one's answer.
+    clearTimeout(this.clearTimer);
     this.setState({ copied: ok });
+    if (ok) this.clearTimer = setTimeout(() => this.setState({ copied: false }), CLEAR_MS);
   }
 
   render({ onion }, { copied }) {
     if (!onion) return null;
+    // The button's accessible name IS its text, so the confirmation cannot live in the label: one
+    // copy would rename the control "Copied" — a state, not the action a returning reader needs.
+    // It goes in a sibling status region instead, which is rendered EMPTY rather than conditionally,
+    // because a live region inserted with its message already in it has no change to announce.
     return html`
       <div class="brand-host text-muted">
         <span class="font-mono">${onion.url}</span>
-        <button
-          type="button"
-          class="btn-range btn-reset"
-          aria-live="polite"
-          onClick=${() => this.copy()}
-        >
-          ${copied ? "Copied" : "Copy"}
+        <button type="button" class="btn-range btn-reset" onClick=${() => this.copy()}>
+          Copy address
         </button>
+        ${" "}
+        <span role="status">${copied ? "Copied" : ""}</span>
         ${
           // Client authorisation on means the URL alone does not open — Tor Browser answers with
           // a generic failure that reads as "the onion is down". Saying so here is the whole

--- a/dashboard/mining_dashboard/web/views.py
+++ b/dashboard/mining_dashboard/web/views.py
@@ -22,11 +22,9 @@ from mining_dashboard.config.config import (
     HOST_IP,
 )
 from mining_dashboard.helper.utils import (
-    detect_host_ipv4,
     format_duration,
     format_hashrate,
     format_time_abs,
-    is_ip_address,
 )
 from mining_dashboard.service.egress import egress_posture_from_config, topology_from_config
 from mining_dashboard.service.metrics import build_metrics
@@ -41,6 +39,10 @@ from mining_dashboard.web.charts import (
     canonical_window,  # noqa: F401 — re-export for server.py
     parse_window,  # noqa: F401 — re-export for server.py
 )
+
+# The header's address block lives in web/header.py (#1853): the hostname/IP line and the
+# .onion URL under it are ways IN to the machine, not readings off it.
+from mining_dashboard.web.header import dashboard_onion, host_display_addr
 
 # The host/rig/node status sections live in web/infra_views.py (#1105). views.py stays the
 # facade: build_state assembles these sections, build_pool_network uses the address elider, and
@@ -199,23 +201,6 @@ def _monero_db_size(monero_sync):
 # --------------------------------------------------------------------------------------
 
 
-def host_display_addr(host):
-    """The numeric IP to show *beside* the configured host in the header, or ``None`` (Issue #119).
-
-    The configured ``dashboard.host`` is often a hostname that won't resolve from another machine
-    on the LAN (flaky mDNS/``.local``, no DNS entry), so we surface the host's primary IP next to
-    it as a fallback way in. Returns ``None`` — meaning "show the host alone" — when there's
-    nothing useful to add: the host is already an IP, the address can't be determined, or it just
-    duplicates the host.
-    """
-    if is_ip_address(host):
-        return None
-    addr = detect_host_ipv4()
-    if not addr or addr == host:
-        return None
-    return addr
-
-
 def _egress_badge(summary):
     """Glanceable header badge for the egress posture (#170): green when Tor-only, red on a leak."""
     ok = summary["level"] == "ok"
@@ -341,6 +326,10 @@ def build_state(data, state_mgr, range_arg, window=None, avg_window=DEFAULT_HASH
         else "Pithead Dashboard",
         "host_ip": HOST_IP,
         "host_addr": host_display_addr(HOST_IP),
+        # {url, client_auth} | None — the dashboard's Tor way in (#1853), shown under the host
+        # line. None whenever the onion is off or not yet provisioned, so the header renders
+        # nothing rather than an empty row. Never carries client-auth key material.
+        "dashboard_onion": dashboard_onion(),
         # The operator-facing stratum port (#172) — feeds the "point your rigs at host:PORT" hint.
         "stratum_port": config.STRATUM_PORT,
         "version": resolve_version(),

--- a/dashboard/tests/frontend/fixtures/_gen_state.py
+++ b/dashboard/tests/frontend/fixtures/_gen_state.py
@@ -13,20 +13,27 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import mining_dashboard.web.header as header
 import mining_dashboard.web.views as views
 
 # Pin everything machine- or time-dependent so the fixture regenerates identically on any box.
 # build_state stamps last_update via time.localtime(time.time()) and the chart x-axis is
 # now-relative, so freeze NOW (2025-01-01 00:00:00 UTC) + patch views.time.time and force UTC
 # for the localtime-based last_update string. host_addr is a live socket lookup
-# (detect_host_ipv4) and host_ip an env default — pin both too.
+# (detect_host_ipv4, now in web/header.py beside the onion reader) and host_ip an env default —
+# pin both too. Patch the lookup where it is LOOKED UP: `views.detect_host_ipv4 = ...` bound a
+# dead attribute once the function moved, and the fixture went machine-dependent without a word.
 os.environ["TZ"] = "UTC"
 time.tzset()
 NOW = 1735689600
 
 views.time.time = lambda: NOW  # build_state's last_update + history cutoff
 views.HOST_IP = "Unknown Host"
-views.detect_host_ipv4 = lambda: "100.68.38.126"
+header.detect_host_ipv4 = lambda: "100.68.38.126"
+# The dashboard onion (#1853) is read from the process environment at call time, so clear it:
+# otherwise this regenerates differently on a box that happens to have an onion provisioned.
+for _var in ("DASHBOARD_ONION_ENABLED", "DASHBOARD_ONION_ADDRESS", "DASHBOARD_ONION_CLIENT_AUTH"):
+    os.environ.pop(_var, None)
 
 HISTORY = [
     {"timestamp": NOW - 600, "v": 10200, "v_p2pool": 8000, "v_xvb": 2200, "t": "a"},

--- a/dashboard/tests/frontend/fixtures/state.json
+++ b/dashboard/tests/frontend/fixtures/state.json
@@ -77,6 +77,7 @@
     ]
   },
   "control_enabled": false,
+  "dashboard_onion": null,
   "db_healthy": true,
   "disk_growth": [],
   "earnings": {

--- a/dashboard/tests/frontend/onionurl.test.mjs
+++ b/dashboard/tests/frontend/onionurl.test.mjs
@@ -54,10 +54,12 @@ test('client authorisation is explained beside the URL when it is on (#1853)', (
     // The WORDS, not the markup. htm strips a whitespace run containing a newline from each end of
     // a static text chunk, so a line break before the <span> renders "to,pithead onion-client-key"
     // — a defect both assertions above stay green on, because each matches one side of the join.
-    assert.match(
-        on.replace(/<[^>]*>/g, ''),
-        /On a machine you can log in to, pithead onion-client-key prints it\./,
-    );
+    // This drops the tags and puts NOTHING in their place, which is the load-bearing half: the
+    // sibling in xvbview.test.mjs substitutes a space, and a space would re-join "to,<span>pithead"
+    // into readable text and pass over the very defect this asserts against. Not a sanitiser — the
+    // result is read by assert.match and never reaches a DOM.
+    const words = on.split(/<[^>]*>/).join('');
+    assert.match(words, /On a machine you can log in to, pithead onion-client-key prints it\./);
     // And is absent when it is off — the same render path, one boolean apart.
     assert.doesNotMatch(withOnion({ url: URL, client_auth: false }), /Client authorisation/);
 });

--- a/dashboard/tests/frontend/onionurl.test.mjs
+++ b/dashboard/tests/frontend/onionurl.test.mjs
@@ -51,6 +51,13 @@ test('client authorisation is explained beside the URL when it is on (#1853)', (
     const on = withOnion({ url: URL, client_auth: true });
     assert.match(on, /Client authorisation is on/);
     assert.match(on, /onion-client-key/);
+    // The WORDS, not the markup. htm strips a whitespace run containing a newline from each end of
+    // a static text chunk, so a line break before the <span> renders "to,pithead onion-client-key"
+    // — a defect both assertions above stay green on, because each matches one side of the join.
+    assert.match(
+        on.replace(/<[^>]*>/g, ''),
+        /On a machine you can log in to, pithead onion-client-key prints it\./,
+    );
     // And is absent when it is off — the same render path, one boolean apart.
     assert.doesNotMatch(withOnion({ url: URL, client_auth: false }), /Client authorisation/);
 });
@@ -69,7 +76,12 @@ test('the block never carries client-auth key material (#1853)', () => {
 
 test('the URL comes with a copy control (#1853)', () => {
     const html = withOnion({ url: URL, client_auth: false });
-    assert.match(html, /<button type="button" class="btn-range btn-reset">\s*Copy\s*<\/button>/);
+    // aria-live is on the button on purpose (#1853 design pass): the label itself changes to
+    // "Copied", so the control IS the status message and a screen reader hears nothing without it.
+    assert.match(
+        html,
+        /<button type="button" class="btn-range btn-reset" aria-live="polite">\s*Copy\s*<\/button>/,
+    );
 });
 
 test('copyText answers whether the clipboard actually took the text (#1853)', async () => {

--- a/dashboard/tests/frontend/onionurl.test.mjs
+++ b/dashboard/tests/frontend/onionurl.test.mjs
@@ -8,10 +8,10 @@
 // they exercise the true server contract; copyText is a pure function and is tested directly,
 // because the render probe deliberately never invokes handlers.
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { mock, test } from 'node:test';
 
 import { clone, renderApp } from './harness.mjs';
-import { copyText } from '../../mining_dashboard/web/static/onionurl.mjs';
+import { CLEAR_MS, OnionUrl, copyText } from '../../mining_dashboard/web/static/onionurl.mjs';
 
 // A run of one letter, not a realistic v3 address: nothing here depends on the characters, and a
 // high-entropy literal is what puts a secret scanner on a test file that holds no secret.
@@ -37,7 +37,7 @@ test('the onion URL renders under the host line, whole (#1853)', () => {
 });
 
 test('no onion means no block at all — not an empty row (#1853)', () => {
-    // On the appliance an empty row reads as "Tor is broken" rather than "Tor is off".
+    // An empty row reads as "Tor is broken" rather than "Tor is off".
     assert.doesNotMatch(withOnion(null), /\.onion/);
     assert.doesNotMatch(withOnion(undefined), /\.onion/);
     // The control: the same fixture, one field filled, does render it — so the assertions above
@@ -74,14 +74,75 @@ test('the block never carries client-auth key material (#1853)', () => {
     assert.doesNotMatch(html, /SENTINEL/);
 });
 
-test('the URL comes with a copy control (#1853)', () => {
+test('the copy control keeps its name, and the confirmation has its own region (#1853)', () => {
     const html = withOnion({ url: URL, client_auth: false });
-    // aria-live is on the button on purpose (#1853 design pass): the label itself changes to
-    // "Copied", so the control IS the status message and a screen reader hears nothing without it.
+    // The button's accessible name IS its text, so the confirmation cannot live in the label: one
+    // copy would leave the control named "Copied", a state rather than the action it performs.
     assert.match(
         html,
-        /<button type="button" class="btn-range btn-reset" aria-live="polite">\s*Copy\s*<\/button>/,
+        /<button type="button" class="btn-range btn-reset">\s*Copy address\s*<\/button>/,
     );
+    // The region is rendered EMPTY rather than conditionally: a live region inserted with its
+    // message already inside it presents no content change, and announces nothing.
+    assert.match(html, /<span role="status"><\/span>/);
+});
+
+// The render probe never invokes handlers, so the copy state machine is driven directly. setState
+// is replaced rather than stubbed away, so each call's payload is observable in order.
+const driveCopy = (clipboard) => {
+    const component = new OnionUrl({ onion: { url: URL, client_auth: false } });
+    const seen = [];
+    component.setState = (patch) => {
+        Object.assign(component.state, patch);
+        seen.push(patch.copied);
+    };
+    const priorNavigator = globalThis.navigator;
+    Object.defineProperty(globalThis, 'navigator', { value: { clipboard }, configurable: true });
+    const restore = () =>
+        Object.defineProperty(globalThis, 'navigator', {
+            value: priorNavigator,
+            configurable: true,
+        });
+    return { component, seen, restore };
+};
+
+test('the confirmation clears itself, so a second copy announces too (#1853)', async (t) => {
+    mock.timers.enable({ apis: ['setTimeout'] });
+    const { component, seen, restore } = driveCopy({ writeText: async () => {} });
+    t.after(() => {
+        mock.timers.reset();
+        restore();
+    });
+
+    await component.copy();
+    assert.deepEqual(seen, [true], 'a successful copy raises the confirmation');
+    // Left standing, the region's content never changes again and every copy after the first is
+    // silent to a screen reader. Coming down is what makes the next one an announcement.
+    mock.timers.tick(CLEAR_MS);
+    assert.deepEqual(seen, [true, false], 'the confirmation is still up after CLEAR_MS elapsed');
+    assert.equal(component.state.copied, false);
+});
+
+test('a failed copy takes a standing confirmation down with it (#1853)', async (t) => {
+    mock.timers.enable({ apis: ['setTimeout'] });
+    const clipboard = { writeText: async () => {} };
+    const { component, seen, restore } = driveCopy(clipboard);
+    t.after(() => {
+        mock.timers.reset();
+        restore();
+    });
+
+    await component.copy();
+    // The clipboard goes away under the operator — a page that lost its secure context, a denied
+    // permission. The previous "Copied" must not read as this attempt's answer.
+    clipboard.writeText = async () => {
+        throw new Error('denied');
+    };
+    await component.copy();
+    assert.deepEqual(seen, [true, false]);
+    // And no timer from the failed attempt is left to fire.
+    mock.timers.tick(CLEAR_MS);
+    assert.deepEqual(seen, [true, false]);
 });
 
 test('copyText answers whether the clipboard actually took the text (#1853)', async () => {

--- a/dashboard/tests/frontend/onionurl.test.mjs
+++ b/dashboard/tests/frontend/onionurl.test.mjs
@@ -1,0 +1,92 @@
+// The .onion URL under the header's hostname/IP line (#1853).
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// New file rather than more of components.test.mjs, which is at its file-budget ceiling. The
+// render cases go through the App root on the real build_state fixture, like every other card, so
+// they exercise the true server contract; copyText is a pure function and is tested directly,
+// because the render probe deliberately never invokes handlers.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { clone, renderApp } from './harness.mjs';
+import { copyText } from '../../mining_dashboard/web/static/onionurl.mjs';
+
+// A run of one letter, not a realistic v3 address: nothing here depends on the characters, and a
+// high-entropy literal is what puts a secret scanner on a test file that holds no secret.
+const ADDR = 'a'.repeat(56) + '.onion';
+const URL = `http://${ADDR}`;
+
+const withOnion = (onion) => {
+    const s = clone();
+    s.dashboard_onion = onion;
+    return renderApp({ state: s });
+};
+
+test('the onion URL renders under the host line, whole (#1853)', () => {
+    const html = withOnion({ url: URL, client_auth: false });
+    // Whole, not elided: 56 characters of base32 carry no redundancy, so a truncated address is
+    // one that does not open — and copying it to a phone is the entire product here.
+    assert.match(html, new RegExp(`<span class="font-mono">${URL}</span>`));
+    // It belongs to the header's address block, not to some card lower down the page. Anchor on
+    // a marker that must exist: indexOf(-1) would slice the whole page and pass vacuously.
+    assert.ok(html.includes('hero-band'), 'the hero band anchor is gone — re-anchor this slice');
+    const header = html.slice(0, html.indexOf('hero-band'));
+    assert.ok(header.includes(URL), 'the onion URL is not in the header block');
+});
+
+test('no onion means no block at all — not an empty row (#1853)', () => {
+    // On the appliance an empty row reads as "Tor is broken" rather than "Tor is off".
+    assert.doesNotMatch(withOnion(null), /\.onion/);
+    assert.doesNotMatch(withOnion(undefined), /\.onion/);
+    // The control: the same fixture, one field filled, does render it — so the assertions above
+    // mean the field was read, not that the harness rendered an empty page.
+    assert.match(withOnion({ url: URL, client_auth: false }), /\.onion/);
+});
+
+test('client authorisation is explained beside the URL when it is on (#1853)', () => {
+    // The URL alone does not open under client auth, and Tor Browser's failure for a missing key
+    // is indistinguishable from the service being down.
+    const on = withOnion({ url: URL, client_auth: true });
+    assert.match(on, /Client authorisation is on/);
+    assert.match(on, /onion-client-key/);
+    // And is absent when it is off — the same render path, one boolean apart.
+    assert.doesNotMatch(withOnion({ url: URL, client_auth: false }), /Client authorisation/);
+});
+
+test('the block never carries client-auth key material (#1853)', () => {
+    // The container is not given the keys, so this pins the shape rather than the plumbing: a
+    // payload that grew a key field would put it on the page, and nothing else would notice.
+    const html = withOnion({
+        url: URL,
+        client_auth: true,
+        client_privkey: 'PRIVKEY-SENTINEL',
+        client_pubkey: 'PUBKEY-SENTINEL',
+    });
+    assert.doesNotMatch(html, /SENTINEL/);
+});
+
+test('the URL comes with a copy control (#1853)', () => {
+    const html = withOnion({ url: URL, client_auth: false });
+    assert.match(html, /<button type="button" class="btn-range btn-reset">\s*Copy\s*<\/button>/);
+});
+
+test('copyText answers whether the clipboard actually took the text (#1853)', async () => {
+    const taken = [];
+    assert.equal(await copyText(URL, { writeText: async (t) => taken.push(t) }), true);
+    assert.deepEqual(taken, [URL]);
+});
+
+test('copyText degrades instead of throwing where there is no clipboard (#1853)', async () => {
+    // Not a secure context, or the test renderer: the button has to fall back to "select it by
+    // hand", and the label must not claim a copy that never happened.
+    assert.equal(await copyText(URL, undefined), false);
+    assert.equal(await copyText(URL, {}), false);
+    assert.equal(await copyText(URL, { writeText: 'not a function' }), false);
+});
+
+test('copyText answers false when the clipboard rejects (#1853)', async () => {
+    const rejects = { writeText: async () => { throw new Error('denied'); } };
+    assert.equal(await copyText(URL, rejects), false);
+});

--- a/dashboard/tests/web/test_header.py
+++ b/dashboard/tests/web/test_header.py
@@ -1,0 +1,112 @@
+"""The header's address block (``web/header.py``): the hostname/IP line and the .onion under it.
+
+Split out of ``test_views.py`` when ``host_display_addr`` moved to ``web/header.py`` alongside the
+onion reader it belongs beside (#1853). The ``host_display_addr`` cases are the originals, moved
+verbatim except for the patch target — they patched ``views``, and a module attribute patched by
+name does not follow a function to its new home.
+
+The address fixture is a run of one letter rather than a realistic v3 address on purpose: nothing
+here depends on the characters, and a realistic-looking high-entropy literal is what puts a repo's
+secret scanner on a test file that holds no secret.
+"""
+
+from unittest.mock import patch
+
+from mining_dashboard.web import header
+from mining_dashboard.web.header import dashboard_onion, host_display_addr
+
+ONION = "a" * 56 + ".onion"
+ON = {"DASHBOARD_ONION_ENABLED": "true", "DASHBOARD_ONION_ADDRESS": ONION}
+
+
+# --- Host address beside the hostname (Issue #119) ------------------------------------
+
+
+class TestHostDisplayAddr:
+    def test_resolves_ip_for_a_hostname(self):
+        with patch.object(header, "detect_host_ipv4", return_value="192.168.1.42"):
+            assert host_display_addr("pithead.local") == "192.168.1.42"
+
+    def test_none_when_host_is_already_an_ip(self):
+        # Nothing to add beside a literal address — don't call detection at all.
+        with patch.object(header, "detect_host_ipv4") as detect:
+            assert host_display_addr("192.168.1.42") is None
+            detect.assert_not_called()
+
+    def test_none_when_ip_undetectable(self):
+        with patch.object(header, "detect_host_ipv4", return_value=None):
+            assert host_display_addr("pithead.local") is None
+
+    def test_none_when_detected_ip_equals_host(self):
+        with patch.object(header, "detect_host_ipv4", return_value="my-rig"):
+            assert host_display_addr("my-rig") is None
+
+
+# --- The dashboard onion in the header (#1853) ----------------------------------------
+
+
+class TestDashboardOnion:
+    def test_enabled_and_provisioned_yields_the_pasteable_url(self):
+        assert dashboard_onion(ON) == {"url": f"http://{ONION}", "client_auth": False}
+
+    def test_the_address_is_carried_whole(self):
+        # The product is a URL someone can paste into a phone. A 56-character base32 address has
+        # no redundancy, so any elision yields a string that does not open.
+        assert dashboard_onion(ON)["url"].endswith(ONION)
+
+    def test_client_auth_is_reported_when_on(self):
+        env = {**ON, "DASHBOARD_ONION_CLIENT_AUTH": "true"}
+        assert dashboard_onion(env)["client_auth"] is True
+
+    def test_off_yields_nothing_even_with_an_address_present(self):
+        # The control for every "renders nothing" case below: the SAME address, one flag flipped,
+        # produces a real payload — so a None here means the flag was read, not that the fixture
+        # was incapable of producing one.
+        assert dashboard_onion({**ON, "DASHBOARD_ONION_ENABLED": "false"}) is None
+        assert dashboard_onion({"DASHBOARD_ONION_ADDRESS": ONION}) is None
+        assert dashboard_onion(ON) is not None
+
+    def test_unprovisioned_placeholder_is_not_an_address(self):
+        # pithead writes the literal "placeholder" into .env before the service exists. Enabled
+        # but unprovisioned has to render as nothing; an empty row reads as breakage.
+        assert dashboard_onion({**ON, "DASHBOARD_ONION_ADDRESS": "placeholder"}) is None
+
+    def test_missing_or_blank_address_yields_nothing(self):
+        assert dashboard_onion({"DASHBOARD_ONION_ENABLED": "true"}) is None
+        assert dashboard_onion({**ON, "DASHBOARD_ONION_ADDRESS": "   "}) is None
+
+    def test_a_value_that_is_not_an_onion_address_yields_nothing(self):
+        # The sanity check that keeps a status word out of the header.
+        assert dashboard_onion({**ON, "DASHBOARD_ONION_ADDRESS": "not-provisioned"}) is None
+
+    def test_flags_tolerate_the_casing_and_padding_env_carries(self):
+        env = {
+            "DASHBOARD_ONION_ENABLED": " True ",
+            "DASHBOARD_ONION_ADDRESS": f"  {ONION} ",
+            "DASHBOARD_ONION_CLIENT_AUTH": "TRUE",
+        }
+        assert dashboard_onion(env) == {"url": f"http://{ONION}", "client_auth": True}
+
+    def test_no_client_key_material_can_reach_the_payload(self):
+        # The keys are not passed into the container at all, but the payload's shape is the thing
+        # a future edit would widen, so pin it: exactly two keys, and nothing carrying a secret
+        # survives into either value even when the environment holds one.
+        env = {
+            **ON,
+            "DASHBOARD_ONION_CLIENT_AUTH": "true",
+            "DASHBOARD_ONION_CLIENT_PRIVKEY": "PRIVKEY-SENTINEL",
+            "DASHBOARD_ONION_CLIENT_PUBKEY": "PUBKEY-SENTINEL",
+        }
+        payload = dashboard_onion(env)
+        assert set(payload) == {"url", "client_auth"}
+        assert "SENTINEL" not in str(payload)
+
+    def test_the_default_reader_is_the_process_environment(self, monkeypatch):
+        # Every other case injects a dict, so on its own the suite would never exercise the path
+        # production actually takes. build_state calls dashboard_onion() with no argument.
+        monkeypatch.setenv("DASHBOARD_ONION_ENABLED", "true")
+        monkeypatch.setenv("DASHBOARD_ONION_ADDRESS", ONION)
+        monkeypatch.delenv("DASHBOARD_ONION_CLIENT_AUTH", raising=False)
+        assert dashboard_onion() == {"url": f"http://{ONION}", "client_auth": False}
+        monkeypatch.setenv("DASHBOARD_ONION_ENABLED", "false")
+        assert dashboard_onion() is None

--- a/dashboard/tests/web/test_views.py
+++ b/dashboard/tests/web/test_views.py
@@ -31,7 +31,6 @@ from mining_dashboard.web.views import (
     build_state,
     canonical_window,
     get_shell_html,
-    host_display_addr,
     visible_update,
 )
 from mining_dashboard.web.worker_detail import build_worker_detail
@@ -187,29 +186,6 @@ class TestPoolNetwork:
         data = {"pool": {"pool": {"last_block_ts": time.time() - 90}}}
         assert build_pool_network(data, _metrics())["pool"]["last_blk"] == "1m 30s ago"
         assert build_pool_network({}, _metrics())["pool"]["last_blk"] == "Never"
-
-
-# --- Host address beside the hostname (Issue #119) ------------------------------------
-
-
-class TestHostDisplayAddr:
-    def test_resolves_ip_for_a_hostname(self):
-        with patch.object(views, "detect_host_ipv4", return_value="192.168.1.42"):
-            assert host_display_addr("pithead.local") == "192.168.1.42"
-
-    def test_none_when_host_is_already_an_ip(self):
-        # Nothing to add beside a literal address — don't call detection at all.
-        with patch.object(views, "detect_host_ipv4") as detect:
-            assert host_display_addr("192.168.1.42") is None
-            detect.assert_not_called()
-
-    def test_none_when_ip_undetectable(self):
-        with patch.object(views, "detect_host_ipv4", return_value=None):
-            assert host_display_addr("pithead.local") is None
-
-    def test_none_when_detected_ip_equals_host(self):
-        with patch.object(views, "detect_host_ipv4", return_value="my-rig"):
-            assert host_display_addr("my-rig") is None
 
 
 # --- build_state integration ----------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -731,6 +731,15 @@ services:
       # When off, the control routes are not registered at all (they 404); the spool mounts above
       # are inert because no host-side runner is installed.
       - DASHBOARD_CONTROL_ENABLED=${DASHBOARD_CONTROL_ENABLED:-false}
+      # Dashboard onion (#343, config.json: dashboard.onion.*), display-only here: the header
+      # shows the .onion URL so an operator can open the dashboard from a phone over Tor without
+      # first reaching a shell — which on the appliance nobody has (#1853). The ADDRESS is
+      # "placeholder" until the service is provisioned, and the header treats that as "no onion".
+      # CLIENT_AUTH is a boolean the header explains; the client keys are NOT passed in, so a
+      # fully compromised container cannot hand out the credential that opens the onion.
+      - DASHBOARD_ONION_ENABLED=${DASHBOARD_ONION_ENABLED:-false}
+      - DASHBOARD_ONION_ADDRESS=${DASHBOARD_ONION_ADDRESS:-}
+      - DASHBOARD_ONION_CLIENT_AUTH=${DASHBOARD_ONION_CLIENT_AUTH:-false}
       # monerod is required: a monerod outage always rejects workers (Issue #31) and the miner
       # is always held until monerod syncs (Issue #35) — not configurable. Tari is optional:
       # TARI_REQUIRED (default true) decides whether a Tari outage rejects workers, whether the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -733,7 +733,8 @@ services:
       - DASHBOARD_CONTROL_ENABLED=${DASHBOARD_CONTROL_ENABLED:-false}
       # Dashboard onion (#343, config.json: dashboard.onion.*), display-only here: the header
       # shows the .onion URL so an operator can open the dashboard from a phone over Tor without
-      # first reaching a shell — which on the appliance nobody has (#1853). The ADDRESS is
+      # first reaching a shell (#1853). These three are the Compose path only — the appliance's
+      # podman quadlet for the dashboard is written without them (#1896). The ADDRESS is
       # "placeholder" until the service is provisioned, and the header treats that as "no onion".
       # CLIENT_AUTH is a boolean the header explains; the client keys are NOT passed in, so a
       # fully compromised container cannot hand out the credential that opens the onion.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -365,11 +365,12 @@ Because a published `.onion` puts a control panel at a stable address, pithead *
   "accept the risk" prompt — the same click you make for the LAN dashboard.
 
 After `apply`, the address is on the dashboard itself: it sits under the machine name in the header,
-in full, with a **Copy** button, whenever the onion is on. That is the surface to use on an
-appliance, where there is no shell to run a command in. `./pithead status` and `./pithead doctor`
-print it too on a machine you can log in to. Treat the `.onion` as a secret: anyone who has it can
-_attempt_ the login (and, without client-auth, reach it), so the header shows it only to a browser
-that is already through the dashboard's own login.
+in full, with a **Copy** button, whenever the onion is on. That is the Compose stack, which hands
+the address to the dashboard container. **The appliance does not show it yet** — its dashboard unit
+is written without the onion variables, so the header block does not render there at all (#1896).
+`./pithead status` and `./pithead doctor` print the address on a machine you can log in to. Treat
+the `.onion` as a secret: anyone who has it can _attempt_ the login (and, without client-auth, reach
+it), so the header shows it only to a browser that is already through the dashboard's own login.
 
 **Connecting with client authorization.** With `client_auth: true` the onion won't answer at all
 until your Tor client presents the private key. Run `./pithead onion-client-key` on the host — it

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -364,9 +364,12 @@ Because a published `.onion` puts a control panel at a stable address, pithead *
   without a manual CA process, and Tor already encrypts the transport, so the browser shows a one-time
   "accept the risk" prompt — the same click you make for the LAN dashboard.
 
-After `apply`, read the address from `./pithead status` or `./pithead doctor` (printed only to that local
-output). Treat the `.onion` as a secret: anyone who has it can _attempt_ the login (and, without
-client-auth, reach it).
+After `apply`, the address is on the dashboard itself: it sits under the machine name in the header,
+in full, with a **Copy** button, whenever the onion is on. That is the surface to use on an
+appliance, where there is no shell to run a command in. `./pithead status` and `./pithead doctor`
+print it too on a machine you can log in to. Treat the `.onion` as a secret: anyone who has it can
+_attempt_ the login (and, without client-auth, reach it), so the header shows it only to a browser
+that is already through the dashboard's own login.
 
 **Connecting with client authorization.** With `client_auth: true` the onion won't answer at all
 until your Tor client presents the private key. Run `./pithead onion-client-key` on the host — it

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1190,11 +1190,11 @@ other three hidden services — the Monero node's, the Tari node's and P2Pool's 
 than by address, so there is nothing of theirs on this page to hide.
 
 The two surfaces disagree about your dashboard's **own** onion on purpose: the header shows it in
-full, with a **Copy** button, because on an appliance there is no shell to read it in and a machine
-you cannot reach is a machine you cannot fix. This panel still redacts it. So a `[redacted].onion`
-here is not a promise that the address is absent from the browser — scroll up and it is in the
-header. When you need one of the node onions, they are in the stack's `.env`, which the encrypted
-backup archive carries.
+full, with a **Copy** button, because a machine you cannot reach is a machine you cannot fix. This
+panel still redacts it. So on the Compose stack a `[redacted].onion` here is not a promise that the
+address is absent from the browser — scroll up and it is in the header. On the appliance the header
+block does not render yet (#1896), so there the redaction is the whole story. When you need one of
+the node onions, they are in the stack's `.env`, which the encrypted backup archive carries.
 
 **Show recent log** returns the last 200 lines from one service, redacted on the host by the same
 redactor the [support bundle](operations.md) uses — so a credential a service echoed on its

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1184,16 +1184,17 @@ those verdicts ask you to save a change rather than to find a console. P2Pool's 
 apply refuses to finish while that one is missing, so no dashboard surface can regenerate it.
 
 One thing reads differently here than at a terminal: the report is redacted on its way to the
-browser, so where `pithead doctor` prints an onion address in full, this panel shows it as
-`[redacted].onion`. The redactor recognises onions by shape, so it covers every one the report
-names — the Monero, Tari and P2Pool hidden services, which reach the browser nowhere else.
+browser, so where `pithead doctor` prints your dashboard's onion address in full, this panel shows
+it as `[redacted].onion`. That is the only address the redaction changes here. The report names the
+other three hidden services — the Monero node's, the Tari node's and P2Pool's — by setting rather
+than by address, so there is nothing of theirs on this page to hide.
 
-Your dashboard's **own** onion is the exception, and the two surfaces disagree about it on purpose:
-the header shows that one in full, with a **Copy** button, because on an appliance there is no shell
-to read it in and a machine you cannot reach is a machine you cannot fix. This panel still redacts
-it. So a `[redacted].onion` here is not a promise that the address is absent from the browser —
-scroll up and it is in the header. Run `pithead doctor` on the host, or check the emergency kit,
-when you need one of the other three.
+The two surfaces disagree about your dashboard's **own** onion on purpose: the header shows it in
+full, with a **Copy** button, because on an appliance there is no shell to read it in and a machine
+you cannot reach is a machine you cannot fix. This panel still redacts it. So a `[redacted].onion`
+here is not a promise that the address is absent from the browser — scroll up and it is in the
+header. When you need one of the node onions, they are in the stack's `.env`, which the encrypted
+backup archive carries.
 
 **Show recent log** returns the last 200 lines from one service, redacted on the host by the same
 redactor the [support bundle](operations.md) uses — so a credential a service echoed on its

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1184,10 +1184,16 @@ those verdicts ask you to save a change rather than to find a console. P2Pool's 
 apply refuses to finish while that one is missing, so no dashboard surface can regenerate it.
 
 One thing reads differently here than at a terminal: the report is redacted on its way to the
-browser, so where `pithead doctor` prints your dashboard onion address in full, this panel shows
-it as `[redacted].onion`. The CLI prints it because you asked for it at your own terminal; this copy crosses
-into the dashboard container, and the address is worth keeping out of there. Run `pithead doctor`
-on the host, or check the emergency kit, when you need the address itself.
+browser, so where `pithead doctor` prints an onion address in full, this panel shows it as
+`[redacted].onion`. The redactor recognises onions by shape, so it covers every one the report
+names — the Monero, Tari and P2Pool hidden services, which reach the browser nowhere else.
+
+Your dashboard's **own** onion is the exception, and the two surfaces disagree about it on purpose:
+the header shows that one in full, with a **Copy** button, because on an appliance there is no shell
+to read it in and a machine you cannot reach is a machine you cannot fix. This panel still redacts
+it. So a `[redacted].onion` here is not a promise that the address is absent from the browser —
+scroll up and it is in the header. Run `pithead doctor` on the host, or check the emergency kit,
+when you need one of the other three.
 
 **Show recent log** returns the last 200 lines from one service, redacted on the host by the same
 redactor the [support bundle](operations.md) uses — so a credential a service echoed on its


### PR DESCRIPTION
Addresses #1853 — deliberately NOT `Closes`. `develop` is now the repository's default branch, so the keyword would fire on merge, and #1853 is the operator's appliance finding: on that machine the header still shows nothing until #1896 wires the quadlet. The issue stays open until #1896 lands, and a human shuts it by hand then.

## What the operator sees change on the Compose stack

When the dashboard onion is on and provisioned, its `.onion` URL sits under the machine name in the header, in full, with a **Copy** button. With client authorisation on, a line beside it says the address only opens for a browser holding the client key, and where to get the key. When the onion is off — or on but not yet provisioned — there is nothing there at all: no empty row, no placeholder.

Before this, the only place the address appeared was a `pithead status` line — a machine's own remote-access address, readable only from a shell on that machine.

**Not on the appliance yet, and this PR does not change that.** The block needs `DASHBOARD_ONION_ENABLED`, `DASHBOARD_ONION_ADDRESS` and `DASHBOARD_ONION_CLIENT_AUTH` inside the dashboard container. `docker-compose.yml` passes them; the appliance's podman quadlet for the dashboard is written with none of them (`lib/pithead/36-quadlet-units.sh`), so there the server sends no onion and the header is correctly blank. That is #1896, on `lib/pithead/` and `os/` — freeze paths this PR does not touch. This PR's prose said the opposite in five places; `cca44e11` corrects all five, and this body was the sixth.

## How

**Plumbing.** `docker-compose.yml` passes `DASHBOARD_ONION_ENABLED`, `DASHBOARD_ONION_ADDRESS` and `DASHBOARD_ONION_CLIENT_AUTH` into the dashboard service. The client keys are **not** passed in, so the container cannot hand out the credential that opens the onion even if it is fully compromised.

**New `web/header.py`** — the header's address block: `host_display_addr` (moved, unchanged) plus `dashboard_onion`, which answers `{url, client_auth}` only when the onion is **enabled and provisioned**. That pair of conditions mirrors the host's own `dashboard_onion_status` (`lib/pithead/04-status.sh`) rather than inventing a second rule: pithead writes the literal `placeholder` into `.env` before the service exists, so "enabled" alone never means "reachable".

**New `static/onionurl.mjs`** — renders what the server hands it and infers nothing. The URL is never elided: 56 characters of base32 carry no redundancy, so a tidy truncation produces a string that does not open, and copying it to a phone is the whole product.

## Three judgement calls, stated so they can be overruled

- **The address check is deliberately loose** — non-empty, not `placeholder`, ends in `.onion`. A strict v3 regex would silently hide a real address the day the format changes, and hiding is the failure that reads as "Tor is broken". A junk string reaching the header is loud and harmless; the reverse is not.
- **The env is read in `header.py`, not `config/config.py`.** Nothing else consumes these three values, `version.py` already establishes the injectable-`env` reader for a presentation value, and it lets the tests pass a dict instead of mutating process state. `config/config.py` is also at its recorded file-budget ceiling and that ratchet only moves down.
- **`host_display_addr` moved out of `views.py`.** The budget answer and the design answer agree: `views.py` was at its ceiling (445/445), and the host line and the onion under it are both *ways in* to the machine rather than readings off it. Now 434.

## A documented stance this contradicts, corrected rather than left standing

`docs/dashboard.md` said the doctor panel redacts the dashboard onion because "this copy crosses into the dashboard container, and the address is worth keeping out of there". After this change the address **is** in the container, by the operator's ruling, so that rationale no longer holds for this one value.

**Corrected again after review — my first replacement traded one false sentence for two.** It said the redactor covers "the Monero, Tari and P2Pool hidden services" in that report and that an operator can run `pithead doctor` to read one. Neither is true, and I re-derived it at source rather than taking it:

- `lib/pithead/06-doctor.sh:295` emits `dr_ok "$k set."` for the three node onion variables — the variable name and a verdict, never the value.
- The failure path (`:294`) prints `(value: '${onion:-empty}')`, and `onion_missing` (`lib/pithead/32-onion-provisioning.sh:66-68`) is `[ -z "$1" ] || [ "$1" == "placeholder" ]`, so the only values that branch can print are the literals `empty` and `placeholder`.
- The remote-node arm prints "not needed" and no value at all.
- The one full address in the document is the dashboard's own: `dr_ok "Dashboard onion: $onion_line"` (`06-doctor.sh:304`, via `dashboard_onion_status`, `lib/pithead/04-status.sh:38-49`).
- `doctor --json` (`06-doctor.sh:359-363`) `jq -Rs`-wraps that same text, so it is not a second document with more in it.

So the doc now says what is true: the panel's redaction acts on exactly one address, the report names the other three hidden services by setting rather than by address, and the pointer for those three goes to the stack `.env` (`33-render-env.sh:382-384`) that the encrypted backup archive carries (`45-control-backup.sh:104`) — not to a command that will not answer. The undefined term "emergency kit" is gone with it. **A `[redacted].onion` in that panel is still not evidence the address is absent from the browser, and the doc says so.**

Worth a ruling from whoever owns the call, and the corrected reading makes it sharper: **after this change the doctor panel's onion redaction protects exactly one value, and that value is now published in the header two inches above it.** I have not changed the panel — that is a different surface and not this issue — but the inconsistency is deliberate on my side and visible, not overlooked.

The same stale rationale still stands in code at `lib/pithead/46a-control-diagnostics.sh:47-54` and its built copy `pithead:11914-11921`. Those are image-freeze paths, so it is **not** touched here; filed as #1883.

## Over-engineering pass

Run by hand on this diff (no such command exists on this box).

- **Acted on.** `copyText` takes the clipboard as an argument instead of reaching for `navigator`. That started as a testability concession and is the better design anyway: it is also the honest answer for a page served outside a secure context, where `navigator.clipboard` is undefined and the button has to degrade rather than throw.
- **Rejected: a new CSS class.** `dashboard.css` is at its recorded ceiling, and the block wants exactly what `.brand-host` already has — the host line's size, spacing and `overflow-wrap: anywhere`. Reusing it and the generic `.btn-range` is both the smaller diff and the more consistent header.
- **Rejected: a strict v3 address regex.** See the judgement calls above — the failure modes are not symmetric.
- **Kept, veto-able: the separate module.** ~50 lines could have gone straight into `components.mjs`, which has 40 lines of headroom. They did not, because this is the file's one stateful control and `components.mjs` is documented as pure functions of the payload. If you would rather have it inline, say so — it is a move, not a rewrite.
- **Kept: the client-auth sentence lives in the client.** The server sends a boolean and the client renders the words, which is the contract the rest of this payload follows. A server-supplied string would have been easier to change and wrong for the same reason every other display string is not one.

## Tests

**Tier 1, `node --test`** — new `dashboard/tests/frontend/onionurl.test.mjs`, 8 tests: the URL renders whole and in the header block; absent onion renders nothing (with a control that the same fixture *does* render it when the field is filled); the client-auth note appears and disappears on the boolean alone; no key-shaped field in the payload reaches the page; the copy control is present; and `copyText` answers honestly — true only when the clipboard took it, false where there is no clipboard and false when it rejects, so the label never claims a copy that did not happen.

**Tier 1, pytest** — new `dashboard/tests/web/test_header.py`, 14 tests. The `host_display_addr` cases moved with the function; the onion cases cover enabled/off, the `placeholder` case, blank and non-onion values, casing and padding, the payload's exact key set against an environment that holds key-shaped sentinels, and — the one the rest would not have caught — that the **default** reader is the process environment, since every other case injects a dict and `build_state` calls it with no argument.

**Mutation battery**, each proved to have applied, each restored, control run clean:

| mutation | tests reddened |
|---|---|
| component never renders | 4 |
| unwire the component from the header | 4 |
| invert the client-auth note | 1 |
| `copyText` claims a copy that never happened | 2 |
| accept the unprovisioned `placeholder` | 2 |
| ignore the enabled flag | 2 |
| render an absent onion anyway | 1 (+74 collateral) |

The "unwire from the header" row is the one that matters: it proves the render tests exercise the wiring and not just the module in isolation.

## The fixture generator, and a trap the move would have set

`tests/frontend/fixtures/_gen_state.py` patched `views.detect_host_ipv4`. After the move that binds a dead attribute on `views` while the real lookup runs live — the fixture would have gone machine-dependent with nothing red. It now patches the function where it is looked up, and clears the three onion vars so a box with a provisioned onion regenerates the same fixture.

`state.json` gains **one line** (`"dashboard_onion": null`), added by hand rather than by regeneration. A clean regeneration also reverts three unrelated value-level drifts in the committed fixture (`sync.tari.local`, a topology edge's route, and two mis-indented lines). Those are outside this issue and reverting them could quietly change what a sibling test means, so I left them alone. The shape guard in `test_xvb_views.py` compares key paths only, so it stays green either way.

## Run locally

- `node --test dashboard/tests/frontend/*.test.mjs` — 552 pass, 0 fail.
- `make test-dashboard` — 2558 passed, coverage **97.48%** against the 80% gate, on the rebased tree.
- `make lint-js lint-md lint-docs-voice lint-operator-strings lint-topology lint-py`, and `scripts/lint-file-budget.sh` — all pass.
- **Not run:** `make lint-sh` (shellcheck is serialized behind another lane's build-machine claim, and no shell file changed), no docker, no KVM, no browser. **The rendering is asserted by a string-level render probe, not a browser — the copy button's click handler is never invoked by it, which is why `copyText` is tested as a function.**

## Shared files

`docker-compose.yml` and `docs/` are shared with other work in flight this week — three added lines in the dashboard service's `environment:` block, and two prose passages. Expect a conflict there and not elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZuzdtxNX8ae4rnDtBqEqR