### PR TITLE
fix(dashboard): #1850 the Advanced pane says what it actually does with a key

### DIFF
--- a/dashboard/mining_dashboard/web/static/confighidden.mjs
+++ b/dashboard/mining_dashboard/web/static/confighidden.mjs
@@ -33,11 +33,11 @@ function isPlainObject(v) {
 // dropped (`_core_keys` and friends are display directives, not configuration) and every hidden
 // path dropped with it.
 //
-// The projection is a deep copy, not the aliased slice the view used to build inline. The form
-// edits the candidate in place, so sharing objects with the fetched config let a field edit
-// rewrite `cfg` too — and `cfg` is what the "a blanked secret returns to the sentinel the server
-// sent" recovery reads back out of. A masked secret is copied as the plain object it is; the
-// sentinel is a shape, not an identity, so it survives the copy.
+// The projection copies every plain object on the way down, not the aliased slice the view used
+// to build inline. The form edits the candidate in place, so sharing objects with the fetched
+// config let a field edit rewrite `cfg` too — and `cfg` is what the "a blanked secret returns to
+// the sentinel the server sent" recovery reads back out of. ARRAYS ride by reference, not copied
+// (`isPlainObject` excludes them) — safe only while nothing edits an array member in place.
 export function editableCandidate(cfg) {
   const out = withoutHidden(cfg || {}, []);
   for (const k of Object.keys(out)) if (k.startsWith("_")) delete out[k];

--- a/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/dashboard/mining_dashboard/web/static/configview.mjs
@@ -389,7 +389,7 @@ export class ConfigView extends Component {
   // upload); it shows byte-for-byte what Save previews, minus the hidden paths (#1850).
   renderJson(editText, jsonError, busy) {
     return html`<details class="card config-section">
-        <summary><strong>Advanced</strong> — the configuration this page can change</summary>
+        <summary><strong>Advanced</strong> — the configuration this page sends</summary>
         <p class="text-muted text-xs">Editing a field above updates it; editing here directly
         wins. Set secrets appear as <code>__secret__</code> markers and stay unchanged unless
         you replace them. Developer-only settings are not listed and are left exactly as they

--- a/dashboard/tests/frontend/configview.test.mjs
+++ b/dashboard/tests/frontend/configview.test.mjs
@@ -335,7 +335,7 @@ test("one surface: the form AND the JSON pane render together, pane collapsed (#
   const out = renderToString(readyView().render());
   assert.match(out, /config-section-core/); // the form
   assert.match(out, /worker-edit/); // the pane's textarea, same class as Worker Inspect
-  assert.match(out, /the configuration this page can change/); // #1850 retitled the pane
+  assert.match(out, /the configuration this page sends/); // #1850 retitled the pane
   assert.doesNotMatch(out, /<details[^>]*\bopen\b/); // pane and sections all start collapsed
 });
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -929,7 +929,7 @@ button sits next to the Simple/Advanced toggle whether or not the channel is on;
 view explains how to turn it on and nothing else.
 
 One editing surface: the form on top and, beneath it, a collapsed **Advanced** pane holding
-the configuration this page can change — both live views of a single candidate. Editing
+the configuration this page sends — both live views of a single candidate. Editing
 a field rewrites the pane; editing the pane refills the fields; what the pane shows is
 byte-for-byte what Save previews, apart from the developer-only keys named below, which the
 machine keeps and this page never touches. (This is the setup wizard's pattern — the first page and


### PR DESCRIPTION
Follow-up to the non-author pass on #1865 (merged as \`a66c3172\`). Its own PR rather than an amend, because that one carried a recorded pass. #1850 stays closed — this corrects text it left behind, it does not reopen the fix.

## What the operator sees change

The **Advanced** pane's title read "the configuration this page can change". It does not change all of it: the pane shows every host-only key the form greys out, and the host's gate refuses those whatever this page sends. "the configuration this page **sends**" is true of both halves. The distinction bites exactly where the old wording was reassuring — an operator editing a key the gate will drop.

## The third site

The review named two sites. **A phrase sweep over the whole tree found a third it did not: \`docs/dashboard.md:932\` carried the same sentence.** With the base leg to make that meaningful: three hits at the merge-base, zero now, three carrying the new wording. A fix applied to a reviewer's site list cannot reach a site the list omitted, so the list is a sample of a class and the class gets swept.

## The second note

\`confighidden.mjs\` called its projection a deep copy. Arrays ride by reference — \`isPlainObject\` excludes them — so \`workers.list\`, \`telegram.control.allowed_ids\` and \`notifications.webhooks\` stay shared with the fetched config. Harmless today because \`withoutHidden\` skips arrays and the pane replaces the candidate wholesale, which is the condition the comment now **states** rather than a safety property it implied. A comment that overstates a guarantee is the shape that gets trusted by the next change.

## Over-engineering pass

Done by hand on this diff (no such command is loadable on this box). Nothing to cut: four lines, three of them one phrase, and every one of them removes a claim rather than adding a mechanism. The alternative considered and rejected was making the pane actually hide host-only keys, which is a behaviour change nobody asked for and would take away a legitimate read-only view.

## Tests — tier 1

\`node --test dashboard/tests/frontend/*.test.mjs\` — 555 pass, 0 fail. The existing assertion at \`configview.test.mjs:338\` moved with the string, so the title stays pinned rather than becoming untested. No Python changed, so \`make test-dashboard\` was not re-run. \`lint-js\`, \`lint-md\`, \`lint-docs-voice\`, \`lint-operator-strings\`, \`lint-topology\` and the file budget all pass; every file is line-neutral. Not run: \`lint-sh\` (no shell file changed), no docker, no KVM, no browser.

\`docs/\` is shared and disclosed per the usual rule — one sentence in \`docs/dashboard.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZuzdtxNX8ae4rnDtBqEqR