### PR TITLE
feat(wizard): #1318 a set-up-again boot opens by naming what the machine already is

### DIFF
--- a/dashboard/mining_dashboard/web/static/savedrole.mjs
+++ b/dashboard/mining_dashboard/web/static/savedrole.mjs
@@ -1,0 +1,73 @@
+// The screen a set-up-again boot opens on (#1318), kept out of wizard.mjs because that file is
+// at its budget ceiling and because the decision this makes is worth testing without a DOM.
+//
+// A boot with `pithead.setup=1` publishes `saved-role.json`, and the host's having named a role
+// is the whole signal: the operator is offered the machine as it stands, and only reaches the
+// setup form by asking for it. Keeping is the default because it changes nothing — the page
+// writes one empty spool file and the host carries on booting with the configuration it has.
+
+import { html } from "./preact.mjs";
+import { Err, Field, Note } from "./wizardparts.mjs";
+
+// What each role is, in the operator's terms rather than the config's. A role NOT in this map
+// is one the page cannot name, and a screen offering to keep "your saved configuration" without
+// saying what it is asks the operator to confirm something they cannot see — so an unknown role
+// falls through to the normal wizard instead.
+const ROLES = {
+  rig: "a rig — it mines toward a Pithead, which manages it from there",
+  pithead: "a Pithead — it runs the node, the pool and this dashboard",
+  both: "a Pithead with its own miner",
+};
+
+/**
+ * What the screen says about the saved role, or null when there is nothing nameable to keep —
+ * no file, a file the server could not use, or a role this page has no words for. Rows follow
+ * the handoff card's rule: a value the host left empty drops its own row rather than rendering
+ * a blank beside a label.
+ */
+export function savedRoleSummary(saved) {
+  const name = ROLES[saved?.role];
+  if (!name) return null;
+  const rows = [];
+  if (saved.pool) rows.push({ label: "Mines toward", value: saved.pool });
+  if (saved.worker) rows.push({ label: "Worker name", value: saved.worker });
+  return { name, rows };
+}
+
+export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) => html`<div
+    class="card">
+    ${
+      kept
+        ? html`<h3>Keeping this machine as it is</h3>
+            <p>Nothing was changed. This page is done — the machine carries on starting up.</p>`
+        : html`<h3>This machine is already set up</h3>
+            <p>It is ${summary.name}.</p>
+            ${summary.rows.map(
+              (r) =>
+                html`<${Field} label=${r.label}><code class="wizard-mono">${r.value}</code><//>`,
+            )}
+            <${Err}>${error}<//>
+            <button type="button" onClick=${onKeep}>Keep it</button>
+            <button type="button" class="wizard-link" onClick=${onSetUpAgain}>Set up again</button>
+            <${Note}>Setting it up again asks the same questions as a first boot, with this
+            machine's answers already filled in. Its login and other secrets are never filled
+            in — you choose those again.<//>`
+    }
+</div>`;
+
+/**
+ * The wizard's setup branch: this screen when the host named a role and the operator has not
+ * asked to start over, otherwise the ordinary form. Owns the Keep button's one call, so the
+ * app itself gains nothing but this dispatch.
+ */
+export function savedRoleOrSetup(app) {
+  const summary = app.state.setUpAgain ? null : savedRoleSummary(app.state.savedRole);
+  if (!summary) return app.renderSetup();
+  const keep = async () => {
+    const ok = (await fetch("/keep-role", { method: "POST" })).ok;
+    app.setState(ok ? { keptRole: true } : { keepError: "could not keep this configuration" });
+  };
+  return html`<${SavedRoleScreen} summary=${summary} kept=${app.state.keptRole}
+    error=${app.state.keepError} onKeep=${keep}
+    onSetUpAgain=${() => app.setState({ setUpAgain: true })} />`;
+}

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -18,6 +18,8 @@ import {
 } from "./configsync.mjs";
 import { Component, html, render } from "./preact.mjs";
 import { rigCardFields, rigCardNote } from "./rigcardlogic.mjs";
+import { savedRoleOrSetup } from "./savedrole.mjs";
+import { Err, Field, Note } from "./wizardparts.mjs";
 
 // The simple questions, each bound to its config path. Conditional blocks name the field that
 // gates them; option lists carry the same guidance the docs give. This is deliberately a
@@ -68,13 +70,6 @@ const TIMEZONES = [
   "Asia/Tokyo",
   "Australia/Sydney",
 ];
-
-const Note = ({ children }) => html`<p class="text-muted wizard-note">${children}</p>`;
-const Err = ({ children }) => (children ? html`<p class="c-bad">${children}</p>` : null);
-
-const Field = ({ label, children }) => html`<label class="config-field">
-    <span class="config-field-name">${label}</span>${children}
-</label>`;
 
 export const Gate = ({ error, onSubmit }) => html`<div class="card">
     <p>Enter the one-time token shown on this machine's console or terminal.</p>
@@ -300,6 +295,7 @@ export class WizardApp extends Component {
       rigDefaults: s.rig_defaults || {},
       dataWiped: s.data_wiped || {},
       handoff: s.handoff || null,
+      savedRole: s.saved_role || null,
     };
     // The host's discovery pre-fills the rig fields, but only while they are untouched — the
     // form polls, and a half-typed pool address must survive it (same rule as cfg below).
@@ -876,7 +872,7 @@ export class WizardApp extends Component {
       view = html`<${Done} status=${status} handoff=${this.state.handoff}
         installer=${this.state.installer} stick=${this.state.chosen === "usb"}
         rig=${this.state.role === "rig"} onAck=${this.ack} />`;
-    else view = this.renderSetup();
+    else view = savedRoleOrSetup(this);
     return html`<h1>Pithead setup</h1>${view}`;
   }
 }

--- a/dashboard/mining_dashboard/web/static/wizardparts.mjs
+++ b/dashboard/mining_dashboard/web/static/wizardparts.mjs
@@ -1,0 +1,12 @@
+// The wizard's three presentational primitives, shared by the app and by the views that had to
+// move out of it (#1318). They live here rather than in wizard.mjs because a second view module
+// importing them from the app would make the two files import each other.
+
+import { html } from "./preact.mjs";
+
+export const Note = ({ children }) => html`<p class="text-muted wizard-note">${children}</p>`;
+export const Err = ({ children }) => (children ? html`<p class="c-bad">${children}</p>` : null);
+
+export const Field = ({ label, children }) => html`<label class="config-field">
+    <span class="config-field-name">${label}</span>${children}
+</label>`;

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -32,6 +32,8 @@ import tempfile
 
 from aiohttp import web
 
+from mining_dashboard.wizard_form import build_config
+
 MAX_FAILURES = 5
 EXIT_TOKEN_LOCKOUT = 3
 # Restore-at-setup upload cap (#909): a Pithead backup holds only config, keys and the
@@ -251,74 +253,6 @@ async def wizard_state(request: web.Request) -> web.Response:
             "handoff": json.loads(raw_handoff) if raw_handoff else None,
         }
     )
-
-
-def build_config(form: dict) -> dict:
-    """Form fields as a pithead config — the fallback for a client that never populated the
-    JSON pane (no JavaScript: the harness's curl, a text browser). Mirrors the CLI wizard's
-    question set; the host's parse_and_validate_config is the validator.
-
-    Keys are omitted rather than written empty: an absent key inherits the documented default,
-    while an empty string is a value and would override it."""
-
-    def s_(name: str) -> str:
-        return str(form.get(name, "")).strip()
-
-    def port(name: str, fallback: int) -> int:
-        raw = s_(name)
-        return int(raw) if raw.isdigit() else fallback
-
-    cfg: dict = {
-        "monero": {"wallet_address": s_("monero_wallet")},
-        "tari": {"wallet_address": s_("tari_wallet")},
-        "p2pool": {"pool": s_("pool") or "mini", "stratum_password": "auto"},
-    }
-
-    if form.get("monero_mode") == "remote":
-        cfg["monero"]["mode"] = "remote"
-        cfg["monero"]["remote"] = {
-            "host": s_("monero_remote_host"),
-            "rpc_port": port("monero_remote_rpc", 18081),
-            "zmq_port": port("monero_remote_zmq", 18083),
-        }
-        if form.get("monero_remote_auth"):
-            cfg["monero"]["node_username"] = s_("monero_remote_user")
-            cfg["monero"]["node_password"] = s_("monero_remote_pass")
-
-    if form.get("tari_mode") == "remote":
-        cfg["tari"]["mode"] = "remote"
-        cfg["tari"]["remote"] = {
-            "host": s_("tari_remote_host"),
-            "grpc_port": port("tari_remote_grpc", 18142),
-        }
-
-    # prune only means anything for a node we run. On remote, the key is noise at best and a
-    # lie at worst — the chain lives on someone else's machine and its shape is not ours.
-    if form.get("monero_mode") != "remote" and form.get("prune") == "false":
-        cfg["monero"]["prune"] = False
-
-    # Optional services: written ONLY when actually filled in. An empty ping_url silently
-    # disables the dead-man's switch the operator thinks they have; a half-configured
-    # Telegram fails validation on a blank they never meant to set.
-    hc = s_("healthchecks_url")
-    if hc:
-        cfg["healthchecks"] = {"ping_url": hc}
-    tg_token, tg_chat = s_("telegram_token"), s_("telegram_chat")
-    if tg_token and tg_chat:
-        cfg["telegram"] = {"enabled": True, "bot_token": tg_token, "chat_id": tg_chat}
-
-    if form.get("local_miner"):
-        cfg["local_miner"] = {"enabled": True}
-
-    if form.get("clearnet_sync") == "true":
-        cfg["monero"]["clearnet_initial_sync"] = True
-        cfg["tari"]["clearnet_initial_sync"] = True
-
-    tz = s_("timezone")
-    if tz and tz != "auto":  # auto IS the documented default — writing it would only pin it
-        cfg.setdefault("dashboard", {})["timezone"] = tz
-
-    return cfg
 
 
 def _spool_write_text(name: str, text: str) -> None:

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -146,6 +146,16 @@ def _data_wiped() -> dict:
     return _spool_json("data-wiped.json")
 
 
+def _saved_role() -> dict | None:
+    """The role this machine is already set up as, published by the HOST only on a set-up-again
+    boot (#1318): {"role": "rig", "pool", "worker"} for a rig, {"role": "pithead"} or
+    {"role": "both"} for a coordinator. Its PRESENCE is the signal to offer "Keep it", so a file
+    that names no role reads as ABSENT rather than as an error — the one thing this screen must
+    never do is offer to keep a role it cannot name. None means "run the normal wizard"."""
+    saved = _spool_json("saved-role.json")
+    return saved if isinstance(saved.get("role"), str) and saved["role"] else None
+
+
 def wizard_stage() -> str:
     """Which step this machine is actually on, decided by the SPOOL — never by the client.
 
@@ -251,6 +261,8 @@ async def wizard_state(request: web.Request) -> web.Response:
             "rig_defaults": _rig_defaults(),
             "data_wiped": _data_wiped(),
             "handoff": json.loads(raw_handoff) if raw_handoff else None,
+            # Always present, null when this is not a set-up-again boot (#1318).
+            "saved_role": _saved_role(),
         }
     )
 
@@ -456,6 +468,18 @@ async def handoff_ack(request: web.Request) -> web.Response:
     return web.json_response({"status": "provisioning"})
 
 
+async def keep_role(request: web.Request) -> web.Response:
+    """The "Keep it" half of the set-up-again screen: the operator wants the machine left as it
+    is, so there is nothing to configure and nothing to submit. The host is waiting on this file
+    to carry on booting with the configuration it already has."""
+    if not _authed(request):
+        raise web.HTTPFound("/")
+    if _saved_role() is None:
+        return web.json_response({"error": "nothing to keep"}, status=400)
+    _spool_write_text("keep-role", "1")
+    return web.json_response({"status": "kept"})
+
+
 async def status(request: web.Request) -> web.Response:
     if installer_mode() and _spool_read("stick") != "1":
         if _spool_read("installed") is not None:
@@ -504,6 +528,7 @@ def make_app(exit_fn=sys.exit) -> web.Application:
             web.post("/submit-restore", submit_restore),
             web.get("/api/handoff", handoff),
             web.post("/handoff-ack", handoff_ack),
+            web.post("/keep-role", keep_role),
             web.get("/status", status),
         ]
     )

--- a/dashboard/mining_dashboard/wizard_form.py
+++ b/dashboard/mining_dashboard/wizard_form.py
@@ -1,0 +1,77 @@
+"""The no-JavaScript fallback for the first-boot wizard's setup form (#77 phase 3).
+
+Split out of ``wizard.py`` so that file has room to grow (#1318): it sits at its
+``docs/dev/file-budget.tsv`` ceiling, and ceilings only ever go down. This was the largest
+self-contained thing in it — a pure mapping from form fields to a pithead config, with no module
+state, no spool access and no request handling — so moving it whole changes nothing about how it
+is reached. ``wizard.py`` re-imports the name, so ``wizard.build_config`` still resolves both for
+the tests and for the one call site in ``submit``.
+"""
+
+
+def build_config(form: dict) -> dict:
+    """Form fields as a pithead config — the fallback for a client that never populated the
+    JSON pane (no JavaScript: the harness's curl, a text browser). Mirrors the CLI wizard's
+    question set; the host's parse_and_validate_config is the validator.
+
+    Keys are omitted rather than written empty: an absent key inherits the documented default,
+    while an empty string is a value and would override it."""
+
+    def s_(name: str) -> str:
+        return str(form.get(name, "")).strip()
+
+    def port(name: str, fallback: int) -> int:
+        raw = s_(name)
+        return int(raw) if raw.isdigit() else fallback
+
+    cfg: dict = {
+        "monero": {"wallet_address": s_("monero_wallet")},
+        "tari": {"wallet_address": s_("tari_wallet")},
+        "p2pool": {"pool": s_("pool") or "mini", "stratum_password": "auto"},
+    }
+
+    if form.get("monero_mode") == "remote":
+        cfg["monero"]["mode"] = "remote"
+        cfg["monero"]["remote"] = {
+            "host": s_("monero_remote_host"),
+            "rpc_port": port("monero_remote_rpc", 18081),
+            "zmq_port": port("monero_remote_zmq", 18083),
+        }
+        if form.get("monero_remote_auth"):
+            cfg["monero"]["node_username"] = s_("monero_remote_user")
+            cfg["monero"]["node_password"] = s_("monero_remote_pass")
+
+    if form.get("tari_mode") == "remote":
+        cfg["tari"]["mode"] = "remote"
+        cfg["tari"]["remote"] = {
+            "host": s_("tari_remote_host"),
+            "grpc_port": port("tari_remote_grpc", 18142),
+        }
+
+    # prune only means anything for a node we run. On remote, the key is noise at best and a
+    # lie at worst — the chain lives on someone else's machine and its shape is not ours.
+    if form.get("monero_mode") != "remote" and form.get("prune") == "false":
+        cfg["monero"]["prune"] = False
+
+    # Optional services: written ONLY when actually filled in. An empty ping_url silently
+    # disables the dead-man's switch the operator thinks they have; a half-configured
+    # Telegram fails validation on a blank they never meant to set.
+    hc = s_("healthchecks_url")
+    if hc:
+        cfg["healthchecks"] = {"ping_url": hc}
+    tg_token, tg_chat = s_("telegram_token"), s_("telegram_chat")
+    if tg_token and tg_chat:
+        cfg["telegram"] = {"enabled": True, "bot_token": tg_token, "chat_id": tg_chat}
+
+    if form.get("local_miner"):
+        cfg["local_miner"] = {"enabled": True}
+
+    if form.get("clearnet_sync") == "true":
+        cfg["monero"]["clearnet_initial_sync"] = True
+        cfg["tari"]["clearnet_initial_sync"] = True
+
+    tz = s_("timezone")
+    if tz and tz != "auto":  # auto IS the documented default — writing it would only pin it
+        cfg.setdefault("dashboard", {})["timezone"] = tz
+
+    return cfg

--- a/dashboard/tests/frontend/savedrole.test.mjs
+++ b/dashboard/tests/frontend/savedrole.test.mjs
@@ -1,0 +1,145 @@
+// The set-up-again screen (#1318): which role the page is willing to offer back, and what it
+// does with each answer. Kept DOM-free — the two branches that matter are a boot state nobody
+// can reach by hand, and the fall-through has to be provable without a browser.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  SavedRoleScreen,
+  savedRoleOrSetup,
+  savedRoleSummary,
+} from "../../mining_dashboard/web/static/savedrole.mjs";
+import { html } from "../../mining_dashboard/web/static/preact.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// The shape wizard.py's _saved_role publishes for a rig.
+const RIG = { role: "rig", pool: "pithead.lan:3333", worker: "rig-01" };
+
+const labels = (s) => savedRoleSummary(s).rows.map((r) => r.label);
+
+// --- savedRoleSummary -------------------------------------------------------------------------
+
+test("savedRoleSummary: a rig names where it mines and what it is called", () => {
+  const s = savedRoleSummary(RIG);
+  assert.match(s.name, /rig/);
+  assert.deepEqual(labels(RIG), ["Mines toward", "Worker name"]);
+  assert.deepEqual(
+    s.rows.map((r) => r.value),
+    [RIG.pool, RIG.worker],
+  );
+});
+
+test("savedRoleSummary: the two coordinators are named apart and carry no rows", () => {
+  const pithead = savedRoleSummary({ role: "pithead" });
+  const both = savedRoleSummary({ role: "both" });
+  assert.deepEqual(pithead.rows, []);
+  assert.deepEqual(both.rows, []);
+  // A coordinator with its own miner is a different machine to the operator, so it must not
+  // read back as the plain one.
+  assert.notEqual(pithead.name, both.name);
+});
+
+test("savedRoleSummary: a role the page cannot name is not one it offers to keep", () => {
+  // Falling through to the normal wizard is the safe answer: a screen that offers to keep
+  // "your configuration" without saying what it is asks for a blind confirmation.
+  for (const saved of [null, undefined, {}, { role: "" }, { role: "future-role" }, { pool: "p" }]) {
+    assert.equal(savedRoleSummary(saved), null, JSON.stringify(saved));
+  }
+});
+
+test("savedRoleSummary: an empty value drops its own row rather than blanking it", () => {
+  assert.deepEqual(labels({ ...RIG, worker: "" }), ["Mines toward"]);
+  assert.deepEqual(labels({ ...RIG, pool: "" }), ["Worker name"]);
+  assert.deepEqual(labels({ role: "rig" }), []);
+  // The sibling that keeps the three above narrow: the same reader, given both values, has to
+  // produce the other answer.
+  assert.deepEqual(labels(RIG), ["Mines toward", "Worker name"]);
+});
+
+// --- the dispatch -----------------------------------------------------------------------------
+
+const fakeApp = (state) => {
+  const app = {
+    state,
+    setState: (patch) => Object.assign(app.state, patch),
+    renderSetup: () => {
+      app.setupRendered = true;
+      return html`<p>the setup form</p>`;
+    },
+    setupRendered: false,
+  };
+  return app;
+};
+
+test("savedRoleOrSetup: a normal boot goes straight to the setup form", () => {
+  const app = fakeApp({ savedRole: null });
+  savedRoleOrSetup(app);
+  assert.equal(app.setupRendered, true);
+});
+
+test("savedRoleOrSetup: asking to set up again reaches the form past a saved role", () => {
+  const app = fakeApp({ savedRole: RIG, setUpAgain: true });
+  savedRoleOrSetup(app);
+  assert.equal(app.setupRendered, true);
+});
+
+test("savedRoleOrSetup: an unnameable role falls through rather than failing", () => {
+  const app = fakeApp({ savedRole: { role: "future-role" } });
+  savedRoleOrSetup(app);
+  assert.equal(app.setupRendered, true);
+});
+
+test("savedRoleOrSetup: a named role opens the screen instead of the form", () => {
+  const app = fakeApp({ savedRole: RIG });
+  const view = savedRoleOrSetup(app);
+  assert.equal(app.setupRendered, false);
+  assert.match(renderToString(view), /already set up/);
+});
+
+// --- rendered ---------------------------------------------------------------------------------
+
+const screen = (props) =>
+  renderToString(html`<${SavedRoleScreen} summary=${savedRoleSummary(RIG)} ...${props} />`);
+
+test("rendered: the screen says what the machine is and offers both answers", () => {
+  const card = screen({});
+  assert.match(card, /already set up/);
+  assert.match(card, /rig/);
+  assert.match(card, new RegExp(RIG.pool.replace(".", "\\.")));
+  assert.match(card, new RegExp(RIG.worker));
+  assert.match(card, /Keep it/);
+  assert.match(card, /Set up again/);
+});
+
+test("rendered: after keeping, the page closes rather than offering the choice again", () => {
+  const card = screen({ kept: true });
+  assert.match(card, /Nothing was changed/);
+  assert.doesNotMatch(card, /Keep it/);
+  assert.doesNotMatch(card, /Set up again/);
+});
+
+test("rendered: a failed keep says so on the screen the operator is still looking at", () => {
+  assert.match(screen({ error: "could not keep this configuration" }), /could not keep/);
+});
+
+// --- the Keep button's one call ---------------------------------------------------------------
+
+test("Keep it posts once and closes the page", async () => {
+  const calls = [];
+  const app = fakeApp({ savedRole: RIG });
+  globalThis.fetch = async (url, opts) => {
+    calls.push([url, opts.method]);
+    return { ok: true };
+  };
+  await savedRoleOrSetup(app).props.onKeep();
+  assert.deepEqual(calls, [["/keep-role", "POST"]]);
+  assert.equal(app.state.keptRole, true);
+});
+
+test("Keep it that the host refuses leaves the choice on screen with a reason", async () => {
+  const app = fakeApp({ savedRole: RIG });
+  globalThis.fetch = async () => ({ ok: false });
+  await savedRoleOrSetup(app).props.onKeep();
+  assert.equal(app.state.keptRole, undefined);
+  assert.match(app.state.keepError, /could not keep/);
+});

--- a/dashboard/tests/web/test_wizard_form.py
+++ b/dashboard/tests/web/test_wizard_form.py
@@ -1,0 +1,110 @@
+"""The no-JavaScript form fallback's optional branches (#77 phase 3, moved out under #1318).
+
+``test_wizard.py`` pins what ``build_config`` does with the questions every operator answers:
+the wallets, the ports and their defaults, the alert pair, the timezone. What it never reached
+is the set of switches an operator turns ON — remote Tari, node credentials, a pruned local
+chain, healthchecks, the local miner, the clearnet first sync. Each writes a key that changes
+what the stack runs, and each was reachable only by a form nothing submitted, so this file
+exercises the ON side of every one of them.
+
+The rule the whole function is built on: a key is written only when the operator actually asked
+for it, because an absent key inherits the documented default while an empty one overrides it.
+Every test here therefore checks BOTH that turning a switch on writes the key and that leaving
+it alone does not.
+"""
+
+from mining_dashboard import wizard
+from mining_dashboard.wizard_form import build_config
+
+# The two wallets are always present; every switch below is an addition to this.
+BASE = {"monero_wallet": "4" + "A" * 94, "tari_wallet": "t"}
+
+
+def test_the_wizard_module_still_serves_the_same_function():
+    # ``submit`` and test_wizard.py both reach it as ``wizard.build_config``. The move is only
+    # safe while that name is this function and not a copy of it.
+    assert wizard.build_config is build_config
+
+
+def test_a_remote_node_that_needs_a_login_carries_one():
+    cfg = build_config(
+        {
+            **BASE,
+            "monero_mode": "remote",
+            "monero_remote_host": "10.0.0.5",
+            "monero_remote_auth": "on",
+            "monero_remote_user": "reader",
+            "monero_remote_pass": "hunter2",
+        }
+    )
+    assert cfg["monero"]["node_username"] == "reader"
+    assert cfg["monero"]["node_password"] == "hunter2"
+
+
+def test_a_remote_node_without_the_box_ticked_carries_no_credential_keys():
+    # An empty username is a value, and writing one would override a node that needs none.
+    cfg = build_config(
+        {
+            **BASE,
+            "monero_mode": "remote",
+            "monero_remote_host": "10.0.0.5",
+            "monero_remote_user": "typed-then-unticked",
+        }
+    )
+    assert "node_username" not in cfg["monero"]
+    assert "node_password" not in cfg["monero"]
+
+
+def test_remote_tari_carries_its_host_and_defaults_its_port():
+    cfg = build_config({**BASE, "tari_mode": "remote", "tari_remote_host": "10.0.0.9"})
+    assert cfg["tari"]["mode"] == "remote"
+    assert cfg["tari"]["remote"] == {"host": "10.0.0.9", "grpc_port": 18142}
+
+
+def test_remote_tari_takes_the_port_it_is_given():
+    cfg = build_config(
+        {**BASE, "tari_mode": "remote", "tari_remote_host": "h", "tari_remote_grpc": "9999"}
+    )
+    assert cfg["tari"]["remote"]["grpc_port"] == 9999
+
+
+def test_a_local_tari_node_is_left_at_its_default_shape():
+    # The sibling that keeps the two above narrow: the same reader, given no mode, writes
+    # neither key rather than writing "local" and a remote block.
+    cfg = build_config(BASE)
+    assert "mode" not in cfg["tari"]
+    assert "remote" not in cfg["tari"]
+
+
+def test_declining_a_pruned_chain_is_recorded_for_a_node_we_run():
+    # Pruning is the default for a local node, so "false" is the only answer worth writing.
+    cfg = build_config({**BASE, "prune": "false"})
+    assert cfg["monero"]["prune"] is False
+
+
+def test_accepting_the_pruned_default_writes_nothing():
+    assert "prune" not in build_config({**BASE, "prune": "true"})["monero"]
+
+
+def test_a_healthchecks_url_is_written_only_when_given():
+    cfg = build_config({**BASE, "healthchecks_url": "https://hc.example/ping/abc"})
+    assert cfg["healthchecks"] == {"ping_url": "https://hc.example/ping/abc"}
+    # Whitespace is not a URL. An empty ping_url disables the dead-man's switch the operator
+    # believes they configured, which is the failure this branch exists to avoid.
+    assert "healthchecks" not in build_config({**BASE, "healthchecks_url": "   "})
+
+
+def test_the_local_miner_is_opt_in():
+    assert build_config({**BASE, "local_miner": "on"})["local_miner"] == {"enabled": True}
+    assert "local_miner" not in build_config(BASE)
+
+
+def test_the_clearnet_first_sync_applies_to_both_chains_or_neither():
+    # One chain syncing over clearnet while the other waits on Tor is not a state the operator
+    # asked for; the question is asked once and answers for both.
+    cfg = build_config({**BASE, "clearnet_sync": "true"})
+    assert cfg["monero"]["clearnet_initial_sync"] is True
+    assert cfg["tari"]["clearnet_initial_sync"] is True
+    plain = build_config({**BASE, "clearnet_sync": "false"})
+    assert "clearnet_initial_sync" not in plain["monero"]
+    assert "clearnet_initial_sync" not in plain["tari"]

--- a/dashboard/tests/web/test_wizard_saved_role.py
+++ b/dashboard/tests/web/test_wizard_saved_role.py
@@ -1,0 +1,128 @@
+"""The set-up-again screen's server half (#1318).
+
+A boot with `pithead.setup=1` publishes one extra spool file, `saved-role.json`, naming the role
+this machine is already set up as. Its PRESENCE is the whole signal: the page offers "Keep it"
+only when the host said what there is to keep. These tests pin that reading and the one write
+the Keep half makes.
+
+They live beside `test_wizard.py` rather than in it because that file is at its budget ceiling.
+"""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    sd.joinpath("config.reference.json").write_text(json.dumps({"p2pool": {"pool": "mini"}}))
+    return sd
+
+
+@pytest.fixture
+async def client(spool):
+    c = TestClient(TestServer(wizard.make_app(exit_fn=lambda code: None)))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def _auth(client, token="pit-X7KM2Q"):  # noqa: S107 — the test fixture's token, not a secret
+    return await client.post("/auth", data={"token": token}, allow_redirects=False)
+
+
+async def _state(client):
+    return await (await client.get("/api/wizard-state")).json()
+
+
+RIG = {"role": "rig", "pool": "pithead.lan:3333", "worker": "rig-01"}
+
+
+# --- what the page reads ---------------------------------------------------------------------
+
+
+async def test_saved_role_is_always_a_key_and_is_null_on_a_normal_boot(client):
+    """The client asserts on null, never on absence — so the key has to be there either way."""
+    await _auth(client)
+    s = await _state(client)
+    assert "saved_role" in s
+    assert s["saved_role"] is None
+
+
+async def test_a_rig_boot_carries_the_pool_and_worker_the_screen_names(client, spool):
+    spool.joinpath("saved-role.json").write_text(json.dumps(RIG))
+    await _auth(client)
+    assert (await _state(client))["saved_role"] == RIG
+
+
+async def test_a_coordinator_boot_carries_the_role_alone(client, spool):
+    """A coordinator has no pool or worker to name, and the file says only what it is."""
+    spool.joinpath("saved-role.json").write_text(json.dumps({"role": "pithead"}))
+    await _auth(client)
+    assert (await _state(client))["saved_role"] == {"role": "pithead"}
+
+
+@pytest.mark.parametrize(
+    ("label", "written"),
+    [
+        ("not json at all", "{"),
+        ("json that is not an object", "[1, 2]"),
+        ("an object naming no role", "{}"),
+        ("a role that is empty", '{"role": ""}'),
+        ("a role that is not a string", '{"role": 3}'),
+        ("a rig whose role key is misspelled", '{"roles": "rig", "worker": "rig-01"}'),
+    ],
+)
+async def test_an_unusable_file_reads_as_absent_rather_than_failing(client, spool, label, written):
+    """Never hard-fail and never offer to keep a role the page cannot name: fall through to the
+    normal wizard. The host writes this file atomically, so a half-written one is not expected —
+    the rule holds anyway, because the cost of being wrong here is a machine that cannot be set
+    up at all."""
+    spool.joinpath("saved-role.json").write_text(written)
+    await _auth(client)
+    s = await _state(client)
+    assert s["saved_role"] is None, label
+    assert s["stage"] == "setup", label  # the normal wizard, not an error page
+
+
+async def test_the_unusable_cases_are_narrow(client, spool):
+    """The control that keeps the row above honest: the same reader, given a usable file, has to
+    produce the OTHER answer. Without this, a reader that returned None for everything would
+    pass every case in that table."""
+    spool.joinpath("saved-role.json").write_text(json.dumps(RIG))
+    await _auth(client)
+    assert (await _state(client))["saved_role"] is not None
+
+
+# --- the one write the Keep half makes -------------------------------------------------------
+
+
+async def test_keep_role_writes_the_file_the_host_waits_on(client, spool):
+    spool.joinpath("saved-role.json").write_text(json.dumps(RIG))
+    await _auth(client)
+    r = await client.post("/keep-role")
+    assert r.status == 200
+    assert (await r.json())["status"] == "kept"
+    assert (spool / "keep-role").read_text() == "1"
+
+
+async def test_keep_role_needs_the_token(client, spool):
+    spool.joinpath("saved-role.json").write_text(json.dumps(RIG))
+    r = await client.post("/keep-role", allow_redirects=False)
+    assert r.status == 302
+    assert not (spool / "keep-role").exists()
+
+
+async def test_keep_role_refuses_when_there_is_no_role_to_keep(client, spool):
+    """The screen is not reachable on a normal boot, so this is a client that invented the call
+    — it writes nothing rather than telling the host to keep a configuration nobody named."""
+    await _auth(client)
+    assert (await client.post("/keep-role")).status == 400
+    assert not (spool / "keep-role").exists()


### PR DESCRIPTION
Closes the wizard half of #1318. The appliance half is pull 1844 (the GRUB entry, the service, the spool publisher); this is only what the operator sees in the browser.

## What it does

A boot carrying `pithead.setup=1` publishes one extra spool file, `saved-role.json`, naming the role the machine is already set up as. Its **presence is the whole signal**: the wizard then opens on a screen that names what the machine is — a rig with the pool it mines toward and its worker name, or one of the two coordinator shapes — and offers **Keep it** (the default; changes nothing, writes one empty `keep-role` spool file, closes the page) or **Set up again** (the ordinary wizard, pre-filled from the spool the host already sends).

On a normal boot the file is absent, `saved_role` is `null`, and nothing about the wizard changes.

## The contract, and the two edges

Agreed with the appliance lane in their pane before either half was written:

- `saved_role` is **always a key** in `/api/wizard-state`, `null` when the file is absent or unusable, the parsed object otherwise. Tests assert on `null`, never on absence. (Note the route is `/api/wizard-state`; an earlier statement of the contract called it `/api/state`.)
- A `saved-role.json` that is malformed, empty, or names no role **falls through to the normal wizard** rather than hard-failing. So does a role this page has no words for. Offering to keep "your configuration" without being able to say what it is asks the operator for a blind confirmation, so the page refuses to.
- The #1836 token is host-side. Nothing for the page to do.

## The extraction, and why it comes first

`wizard.py` was at its `docs/dev/file-budget.tsv` ceiling (674/674) and ceilings only go down, so the feature's ~11 lines had to be bought. The first commit moves `build_config` — the no-JavaScript form fallback, the largest self-contained thing in the file: no module state, no spool access, no request handling — into `mining_dashboard/wizard_form.py`, byte-identically. `wizard.py` re-imports the name, so `wizard.build_config` still resolves for `submit` and for the existing tests, which needed no edit.

Same shape on the client: the screen and its one decision live in a new `savedrole.mjs`, and the three presentational helpers both files now need moved to a new `wizardparts.mjs`. `wizard.mjs` gains two imports, one state line and one changed line, and **shrinks** on net.

| file | before | after | ceiling |
|---|---|---|---|
| `wizard.py` | 674 | 633 | 674 |
| `wizard.mjs` | 888 | 884 | 889 |

New files carry no budget row.

## Third commit: the coverage the extraction exposed

Moving `build_config` made every one of its lines a changed line, and `test-patch-coverage` then graded six branches the suite had never reached — remote Tari, a node login, declining a pruned chain, healthchecks, the local miner, the clearnet first sync. Each writes a key that changes what the stack runs, so each got a test on both sides (on writes the key, off writes nothing) rather than a gate exemption.

## What was RUN, at the pushed head `c52f2ef4`

- All 12 non-shell lints, **rc 0 each**: `lint-py`, `lint-js`, `lint-yaml`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget`, `lint-pithead-parity`, `lint-trivy-parity`, `lint-proto`, `lint-toml`.
- `make test-frontend` — **579 / 579**, 0 fail (13 new in `savedrole.test.mjs`).
- `make test-dashboard` — **2572 passed**, total coverage 97.59% against the 80% gate (13 new in `test_wizard_saved_role.py`, 11 new in `test_wizard_form.py`).
- `make test-patch-coverage` — **100%**, 44 changed lines, 0 missing.

**Fired controls.** Patch coverage is the one claim that could be vacuous, so it was made to produce both answers on the same instrument: it measured **79%, 9 lines missing** at the commit before the test commit, and **100%, 0 missing** after — a gate shown able to fail on this diff, not merely observed passing. Separately, `git merge-tree --write-tree` was used to check this branch against pull 1864 while that was still open; it returned rc 1 with a real conflict there and rc 0 against a clean counterparty, so that instrument produced both answers too.

Two tests exist only as near-miss siblings, to keep narrower assertions from passing by construction: `savedRoleSummary: an empty value drops its own row rather than blanking it` ends by giving the same reader both values and demanding the other answer, and `a local Tari node is left at its default shape` sits beside the two remote-Tari tests.

## What was NOT run

- **`make lint-sh`** — exits rc 137 on this box for pre-existing reasons (#1206, shellcheck killed at the local 6G cap); the identical target dies the same way on an unmodified base. CI's uncapped shellcheck is the authority. This diff contains no shell.
- **`tests/stack/run.sh`, the docker mini-stack, `test-compose`** — no shell, no compose and no container bytes are touched.
- **`Secret scan (gitleaks)`** — not part of `make lint`, and it runs from a pinned container this box has no local binary for. Checked by hand instead: the only fixture token in the new tests is `pit-X7KM2Q`, which already appears in three test files on `develop-v2` and so already passes the scan; the one genuinely new literal is a 7-character joke password in a test, whose class has precedent on `develop-v2` (`"pass": "secret"` in `test_worker_config_drift.py`). Stated as a hand check, not as a scan.

## ASSUMED

**A refresh after "Keep it" re-shows the choice**, because `saved-role.json` is still on the spool. That is safe and idempotent — keeping changes nothing and the host is waiting on a file that is written the same way each time — but it is a choice, not a fact the contract settles. `wizard_stage()` is deliberately untouched: inventing a stage transition would be a contract change, and this half has no standing to make one.

## Docs

**Deliberately not written here, because they already exist.** The appliance lane's pull 1844 documents this screen in operator terms in `docs/appliance.md` (§ Set up again). Their hunks were read and this implementation was cross-checked against their prose rather than adding a second paragraph to a file both lanes are editing. No `docs/` file is touched by this branch, so there is no `_shared.paths` edit to disclose.

## Sequencing

Rebased onto `d6274df3` after pull 1864 (#1836) merged; the only conflict was the import block at the top of `wizard.mjs`, where both branches add imports, resolved by keeping both. The replayed file set was re-read afterwards and is identical to the pre-rebase set (7 files, 466 insertions, 76 deletions), since `git rebase --continue` does not run the pre-commit hook.

The appliance lane confirmed no battery is live and no GA soak has started, so `dashboard/` is not yet under the image freeze.

## Over-engineering pass

Run before opening this. Each new module was checked against the alternative of not having it: `wizard_form.py` and `savedrole.mjs` are both forced by hard budget ceilings and both make pure logic testable without a DOM or a request; `wizardparts.mjs` is structurally required, since `wizard.mjs` imports `savedrole.mjs` and the reverse import would be a cycle. The `ROLES` map has exactly the three roles the contract names and no speculative fourth. The one guard that could have been dropped — `keep_role` refusing when there is nothing to keep — is kept because without it a stray POST writes a spool file the host acts on. The keep handler checks `fetch`'s `.ok` where the neighbouring `ack` handler checks nothing; that is one line more careful than the house pattern, not less.

---

**Not mine to merge** — I authored all three commits. Needs a recorded non-author pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7txeRNDQmj5b4Wsx33mCF
