### PR TITLE
fix(wizard): #1879 a value with no break opportunity no longer runs past the card

### DIFF
--- a/dashboard/mining_dashboard/web/static/wizard.css
+++ b/dashboard/mining_dashboard/web/static/wizard.css
@@ -14,6 +14,20 @@
   font-size: 0.82rem;
 }
 
+/* A stratum URL and the rig's 32-character control token carry no break opportunity of their own,
+ * and .config-field's value column takes its minimum width from the string, so on a phone the row
+ * pushed the card past the viewport and the token's last characters sat outside the border with no
+ * cue that there was more (#1879). The label column already breaks this way — .config-field-name in
+ * dashboard.css — so this is the same rule for the value beside it.
+ *
+ * Scoped to <code>, not to .wizard-mono: that class is also on three inputs and on the JSON
+ * textarea, where breaking mid-token would change a surface nobody reported. Descending from
+ * .wizard-shell covers every value the wizard renders, including the discovered pool address that
+ * appears in prose rather than in a card row. */
+.wizard-shell code {
+  overflow-wrap: anywhere;
+}
+
 .wizard-json {
   width: 100%;
   min-height: 22rem;

--- a/dashboard/mining_dashboard/web/static/wizard.css
+++ b/dashboard/mining_dashboard/web/static/wizard.css
@@ -17,8 +17,13 @@
 /* A stratum URL and the rig's 32-character control token carry no break opportunity of their own,
  * and .config-field's value column takes its minimum width from the string, so on a phone the row
  * pushed the card past the viewport and the token's last characters sat outside the border with no
- * cue that there was more (#1879). The label column already breaks this way — .config-field-name in
- * dashboard.css — so this is the same rule for the value beside it.
+ * cue that there was more (#1879). Two levers, because the track is `2fr` = minmax(auto, 2fr) and a
+ * grid item's `min-width: auto` resolves to its content-based minimum: `overflow-wrap: anywhere`
+ * lowers that minimum (unlike `break-word`, its break opportunities COUNT toward min-content), and
+ * `min-width: 0` removes the floor outright. `.config-field input, select` already carries the
+ * second at dashboard.css:1435; the <code> value had neither. Both together are what #83 (9330cce6)
+ * verified in a browser for this same class — `.config-field-name` is NOT the precedent it looks
+ * like, since it sits in minmax(140px, 1fr) and only ever wraps inside a fixed width.
  *
  * Scoped to <code>, not to .wizard-mono: that class is also on three inputs and on the JSON
  * textarea, where breaking mid-token would change a surface nobody reported. Descending from
@@ -26,6 +31,7 @@
  * appears in prose rather than in a card row. */
 .wizard-shell code {
   overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 .wizard-json {

--- a/dashboard/tests/frontend/wizardcss.test.mjs
+++ b/dashboard/tests/frontend/wizardcss.test.mjs
@@ -1,0 +1,72 @@
+// The wizard's stylesheet, asserted the way workerview.test.mjs asserts dashboard.css: parse the
+// file and read the declarations. This proves the RULE IS DECLARED and that the markup it targets
+// still exists — it does not lay the page out, so it cannot prove a glyph landed inside the card.
+// The behavioural evidence for #1879 is the Chromium measurement in the issue (390 px: the card's
+// content box is 332 px and documentElement.scrollWidth was 446).
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+const WIZARD_CSS = read("../../mining_dashboard/web/static/wizard.css");
+const WIZARD_MJS = read("../../mining_dashboard/web/static/wizard.mjs");
+const WIZARD_HTML = read("../../mining_dashboard/web/templates/wizard.html");
+
+// The rule under test, found by its selector rather than by position, so reordering the file does
+// not move the test.
+function ruleFor(css, selectorRe) {
+  const m = css.match(new RegExp(`(^|\\})\\s*(${selectorRe.source})\\s*\\{([^}]*)\\}`, "m"));
+  return m ? { selector: m[2].trim(), body: m[3] } : null;
+}
+
+test("wizard.css: a value inside the wizard breaks rather than running past the card (#1879)", () => {
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+code/);
+  assert.ok(rule, "expected a `.wizard-shell code` rule in wizard.css");
+  assert.match(
+    rule.body,
+    /overflow-wrap:\s*anywhere/,
+    "the control token and the stratum URL have no break opportunity of their own; without " +
+      "overflow-wrap the .config-field value column takes its width from the string itself",
+  );
+});
+
+test("wizard.css: the break rule is scoped to <code>, so the JSON editor keeps its own wrapping", () => {
+  // .wizard-mono is also on three <input> and on the config textarea (wizard.mjs). Breaking JSON
+  // mid-token is a change to a surface nobody reported, so the rule names an element, not the class.
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+code/);
+  assert.match(rule.selector, /\bcode\b/);
+  const mono = ruleFor(WIZARD_CSS, /\.wizard-mono/);
+  assert.ok(mono, "expected the .wizard-mono font rule to still exist");
+  assert.doesNotMatch(
+    mono.body,
+    /overflow-wrap|word-break/,
+    ".wizard-mono is shared with inputs and the JSON textarea — keep it font-only",
+  );
+});
+
+// The two ways the rule above goes dead without anything failing: the mount loses the class the
+// selector descends from, or the values stop being <code>. Both are one careless edit away, and
+// neither shows up in a screenshot of the desktop layout.
+
+test("wizard.html: the app mounts inside .wizard-shell, which the break rule descends from", () => {
+  assert.match(WIZARD_HTML, /<main[^>]*id="app"[^>]*class="[^"]*\bwizard-shell\b/);
+});
+
+test("wizard.mjs: the handoff values the operator transcribes are still <code> elements", () => {
+  // The rig card's rows (#1836) and the coordinator card's four values are the sites the issue
+  // measured. Each renders its value in a <code>; a <span> here would leave the rule matching
+  // nothing while every other test stayed green.
+  const codes = WIZARD_MJS.match(/<code\b/g) || [];
+  assert.ok(codes.length >= 6, `expected the card values to render as <code>, found ${codes.length}`);
+  // Same line, so `.` is enough and the callback's own parentheses do not end the match early.
+  assert.match(WIZARD_MJS, /rigCardFields\(handoff\)\.map\(.*<code\b/);
+  for (const label of ["Dashboard password", "Point miners at"]) {
+    assert.match(
+      WIZARD_MJS,
+      new RegExp(`label="${label}"><code\\b`),
+      `${label} renders its value outside a <code>, so the wrap rule no longer covers it`,
+    );
+  }
+});

--- a/dashboard/tests/frontend/wizardcss.test.mjs
+++ b/dashboard/tests/frontend/wizardcss.test.mjs
@@ -35,8 +35,6 @@ test("wizard.css: a value inside the wizard breaks rather than running past the 
 test("wizard.css: the break rule is scoped to <code>, so the JSON editor keeps its own wrapping", () => {
   // .wizard-mono is also on three <input> and on the config textarea (wizard.mjs). Breaking JSON
   // mid-token is a change to a surface nobody reported, so the rule names an element, not the class.
-  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+code/);
-  assert.match(rule.selector, /\bcode\b/);
   const mono = ruleFor(WIZARD_CSS, /\.wizard-mono/);
   assert.ok(mono, "expected the .wizard-mono font rule to still exist");
   assert.doesNotMatch(
@@ -58,8 +56,6 @@ test("wizard.mjs: the handoff values the operator transcribes are still <code> e
   // The rig card's rows (#1836) and the coordinator card's four values are the sites the issue
   // measured. Each renders its value in a <code>; a <span> here would leave the rule matching
   // nothing while every other test stayed green.
-  const codes = WIZARD_MJS.match(/<code\b/g) || [];
-  assert.ok(codes.length >= 6, `expected the card values to render as <code>, found ${codes.length}`);
   // Same line, so `.` is enough and the callback's own parentheses do not end the match early.
   assert.match(WIZARD_MJS, /rigCardFields\(handoff\)\.map\(.*<code\b/);
   for (const label of ["Dashboard password", "Point miners at"]) {


### PR DESCRIPTION
Addresses #1879. **This PR must NOT auto-close it** — the `user-select: all` half of #1879 is deliberately left open, so the closing keyword is removed rather than qualified. The base is now `develop`, which is the repository's default branch, so a closing keyword here FIRES on merge; "by hand" does not defuse one. Verified with GitHub's own link resolution (`closingIssuesReferences`), which now returns an empty list for this PR.

## What the operator sees change

On a phone, the wizard's rig handoff card ("Check this rig") no longer runs past its own right
edge and the page no longer scrolls sideways. The two rows that did it are **Mines toward** (a
stratum URL) and **Control token** — the one value on that card the operator has to transcribe
exactly, under a note telling them to copy it now, whose last characters sat outside the border
with no cue that there was more.

## Mechanism

`.config-field` (`dashboard.css:1415-1420`) is a two-column grid, `minmax(140px, 1fr) 2fr`, so the
value column's minimum size is the string's own width and the grid grows to it. The value is a
`<code class="wizard-mono">` whose only rules were a font stack and a size (`wizard.css:12-15`).

The label column beside it already breaks this way — `.config-field-name` carries
`overflow-wrap: anywhere` at `dashboard.css:1425`. The value column had no equivalent. This adds
the same rule for the value, in `wizard.css`.

## Two scope decisions, both deliberate

**Scoped to `<code>`, not to `.wizard-mono`.** That class is also on three `<input>`
(`wizard.mjs:527,670,678`) where the property is inert, and on the JSON `<textarea>`
(`wizard.mjs:845`) where `anywhere` would let JSON break mid-token — a change to a surface nobody
reported. An element selector excludes both at no cost.

**Descending from `.wizard-shell`**, the app's mount (`templates/wizard.html:18`), so the rule
covers every value the wizard renders. That picks up one site the issue does not name:
`wizard.mjs:534` renders the host-discovered pool address in a `<code>` inside prose, with no
class at all — the same defect class, reachable with host-supplied content.

**Not taken here:** the issue also asks for `user-select: all` on the token so one tap selects it.
That needs a per-row class in `wizard.mjs`, which another open PR of mine is mid-review on, and
applied across the card it would forbid partial selection on the URL rows. It stays on the issue,
which therefore stays open after this merges.

The fix could not have gone in `dashboard.css` in any case: that file is at 1579 against a 1579
ceiling. `wizard.css` (44 -> 58) and the new test file (72) carry no budget row and are under the
400-line target.

## What was RUN, at this head

- `make test-frontend` — **570/570 pass**. 4 of those are this PR's; the 566 base figure is
  derived by subtraction from the single-file run, not separately measured.
- `make lint-js lint-md lint-py lint-file-budget lint-topology lint-docs-voice
  lint-operator-strings lint-yaml lint-toml lint-proto` — **rc 0 each, ten targets.**
- **FIRED CONTROL for the lint that matters.** `lint-js` passing says nothing unless biome
  actually reads CSS, so I appended a malformed rule to `wizard.css` and re-ran it: **rc 2 seeded,
  rc 0 restored.** The green above is evidence about the file this PR changes. Restore verified by
  `git status` and by the diff carrying only the intended rule.
- **FIRED CONTROL for the tests.** Both wrap assertions were run against the unfixed tree and
  **failed** there; the two coupling assertions **passed** there. So the wrap tests can fail, and
  the coupling tests are not vacuously green.
- `make test-dashboard` — result stated in a follow-up comment; this PR changes no Python.

## What this does NOT prove, and what was NOT run

- The tests assert the declaration exists and that the markup it targets still does. **They do not
  lay the page out** — no layout engine runs on this box, so nothing here proves a glyph landed
  inside the card. The behavioural evidence is the Chromium measurement in the issue (390 px:
  content box 332 px, `documentElement.scrollWidth` 446).
- `make lint-sh` — not run: pre-existing rc 137 on this box (#1206), and no shell in the diff.
- Docker, KVM, browser — not run. The appliance lane holds the bench.
- `make test-patch-coverage` — this diff is CSS and a test file, no Python, so diff-cover has
  nothing to measure. A pass from it here would be vacuous and is not claimed.

## Lane notes

Both files are under `dashboard/`, which is in this lane's `.paths`. No `.lane-override` was
needed and none was touched. No `_shared.paths` file is edited. The `dashboard` lane also holds
`dashboard/` and is live on `wizard.mjs` for the Tari/XvB question block — this PR touches no
`.mjs` under `mining_dashboard/`, only `wizard.css` and a new test file, so the hunks cannot
collide.

Never merged by its author.

