### PR TITLE
fix(wizard): #1868 the wizard's buttons look like the product, and the shell stops leaking

### DIFF
--- a/dashboard/mining_dashboard/web/static/savedrole.mjs
+++ b/dashboard/mining_dashboard/web/static/savedrole.mjs
@@ -47,7 +47,7 @@ export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) 
                 html`<${Field} label=${r.label}><code class="wizard-mono">${r.value}</code><//>`,
             )}
             <${Err}>${error}<//>
-            <button type="button" onClick=${onKeep}>Keep it</button>
+            <button type="button" class="btn-toggle active" onClick=${onKeep}>Keep it</button>
             <button type="button" class="wizard-link" onClick=${onSetUpAgain}>Set up again</button>
             <${Note}>Setting it up again asks the same questions as a first boot, with this
             machine's answers already filled in. Its login and other secrets are never filled

--- a/dashboard/mining_dashboard/web/static/wizard.css
+++ b/dashboard/mining_dashboard/web/static/wizard.css
@@ -42,3 +42,33 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+/* The wizard's buttons take the dashboard's own skin (.btn-toggle / .btn-toggle.active) so the
+ * first page anyone sees matches the app it hands over to. That class is built for a segmented
+ * control — no border of its own, radius from its parent — so a standalone button needs the same
+ * adaptation the config modal already makes at `.config-modal-actions .btn-toggle`. Without any of
+ * it these fell through to the user-agent style, and Apply failed WCAG 2.5.8 target size at under
+ * 24px tall (#1868). min-height states that bar directly rather than leaving it to font metrics.
+ * `.wizard-link` is a button deliberately styled as text and keeps its own look. */
+.wizard-shell button:not(.wizard-link) {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-height: 32px;
+}
+
+.wizard-shell button:not(.wizard-link):disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* A section heading sat hard against the field above it and read as that field's label: h3 carries
+ * `margin: 0 0 15px` from dashboard.css, so the space above it was whatever the preceding help
+ * paragraph happened to leave — headings after a bare select got none. A heading that opens its
+ * own card still needs zero, which is what the :first-child reset is for (#1868). */
+.wizard-shell h3 {
+  margin-top: 22px;
+}
+
+.wizard-shell h3:first-child {
+  margin-top: 0;
+}

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -80,7 +80,7 @@ export const Gate = ({ error, onSubmit }) => html`<div class="card">
                 spellcheck=${false} placeholder="pit-XXXXXX" />
         <//>
         <${Note}>Case doesn't matter, and the ${" "}<code>pit-</code>${" "}prefix is optional.<//>
-        <button type="submit">Continue</button>
+        <button type="submit" class="btn-toggle active">Continue</button>
     </form>
 </div>`;
 
@@ -206,7 +206,7 @@ export const Done = ({ status, handoff, installer, stick, rig, onAck }) => html`
             <p>This is what the machine will be.</p>
             ${rigCardFields(handoff).map((f) => html`<${Field} label=${f.label}><code class="wizard-mono">${f.value}</code><//>`)}
             <${Note}>${rigCardNote(handoff)}<//>
-            <button type="button" onClick=${onAck}>
+            <button type="button" class="btn-toggle active" onClick=${onAck}>
                 ${installer && !stick ? "Looks right — erase the disk and install" : "Looks right — save it"}</button>`
         : handoff
           ? html`<h3>Save this before anything else</h3>
@@ -215,7 +215,7 @@ export const Done = ({ status, handoff, installer, stick, rig, onAck }) => html`
             <${Field} label="Dashboard password"><code class="wizard-mono">${handoff.password}</code><//>
             <${Field} label="Dashboard address"><code class="wizard-mono">${handoff.dashboard}</code><//>
             <${Field} label="Point miners at"><code class="wizard-mono">${handoff.stratum}</code><//>
-            <button type="button" onClick=${onAck}>
+            <button type="button" class="btn-toggle active" onClick=${onAck}>
                 ${installer ? "I saved these — erase the disk and install" : "I saved these — start provisioning"}</button>
             <${Note}>${
               installer
@@ -571,7 +571,7 @@ export class WizardApp extends Component {
               html`<${RestoreSection} file=${this.state.restoreFile} passphrase=${restorePassphrase}
                 onFile=${(e) => this.setState({ restoreFile: e.target.files[0] || null })}
                 onPassphrase=${(e) => this.setState({ restorePassphrase: e.target.value })} />
-            <button type="submit" disabled=${submitting}>
+            <button type="submit" class="btn-toggle active" disabled=${submitting}>
                 ${submitting ? "Validating…" : "Restore and provision"}</button>`
             }
         </form>
@@ -846,7 +846,7 @@ export class WizardApp extends Component {
 
             ${
               diskPicked &&
-              html`<button type="submit" disabled=${(!rig && !!jsonError) || this.state.submitting}>
+              html`<button type="submit" class="btn-toggle active" disabled=${(!rig && !!jsonError) || this.state.submitting}>
                 ${
                   this.state.submitting
                     ? "Validating…"
@@ -877,8 +877,9 @@ export class WizardApp extends Component {
   }
 }
 
-// Mount only in a browser: node --test imports this module to render-probe the views, and a
-// bare `document` reference at import time would make the whole file untestable.
+// Mount only in a browser (node --test imports this module; a bare `document` would break that).
+// Clear #app: the shell ships the heading and "Loading…" inside it, and preact APPENDS (#1868).
 if (typeof document !== "undefined") {
+  document.getElementById("app").replaceChildren();
   render(html`<${WizardApp} />`, document.getElementById("app"));
 }

--- a/dashboard/tests/frontend/wizardshell.test.mjs
+++ b/dashboard/tests/frontend/wizardshell.test.mjs
@@ -7,7 +7,7 @@
 // A new file rather than wizard.test.mjs, which is at 765 against a 765 ceiling.
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import test from "node:test";
 
 const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
@@ -20,14 +20,36 @@ function ruleFor(css, selectorRe) {
   return m ? { selector: m[2].trim(), body: m[3] } : null;
 }
 
-test("wizard.mjs: every button declares a class, so none falls through to the browser default", () => {
-  // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag itself
-  // can hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
-  const tags = WIZARD_MJS.split("<button").slice(1).map((s) => s.slice(0, 200));
-  assert.ok(tags.length >= 7, `expected the wizard's buttons, found ${tags.length}`);
-  const bare = tags.filter((t) => !/class="(btn-toggle[^"]*|wizard-link)"/.test(t));
+// The wizard's view modules, found by the import they share rather than by a hand-kept list — a new
+// view that renders a button is then covered the day it is written. The first sweep here read only
+// wizard.mjs and was blind to savedrole.mjs's "Keep it", which is exactly this defect in a file the
+// needle never looked at.
+const STATIC = new URL("../../mining_dashboard/web/static/", import.meta.url);
+const VIEWS = readdirSync(STATIC)
+  .filter((f) => f.endsWith(".mjs"))
+  .map((f) => [f, readFileSync(new URL(f, STATIC), "utf8")])
+  .filter(([f, src]) => f === "wizard.mjs" || src.includes("./wizardparts.mjs"));
+
+test("every wizard view: a button declares a class, so none falls through to the browser default", () => {
+  // An enumeration that quietly found nothing would pass this test while proving nothing, so the
+  // root is asserted before the property is.
+  assert.ok(VIEWS.length >= 2, `expected the wizard's view modules, found ${VIEWS.length}`);
+  assert.ok(
+    VIEWS.some(([f]) => f === "savedrole.mjs"),
+    "savedrole.mjs no longer matches the wizard-view marker — widen the root, do not narrow the claim",
+  );
+  const bare = [];
+  for (const [file, src] of VIEWS) {
+    // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag can
+    // hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
+    for (const tag of src.split("<button").slice(1).map((s) => s.slice(0, 200))) {
+      if (!/class="(btn-toggle[^"]*|wizard-link)"/.test(tag)) {
+        bare.push(`${file}: <button${tag.split("\n")[0].trim()}`);
+      }
+    }
+  }
   assert.deepEqual(
-    bare.map((t) => t.split("\n")[0].trim()),
+    bare,
     [],
     "a button with no class renders as the user-agent control (#1868): give it the dashboard's " +
       "btn-toggle skin, or wizard-link if it is deliberately a text link",

--- a/dashboard/tests/frontend/wizardshell.test.mjs
+++ b/dashboard/tests/frontend/wizardshell.test.mjs
@@ -1,0 +1,73 @@
+// The wizard's shell and chrome (#1868), asserted the way workerview.test.mjs asserts dashboard.css:
+// parse the files and read what they declare. These are static assertions — no layout engine runs
+// here, so nothing below proves a rendered button measured 32 px. What they DO hold is the property
+// that broke: a control that carries no class at all falls through to the user-agent style, and a
+// mount that is never cleared keeps whatever the server shipped inside it.
+//
+// A new file rather than wizard.test.mjs, which is at 765 against a 765 ceiling.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
+const WIZARD_MJS = read("../../mining_dashboard/web/static/wizard.mjs");
+const WIZARD_CSS = read("../../mining_dashboard/web/static/wizard.css");
+const WIZARD_HTML = read("../../mining_dashboard/web/templates/wizard.html");
+
+function ruleFor(css, selectorRe) {
+  const m = css.match(new RegExp(`(^|\\})\\s*(${selectorRe.source})\\s*\\{([^}]*)\\}`, "m"));
+  return m ? { selector: m[2].trim(), body: m[3] } : null;
+}
+
+test("wizard.mjs: every button declares a class, so none falls through to the browser default", () => {
+  // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag itself
+  // can hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
+  const tags = WIZARD_MJS.split("<button").slice(1).map((s) => s.slice(0, 200));
+  assert.ok(tags.length >= 7, `expected the wizard's buttons, found ${tags.length}`);
+  const bare = tags.filter((t) => !/class="(btn-toggle[^"]*|wizard-link)"/.test(t));
+  assert.deepEqual(
+    bare.map((t) => t.split("\n")[0].trim()),
+    [],
+    "a button with no class renders as the user-agent control (#1868): give it the dashboard's " +
+      "btn-toggle skin, or wizard-link if it is deliberately a text link",
+  );
+});
+
+test("wizard.css: a standalone button gets the border and radius .btn-toggle takes from its parent", () => {
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+button:not\(\.wizard-link\)/);
+  assert.ok(rule, "expected a `.wizard-shell button:not(.wizard-link)` rule in wizard.css");
+  assert.match(rule.body, /border:\s*1px solid var\(--border\)/);
+  assert.match(rule.body, /border-radius:/);
+});
+
+test("wizard.css: the button's target size clears WCAG 2.2 SC 2.5.8 (24px) as a declared floor", () => {
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+button:not\(\.wizard-link\)/);
+  const mh = rule.body.match(/min-height:\s*(\d+)px/);
+  assert.ok(mh, "expected an explicit min-height rather than one implied by padding + line-height");
+  assert.ok(
+    Number(mh[1]) >= 24,
+    `min-height ${mh[1]}px is below the 24px target-size floor (SC 2.5.8)`,
+  );
+});
+
+test("wizard.mjs: the mount clears #app, which the shell deliberately ships non-empty", () => {
+  // The two halves are a pair: the template ships the heading and "Loading…" inside #app so a curl
+  // can recognize the page, and preact's render appends. Assert both, or a later edit to either one
+  // silently restores the residue.
+  assert.match(WIZARD_HTML, /<main[^>]*id="app"[^>]*>\s*<h1>/, "the shell still ships markup in #app");
+  const mount = WIZARD_MJS.slice(WIZARD_MJS.indexOf('typeof document !== "undefined"'));
+  const clearAt = mount.indexOf("replaceChildren()");
+  const renderAt = mount.indexOf("render(");
+  assert.ok(clearAt !== -1, "#app is never cleared, so the shell's markup outlives every stage");
+  assert.ok(clearAt < renderAt, "#app must be cleared BEFORE render, not after");
+});
+
+test("wizard.css: a section heading is spaced from the field above, but not when it opens a card", () => {
+  const h3 = ruleFor(WIZARD_CSS, /\.wizard-shell\s+h3/);
+  assert.ok(h3, "expected a `.wizard-shell h3` rule");
+  assert.match(h3.body, /margin-top:\s*[1-9]/, "a heading with no top margin reads as the label of the field above it");
+  const first = ruleFor(WIZARD_CSS, /\.wizard-shell\s+h3:first-child/);
+  assert.ok(first, "expected the :first-child reset");
+  assert.match(first.body, /margin-top:\s*0/);
+});


### PR DESCRIPTION
Addresses #1868 and deliberately does NOT close it — one of the issue's four asks is left for the design lane, see **What I did not do**. No closing keyword is used, which now matters: the base is `develop`, the repository's default branch, where a closing keyword FIRES on merge. Confirmed with GitHub's own link resolution (`closingIssuesReferences`), which returns an empty list for this PR.

## What the operator sees change

The setup wizard's buttons look like the dashboard they hand over to instead of like raw browser controls; the "Loading…" line and a duplicate page heading stop sitting under the card on every stage; and a section heading is no longer jammed against the field above it.

## The three fixes

**Buttons.** `Continue`, `Apply`, the two handoff acknowledgements and the restore submit carried no class at all, and `dashboard.css` has no bare `button` rule, so they fell through to the user-agent style. axe-core flagged `Apply` under `target-size` (WCAG 2.2 SC 2.5.8).

They now carry `.btn-toggle` / `.btn-toggle.active` — the dashboard's own classes, and what the config view's confirm modal already uses for a standalone primary action (`configview.mjs:166-169`). That class is built for a segmented control (`border: none`, radius inherited from its parent), so `wizard.css` makes the same adaptation the modal makes at `.config-modal-actions .btn-toggle` (`dashboard.css:1460-1468`): a border, a radius, a disabled rule. `min-height: 32px` states the target-size bar directly rather than leaving it to be derived from padding plus line-height.

**⚠️ Correction to the issue, worth reading before reviewing:** the issue proposes sharing "the dashboard's `.btn-primary`-style controls (the config view's Apply already has one)". **There is no `.btn-primary` anywhere in `dashboard/mining_dashboard/web/`** — I grepped. The precedent is real but it is `.btn-toggle active`, which is what this uses. Copying `.btn-toggle`'s declarations into `wizard.css` instead would have re-spelled a skin that then drifts from the one it copies.

**The shell's residue.** `templates/wizard.html:18` ships the heading and `Loading…` inside `<main id="app">` *deliberately* — so a `curl` and the tier-4 harness can recognize the page without executing the module. `preact`'s `render` appends to its container, so both survived every stage. Since the app renders its own `<h1>`, the page was also carrying **two** `<h1>Pithead setup</h1>` — which the issue does not name. The mount now clears `#app` first, fixing both. The server-side markup is untouched, so what `curl` sees does not change.

**Heading rhythm.** `h3` carries `margin: 0 0 15px` from `dashboard.css:261`, so the space above a section heading was whatever the preceding help paragraph happened to leave; headings following a bare select (`Tari node`, `Mining`, `Dashboard login`) got none. A top margin fixes it, with a `:first-child` reset so a heading opening its own card is unchanged.

## What I did NOT do

**The issue's fourth ask — retag the section headings `<h3>` → `<h2>` for axe's `heading-order` — is not here, on purpose.** In this stylesheet `h2` is the 1.5rem card-title style (`dashboard.css:256`) and `h3` is the uppercase, muted, bottom-ruled section style (`:261`). Retagging as written would restyle all 13 wizard section headings. Preserving the look means duplicating the `h3` rule under a wizard-scoped `h2` — the same re-spelling avoided in the button fix. Choosing between that, an `aria-level`, and a new shared section-heading class is a design decision, not mine to guess; **#1868 stays open for it.**

Also not done: no browser or screenshot proof (no layout engine on this box), and I did not re-verify the axe-core findings myself — those are the issue's, taken as filed.

## Evidence at this head

- `make test-frontend` — **571/571 pass.** Base measured at **566** on `8c7874c9`; the 5 new assertions are this PR's.
- Ten lint targets rc 0 each: `lint-js lint-md lint-py lint-file-budget lint-topology lint-docs-voice lint-operator-strings lint-yaml lint-toml lint-proto`. `lint-file-budget` runs its own self-tests and they passed.
- **FIRED CONTROL.** All five new assertions were run against the unfixed files (`git checkout 8c7874c9 -- wizard.mjs wizard.css`) and **all five failed**; all five pass restored. The fix was committed *before* the control ran, so the restoring `checkout` could not discard it. Worktree confirmed clean afterwards.
- `make test-dashboard` — reported in a follow-up comment; this diff contains no Python.

**What the tests do not prove:** they are static. They parse the files and read what is declared; nothing here renders a page, so no assertion proves a button measured 32 px on screen. They hold the property that actually broke — a control with no class, and a mount that is never cleared.

## Budget

`wizard.mjs` lands at **885 against its 889 ceiling — four lines of headroom**, re-derived at this head with the gate's own counter (`awk 'END{print NR+0}'`): base `0a4195c9` 884, head `4c31a7a3` 885. The button classes are added to existing lines; the only new line is the `replaceChildren()` call, paid for by compressing the comment above it. `wizard.css` 44 → 74, `savedrole.mjs` 73 (unchanged count) and the new test file (95) carry no budget row.

**CORRECTED 2026-09-06, in place.** This paragraph previously read *"889 against its 889 ceiling — the file is pinned and any further edit must be line-neutral until pull 1884 merges, which takes it to 884"*, and called the new test file 76 lines. Pull 1884 **has merged** (`c3065010`, an ancestor of the current base), so the figure was stale and **the line-neutral instruction it carried was false** — a wrong number with a live imperative attached is the part that could have cost someone a wasted edit. The test file is 95 lines, not 76.

## Lane notes

`dashboard/` only, in this lane's `.paths`; no `.lane-override` needed or touched, no `_shared.paths` file edited. Coordinated with the `dashboard` lane, who took #1869 and #1878 into their #1848/#1854. Pull 1884 has merged, so that half of the earlier sequencing note is spent.

⛔ **SEQUENCING, MEASURED — this branch and pull 1927 CONFLICT, and neither branch can see it.** Both edit `dashboard/mining_dashboard/web/static/savedrole.mjs`: this PR adds `class="btn-toggle active"` to the *Keep it* button, pull 1927 rewrites the same screen's buttons for the restore door. `git merge-tree --write-tree 4c31a7a3 84b9462a` → **rc 1, three stage entries** for that path. **Control, same instrument, same session:** `git merge-tree --write-tree 4c31a7a3 5391eafc` (this branch × pull 1885) → **rc 0, tree `ce80cfdd`, zero stage entries** — so the rc 1 is a real conflict, not the tool always disagreeing. **Whichever of 1893 and 1927 merges second must rebase before it is merged; they must never be merged back to back unread.** Order is otherwise free.

Never merged by its author.


