### PR TITLE
feat(os): #1892 a debug build against a non-default registry pins it into the boot units and trusts its CA

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -174,9 +174,10 @@ Two build variants, chosen by one flag:
   over SSH. Verify with `tests/os/verify-image.sh IMAGE --test`. A bench that takes an A/B
   update to a *release* bundle loses SSH — deliberate, and worth remembering before pressing
   install. Built with `PITHEAD_REGISTRY` set to a non-default namespace, a debug image also
-  pins that registry into its boot units and marks it insecure for podman, so a bench box can
-  provision from a registry on the LAN (#1892); the release variant never carries either file,
-  and `verify-image.sh` checks both ways.
+  pins that registry into its boot units and tells podman how to trust it — the CA file named
+  by `PITHEAD_REGISTRY_CA` for a TLS registry, or an insecure entry without one — so a bench box
+  can provision from a registry on the LAN (#1892); the release variant never carries any of
+  those files, and `verify-image.sh` checks both ways.
 
 The updater defaults to RAUC; an image built without it cannot take another update, and the
 only way to get one now is to set `PITHEAD_UPDATER` to something else on purpose.

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -173,7 +173,10 @@ Two build variants, chosen by one flag:
   own `~/.ssh/id_ed25519.pub`) as root's authorized key and enables sshd, for benches driven
   over SSH. Verify with `tests/os/verify-image.sh IMAGE --test`. A bench that takes an A/B
   update to a *release* bundle loses SSH — deliberate, and worth remembering before pressing
-  install.
+  install. Built with `PITHEAD_REGISTRY` set to a non-default namespace, a debug image also
+  pins that registry into its boot units and marks it insecure for podman, so a bench box can
+  provision from a registry on the LAN (#1892); the release variant never carries either file,
+  and `verify-image.sh` checks both ways.
 
 The updater defaults to RAUC; an image built without it cannot take another update, and the
 only way to get one now is to set `PITHEAD_UPDATER` to something else on purpose.

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -69,6 +69,16 @@ fi
 # provision time for now — baking the full set is tracked with the appliance-size work.
 STACK_VERSION="v$(tr -d ' \t\r\n' <VERSION)"
 WIZARD_IMAGE="${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-dashboard:${STACK_VERSION}"
+# A DEBUG build against a non-default registry pins that registry into the image's boot units
+# and marks it insecure for podman (#1892). The wizard archive above is NAMED with the build-time
+# registry and first boot re-derives the same name at runtime, so the two must agree, and nothing
+# on the box sets the runtime half otherwise. Release builds never carry either file.
+TEST_REGISTRY=""
+if [ -n "${PITHEAD_TEST_SSH_PUBKEY:-}" ] && [ -n "${PITHEAD_REGISTRY:-}" ] &&
+    [ "$PITHEAD_REGISTRY" != "ghcr.io/p2pool-starter-stack" ]; then
+    TEST_REGISTRY="$PITHEAD_REGISTRY"
+    echo "==> debug build: the image will provision from $TEST_REGISTRY (insecure for podman)"
+fi
 mkdir -p os/rootfs/images
 echo "==> staging wizard image $WIZARD_IMAGE"
 if [ "${PITHEAD_WIZARD_FROM_REGISTRY:-0}" = "1" ]; then
@@ -121,6 +131,7 @@ trap 'rm -f "$build_log"' EXIT
 if ! docker build -f os/rootfs/Dockerfile -t "$ROOTFS_TAG" \
     --build-arg PITHEAD_TEST_SSH_PUBKEY="${PITHEAD_TEST_SSH_PUBKEY:-}" \
     --build-arg PITHEAD_TEST_MARKER="${PITHEAD_TEST_MARKER:-}" \
+    --build-arg PITHEAD_TEST_REGISTRY="$TEST_REGISTRY" \
     --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" \
     --build-arg APT_INDEX_STAMP="$apt_index_stamp" . 2>&1 | tee "$build_log"; then
     apt_fetch_failure_hint "$(cat "$build_log")"
@@ -130,4 +141,21 @@ cid=$(docker create "$ROOTFS_TAG")
 mkdir -p os/build
 docker export --output os/build/pithead-root.tar "$cid"
 docker rm "$cid" >/dev/null
+if [ -n "$TEST_REGISTRY" ]; then
+    # Appended to the exported rootfs rather than baked by the Dockerfile: the release rootfs is
+    # then byte-identical to a build that never heard of a test registry. Leaf files only — a
+    # directory entry would re-apply the staging dir's mode onto /etc on extraction.
+    stage="$(mktemp -d)"
+    for u in pithead-boot pithead-firstboot pithead-setup-again; do
+        mkdir -p "$stage/etc/systemd/system/$u.service.d"
+        printf '[Service]\nEnvironment=PITHEAD_REGISTRY=%s\n' "$TEST_REGISTRY" \
+            >"$stage/etc/systemd/system/$u.service.d/pithead-test-registry.conf"
+    done
+    mkdir -p "$stage/etc/containers/registries.conf.d"
+    printf '[[registry]]\nlocation = "%s"\ninsecure = true\n' "${TEST_REGISTRY%%/*}" \
+        >"$stage/etc/containers/registries.conf.d/pithead-test-registry.conf"
+    (cd "$stage" && find etc -type f) |
+        tar --append -f os/build/pithead-root.tar --owner=0 --group=0 --mode=0644 -C "$stage" -T -
+    rm -r "$stage"
+fi
 echo "==> rootfs: os/build/pithead-root.tar ($(du -h os/build/pithead-root.tar | cut -f1))"

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -140,7 +140,6 @@ trap 'rm -f "$build_log"' EXIT
 if ! docker build -f os/rootfs/Dockerfile -t "$ROOTFS_TAG" \
     --build-arg PITHEAD_TEST_SSH_PUBKEY="${PITHEAD_TEST_SSH_PUBKEY:-}" \
     --build-arg PITHEAD_TEST_MARKER="${PITHEAD_TEST_MARKER:-}" \
-    --build-arg PITHEAD_TEST_REGISTRY="$TEST_REGISTRY" \
     --build-arg PITHEAD_UPDATER="${PITHEAD_UPDATER:-rauc}" \
     --build-arg APT_INDEX_STAMP="$apt_index_stamp" . 2>&1 | tee "$build_log"; then
     apt_fetch_failure_hint "$(cat "$build_log")"

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -79,7 +79,10 @@ if [ -n "${PITHEAD_TEST_SSH_PUBKEY:-}" ] && [ -n "${PITHEAD_REGISTRY:-}" ] &&
     [ "$PITHEAD_REGISTRY" != "ghcr.io/p2pool-starter-stack" ]; then
     TEST_REGISTRY="$PITHEAD_REGISTRY"
     if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
-        [ -s "$PITHEAD_REGISTRY_CA" ] || { echo "PITHEAD_REGISTRY_CA: $PITHEAD_REGISTRY_CA is not a readable file" >&2; exit 1; }
+        [ -s "$PITHEAD_REGISTRY_CA" ] || {
+            echo "PITHEAD_REGISTRY_CA: $PITHEAD_REGISTRY_CA is not a readable file" >&2
+            exit 1
+        }
         echo "==> debug build: the image will provision from $TEST_REGISTRY (TLS, CA $PITHEAD_REGISTRY_CA)"
     else
         echo "==> debug build: the image will provision from $TEST_REGISTRY (insecure for podman)"

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -70,14 +70,20 @@ fi
 STACK_VERSION="v$(tr -d ' \t\r\n' <VERSION)"
 WIZARD_IMAGE="${PITHEAD_REGISTRY:-ghcr.io/p2pool-starter-stack}/pithead-dashboard:${STACK_VERSION}"
 # A DEBUG build against a non-default registry pins that registry into the image's boot units
-# and marks it insecure for podman (#1892). The wizard archive above is NAMED with the build-time
+# and tells podman how to trust it — a CA file (PITHEAD_REGISTRY_CA) for a TLS registry, else an
+# insecure (HTTP) entry (#1892). The wizard archive above is NAMED with the build-time
 # registry and first boot re-derives the same name at runtime, so the two must agree, and nothing
 # on the box sets the runtime half otherwise. Release builds never carry either file.
 TEST_REGISTRY=""
 if [ -n "${PITHEAD_TEST_SSH_PUBKEY:-}" ] && [ -n "${PITHEAD_REGISTRY:-}" ] &&
     [ "$PITHEAD_REGISTRY" != "ghcr.io/p2pool-starter-stack" ]; then
     TEST_REGISTRY="$PITHEAD_REGISTRY"
-    echo "==> debug build: the image will provision from $TEST_REGISTRY (insecure for podman)"
+    if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
+        [ -s "$PITHEAD_REGISTRY_CA" ] || { echo "PITHEAD_REGISTRY_CA: $PITHEAD_REGISTRY_CA is not a readable file" >&2; exit 1; }
+        echo "==> debug build: the image will provision from $TEST_REGISTRY (TLS, CA $PITHEAD_REGISTRY_CA)"
+    else
+        echo "==> debug build: the image will provision from $TEST_REGISTRY (insecure for podman)"
+    fi
 fi
 mkdir -p os/rootfs/images
 echo "==> staging wizard image $WIZARD_IMAGE"
@@ -151,9 +157,16 @@ if [ -n "$TEST_REGISTRY" ]; then
         printf '[Service]\nEnvironment=PITHEAD_REGISTRY=%s\n' "$TEST_REGISTRY" \
             >"$stage/etc/systemd/system/$u.service.d/pithead-test-registry.conf"
     done
-    mkdir -p "$stage/etc/containers/registries.conf.d"
-    printf '[[registry]]\nlocation = "%s"\ninsecure = true\n' "${TEST_REGISTRY%%/*}" \
-        >"$stage/etc/containers/registries.conf.d/pithead-test-registry.conf"
+    # containers/image reads /etc/containers/certs.d/<host:port>/ca.crt for a TLS registry; the
+    # insecure entry is the HTTP fallback. One or the other, never both.
+    if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
+        mkdir -p "$stage/etc/containers/certs.d/${TEST_REGISTRY%%/*}"
+        cp "$PITHEAD_REGISTRY_CA" "$stage/etc/containers/certs.d/${TEST_REGISTRY%%/*}/ca.crt"
+    else
+        mkdir -p "$stage/etc/containers/registries.conf.d"
+        printf '[[registry]]\nlocation = "%s"\ninsecure = true\n' "${TEST_REGISTRY%%/*}" \
+            >"$stage/etc/containers/registries.conf.d/pithead-test-registry.conf"
+    fi
     (cd "$stage" && find etc -type f) |
         tar --append -f os/build/pithead-root.tar --owner=0 --group=0 --mode=0644 -C "$stage" -T -
     rm -r "$stage"

--- a/tests/os/verify-image-variant.sh
+++ b/tests/os/verify-image-variant.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=bash
+# Sourced by verify-image.sh: the variant material — what a debug image must carry and a release
+# image must not (#1892 split it out for the file budget). Runs with the caller's $ROOT, $MODE and
+# chk; a debug build's test-registry pin and trust are asserted from the same PITHEAD_REGISTRY /
+# PITHEAD_REGISTRY_CA the builder was given.
+
+echo "==> test material"
+# The variant stamp must MATCH the material, not just exist: a debug image stamped "release"
+# defeats the os-update guard that keeps a debug box from silently dropping its own SSH.
+if [ "$MODE" = "--test" ]; then
+    chk "test SSH key present (harness build)" '[ -s "$ROOT/root/.ssh/authorized_keys" ]'
+    chk "variant stamp says debug" '[ "$(cat "$ROOT/etc/pithead-variant")" = "debug" ]'
+    # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
+    if [ -n "${PITHEAD_REGISTRY:-}" ] && [ "$PITHEAD_REGISTRY" != ghcr.io/p2pool-starter-stack ]; then
+        chk "boot units pinned to the test registry" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf"'
+        # The trust half is whichever the builder chose: the CA it was handed, byte for byte, or the insecure entry.
+        if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
+            chk "podman trusts the test registry's CA, and no insecure entry" 'cmp -s "$PITHEAD_REGISTRY_CA" "$ROOT/etc/containers/certs.d/${PITHEAD_REGISTRY%%/*}/ca.crt" && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ]'
+        else
+            chk "podman told the test registry is insecure, and no CA" 'grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && [ ! -e "$ROOT/etc/containers/certs.d" ]'
+        fi
+    fi
+else
+    # The reason this script exists in versioned form: a leaked test key on a release image is a
+    # backdoor, and ad-hoc eyeballing is how one ships.
+    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
+    chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
+    chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
+    chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'
+    # The keyring is the fleet's update trust root. A dev build auto-generates a CN=pithead-dev
+    # cert; if that baked as the release keyring, every device would trust a throwaway,
+    # unencrypted key with no offline backup — a backdoor of the same class as a leaked SSH key,
+    # so it is a hard fail here (the build guard should stop it upstream, this catches a slip at
+    # the artifact). A legitimately self-signed release root is fine — only the known dev CN is
+    # refused, so this never false-positives on a real single-cert keyring.
+    chk "keyring is NOT the dev signing cert (CN=pithead-dev)" \
+        '! openssl x509 -in "$ROOT/etc/rauc/keyring.pem" -noout -subject 2>/dev/null | grep -q "pithead-dev"'
+fi

--- a/tests/os/verify-image-variant.sh
+++ b/tests/os/verify-image-variant.sh
@@ -12,18 +12,18 @@ if [ "$MODE" = "--test" ]; then
     chk "variant stamp says debug" '[ "$(cat "$ROOT/etc/pithead-variant")" = "debug" ]'
     # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
     if [ -n "${PITHEAD_REGISTRY:-}" ] && [ "$PITHEAD_REGISTRY" != ghcr.io/p2pool-starter-stack ]; then
-        chk "boot units pinned to the test registry" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf"'
+        chk "all three boot units pinned to the test registry" '[ "$(grep -lxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT"/etc/systemd/system/{pithead-boot,pithead-firstboot,pithead-setup-again}.service.d/pithead-test-registry.conf 2>/dev/null | wc -l)" = 3 ]'
         # The trust half is whichever the builder chose: the CA it was handed, byte for byte, or the insecure entry.
         if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
             chk "podman trusts the test registry's CA, and no insecure entry" 'cmp -s "$PITHEAD_REGISTRY_CA" "$ROOT/etc/containers/certs.d/${PITHEAD_REGISTRY%%/*}/ca.crt" && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ]'
         else
-            chk "podman told the test registry is insecure, and no CA" 'grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && [ ! -e "$ROOT/etc/containers/certs.d" ]'
+            chk "podman told the test registry is insecure, and no CA" 'grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && grep -qxF "insecure = true" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && [ ! -e "$ROOT/etc/containers/certs.d" ]'
         fi
     fi
 else
     # The reason this script exists in versioned form: a leaked test key on a release image is a
     # backdoor, and ad-hoc eyeballing is how one ships.
-    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
+    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && ! ls "$ROOT"/etc/systemd/system/*/pithead-test-registry.conf >/dev/null 2>&1'
     chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
     chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -300,13 +300,11 @@ echo "==> host identity never ships baked (#894/#895)"
 # host identity underneath it must be exactly as per-machine as a release image's.
 chk "no SSH host keys baked (extractable + shared across every machine otherwise)" \
     '! ls "$ROOT"/etc/ssh/ssh_host_* >/dev/null 2>&1'
-chk "machine-id ships empty (systemd's own read-only-root first-boot semantics)" \
-    '[ ! -s "$ROOT/etc/machine-id" ]'
+chk "machine-id ships empty (systemd's own read-only-root first-boot semantics)" '[ ! -s "$ROOT/etc/machine-id" ]'
 # systemd's first-boot logic PREFERS /var/lib/dbus/machine-id when it exists — dbus's postinst
 # bakes one at build, and a baked copy gives every machine flashed from this release the SAME
 # identity. The symlink makes dbus follow the per-machine /etc/machine-id instead.
-chk "dbus machine-id is a symlink (no per-release baked identity)" \
-    '[ -L "$ROOT/var/lib/dbus/machine-id" ]'
+chk "dbus machine-id is a symlink (no per-release baked identity)" '[ -L "$ROOT/var/lib/dbus/machine-id" ]'
 chk "SSH host-key generator baked and executable" '[ -x "$ROOT/usr/local/sbin/pithead-ssh-host-keys" ]'
 chk "ssh.service host-key drop-in orders after /data" \
     'grep -q "RequiresMountsFor=/data" "$ROOT/etc/systemd/system/ssh.service.d/pithead-host-keys.conf"'
@@ -362,10 +360,12 @@ echo "==> test material"
 if [ "$MODE" = "--test" ]; then
     chk "test SSH key present (harness build)" '[ -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "variant stamp says debug" '[ "$(cat "$ROOT/etc/pithead-variant")" = "debug" ]'
+    # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
+    [ -z "${PITHEAD_REGISTRY:-}" ] || [ "$PITHEAD_REGISTRY" = ghcr.io/p2pool-starter-stack ] || chk "boot units pinned to the test registry, podman told to trust it" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf" && grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf"'
 else
     # The reason this script exists in versioned form: a leaked test key on a release image is a
     # backdoor, and ad-hoc eyeballing is how one ships.
-    chk "NO test marker" '[ ! -e "$ROOT/etc/pithead-test-marker" ]'
+    chk "NO test marker, NO test registry pin (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
     chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
     chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -361,11 +361,19 @@ if [ "$MODE" = "--test" ]; then
     chk "test SSH key present (harness build)" '[ -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "variant stamp says debug" '[ "$(cat "$ROOT/etc/pithead-variant")" = "debug" ]'
     # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
-    [ -z "${PITHEAD_REGISTRY:-}" ] || [ "$PITHEAD_REGISTRY" = ghcr.io/p2pool-starter-stack ] || chk "boot units pinned to the test registry, podman told to trust it" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf" && grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf"'
+    if [ -n "${PITHEAD_REGISTRY:-}" ] && [ "$PITHEAD_REGISTRY" != ghcr.io/p2pool-starter-stack ]; then
+        chk "boot units pinned to the test registry" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf"'
+        # The trust half is whichever the builder chose: the CA it was handed, byte for byte, or the insecure entry.
+        if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
+            chk "podman trusts the test registry's CA, and no insecure entry" 'cmp -s "$PITHEAD_REGISTRY_CA" "$ROOT/etc/containers/certs.d/${PITHEAD_REGISTRY%%/*}/ca.crt" && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ]'
+        else
+            chk "podman told the test registry is insecure, and no CA" 'grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && [ ! -e "$ROOT/etc/containers/certs.d" ]'
+        fi
+    fi
 else
     # The reason this script exists in versioned form: a leaked test key on a release image is a
     # backdoor, and ad-hoc eyeballing is how one ships.
-    chk "NO test marker, NO test registry pin (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
+    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
     chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
     chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -354,38 +354,8 @@ chk "blanket disable preset baked (first-boot preset-all must be a no-op)" \
 chk "systemd-firstboot masked (every boot is a first boot with an empty machine-id)" \
     '[ "$(readlink "$ROOT/etc/systemd/system/systemd-firstboot.service")" = "/dev/null" ]'
 
-echo "==> test material"
-# The variant stamp must MATCH the material, not just exist: a debug image stamped "release"
-# defeats the os-update guard that keeps a debug box from silently dropping its own SSH.
-if [ "$MODE" = "--test" ]; then
-    chk "test SSH key present (harness build)" '[ -s "$ROOT/root/.ssh/authorized_keys" ]'
-    chk "variant stamp says debug" '[ "$(cat "$ROOT/etc/pithead-variant")" = "debug" ]'
-    # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
-    if [ -n "${PITHEAD_REGISTRY:-}" ] && [ "$PITHEAD_REGISTRY" != ghcr.io/p2pool-starter-stack ]; then
-        chk "boot units pinned to the test registry" 'grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" && grep -qxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/systemd/system/pithead-firstboot.service.d/pithead-test-registry.conf"'
-        # The trust half is whichever the builder chose: the CA it was handed, byte for byte, or the insecure entry.
-        if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
-            chk "podman trusts the test registry's CA, and no insecure entry" 'cmp -s "$PITHEAD_REGISTRY_CA" "$ROOT/etc/containers/certs.d/${PITHEAD_REGISTRY%%/*}/ca.crt" && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ]'
-        else
-            chk "podman told the test registry is insecure, and no CA" 'grep -qF "location = \"${PITHEAD_REGISTRY%%/*}\"" "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" && [ ! -e "$ROOT/etc/containers/certs.d" ]'
-        fi
-    fi
-else
-    # The reason this script exists in versioned form: a leaked test key on a release image is a
-    # backdoor, and ad-hoc eyeballing is how one ships.
-    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && [ ! -e "$ROOT/etc/systemd/system/pithead-boot.service.d/pithead-test-registry.conf" ]'
-    chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
-    chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
-    chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'
-    # The keyring is the fleet's update trust root. A dev build auto-generates a CN=pithead-dev
-    # cert; if that baked as the release keyring, every device would trust a throwaway,
-    # unencrypted key with no offline backup — a backdoor of the same class as a leaked SSH key,
-    # so it is a hard fail here (the build guard should stop it upstream, this catches a slip at
-    # the artifact). A legitimately self-signed release root is fine — only the known dev CN is
-    # refused, so this never false-positives on a real single-cert keyring.
-    chk "keyring is NOT the dev signing cert (CN=pithead-dev)" \
-        '! openssl x509 -in "$ROOT/etc/rauc/keyring.pem" -noout -subject 2>/dev/null | grep -q "pithead-dev"'
-fi
+# shellcheck source=tests/os/verify-image-variant.sh
+. "$SCRIPT_DIR/verify-image-variant.sh"
 
 echo ""
 printf 'verify-image: \033[1;32m%d passed\033[0m, ' "$PASS"

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -354,6 +354,12 @@ chk "blanket disable preset baked (first-boot preset-all must be a no-op)" \
 chk "systemd-firstboot masked (every boot is a first boot with an empty machine-id)" \
     '[ "$(readlink "$ROOT/etc/systemd/system/systemd-firstboot.service")" = "/dev/null" ]'
 
+# The sibling carries the refusals that stop a debug image shipping as a release; this script runs
+# without -e, so a missing sibling must refuse here rather than source nothing and report clean.
+[ -r "$SCRIPT_DIR/verify-image-variant.sh" ] || {
+    echo "verify-image: $SCRIPT_DIR/verify-image-variant.sh is missing — refusing to report" >&2
+    exit 2
+}
 # shellcheck source=tests/os/verify-image-variant.sh
 . "$SCRIPT_DIR/verify-image-variant.sh"
 


### PR DESCRIPTION
Closes #1892.

## What changes

A debug build (`--ssh`) run with `PITHEAD_REGISTRY` set to a non-default namespace now produces an image that provisions from that registry end to end, instead of from the org's packages:

- `os/build-image.sh` appends three systemd drop-ins (`pithead-boot`, `pithead-firstboot`, `pithead-setup-again`) carrying `Environment=PITHEAD_REGISTRY=<value>` to the exported rootfs, so the runtime half matches the build-time half the wizard archive was named with. Nothing on the box set it before, so a build-time/runtime mismatch made first boot look for a wizard image it did not have. #1844 landed the `pithead-setup-again` unit on the base this branch is rebased onto, so all three pins are live.
- Trust is whichever the builder chose: `PITHEAD_REGISTRY_CA=<file>` bakes the CA to `/etc/containers/certs.d/<host:port>/ca.crt` (containers/image's per-registry trust dir, so podman speaks TLS with no insecure flag); without it, a `registries.conf.d` entry marks the registry `insecure = true` as the HTTP fallback. One or the other, never both.
- The files are appended to the exported tar, not baked by the Dockerfile, so the release rootfs is byte-identical to a build that never heard of a test registry. Leaf files only: a directory entry would re-apply the staging dir's mode onto `/etc`.
- `tests/os/verify-image.sh` in `--test` mode asserts the boot-unit pins and whichever trust file the builder chose, and refuses the other; release mode refuses all of them (test marker, registry pin, `certs.d`, insecure entry). The variant material (what a debug image must carry and a release image must not) moved into a sourced sibling, `tests/os/verify-image-variant.sh`, so the main script stays under the file budget's target.
- `docs/dev/appliance-release.md` gains one sentence under the build variants.

## What was RUN

- `bash -n` on both scripts: clean.
- `shellcheck -x os/build-image.sh tests/os/verify-image.sh`: 113 findings, all `(info)` and all pre-existing (SC2016 on the single-quoted `chk` conditions the file uses throughout; SC2317 at `build-image.sh:63`). Zero warning or error.
- After the rebase onto the develop tip (no conflicts): `bash -n` on all three scripts clean; `scripts/lint-file-budget.sh`: `file budget OK`; `make lint-docs-voice`: OK, 41 prose docs.
- **KVM proof, run 2 (PROVEN by me on the pre-rebase head; the rebase is patch-identical and touched no file the run reads):** `tests/os/run.sh --phase provision --keep` under `sudo` with `PITHEAD_REGISTRY` and `PITHEAD_REGISTRY_CA` exported, so `_build_image` bakes the pin and the CA: os harness **49 passed, 0 failed**, chain rc 0. `verify-image.sh --test` on the rootfs that run built: **105 passed, 0 failed**, including "boot units pinned to the test registry" and "podman trusts the test registry's CA, and no insecure entry". In the kept guest, read over SSH after the run: `podman images` lists all five stack images under the test registry's namespace at the tree's version tag and no copy from the org's registry; the running `tor`, `monerod` and `dashboard` containers name those images; `systemctl show -p Environment` on `pithead-boot` and `pithead-firstboot` carries the pin. The registry's own access log was NOT the discriminator: the daemon's port proxy rewrites every client address to the bridge gateway, so a guest fetch and a host fetch are indistinguishable there. The guest-side image list and unit environment are the evidence. The registry's address is topology and does not appear here.
- A first proof run was VOID and is recorded so nobody repeats it: `tests/os/run.sh`'s provision phase rebuilds its image through `_build_image` and ignores `--image` (only the boot phase boots the file it is given), and that run invoked it under `sudo` without `PITHEAD_REGISTRY` / `PITHEAD_REGISTRY_CA`, so the guest booted an unpinned rootfs and provisioned from the org's registry while the harness reported 49 passed. The tell was the discriminating instrument, not the harness: the registry's access log had no fetch from the guest, and the first-boot journal named the org's registry in every pull. The drop-in mechanism itself was proven on that guest with a control drop-in on `pithead-firstboot.service` read back through `systemctl show -p Environment`.

## What was NOT done

- No tier-1 test of the tar-append itself beyond `verify-image.sh`'s reads of the finished rootfs; the KVM leg is the behavioural check.
- The appliance's own provision pull remains unverified by cosign (#1891, separate finding). This PR changes only how podman trusts the registry, not whether the pull is signature-checked.
- The host-side verifier (`cosign_run`) has no path to a private CA without a code change to a release path; that is a seat decision recorded outside this PR.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this lane's cwd and is a one-shot prompt, not a proof)

- Two build-time variables (`PITHEAD_REGISTRY`, `PITHEAD_REGISTRY_CA`) rather than one: the registry is a name the compose file already reads; the CA is a file. Folding both into one value was available and rejected because the release build reads the first and must never see the second.
- Both trust routes kept rather than TLS only: the registry the RC images live in may end up HTTP if TLS proves impractical on the host side, and the fallback is four lines.
- Dockerfile `ARG` route was available and rejected: it would bake the registry into the image layer and change the release rootfs's bytes for a debug-only concern.
- Files touched: `os/build-image.sh`, `tests/os/verify-image.sh`, `tests/os/verify-image-variant.sh` (this lane's paths) and `docs/dev/appliance-release.md` (shared `docs/`, disclosed per COMMON). One sibling rather than a second `chk` file per variant: release mode's refusals and test mode's assertions read the same paths, so one file holds both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
