### PR TITLE
feat(wizard): #1855 #1848 the setup page can decline merge-mining, and a new machine arrives declining it

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ mining, and the **Compose stack** you run on a host you manage.
 ## What it does
 
 - ⛏️ **P2Pool payouts, Tari merge-mined.** Mines Monero on [P2Pool](https://p2pool.io/): no pool
-  operator, no fee, rewards paid to your own wallet. Every hash merge-mines Tari on the same work.
+  operator, no fee, rewards paid to your own wallet. Every hash can merge-mine Tari on the same
+  work — the appliance's setup wizard asks, and a machine that declines mines Monero alone.
 - 🧠 **XvB switching engine.** Watches the XMRvsBeast raffle and shifts hashrate to hold your tier,
   donating the minimum needed and routing the rest to your P2Pool payouts.
 - 🧅 **Tor-first networking.** A built-in Tor daemon gives P2Pool an onion address, and the Monero

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -19,6 +19,7 @@ import {
 import { Component, html, render } from "./preact.mjs";
 import { rigCardFields, rigCardNote } from "./rigcardlogic.mjs";
 import { savedRoleOrSetup } from "./savedrole.mjs";
+import { TariSection, tariAnswer, XvbField } from "./wizardmining.mjs";
 import { Err, Field, Note } from "./wizardparts.mjs";
 
 // The simple questions, each bound to its config path. Conditional blocks name the field that
@@ -39,6 +40,7 @@ const FIELDS = {
   tariRemoteGrpc: { path: "tari.remote.grpc_port" },
   pool: { path: "p2pool.pool" },
   localMiner: { path: "local_miner.enabled" },
+  xvb: { path: "xvb.enabled" },
   clearnetSync: { path: "monero.clearnet_initial_sync" },
   healthchecks: { path: "healthchecks.ping_url" },
   telegramToken: { path: "telegram.bot_token" },
@@ -589,7 +591,7 @@ export class WizardApp extends Component {
     const addr = classifyMoneroAddress(v("moneroWallet"));
     const tg = telegramPairReady(v("telegramToken"), v("telegramChat"));
     const remoteMonero = v("moneroMode") === "remote";
-    const remoteTari = v("tariMode") === "remote";
+    const tariMode = tariAnswer(v("tariMode"));
     const { installer, disks, chosen, confirm, wipe, dataWiped } = this.state;
     // The select is stored for a rig and read out of the config for the two coordinators.
     const role = this.state.role || (v("localMiner") ? "both" : "pithead");
@@ -660,8 +662,8 @@ export class WizardApp extends Component {
               diskPicked &&
               !keepEverything &&
               !rig &&
-              html`<h3>Payout addresses</h3>
-            <${Note}>Paste these — they are far too long to type, and a typo pays a stranger.<//>
+              html`<h3>Payout address</h3>
+            <${Note}>Paste it — it is far too long to type, and a typo pays a stranger.<//>
             <${Field} label="Monero payout address">
                 <input class="wizard-mono" value=${v("moneroWallet") || ""} onInput=${on("moneroWallet")}
                     autocomplete="off" autocapitalize="off" spellcheck=${false}
@@ -670,12 +672,6 @@ export class WizardApp extends Component {
             <p class=${addr.kind === "ok" || addr.kind === "empty" || addr.kind === "partial" ? "text-muted" : "c-bad"}>
                 ${addr.message}
             </p>
-            <${Field} label="Tari payout address">
-                <input class="wizard-mono" value=${v("tariWallet") || ""} onInput=${on("tariWallet")}
-                    autocomplete="off" autocapitalize="off" spellcheck=${false} required />
-            <//>
-            <${Note}>Merge-mining earns Tari from the same work that mines Monero — this stack
-            always does both, so it needs both addresses.<//>
 
             <h3>Monero node</h3>
             <${Field} label="Where does Monero data come from?">
@@ -710,28 +706,7 @@ export class WizardApp extends Component {
                 : null
             }
 
-            <h3>Tari node</h3>
-            <${Field} label="Where does Tari data come from?">
-                <select value=${remoteTari ? "remote" : "local"} onChange=${on("tariMode")}>
-                    <option value="local">Run the bundled node on this machine (default)</option>
-                    <option value="remote">Use a Tari node I already run</option>
-                </select>
-            <//>
-            ${
-              remoteTari &&
-              html`<div class="wizard-when">
-                <${Field} label="Node host">
-                    <input value=${v("tariRemoteHost") || ""} onInput=${on("tariRemoteHost")}
-                        placeholder="192.168.1.10 or my-node.local" autocomplete="off" spellcheck=${false} />
-                <//>
-                <${Field} label="gRPC port">
-                    <input value=${v("tariRemoteGrpc") ?? 18142} onInput=${on("tariRemoteGrpc")}
-                        inputmode="numeric" pattern="[0-9]+" />
-                <//>
-                <${Note}>An IP or a hostname both work. Only over a network you trust — this
-                connection is not encrypted.<//>
-            </div>`
-            }
+            <${TariSection} answer=${tariMode} v=${v} on=${on} />
 
             
             <h3>Mining</h3>
@@ -759,6 +734,7 @@ export class WizardApp extends Component {
                 CPU governor, memory reservations — which is exactly what a dedicated
                 appliance is for.<//>`
             }
+            <${XvbField} v=${v} on=${on} />
 
             <h3>First sync</h3>
             <${Field} label="Downloading the chain the first time">
@@ -816,9 +792,12 @@ export class WizardApp extends Component {
                         <option value="false">Full — about 320 GB (only if you need the whole chain)</option>
                     </select>
                 <//>
-                <${Note}>A local Tari node adds about 170 GB on top. Under roughly 350 GB of
-                disk, pruned Monero plus a ${" "}<em>remote</em>${" "}Tari node is the
-                combination that fits.<//>`
+                ${
+                  tariMode !== "off" &&
+                  html`<${Note}>A local Tari node adds about 170 GB on top. Under roughly 350 GB
+                    of disk, pruned Monero plus a ${" "}<em>remote</em>${" "}Tari node is the
+                    combination that fits.<//>`
+                }`
                 }
                 <${Field} label="Healthchecks.io ping URL">
                     <input value=${v("healthchecks") || ""} onInput=${on("healthchecks")}

--- a/dashboard/mining_dashboard/web/static/wizardmining.mjs
+++ b/dashboard/mining_dashboard/web/static/wizardmining.mjs
@@ -1,0 +1,88 @@
+// The wizard's two opt-in mining questions: whether this machine merge-mines Tari (#1855) and
+// whether it joins the XvB raffle (#1848). They live here rather than in wizard.mjs because that
+// file is at its budget ceiling, and because the Tari answer is not a boolean — it decides
+// whether a whole block of the form exists — so the mapping from a stored `tari.mode` to the
+// answer shown is worth proving without a browser.
+
+import { html } from "./preact.mjs";
+import { Field, Note } from "./wizardparts.mjs";
+
+/**
+ * Which of the three answers a stored `tari.mode` is, for the select to show.
+ *
+ * Only the literal "off" reads as declined. Everything else — a missing key included — is a yes,
+ * because that is what the host does with a config written before the question existed
+ * (`lib/pithead/28-parse-and-validate-config.sh`: no key means `local`). Reading an absent key as
+ * "off" would show an upgraded 1.x install as having declined merge-mining, and submitting that
+ * screen would then write the decline back.
+ *
+ * The opposite coercion is what this replaces: the select used to be `remoteTari ? "remote" :
+ * "local"`, which had no way to say "off" at all — a machine that had declined rendered as
+ * "local" and submit wrote `local` back, silently re-enabling the merge-mining its operator
+ * turned down.
+ */
+export function tariAnswer(mode) {
+  if (mode === "off") return "off";
+  return mode === "remote" ? "remote" : "local";
+}
+
+/**
+ * The Tari merge-mining question and everything that hangs off a yes.
+ *
+ * The payout address moved in here from the Payout addresses section: a machine that does not
+ * merge-mine has nowhere to be paid in Tari, and the field carried `required`, so leaving it up
+ * there would have blocked submit on a form that never asks the question. `required` stays on it
+ * for a yes — that is the same bar the Monero address holds.
+ */
+export const TariSection = ({ answer, v, on }) => html`<h3>Tari merge-mining</h3>
+    <${Field} label="Merge-mine Tari?">
+        <select value=${answer} onChange=${on("tariMode")}>
+            <option value="off">No — mine Monero only (default)</option>
+            <option value="local">Yes — run a Tari node on this machine</option>
+            <option value="remote">Yes — use a Tari node I already run</option>
+        </select>
+    <//>
+    <${Note}>Merge-mining earns Tari from the same work that mines Monero, so it costs no
+    hashrate — but it needs its own payout address and a node of its own, and the bundled node
+    wants about 170 GB of disk on top of Monero's. You can turn it on later from the dashboard's
+    Configuration view.<//>
+    ${
+      answer !== "off" &&
+      html`<div class="wizard-when">
+        <${Field} label="Tari payout address">
+            <input class="wizard-mono" value=${v("tariWallet") || ""} onInput=${on("tariWallet")}
+                autocomplete="off" autocapitalize="off" spellcheck=${false} required />
+        <//>
+        <${Note}>Paste it — like the Monero address, it is far too long to type, and a typo pays
+        a stranger.<//>
+        ${
+          answer === "remote" &&
+          html`<${Field} label="Node host">
+            <input value=${v("tariRemoteHost") || ""} onInput=${on("tariRemoteHost")}
+                placeholder="192.168.1.10 or my-node.local" autocomplete="off" spellcheck=${false} />
+        <//>
+        <${Field} label="gRPC port">
+            <input value=${v("tariRemoteGrpc") ?? 18142} onInput=${on("tariRemoteGrpc")}
+                inputmode="numeric" pattern="[0-9]+" />
+        <//>
+        <${Note}>An IP or a hostname both work. Only over a network you trust — this connection
+        is not encrypted.<//>`
+        }
+      </div>`
+    }`;
+
+/**
+ * The raffle switch (#1848). Opt-OUT, unlike Tari: `xvb.enabled` is true in the reference, so the
+ * default answer here is the one a machine already had, and only a No changes anything. There is
+ * no follow-up question by design — the donor id and tier keep their defaults and stay editable
+ * from the dashboard, which is where the raffle's own decision table lives.
+ */
+export const XvbField = ({ v, on }) => html`<${Field} label="Join the XMRvsBeast raffle?">
+        <select value=${String(v("xvb") ?? true)} onChange=${on("xvb")}>
+            <option value="true">Yes — donate a slice of hashrate to the raffle (default)</option>
+            <option value="false">No — send everything to P2Pool</option>
+        </select>
+    <//>
+    <${Note}>The switching engine donates only enough hashrate to hold your target tier and routes
+    everything else to P2Pool. Donating above a tier's threshold earns nothing extra, because the
+    raffle picks its winners at random.<//>`;

--- a/dashboard/mining_dashboard/web/static/wizardmining.mjs
+++ b/dashboard/mining_dashboard/web/static/wizardmining.mjs
@@ -7,33 +7,29 @@
 import { html } from "./preact.mjs";
 import { Field, Note } from "./wizardparts.mjs";
 
-/**
- * Which of the three answers a stored `tari.mode` is, for the select to show.
- *
- * Only the literal "off" reads as declined. Everything else — a missing key included — is a yes,
- * because that is what the host does with a config written before the question existed
- * (`lib/pithead/28-parse-and-validate-config.sh`: no key means `local`). Reading an absent key as
- * "off" would show an upgraded 1.x install as having declined merge-mining, and submitting that
- * screen would then write the decline back.
- *
- * The opposite coercion is what this replaces: the select used to be `remoteTari ? "remote" :
- * "local"`, which had no way to say "off" at all — a machine that had declined rendered as
- * "local" and submit wrote `local` back, silently re-enabling the merge-mining its operator
- * turned down.
- */
+// Which of the three answers a stored `tari.mode` is, for the select to show.
+//
+// Only the literal "off" reads as declined. Everything else — a missing key included — is a yes,
+// because that is what the host does with a config written before the question existed
+// (`lib/pithead/28-parse-and-validate-config.sh`: no key means `local`). Reading an absent key as
+// "off" would show an upgraded 1.x install as having declined merge-mining, and submitting that
+// screen would then write the decline back.
+//
+// The opposite coercion is what this replaces: the select used to be `remoteTari ? "remote" :
+// "local"`, which had no way to say "off" at all — a machine that had declined rendered as
+// "local" and submit wrote `local` back, silently re-enabling the merge-mining its operator
+// turned down.
 export function tariAnswer(mode) {
   if (mode === "off") return "off";
   return mode === "remote" ? "remote" : "local";
 }
 
-/**
- * The Tari merge-mining question and everything that hangs off a yes.
- *
- * The payout address moved in here from the Payout addresses section: a machine that does not
- * merge-mine has nowhere to be paid in Tari, and the field carried `required`, so leaving it up
- * there would have blocked submit on a form that never asks the question. `required` stays on it
- * for a yes — that is the same bar the Monero address holds.
- */
+// The Tari merge-mining question and everything that hangs off a yes.
+//
+// The payout address moved in here from the Payout addresses section: a machine that does not
+// merge-mine has nowhere to be paid in Tari, and the field carried `required`, so leaving it up
+// there would have blocked submit on a form that never asks the question. `required` stays on it
+// for a yes — that is the same bar the Monero address holds.
 export const TariSection = ({ answer, v, on }) => html`<h3>Tari merge-mining</h3>
     <${Field} label="Merge-mine Tari?">
         <select value=${answer} onChange=${on("tariMode")}>
@@ -71,12 +67,10 @@ export const TariSection = ({ answer, v, on }) => html`<h3>Tari merge-mining</h3
       </div>`
     }`;
 
-/**
- * The raffle switch (#1848). Opt-OUT, unlike Tari: `xvb.enabled` is true in the reference, so the
- * default answer here is the one a machine already had, and only a No changes anything. There is
- * no follow-up question by design — the donor id and tier keep their defaults and stay editable
- * from the dashboard, which is where the raffle's own decision table lives.
- */
+// The raffle switch (#1848). Opt-OUT, unlike Tari: `xvb.enabled` is true in the reference, so the
+// default answer here is the one a machine already had, and only a No changes anything. There is
+// no follow-up question by design — the donor id and tier keep their defaults and stay editable
+// from the dashboard, which is where the raffle's own decision table lives.
 export const XvbField = ({ v, on }) => html`<${Field} label="Join the XMRvsBeast raffle?">
         <select value=${String(v("xvb") ?? true)} onChange=${on("xvb")}>
             <option value="true">Yes — donate a slice of hashrate to the raffle (default)</option>

--- a/dashboard/mining_dashboard/web/static/wizardmining.mjs
+++ b/dashboard/mining_dashboard/web/static/wizardmining.mjs
@@ -40,8 +40,8 @@ export const TariSection = ({ answer, v, on }) => html`<h3>Tari merge-mining</h3
     <//>
     <${Note}>Merge-mining earns Tari from the same work that mines Monero, so it costs no
     hashrate — but it needs its own payout address and a node of its own, and the bundled node
-    wants about 170 GB of disk on top of Monero's. You can turn it on later from the dashboard's
-    Configuration view.<//>
+    wants about 170 GB of disk on top of Monero's. Turning it on later means setting this machine
+    up again from the boot menu — the Configuration view does not carry this switch.<//>
     ${
       answer !== "off" &&
       html`<div class="wizard-when">

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -130,6 +130,18 @@ def _last_attempt() -> dict:
     return _spool_json("last-attempt.json")
 
 
+# What a machine that has NEVER been configured is served, for the answers where the PAGE's
+# default and the REFERENCE's differ. `local_miner.enabled` was always one. `tari.mode` joins it
+# for #1855: merge-mining is opt-in on a new machine, while config.reference.json keeps
+# `tari.mode: "local"` and must keep it — the reference is the default for a config that ALREADY
+# EXISTS, so flipping it there would stop merge-mining on every upgraded install.
+#
+# It reaches the page only through the `or` below, so it is exactly the never-configured case. A
+# pre-seed, a reinstall pre-fill or a rejected submission is a machine that HAS answers; each of
+# those wins whole and is never handed this.
+_NEW_MACHINE_ANSWERS = {"local_miner": {"enabled": True}, "tari": {"mode": "off"}}
+
+
 def _rig_defaults() -> dict:
     """The rig role's pre-fill, published by the HOST like the disk inventory: a Pithead pool
     discovered on the LAN (when one answered) and this machine's own name for the worker
@@ -254,7 +266,7 @@ async def wizard_state(request: web.Request) -> web.Response:
             "stage": stage,
             # Kept for the field's original meaning; `stage` is what the client renders from.
             "mode": "installer" if installer_mode() else "setup",
-            "config": _deep_merge(ref, _last_attempt() or {"local_miner": {"enabled": True}}),
+            "config": _deep_merge(ref, _last_attempt() or _NEW_MACHINE_ANSWERS),
             "reference": ref,
             "error": _spool_read("error.txt"),
             "disks": _disks(),

--- a/dashboard/mining_dashboard/wizard_form.py
+++ b/dashboard/mining_dashboard/wizard_form.py
@@ -26,9 +26,22 @@ def build_config(form: dict) -> dict:
 
     cfg: dict = {
         "monero": {"wallet_address": s_("monero_wallet")},
-        "tari": {"wallet_address": s_("tari_wallet")},
         "p2pool": {"pool": s_("pool") or "mini", "stratum_password": "auto"},
     }
+
+    # Merge-mining Tari is opt-in, and "off" is what a new machine gets (#1855). The mode is
+    # written EXPLICITLY on every submit, which is the one place this function departs from the
+    # omit-and-inherit rule above, and it departs on purpose: a config with no tari.mode still
+    # parses as "local", so omitting the key would quietly merge-mine on a machine whose
+    # operator answered No. The default is only right for configs written before the question
+    # existed; it is wrong for every answer this form collects.
+    tari_mode = s_("tari_mode") or "off"
+    cfg["tari"] = {"mode": tari_mode}
+    if tari_mode != "off":
+        # A machine that does not merge-mine has nowhere to be paid, so the key is omitted
+        # rather than sent empty. When it DOES merge-mine, an empty value still flows through
+        # so the HOST produces the rejection, as it does for the Monero address.
+        cfg["tari"]["wallet_address"] = s_("tari_wallet")
 
     if form.get("monero_mode") == "remote":
         cfg["monero"]["mode"] = "remote"
@@ -41,8 +54,7 @@ def build_config(form: dict) -> dict:
             cfg["monero"]["node_username"] = s_("monero_remote_user")
             cfg["monero"]["node_password"] = s_("monero_remote_pass")
 
-    if form.get("tari_mode") == "remote":
-        cfg["tari"]["mode"] = "remote"
+    if tari_mode == "remote":
         cfg["tari"]["remote"] = {
             "host": s_("tari_remote_host"),
             "grpc_port": port("tari_remote_grpc", 18142),
@@ -65,6 +77,12 @@ def build_config(form: dict) -> dict:
 
     if form.get("local_miner"):
         cfg["local_miner"] = {"enabled": True}
+
+    # The raffle is opt-out: xvb.enabled is true in config.reference.json, so only the OFF
+    # answer is worth writing. Writing True would pin a default the operator never chose to
+    # pin, and pinning it is what makes a later change to the reference not reach this machine.
+    if s_("xvb") == "false":
+        cfg["xvb"] = {"enabled": False}
 
     if form.get("clearnet_sync") == "true":
         cfg["monero"]["clearnet_initial_sync"] = True

--- a/dashboard/tests/frontend/wizard.test.mjs
+++ b/dashboard/tests/frontend/wizard.test.mjs
@@ -306,7 +306,7 @@ async function appWithPick(chosen, wipe) {
 
 test("keep everything: the whole config half disappears — the survivor config wins", async () => {
   const out = await appWithPick("sda", "keep");
-  assert.doesNotMatch(out, /Payout addresses/);
+  assert.doesNotMatch(out, /Payout address/);
   assert.doesNotMatch(out, /Dashboard login/);
   assert.doesNotMatch(out, /Advanced/);
   assert.match(out, /keeps everything/);
@@ -318,9 +318,9 @@ test("keep the blockchains still asks the node questions — kept chains only an
   // sections forced Tari local and re-downloaded the very chain remote mode avoids (bench).
   const out = await appWithPick("sda", "data");
   assert.match(out, /Where does Monero data come from/);
-  assert.match(out, /Where does Tari data come from/);
+  assert.match(out, /Merge-mine Tari\?/);
   assert.match(out, /First sync/);
-  assert.match(out, /Payout addresses/);
+  assert.match(out, /Payout address/);
   assert.match(out, /Dashboard login/);
 });
 
@@ -329,7 +329,7 @@ test("wipe everything (or an empty disk): the full form asks everything", async 
   assert.match(all, /Where does Monero data come from/);
   assert.match(all, /First sync/);
   const empty = await appWithPick("sdb", "keep");
-  assert.match(empty, /Payout addresses/);
+  assert.match(empty, /Payout address/);
 });
 
 test("chain size, healthchecks and time zone sit under Advanced, not the first-run form", async () => {
@@ -344,7 +344,7 @@ test("chain size, healthchecks and time zone sit under Advanced, not the first-r
     assert.ok(at > advancedAt, `${label} should render inside the Advanced pane, not the main form`);
   }
   // The primary form's own headings stay above Advanced, unmoved.
-  for (const label of ["Payout addresses", "Dashboard login", "Alerts"]) {
+  for (const label of ["Payout address", "Dashboard login", "Alerts"]) {
     assert.ok(all.indexOf(label) < advancedAt, `${label} should stay in the primary form`);
   }
 });
@@ -438,7 +438,7 @@ test("role Pithead + RigForge presets the local-miner switch and keeps the full 
   inst.setRole({ target: { value: "both" } });
   assert.equal(inst.state.cfg.local_miner.enabled, true);
   const out = renderToString(inst.render());
-  assert.match(out, /Payout addresses/); // still Pithead's form — no new UI beyond the select
+  assert.match(out, /Payout address/); // still Pithead's form — no new UI beyond the select
   assert.match(out, /Nothing to install/); // the preset shows as the live switch's Yes note
   // Back to plain Pithead: the documented default returns — today's config, byte for byte.
   inst.setRole({ target: { value: "pithead" } });
@@ -453,7 +453,7 @@ test("role RigForge collapses the form to pool, worker, password — none of the
   assert.match(out, /Pool address/);
   assert.match(out, /Worker name/);
   assert.match(out, /Stratum password/);
-  assert.doesNotMatch(out, /Payout addresses/);
+  assert.doesNotMatch(out, /Payout address/);
   assert.doesNotMatch(out, /Dashboard login/);
   assert.doesNotMatch(out, /Advanced/);
   assert.doesNotMatch(out, /First sync/);
@@ -579,13 +579,13 @@ test("before a disk is chosen, the page asks ONLY that", async () => {
   const out = renderToString(inst.render());
   assert.match(out, /Choose the disk to install onto/);
   assert.match(out, /Target disk/);
-  assert.doesNotMatch(out, /Payout addresses/);
+  assert.doesNotMatch(out, /Payout address/);
   assert.doesNotMatch(out, /Type the disk name to confirm/);
   assert.doesNotMatch(out, /<button type="submit"/);
   // Picking the disk reveals the rest.
   inst.setState({ chosen: "sda", wipe: "all" });
   const after = renderToString(inst.render());
-  assert.match(after, /Payout addresses/);
+  assert.match(after, /Payout address/);
   assert.match(after, /Type the disk name to confirm/);
   restore();
 });
@@ -613,7 +613,7 @@ test("the setup form offers a toggle into restore mode, and back again", async (
   inst.setState({ restoreMode: true });
   const during = renderToString(inst.render());
   assert.match(during, /Restore from a backup/);
-  assert.doesNotMatch(during, /Payout addresses/); // the normal form is gone, not just hidden
+  assert.doesNotMatch(during, /Payout address/); // the normal form is gone, not just hidden
   assert.match(during, /Back to the setup form/);
   restore();
 });

--- a/dashboard/tests/frontend/wizardmining.test.mjs
+++ b/dashboard/tests/frontend/wizardmining.test.mjs
@@ -255,6 +255,32 @@ test("leaving the raffle writes a BOOLEAN false to xvb.enabled (#1848)", () => {
 
 // --- the components on their own ---------------------------------------------------------------
 
+test("the Tari note does not send the operator to a view that cannot change tari.mode", () => {
+  // The defect this guards: the note promised "turn it on later from the dashboard's
+  // Configuration view", and tari.mode is NOT editable there. control_service.py's
+  // EDITABLE_ENV_KEY_PATHS carries only dashboard.tari_required, tari.mem_limit, tari.data_dir
+  // and tari.clearnet_initial_sync, and the host's own allowlist has no TARI_MODE either — so
+  // the field renders greyed and the operator is hunting for a control that is not there.
+  //
+  // Scoped to TariSection ON PURPOSE. The XvbField sibling says "Changeable later" and that is
+  // TRUE (XVB_ENABLED -> xvb.enabled), so a needle swept over the whole form would match the
+  // honest row and this guard would be pinning the wrong subject.
+  const v = (name) => ({ tariWallet: "", tariRemoteHost: "", xvb: true })[name];
+  const on = () => () => {};
+  // Source wrapping puts newlines inside the sentences, so match on collapsed whitespace.
+  const out = renderToString(html`<${TariSection} answer="off" v=${v} on=${on} />`).replace(
+    /\s+/g,
+    " ",
+  );
+  // The needle forbids the PROMISE, not the phrase: the honest copy names the Configuration
+  // view too, to say it does NOT carry this switch. A bare /Configuration view/ needle reddens
+  // on the fix as readily as on the defect.
+  assert.doesNotMatch(out, /(turn|change) it on later from the dashboard/i);
+  assert.doesNotMatch(out, /later from the dashboard's Configuration view/i);
+  assert.match(out, /Configuration view does not carry this switch/);
+  assert.match(out, /setting this machine up again from the boot menu/);
+});
+
 test("TariSection and XvbField render from props alone, with no app around them", () => {
   // The form tests above are the ones that matter; this is the narrow guard that neither export
   // reaches back into WizardApp, so a second view can render either one from props alone.

--- a/dashboard/tests/frontend/wizardmining.test.mjs
+++ b/dashboard/tests/frontend/wizardmining.test.mjs
@@ -114,10 +114,9 @@ const inputFor = controlFor("input");
 const TARI_Q = "Merge-mine Tari?";
 const XVB_Q = "Join the XMRvsBeast raffle?";
 
-const setupOn = (tariMode, extra = {}) => {
+const setupOn = (tariMode) => {
   const cfg = clone(REF);
   cfg.tari.mode = tariMode;
-  Object.assign(cfg, extra);
   const inst = form(cfg);
   return { inst, tree: inst.renderSetup() };
 };

--- a/dashboard/tests/frontend/wizardmining.test.mjs
+++ b/dashboard/tests/frontend/wizardmining.test.mjs
@@ -1,0 +1,269 @@
+// The wizard's two opt-in mining questions (mining_dashboard/web/static/wizardmining.mjs):
+// merge-mine Tari or not (#1855), join the XvB raffle or not (#1848).
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+//
+// Two tiers here on purpose. `tariAnswer` is pure and carries the migration rule, so it is proved
+// alone. Everything else is proved through WizardApp's REAL setup form rather than through the
+// components in isolation: the defect this replaces was a binding defect — a select that showed
+// one answer while the config held another — and a component rendered with hand-made props cannot
+// see it. The form's own select is found by its LABEL and its handler is fired, so the assertion
+// covers the path an operator's click actually takes.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { html } from "../../mining_dashboard/web/static/preact.mjs";
+import { WizardApp } from "../../mining_dashboard/web/static/wizard.mjs";
+import { TariSection, XvbField, tariAnswer } from "../../mining_dashboard/web/static/wizardmining.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// --- tariAnswer: the migration rule -----------------------------------------------------------
+
+test("tariAnswer shows back the mode that is stored, off included (#1855)", () => {
+  assert.equal(tariAnswer("off"), "off");
+  assert.equal(tariAnswer("local"), "local");
+  assert.equal(tariAnswer("remote"), "remote");
+});
+
+test("tariAnswer reads a config that never mentioned Tari as merge-mining, not as declined", () => {
+  // THE MIGRATION TRAP. `tari.mode` did not exist before 2.0, and the host still reads a missing
+  // key as `local` (lib/pithead/28-parse-and-validate-config.sh). If this said "off", an upgraded
+  // 1.x machine would open the wizard, be told it had declined merge-mining, and write that
+  // decline back on submit — turning off a payout the operator never asked to stop.
+  for (const missing of [undefined, null, "", {}, 0, false]) {
+    assert.equal(tariAnswer(missing), "local", `${JSON.stringify(missing)} must not read as off`);
+  }
+  // "off" is the exact literal the host accepts; a near-miss is not a decline. It stays a yes on
+  // screen and the host rejects it on submit, which fails loudly instead of quietly obeying a
+  // typo. The sibling that keeps the row above narrow: the same reader still says off for "off".
+  for (const near of ["Off", "OFF", " off", "off ", "no", "false", "disabled"]) {
+    assert.equal(tariAnswer(near), "local", `${JSON.stringify(near)} is not the literal off`);
+  }
+  assert.equal(tariAnswer("off"), "off");
+});
+
+// --- the form ---------------------------------------------------------------------------------
+
+// The reference config the server merges under every answer, trimmed to the keys these tests
+// read. `tari.mode` is "local" here because that is what config.reference.json says and must keep
+// saying — the reference is the host's default for an EXISTING config, not the wizard's answer
+// for a new machine. Those two being different is the whole point of #1855.
+const REF = {
+  monero: { wallet_address: "", prune: true, mode: "local" },
+  tari: { mode: "local", wallet_address: "", remote: { host: "", grpc_port: 18142 } },
+  p2pool: { pool: "mini" },
+  xvb: { enabled: true },
+};
+
+const clone = (o) => JSON.parse(JSON.stringify(o));
+
+// A WizardApp sitting on the setup form with `cfg`, with setState applied synchronously so a
+// fired handler is visible to the next assertion.
+function form(cfg) {
+  const inst = new WizardApp({});
+  inst.setState = (patch) => {
+    Object.assign(inst.state, typeof patch === "function" ? patch(inst.state, inst.props) : patch);
+  };
+  Object.assign(inst.state, {
+    stage: "setup",
+    cfg,
+    reference: REF,
+    jsonText: JSON.stringify(cfg, null, 2),
+  });
+  return inst;
+}
+
+// The vnode walker renderToString does, stopping to collect element vnodes instead of stringifying
+// them — the only way to reach a handler, which renderToString drops by design.
+function walk(vnode, out = []) {
+  if (vnode == null || typeof vnode !== "object") return out;
+  if (Array.isArray(vnode)) {
+    for (const child of vnode) walk(child, out);
+    return out;
+  }
+  const { type, props = {} } = vnode;
+  if (type == null) return out;
+  if (typeof type === "function") {
+    if (type.prototype && typeof type.prototype.render === "function") {
+      const inst = new type(props);
+      inst.props = props;
+      if (inst.state == null) inst.state = {};
+      return walk(inst.render(inst.props, inst.state, inst.context), out);
+    }
+    return walk(type(props), out);
+  }
+  out.push(vnode);
+  return walk(props.children, out);
+}
+
+// The <select> inside the Field whose label reads `label`. Binding the lookup to the label rather
+// than to document order is what makes each assertion below a claim about the question an
+// operator reads, and keeps it from silently following the wrong control after a reorder.
+const controlFor = (kind) => (tree, label) => {
+  for (const node of walk(tree)) {
+    if (node.type !== "label" || !renderToString(node).includes(label)) continue;
+    const found = walk(node).find((n) => n.type === kind);
+    if (found) return found;
+  }
+  return null;
+};
+const selectFor = controlFor("select");
+const inputFor = controlFor("input");
+
+const TARI_Q = "Merge-mine Tari?";
+const XVB_Q = "Join the XMRvsBeast raffle?";
+
+const setupOn = (tariMode, extra = {}) => {
+  const cfg = clone(REF);
+  cfg.tari.mode = tariMode;
+  Object.assign(cfg, extra);
+  const inst = form(cfg);
+  return { inst, tree: inst.renderSetup() };
+};
+
+test("the wizard asks whether to merge-mine at all, with No as the first answer (#1855)", () => {
+  const { tree } = setupOn("off");
+  const select = selectFor(tree, TARI_Q);
+  assert.ok(select, "the form asks the merge-mining question");
+  const options = walk(select)
+    .filter((n) => n.type === "option")
+    .map((n) => n.props.value);
+  assert.deepEqual(options, ["off", "local", "remote"]);
+  // A select truncates on the right and the first option is what an operator who reads nothing
+  // gets. Both have to say No.
+  assert.match(renderToString(select), /No — mine Monero only/);
+});
+
+test("a machine that declined merge-mining reads back as declined, not as local (#1855)", () => {
+  // The defect this replaces: the select was `remoteTari ? "remote" : "local"`, which had no way
+  // to say off. A config holding "off" rendered as "Run the bundled node on this machine", so the
+  // wizard misreported the machine to its own operator, and one touch of that control wrote a yes.
+  assert.equal(selectFor(setupOn("off").tree, TARI_Q).props.value, "off");
+  assert.equal(selectFor(setupOn("local").tree, TARI_Q).props.value, "local");
+  assert.equal(selectFor(setupOn("remote").tree, TARI_Q).props.value, "remote");
+});
+
+test("answering the merge-mining question writes tari.mode and nothing else (#1855)", () => {
+  for (const answer of ["off", "local", "remote"]) {
+    const { inst, tree } = setupOn("local");
+    selectFor(tree, TARI_Q).props.onChange({ target: { value: answer } });
+    assert.equal(inst.state.cfg.tari.mode, answer, `answering ${answer}`);
+    // The JSON pane underneath is what gets submitted, so a field edit that does not reach it
+    // is an answer the machine never sees.
+    assert.equal(JSON.parse(inst.state.jsonText).tari.mode, answer, `${answer} reaches the JSON`);
+  }
+});
+
+test("declining Tari asks for no Tari payout address, and no node (#1855)", () => {
+  const out = renderToString(setupOn("off").tree);
+  assert.doesNotMatch(out, /Tari payout address/);
+  assert.doesNotMatch(out, /gRPC port/);
+  // The Monero half of the form is untouched by the decline — the machine still mines Monero.
+  assert.match(out, /Monero payout address/);
+  assert.match(out, /Where does Monero data come from\?/);
+});
+
+test("the retired prose does not survive the decline it contradicts (#1855)", () => {
+  // "this stack always does both, so it needs both addresses" was true until this issue and is
+  // now false at every setting, so it must be gone from the form rather than merely hidden when
+  // Tari is off. Prose that explains a behaviour is where the stale claim lives, and it never
+  // goes red on its own.
+  for (const mode of ["off", "local", "remote"]) {
+    const out = renderToString(setupOn(mode).tree);
+    assert.doesNotMatch(out, /always does both/, mode);
+    assert.doesNotMatch(out, /Where does Tari data come from\?/, mode);
+  }
+});
+
+test("saying yes asks for the payout address, and only a remote node asks where it is (#1855)", () => {
+  const yes = setupOn("local");
+  const local = renderToString(yes.tree);
+  assert.match(local, /Tari payout address/);
+  assert.doesNotMatch(local, /gRPC port/);
+  assert.doesNotMatch(local, /Node host/);
+  // Named at its own input, not swept for in the page text: /required/ would also match the
+  // Monero address's, so the loose form is a check that cannot fail while that field exists.
+  assert.equal(inputFor(yes.tree, "Tari payout address").props.required, true);
+  assert.equal(inputFor(yes.tree, "Monero payout address").props.required, true);
+
+  const remote = renderToString(setupOn("remote").tree);
+  assert.match(remote, /Tari payout address/);
+  assert.match(remote, /Node host/);
+  assert.match(remote, /gRPC port/);
+  assert.match(remote, /not encrypted/);
+});
+
+test("the disk cost of saying yes is stated before the answer, not after it (#1855)", () => {
+  // The operator's complaint was meeting Tari on a machine that never asked for it. A decline
+  // that is cheap to make has to state what it costs to accept, so the figure sits on the
+  // question itself and shows at every answer, off included.
+  for (const mode of ["off", "local", "remote"]) {
+    assert.match(renderToString(setupOn(mode).tree), /about 170 GB/, mode);
+  }
+});
+
+test("the chain-size advice stops citing a Tari node on a machine that has none (#1855)", () => {
+  // Advanced's "pruned Monero plus a remote Tari node is the combination that fits" is disk
+  // arithmetic for a machine that runs Tari. With Tari off it is advice about software this
+  // machine will not install. It is right for BOTH yes answers — that is what makes the gate a
+  // gate on the decline and not on the remote branch.
+  assert.doesNotMatch(renderToString(setupOn("off").tree), /combination that fits/);
+  assert.match(renderToString(setupOn("local").tree), /combination that fits/);
+  assert.match(renderToString(setupOn("remote").tree), /combination that fits/);
+});
+
+// --- the raffle (#1848) -----------------------------------------------------------------------
+
+test("the wizard offers the raffle as a first-boot switch (#1848)", () => {
+  const { tree } = setupOn("off");
+  const select = selectFor(tree, XVB_Q);
+  assert.ok(select, "the form asks the raffle question");
+  assert.deepEqual(
+    walk(select)
+      .filter((n) => n.type === "option")
+      .map((n) => n.props.value),
+    ["true", "false"],
+  );
+  // The docs' own sentence, so the wizard cannot drift from them or invent a figure.
+  assert.match(renderToString(tree), /earns nothing extra/);
+});
+
+test("the raffle switch defaults to the reference's answer, not to off (#1848)", () => {
+  // xvb.enabled is true in config.reference.json: the raffle is opt-OUT, and a switch that
+  // rendered No would show every new machine a state it is not in.
+  assert.equal(selectFor(setupOn("off").tree, XVB_Q).props.value, "true");
+  const off = clone(REF);
+  off.tari.mode = "off";
+  off.xvb.enabled = false;
+  assert.equal(selectFor(form(off).renderSetup(), XVB_Q).props.value, "false");
+  // A config with no xvb key at all still shows the reference's answer rather than blanking.
+  const bare = clone(REF);
+  bare.tari.mode = "off";
+  delete bare.xvb;
+  assert.equal(selectFor(form(bare).renderSetup(), XVB_Q).props.value, "true");
+});
+
+test("leaving the raffle writes a BOOLEAN false to xvb.enabled (#1848)", () => {
+  const { inst, tree } = setupOn("off");
+  selectFor(tree, XVB_Q).props.onChange({ target: { value: "false" } });
+  // The string "false" is truthy everywhere downstream — in the host's config parse and in the
+  // dashboard — so a binding that skipped coercion would read as the raffle still being on.
+  assert.equal(inst.state.cfg.xvb.enabled, false);
+  assert.notEqual(inst.state.cfg.xvb.enabled, "false");
+  assert.equal(JSON.parse(inst.state.jsonText).xvb.enabled, false);
+});
+
+// --- the components on their own ---------------------------------------------------------------
+
+test("TariSection and XvbField render from props alone, with no app around them", () => {
+  // The form tests above are the ones that matter; this is the narrow guard that neither export
+  // reaches back into WizardApp, so a second view can render either one from props alone.
+  const v = (name) => ({ tariWallet: "", tariRemoteHost: "", xvb: true })[name];
+  const on = () => () => {};
+  assert.match(
+    renderToString(html`<${TariSection} answer="off" v=${v} on=${on} />`),
+    /Merge-mine Tari\?/,
+  );
+  assert.match(renderToString(html`<${XvbField} v=${v} on=${on} />`), /XMRvsBeast/);
+});

--- a/dashboard/tests/web/test_wizard.py
+++ b/dashboard/tests/web/test_wizard.py
@@ -294,11 +294,11 @@ async def test_form_fields_still_work_without_the_pane(client, seeded):
     assert cfg["monero"]["wallet_address"].startswith("4")
 
 
-def test_both_wallets_always_flow_to_the_host_validator():
-    # tari.mode is local|remote only — there is no Monero-only mode, and the wizard must not
-    # invent one. An empty value still passes through so the HOST produces the rejection.
+def test_a_machine_that_never_answered_the_tari_question_declines_it():
+    # This read "tari.mode is local|remote only" until #1855 made that false: off is what a new
+    # machine gets, written EXPLICITLY because an omitted key still parses as local.
     cfg = wizard.build_config({"monero_wallet": "4" + "A" * 94, "tari_wallet": ""})
-    assert cfg["tari"]["wallet_address"] == ""
+    assert cfg["tari"] == {"mode": "off"}
 
 
 def test_remote_monero_carries_ports_and_defaults_them():

--- a/dashboard/tests/web/test_wizard_form.py
+++ b/dashboard/tests/web/test_wizard_form.py
@@ -68,11 +68,12 @@ def test_remote_tari_takes_the_port_it_is_given():
     assert cfg["tari"]["remote"]["grpc_port"] == 9999
 
 
-def test_a_local_tari_node_is_left_at_its_default_shape():
-    # The sibling that keeps the two above narrow: the same reader, given no mode, writes
-    # neither key rather than writing "local" and a remote block.
+def test_no_answer_writes_no_remote_block():
+    # The sibling that keeps the two above narrow: the same reader, given no mode, writes no
+    # remote block. It asserted "mode" not in cfg["tari"] until #1855 — the mode key is now
+    # always written, and which value it takes is pinned by the every-answer test below, so
+    # this one stays narrowly about the remote block it was written to guard.
     cfg = build_config(BASE)
-    assert "mode" not in cfg["tari"]
     assert "remote" not in cfg["tari"]
 
 
@@ -108,3 +109,58 @@ def test_the_clearnet_first_sync_applies_to_both_chains_or_neither():
     plain = build_config({**BASE, "clearnet_sync": "false"})
     assert "clearnet_initial_sync" not in plain["monero"]
     assert "clearnet_initial_sync" not in plain["tari"]
+
+
+def test_the_mode_key_is_written_for_every_answer_including_the_default():
+    # The migration trap in #1855, as an assertion. A config that omits tari.mode parses as
+    # "local", so the ONE thing this form must never do is leave the key out — an operator who
+    # answered No would get a merge-mining machine. Every answer, the unanswered one included.
+    for form, expected in (
+        ({}, "off"),
+        ({"tari_mode": ""}, "off"),
+        ({"tari_mode": "off"}, "off"),
+        ({"tari_mode": "local"}, "local"),
+        ({"tari_mode": "remote"}, "remote"),
+    ):
+        cfg = build_config({**BASE, **form})
+        assert cfg["tari"]["mode"] == expected, form
+
+
+def test_declining_tari_asks_for_no_payout_address():
+    # Nowhere to be paid, so no key at all. An empty string is a value and would override the
+    # documented default; the operator is not being asked to supply one.
+    cfg = build_config({**BASE, "tari_mode": "off"})
+    assert "wallet_address" not in cfg["tari"]
+    assert "remote" not in cfg["tari"]
+
+
+def test_merge_mining_locally_still_carries_the_payout_address():
+    # The other direction of the test above: turning it on puts the address back.
+    cfg = build_config({**BASE, "tari_mode": "local"})
+    assert cfg["tari"] == {"mode": "local", "wallet_address": "t"}
+
+
+def test_an_empty_address_on_a_machine_that_merge_mines_reaches_the_host():
+    # The host is the validator (see the module docstring). When Tari is ON, an empty address
+    # must flow through rather than be omitted, or the host has nothing to reject and the
+    # machine comes up merge-mining to nowhere.
+    cfg = build_config({**BASE, "tari_wallet": "", "tari_mode": "local"})
+    assert cfg["tari"]["wallet_address"] == ""
+
+
+def test_a_remote_tari_node_carries_its_endpoint_and_the_address():
+    cfg = build_config(
+        {**BASE, "tari_mode": "remote", "tari_remote_host": "10.0.0.9", "tari_remote_grpc": "1"}
+    )
+    assert cfg["tari"]["mode"] == "remote"
+    assert cfg["tari"]["remote"] == {"host": "10.0.0.9", "grpc_port": 1}
+    assert cfg["tari"]["wallet_address"] == "t"
+
+
+def test_leaving_the_raffle_writes_the_key_and_staying_in_writes_nothing():
+    # xvb.enabled is true in config.reference.json, so only the OFF answer is worth writing:
+    # writing True would pin a default the operator never chose to pin. Both directions, and
+    # the unanswered form, because that is what every existing caller submits.
+    assert build_config({**BASE, "xvb": "false"})["xvb"] == {"enabled": False}
+    assert "xvb" not in build_config({**BASE, "xvb": "true"})
+    assert "xvb" not in build_config(BASE)

--- a/dashboard/tests/web/test_wizard_new_machine.py
+++ b/dashboard/tests/web/test_wizard_new_machine.py
@@ -1,0 +1,106 @@
+"""What the wizard serves a machine that has never been configured (#1855, #1848).
+
+The state API hands the page a config built from two sources: `config.reference.json`, which the
+host publishes, and the page's own answers for a machine with no configuration yet. Those two
+disagree on exactly one key now, and the disagreement is the point of #1855 — the reference says
+`tari.mode: "local"` and must keep saying it, while a NEW machine is served `"off"`.
+
+That split is easy to get wrong in the direction nobody sees: a page whose components can render
+"No" but whose served config says "local" shows every new operator a Yes, and the whole finding
+survives the fix. So these pin the SERVED value, not the component.
+
+They live beside `test_wizard.py` rather than in it because that file is at its budget ceiling,
+and they carry their own fixtures for the same reason its three other siblings do.
+"""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+# The host's published reference, trimmed to what these read. `tari.mode` is "local" here because
+# that is what config.reference.json says: a config that omits the key means local, which is what
+# keeps a 1.x install merge-mining across the 2.0 upgrade.
+REFERENCE = {
+    "monero": {"wallet_address": "", "mode": "local", "prune": True},
+    "tari": {"wallet_address": "", "mode": "local"},
+    "p2pool": {"pool": "mini"},
+    "xvb": {"enabled": True},
+}
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    sd.joinpath("config.reference.json").write_text(json.dumps(REFERENCE))
+    return sd
+
+
+@pytest.fixture
+async def client(spool):
+    c = TestClient(TestServer(wizard.make_app(exit_fn=lambda code: None)))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def _auth(client, token="pit-X7KM2Q"):  # noqa: S107 — the test fixture's token, not a secret
+    return await client.post("/auth", data={"token": token}, allow_redirects=False)
+
+
+async def _state(client):
+    await _auth(client)
+    return await (await client.get("/api/wizard-state")).json()
+
+
+async def test_a_new_machine_is_served_a_decline_the_reference_does_not_carry(client):
+    """The finding: a fresh install showed Tari coming up for an operator who never asked."""
+    s = await _state(client)
+    assert s["config"]["tari"]["mode"] == "off"
+    # The reference the same response carries is untouched, and that is not incidental: the page
+    # diffs against it to decide what to write, and the host reads a missing key as "local". If
+    # this ever came back "off", `strip_defaults` would drop the decline as a no-op default and
+    # the machine would merge-mine anyway.
+    assert s["reference"]["tari"]["mode"] == "local"
+
+
+async def test_the_page_default_does_not_reach_a_machine_that_already_answered(client, spool):
+    """The migration guard, at the seam where it actually acts."""
+    for attempt, expected in (
+        # An install that chose local keeps local — the obvious half.
+        ({"tari": {"mode": "local"}}, "local"),
+        # The half that matters: a 1.x config predates the question entirely. It is still a
+        # machine WITH answers, so it falls through to the reference's "local" and is never
+        # handed the new machine's decline. Serving "off" here would tell an upgraded install it
+        # had declined merge-mining, and submitting that page would write the decline back.
+        ({"monero": {"wallet_address": "4AAA"}}, "local"),
+    ):
+        spool.joinpath("last-attempt.json").write_text(json.dumps(attempt))
+        assert (await _state(client))["config"]["tari"]["mode"] == expected, attempt
+
+
+async def test_a_rejected_attempt_keeps_the_decline_the_operator_just_made(client, spool):
+    # The same path carries a submission the host bounced. An operator who answered No, hit a
+    # validation error on some other field, and got the form back must not find Tari switched
+    # back on underneath the error.
+    spool.joinpath("last-attempt.json").write_text(json.dumps({"tari": {"mode": "off"}}))
+    assert (await _state(client))["config"]["tari"]["mode"] == "off"
+
+
+async def test_the_raffle_is_served_from_the_reference_and_not_pinned_by_the_page(client, spool):
+    """#1848 is opt-OUT, so the page has no answer of its own to add here.
+
+    Asserted by moving the reference and watching the served value follow, rather than by
+    reading the page's own defaults: a value that merely happens to equal the reference today
+    proves nothing about where it came from.
+    """
+    assert (await _state(client))["config"]["xvb"]["enabled"] is True
+    spool.joinpath("config.reference.json").write_text(
+        json.dumps({**REFERENCE, "xvb": {"enabled": False}})
+    )
+    assert (await _state(client))["config"]["xvb"]["enabled"] is False

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -221,7 +221,7 @@ Everything below applies to the **Pithead** and **Pithead + RigForge** roles. A 
 rig skips all of it — see [What is this machine?](#what-is-this-machine) above for its three
 questions.
 
-**Paste your payout addresses — do not type them.** A Monero address is 95 characters and a
+**Paste your payout address — do not type it.** A Monero address is 95 characters and a
 single wrong character pays a stranger. The page checks the address as you paste it and tells
 you immediately if it is the wrong kind: p2pool cannot pay a subaddress (starting `8`) or an
 integrated address, only your **primary** address, which starts with `4`.
@@ -230,11 +230,12 @@ Then a handful of choices, all with sensible defaults:
 
 | Question | Default | When to change it |
 |---|---|---|
-| Tari payout address | — | Required, like the Monero one: this stack always merge-mines both coins from the same work. |
+| Merge-mine Tari? | no | Off on a new machine. Say yes and the same work earns on both chains, at no cost in hashrate; it then asks for a Tari payout address — paste that one too — and where the Tari node runs. Turn it on later from the dashboard's Configuration view. |
 | P2Pool sidechain | mini | `nano` for a single low-power rig, `main` only for very large hashrate. Changeable later. |
 | Telegram bot | — | Optional. Alerts and status commands; needs both the token and the chat id. |
 | Monero node | run it here | Point at a node you already run. It has to be on your own network — a private address (10.x, 172.16–31.x, 192.168.x) or one reached over a VPN — because the machine only lets the mining containers dial private ranges; everything else goes through Tor. |
-| Tari node | run it here | Same, over a network you trust, and the same private-address requirement. Pointing Tari elsewhere is the single biggest saving on a small disk: it takes about 200 GB out of the budget. |
+| Where the Tari node runs | run it here | Only asked once you say yes above. Same private-address requirement as the Monero node, over a network you trust. Pointing Tari elsewhere is the single biggest saving on a small disk: it takes about 200 GB out of the budget. |
+| Join the XMRvsBeast raffle? | on | Off if you would rather send every hash to your own P2Pool payouts. On, the switching engine donates only enough hashrate to hold your tier and routes the rest to P2Pool; donating past a tier's threshold earns nothing extra, because the raffle picks its winners at random. Changeable later. |
 | Mine on this machine too? | on | Off if this box should only coordinate — it is the same answer as the **Pithead** role above. Nothing to install: the image carries its own [RigForge](https://github.com/p2pool-starter-stack/rigforge) miner, pointed at this machine's own pool. It starts by itself once the stack is up, comes back on every boot, and appears in the dashboard's Workers view. The box is tuned for hashrate either way — the CPU governor and the HugePages reservation are set on every boot whether or not this switch is on. |
 | First sync | private over Tor | Faster over the open internet if days of syncing is too slow; it uses Tor afterwards either way. |
 | Dashboard login | generate one for me | Or choose your own password. "No login" is offered but leaves the dashboard — payout addresses, hashrate — open to anyone on your network; never combine it with the Tor onion. It also leaves the machine **unconfigurable from the dashboard** — editing settings can change the payout address, so that stays behind a login — and on a machine with no shell that is permanent: changing it means a factory reset and setting up again. |

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -230,7 +230,7 @@ Then a handful of choices, all with sensible defaults:
 
 | Question | Default | When to change it |
 |---|---|---|
-| Merge-mine Tari? | no | Off on a new machine. Say yes and the same work earns on both chains, at no cost in hashrate; it then asks for a Tari payout address — paste that one too — and where the Tari node runs. Turn it on later from the dashboard's Configuration view. |
+| Merge-mine Tari? | no | Off on a new machine. Say yes and the same work earns on both chains, at no cost in hashrate; it then asks for a Tari payout address — paste that one too — and where the Tari node runs. It cannot be turned on from the dashboard afterwards — the Configuration view does not carry this switch; set the machine up again from the boot menu to change it. |
 | P2Pool sidechain | mini | `nano` for a single low-power rig, `main` only for very large hashrate. Changeable later. |
 | Telegram bot | — | Optional. Alerts and status commands; needs both the token and the chat id. |
 | Monero node | run it here | Point at a node you already run. It has to be on your own network — a private address (10.x, 172.16–31.x, 192.168.x) or one reached over a VPN — because the machine only lets the mining containers dial private ranges; everything else goes through Tor. |

--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -311,7 +311,8 @@ holds a Pithead `data` partition. Expected: listed as "reinstall, keeps existing
 and `/data` survives with its contents. *This is the one that costs a user days of
 re-syncing if it is wrong.*
 
-**M6 — configure by paste.** Complete the wizard using copy/paste for both addresses.
+**M6 — configure by paste.** Answer **yes** to merge-mining so the Tari address is asked at
+all, then complete the wizard using copy/paste for both addresses.
 Confirm a pasted **subaddress** (`8…`) is rejected with an explanation before submitting.
 Expected: the stack provisions and the dashboard comes up.
 

--- a/docs/dev/manual-release-checklist.md
+++ b/docs/dev/manual-release-checklist.md
@@ -76,7 +76,8 @@ health-gated commit, the migration hold). They have never been proven on real ha
   (this is M5, and it is where the corrupt-container-store blocker was found: a partially written
   image store left every `podman run` failing, so the wizard never served).
 - Reaching the wizard **by mDNS name** and **by IP**, since the appliance serves both.
-- Configuring **by paste** for both addresses (M6): a wallet address typed by hand is a support
+- Configuring **by paste** for both addresses (M6, which now needs a yes to merge-mining first —
+  a new machine is asked for the Monero address only): a wallet address typed by hand is a support
   ticket waiting to happen.
 
 ---


### PR DESCRIPTION
The setup page can finally answer **No** to merge-mining, and a new machine arrives holding that answer. This is #1855's wizard half plus #1848, and it completes the operator's finding that a fresh box showed Tari coming up for someone who never asked for it.

⛔ **This must not merge before #1905.** `28-parse-and-validate-config.sh:78-81` on `origin/develop` today accepts `local|remote` and errors on anything else, so a tree carrying this branch without the host half refuses to provision **any** new machine — #1847's browser-submit KVM leg included, since it posts the served config whole. Nothing mechanical enforces the order. The appliance lane has recorded it (its battery tip will not carry this).

## What the operator sees change on the appliance

- The wizard asks **"Merge-mine Tari?"** — *No — mine Monero only (default)* / *Yes, run a Tari node on this machine* / *Yes, use a Tari node I already run* — and a fresh machine opens on **No**.
- Saying No means no Tari payout address, no node questions, and no chain-size advice about a Tari node this machine will not install. Saying Yes reveals the payout address; only *remote* asks where the node is.
- A new question under Mining: **"Join the XMRvsBeast raffle?"**, default Yes, its note lifted from the FAQ rather than invented.
- The Payout addresses section is now **Payout address** — Monero's, alone, unless Tari is on.

## The three commits, and why the third exists

1. **The no-JS form** (`build_config`): writes `tari.mode` explicitly on every submit, omits `tari.wallet_address` on a decline, writes `xvb.enabled: false` only on the Off answer.
2. **The page**: the three-answer question in a new `wizardmining.mjs`, because `wizard.mjs` was 884/889 and `wizard.test.mjs` 765/765 — the budget decided the design, as it did for #1850 and #1853. `wizard.mjs` comes out 21 lines lighter.
3. **The served default.** Commit 2 was not enough and the tests did not say so — I found it by re-reading #1847's KVM leg, which posts back whatever `/api/wizard-state` served it, and going to look at what that is. It was `local`. The state API merges the reference under the last attempt, and a machine with no attempt fell through to a seed carrying only `local_miner.enabled`, so the reference decided and the reference says `local`. **A page whose component can render No while its served config says local shows every new operator a Yes, and the finding survives the fix intact.** The seed gains `"tari": {"mode": "off"}` and a name.

`config.reference.json` still says `tari.mode: "local"` and must. That is the migration trap in #1855: the reference is the default for a config that **already exists**, and moving it there stops merge-mining on every upgraded install. The two facts look contradictory and are the design; the comment says so where the constant lives.

## Tiers

Tier 1 throughout, at the layer that can actually see each claim.

- `tariAnswer` alone for the migration rule — only the literal `"off"` is a decline; a missing key is `local`, because that is what the host does with a config written before the question existed.
- The rest through **WizardApp's real setup form**, not through components with hand-made props: the defect being replaced was a *binding* defect (a select showing one answer while the config held another), and a component rendered from props cannot see one. Each select is found by its **label** and its handler is fired, so the assertion covers the path a click takes.
- The served default at the server, where the seed lives: a new machine gets `off`, a machine with any prior attempt gets the reference's `local`, and a rejected submission keeps the decline the operator just made.

**Two mutation batteries, each mutation proven to have applied (pattern matched exactly once, file byte-compared after write and after restore), each run against a 0-red baseline.** 9 mutations on the JS half and 4 on the seed; every one reddened the row that names it, none survived. They include the exact pre-fix states: the two-state coercion, and the seed without `tari.mode`.

## Prose the change falsifies — swept for, not remembered

`README.md`'s "every hash merge-mines Tari"; `docs/appliance.md`'s *"Required, like the Monero one: this stack always merge-mines both coins"*, plus its Tari-node row and a new raffle row; and the two dev recipes whose **M6** tells a tester to paste both addresses into a form that now asks for one. Four render probes in `wizard.test.mjs` asserted the old heading and the retired question — corrected in place, line-neutral (765/765 holds). The three `doesNotMatch(/Payout addresses/)` among them mattered most: left alone they would have passed over a rendered "Payout address" forever.

## Over-engineering pass (ponytail gate)

Run over the whole three-commit diff. **One finding, applied:** `setupOn` in the new frontend test carried an `extra` parameter and an `Object.assign` no caller ever used — dead API on a helper written minutes earlier. Held after review, with the reason each was weighed against: the new module (the budget ceiling forced it, it was not chosen); `tariAnswer` as its own export (four lines that carry the migration rule and are provable with no DOM); the test's vnode walker (string matching cannot reach a handler, and the battery shows two mutations that would have survived without it); `_NEW_MACHINE_ANSWERS` as a named constant (the name is load-bearing — the comment on it explains a design that reads as a contradiction); and the separate Python test file (three siblings already split for the same 974-line ceiling). The weakest thing kept is the eight-line "renders from props alone" probe, which earns its place only by proving neither export reaches back into `WizardApp`.

## PROVEN at this head (`2812f163`, rebased on `4402eec5`)

`make test-dashboard` **2582 passed / 0 failed, coverage 97.59%**; `make test-patch-coverage` **100% on 8 changed lines**, with the wrapper's overlap check confirming it is not #1000's vacuous pass; `node --test dashboard/tests/frontend/` **593 passed**; the six wizard Python modules **132 passed**, settled from `--junitxml` rather than a count line; `lint-js`, `lint-py`, `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-topology`, `lint-file-budget` (`wizard.mjs` 863/889, `wizard.py` 645/674), `lint-pithead-parity`.

**ASSUMED:** all CI. **NOT RUN:** `lint-sh`, docker, KVM, a real browser.

## Said rather than hidden

- **`./pithead setup` still cannot decline.** The CLI wizard demands a Tari address and never asks the mode, so only the browser path can express the ruling's default. `lib/pithead/` is not this lane's — filed as **#1916**, not an RC1 blocker.
- **A green from `lint-operator-strings` was false.** It enumerates with `git ls-files`, so it scanned a clean tree while my new module was untracked, and flagged it only after the commit. It also treats a `#NNNN` inside a JSDoc block as operator text although its own header exempts docstrings. Both controlled and filed as **#1918**. I worked around the second by writing the module's comments as `//` rather than touching a shared gate mid-RC — a workaround, not a repair, and I say so on the issue.
- **A figure I did not reconcile:** `docs/appliance.md` says a remote Tari node saves ~200 GB while the wizard says a local one adds ~170 GB. Both predate this branch. I used each doc's own existing number rather than guessing which is right.
- **#1903 still stands:** with `tari.mode: off` the bundled node stops, but p2pool is handed its merge-mine arguments until that lands. That is the host half's carve-out, unchanged by this PR.
- **Not rebased onto any `fixes` PR** — no hunk of this branch touches `wizard.css`, `wizard.py`'s first screen, or the password card. It rebases cleanly on `origin/develop` at `4402eec5`.

Addresses #1855 and #1848 — deliberately no closing keyword: the host half carries the other half of #1855, and #1903 is still open behind it.