### PR TITLE
fix(dashboard): #1886 the sync screen names the wait, instead of leaving it to the logs

### DIFF
--- a/dashboard/mining_dashboard/web/static/syncview.mjs
+++ b/dashboard/mining_dashboard/web/static/syncview.mjs
@@ -23,10 +23,31 @@ export function Gauge({ percent, state }) {
     </div>`;
 }
 
+// What the screen says while it holds (#1886 gap 3). The headline alone named neither mechanism
+// behind the wait, so an operator who changed a setting and saw nothing happen could not tell a
+// working machine from a stuck one. Both added sentences are about a clock this page does not
+// control: workers are readmitted on NodeHealthMonitor.healthy (reachable continuously for
+// NODE_RECOVERY_AFTER_SEC, deliberately distinct from "not down"), and TARI_REQUIRED is read at
+// import, so a change reaches the dashboard only when apply recreates the container. No durations
+// are printed — both windows are env-tunable and a number here would read as a promise.
+//
+// The readmission sentence is scoped to a node that went away and came back, because
+// _apply_worker_rejection has exactly one call site and it is guarded by `if self.miner_released:`
+// — a one-way latch that is False until the sync gate first releases. On a first sync there are no
+// rejected workers to readmit, so an unscoped sentence promised a wait that cannot occur on this
+// screen's own primary path (found reviewing PR #1926; no test caught it).
 export function SyncView({ sync }) {
   return html`
     <div id="sync-view">
-        <div class="header-placeholder"><p>System is currently synchronizing with the network.</p></div>
+        <div class="header-placeholder">
+            <p>System is currently synchronizing with the network.</p>
+            <p class="text-muted">This screen clears itself once the required chains are ready —
+            nothing here needs a click. If the node went unreachable and is catching up again,
+            workers are readmitted once the node has stayed reachable for a recovery window,
+            rather than on the first check that succeeds. Whether Tari is required is read when
+            the dashboard starts, so changing it takes effect once you apply the change, not
+            while this screen is up.</p>
+        </div>
         <div class="grid">
             <div class="card">
                 <h2 class="text-accent text-center">Monero Sync</h2>

--- a/dashboard/tests/frontend/syncview.test.mjs
+++ b/dashboard/tests/frontend/syncview.test.mjs
@@ -1,0 +1,97 @@
+// What the full-screen sync takeover TELLS the operator (#1886 gap 3, the copy half).
+//
+// A sibling file rather than rows in an existing one: there was no syncview test at all, and the
+// nearest candidates are at or near their recorded ceilings in docs/dev/file-budget.tsv.
+//
+// These assert PROSE, which is the weakest kind of test there is, so each row below is written to
+// fail for the reason it names rather than for any reason at all: every needle names the SUBJECT
+// of the sentence (a bare /recovery/ or /apply/ would match a chain card, a future banner, or the
+// word "applies" in unrelated copy), and the fixture deliberately carries a near-miss sibling —
+// a Tari card whose own text contains "syncing" and a Monero card carrying a mode string — so a
+// needle that has quietly widened to match the whole page is visible here rather than in review.
+//
+// Run with Node's built-in test runner (CI runs exactly this):
+//     node --test dashboard/tests/frontend/
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { SyncView } from "../../mining_dashboard/web/static/syncview.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+// A machine mid-sync, with the near-miss sibling text described above: the cards carry their own
+// words so a needle can be shown to be scoped to the header rather than to the page.
+const SYNCING = {
+  monero: {
+    percent: 41,
+    state: "syncing",
+    current: "1,200,000",
+    target: "2,900,000",
+    remaining: "1,700,000",
+    mode: "Pruned",
+    db_size: "58 GB",
+  },
+  tari: {
+    percent: 8,
+    state: "syncing",
+    current: "40,000",
+    target: "500,000",
+    remaining: "460,000",
+  },
+};
+
+const headerOf = (out) => {
+  const m = out.match(/<div class="header-placeholder">([\s\S]*?)<\/div>/);
+  assert.ok(m, "the sync screen has no header-placeholder block to read");
+  return m[1];
+};
+
+test("the sync screen still leads with the headline the docs quote (#1886)", () => {
+  // docs/dashboard.md quotes this sentence verbatim. Added copy must not silently retire it, or
+  // the doc goes false in a file this change never touches.
+  assert.match(headerOf(renderToString(SyncView({ sync: SYNCING }))), /System is currently synchronizing with the network\./);
+});
+
+test("the sync screen says workers wait for a STABLE window, not one good check (#1886 gap 3)", () => {
+  // The mechanism: readmission gates on NodeHealthMonitor.healthy — reachable continuously for
+  // NODE_RECOVERY_AFTER_SEC — which service/node_health.py documents as deliberately distinct
+  // from "not down". Without this the operator sees a synced chain and an idle miner and has no
+  // way to tell that from a fault. Both halves are asserted: that a window is named, and that
+  // the "not on the first success" half is there, because the first half alone reads as a
+  // promise that mining starts on the next poll.
+  const header = headerOf(renderToString(SyncView({ sync: SYNCING })));
+  assert.match(header, /workers are readmitted once the node has stayed reachable/);
+  assert.match(header, /rather than on the first check that succeeds/);
+  // The scope clause is load-bearing, not throat-clearing: `_apply_worker_rejection` has exactly
+  // one call site and it sits under `if self.miner_released:`, a one-way latch that is False until
+  // the sync gate first releases. A machine reaching this screen for the first time has no
+  // rejected workers to readmit, so an unscoped sentence promises a wait that cannot happen on the
+  // very path the screen is most often on. Asserted here so a future trim of the clause reddens.
+  assert.match(header, /If the node went unreachable and is catching up again/);
+});
+
+test("the sync screen says a Tari-required change lands on apply, not live (#1886 gap 3)", () => {
+  // TARI_REQUIRED is read at import (config/config.py), so it reaches the dashboard only when
+  // apply recreates the container. This is the half the operator actually hit: they flipped the
+  // setting and watched a screen that could not have known about it yet.
+  const header = headerOf(renderToString(SyncView({ sync: SYNCING })));
+  assert.match(header, /Whether Tari is required is read when\s+the dashboard starts/);
+  assert.match(header, /takes effect once you apply the change/);
+});
+
+test("the screen promises it clears itself, so waiting is not mistaken for hanging (#1886)", () => {
+  assert.match(headerOf(renderToString(SyncView({ sync: SYNCING }))), /clears itself once the required chains are ready/);
+});
+
+test("the added copy is in the HEADER, not smeared across the chain cards (#1886 narrowness)", () => {
+  // The control for every row above: they read the header block only, so this pins that the
+  // block is a real subset of the page. If the added text ever moves into a card, the rows above
+  // keep passing while the screen changes shape — this is what notices.
+  const out = renderToString(SyncView({ sync: SYNCING }));
+  const header = headerOf(out);
+  assert.ok(header.length < out.length, "header block is the whole page — the rows above prove nothing about placement");
+  // The cards' own words are present on the page and absent from the header: that is what makes
+  // "scoped to the header" a measurement rather than an assumption.
+  assert.match(out, /Monero Sync/);
+  assert.doesNotMatch(header, /Monero Sync/);
+  assert.doesNotMatch(header, /blocks left/);
+});

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -15,6 +15,14 @@ The dashboard shows Sync Mode the first time you start the stack, or any time th
 node is still catching up. A `Syncing...` badge appears next to the hostname, the headline reads
 *"System is currently synchronizing with the network,"* and no hashrate is routed yet.
 
+The screen also says what it is waiting on, because two of the clocks involved are not the progress
+bars and an operator watching only those reads a working machine as a stuck one. If the node went
+unreachable and is catching up again, workers are readmitted once the node has stayed reachable for
+a recovery window rather than on the first check that succeeds — a machine starting for the first
+time has no rejected workers, so that wait belongs to a node that dropped out, not to a first run.
+And `dashboard.tari_required` is read when the dashboard starts, so changing it takes effect once
+you apply the change, not while the screen is up.
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./images/launch/sync.png">
   <img alt="Sync Mode" src="./images/launch/sync-light.png">


### PR DESCRIPTION
Closes nothing on its own — this is **half (b) of #1886 gap 3**, the copy half. Half (a) (a tier-1 test pinning "tari_required false releases the gate on monerod alone") was closed separately by the fixes lane and is not touched here.

## What the operator sees change on the appliance

The full-screen sync takeover gains a second paragraph under its headline. Today that screen's entire operator-facing text is one sentence — *"System is currently synchronizing with the network."* — and it names neither mechanism behind the wait.

That is the screen the operator in #1886 gap 3 was looking at when they flipped `dashboard.tari_required` off on a syncing machine and then waited several minutes for anything to happen. Nothing on the page could distinguish "working, on a clock you cannot see" from "stuck".

## The two clocks, and why they belong on the screen rather than in the log

Neither is a progress bar, which is the whole problem — an operator watching only the bars reads a working machine as a broken one.

1. **Readmission waits for a stable window, not one good poll.** `_apply_worker_rejection` readmits on `self.monero_health.healthy`, and `NodeHealthMonitor` (`service/node_health.py`) sets `healthy` only after the node has been *continuously* reachable for `NODE_RECOVERY_AFTER_SEC`. Its own docstring calls this "distinct from `not down`" and says why: a dashboard restart mid-outage must not readmit workers to a stack that cannot mine.
2. **`TARI_REQUIRED` is read at import.** So a change to `dashboard.tari_required` reaches the dashboard only when `apply` recreates the container. The operator's flip could not have been visible to the running page at all.

**No durations are printed, deliberately.** Both windows are env-tunable (`NODE_RECOVERY_AFTER_SEC` defaults to 60), and a number rendered on a screen goes stale in the one direction that reads as a promise.

## Tier and coverage

**Tier 3 (node)**, in a new sibling file `dashboard/tests/frontend/syncview.test.mjs` — there was no `syncview` test at all, and the nearest existing files sit at their recorded ceilings in `docs/dev/file-budget.tsv`, where ceilings only go down. Five rows; both new files stay well under 400 lines, so no budget row is added (`make lint-file-budget` rc 0).

These assert prose, which is the weakest kind of test there is, so they are built to fail for the reason they name: every needle names the **subject** of its sentence (a bare `/recovery/` or `/apply/` would match a chain card or unrelated copy), each reads a `header-placeholder` block extracted from the render rather than the whole page, and the fixture carries a **near-miss sibling** — cards whose own text contains "syncing", a mode string and "blocks left" — so a needle that has quietly widened to match the page is visible here rather than in review.

## What was RUN

- `node --test dashboard/tests/frontend/` — **584 passed, 0 failed.**
- **The control, and its shape is the point.** With `syncview.mjs` reverted to `origin/develop` and the new test file kept: **3 failed, 2 passed.** The three that assert the new copy went red; the two control rows (the headline the docs quote, and the placement check) stayed green *on both sides*, which is what they are for — an all-red result would have meant my needles were matching nothing in particular rather than matching this change. I proved the revert actually applied rather than assuming it (`grep -c 'recovery window'` → `0` reverted, `1` restored), because a mutation that silently fails to apply passes for the wrong reason.
- `make lint-js` (which also lints CSS), `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-file-budget` — **all rc 0**, run after `git add` (a `git ls-files` gate is blind to work that is not staged).
- **A firing control for those greens**, because identical rc-0 rows prove nothing on their own: a malformed declaration seeded into `syncview.mjs` took `lint-js` to **rc 2**, and a banned marketing word seeded into `docs/dashboard.md` took `lint-docs-voice` to **rc 2**; both files restored and verified byte-identical by `sha256sum -c`. `lint-docs-voice`, `lint-operator-strings` and `lint-file-budget` also run their own self-test.
- **`lint-md`: rc 0, and now shown able to fail — the earlier caveat here was about my SEED, not the gate.** I first wrote that this green was not evidence, because a well-formed prose sentence seeded into `docs/dashboard.md` left it rc 0. That seed was satisfiable, not the gate blind: an **MD022** seed (a heading with no blank line around it) reds `lint-md` at **rc 2** and restores to rc 0, measured by me on this file. Corrected in place rather than deleted, because the wrong version was published. The lesson is promoted to the fleet's verification notes: a control that does not fire indicts the seed first, and the tool's config says which rules are live.

## The review finding, and what changed after the PASS at `2a80ad21`

The `fixes` lane recorded a non-author PASS at `2a80ad21` with one non-blocking finding, and it was the right one. **I re-derived it at source rather than taking the relay:** `_apply_worker_rejection` has exactly one production call site (`data_service.py:1120`) and it sits under `if self.miner_released:` (`:1119`) — a one-way latch that is False until the sync gate first releases (`:308-313`, `:404-409`). So on a **first sync there are no rejected workers to readmit**, and the unscoped sentence *"Mining does not always begin the moment the bars fill"* promised a wait that cannot occur on the screen's own primary path — while sitting directly under the docs line *"the first time you start the stack"*.

The sentence was not false. It is reachable for a machine that had released, lost monerod, had workers rejected, and caught up inside the recovery window. It was **unscoped**, which is a different defect and the one this lane keeps shipping.

**The fix is one clause** — *"If the node went unreachable and is catching up again, workers are readmitted once the node has stayed reachable for a recovery window, rather than on the first check that succeeds"* — in the screen copy, the same clause in `docs/dashboard.md` (plus a sentence naming what a first run sees instead), and the guard recorded in the in-code comment so the next reader does not re-derive it.

**One correction to the review, offered because a row would have gone red on merge:** the suggested wording said *"workers are readmitted once **it** has stayed reachable"*, and the existing needle is `/workers are readmitted once **the node** has stayed reachable/`. That clause would have reddened the row it was described as preserving. The wording shipped here keeps both original needles verbatim; **verified by running them, not by reading them.**

**Added a sixth assertion** (not a sixth row — it joins the workers row) pinning the scope clause, so a future trim of it reddens rather than silently restoring the unscoped promise.

## What was RUN at `f32dde0a` (the pushed head), re-measured rather than carried forward

- `node --test dashboard/tests/frontend/` — **584 passed, 0 failed.**
- **The full-revert control, re-derived at this head:** `syncview.mjs` at `origin/develop`, test file kept — **3 failed, 2 passed**, the same shape as before, with the two control rows green on both sides.
- **A narrow control for the new assertion:** reverting *only* the scope clause to the old unscoped sentence reddens **exactly one row** — the workers row — and nothing else; needle count `1 → 0 → 1`, restored byte-identical by sha256. That is what makes the new assertion a measurement of the fix rather than of the paragraph's existence.

## What was NOT run

`make lint-sh`, `tests/stack/run.sh`, pytest, docker, KVM, and any browser. The appliance lane holds the bench for the #1318 battery, so this lane is node/pytest-only this cycle; nothing here is Python or shell, so the node tier is the tier that covers it. **CI is the gate for everything above that.** No CSS class was added — `dashboard.css` is at its ceiling, so the new paragraph reuses `text-muted`.

## Shared-file disclosure

`docs/dashboard.md` is edited (it is in `_shared.paths`, disclosed here per lane policy). It is not optional housekeeping: that file **quotes the old headline verbatim**, so adding copy around it risked leaving prose false in a file this change does not otherwise touch. The headline is kept and is now pinned by its own test row so a later edit cannot silently retire the quoted sentence.

## Over-engineering pass (ponytail gate)

Two findings on my own diff. One acted on, one deliberately kept, both recorded rather than quietly resolved.

- **Acted on: the in-code comment was 9 lines of prose for a 6-line copy change**, and it repeated what the commit message and this body already say. Trimmed to 7, keeping only what a reader of `syncview.mjs` alone cannot reconstruct — the two mechanism citations and the reason no duration is printed. **Corrected at `f32dde0a`: that block is now 13 lines**, because the review finding below put a third thing in it that a reader of this file alone cannot reconstruct — the guard that scopes the readmission sentence. Re-ran the suite and the lints after the trim rather than assuming a comment edit is inert.
- **Kept, with the reasoning stated: five test rows for a copy change looks like a lot.** Two of them are controls that must pass on *both* sides of the change, so the assertion count is three. I considered dropping the "clears itself" row as reassurance copy rather than a mechanism, and did not: without it that sentence is the one line of the new paragraph no test protects, and the marginal cost is three lines in a file with no budget row. If a reviewer disagrees, it is the cheapest row to lose and nothing else depends on it.

No third finding. The change adds no abstraction, no new CSS class, no helper beyond a four-line `headerOf` used by every row, and no configuration surface.