### PR TITLE
fix(wizard): #1923 the "Set up again" screen offers the restore it was hiding

### DIFF
--- a/dashboard/mining_dashboard/web/static/savedrole.mjs
+++ b/dashboard/mining_dashboard/web/static/savedrole.mjs
@@ -5,6 +5,15 @@
 // is the whole signal: the operator is offered the machine as it stands, and only reaches the
 // setup form by asking for it. Keeping is the default because it changes nothing — the page
 // writes one empty spool file and the host carries on booting with the configuration it has.
+//
+// The third choice, restore (#1923), is a door onto machinery that already exists: restore at
+// setup shipped under #909, and a restore submitted from a set-up-again boot lands today —
+// `12-firstboot-wizard.sh:129` skips the wizard only when `! setup_again_mode`, and
+// `restore_apply` refuses on size, magic, passphrase, integrity, unsafe paths and an unusable
+// config, never on the machine already having a configuration. So this adds no host behaviour.
+// It is deliberately NOT confirm-gated: the restore form is itself a file, usually a passphrase
+// and a second button, which is a more informative wall than a modal, and the consequence an
+// operator needs is WHAT it replaces — named in the note beside the choice, not behind it.
 
 import { html } from "./preact.mjs";
 import { Err, Field, Note } from "./wizardparts.mjs";
@@ -34,7 +43,14 @@ export function savedRoleSummary(saved) {
   return { name, rows };
 }
 
-export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) => html`<div
+export const SavedRoleScreen = ({
+  summary,
+  kept,
+  error,
+  onKeep,
+  onSetUpAgain,
+  onRestore,
+}) => html`<div
     class="card">
     ${
       kept
@@ -48,10 +64,13 @@ export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) 
             )}
             <${Err}>${error}<//>
             <button type="button" onClick=${onKeep}>Keep it</button>
+            <button type="button" onClick=${onRestore}>Restore from a backup</button>
             <button type="button" class="wizard-link" onClick=${onSetUpAgain}>Set up again</button>
             <${Note}>Setting it up again asks the same questions as a first boot, with this
             machine's answers already filled in. Its login and other secrets are never filled
-            in — you choose those again.<//>`
+            in — you choose those again. Restoring from a backup goes the other way: it replaces
+            this machine's configuration and secrets, its onion address among them, with the ones
+            in the archive you upload.<//>`
     }
 </div>`;
 
@@ -61,7 +80,15 @@ export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) 
  * app itself gains nothing but this dispatch.
  */
 export function savedRoleOrSetup(app) {
-  const summary = app.state.setUpAgain ? null : savedRoleSummary(app.state.savedRole);
+  // Both ways of leaving this screen fall through to `renderSetup`, because its own first line
+  // dispatches `restoreMode` to `renderRestore` (`wizard.mjs`) — so the restore branch #909 built
+  // needs no new route, only a door. Asking for restore from HERE is what #1923 adds: the
+  // operator most likely to boot "Set up again" is the one holding a backup, and this was the one
+  // screen in the product that did not mention it. Pressing Back on the restore form clears the
+  // flag and lands here again rather than on the setup form, which is the right place to return
+  // to on this boot.
+  const leaving = app.state.setUpAgain || app.state.restoreMode;
+  const summary = leaving ? null : savedRoleSummary(app.state.savedRole);
   if (!summary) return app.renderSetup();
   const keep = async () => {
     const ok = (await fetch("/keep-role", { method: "POST" })).ok;
@@ -69,5 +96,12 @@ export function savedRoleOrSetup(app) {
   };
   return html`<${SavedRoleScreen} summary=${summary} kept=${app.state.keptRole}
     error=${app.state.keepError} onKeep=${keep}
-    onSetUpAgain=${() => app.setState({ setUpAgain: true })} />`;
+    onSetUpAgain=${() => app.setState({ setUpAgain: true })}
+    onRestore=${() =>
+      // `keepError` is cleared too, and only this exit needs to: restore is the first choice
+      // with a way BACK to this screen (the restore form's own Back clears `restoreMode`), so a
+      // failed Keep would otherwise be waiting here still, reporting an action the operator has
+      // since abandoned. `error` is the wizard's own field, cleared the way the setup form's
+      // restore link clears it.
+      app.setState({ restoreMode: true, error: "", keepError: "" })} />`;
 }

--- a/dashboard/tests/frontend/savedrole.test.mjs
+++ b/dashboard/tests/frontend/savedrole.test.mjs
@@ -83,6 +83,34 @@ test("savedRoleOrSetup: asking to set up again reaches the form past a saved rol
   assert.equal(app.setupRendered, true);
 });
 
+test("savedRoleOrSetup: asking to restore reaches the form past a saved role (#1923)", () => {
+  // The same fall-through set-up-again uses. `renderSetup`'s own first line dispatches
+  // `restoreMode` to `renderRestore` (`wizard.mjs`), which `wizard.test.mjs` covers at seven
+  // sites — so this row proves THIS side of the seam (the screen lets go) and cites the other.
+  const app = fakeApp({ savedRole: RIG, restoreMode: true });
+  savedRoleOrSetup(app);
+  assert.equal(app.setupRendered, true);
+});
+
+test("Restore from a backup asks for the restore branch and clears a stale error (#1923)", () => {
+  // The error being cleared is not decoration: a failed Keep leaves its reason on screen, and
+  // carrying it onto the restore form would blame the upload for the previous action's failure.
+  const app = fakeApp({ savedRole: RIG, keepError: "could not keep this configuration" });
+  savedRoleOrSetup(app).props.onRestore();
+  assert.equal(app.state.restoreMode, true);
+  assert.equal(app.state.error, "");
+  // The restore form's Back clears `restoreMode` and lands on THIS screen again — the first
+  // choice here with a way back — so a failed Keep left in `keepError` would be waiting for the
+  // operator on their return, reporting an action they have since abandoned.
+  assert.equal(app.state.keepError, "");
+  // The control: the OTHER exit does not set the restore flag, so this row is about the door it
+  // names rather than about any button on the screen.
+  const other = fakeApp({ savedRole: RIG });
+  savedRoleOrSetup(other).props.onSetUpAgain();
+  assert.equal(other.state.restoreMode, undefined);
+  assert.equal(other.state.setUpAgain, true);
+});
+
 test("savedRoleOrSetup: an unnameable role falls through rather than failing", () => {
   const app = fakeApp({ savedRole: { role: "future-role" } });
   savedRoleOrSetup(app);
@@ -101,7 +129,7 @@ test("savedRoleOrSetup: a named role opens the screen instead of the form", () =
 const screen = (props) =>
   renderToString(html`<${SavedRoleScreen} summary=${savedRoleSummary(RIG)} ...${props} />`);
 
-test("rendered: the screen says what the machine is and offers both answers", () => {
+test("rendered: the screen says what the machine is and offers all three answers", () => {
   const card = screen({});
   assert.match(card, /already set up/);
   assert.match(card, /rig/);
@@ -109,6 +137,21 @@ test("rendered: the screen says what the machine is and offers both answers", ()
   assert.match(card, new RegExp(RIG.worker));
   assert.match(card, /Keep it/);
   assert.match(card, /Set up again/);
+  // #1923: the operator most likely to boot this screen is the one holding a backup, and it was
+  // the one screen in the product that did not mention restoring from one.
+  assert.match(card, /Restore from a backup/);
+});
+
+test("rendered: the restore choice names what it REPLACES, not just that it exists (#1923)", () => {
+  // A door labelled only "Restore from a backup" asks for a blind choice on the one path where
+  // the machine has something to lose: this boot already has an identity, and restoring
+  // overwrites it. The fresh-boot path has nothing to destroy and says less, deliberately.
+  const card = screen({});
+  assert.match(card, /replaces\s+this machine's configuration and secrets/);
+  assert.match(card, /onion address/);
+  // Narrowness: the same note must still distinguish the OTHER destructive-sounding choice,
+  // which does not replace secrets — a needle that has widened to "any scary sentence" fails here.
+  assert.match(card, /Its login and other secrets are never filled\s+in/);
 });
 
 test("rendered: after keeping, the page closes rather than offering the choice again", () => {
@@ -116,6 +159,9 @@ test("rendered: after keeping, the page closes rather than offering the choice a
   assert.match(card, /Nothing was changed/);
   assert.doesNotMatch(card, /Keep it/);
   assert.doesNotMatch(card, /Set up again/);
+  // The third choice has to leave with the other two: a restore door still open on a screen that
+  // has already committed to keeping would act on a decision the operator has finished making.
+  assert.doesNotMatch(card, /Restore from a backup/);
 });
 
 test("rendered: a failed keep says so on the screen the operator is still looking at", () => {


### PR DESCRIPTION
Closes #1923

## What the operator sees change on the appliance

A machine booted through the boot menu's **Set up again** entry opens on a screen offering **Keep it** and **Set up again**. It gains a third: **Restore from a backup**.

The operator most likely to boot that entry is the one whose machine went wrong and who is holding a backup archive. They were being shown the one screen in the product that did not mention restoring from one — to reach it they had to press "Set up again", which reads like *start over and retype everything*, and then notice a text link above the form.

## This is a door, not a feature — and that claim is the one to check

Restore-at-setup shipped under #909. A restore submitted from a set-up-again boot **lands today**; the machine simply never offers it. Both halves re-derived at source, and posted in full on the issue rather than only here:

- `lib/pithead/12-firstboot-wizard.sh:129` is `if [ -f "$PWD/config.json" ] && ! setup_again_mode; then`, and `setup_again_mode()` is `[ -n "${PITHEAD_SETUP_AGAIN:-}" ]` (`12a-setup-again.sh:8`). A set-up-again boot does not take the skip, so the wizard loop runs with a config already on disk.
- `restore_apply` refuses on oversize, bad magic, missing/wrong passphrase, failed `tar` integrity, unsafe paths or links, and a staged config that is missing or fails validation. **That is the complete list**, and none of them consults the machine's current state. Its call site adds nothing — `firstboot_consume_restore` guards only on `[ -f "$archive" ] || return 2`.

**No host change here.** `#1854`'s scope note says restore "is refused on a machine that already has a configuration"; that note does not survive either site, and the re-derivation is on #1923.

## Why the whole diff is one file

`renderSetup()`'s own first line is `if (this.state.restoreMode) return this.renderRestore();`. So letting the saved-role screen fall through on `restoreMode` — exactly as it already does on `setUpAgain` — reaches the branch #909 built with **no new route and no line spent in `wizard.mjs`**, which this lane does not touch (`wizard.mjs` also has 5 lines of headroom against its 889 ceiling; this spends none of them). `savedrole.mjs` goes 73 → 101 lines, no budget row (the threshold is 400).

Both sides of that seam are covered by different files: this PR proves the screen lets go, and `wizard.test.mjs` already exercises `restoreMode → renderRestore` at seven sites.

## Two decisions taken rather than assumed

**Not confirm-gated.** The issue asks whether overwriting a machine's identity warrants a confirmation step when the fresh-boot path has none. It does not: the restore form is itself a file, usually a passphrase, and a second button — a more informative wall than a modal, and a modal answers "are you sure" without saying what of. What the operator needs is *what it replaces*, so the note beside the choice names it: this machine's configuration and secrets, **its onion address among them**.

**A plain button, not another link-styled one.** The design lane recorded (#1868) that `<button class="wizard-link">Set up again</button>` already fails axe `target-size` on this very screen at under 24 px. A third link-styled control would have added a second instance of a known defect. That existing failure is **not** fixed here — it belongs to the #1868 retag follow-up, which is sequenced below.

## The over-engineering pass found one real defect, and it is fixed here

Restore is the **first** choice on this screen with a way *back* to it — the restore form's own Back button clears `restoreMode`, which lands on this screen again. So a failed Keep sitting in `keepError` would have been waiting for the operator on their return, reporting an action they had since abandoned. Neither existing exit could produce that, which is why it did not exist before. Cleared on that exit, and asserted with its own control.

Considered and kept, with reasons: the 8-line header comment (it records two host facts that cost real re-derivation and that the next reader would otherwise redo), and the named `leaving` const over an inline condition.

## What was RUN, at the pushed head `84b9462a`

- `node --test dashboard/tests/frontend/` — **582 passed, 0 failed.**
- **The revert control:** `savedrole.mjs` at `origin/develop`, the new tests kept — **4 failed, 578 passed**, and the four are exactly the four rows that assert the new behaviour. The fifth new assertion (restore absent from the post-Keep branch) passes on **both** sides by design: it is a placement control, and the string is genuinely on the page in the other branch, so it is not vacuous.
- **A narrow control for the `keepError` fix:** removing only that one clause reddens **exactly one row** and nothing else. Restored byte-identical by `sha256sum -c` after every control.
- `make lint-js` (which also lints CSS), `lint-md`, `lint-docs-voice`, `lint-operator-strings`, `lint-file-budget` — **all rc 0**, run after `git add`.
- **The suite total reconciles, which is itself the independence check:** 584 on my #1926 branch − its 5 `syncview` rows + 3 new rows here = **582**. I branched this off the wrong base first and caught it that way; the figures above are all re-measured at the develop base, not carried over.

## What was NOT run

`make lint-sh`, `tests/stack/run.sh`, pytest, docker, KVM, any browser. Zero shell and zero Python in this diff; `lint-sh` also dies at the shellcheck memory cap on this box and takes a fleet-wide lock. **CI is the gate for those.** The axe/`target-size` claim above is the design lane's measurement, **relayed, not re-derived by me** — I ran no browser.

## Sequencing — please do not merge this in parallel with the #1868 retag

The design ruling on #1868 retags 15 `<h3>` → `<h2>`, **two of them in this same file** (`savedrole.mjs:41,43`). That work is also this lane's, and it is **not buildable yet**: it edits `.wizard-shell h3` rules that exist only on #1893's head `c480e766` and are not on `develop`. So the order is forced rather than chosen — this PR first, the retag rebased over it once #1893 merges. They were not folded because folding would drag this unblocked change behind a blocked one.

## Shared-file disclosure

None. Two files, both `dashboard/`, both in this lane's paths.

## Scope

**RC2, not RC1.** `dashboard/` is image bytes, and RC1's gate is the #1318 battery leg green **on the tip** — a merge here moves the tip out from under a verdict that names a `BUILD_COMMIT`. Note that the leg would not otherwise notice this change: `tests/os/setup-again-leg.sh` never renders the screen, it drives the host by writing spool files over SSH, so a third button has **no tier-4 cover** and the node rows above are the coverage.
