### PR TITLE
fix(os): #1931 the debug variant pins the test registry into /etc/environment too

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -174,10 +174,11 @@ Two build variants, chosen by one flag:
   over SSH. Verify with `tests/os/verify-image.sh IMAGE --test`. A bench that takes an A/B
   update to a *release* bundle loses SSH — deliberate, and worth remembering before pressing
   install. Built with `PITHEAD_REGISTRY` set to a non-default namespace, a debug image also
-  pins that registry into its boot units and tells podman how to trust it — the CA file named
-  by `PITHEAD_REGISTRY_CA` for a TLS registry, or an insecure entry without one — so a bench box
-  can provision from a registry on the LAN (#1892); the release variant never carries any of
-  those files, and `verify-image.sh` checks both ways.
+  pins that registry into its boot units and into `/etc/environment` (so a `pithead` verb run
+  by hand over SSH pulls from the same place, #1931) and tells podman how to trust it — the CA
+  file named by `PITHEAD_REGISTRY_CA` for a TLS registry, or an insecure entry without one — so
+  a bench box can provision from a registry on the LAN (#1892); the release variant never
+  carries any of that, and `verify-image.sh` checks both ways.
 
 The updater defaults to RAUC; an image built without it cannot take another update, and the
 only way to get one now is to set `PITHEAD_UPDATER` to something else on purpose.

--- a/os/build-image.sh
+++ b/os/build-image.sh
@@ -159,6 +159,14 @@ if [ -n "$TEST_REGISTRY" ]; then
         printf '[Service]\nEnvironment=PITHEAD_REGISTRY=%s\n' "$TEST_REGISTRY" \
             >"$stage/etc/systemd/system/$u.service.d/pithead-test-registry.conf"
     done
+    # An SSH shell running ./pithead by hand reads /etc/environment through PAM, never a unit's
+    # drop-in (#1931): the pin goes there too, appended to the file the rootfs already carries
+    # (PITHEAD_ENGINE, Dockerfile) so the later tar entry replaces it whole and loses nothing.
+    tar -xOf os/build/pithead-root.tar etc/environment >"$stage/etc/environment" || {
+        echo "build-image: the exported rootfs has no etc/environment to pin the registry into" >&2
+        exit 1
+    }
+    printf 'PITHEAD_REGISTRY=%s\n' "$TEST_REGISTRY" >>"$stage/etc/environment"
     # containers/image reads /etc/containers/certs.d/<host:port>/ca.crt for a TLS registry; the
     # insecure entry is the HTTP fallback. One or the other, never both.
     if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then

--- a/tests/os/verify-image-variant.sh
+++ b/tests/os/verify-image-variant.sh
@@ -13,6 +13,8 @@ if [ "$MODE" = "--test" ]; then
     # #1892: built against a non-default registry, the boot units must carry it AND podman must trust it — one without the other is a first boot that cannot find its wizard image, or a provision that refuses the pull.
     if [ -n "${PITHEAD_REGISTRY:-}" ] && [ "$PITHEAD_REGISTRY" != ghcr.io/p2pool-starter-stack ]; then
         chk "all three boot units pinned to the test registry" '[ "$(grep -lxF "Environment=PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT"/etc/systemd/system/{pithead-boot,pithead-firstboot,pithead-setup-again}.service.d/pithead-test-registry.conf 2>/dev/null | wc -l)" = 3 ]'
+        # #1931: a PAM login (an SSH shell running ./pithead by hand) reads /etc/environment, not the drop-ins; the engine pin beside it proves the file was appended to, not replaced.
+        chk "/etc/environment pinned to the test registry, engine pin kept" 'grep -qxF "PITHEAD_REGISTRY=$PITHEAD_REGISTRY" "$ROOT/etc/environment" && grep -qxF "PITHEAD_ENGINE=podman" "$ROOT/etc/environment"'
         # The trust half is whichever the builder chose: the CA it was handed, byte for byte, or the insecure entry.
         if [ -n "${PITHEAD_REGISTRY_CA:-}" ]; then
             chk "podman trusts the test registry's CA, and no insecure entry" 'cmp -s "$PITHEAD_REGISTRY_CA" "$ROOT/etc/containers/certs.d/${PITHEAD_REGISTRY%%/*}/ca.crt" && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ]'
@@ -23,7 +25,7 @@ if [ "$MODE" = "--test" ]; then
 else
     # The reason this script exists in versioned form: a leaked test key on a release image is a
     # backdoor, and ad-hoc eyeballing is how one ships.
-    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && ! ls "$ROOT"/etc/systemd/system/*/pithead-test-registry.conf >/dev/null 2>&1'
+    chk "NO test marker, NO test registry pin or trust (#1892)" '[ ! -e "$ROOT/etc/pithead-test-marker" ] && [ ! -e "$ROOT/etc/containers/registries.conf.d/pithead-test-registry.conf" ] && [ ! -e "$ROOT/etc/containers/certs.d" ] && ! ls "$ROOT"/etc/systemd/system/*/pithead-test-registry.conf >/dev/null 2>&1 && ! grep -q "^PITHEAD_REGISTRY=" "$ROOT/etc/environment"'
     chk "NO SSH authorized_keys" '[ ! -s "$ROOT/root/.ssh/authorized_keys" ]'
     chk "ssh service disabled" '! ls "$ROOT"/etc/systemd/system/multi-user.target.wants/ssh.service'
     chk "variant stamp says release" '[ "$(cat "$ROOT/etc/pithead-variant")" = "release" ]'


### PR DESCRIPTION
Closes #1931. **Stacked on #1915** (`feat/lan-registry-debug-variant`, MERGE-READY at its head): the base is that branch so the diff is the fix alone; retarget to `develop` once #1915 merges.

## What changes

- `os/build-image.sh`: the debug-variant tar-append (#1915's block) also writes `/etc/environment`. The file is copied out of the exported rootfs (it carries `PITHEAD_ENGINE=podman` from the Dockerfile), the `PITHEAD_REGISTRY=…` line is appended, and the result goes into the tar as a leaf file. GNU tar extracts in order, so `mkimage.sh`'s `tar -xf` lands the later copy, whole. A rootfs without the file is a loud refusal, not a silent skip.
- `tests/os/verify-image-variant.sh`: `--test` with a non-default `PITHEAD_REGISTRY` asserts the pin line AND the engine line in `/etc/environment` (the second proves the file was appended to, not replaced); release mode refuses any `PITHEAD_REGISTRY=` line there, in the same check that refuses the drop-ins.
- `docs/dev/appliance-release.md`: the debug-variant sentence names the file (shared `docs/`, disclosed per COMMON).

Why the image and not the harness: the harness runs `./pithead backup` over SSH exactly as a developer on the `--ssh` variant does, which is what the variant is for, and the RC1 image fails that path for both. The release rootfs is untouched: the append runs only under a non-default registry with the test key.

## What was RUN

- Synthetic tar on the host: a tar carrying `etc/environment` with the engine line; the block's own commands appended the pin; `tar -xf` extracted BOTH lines in one file and the sibling file survived. That is the override `mkimage.sh:86` relies on.
- NEGATIVE control, the new assertion against the RC1 image (BUILD_COMMIT `d7602bcc`, built without this fix): `verify-image.sh --test` gives 119 passed, 1 failed, the one failure being the new `/etc/environment` row. The same image was 119/0 under the pre-fix verifier in the RC1 chain, so the delta is exactly the new row.
- `bash -n`, `shfmt -i 4 -d`, `shellcheck -x -S warning` on both scripts: clean. `make lint-docs-voice` and `scripts/lint-file-budget.sh`: OK.

## What was NOT done

- POSITIVE control: a debug image built with this fix, verified 120/0, and a `./pithead backup` over SSH on it that brings the stack back from the private registry. The bench is under the RC1 battery; this runs on the first free slot and the verdict lands here with its BUILD_COMMIT. **Draft until then.**
- Release mode on a real release build: the refusal is asserted textually only; no release image was built tonight.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this lane's cwd)

- `/etc/environment` over `/etc/profile.d/`: a non-interactive `ssh host './pithead …'` never sources profile.d; PAM applies `/etc/environment` to every session, and the rootfs already uses it for the engine pin (`Dockerfile:244`).
- Append-over-copy rather than a Dockerfile `RUN`: keeps #1915's invariant that the release rootfs is byte-identical to a build that never heard of a test registry.
- Not a `pithead`-side reader of a pinned file: a code path in the release script for a debug-only concern.
- Two scripts plus a doc sentence; no adjacent merge available (the variant material already lives in one sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
