### PR TITLE
test(os): #1932 the browser-shaped submit polls the state read and names what it saw

### DIFF
--- a/tests/os/provision-browser-submit.sh
+++ b/tests/os/provision-browser-submit.sh
@@ -2,7 +2,7 @@
 #
 # The browser-shaped wizard submit for phase_provision (#1846). Sourced by tests/os/run.sh.
 # What a person's browser sends is not the no-JS field form: wizard.mjs takes the page's own
-# served config (/api/state .config — the reference merged with the last attempt), sets the
+# served config (/api/wizard-state .config — the reference merged with the last attempt), sets the
 # operator's answers on the same paths the page uses, and POSTs it whole as `config=<JSON>`
 # beside `auth_mode=auto` (the recommended "generate a strong password for me"). The old leg
 # posted `monero_wallet=…&pool=…`, which build_config() turns into a config server-side, so the
@@ -21,7 +21,7 @@ provision_browser_submit() { # <ip> <jar> [field=value]...
     # head of the body — so the log discriminates a refusal from a timeout from a non-JSON page (#1932).
     local raw="" http="" crc=0 tries=0
     while [ "$tries" -lt 6 ]; do
-        raw=$(curl -sSk -b "$jar" -m 5 -w '\n%{http_code}' "https://$ip/api/state" 2>/dev/null)
+        raw=$(curl -sSk -b "$jar" -m 5 -w '\n%{http_code}' "https://$ip/api/wizard-state" 2>/dev/null)
         crc=$?
         http=${raw##*$'\n'}
         raw=${raw%$'\n'*}
@@ -49,5 +49,5 @@ provision_browser_submit() { # <ip> <jar> [field=value]...
 # The page's own error line, for a red that names the refusal instead of a timeout. Empty when
 # the page shows none (or cannot be reached).
 provision_page_error() { # <ip> <jar>
-    curl -sSk -b "$2" -m 5 "https://$1/api/state" 2>/dev/null | jq -r '.error // ""' 2>/dev/null
+    curl -sSk -b "$2" -m 5 "https://$1/api/wizard-state" 2>/dev/null | jq -r '.error // ""' 2>/dev/null
 }

--- a/tests/os/provision-browser-submit.sh
+++ b/tests/os/provision-browser-submit.sh
@@ -16,9 +16,23 @@ provision_browser_submit() { # <ip> <jar> [field=value]...
     local ip="$1" jar="$2" served cfg extra=()
     shift 2
     for f in "$@"; do extra+=(--data-urlencode "$f"); done
-    served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/state" 2>/dev/null | jq -c '.config // empty' 2>/dev/null)
+    # A few reads, the way a person waits for the page: one cold read at -m 5 is not a verdict.
+    # When none serves a config, the reason prints what the helper saw — status, curl's rc, the
+    # head of the body — so the log discriminates a refusal from a timeout from a non-JSON page (#1932).
+    local raw="" http="" crc=0 tries=0
+    while [ "$tries" -lt 6 ]; do
+        raw=$(curl -sSk -b "$jar" -m 5 -w '\n%{http_code}' "https://$ip/api/state" 2>/dev/null)
+        crc=$?
+        http=${raw##*$'\n'}
+        raw=${raw%$'\n'*}
+        served=$(printf '%s' "$raw" | jq -c '.config // empty' 2>/dev/null)
+        [ -n "$served" ] && break
+        tries=$((tries + 1))
+        sleep 5
+    done
     [ -n "$served" ] || {
-        printf 'no-served-config'
+        printf 'no-served-config(http=%s curl=%s after %sx5s body=%s)' "${http:-none}" "$crc" "$tries" \
+            "$(printf '%s' "$raw" | head -c 60 | tr -c '[:print:]' '?')"
         return 1
     }
     # The four answers the Both role gives on the page, on the page's own paths (wizard.mjs

--- a/tests/os/reinstall-prefill-submit-leg.sh
+++ b/tests/os/reinstall-prefill-submit-leg.sh
@@ -60,7 +60,7 @@ phase_install_prefill_submit_leg() { # <target-disk>
     }
     # Fixture-works control: the page must be OFFERING the previous install's answers, or the
     # candidate below is a blank form and the row cannot reach the #1846 path.
-    served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/state" 2>/dev/null | jq -r '.config.monero.wallet_address // ""' 2>/dev/null)
+    served=$(curl -sSk -b "$jar" -m 5 "https://$ip/api/wizard-state" 2>/dev/null | jq -r '.config.monero.wallet_address // ""' 2>/dev/null)
     case "$served" in
     "${HARNESS_WALLET:0:8}"*) ok "pre-fill submit leg: the page offers the previous install's answers (pre-fill armed)" ;;
     *)


### PR DESCRIPTION
Closes #1932.

## What changes

**Second commit `d9731630` — the fix the first commit's reason line found.** Both reads in the helper move from `/api/state` to `/api/wizard-state`. The wizard registers only the latter (`dashboard/mining_dashboard/wizard.py:526`); `/api/state` is the provisioned dashboard's endpoint and does not exist on the wizard, so the browser-shaped submit has returned 404 on every battery since #1847. `run.sh`'s own pre-fill check already reads `/api/wizard-state` (`run.sh:1428`); the three `/api/state` reads left in `run.sh` are against the provisioned dashboard with basic auth and are correct.

**First commit `f2684e4c`:** `tests/os/provision-browser-submit.sh`: the served-config read polls `/api/state` up to six times, 5 s apart (the way the handoff poll in `run.sh` waits, and the way a person waits for a page), and when no read serves a `.config` the reason names what the helper saw: `no-served-config(http=<code> curl=<rc> after <n>x5s body=<first 60 printable bytes>)`. The contract to its two callers is unchanged: the HTTP status of `/submit`, or a short reason.

## Why

The RC1 battery's provision phase reddened on the bare word `no-served-config`, and `wizard_state` returns `config` on every authenticated request (`dashboard/mining_dashboard/wizard.py:242-266`; `_spool_json` fails open), so the word covered three different failures, a non-200, a 5 s timeout on a cold first read, a non-JSON body, and the log could not say which. The next battery will.

## What was RUN

- **KVM provision phase, first commit cherry-picked onto the #1942 branch** (BUILD_COMMIT `e1f7cca3`, 2026-09-06 12:57Z, evidence `~/kvm1942b-20260906T1246Z` on the build box): `no-served-config(http=404 curl=0 after 6x5s body=404: Not Found)` — the reason line did its job on its first run. The route mismatch was then read at source (`wizard.py:526`).
- The three shapes the parse must handle, measured on the host with the same lines: a timeout (`curl` rc 28 gives `http=000` and an empty body), a live 200 with a JSON body lacking `.config` (gives `http=200`, served empty, falls through to the reason), and a JSON body with a trailing newline before the status line (`.config` extracted intact).
- `bash -n`, `shfmt -i 4 -d`, `shellcheck -x -S warning`: clean. `run.sh` is `set -uo pipefail` (no `-e`), so the failing assignment cannot exit the harness.

## What was NOT done

- KVM: the provision phase WITH the second commit. It runs next on the bench (as the #1942 re-proof, which carries this branch cherry-picked); rc and BUILD_COMMIT are posted here when it lands. Until then the route fix is proven by source (`wizard.py:526`, `run.sh:1428`) and by the 404 above, not by a green leg.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this lane's cwd)

- Polling rather than a longer `-m`: one 30 s read hides a slow server behind a slow network; six short reads say how many it took.
- The reason carries the body head, not the whole body: 60 printable bytes tells an HTML error page from JSON and keeps the log line readable.
- One file; `run.sh` sits at its 3423-line ceiling and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ



**Third commit `9fbc6e80` — the fourth `/api/state` site, found by the fixes lane at source.** `tests/os/reinstall-prefill-submit-leg.sh:63`, the fixture-works control at the top of the install-phase pre-fill leg, read `/api/state` with the wizard's session jar; it now reads `/api/wizard-state`, whose `config` carries the `monero.wallet_address` it compares. That leg is live (`run.sh:1958`) but has never run past the restore leg's red, so no battery had reached it yet; PR #1947 is what lets a run reach it. The three `/api/state` reads left in `run.sh` are basic-auth reads against the provisioned dashboard and stay. Bench evidence for the second commit's route fix: #1942 run 3 on BUILD_COMMIT `2d7c2a12` (this branch's first two commits over fix/1896) — the browser-shaped submit passed and the provision phase ran on; rc posted on this PR when the leg finished.
