### PR TITLE
feat(wizard): #1889 the setup page names which node check failed, and what a pass actually proved

### DIFF
--- a/dashboard/mining_dashboard/web/static/nodeprobe.mjs
+++ b/dashboard/mining_dashboard/web/static/nodeprobe.mjs
@@ -1,0 +1,124 @@
+// The host's remote-node probe report, rendered (#1889). ONE module, because the same report
+// reaches an operator on two surfaces — the wizard's setup screen, and the Configuration view's
+// preview once the control channel carries a probe of its own — and seven failure reasons worded
+// two ways is exactly how two surfaces come to disagree about what a failure means.
+//
+// IT GATES NOTHING. `preflight_remote_nodes` refuses to provision and hands the form back
+// (12-firstboot-wizard.sh), which is the same side wizard.py already puts "which step this machine
+// is on" on. A client-side disable here would be worse than a courtesy: the only way out of a
+// failed probe is to correct the host or the port and submit again, and a disabled button takes
+// that away. The CONSEQUENCE sentence is the surface's own, passed in — setup halting and an apply
+// being refused are different things — so it arrives as this component's children, while the
+// vocabulary below is shared so it cannot drift between the two.
+
+import { html } from "./preact.mjs";
+
+// What each row is, in the operator's terms. A target/check pair this map has no name for still
+// renders: the host and port beside it are what identify an endpoint, so an unnamed row reads
+// vague rather than wrong.
+const ENDPOINTS = {
+  "monero:rpc": "Monero node, RPC port",
+  "monero:zmq": "Monero node, ZMQ port",
+  "tari:connect": "Tari node, gRPC port",
+};
+
+// Why a check did not pass. Two of these are not reachability failures at all, and copy that
+// lumps them in with the rest sends the operator to check something that is working:
+//   - `auth` is a node that ANSWERED and wanted a login. It is a dead end, not a retry — there is
+//     nowhere in a remote-node config to put credentials.
+//   - `missing-tool` is curl missing on THIS machine. Nothing about the operator's node is known.
+// An unlisted reason falls to "did not complete" and never to "not reached": inventing a
+// reachability claim for a value this page does not recognise is the defect #1913 names, and the
+// probe's vocabulary is expected to grow a name-resolution reason.
+const REASONS = {
+  protocol: "The port is open, and what is listening there is not the node this expects.",
+  timeout: "Nothing answered within the time the check allows.",
+  refused: "Not reached — no connection was made to that address.",
+  auth: "The node answered, and asked for a login this machine has nowhere to keep.",
+  "missing-tool": "This machine could not run the check — the fault is here, not with your node.",
+  unknown: "The check did not complete.",
+};
+const UNRECOGNISED = REASONS.unknown;
+
+// What a pass PROVED, which is not the same claim on every endpoint. A bare TCP connect is
+// satisfied by any socket that accepts — an ssh forward, a stray container, the right port on the
+// wrong host — and the shipped CLI has no Tari client to ask further, so that pass is always
+// reported qualified rather than as a verified node.
+const PASSED = {
+  connect:
+    "The port accepted a connection. What is listening behind it was not checked — any socket that accepts satisfies this.",
+};
+const PASSED_DEFAULT = "Reached, and it answered a live check of the protocol itself.";
+
+/**
+ * What the surfaces render, or null when there is nothing to say: no report, a report whose
+ * verdict did not arrive as a real boolean, or a configuration that asked for no remote node at
+ * all. An ABSENT report is not a failed one — a machine running its own nodes probes nothing.
+ */
+export function probeSummary(report) {
+  if (!report || typeof report.ok !== "boolean") return null;
+  const probes = Array.isArray(report.probes) ? report.probes : [];
+  // `configured` is what the config ASKED for; `probes` is what arrived. The gap between them is a
+  // skipped endpoint, measured against the array rather than the report's own `probed` count: in a
+  // well-formed report the two are the same number, and in a malformed one the array is the thing
+  // actually on screen.
+  const configured = Number.isInteger(report.configured) ? report.configured : probes.length;
+  // Nothing asked and nothing checked is the healthy all-local machine, not a subject. A card
+  // about node checks on a machine that has no remote node is a puzzle, so it says nothing.
+  if (!configured && !probes.length) return null;
+  return {
+    ok: report.ok,
+    configured,
+    skipped: Math.max(0, configured - probes.length),
+    rows: probes.map(summariseRow),
+  };
+}
+
+function summariseRow(p) {
+  // Strictly `true`, the same discipline wizard.py reads the top-level verdict with: a string
+  // "false" arriving here must not read as a pass on the one screen that would show it.
+  const ok = p.ok === true;
+  const host = typeof p.host === "string" ? p.host : "";
+  return {
+    name: ENDPOINTS[`${p.target}:${p.checked}`] || "A node this machine was told to use",
+    where: host ? `${host}:${p.port}` : "",
+    ok,
+    verdict: ok ? "Reached" : "Not verified",
+    sentence: ok ? PASSED[p.checked] || PASSED_DEFAULT : REASONS[p.reason] || UNRECOGNISED,
+    // The host writes a sentence per row, and for one reason it is actively misleading: a
+    // `missing-tool` failure keeps the generic reach text, which names the operator's host, port
+    // and LAN switch — none of which has anything to do with a missing curl on this machine.
+    // Every other reason either gets a precise sentence from the host or a generic one still true.
+    detail: p.reason === "missing-tool" || typeof p.detail !== "string" ? "" : p.detail,
+  };
+}
+
+export const NodeProbeReport = ({ report, children }) => {
+  const s = probeSummary(report);
+  if (!s) return null;
+  return html`<div class="card">
+    <h3 class=${s.ok ? "c-ok" : "c-bad"}>
+      ${
+        s.ok
+          ? "Every node check this configuration asks for passed."
+          : "A node this machine was told to use could not be verified."
+      }
+    </h3>
+    ${!s.ok && children && html`<p>${children}</p>`}
+    <ul class="config-preview-list">
+      ${s.rows.map(
+        (r) => html`<li>
+          <strong>${r.name}</strong>${
+            r.where ? html` <code class="wizard-mono">${r.where}</code>` : null
+          } — <span class=${r.ok ? "c-ok" : "c-bad"}>${r.verdict}</span>. ${r.sentence}
+          ${r.detail ? html`<p class="text-muted">${r.detail}</p>` : null}
+        </li>`,
+      )}
+    </ul>
+    ${
+      s.skipped > 0 &&
+      html`<p class="c-bad">${s.skipped} of the ${s.configured} checks this configuration asks for
+      produced no result at all, so nothing here covers them.</p>`
+    }
+  </div>`;
+};

--- a/dashboard/mining_dashboard/web/static/nodeprobe.mjs
+++ b/dashboard/mining_dashboard/web/static/nodeprobe.mjs
@@ -1,6 +1,6 @@
 // The host's remote-node probe report, rendered (#1889). ONE module, because the same report
 // reaches an operator on two surfaces — the wizard's setup screen, and the Configuration view's
-// preview once the control channel carries a probe of its own — and seven failure reasons worded
+// preview once the control channel carries a probe of its own — and six failure reasons worded
 // two ways is exactly how two surfaces come to disagree about what a failure means.
 //
 // IT GATES NOTHING. `preflight_remote_nodes` refuses to provision and hands the form back
@@ -96,10 +96,17 @@ function summariseRow(p) {
 export const NodeProbeReport = ({ report, children }) => {
   const s = probeSummary(report);
   if (!s) return null;
+  // The headline has to agree with the skipped paragraph below it. `ok` alone would put a green
+  // "every check passed" over a red "2 of the 3 produced no result" — unreachable from the shipped
+  // producer, whose `ok` already implies `probed == configured`, but this is precisely the
+  // malformed report `skipped` exists to survive, and an endpoint that produced no row was not
+  // verified. The CONSEQUENCE below deliberately stays on `s.ok`: a host that published `ok: true`
+  // DID proceed, so telling the operator setup had stopped would be the opposite lie.
+  const passed = s.ok && s.skipped === 0;
   return html`<div class="card">
-    <h3 class=${s.ok ? "c-ok" : "c-bad"}>
+    <h3 class=${passed ? "c-ok" : "c-bad"}>
       ${
-        s.ok
+        passed
           ? "Every node check this configuration asks for passed."
           : "A node this machine was told to use could not be verified."
       }

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -16,6 +16,7 @@ import {
   pathSet,
   telegramPairReady,
 } from "./configsync.mjs";
+import { NodeProbeReport } from "./nodeprobe.mjs";
 import { Component, html, render } from "./preact.mjs";
 import { rigCardFields, rigCardNote } from "./rigcardlogic.mjs";
 import { savedRoleOrSetup } from "./savedrole.mjs";
@@ -296,6 +297,7 @@ export class WizardApp extends Component {
       dataWiped: s.data_wiped || {},
       handoff: s.handoff || null,
       savedRole: s.saved_role || null,
+      nodeProbe: s.node_probe || null,
     };
     // The host's discovery pre-fills the rig fields, but only while they are untouched — the
     // form polls, and a half-typed pool address must survive it (same rule as cfg below).
@@ -636,6 +638,8 @@ export class WizardApp extends Component {
             onClick=${() => this.setState({ restoreMode: true, error: "" })}>
             Restoring an existing Pithead? Upload its backup instead.</button></p>
         <${Err}>${error}<//>
+        <${NodeProbeReport} report=${this.state.nodeProbe}>Setup does not continue while a
+        check is failing. Correct the address below and submit again.<//>
         <form onSubmit=${this.submit}>
             <${Field} label="What is this machine?">
                 <select value=${role} onChange=${this.setRole}>

--- a/dashboard/mining_dashboard/wizard.py
+++ b/dashboard/mining_dashboard/wizard.py
@@ -156,6 +156,25 @@ def _saved_role() -> dict | None:
     return saved if isinstance(saved.get("role"), str) and saved["role"] else None
 
 
+def _node_probe() -> dict | None:
+    """The host's remote-node probe report (#1889), published beside the config it judged:
+    ``{ok, configured, probed, probes: [{target, host, port, ok, checked, reason, detail,
+    elapsed_ms}]}``.
+
+    None means NO REPORT, which is not the same as a failed one and must render as nothing at
+    all: an all-local machine probes nothing, and a host older than the report writes no file.
+    `ok` is missing from an absent file exactly as it is from a truncated one, so PRESENCE is
+    what separates them and the check is that `ok` arrived as a real bool — reading a falsy
+    default here would block every machine that runs its own nodes.
+
+    This is the report that says WHY, never a second opinion about whether to proceed: the gate
+    is the HOST's, in 12-firstboot-wizard.sh, which calls preflight_remote_nodes before
+    provisioning commits and refuses there.
+    """
+    report = _spool_json("node-probe.json")
+    return report if isinstance(report.get("ok"), bool) else None
+
+
 def wizard_stage() -> str:
     """Which step this machine is actually on, decided by the SPOOL — never by the client.
 
@@ -263,6 +282,8 @@ async def wizard_state(request: web.Request) -> web.Response:
             "handoff": json.loads(raw_handoff) if raw_handoff else None,
             # Always present, null when this is not a set-up-again boot (#1318).
             "saved_role": _saved_role(),
+            # Always present, null when no probe ran at all (#1889).
+            "node_probe": _node_probe(),
         }
     )
 

--- a/dashboard/tests/frontend/wizardprobe.test.mjs
+++ b/dashboard/tests/frontend/wizardprobe.test.mjs
@@ -205,6 +205,22 @@ test("skipped: the gap is named on screen, and stays silent when there is none",
   assert.doesNotMatch(card(report([RPC, ZMQ])), /checks this configuration asks for/);
 });
 
+test("skipped: a gap contradicts the headline, whatever the verdict says", () => {
+  // `ok: true` beside a gap is unreachable from the shipped producer — its `ok` already implies
+  // `probed == configured` — but it is exactly the malformed report `skipped` exists to survive,
+  // and the two lines are computed independently. A green "every check passed" above a red "2 of
+  // the 3 produced no result" is one card telling the operator both things at once.
+  const out = card(report([RPC], { ok: true, configured: 3 }));
+  assert.doesNotMatch(out, /Every node check this configuration asks for passed/);
+  assert.match(out, /2 of the 3 checks/);
+  // The consequence still keys on the verdict, not on the gap: this host published `ok: true` and
+  // DID proceed, so claiming setup had stopped would be the opposite lie.
+  assert.doesNotMatch(card(report([RPC], { ok: true, configured: 3 }), "Setup does not continue."), /Setup does not continue/);
+  // The two controls that keep this narrow: a clean pass still says so, and the gap is what moved
+  // the headline — not the mere presence of the paragraph.
+  assert.match(card(report([RPC, ZMQ])), /Every node check this configuration asks for passed/);
+});
+
 // --- rendered -----------------------------------------------------------------------------------
 
 test("rendered: a failure names the endpoint, the address, the reason and the host's detail", () => {

--- a/dashboard/tests/frontend/wizardprobe.test.mjs
+++ b/dashboard/tests/frontend/wizardprobe.test.mjs
@@ -1,0 +1,301 @@
+// The remote-node probe report as an operator reads it (#1889). The host refuses to provision when
+// a configured node does not answer; this module is what turns that refusal into which endpoint and
+// why. Kept DOM-free — every branch here is a boot state nobody can reach by hand.
+//
+// The fixtures are the producer's shape, taken from node_probe_one in 10-installer-preseed.sh: the
+// row keys, the seven reasons, and the host's own `detail` sentence for each.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  NodeProbeReport,
+  probeSummary,
+} from "../../mining_dashboard/web/static/nodeprobe.mjs";
+import { html } from "../../mining_dashboard/web/static/preact.mjs";
+import { WizardApp } from "../../mining_dashboard/web/static/wizard.mjs";
+import { renderToString } from "./helpers/render.mjs";
+
+const RPC = {
+  target: "monero",
+  host: "192.168.1.10",
+  port: 18081,
+  ok: true,
+  checked: "rpc",
+  reason: "ok",
+  detail: "reached 192.168.1.10:18081 and verified it with a live rpc check",
+  elapsed_ms: 12,
+};
+const ZMQ = { ...RPC, port: 18083, checked: "zmq" };
+const TARI = {
+  ...RPC,
+  target: "tari",
+  port: 18142,
+  checked: "connect",
+  detail: "192.168.1.10:18142 accepted a TCP connection; the protocol behind it was NOT checked",
+};
+
+// The generic reach sentence the host writes for any failure it cannot name more precisely — the
+// one that sends the operator to their host, their port and their LAN switch.
+const REACH = "cannot reach the remote Monero node at 192.168.1.10:18081 — check the host, the port, and that the node allows LAN access";
+
+const failed = (reason, over = {}) => ({ ...RPC, ok: false, reason, detail: REACH, ...over });
+const report = (probes, over = {}) => ({
+  ok: probes.every((p) => p.ok === true),
+  configured: probes.length,
+  probed: probes.length,
+  ...over,
+  probes,
+});
+
+const rowsOf = (probes, over) => probeSummary(report(probes, over)).rows;
+const one = (probe) => rowsOf([probe])[0];
+const card = (rep, children) =>
+  renderToString(html`<${NodeProbeReport} report=${rep}>${children}<//>`);
+
+// --- the absent report is not a failed one ----------------------------------------------------
+
+test("probeSummary: no usable verdict is nothing to render, not a failure", () => {
+  // Same discipline wizard.py reads the file with, repeated here because this module is also the
+  // one a second producer will feed. `null` is the ordinary state of a machine older than the
+  // report, and of one whose report could not be parsed.
+  for (const r of [null, undefined, {}, { probes: [] }]) {
+    assert.equal(probeSummary(r), null, JSON.stringify(r));
+  }
+  // A verdict that is not a real boolean, on a report that DOES carry rows — the rows matter,
+  // because otherwise the empty-configuration door below answers for this one and the check here
+  // is never exercised. `ok: "false"` is the shape that bites: it is TRUTHY, so reading presence
+  // as `!= null` would put "every check passed" over a refusal.
+  for (const ok of ["true", "false", 1, 0, null, undefined]) {
+    const r = { ok, configured: 2, probed: 2, probes: [RPC, ZMQ] };
+    assert.equal(probeSummary(r), null, JSON.stringify(ok));
+  }
+  // The control that proves those fixtures arm at all: the same report with a real boolean is
+  // rendered, so the six above are not passing because nothing reaches the check.
+  assert.notEqual(probeSummary({ ok: false, configured: 2, probed: 2, probes: [RPC, ZMQ] }), null);
+});
+
+test("probeSummary: a machine that runs its own nodes says nothing at all", () => {
+  // 0 of 0 is a PASS on the host and a non-subject on the page: a card about node checks on a
+  // machine with no remote node is a puzzle, not reassurance.
+  assert.equal(probeSummary({ ok: true, configured: 0, probed: 0, probes: [] }), null);
+  assert.equal(card({ ok: true, configured: 0, probed: 0, probes: [] }), "");
+  // The sibling that keeps that narrow: one configured endpoint IS a subject.
+  assert.notEqual(probeSummary(report([RPC])), null);
+});
+
+// --- which endpoint ---------------------------------------------------------------------------
+
+test("rows: the three real endpoints are named apart, and carry the address probed", () => {
+  const names = rowsOf([RPC, ZMQ, TARI]).map((r) => r.name);
+  assert.equal(new Set(names).size, 3, names.join(" | "));
+  assert.match(names[0], /Monero/);
+  assert.match(names[1], /Monero/);
+  assert.match(names[2], /Tari/);
+  assert.deepEqual(
+    rowsOf([RPC, ZMQ, TARI]).map((r) => r.where),
+    ["192.168.1.10:18081", "192.168.1.10:18083", "192.168.1.10:18142"],
+  );
+});
+
+test("rows: an endpoint this page has no name for still renders, identified by its address", () => {
+  // The probe's vocabulary is expected to grow. A row it cannot name reads vague; it must not read
+  // as some other endpoint, and it must not vanish.
+  const r = one({ ...RPC, target: "future-chain", checked: "future-check" });
+  assert.doesNotMatch(r.name, /Monero|Tari/);
+  assert.equal(r.where, "192.168.1.10:18081");
+});
+
+test("rows: a host the config left blank drops the address rather than rendering a bare port", () => {
+  assert.equal(one({ ...RPC, host: "" }).where, "");
+  assert.equal(one({ ...RPC, host: null }).where, "");
+});
+
+// --- what a pass proved -----------------------------------------------------------------------
+
+test("rows: a bare TCP connect renders QUALIFIED, never as a verified node", () => {
+  // Any socket that accepts satisfies a connect — an ssh forward, a stray container, the right
+  // port on the wrong host — and there is no Tari client here to ask further.
+  const r = one(TARI);
+  assert.equal(r.ok, true);
+  assert.match(r.sentence, /not checked/);
+  assert.doesNotMatch(r.sentence, /verified|protocol itself/);
+  // The sibling that keeps it narrow: a live protocol check says so, and says it differently.
+  assert.match(one(RPC).sentence, /live check of the protocol/);
+  assert.notEqual(one(RPC).sentence, r.sentence);
+});
+
+test("rows: only a strict true is a pass", () => {
+  // The report is JSON from a shell script. A string "false" reading as a pass would show a green
+  // row for an endpoint the host refused to provision against.
+  for (const ok of ["false", "true", 1, 0, null, undefined]) {
+    assert.equal(one({ ...RPC, ok }).ok, false, JSON.stringify(ok));
+  }
+  assert.equal(one(RPC).ok, true);
+});
+
+// --- why it failed ----------------------------------------------------------------------------
+
+test("reasons: each of the six failure reasons gets its own sentence", () => {
+  const reasons = ["protocol", "timeout", "refused", "auth", "missing-tool", "unknown"];
+  const said = reasons.map((r) => one(failed(r)).sentence);
+  assert.equal(new Set(said).size, reasons.length, said.join(" | "));
+});
+
+test("reasons: refused reads as NOT REACHED, never as reached and declined", () => {
+  // One unresolvable host makes the ZMQ leg say `refused` and the RPC leg say `unknown` — neither
+  // may claim the node answered, and neither may blame the operator's network.
+  const s = one(failed("refused")).sentence;
+  assert.match(s, /Not reached/);
+  assert.doesNotMatch(s, /answered|declined|refused the connection|your network/i);
+  // The sibling: `protocol` is the reason that DOES get to say the port is open, because it is
+  // the one where something replied.
+  assert.match(one(failed("protocol")).sentence, /port is open/);
+});
+
+test("reasons: auth is a dead end, not a reachability failure", () => {
+  // The node ANSWERED and wanted a login, and a remote-node config has nowhere to put one. Copy
+  // that lumps this in with `refused` sends the operator to re-check a working firewall.
+  const s = one(failed("auth")).sentence;
+  assert.match(s, /answered/);
+  assert.match(s, /login/);
+  assert.doesNotMatch(s, /Not reached/);
+});
+
+test("reasons: an unrecognised reason did not COMPLETE, and is never reported as NOT REACHED", () => {
+  // The probe grows a name-resolution reason next. Inventing a reachability claim for a value this
+  // page has never seen is the defect that fix exists to end, so the default must not make one.
+  for (const reason of ["dns", "", null, undefined, "ok"]) {
+    const s = one(failed(reason)).sentence;
+    assert.equal(s, "The check did not complete.", JSON.stringify(reason));
+  }
+  // The sibling that proves the assertion above is not vacuous: a reason it DOES know reads
+  // differently, so "did not complete" is not simply what every row says.
+  assert.notEqual(one(failed("refused")).sentence, "The check did not complete.");
+});
+
+test("reasons: missing-tool blames THIS machine, and drops the host's sentence that blames yours", () => {
+  // curl rc 127 is our binary missing. The host keeps its generic reach text on that row, which
+  // names the operator's host, port and LAN switch — every one of them innocent.
+  const r = one(failed("missing-tool"));
+  assert.match(r.sentence, /fault is here/);
+  assert.doesNotMatch(r.sentence, /Not reached/);
+  assert.equal(r.detail, "");
+  // The sibling that keeps the suppression to the one reason that needs it: the SAME host sentence
+  // on a `refused` row is shown, because there it is true.
+  assert.equal(one(failed("refused")).detail, REACH);
+});
+
+test("rows: a detail the host did not write is dropped rather than rendered as text", () => {
+  assert.equal(one(failed("refused", { detail: null })).detail, "");
+  assert.equal(one(failed("refused", { detail: 7 })).detail, "");
+});
+
+// --- the endpoints that produced no row at all ------------------------------------------------
+
+test("skipped: an endpoint that emitted no row is counted from the array, not from `probed`", () => {
+  // `probed` is the producer's own count; the array is what is on screen. In a well-formed report
+  // they agree, and in a malformed one only one of them is the truth.
+  assert.equal(probeSummary(report([RPC], { configured: 3, probed: 3 })).skipped, 2);
+  assert.equal(probeSummary(report([RPC, ZMQ])).skipped, 0);
+  assert.equal(probeSummary(report([RPC], { configured: 0 })).skipped, 0);
+});
+
+test("skipped: the gap is named on screen, and stays silent when there is none", () => {
+  assert.match(card(report([RPC], { configured: 3, ok: false })), /2 of the 3 checks/);
+  assert.doesNotMatch(card(report([RPC, ZMQ])), /checks this configuration asks for/);
+});
+
+// --- rendered -----------------------------------------------------------------------------------
+
+test("rendered: a failure names the endpoint, the address, the reason and the host's detail", () => {
+  const out = card(report([failed("timeout"), ZMQ]));
+  assert.match(out, /could not be verified/);
+  assert.match(out, /Monero node, RPC port/);
+  assert.match(out, /192\.168\.1\.10:18081/);
+  assert.match(out, /Nothing answered within the time/);
+  assert.match(out, new RegExp(REACH.slice(0, 40).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  // The passing sibling endpoint is still shown: "the node is not the problem" is worth as much as
+  // naming the one that is.
+  assert.match(out, /Monero node, ZMQ port/);
+});
+
+test("rendered: a pass does not claim more than the checks proved", () => {
+  const out = card(report([RPC, TARI]));
+  assert.match(out, /Every node check this configuration asks for passed/);
+  // The headline defers to the rows rather than saying every node "answered" — a connect did not.
+  assert.match(out, /any socket that accepts satisfies this/);
+});
+
+test("rendered: the consequence is the surface's sentence, and only a failure has one", () => {
+  const words = "Setup does not continue while a check is failing.";
+  assert.match(card(report([failed("refused")]), words), /Setup does not continue/);
+  assert.doesNotMatch(card(report([RPC]), words), /Setup does not continue/);
+});
+
+test("rendered: the report offers no control — it gates nothing", () => {
+  // The gate is the host's: preflight_remote_nodes refuses to provision and hands the form back.
+  // A client-side disable would take away the only way out of a failed probe, which is to correct
+  // the address and submit again.
+  const out = card(report([failed("refused")]), "Setup does not continue.");
+  assert.doesNotMatch(out, /<button|<input|<form|disabled/);
+});
+
+// --- the seam ------------------------------------------------------------------------------------
+// A correct component over a wrong served value is the shape that survived the last fix on this
+// page: every component test passed the value in explicitly and saw nothing. So this drives the
+// real app against a real /api/wizard-state body and reads what the setup screen actually paints.
+
+async function setupScreen(nodeProbe) {
+  const inst = new WizardApp({});
+  inst.setState = (patch) => Object.assign(inst.state, patch);
+  inst.poll = () => {};
+  const real = globalThis.fetch;
+  const cfg = { monero: { wallet_address: "", prune: true }, p2pool: { pool: "mini" } };
+  globalThis.fetch = async (url) =>
+    String(url).includes("/api/wizard-state")
+      ? {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            stage: "setup",
+            config: cfg,
+            reference: cfg,
+            error: "cannot reach the remote Monero node",
+            disks: [],
+            handoff: null,
+            saved_role: null,
+            node_probe: nodeProbe,
+          }),
+        }
+      : { ok: true, status: 200, json: async () => ({}), text: async () => "" };
+  await inst.loadState();
+  globalThis.fetch = real;
+  return renderToString(inst.renderSetup());
+}
+
+test("seam: the setup screen paints what /api/wizard-state actually serves as node_probe", async () => {
+  const out = await setupScreen(report([failed("protocol"), ZMQ]));
+  assert.match(out, /could not be verified/);
+  assert.match(out, /Monero node, RPC port/);
+  assert.match(out, /port is open/);
+  // The consequence sentence belongs to this surface, and this is the only place it is written.
+  assert.match(out, /Setup does not continue/);
+  // The host's one-line error still stands above it — the report explains that line, never
+  // replaces it.
+  assert.match(out, /cannot reach the remote Monero node/);
+});
+
+test("seam: a machine that was never probed gets the ordinary form, with nothing extra on it", async () => {
+  // `null` is what wizard.py serves for an all-local machine and for any host older than the
+  // report, and it is the common case — the form must not grow a card for it.
+  const out = await setupScreen(null);
+  assert.doesNotMatch(out, /could not be verified|node check this configuration/);
+  assert.match(out, /What is this machine\?/);
+});
+
+test("seam: the submit button stays live under a failed probe", async () => {
+  // The gate is the host's. The operator's only way out is to correct the address and submit
+  // again, so a failing report must not take the button away.
+  const out = await setupScreen(report([failed("refused")]));
+  assert.match(out, /<button type="submit">/);
+});

--- a/dashboard/tests/web/test_wizard_probe.py
+++ b/dashboard/tests/web/test_wizard_probe.py
@@ -105,9 +105,7 @@ async def test_a_passing_report_is_served_verbatim(client, spool):
     assert (await _state(client))["node_probe"] == _report()
 
 
-async def test_a_failing_report_keeps_every_row_so_the_page_can_say_which_leg_failed(
-    client, spool
-):
+async def test_a_failing_report_keeps_every_row_so_the_page_can_say_which_leg_failed(client, spool):
     """Monero contributes two rows to Tari's one, and the operator needs the one that failed
     named — a report reduced to its top-level verdict cannot say which."""
     rows = [

--- a/dashboard/tests/web/test_wizard_probe.py
+++ b/dashboard/tests/web/test_wizard_probe.py
@@ -1,0 +1,199 @@
+"""The remote-node probe report's server half (#1889).
+
+Before provisioning commits, the HOST dials every remote node the config asked for and refuses
+if one does not answer — `preflight_remote_nodes`, called from `12-firstboot-wizard.sh`. Beside
+that refusal it publishes `node-probe.json`, the report that says WHY. These tests pin what the
+wizard's state API does with it.
+
+The distinction they exist for: **an absent report is not a failed one.** An all-local machine
+probes nothing and a host older than the report writes no file, and in both cases `ok` is
+missing from the parsed dict exactly as it would be from a truncated one. Reading a falsy
+default there would block every machine that runs its own nodes, so PRESENCE — `ok` arriving as
+a real bool — is the whole check.
+
+They live beside `test_wizard.py` rather than in it because that file is at its budget ceiling.
+"""
+
+import json
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from mining_dashboard import wizard
+
+
+@pytest.fixture
+def spool(tmp_path, monkeypatch):
+    sd = tmp_path / "spool"
+    sd.mkdir()
+    monkeypatch.setenv("WIZARD_SPOOL", str(sd))
+    monkeypatch.setenv("WIZARD_TOKEN", "pit-X7KM2Q")
+    sd.joinpath("config.reference.json").write_text(json.dumps({"p2pool": {"pool": "mini"}}))
+    return sd
+
+
+@pytest.fixture
+async def client(spool):
+    c = TestClient(TestServer(wizard.make_app(exit_fn=lambda code: None)))
+    await c.start_server()
+    yield c
+    await c.close()
+
+
+async def _auth(client, token="pit-X7KM2Q"):  # noqa: S107 — the test fixture's token, not a secret
+    return await client.post("/auth", data={"token": token}, allow_redirects=False)
+
+
+async def _state(client):
+    return await (await client.get("/api/wizard-state")).json()
+
+
+def _row(**over):
+    """One probe row in the shape 10-installer-preseed.sh emits."""
+    row = {
+        "target": "monero",
+        "host": "node.lan",
+        "port": 18081,
+        "ok": True,
+        "checked": "rpc",
+        "reason": "ok",
+        "detail": "reached node.lan:18081 and verified it with a live rpc check",
+        "elapsed_ms": 12,
+    }
+    row.update(over)
+    return row
+
+
+def _report(**over):
+    rep = {"ok": True, "configured": 1, "probed": 1, "probes": [_row()]}
+    rep.update(over)
+    return rep
+
+
+# --- absent is not failed --------------------------------------------------------------------
+
+
+async def test_node_probe_is_always_a_key_and_is_null_when_no_report_was_written(client):
+    """The client asserts on null, never on absence — so the key has to be there either way."""
+    await _auth(client)
+    s = await _state(client)
+    assert "node_probe" in s
+    assert s["node_probe"] is None
+
+
+async def test_a_machine_that_probed_nothing_is_not_reported_as_a_failure(client, spool):
+    """The defect this file exists for. An all-local machine writes no report, and the parsed
+    dict is then `{}` — whose `ok` is missing exactly as a FAILED report's would be if we read
+    it by truthiness. The two must not collapse: one blocks provisioning, the other is the
+    healthy default state of every machine running its own nodes."""
+    await _auth(client)
+    absent = (await _state(client))["node_probe"]
+
+    spool.joinpath("node-probe.json").write_text(json.dumps(_report(ok=False)))
+    failed = (await _state(client))["node_probe"]
+
+    assert absent is None
+    assert failed is not None and failed["ok"] is False
+
+
+# --- a report that exists is passed through whole -----------------------------------------
+
+
+async def test_a_passing_report_is_served_verbatim(client, spool):
+    spool.joinpath("node-probe.json").write_text(json.dumps(_report()))
+    await _auth(client)
+    assert (await _state(client))["node_probe"] == _report()
+
+
+async def test_a_failing_report_keeps_every_row_so_the_page_can_say_which_leg_failed(
+    client, spool
+):
+    """Monero contributes two rows to Tari's one, and the operator needs the one that failed
+    named — a report reduced to its top-level verdict cannot say which."""
+    rows = [
+        _row(checked="rpc"),
+        _row(checked="zmq", port=18083, ok=False, reason="refused", detail="cannot reach"),
+    ]
+    spool.joinpath("node-probe.json").write_text(
+        json.dumps({"ok": False, "configured": 2, "probed": 2, "probes": rows})
+    )
+    await _auth(client)
+    served = (await _state(client))["node_probe"]
+    assert served["probes"] == rows
+    assert [p["checked"] for p in served["probes"]] == ["rpc", "zmq"]
+
+
+async def test_nothing_configured_is_a_pass_and_reaches_the_page_as_one(client, spool):
+    """0 of 0 PASSES. `all()` over an empty array is true and that is the CORRECT answer for an
+    all-local config — `configured` is what separates it from a run that probed nothing of the
+    three it was asked for."""
+    spool.joinpath("node-probe.json").write_text(
+        json.dumps({"ok": True, "configured": 0, "probed": 0, "probes": []})
+    )
+    await _auth(client)
+    served = (await _state(client))["node_probe"]
+    assert served["ok"] is True
+    assert (served["configured"], served["probed"]) == (0, 0)
+
+
+async def test_a_run_that_probed_fewer_than_it_was_asked_is_served_as_a_failure(client, spool):
+    """The skipped-endpoint case: a SKIPPED endpoint emits no row at all, so the page renders it
+    from the `probed < configured` gap and the host has already called it not-ok."""
+    spool.joinpath("node-probe.json").write_text(
+        json.dumps({"ok": False, "configured": 3, "probed": 0, "probes": []})
+    )
+    await _auth(client)
+    served = (await _state(client))["node_probe"]
+    assert served["ok"] is False
+    assert served["probed"] < served["configured"]
+
+
+async def test_every_reason_the_host_can_emit_survives_the_trip(client, spool):
+    """The emitter has SEVEN reasons, not the two the first contract named, and the page
+    enumerates them — so a value dropped in transit would render as the neutral fallback and
+    look like a rendering choice rather than a lost field."""
+    reasons = ["ok", "protocol", "timeout", "refused", "auth", "missing-tool", "unknown"]
+    rows = [_row(reason=r, ok=(r == "ok")) for r in reasons]
+    spool.joinpath("node-probe.json").write_text(
+        json.dumps({"ok": False, "configured": len(rows), "probed": len(rows), "probes": rows})
+    )
+    await _auth(client)
+    served = (await _state(client))["node_probe"]
+    assert [p["reason"] for p in served["probes"]] == reasons
+
+
+# --- a broken report blocks nothing ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "written",
+    [
+        pytest.param("{ not json", id="unparseable"),
+        pytest.param("[]", id="a list, not an object"),
+        pytest.param('"ok"', id="a bare string"),
+        pytest.param("{}", id="an empty object"),
+        pytest.param('{"configured": 2, "probed": 0}', id="counts but no verdict"),
+        pytest.param('{"ok": "true"}', id="ok as a STRING, not a bool"),
+        pytest.param('{"ok": 1}', id="ok as 1 — truthy, and still not a bool"),
+        pytest.param('{"ok": null}', id="ok explicitly null"),
+    ],
+)
+async def test_a_report_that_carries_no_real_verdict_reads_as_no_report(client, spool, written):
+    """Fails open, like every other spool reader: a broken file blocks nothing.
+
+    The string and integer cases pin the mechanism rather than its effect. `isinstance(x, bool)`
+    is not truthiness — `"true"` and `1` are both truthy and neither is a verdict the host
+    wrote, and a check written as `if report.get("ok") is not None` would let all three of the
+    last cases through while still passing every other test in this file.
+    """
+    spool.joinpath("node-probe.json").write_text(written)
+    await _auth(client)
+    assert (await _state(client))["node_probe"] is None
+
+
+async def test_the_report_is_behind_the_token_gate_like_the_rest_of_the_state(client, spool):
+    """It names hosts and ports on the operator's LAN, so it is not readable unauthenticated."""
+    spool.joinpath("node-probe.json").write_text(json.dumps(_report()))
+    r = await client.get("/api/wizard-state")
+    assert r.status == 401
+    assert "node_probe" not in await r.json()

--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -261,8 +261,13 @@ wins. Paste a whole `config.json` in there if you have one.
 ### Press "Validate, then install"
 
 The machine checks your answers first — including dialing any remote node you named, so a
-wrong host fails here with the reason and your answers kept, not after the disk is gone. Only
-when everything passes does it show you, on this page, the things you must save:
+wrong host fails here with the reason and your answers kept, not after the disk is gone. The
+page lists every endpoint it tried and the address it used: a Monero node is checked twice, on
+its RPC port and its ZMQ port, and each of those is answered by a live check of the protocol
+itself. A Tari node's gRPC port is only dialed, so a pass there says the port accepted a
+connection and nothing about what is listening behind it — there is no Tari client on the
+machine to ask. Only when everything passes does it show you, on this page, the things you
+must save:
 
 - the **dashboard login** (generated, or the one you chose)
 - the **dashboard address** (`https://pithead.local`)

--- a/docs/dev/appliance-wizard.md
+++ b/docs/dev/appliance-wizard.md
@@ -121,6 +121,17 @@ file, so `node_probe` is `null` there and on any host older than the report; the
 verdict only when `ok` arrives as a real boolean, and a malformed file falls through to `null` the
 way every other spool reader fails open.
 
+`nodeprobe.mjs` renders it, and owns the operator's words for all seven reasons in one place: the
+setup screen shows the report today, and the Configuration view's preview will show the same one
+once the control channel carries a probe of its own, so a reason worded twice cannot come to mean
+two things. Three rules in it are load-bearing rather than stylistic. A reason the module does not
+recognise reads as "the check did not complete" and never as "not reached", because the probe's
+vocabulary is expected to grow and an invented reachability claim is the defect that growth would
+otherwise reintroduce. A `missing-tool` row drops the host's own `detail`, which is the generic
+reach sentence naming the operator's host, port and LAN switch — none of them at fault when the
+check could not run at all. And the module renders no control: the gate is the host's, so a failed
+probe leaves the form editable and the submit button live, which is the only way out of it.
+
 ### The machine-role contract
 
 What the boot path reads, written by the host at the moment a role is accepted:

--- a/docs/dev/appliance-wizard.md
+++ b/docs/dev/appliance-wizard.md
@@ -91,6 +91,36 @@ The rig submission travels on its own spool channel (`rig-request.json`; the ser
 writes a `config.json` candidate for it), and the host dials the pool BEFORE anything
 irreversible — the same discipline `preflight_remote_nodes` gives remote nodes.
 
+### The remote-node probe report
+
+`preflight_remote_nodes` refuses to provision when a configured remote node does not answer, and
+it publishes what it found beside that refusal as `node-probe.json` (#1889). The wizard serves it
+as `node_probe` so the page can say WHICH endpoint failed and why, rather than showing one line of
+error text.
+
+| Field | Meaning |
+|---|---|
+| `ok` | the verdict, and the ONLY gate — true when every configured endpoint was probed and every probe passed |
+| `configured` | endpoints the config asked for: a remote Monero node contributes 2 (RPC and ZMQ), a remote Tari node 1 |
+| `probed` | rows actually produced; a skipped endpoint emits no row, so `probed < configured` is how the page names one |
+| `probes[]` | `{target, host, port, ok, checked, reason, detail, elapsed_ms}` per endpoint |
+
+`reason` is one of `ok`, `protocol`, `timeout`, `refused`, `auth`, `missing-tool` or `unknown`.
+Two of those do not mean the node is unreachable: `auth` is a node that ANSWERED and asked for
+credentials Pithead has nowhere to store, which is a dead end rather than something to retry, and
+`missing-tool` is this machine failing to run the check at all. A reason the page does not
+recognise reads as "the check did not complete" — never as "not reached", because inventing a
+reachability claim for an unrecognised value is the defect #1913 names.
+
+`checked` says what was proved: `rpc` and `zmq` are live protocol checks, while `connect` is a
+bare TCP connect and passes on ANY socket that accepts — so a Tari row that passed is reported as
+qualified, not as a verified node.
+
+An ABSENT report is not a failed one. A machine running its own nodes probes nothing and writes no
+file, so `node_probe` is `null` there and on any host older than the report; the wizard reads the
+verdict only when `ok` arrives as a real boolean, and a malformed file falls through to `null` the
+way every other spool reader fails open.
+
 ### The machine-role contract
 
 What the boot path reads, written by the host at the moment a role is accepted:


### PR DESCRIPTION
The UI half of #1889. **The issue stays open** — item 3 (the same report in the Configuration view) has no producer yet, so no closing keyword is used here on purpose.

## What the operator sees change on the appliance

Today a remote node that does not answer fails at "Validate, then install" with **one line of error text**. The host already knows far more than that — `preflight_remote_nodes` probes every configured endpoint and writes the full report — and none of it reached the page.

Now the setup screen shows, under that same error line, one row per endpoint: which node, which port, the address it dialled, and what happened. A Monero node contributes two rows (RPC and ZMQ), a remote Tari node one.

Three things it deliberately does **not** do:

- It does not disable the submit button. The gate is the host's; correcting the address and submitting again is the operator's only way out of a failed probe, and a dead button takes it away. A test forbids a control appearing in this card.
- It does not report a Tari pass as a verified node. `connect` is a bare TCP dial satisfied by any socket that accepts, and there is no Tari client on the machine to ask further — so that pass reads "the port accepted a connection; what is listening behind it was not checked".
- It does not blame the operator's node for a `missing-tool` failure. curl rc 127 is *our* binary missing; the host keeps its generic reach sentence on that row, naming the operator's host, port and LAN switch, all innocent. That one reason drops the host detail and says the fault is here.

A machine that runs its own nodes probes nothing, so it sees no card at all — an absent report is not a failed one.

## What is actually in the diff

Four commits, two halves. The body originally described only the second half — the reviewer's NIT C, taken.

| | |
|---|---|
| `dashboard/mining_dashboard/wizard.py` | +21 — the READ half: `_node_probe()` serves `node-probe.json` as `node_probe`, via the existing `_spool_json` idiom. 654/674. |
| `dashboard/tests/web/test_wizard_probe.py` | +197 — **9 test functions, 16 cases as pytest collects them** (one is parametrised). `test_wizard.py` is at its 974/974 ceiling. |
| `dashboard/mining_dashboard/web/static/nodeprobe.mjs` | +131, NEW — the render half. |
| `dashboard/mining_dashboard/web/static/wizard.mjs` | +4 — import, state, and the card on the setup screen. 888/889. |
| `dashboard/tests/frontend/wizardprobe.test.mjs` | +317, NEW — 23 tests. |
| `docs/appliance.md`, `docs/dev/appliance-wizard.md` | prose. |

Python checks: `lint-py` rc 0 (`ruff check` all passed; `ruff format --check` 227 files already formatted) and the 16 cases pass rc 0 locally. The read half originally shipped without `lint-py` having been run, which is what CI's ruff job caught at `a355a1b4`; fixed in `64c21cff`.

## Review

Non-author PASS from the ephemeral `reviewer` at `64c21cff` (comment `5558611434`), conditional on the pending CI jobs. **That pass named `64c21cff` and the head has since moved to `57784daf`, so it does not cover the tip — it needs a re-pass at the current head.**

- **FINDING A taken** in `57784daf`: the headline keyed on `s.ok` while the skipped paragraph was independent, so a malformed `{ok: true, configured: 3, probed: 1}` rendered a green "every check passed" above a red "2 of the 3 produced no result". The reviewer's tell was right — my own skipped-render test forced `ok: false` into its fixture, so nothing exercised the pair. The consequence line deliberately did NOT move: a host that published `ok: true` proceeded. Both the defect and that over-correction redden the new test.
- **NIT D taken**: the module header said "seven failure reasons"; six are failures.
- **FINDING B is NOT this branch's** — a stale `node-probe.json` can outlive the config it judged, because nothing removes it while `error.txt` is cleared on every submit. That is one line on the producer's reject arm and is blocking on #1898. Relayed to the lane that owns it; recorded here so it is not lost if these merge out of order.

## Stacking and base

- Based on `origin/develop` (merge-base `0a4195c9`). Not rebased onto any PR.
- The **producer is #1898 (`fix/1889-remote-node-probe`), UNMERGED**. Nothing writes `node-probe.json` on `develop`, so the consumer is built against fixtures taken from `node_probe_one` at `00f7d062` — the row keys, the seven reasons, and the host's own `detail` sentence for each. The two land in either order: with #1898 unmerged the served value is `null` and the screen is unchanged.
- No conflicts with my other open PRs — this touches `nodeprobe.mjs` (new), `wizard.mjs` and two docs; no other in-flight branch of mine edits `wizard.mjs`.

## What is NOT here, and why

Item 3 of the issue — the same report in the Configuration view's preview, with apply refused while it fails — **has no producer**. Nothing serves a probe to `/api/control/preview` at any head; I checked #1888's branch as well as `develop` rather than assuming its preview changes covered it. Building the consumer now would be a view with nothing to view. The render module is written so that surface passes its own consequence sentence and reuses the same reason vocabulary, so the two cannot come to disagree about what a failure means.

## Tier

**Tier 1** (frontend logic + render probes), per `docs/dev/testing-strategy.md` — 23 tests in a new file, `dashboard/tests/frontend/wizardprobe.test.mjs`. A new file rather than an append because `wizard.test.mjs` is at its 765/765 ceiling; split by defect class, reusing the sibling harness.

The issue also names tier 3 (a KVM provision leg against a guest that is not listening). That belongs with the host half and is not added here — and `tests/os/setup-again-leg.sh` never renders a wizard screen (it spools over SSH), so wizard-screen work has no tier-4 cover either way. Recorded, not silently skipped.

## Evidence

- **Mutation battery**, each mutation asserted to have applied (a needle that does not match writes the file back unchanged) and restored by sha256, not by `git checkout`. Seven on `nodeprobe.mjs` — unrecognised reason defaulting to "not reached"; `missing-tool` keeping the host's detail; a truthy `ok` as a pass; a connect pass reading as verified; the skipped gap trusting `probed`; the all-local card; presence as `!= null` — **each reddens exactly the row that pins its mechanism, none survives.** Two on `wizard.mjs` (drop `nodeProbe` from state; drop the card from the screen) both redden the seam test.
- **M7 survived the first battery and the fixture was the bug.** Relaxing the presence check reddened nothing, because every malformed-verdict fixture carried no probes and the empty-configuration door answered for it — those rows were green for the wrong reason. Widening them to carry real probes (`ok: "false"` is truthy, which is the shape that bites) reddens it, and a control proves the widened fixtures arm.
- **A seam test**, because a correct component over a wrong served value is what survived the last fix on this page. It drives the real `WizardApp` against a real `/api/wizard-state` body and reads what the setup screen paints, rather than props handed in by hand.
- Frontend suite **602 passed, 0 failed, rc 0**. `lint-js`, `lint-docs-voice`, `lint-operator-strings`, `lint-file-budget` all rc 0, run **after staging** so the two new untracked files were in scope.
- No shellcheck and no docker or KVM: another lane holds the bench for a battery.

## Budgets

`wizard.mjs` 888/889 (4 of the 5 free lines spent). `nodeprobe.mjs` 131 and `wizardprobe.test.mjs` 317 are both under the 400-line threshold that would demand a budget row, so `file-budget.tsv` is untouched.

## Docs

`docs/appliance.md` gains what the operator meets at "Validate, then install" — a Monero node is two live protocol checks, a Tari node one dial that proves only that the port accepted. `docs/dev/appliance-wizard.md` gains the three load-bearing render rules.

## Over-engineering pass

Run on the merits, not by the hook — five things weighed, one kept with a caveat.

- **The consequence sentence arrives as `children` rather than being hard-coded.** This is the diff's thinnest justification: only one surface passes it today. Kept because it is a prop read replacing a string literal — no extra code — and because "setup does not continue" and "the apply is refused" are genuinely different sentences that should not be chosen inside the shared module.
- **`probeSummary` is exported apart from the component.** Justified: 16 of the 23 tests assert the vocabulary against it directly, never rendering the card, and asserting seven reason sentences through rendered HTML would be noise.
- **The defensive coercions each trace to a real producer shape**, not a hypothetical one: `host` can be `""` (jq `// ""`), the report is JSON written by a shell script, and the spool reader fails open to `{}`. None is speculative.
- **Two fields per row (`verdict` + `sentence`)** rather than one, kept: the verdict is the scannable coloured word, the sentence is the explanation, and merging them makes the failure list unreadable at a glance.
- **Considered and rejected: drop the reason table and render only the host's `detail`.** Smaller, and it is precisely the defect — the host's sentence is wrong for `missing-tool` and absent for any reason it does not name.

I am the author, so I do not merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZuzdtxNX8ae4rnDtBqEqR