### PR TITLE
test(os): #1935 verify-image names the step when the baked wizard.py cannot be extracted

### DIFF
--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -293,10 +293,10 @@ if [ -f ./pithead ] && [ -f dashboard/mining_dashboard/wizard.py ]; then
                     WIZ_SHIPPED="$WIZ_TMP/shipped-wizard.py"
                     break
                 fi
-                WIZ_WHY="tar -xOf $member from $(basename "$layer" | cut -c1-12) failed: $(head -c 120 "$WIZ_TMP/extract.err")"
+                WIZ_WHY="tar -xOf $member from $(basename "$layer" | cut -c1-12) failed: $(head -c 120 "$WIZ_TMP/extract.err" | tr -c '[:print:]' '?')"
             done
         else
-            WIZ_WHY="tar -xzf $(basename "$WIZ_ARCHIVE") failed: $(head -c 120 "$WIZ_TMP/untar.err")"
+            WIZ_WHY="tar -xzf $(basename "$WIZ_ARCHIVE") failed: $(head -c 120 "$WIZ_TMP/untar.err" | tr -c '[:print:]' '?')"
         fi
     fi
     chk "the baked wizard image contains the tree's wizard.py" \

--- a/tests/os/verify-image.sh
+++ b/tests/os/verify-image.sh
@@ -277,19 +277,35 @@ if [ -f ./pithead ] && [ -f dashboard/mining_dashboard/wizard.py ]; then
     WIZ_ARCHIVE=$(ls "$ROOT"/opt/pithead/images/*.tar.gz 2>/dev/null | head -1)
     WIZ_TMP=$(mktemp -d)
     WIZ_SHIPPED=""
-    if [ -n "$WIZ_ARCHIVE" ] && tar -xzf "$WIZ_ARCHIVE" -C "$WIZ_TMP" 2>/dev/null; then
-        for layer in "$WIZ_TMP"/blobs/sha256/* "$WIZ_TMP"/*/layer.tar; do
-            [ -f "$layer" ] || continue
-            member=$(tar -tf "$layer" 2>/dev/null | grep -m1 'mining_dashboard/wizard\.py$') || continue
-            tar -xOf "$layer" "$member" >"$WIZ_TMP/shipped-wizard.py" 2>/dev/null && {
-                # shellcheck disable=SC2034  # read inside chk's eval'd condition below
-                WIZ_SHIPPED="$WIZ_TMP/shipped-wizard.py"
-                break
-            }
-        done
+    # #1935: this check reddened once in a battery, re-passed on the same image, and the log could not
+    # say which step produced no file — so each step names itself, and a mismatch prints cmp's verdict.
+    WIZ_WHY="no *.tar.gz under opt/pithead/images"
+    if [ -n "$WIZ_ARCHIVE" ]; then
+        if tar -xzf "$WIZ_ARCHIVE" -C "$WIZ_TMP" 2>"$WIZ_TMP/untar.err"; then
+            WIZ_WHY="no layer lists mining_dashboard/wizard.py"
+            for layer in "$WIZ_TMP"/blobs/sha256/* "$WIZ_TMP"/*/layer.tar; do
+                [ -f "$layer" ] || continue
+                # sed, not grep -m1: an early exit would SIGPIPE tar and, under pipefail, skip the layer.
+                member=$(tar -tf "$layer" 2>/dev/null | grep 'mining_dashboard/wizard\.py$' | sed -n '1p')
+                [ -n "$member" ] || continue
+                if tar -xOf "$layer" "$member" >"$WIZ_TMP/shipped-wizard.py" 2>"$WIZ_TMP/extract.err"; then
+                    # shellcheck disable=SC2034  # read inside chk's eval'd condition below
+                    WIZ_SHIPPED="$WIZ_TMP/shipped-wizard.py"
+                    break
+                fi
+                WIZ_WHY="tar -xOf $member from $(basename "$layer" | cut -c1-12) failed: $(head -c 120 "$WIZ_TMP/extract.err")"
+            done
+        else
+            WIZ_WHY="tar -xzf $(basename "$WIZ_ARCHIVE") failed: $(head -c 120 "$WIZ_TMP/untar.err")"
+        fi
     fi
     chk "the baked wizard image contains the tree's wizard.py" \
         '[ -n "$WIZ_SHIPPED" ] && cmp -s "$WIZ_SHIPPED" dashboard/mining_dashboard/wizard.py'
+    if [ -z "$WIZ_SHIPPED" ]; then
+        echo "     · wizard.py was not extracted: $WIZ_WHY"
+    elif ! cmp -s "$WIZ_SHIPPED" dashboard/mining_dashboard/wizard.py; then
+        echo "     · shipped wizard.py differs from the tree's: $(cmp "$WIZ_SHIPPED" dashboard/mining_dashboard/wizard.py 2>&1 | head -1)"
+    fi
     rm -rf "$WIZ_TMP"
 else
     skip "the artifact matches the tree it was built from" "not run from the repo root"


### PR DESCRIPTION
Closes #1935.

## What changes

`tests/os/verify-image.sh`, the "the baked wizard image contains the tree's wizard.py" check: every step that can leave `WIZ_SHIPPED` empty now names itself on the red (no archive under `opt/pithead/images`, `tar -xzf` failing with its stderr, no layer listing `wizard.py`, `tar -xOf` failing with its stderr), and a real mismatch prints `cmp`'s first differing byte. The assertion is unchanged. The layer listing goes through `grep | sed -n '1p'` instead of `grep -m1`, so an early exit cannot SIGPIPE `tar` under `pipefail` and skip the layer.

## Why

The RC1 battery's reset-phase rebuild reddened on this check once (118/1) and aborted the phase; the same image re-passed 119/0 by hand, and the baked `wizard.py` is byte-identical to the tree's. The log had nothing to say about which step failed, because the check discarded every step's error. Cause NOT established (#1935 has the measurements); this makes the next flake diagnosable.

## What was RUN

- The shipped extraction loop, verbatim, 40 times over the archive that build baked: 0 failures. Same for the `sed` form: 0 failures. So the SIGPIPE change is a hazard removed in passing, not the measured cause, and the PR says so.
- `bash -n`, `shfmt -i 4 -d`, `shellcheck -x -S warning` (from the repo root, so the `source=` directive resolves): clean. `scripts/lint-file-budget.sh`: OK. The file is at 400 lines, the target, so no budget row.
- The new reason line was NOT exercised against a real failure (none reproduces); its four branches are plain string assignments read by one `echo`.

## What was NOT done

- No KVM run; this changes only what a red prints. The next battery's reset phase is the check.
- Not taken: retrying the extraction. A retry would hide the flake the reason line exists to expose.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this lane's cwd)

- One variable (`WIZ_WHY`) rewritten per step rather than a step counter or a case table: the red carries one reason, the last step that failed, which is the one that matters.
- stderr goes to two files in the already-existing `WIZ_TMP` rather than to variables: no new temp handling, removed by the existing `rm -rf`.
- A layer counter was written and removed to stay at the 400-line target; the reason names the archive, which is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
