### PR TITLE
fix(pithead): #1930 the backup header names the dashboard DB among what it always keeps

### DIFF
--- a/lib/pithead/17-backup-restore.sh
+++ b/lib/pithead/17-backup-restore.sh
@@ -1,7 +1,7 @@
 # --- Backup / Restore ---
-# Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, and the Tor
-# data dir (onion service keys). The blockchains and dashboard DB re-sync, so they're excluded
-# by default; pass --with-chains to also fold in the Monero/Tari/P2Pool data dirs.
+# Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, the Tor data dir
+# (onion service keys), and the dashboard data dir (its DB never re-syncs). The blockchains do
+# re-sync, so they're excluded by default; pass --with-chains to fold in Monero/Tari/P2Pool data.
 #
 # The two files a backup archive cannot be worth taking without (#1059/#1244): config.json and
 # .env carry the node credentials and secrets, unlike every optional item stack_backup adds

--- a/pithead
+++ b/pithead
@@ -4198,9 +4198,9 @@ factory_reset() {
 }
 
 # --- Backup / Restore ---
-# Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, and the Tor
-# data dir (onion service keys). The blockchains and dashboard DB re-sync, so they're excluded
-# by default; pass --with-chains to also fold in the Monero/Tari/P2Pool data dirs.
+# Protect the irreplaceable bits: config.json, .env (secrets), the Caddyfile, the Tor data dir
+# (onion service keys), and the dashboard data dir (its DB never re-syncs). The blockchains do
+# re-sync, so they're excluded by default; pass --with-chains to fold in Monero/Tari/P2Pool data.
 #
 # The two files a backup archive cannot be worth taking without (#1059/#1244): config.json and
 # .env carry the node credentials and secrets, unlike every optional item stack_backup adds


### PR DESCRIPTION
Closes #1930.

## What changes

`lib/pithead/17-backup-restore.sh`, header lines 2-4: the dashboard data dir is named among the irreplaceable bits the default backup keeps, with the reason the code already gives (its database, hashrate history and settings, never re-syncs). `--with-chains` is described as folding in the chain data dirs only. The rewrite is three lines for three, so the concatenated `pithead` moves by the same three lines and keeps its budget row. `pithead` is rebuilt from the slices.

## Why

The header said the dashboard DB re-syncs and is excluded by default; `stack_backup` has always included it unconditionally, outside the `--with-chains` branch, and its own comment at the include says why. The wrong claim sat where a skimming reader stops, and stated itself as a rationale. The docs already say the true thing (`docs/appliance.md`, `docs/dev/appliance-wizard.md`, the dual-distribution plan), so only the header moves.

## What was RUN

- `scripts/build-pithead.sh` then `scripts/build-pithead.sh --check`: parity OK, 54 slices.
- `git diff --numstat`: 3/3 on the slice, 3/3 on `pithead`. `scripts/lint-file-budget.sh`: OK.
- `bash -n` on both files.

## What was NOT done

- No shellcheck run: the diff is comment-only in a slice `make lint-sh` reads through `pithead`, and CI's Shell tests job runs it. No suite: no code changed.
- No image: `lib/pithead/` is an image-freeze path. This is a comment; it changes no byte of behaviour, but it does move the tree the next RC builds from. RC2 material, not RC1.

## Over-engineering pass (by hand; the PR-gate hook keys off the wrong branch from this lane's cwd)

- One clause in the header rather than a paragraph: the code's own comment at the include already carries the full reason, and the header's job is the list.
- Not taken: moving the reason out of the code comment into the header. Two sites, each true, is the state the file was meant to have; the defect was that one of them lied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeSaJPWy7AkhYcYpGVkxBJ
