### PR TITLE
fix(dashboard): #1858 a badge-shaped button drops the UA chrome that ignores the theme

### DIFF
--- a/dashboard/mining_dashboard/web/static/configview.mjs
+++ b/dashboard/mining_dashboard/web/static/configview.mjs
@@ -581,7 +581,7 @@ export class UpgradeControl extends Component {
           </div>
       </div>`;
     }
-    return html`<button class="badge badge-accent version-badge upgrade-btn ml-2"
+    return html`<button class="badge badge-accent version-badge ml-2"
             title=${"Upgrade the stack to " + version + " from the dashboard"}
             onClick=${() => this.setState({ phase: "confirm", confirmText: "" })}>
             Upgrade to ${version}

--- a/dashboard/mining_dashboard/web/static/dashboard.css
+++ b/dashboard/mining_dashboard/web/static/dashboard.css
@@ -746,6 +746,8 @@ tr:last-child td {
   font-weight: 600;
   vertical-align: middle;
   display: inline-block;
+  background: transparent; /* a <button> badge alone takes the UA fill: 2.67:1 in dark (#1858) */
+  border: none; /* ...and an outset border. Both sit above the variants, which still win. */
 }
 .badge-outline {
   border: 1px solid var(--border);
@@ -788,10 +790,8 @@ tr:last-child td {
 .version-badge.version-dev {
   border-style: dashed;
 }
-/* One-click upgrade button (#59): a badge-shaped <button>, so reset the UA button chrome. */
-button.upgrade-btn {
-  border: none;
-  cursor: pointer;
+button.badge {
+  cursor: pointer; /* the one UA reset that must not reach a <span>/<a> badge (#59) */
 }
 
 .wallet-text {

--- a/dashboard/tests/frontend/badgebutton.test.mjs
+++ b/dashboard/tests/frontend/badgebutton.test.mjs
@@ -1,0 +1,77 @@
+// Unit tests for the badge chrome in mining_dashboard/web/static/dashboard.css (#1858).
+//
+// A badge renders as a <span>, an <a> or a <button>, and only the <button> arrives with UA chrome:
+// Chromium paints it with the `ButtonFace` system colour (#efefef) and an outset border, neither of
+// which follows our theme. In dark, `badge-outline`'s --text-muted on that fill measures 2.67:1 —
+// below the 4.5:1 WCAG AA needs — so the "OS updates" badge alone was a light box in a dark header.
+//
+// These run with no DOM, so they prove the stylesheet's own cascade rather than a painted pixel:
+// the reset is declared on `.badge`, it sits ABOVE the variants (equal specificity, so source order
+// decides), and the pair the reset leaves behind clears AA in both themes.
+// Run with: node --test dashboard/tests/frontend/
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+  contrastRatio,
+  DARK_BLOCK,
+  DASHBOARD_CSS,
+  LIGHT_BLOCK,
+  themeToken,
+} from "./helpers/contrast.mjs";
+
+const STATIC_DIR = new URL("../../mining_dashboard/web/static/", import.meta.url);
+
+// The variants that carry a badge's colour. `badge-row` is a layout class, not a variant.
+const VARIANTS = ["badge-outline", "badge-ok", "badge-bad", "badge-warn", "badge-accent", "badge-purple"];
+
+test("dashboard.css: .badge clears the UA <button> fill and border (#1858)", () => {
+  const rule = DASHBOARD_CSS.match(/^\.badge \{([^}]*)\}/m);
+  assert.ok(rule, "expected a `.badge` rule in dashboard.css");
+  assert.match(rule[1], /background:\s*transparent/, "a <button> badge would keep the UA ButtonFace fill");
+  assert.match(rule[1], /border:\s*none/, "a <button> badge would keep the UA outset border");
+});
+
+test("dashboard.css: the reset sits above the variants, so their fills and border still win (#1858)", () => {
+  // `.badge` and every `.badge-*` variant are single-class selectors, so specificity ties and the
+  // LATER rule wins. Moving the reset below them would silently blank every coloured badge.
+  const resetAt = DASHBOARD_CSS.search(/^\.badge \{/m);
+  assert.ok(resetAt >= 0, "expected a `.badge` rule in dashboard.css");
+  for (const variant of VARIANTS) {
+    const at = DASHBOARD_CSS.search(new RegExp(`^\\.${variant} \\{`, "m"));
+    assert.ok(at > resetAt, `.${variant} must be declared after .badge, or the reset overrides it`);
+  }
+  const outline = DASHBOARD_CSS.match(/^\.badge-outline \{([^}]*)\}/m);
+  assert.match(outline[1], /border:\s*1px solid/, ".badge-outline must re-add the border .badge clears");
+});
+
+test("dashboard.css: a transparent badge button's muted text clears AA on the page background (#1858)", () => {
+  // With the UA fill gone, an outline badge sits on the header, which sets no background of its own
+  // — so the backdrop is --bg. Pre-fix this pair was --text-muted on #efefef: 2.67:1 in dark.
+  for (const [theme, block] of [["dark", DARK_BLOCK], ["light", LIGHT_BLOCK]]) {
+    const muted = themeToken(DASHBOARD_CSS, block, "--text-muted");
+    const bg = themeToken(DASHBOARD_CSS, block, "--bg");
+    const ratio = contrastRatio(muted, bg);
+    assert.ok(ratio >= 4.5, `${theme} badge-outline contrast ${ratio.toFixed(2)}:1 is below AA (4.5:1)`);
+  }
+});
+
+test("every element carrying a badge variant also carries the base badge class (#1858)", () => {
+  // The reset keys on `.badge`, so a variant used without it silently misses the fix. Scanned from
+  // the class attribute's literal text; a variant supplied by a concatenated expression (osupdate's
+  // `attention`) is not visible here — that path is covered by the source-order test above.
+  const files = readdirSync(STATIC_DIR).filter((f) => f.endsWith(".mjs"));
+  assert.ok(files.length > 0, "expected to find static .mjs sources to scan");
+  let checked = 0;
+  for (const file of files) {
+    const src = readFileSync(new URL(file, STATIC_DIR), "utf8");
+    for (const m of src.matchAll(/class=(?:"([^"]*)"|\$\{"([^"]*)")/g)) {
+      const classes = (m[1] ?? m[2]).split(/\s+/);
+      if (!classes.some((c) => VARIANTS.includes(c))) continue;
+      checked += 1;
+      assert.ok(classes.includes("badge"), `${file}: "${m[1] ?? m[2]}" uses a variant without .badge`);
+    }
+  }
+  assert.ok(checked > 0, "the scan matched no badge variants at all — the needle is broken");
+});

--- a/dashboard/tests/frontend/badgebutton.test.mjs
+++ b/dashboard/tests/frontend/badgebutton.test.mjs
@@ -49,6 +49,8 @@ test("dashboard.css: the reset sits above the variants, so their fills and borde
 test("dashboard.css: a transparent badge button's muted text clears AA on the page background (#1858)", () => {
   // With the UA fill gone, an outline badge sits on the header, which sets no background of its own
   // — so the backdrop is --bg. Pre-fix this pair was --text-muted on #efefef: 2.67:1 in dark.
+  // Not read here: the prefers-color-scheme auto block (dashboard.css:68-86), whose tokens are
+  // byte-identical to the light block's today. A divergence there would pass this test unnoticed.
   for (const [theme, block] of [["dark", DARK_BLOCK], ["light", LIGHT_BLOCK]]) {
     const muted = themeToken(DASHBOARD_CSS, block, "--text-muted");
     const bg = themeToken(DASHBOARD_CSS, block, "--bg");

--- a/dashboard/tests/frontend/helpers/contrast.mjs
+++ b/dashboard/tests/frontend/helpers/contrast.mjs
@@ -1,0 +1,41 @@
+// WCAG contrast helpers shared by the stylesheet tests (#1232, #1858). The ratio is the
+// relative-luminance formula computed directly from the theme tokens dashboard.css declares — not a
+// rendered or measured colour, since these tests run with no DOM. AA for normal text is 4.5:1.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+export const DASHBOARD_CSS = readFileSync(
+  new URL("../../../mining_dashboard/web/static/dashboard.css", import.meta.url),
+  "utf8",
+);
+
+// Dark is the base palette (`:root`); light is the explicit override block. Pull each pair
+// independently — the two blocks declare the same variable names to different values.
+export const DARK_BLOCK = /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/;
+export const LIGHT_BLOCK = /:root\[data-theme="light"\]\s*\{[^}]*\}/;
+
+function srgbToLinear(c) {
+  const v = c / 255;
+  return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex) {
+  const n = Number.parseInt(hex.replace("#", ""), 16);
+  const r = srgbToLinear((n >> 16) & 0xff);
+  const g = srgbToLinear((n >> 8) & 0xff);
+  const b = srgbToLinear(n & 0xff);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(hexA, hexB) {
+  const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort((a, b) => b - a);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
+
+export function themeToken(css, themeBlockRe, varName) {
+  const block = css.match(themeBlockRe);
+  assert.ok(block, `expected to find the ${varName} theme block in dashboard.css`);
+  const tok = block[0].match(new RegExp(`${varName}:\\s*(#[0-9a-fA-F]{6})`));
+  assert.ok(tok, `expected ${varName} inside the matched theme block`);
+  return tok[1];
+}

--- a/dashboard/tests/frontend/workerview.test.mjs
+++ b/dashboard/tests/frontend/workerview.test.mjs
@@ -4,10 +4,10 @@
 // walker (helpers/render.mjs); apply()/onJsonInput/onFilePick are called directly against a
 // WorkerInspect instance — no DOM, no npm deps. Run with: node --test dashboard/tests/frontend/
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import { StatsTable, WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
+import { contrastRatio, DASHBOARD_CSS, themeToken } from "./helpers/contrast.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 const SENTINEL = { __secret__: true };
@@ -448,36 +448,6 @@ test("StatsTable: a warn-variant value keeps its status colour alongside stat-va
   assert.match(valueCell[1], /\bstat-value\b/);
   assert.match(valueCell[1], /\bstatus-warn\b/);
 });
-
-// WCAG contrast ratio (relative-luminance formula) computed directly from the theme tokens the CSS declares — not a rendered/measured colour, since these tests run with no DOM. AA is 4.5:1.
-function srgbToLinear(c) {
-  const v = c / 255;
-  return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
-}
-function relativeLuminance(hex) {
-  const n = Number.parseInt(hex.replace("#", ""), 16);
-  const r = srgbToLinear((n >> 16) & 0xff);
-  const g = srgbToLinear((n >> 8) & 0xff);
-  const b = srgbToLinear(n & 0xff);
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
-function contrastRatio(hexA, hexB) {
-  const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort((a, b) => b - a);
-  return (l1 + 0.05) / (l2 + 0.05);
-}
-
-const DASHBOARD_CSS = readFileSync(
-  new URL("../../mining_dashboard/web/static/dashboard.css", import.meta.url),
-  "utf8",
-);
-
-function themeToken(css, themeBlockRe, varName) {
-  const block = css.match(themeBlockRe);
-  assert.ok(block, `expected to find the ${varName} theme block in dashboard.css`);
-  const tok = block[0].match(new RegExp(`${varName}:\\s*(#[0-9a-fA-F]{6})`));
-  assert.ok(tok, `expected ${varName} inside the matched theme block`);
-  return tok[1];
-}
 
 test("dashboard.css: .stat-value declares an explicit --text colour, not an empty/inherited one (#1232)", () => {
   const rule = DASHBOARD_CSS.match(/\.stat-value\s*\{([^}]*)\}/);

--- a/dashboard/tests/frontend/workerview.test.mjs
+++ b/dashboard/tests/frontend/workerview.test.mjs
@@ -7,7 +7,13 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { StatsTable, WorkerInspect } from "../../mining_dashboard/web/static/workerview.mjs";
-import { contrastRatio, DASHBOARD_CSS, themeToken } from "./helpers/contrast.mjs";
+import {
+  contrastRatio,
+  DARK_BLOCK,
+  DASHBOARD_CSS,
+  LIGHT_BLOCK,
+  themeToken,
+} from "./helpers/contrast.mjs";
 import { renderToString } from "./helpers/render.mjs";
 
 const SENTINEL = { __secret__: true };
@@ -458,10 +464,10 @@ test("dashboard.css: .stat-value declares an explicit --text colour, not an empt
 
 test("dashboard.css: .stat-value's --text on --card meets WCAG AA (>= 4.5:1) in dark AND light (#1232)", () => {
   // Dark is the base palette; light is the explicit override block — pull each theme's pair independently.
-  const darkText = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--text");
-  const darkCard = themeToken(DASHBOARD_CSS, /:root,\s*:root\[data-theme="dark"\]\s*\{[^}]*\}/, "--card");
-  const lightText = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--text");
-  const lightCard = themeToken(DASHBOARD_CSS, /:root\[data-theme="light"\]\s*\{[^}]*\}/, "--card");
+  const darkText = themeToken(DASHBOARD_CSS, DARK_BLOCK, "--text");
+  const darkCard = themeToken(DASHBOARD_CSS, DARK_BLOCK, "--card");
+  const lightText = themeToken(DASHBOARD_CSS, LIGHT_BLOCK, "--text");
+  const lightCard = themeToken(DASHBOARD_CSS, LIGHT_BLOCK, "--card");
 
   const darkRatio = contrastRatio(darkText, darkCard);
   const lightRatio = contrastRatio(lightText, lightCard);

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -32,7 +32,7 @@ dashboard/tests/frontend/components.test.mjs	1055
 dashboard/tests/frontend/configview.test.mjs	492
 dashboard/tests/frontend/logic.test.mjs	727
 dashboard/tests/frontend/wizard.test.mjs	765
-dashboard/tests/frontend/workerview.test.mjs	518
+dashboard/tests/frontend/workerview.test.mjs	488
 dashboard/tests/frontend/xvbview.test.mjs	431
 dashboard/tests/service/test_alert_service.py	1092
 dashboard/tests/service/test_algo_service.py	822

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -32,7 +32,7 @@ dashboard/tests/frontend/components.test.mjs	1055
 dashboard/tests/frontend/configview.test.mjs	492
 dashboard/tests/frontend/logic.test.mjs	727
 dashboard/tests/frontend/wizard.test.mjs	765
-dashboard/tests/frontend/workerview.test.mjs	488
+dashboard/tests/frontend/workerview.test.mjs	494
 dashboard/tests/frontend/xvbview.test.mjs	431
 dashboard/tests/service/test_alert_service.py	1092
 dashboard/tests/service/test_algo_service.py	822


### PR DESCRIPTION
Closes #1858.

## What the operator sees

In the dark theme, the **OS updates** control in the dashboard header stops being a light grey box and reads as a badge like the ones beside it. Its label goes from 2.67:1 to 6.15:1 against the header background — WCAG AA is 4.5:1. The light theme already passed (5.32:1) and improves to 6.11:1. Nothing else about the control changes; the same badge now also gets a pointer cursor on hover.

## Mechanism

A badge renders as a `<span>`, an `<a>` or a `<button>`, and only the `<button>` arrives with UA chrome: Chromium paints it with the `ButtonFace` system colour (`#efefef`) and an outset border, neither of which follows our theme. `.badge` set no `background`, and `.badge-outline` sets only a border and `color: var(--text-muted)` — so that one badge alone painted a light box in a dark header.

The reset goes on `.badge` itself, **above** the variants. `.badge` and every `.badge-*` are single-class selectors, so specificity ties and source order decides: `.badge-outline` re-adds its border and each coloured variant re-adds its fill, while the button's UA fill and border are gone. With the fill cleared the badge sits on `--bg`.

`#59`'s `button.upgrade-btn` was the single-site version of this same reset, so it generalises to `button.badge`, which now carries only `cursor: pointer` — the one reset that must not reach a `<span>`/`<a>` badge. `upgrade-btn` was a class hook for that rule alone, so it is dropped from the markup with it.

## The issue names one site; the class sweep found four

`osupdate.mjs` (the reported site), `configview.mjs`'s upgrade button, and two in `components.mjs` — including the "not adopted" button from #1857, which carries the same `badge badge-outline` pair and therefore had the same 2.67:1 defect. That site is on #1948's branch, not here, so it is not visible in this diff; a class-level reset covers it the moment #1948 merges, where a fix at the named site would not have.

## What I did not do

- **The issue suggests `font: inherit`. That is wrong here** and is not applied: `button.badge` out-specifies `.version-badge`, so the shorthand would strip monospace from the version badges. The `<button>`-vs-`<span>` font-family difference is left alone.
- **No doc change is owed.** `docs/dashboard.md:1292` and `docs/appliance.md:343` describe the OS-update control functionally; neither states a colour, so neither goes stale.
- **No security review.** The diff touches no control channel, auth, or outbound fetch.
- `border: none` is not strictly required by the contrast defect — it is what makes `button.upgrade-btn` redundant, and it also clears the UA outset border on `components.mjs`'s Inspect button. Called out so a reviewer can veto it.

## Tier and evidence

Frontend unit (node), the same tier and idiom as #1232's contrast test. The WCAG helpers move to `tests/frontend/helpers/contrast.mjs` so #1232 and #1858 share one implementation instead of two copies; that shrinks `workerview.test.mjs` 518 -> 488.

**Every one of the four new tests was shown able to fail**, each on its own seeded control, each reddening only its own test:

| control | seeded | reds |
|---|---|---|
| A | the pre-merge stylesheet | test 1 only — 2/3/4 are guards, not detectors |
| B | a variant used without the base `badge` class | test 4 |
| C | a low-contrast `--text-muted` | test 3 |
| D | `.badge-outline` moved above `.badge` | test 2 |

Both seeded files were restored and verified by `sha256sum -c`.

RAN at this head, each rc captured to a file rather than off a pipeline tail:

- `node --test dashboard/tests/frontend/` — **583 pass, 0 fail**, rc 0
- `make test-dashboard` — **2572 passed**, rc 0
- `make test-fakes` — **31 passed**, rc 0
- `make lint-py` — rc 0
- CI's own per-surface line, all ten targets — rc 0: `lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity lint-js lint-yaml lint-md lint-proto lint-toml`

`lint-js` caught the first form of the `button.badge` comment (biome moves a comment placed after `{` onto its own line, which would have broken line-neutrality); the comment sits on the declaration line instead.

## Shared file

`docs/dev/file-budget.tsv`: `dashboard/mining_dashboard/web/static/dashboard.css` was at **1579/1579 with zero headroom**, so the change is line-neutral by construction — the two resets on `.badge` (+2) are paid for by generalising `#59`'s five-line block (-5) into a three-line `button.badge`. The file is still 1579. The only row edited is `workerview.test.mjs` 518 -> 488, lowered because this diff shrank that file; an un-rebased branch touching it may red until it rebases.

## Over-engineering pass (by hand, on merits)

- The helper extraction removes a duplicate WCAG implementation rather than adding a layer, and it shrinks the file it came from. Kept.
- Test 2 (source order) is the one that guards the most damaging regression this change makes possible: moving `.badge` below the variants would silently blank every coloured badge. Kept.
- Test 4 (markup scan) guards the assumption the whole fix rests on — that the reset keys on `.badge`. It asserts its own needle matched at least once, so it cannot pass vacuously. Kept.
- Scope checked against the cascade, not just the named site: no `badge` rule exists anywhere in `dashboard.css` before `.badge`, `version-dev` has exactly one producer (a `<span>`, always paired with `badge-outline`), and the wizard markup uses no badges — so nothing else can be blanked by the reset.

MERGE-READY: not yet — needs a recorded non-author PASS. I do not merge my own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZuzdtxNX8ae4rnDtBqEqR
