### PR TITLE
fix(dashboard): #1856 the two LAN ingress hops stop drawing as "this machine"

### DIFF
--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -30,9 +30,12 @@ from mining_dashboard.config import config
 from mining_dashboard.service.topology_graph import (  # noqa: F401  (re-exported)
     CLEARNET,
     INACTIVE,
+    LAN,
     LOCAL,
     TOPOLOGY_NODES,
     TOR,
+    edge,
+    ext_node,
     node_route,
     topology_nodes,
 )
@@ -108,6 +111,7 @@ def compute_egress_posture(
     notify_tor=True,
     notify_sinks_private=False,
     xvb_standby_source="",
+    tor_auto_heal=False,
 ):
     """Pure derivation of the egress posture from config knobs. Returns ``{components, summary}``."""
     xvb = _xvb_route(xvb_enabled, xvb_tor)
@@ -185,6 +189,8 @@ def compute_egress_posture(
                 # any non-private source rides Tor (like every read above); only a private-IP-literal
                 # primary is a LAN hop (local). Never clearnet, so it can't leak the backup's IP.
                 {"to": "XvB standby pull (backup ← primary)", "route": standby},
+                # Tor egress probe (#424) — opt-in via tor.auto_heal, socks5h, so never a leak.
+                {"to": "Tor egress probe", "route": TOR if tor_auto_heal else INACTIVE},
             ],
         },
         {
@@ -240,17 +246,18 @@ def egress_posture_from_config():
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],
         xvb_standby_source=config.XVB_STANDBY_SOURCE,
-        **_notify_knobs(),
+        **_shared_knobs(),
     )
 
 
-def _notify_knobs():
-    """The #380 alert-sink knobs, shared by both from-config builders."""
+def _shared_knobs():
+    """The knobs both from-config builders read: the #380 alert sinks and the #424 Tor probe."""
     urls = [*config.NOTIFY_WEBHOOK_URLS, config.NTFY_URL]
     return {
         "notify_sinks_enabled": any(u.strip() for u in urls if u),
         "notify_tor": config.NOTIFY_TOR,
         "notify_sinks_private": _sinks_all_private(urls),
+        "tor_auto_heal": config.TOR_AUTO_HEAL,
     }
 
 
@@ -258,16 +265,6 @@ def _notify_knobs():
 # The egress list above answers "is anything leaking?"; the topology answers "how is the whole
 # stack wired?" — every component and the route of each link (ingress, egress, internal). Same
 # config-derived routes, so the two views can never disagree (the summary is shared verbatim).
-
-
-def _edge(src, dst, route, label, kind):
-    return {"from": src, "to": dst, "route": route, "label": label, "kind": kind}
-
-
-def _ext(route):
-    # Where a component's external link lands in the diagram: a Tor-routed link terminates at the
-    # `tor` hub; a clearnet link goes STRAIGHT to the internet node, so a leak visibly bypasses Tor.
-    return "internet" if route == CLEARNET else "tor"
 
 
 def compute_topology(
@@ -291,6 +288,7 @@ def compute_topology(
     notify_tor=True,
     notify_sinks_private=False,
     xvb_standby_source="",
+    tor_auto_heal=False,
 ):
     """Pure derivation of the stack topology. Returns ``{nodes, edges, summary}``.
 
@@ -313,6 +311,7 @@ def compute_topology(
         notify_tor=notify_tor,
         notify_sinks_private=notify_sinks_private,
         xvb_standby_source=xvb_standby_source,
+        tor_auto_heal=tor_auto_heal,
     )
     xvb = _xvb_route(xvb_enabled, xvb_tor)
     sinks = _notify_route(notify_sinks_enabled, notify_tor, notify_sinks_private)
@@ -320,20 +319,21 @@ def compute_topology(
     sidechain = CLEARNET if p2pool_clearnet else TOR
 
     edges = [
-        # Ingress from your LAN — the only listeners actually exposed to the network.
-        _edge("rigs", "xmrig-proxy", LOCAL, f"stratum :{config.STRATUM_PORT}", "ingress"),
-        _edge("browser", "caddy", LOCAL, "https :443", "ingress"),
+        # Ingress from your LAN — the only listeners actually exposed to the network (#1856).
+        edge("rigs", "xmrig-proxy", LAN, f"stratum :{config.STRATUM_PORT}", "ingress"),
+        edge("browser", "caddy", LAN, "https :443", "ingress"),
         # Daemon P2P: bidirectional (outbound peers + inbound via Tor onion services).
-        _edge("p2pool", _ext(sidechain), sidechain, "sidechain P2P", "p2p"),
-        _edge("monerod", "tor", TOR, "Monero P2P + tx", "p2p"),
-        _edge("tari", "tor", TOR, "Tari P2P", "p2p"),
+        edge("p2pool", ext_node(sidechain), sidechain, "sidechain P2P", "p2p"),
+        edge("monerod", "tor", TOR, "Monero P2P + tx", "p2p"),
+        edge("tari", "tor", TOR, "Tari P2P", "p2p"),
         # App-level egress.
-        _edge("xmrig-proxy", _ext(xvb), xvb, "XvB donation", "egress"),
-        _edge("dashboard", "tor", TOR, "update check", "egress"),
+        edge("xmrig-proxy", ext_node(xvb), xvb, "XvB donation", "egress"),
+        edge("dashboard", "tor", TOR, "update check", "egress"),
         # XvB stats fetch — unconditionally Tor (#163/#701); xvb.tor only gates the donation dial.
-        _edge("dashboard", "tor", TOR if xvb_enabled else INACTIVE, "XvB stats", "egress"),
+        edge("dashboard", "tor", TOR if xvb_enabled else INACTIVE, "XvB stats", "egress"),
+        edge("dashboard", "tor", TOR if tor_auto_heal else INACTIVE, "Tor egress probe", "egress"),
         # Healthchecks.io ping — always over Tor when a URL is set (#79).
-        _edge(
+        edge(
             "dashboard",
             "tor",
             TOR if healthchecks_enabled else INACTIVE,
@@ -341,7 +341,7 @@ def compute_topology(
             "egress",
         ),
         # Telegram bot (alerts + command long-poll) — always over Tor when on (#121/#340).
-        _edge(
+        edge(
             "dashboard",
             "tor",
             TOR if telegram_enabled else INACTIVE,
@@ -349,7 +349,7 @@ def compute_topology(
             "egress",
         ),
         # XMR/XTM price feed (#520) — always over Tor when opted in (energy.price_feed).
-        _edge(
+        edge(
             "dashboard",
             "tor",
             TOR if price_feed_enabled else INACTIVE,
@@ -360,7 +360,7 @@ def compute_topology(
         # node — a LAN appliance isn't in the diagram — so it draws no edge; the shared summary
         # still reflects it (as no leak), and the egress list shows the ``local`` route.
         *(
-            [_edge("dashboard", _ext(sinks), sinks, "alert sinks", "egress")]
+            [edge("dashboard", ext_node(sinks), sinks, "alert sinks", "egress")]
             if sinks != LOCAL
             else []
         ),
@@ -368,37 +368,37 @@ def compute_topology(
         # LAN hop with no placeable node (like the alert-sink LAN carve-out), so it draws no edge.
         # The route is never clearnet, so it can never bypass the hub to the internet node.
         *(
-            [_edge("dashboard", _ext(standby), standby, "XvB standby", "egress")]
+            [edge("dashboard", ext_node(standby), standby, "XvB standby", "egress")]
             if standby != LOCAL
             else []
         ),
         # The Tor hub to the network: SOCKS egress for every daemon + onion-service ingress.
-        _edge("tor", "internet", TOR, "SOCKS + onion circuits", "p2p"),
+        edge("tor", "internet", TOR, "SOCKS + onion circuits", "p2p"),
         # Internal mesh (hidden until expanded).
-        _edge("xmrig-proxy", "p2pool", LOCAL, "upstream pool", "internal"),
-        _edge("p2pool", "monerod", monero_route, "RPC / ZMQ", "internal"),
-        _edge("p2pool", "tari", tari_route, "gRPC merge-mine", "internal"),
-        _edge("caddy", "dashboard", LOCAL, "reverse-proxy :8000", "internal"),
-        _edge("dashboard", "monerod", monero_route, "get_info RPC", "internal"),
-        _edge("dashboard", "xmrig-proxy", LOCAL, "proxy API", "internal"),
-        _edge("dashboard", "tari", tari_route, "gRPC", "internal"),
-        _edge("dashboard", "docker", LOCAL, "container API", "internal"),
+        edge("xmrig-proxy", "p2pool", LOCAL, "upstream pool", "internal"),
+        edge("p2pool", "monerod", monero_route, "RPC / ZMQ", "internal"),
+        edge("p2pool", "tari", tari_route, "gRPC merge-mine", "internal"),
+        edge("caddy", "dashboard", LOCAL, "reverse-proxy :8000", "internal"),
+        edge("dashboard", "monerod", monero_route, "get_info RPC", "internal"),
+        edge("dashboard", "xmrig-proxy", LOCAL, "proxy API", "internal"),
+        edge("dashboard", "tari", tari_route, "gRPC", "internal"),
+        edge("dashboard", "docker", LOCAL, "container API", "internal"),
     ]
     # Optional clearnet initial-sync paths (#183) bypass the Tor hub straight to the internet.
     if monero_clearnet_sync:
-        edges.append(_edge("monerod", "internet", CLEARNET, "clearnet IBD", "egress"))
+        edges.append(edge("monerod", "internet", CLEARNET, "clearnet IBD", "egress"))
     if tari_clearnet_sync:
-        edges.append(_edge("tari", "internet", CLEARNET, "clearnet IBD", "egress"))
+        edges.append(edge("tari", "internet", CLEARNET, "clearnet IBD", "egress"))
 
     # Tag clearnet links as a real leak vs firewall-blocked — same rule as the egress list. Only the
     # host-networked dashboard escapes the #270 container firewall, so its clearnet links truly leak.
-    for edge in edges:
-        if edge["route"] != CLEARNET:
+    for link in edges:
+        if link["route"] != CLEARNET:
             continue
-        if edge["from"] != "dashboard" and firewall:
-            edge["blocked_by_firewall"] = True
+        if link["from"] != "dashboard" and firewall:
+            link["blocked_by_firewall"] = True
         else:
-            edge["leak"] = True
+            link["leak"] = True
 
     nodes = topology_nodes(monero_route=monero_route, tari_route=tari_route)
     return {"nodes": nodes, "edges": edges, "summary": posture["summary"]}
@@ -419,5 +419,5 @@ def topology_from_config():
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],
         xvb_standby_source=config.XVB_STANDBY_SOURCE,
-        **_notify_knobs(),
+        **_shared_knobs(),
     )

--- a/dashboard/mining_dashboard/service/topology_graph.py
+++ b/dashboard/mining_dashboard/service/topology_graph.py
@@ -50,6 +50,18 @@ TOPOLOGY_NODES = [
 ]
 
 
+def edge(src, dst, route, label, kind):
+    """One hop in the diagram. Lives here, not in ``egress``, for the same reason the route
+    constants do: ``egress`` sits at its file-budget ceiling and this is graph vocabulary."""
+    return {"from": src, "to": dst, "route": route, "label": label, "kind": kind}
+
+
+def ext_node(route):
+    # Where a component's external link lands in the diagram: a Tor-routed link terminates at the
+    # `tor` hub; a clearnet link goes STRAIGHT to the internet node, so a leak visibly bypasses Tor.
+    return "internet" if route == CLEARNET else "tor"
+
+
 def node_route(address, *, is_local):
     """Route of a hop to a relocatable node, from its configured address SHAPE alone (#1350).
 

--- a/dashboard/tests/frontend/fixtures/state.json
+++ b/dashboard/tests/frontend/fixtures/state.json
@@ -213,6 +213,10 @@
           {
             "route": "inactive",
             "to": "XvB standby pull (backup \u2190 primary)"
+          },
+          {
+            "route": "inactive",
+            "to": "Tor egress probe"
           }
         ],
         "firewalled": false,
@@ -374,7 +378,7 @@
       "current": 3000000,
       "db_size": "\u2014",
       "local": true,
-    "mode": "Pruned",
+      "mode": "Pruned",
       "percent": 100,
       "remaining": 0,
       "state": "done",
@@ -382,8 +386,8 @@
     },
     "tari": {
       "current": 50000,
-      "local": true,
-    "percent": 100,
+      "local": false,
+      "percent": 100,
       "remaining": 0,
       "state": "done",
       "target": 50000
@@ -433,14 +437,14 @@
         "from": "rigs",
         "kind": "ingress",
         "label": "stratum :3333",
-        "route": "local",
+        "route": "lan",
         "to": "xmrig-proxy"
       },
       {
         "from": "browser",
         "kind": "ingress",
         "label": "https :443",
-        "route": "local",
+        "route": "lan",
         "to": "caddy"
       },
       {
@@ -483,6 +487,13 @@
         "kind": "egress",
         "label": "XvB stats",
         "route": "tor",
+        "to": "tor"
+      },
+      {
+        "from": "dashboard",
+        "kind": "egress",
+        "label": "Tor egress probe",
+        "route": "inactive",
         "to": "tor"
       },
       {
@@ -545,7 +556,7 @@
         "from": "p2pool",
         "kind": "internal",
         "label": "gRPC merge-mine",
-        "route": "local",
+        "route": "lan",
         "to": "tari"
       },
       {
@@ -573,7 +584,7 @@
         "from": "dashboard",
         "kind": "internal",
         "label": "gRPC",
-        "route": "local",
+        "route": "lan",
         "to": "tari"
       },
       {
@@ -619,13 +630,13 @@
         "id": "monerod",
         "label": "monerod",
         "remote": false,
-          "zone": "host"
+        "zone": "host"
       },
       {
         "id": "tari",
         "label": "tari",
-        "remote": false,
-          "zone": "host"
+        "remote": true,
+        "zone": "host"
       },
       {
         "id": "docker",

--- a/dashboard/tests/service/test_egress.py
+++ b/dashboard/tests/service/test_egress.py
@@ -128,7 +128,7 @@ def test_sinks_all_private_requires_ip_literal_proof():
     assert _sinks_all_private(["http://192.168.1.5/hook"]) is True
     assert _sinks_all_private(["http://127.0.0.1:8080/hook", "http://[::1]/ntfy/alerts"]) is True
     assert _sinks_all_private(["http://[fc00::1]/hook"]) is True  # IPv6 ULA — the v6 LAN case
-    # The real _notify_knobs shape: webhook configured, NTFY_URL unset ("" must not veto).
+    # The real _shared_knobs shape: webhook configured, NTFY_URL unset ("" must not veto).
     assert _sinks_all_private(["http://192.168.1.5/hook", ""]) is True
     assert _sinks_all_private(["http://192.168.1.5/hook", "https://ntfy.sh/mytopic"]) is False
     assert _sinks_all_private(["http://nas.local/hook"]) is False  # hostname — unknowable

--- a/dashboard/tests/service/test_egress.py
+++ b/dashboard/tests/service/test_egress.py
@@ -218,10 +218,10 @@ def test_topology_safe_has_no_leaks_and_hub_nodes(_topo):
 
 
 def test_topology_lan_ingress_edges(_edge, _topo):
+    # Both hops LEAVE this box, so the legend's own split makes them LAN, never Local (#1856).
     topo = _topo()
-    rigs = _edge(topo, "rigs", "xmrig-proxy")
-    assert rigs["kind"] == "ingress" and rigs["route"] == "local"
-    assert _edge(topo, "browser", "caddy")["kind"] == "ingress"
+    for e in (_edge(topo, "rigs", "xmrig-proxy"), _edge(topo, "browser", "caddy")):
+        assert e["kind"] == "ingress" and e["route"] == "lan", e
 
 
 def test_topology_daemon_p2p_is_bidirectional_over_tor(_edge, _topo):

--- a/dashboard/tests/service/test_tor_probe_egress.py
+++ b/dashboard/tests/service/test_tor_probe_egress.py
@@ -1,0 +1,58 @@
+"""The #424 Tor egress probe, in both privacy views (#1856 row 13b).
+
+``tor_heal`` sends ``PROBE_URL`` through ``TOR_SOCKS_PROXY`` every five minutes while
+``tor.auto_heal`` is on (``service/tor_heal.py:63``, ``:130-134``). That is a real outbound call,
+so the egress list and the topology diagram both have to name it: an operator auditing "All
+connections" was reading a list that did not contain every connection.
+
+Its own module rather than ``test_egress.py`` because that file is at its file-budget ceiling
+(451/451). The same ceiling kept ``tor_auto_heal`` out of the ``_KNOBS`` product there, which
+costs less than it looks: the row and the edge are UNCONDITIONAL — only their route varies — so
+the exhaustive sweeps already cover the off branch, well-formedness and summary agreement. What
+they cannot see is the on branch, and that is what this module pins.
+"""
+
+import itertools
+
+from mining_dashboard.service.egress import CLEARNET, INACTIVE, TOR
+
+_PROBE = "Tor egress probe"
+
+
+def _conn(posture):
+    dashboard = next(c for c in posture["components"] if c["name"] == "dashboard")
+    return next(c for c in dashboard["conns"] if c["to"] == _PROBE)
+
+
+def _edge_of(topo):
+    return next(e for e in topo["edges"] if e["label"] == _PROBE)
+
+
+def test_the_probe_is_inactive_until_auto_heal_is_turned_on(_posture, _topo):
+    # tor.auto_heal is opt-in, so the resting box makes no probe at all. The row has to say that
+    # rather than show a connection nothing is making — an inactive row is the honest answer.
+    assert _conn(_posture())["route"] == INACTIVE
+    assert _edge_of(_topo())["route"] == INACTIVE
+
+
+def test_the_probe_rides_tor_when_auto_heal_is_on(_posture, _topo):
+    # tor_heal passes TOR_SOCKS_PROXY for both schemes, so Tor is the only honest route, and the
+    # edge has to land on the hub — a probe drawn straight to `internet` would read as a leak.
+    assert _conn(_posture(tor_auto_heal=True))["route"] == TOR
+    edge = _edge_of(_topo(tor_auto_heal=True))
+    assert (edge["route"], edge["to"], edge["kind"]) == (TOR, "tor", "egress")
+
+
+def test_the_probe_never_leaks_and_the_two_views_never_disagree(_posture, _topo):
+    # The probe's half of test_egress.py::_TOR_HARDWIRED, which could not take another row. No
+    # knob combination may derive a clearnet route for a socks5h-only client, and turning one on
+    # may never move the privacy verdict — a headline that shifted here would blame the probe for
+    # a leak it cannot cause. The list and the diagram are derived separately, so they are also
+    # asserted to agree rather than assumed to.
+    for auto_heal, firewall, xvb_tor in itertools.product((False, True), repeat=3):
+        knobs = {"firewall": firewall, "xvb_tor": xvb_tor, "tor_auto_heal": auto_heal}
+        posture = _posture(**knobs)
+        assert _conn(posture)["route"] != CLEARNET, knobs
+        assert _conn(posture)["route"] == _edge_of(_topo(**knobs))["route"], knobs
+        flipped = _posture(**{**knobs, "tor_auto_heal": not auto_heal})
+        assert posture["summary"] == flipped["summary"], knobs

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -116,6 +116,7 @@ What the running stack sends to the internet, connection by connection.
 | **Telegram** bot (#121) | `api.telegram.org` | nothing about you — Telegram sees a **Tor exit**, not your IP | ✅ **always** Tor (`socks5h`, #340) | **off** | opt-in; both the alert sends and the command poll ride Tor |
 | Dashboard **Healthchecks** ping (#79) | `hc-ping.com` (or self-hosted) | nothing about you — the endpoint sees a **Tor exit**, not your IP | ✅ **always** Tor (`socks5h`) | opt-in (set `healthchecks.ping_url`; off until set) | the ping URL must be Tor-reachable (hosted, public, or an onion self-hosted instance) — there is no clearnet mode |
 | Dashboard **price feed** (#520) | `api.coingecko.com` | nothing about you — CoinGecko sees a **Tor exit**, not your IP | ✅ **always** Tor (`socks5h`) | **off** | opt-in (`dashboard.energy.price_feed: true`); fetches the XMR + XTM spot prices every 15 min; fails silently, static config prices are the fallback |
+| Dashboard **Tor egress probe** (#424) | `www.google.com/generate_204` | nothing about you — the endpoint sees a **Tor exit**, not your IP, and a 204 carries no content | ✅ **always** Tor (`socks5h`) | **off** | opt-in (`tor.auto_heal: true`); a reachability check every 5 min that decides whether the Tor guard is stuck. Fifteen minutes of sustained failure restarts the tor container; the probe never falls back to clearnet, so a broken Tor means no probe, not an exposed one |
 | **Webhook / ntfy** alert sinks (#380) | your configured URLs | alert texts; the endpoint sees a **Tor exit**, not your IP | ✅ Tor (`socks5h`) by default | opt-in (set `notifications.webhooks` / `notifications.ntfy.url`; off until set) | `notifications.tor: false` is the LAN carve-out (Tor exits can't reach private addresses) — with it, a **clearnet** endpoint sees your host IP on every alert |
 
 `socks5h` (used for the XvB stats fetch) routes DNS resolution through Tor too, so the hostname isn't
@@ -142,6 +143,14 @@ counted. A node configured by **hostname** draws as **Unverified** — the diagr
 a name to classify it, because that lookup would itself be an egress, and on a Tor-routed stack it
 would cause the exact exposure the panel exists to warn about, on every render. Unverified is not
 counted as a leak either; the panel says it cannot tell rather than guessing in either direction.
+
+The same split decides the two **ingress** hops the diagram draws. Your mining rigs and the
+browser you open the dashboard in sit on your network, not on this machine, so the stratum
+connection into xmrig-proxy and the HTTPS connection into Caddy both draw as **LAN**. They drew as
+**Local** until #1856, which claimed a trust boundary the stack does not have: these two listeners
+are the only ones exposed to your network at all, and reading them as "this machine" is what makes
+that worth stating plainly. Neither is a leak — a LAN hop does not reach the internet — but the
+panel now says which side of the box they are on.
 
 **LAN is a statement about exposure, not about encryption.** A remote-node hop is a plaintext
 connection whichever way it draws, so the rows above still apply: anyone who can watch your local


### PR DESCRIPTION
## What was wrong

The Stack Topology diagram drew the two ingress hops as **Local**, which its own legend defines as "this machine" (`web/static/topology.mjs:46-47`). Both endpoints sit in the LAN zone (`service/topology_graph.py:39-40`), so both hops leave the box. The comment directly above those two edges already read "Ingress from your LAN" — only the code disagreed.

This is the security panel. Reading a hop that crosses onto your network as "this machine" overstates the trust boundary, which is the one thing this card exists to state correctly.

Second half, the same issue's row 13b: the #424 Tor egress probe was in **neither** privacy view and in no doc. `tor_heal` sends `PROBE_URL` through `TOR_SOCKS_PROXY` every five minutes while `tor.auto_heal` is on (`service/tor_heal.py:63`, `:130-134`). An operator auditing "All connections" was reading a list that omitted a connection.

## What changed

- `egress.py:323-324` — the rigs and browser ingress edges route `LAN`, not `LOCAL`.
- A "Tor egress probe" row in the egress list and a matching edge in the topology, both keyed on `tor.auto_heal`, both `INACTIVE` until it is on. Unconditional rows, like the four Tor-only dashboard clients beside them, so the existing exhaustive sweeps see them.
- `docs/privacy.md` — the probe gets a row in the runtime-egress table (it was absent entirely), and the topology section explains why the two ingress hops read LAN.

**No leak count, headline, legend entry or node changes.** A LAN hop is not egress, so `leaks` is untouched — asserted, not assumed.

## Budget, and where code went

`egress.py` was at **423/424** and this needs nine lines. `check_monotonic` refuses a ceiling raise, so `edge`/`ext_node` move to `topology_graph.py`, whose docstring already records "egress has no room" as why the route vocabulary lives there. They are re-exported; no importer changes. Final: **423/424**.

That rename collided with `for edge in edges:` in the firewall-tagging pass, shadowing the import — the suite caught it, not review. Loop variable renamed to `link`.

`_notify_knobs` → `_shared_knobs` (it now carries the probe knob both from-config builders read) — this is the line that paid for a second config read at two call sites.

Declined on merits: folding the five `TOR if <flag> else INACTIVE` conn/edge pairs into one table. It is real duplication, but it is a refactor of the whole panel during an RC cut, and it is not this bug.

## Tier and what was run

Unit. `tests/service/test_tor_probe_egress.py` is a **new module** because `test_egress.py` is at **451/451**; the ingress test there is corrected in place, line-neutral, and now checks both edges' route where it checked only the rigs one. The same ceiling kept `tor_auto_heal` out of the `_KNOBS` product, which costs little: the row and edge are unconditional, so the sweeps already cover the off branch, well-formedness and summary agreement. The new module pins the on branch.

Run by me at this head:

- `pytest` (full dashboard suite): **2575 passed**, rc 0
- `node --test dashboard/tests/frontend/`: **579 pass / 0 fail**, rc 0
- `make test-fakes`: **31 passed**, rc 0 — run because this changes the payload
- `make lint-py lint-js lint-docs-voice lint-operator-strings lint-topology lint-file-budget lint-trivy-parity lint-yaml lint-md lint-proto lint-toml`: rc 0. The budget gate self-tested and then reported every file within its ceiling.

Not run: `make lint-sh` (no shell files in this diff, and the appliance lane holds the box), and no docker, KVM or bench work.

## The frontend fixture, which is a wider change than it looks

`tests/frontend/fixtures/state.json` is regenerated, and the diff carries `tari` values and an indentation fix my change does not explain. **It was already stale on `develop` and had been hand-edited** — it held indentation `json.dump` cannot emit, and `tari.local`/`remote` values the generator does not produce.

Proven independently of this diff: `tari_is_local()` returns `False` at defaults — the default `TARI_GRPC_ADDRESS` is a loopback literal, which does not carry the local-monerod subnet prefix that check compares against (`config/config.py:71-75`) — and this branch touches no config file — so any faithful regeneration on `develop` yields the same values. Its drift guard (`tests/web/test_xvb_views.py:503`) compares dotted key paths only, **never values**, so value drift there is invisible to CI. Regenerating is the fixture's own documented contract.

## What the operator sees on the appliance

In Advanced view, **Stack Topology & Egress**: the two arrows entering `xmrig-proxy` and `caddy` turn blue (LAN) instead of grey (Local). "All connections" gains a **Tor egress probe** row, showing Inactive unless `tor.auto_heal: true`. Nothing else moves — same headline, same badge, same node boxes.

## What I did NOT do

**#1856 stays open.** Row 1's second half — the on-box `local_miner` internal edge — is not here. It needs a new node id, which touches `TOPOLOGY_NODES`, the frontend `POS` map, and two canonical-id lists that assert an exact set, one of them in `test_egress.py` at its ceiling. That is a layout decision plus a contract change in four places, not a colour fix, and it is a gap rather than a regression: the "Mining rigs" node is an external actor, so drawing its hop as LAN says nothing false about an on-box miner, which is undrawn today and stays undrawn.

Also untouched, per the issue's own split: rows 4/5/15 belong to #1849, row 2b to #1853. The issue's "Taste" suggestion — a sub-line counting LAN and unverified hops under the "All egress via Tor" headline — is not done; it is a new claim on the panel, not a correction.

`docs/` is shared (`_shared.paths`), so no lane-override was needed; disclosing the edit here as the rule asks.

## Merge

Not mine to merge. Needs a recorded non-author PASS at this head plus green CI, and the seat's `--admin` on `develop`.
