### PR TITLE
Make worker and calculator gaps truthful

### DIFF
--- a/dashboard/mining_dashboard/client/rigforge_freshness.py
+++ b/dashboard/mining_dashboard/client/rigforge_freshness.py
@@ -1,0 +1,24 @@
+"""Freshness contract for RigForge's generated sister feed."""
+
+import time
+from datetime import UTC, datetime
+
+STALE_AFTER_S = 60
+
+
+def feed_age(stamp, now=None) -> int | None:
+    """Return age in seconds, or None when the UTC stamp cannot prove freshness."""
+    try:
+        generated = datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC).timestamp()
+        age = (time.time() if now is None else now) - generated
+        return max(0, round(age)) if age >= -STALE_AFTER_S else None
+    except (TypeError, ValueError):
+        return None
+
+
+def feed_stale(report, now=None) -> bool:
+    """Re-age a stored report; missing or invalid producer stamps fail closed."""
+    if not isinstance(report, dict):
+        return True
+    age = feed_age(report.get("generated_at"), now)
+    return age is None or age > STALE_AFTER_S

--- a/dashboard/mining_dashboard/client/xmrig_client.py
+++ b/dashboard/mining_dashboard/client/xmrig_client.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from mining_dashboard.client.rig_config_meta import parse_config_meta
+from mining_dashboard.client.rigforge_freshness import STALE_AFTER_S, feed_age
 from mining_dashboard.config.config import (
     API_TIMEOUT,
     DASHBOARD_WORKERS,
@@ -52,29 +53,25 @@ except ValueError:
     _INTERNAL_NET = ipaddress.ip_network("172.28.0.0/16")
 
 
-def parse_rigforge(payload):
+def parse_rigforge(payload, now=None):
     """Normalize the optional ``rigforge`` block off a worker ``/1/summary`` (#235).
 
     A RigForge rig serves an ENRICHED feed on its ``api_port`` (default 8081): the whole XMRig
     ``/1/summary`` object unchanged, plus one added ``rigforge`` key (rigforge#99). Point the rig's
     descriptor ``port`` at that feed and the block rides in on the existing poll — no new read path.
-    A plain-xmrig rig has no ``rigforge`` key, so this returns ``None`` and the UI renders it exactly
-    as before (backward compatible).
+    A plain-xmrig rig has no ``rigforge`` key, so this returns ``None``. Nullable enriched fields
+    are defaulted; ``xmrig_api == "unreachable"`` becomes ``miner_down``. The top-level RigForge
+    ``generated_at`` stamp decides whether live telemetry is stale.
 
-    Every enriched field is nullable on the wire — no RAPL / non-root → ``power.watts`` null, no
-    governor read → ``governor`` null — so each access is defaulted. A present-but-miner-down rig
-    (``xmrig_api == "unreachable"``, XMRig keys absent) is flagged via ``miner_down`` so the UI can
-    show it as up-but-miner-down rather than offline. Returns a compact dict for the UI, or ``None``.
-
-    ``config`` is the rig's EFFECTIVE writable config (rigforge#253, shipped in RigForge v1.10.0),
-    riding this same poll. It is what the Worker Inspect editor prefills from (#1235): the rig's
-    own current values, rather than Pithead's record of what it last pushed — which is empty on a
-    never-edited rig and stale on one changed directly with ``rigforge.sh apply``. A rig older than
+    ``config`` is the rig's EFFECTIVE writable config (rigforge#253). Worker Inspect prefills it
+    from (#1235), rather than Pithead's last pushed record. A rig older than
     v1.10.0 sends no ``config`` and this stays ``None``, so the editor falls back to the record.
     """
     rf = payload.get("rigforge") if isinstance(payload, dict) else None
     if not isinstance(rf, dict):
         return None
+    stamp = payload.get("generated_at")
+    age = feed_age(stamp, now)
     tune = rf.get("tune") or {}
     autotune = tune.get("autotune") or {}
     power = rf.get("power") or {}
@@ -83,6 +80,9 @@ def parse_rigforge(payload):
     watchdog = rf.get("watchdog") or {}
     wd_on = watchdog.get("mode") == "enabled"
     return {
+        "generated_at": stamp if age is not None else None,
+        "age_sec": age,
+        "stale": age is None or age > STALE_AFTER_S,
         "version": rf.get("version"),
         "miner_down": rf.get("xmrig_api") == "unreachable",
         "power": {"watts": power.get("watts"), "hs_per_watt": power.get("hs_per_watt")},

--- a/dashboard/mining_dashboard/service/data_helpers.py
+++ b/dashboard/mining_dashboard/service/data_helpers.py
@@ -80,23 +80,22 @@ def _xvb_winners_gate_sec(avg_1h, avg_24h, tiers, last_win_ts, now):
     return _XVB_WINNERS_SYNC_SEC
 
 
-def _parse_proxy_list_worker(w):
+def _parse_proxy_list_worker(w, now=None):
     """Parse one xmrig-proxy 6.x positional row into a worker dict.
 
-    Online/offline is derived from the active connection count, not mere presence —
-    xmrig-proxy keeps a worker in /workers with a decaying hashrate after it disconnects,
-    so a stopped miner would otherwise stay green and inflate the total. The proxy lacks a
-    10s window, so the 1-minute rate backs both h10 and h60; the 10-minute rate is h15.
+    Online/offline comes from a live connection or a recent accepted share; mere presence is not
+    enough because the proxy keeps disconnected workers. Its 1-minute rate backs h10 and h60.
     """
-    # Uptime starts at 0 here: WorkerLifecycle fills it with the real connection uptime
-    # (now - connected_since) for online workers, and the direct miner API overrides it when
-    # reachable. The old "seconds since last share" fallback was misleading both ways — it climbed
-    # forever for a disconnected worker (read like uptime, was downtime) and read near-zero for a
-    # healthy rig whose direct API was just unreachable (#169).
+    # WorkerLifecycle or the direct miner API supplies uptime; last-share age is not uptime (#169).
+    now = datetime.now(UTC).timestamp() if now is None else now
+    share_age = now - (w[_PX_LAST_SHARE_MS] or 0) / 1000
     return {
         "name": w[_PX_NAME],
         "ip": w[_PX_IP],
-        "status": "online" if w[_PX_CONNECTIONS] > 0 else "offline",
+        "status": "online"
+        if w[_PX_CONNECTIONS] > 0
+        or (w[_PX_ACCEPTED] > 0 and 0 <= share_age <= config.WORKER_OFFLINE_AFTER_SEC)
+        else "offline",
         "h10": w[_PX_HR_1M] * _KHS_TO_HS,
         "h60": w[_PX_HR_1M] * _KHS_TO_HS,
         "h15": w[_PX_HR_10M] * _KHS_TO_HS,
@@ -136,7 +135,7 @@ def _parse_legacy_dict_worker(w):
     }
 
 
-def _normalize_proxy_workers(proxy_data):
+def _normalize_proxy_workers(proxy_data, now=None):
     """Normalize an xmrig-proxy ``/workers`` payload into a uniform worker list.
 
     Dispatches each entry to the right parser for the two shapes the proxy emits — the 6.x
@@ -149,7 +148,7 @@ def _normalize_proxy_workers(proxy_data):
     workers = []
     for w in proxy_data["workers"]:
         if isinstance(w, list) and len(w) >= _PX_MIN_FIELDS:
-            workers.append(_parse_proxy_list_worker(w))
+            workers.append(_parse_proxy_list_worker(w, now=now))
         elif isinstance(w, dict):
             workers.append(_parse_legacy_dict_worker(w))
     return workers

--- a/dashboard/mining_dashboard/service/data_service.py
+++ b/dashboard/mining_dashboard/service/data_service.py
@@ -330,6 +330,10 @@ class DataService:
             # restored `rigforge_release` would keep serving stale per-worker badges until the
             # first poll cycle. The checker re-fetches on its cadence; drop it on restore.
             loaded_snapshot.pop("rigforge_release", None)
+            for worker in loaded_snapshot.get("workers", []):
+                rigforge = worker.get("rigforge") or {}
+                if rigforge and "generated_at" not in rigforge:
+                    rigforge["stale"] = True
             self.latest_data.update(loaded_snapshot)
             self.workers_rejected = bool(self.latest_data.get("workers_rejected", False))
             self.miner_released = bool(self.latest_data.get("miner_released", False))

--- a/dashboard/mining_dashboard/service/worker_refresh.py
+++ b/dashboard/mining_dashboard/service/worker_refresh.py
@@ -51,6 +51,8 @@ async def _poll_until_matched(worker_client, ip, name, target, entry, attempts, 
         if rf is None:
             continue
         entry["rigforge"] = rf
+        if rf.get("stale"):
+            continue
         reported = parse_semver(rf.get("version"))
         if target is None or (reported and reported == target):
             return True

--- a/dashboard/mining_dashboard/web/infra_views.py
+++ b/dashboard/mining_dashboard/web/infra_views.py
@@ -15,9 +15,12 @@ formats at the edge and emits tokens the client maps to CSS, never HTML.
 import logging
 import time
 
+from mining_dashboard.client.rigforge_freshness import feed_stale
 from mining_dashboard.config import config
 from mining_dashboard.helper.utils import format_disk_size, format_duration, format_hashrate
 from mining_dashboard.service.update_checker import compute_update
+from mining_dashboard.web.rigforge_views import _num
+from mining_dashboard.web.rigforge_views import rigforge_display as _rigforge_display
 
 # Same logger name as views.py on purpose: these sections were emitting under "WebViews" before the
 # split and a rename would silently change every operator's log output.
@@ -51,134 +54,6 @@ def _reject_flag(accepted, rejected):
     if rate < _REJECT_FLAG_RATE:
         return None
     return {"text": "⚠", "title": f"High reject rate: {rate * 100:.1f}% ({rejected} rejected)"}
-
-
-def _num(v):
-    """A number for display, or None for anything non-numeric (incl. bools, which JSON booleans
-    would otherwise pass as 0/1). Every enriched RigForge field is nullable on the wire (#235)."""
-    return v if isinstance(v, (int, float)) and not isinstance(v, bool) else None
-
-
-def _fmt_num(v):
-    """Trim a display number: drop a pointless ``.0`` so ``142.0 W`` reads ``142 W``."""
-    return str(int(v)) if isinstance(v, float) and v.is_integer() else str(v)
-
-
-def _rigforge_display(rf):
-    """A ``{version, miner_down, chips, stats}`` view of a worker's parsed ``rigforge`` block, or
-    ``None`` for a plain-xmrig worker (#235). Each metric is emitted ONLY when its data is present —
-    a rig with no RAPL shows no power row, a disabled watchdog shows no watchdog row.
-
-    Both outputs come from one pass so they can't drift: ``chips`` is the merged ``{text, variant,
-    title}`` badge shape the compact Workers-Alive list renders, and ``stats`` is the same metrics
-    split into ``{label, value, variant, title}`` for the Worker Inspect detail table (#507).
-    Building the set (and its thresholds) here keeps the client a dumb renderer, matching the
-    ``_reject_flag`` precedent."""
-    if not rf:
-        return None
-    rows = []
-
-    def add(label, value, chip, variant, title):
-        rows.append(
-            {"label": label, "value": value, "chip": chip, "variant": variant, "title": title}
-        )
-
-    if rf.get("miner_down"):
-        add(
-            "Miner",
-            "down",
-            "miner down",
-            "bad",
-            "RigForge is up but its XMRig API is unreachable — the rig is present but not mining. "
-            "Live hashrate and uptime come from the proxy.",
-        )
-
-    health = rf.get("health") or {}
-    if health.get("throttling") is True:
-        add("CPU", "throttling", "throttling", "bad", "CPU is thermal/power throttling.")
-    gov = health.get("governor")
-    if gov:
-        ok = gov == "performance"
-        add(
-            "Governor",
-            gov,
-            f"gov: {gov}",
-            "ok" if ok else "warn",
-            "CPU frequency governor"
-            + ("" if ok else " — 'performance' is recommended for mining."),
-        )
-    hp = _num(health.get("hugepages_total"))
-    if hp is not None:
-        add(
-            "HugePages",
-            _fmt_num(hp),
-            f"HP {_fmt_num(hp)}",
-            "outline",
-            f"HugePages allocated: {_fmt_num(hp)}.",
-        )
-    board = health.get("board")
-    if board:
-        add("Mainboard", board, board, "outline", "Mainboard (firmware).")
-
-    power = rf.get("power") or {}
-    watts = _num(power.get("watts"))
-    hspw = _num(power.get("hs_per_watt"))
-    if watts is not None or hspw is not None:
-        parts = []
-        if watts is not None:
-            parts.append(f"{_fmt_num(round(watts, 1))} W")
-        if hspw is not None:
-            parts.append(f"{_fmt_num(round(hspw, 1))} H/s·W")
-        text = " · ".join(parts)
-        add("Power / efficiency", text, text, "outline", "Power draw / efficiency.")
-
-    tune = rf.get("tune") or {}
-    if tune.get("target"):
-        add(
-            "Tuning target",
-            tune["target"],
-            f"tune: {tune['target']}",
-            "outline",
-            "Active tuning target.",
-        )
-    if tune.get("autotune_enabled") and tune.get("autotune_next"):
-        add(
-            "Autotune",
-            tune["autotune_next"],
-            f"autotune → {tune['autotune_next']}",
-            "outline",
-            "Next scheduled autotune run.",
-        )
-
-    wd = rf.get("watchdog") or {}
-    if wd.get("enabled"):
-        temp = _num(wd.get("temp_c"))
-        maxt = _num(wd.get("max_temp_c"))
-        if wd.get("thermal_hold") is True:
-            add(
-                "Watchdog",
-                "thermal hold",
-                "thermal hold",
-                "bad",
-                "Watchdog is holding the rig back — temperature above its ceiling.",
-            )
-        elif temp is not None:
-            text = f"{_fmt_num(round(temp, 1))}°C"
-            if maxt is not None:
-                text += f" / {_fmt_num(maxt)}°C"
-            add("Temp / max", text, text, "outline", "Watchdog temperature / ceiling.")
-
-    chips = [{"text": r["chip"], "variant": r["variant"], "title": r["title"]} for r in rows]
-    stats = [
-        {"label": r["label"], "value": r["value"], "variant": r["variant"], "title": r["title"]}
-        for r in rows
-    ]
-    return {
-        "version": rf.get("version"),
-        "miner_down": bool(rf.get("miner_down")),
-        "chips": chips,
-        "stats": stats,
-    }
 
 
 def build_system(data):
@@ -247,7 +122,10 @@ def rigforge_update_for(worker, release):
     cached release → ``None``, an honest "unknown", not a false "up to date"."""
     if not worker or not release:
         return None
-    version = (worker.get("rigforge") or {}).get("version")
+    rigforge = worker.get("rigforge") or {}
+    if feed_stale(rigforge):
+        return None
+    version = rigforge.get("version")
     if not version:
         return None
     return compute_update(version, release.get("tag"), release.get("url"))
@@ -306,7 +184,9 @@ def build_workers(workers, rigforge_release=None):
                     "adopted": worker.get("adopted"),
                     # RigForge enriched feed (#235): version badge + health/power/tune/watchdog
                     # chips, or None for a plain-xmrig worker (renders nothing extra).
-                    "rigforge": _rigforge_display(worker.get("rigforge")),
+                    "rigforge": _rigforge_display(
+                        worker.get("rigforge"), worker.get("status") == "online"
+                    ),
                     # {available, latest, url} | None — this rig runs an older RigForge (#596).
                     "rigforge_update": rigforge_update_for(worker, rigforge_release),
                 }
@@ -384,6 +264,8 @@ def build_energy(workers, prices=None):
     for worker in workers:
         name = worker.get("name", "")
         rf = worker.get("rigforge") or {}
+        if feed_stale(rf):
+            rf = {}
         power = rf.get("power") or {}
         watts = _num(power.get("watts"))
         estimated = False

--- a/dashboard/mining_dashboard/web/rigforge_views.py
+++ b/dashboard/mining_dashboard/web/rigforge_views.py
@@ -1,0 +1,148 @@
+"""RigForge worker telemetry presentation."""
+
+from mining_dashboard.client.rigforge_freshness import feed_age, feed_stale
+from mining_dashboard.helper.utils import format_duration
+
+
+def _num(value):
+    return value if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def _fmt(value):
+    return str(int(value)) if isinstance(value, float) and value.is_integer() else str(value)
+
+
+def rigforge_display(rf, proxy_online=False):
+    """Build worker-list chips and Worker Inspect rows from a current agent report."""
+    if not rf:
+        return None
+    if feed_stale(rf):
+        age = feed_age(rf.get("generated_at"))
+        if age is None and "generated_at" not in rf:
+            age = rf.get("age_sec")
+        value = f"stale for {format_duration(age)}" if age is not None else "freshness unknown"
+        title = (
+            f"RigForge's report is {format_duration(age)} old. Live agent version, miner state, "
+            "temperature and health are hidden until a current report arrives."
+            if age is not None
+            else "This RigForge report has no valid generation stamp, so its live agent version, "
+            "miner state, temperature and health cannot be trusted."
+        )
+        row = {"label": "Agent report", "value": value, "variant": "warn", "title": title}
+        return {
+            "version": None,
+            "miner_down": False,
+            "chips": [{"text": f"agent {value}", "variant": "warn", "title": title}],
+            "stats": [row],
+        }
+    rows = []
+
+    def add(label, value, chip, variant, title):
+        rows.append(
+            {"label": label, "value": value, "chip": chip, "variant": variant, "title": title}
+        )
+
+    if rf.get("miner_down"):
+        add(
+            "Miner",
+            "agent reports down" if proxy_online else "down",
+            "agent reports miner down" if proxy_online else "miner down",
+            "warn" if proxy_online else "bad",
+            (
+                "The current RigForge report cannot reach XMRig, but the proxy still sees this "
+                "worker connected and accepting shares. Proxy-observed mining state wins."
+                if proxy_online
+                else "RigForge is up but its XMRig API is unreachable, and the proxy does not see "
+                "the worker online."
+            ),
+        )
+
+    health = rf.get("health") or {}
+    if health.get("throttling") is True:
+        add("CPU", "throttling", "throttling", "bad", "CPU is thermal/power throttling.")
+    governor = health.get("governor")
+    if governor:
+        ok = governor == "performance"
+        add(
+            "Governor",
+            governor,
+            f"gov: {governor}",
+            "ok" if ok else "warn",
+            "CPU frequency governor"
+            + ("" if ok else " — 'performance' is recommended for mining."),
+        )
+    hugepages = _num(health.get("hugepages_total"))
+    if hugepages is not None:
+        add(
+            "HugePages",
+            _fmt(hugepages),
+            f"HP {_fmt(hugepages)}",
+            "outline",
+            f"HugePages allocated: {_fmt(hugepages)}.",
+        )
+    board = health.get("board")
+    if board:
+        add("Mainboard", board, board, "outline", "Mainboard (firmware).")
+
+    power = rf.get("power") or {}
+    watts, efficiency = _num(power.get("watts")), _num(power.get("hs_per_watt"))
+    if watts is not None or efficiency is not None:
+        parts = []
+        if watts is not None:
+            parts.append(f"{_fmt(round(watts, 1))} W")
+        if efficiency is not None:
+            parts.append(f"{_fmt(round(efficiency, 1))} H/s·W")
+        text = " · ".join(parts)
+        add("Power / efficiency", text, text, "outline", "Power draw / efficiency.")
+
+    tune = rf.get("tune") or {}
+    if tune.get("target"):
+        add(
+            "Tuning target",
+            tune["target"],
+            f"tune: {tune['target']}",
+            "outline",
+            "Active tuning target.",
+        )
+    if tune.get("autotune_enabled") and tune.get("autotune_next"):
+        add(
+            "Autotune",
+            tune["autotune_next"],
+            f"autotune → {tune['autotune_next']}",
+            "outline",
+            "Next scheduled autotune run.",
+        )
+
+    watchdog = rf.get("watchdog") or {}
+    if watchdog.get("enabled"):
+        temp, maximum = _num(watchdog.get("temp_c")), _num(watchdog.get("max_temp_c"))
+        if watchdog.get("thermal_hold") is True:
+            add(
+                "Watchdog",
+                "thermal hold",
+                "thermal hold",
+                "bad",
+                "Watchdog is holding the rig back — temperature above its ceiling.",
+            )
+        elif temp is not None:
+            text = f"{_fmt(round(temp, 1))}°C"
+            if maximum is not None:
+                text += f" / {_fmt(maximum)}°C"
+            add("Temp / max", text, text, "outline", "Watchdog temperature / ceiling.")
+
+    return {
+        "version": rf.get("version"),
+        "miner_down": bool(rf.get("miner_down")),
+        "chips": [
+            {"text": row["chip"], "variant": row["variant"], "title": row["title"]} for row in rows
+        ],
+        "stats": [
+            {
+                "label": row["label"],
+                "value": row["value"],
+                "variant": row["variant"],
+                "title": row["title"],
+            }
+            for row in rows
+        ],
+    }

--- a/dashboard/mining_dashboard/web/server.py
+++ b/dashboard/mining_dashboard/web/server.py
@@ -7,6 +7,7 @@ import re
 
 from aiohttp import web
 
+from mining_dashboard.client.rigforge_freshness import feed_stale
 from mining_dashboard.client.xmrig_client import strip_sentinel_credentials
 from mining_dashboard.config import config
 from mining_dashboard.service import audit_service, control_service, worker_adopt, worker_refresh
@@ -407,7 +408,8 @@ async def handle_worker_upgrade(request):
         raise web.HTTPBadRequest(text="'version' must look like vX.Y.Z.")
     data = request.app["latest_data"] or {}
     live = next((w for w in data.get("workers", []) if w.get("name") == worker), None)
-    running = ((live or {}).get("rigforge") or {}).get("version")
+    rigforge = (live or {}).get("rigforge") or {}
+    running = None if feed_stale(rigforge) else rigforge.get("version")
     # The rig reports bare "1.11.2", the badge proposes tag "v1.11.2" — compare parsed (#596).
     if running and parse_semver(running) and parse_semver(running) == parse_semver(version):
         return web.json_response(

--- a/dashboard/mining_dashboard/web/static/xvbview.mjs
+++ b/dashboard/mining_dashboard/web/static/xvbview.mjs
@@ -57,6 +57,19 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
   const oddsPendingTitle = calc.enabled
     ? "No round statistics are cached right now — XvB's winners feed fills this in at the next sync."
     : "XvB is off, so its winners feed is never read — and that feed is the only source for draw frequency and qualifier counts. Enable XvB to compute this.";
+  const rewardPending = calc.enabled
+    ? calc.estimates_stale
+      ? "reward feed stale"
+      : calc.estimates_available
+        ? "no published reward for this tier"
+        : "waiting for reward feed"
+    : "no published reward for this tier";
+  const missingNet = (r) => {
+    if (!(hr > 0)) return "needs hashrate";
+    if (!r.sustainable) return "insufficient hashrate";
+    if (!(coeffDay > 0)) return "needs P2Pool network stats";
+    return rewardPending;
+  };
   return html`
         <div class="xvb-comparison">
             <label class="xvb-compare-label">Should I donate? — per-tier verdict (per year)</label>
@@ -76,18 +89,18 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
                     ${r.name}${r.sustainable ? "" : " ⚠"}</h5>
                 <div class="stat-grid">
                     <${StatCard} label="Net (XvB says)"
-                        value=${r.sustainable ? fmtMid(r.netFace) : "—"}
+                        value=${r.sustainable && r.netFace ? fmtMid(r.netFace) : missingNet(r)}
                         cls=${r.sustainable ? r.clsFace : ""}
                         title=${`XvB's own published reward minus the P2Pool earnings given up. ${costNote} Green: profits. Amber: could go either way. Red: loses.`} />
                     <${StatCard} label=${`Net (${measured ? "yours" : "study"})`}
-                        value=${r.sustainable ? fmtMid(r.net) : "—"}
+                        value=${r.sustainable && r.net ? fmtMid(r.net) : missingNet(r)}
                         cls=${r.sustainable ? r.cls : ""}
                         title=${`The ${measured ? "measured" : "study"} estimate minus the P2Pool earnings given up — the verdict this table is about. ${costNote} ${bandNote(r.net)} Green: profits even at the pessimistic end. Amber: the range straddles zero. Red: loses even at the optimistic end.`} />
                 </div>
                 <p class="text-muted text-xs mt-1">
-                    <span title="P2Pool earnings forgone by donating the tier threshold for a year, at your current rate.">Cost ${r.cost !== null ? formatXmr(r.cost) : "—"}</span> ·
-                    <span title="XvB's own published expected reward — face value: prices every bonus hash at full block reward.">XvB says ${r.xvbSays !== null ? formatXmr(r.xvbSays) : "—"}</span> ·
-                    <span title=${`${estTitle} ${bandNote(est)}`}>${estLabel} ${fmtMid(est)}</span> ·
+                    <span title="P2Pool earnings forgone by donating the tier threshold for a year, at your current rate.">Cost ${r.cost !== null ? formatXmr(r.cost) : "needs P2Pool network stats"}</span> ·
+                    <span title="XvB's own published expected reward — face value: prices every bonus hash at full block reward.">XvB says ${r.xvbSays !== null ? formatXmr(r.xvbSays) : rewardPending}</span> ·
+                    <span title=${`${estTitle} ${bandNote(est)}`}>${estLabel} ${est !== null ? fmtMid(est) : rewardPending}</span> ·
                     <span title=${r.oddsPer30d ? oddsTitle : oddsPendingTitle}>Odds / 30d ${r.oddsPer30d ? `≈ ${Number(r.oddsPer30d.toPrecision(2))} wins · ${Number((r.players || 0).toPrecision(2))} players` : oddsPending}</span>
                 </p>
               </div>`;
@@ -97,6 +110,15 @@ function XvbDecisionTable({ calc, coeffDay, hr, energy }) {
               energy && energy.xmr_price > 0 && best
                 ? html`<p class="text-muted text-xs mt-1" id="xvb-fiat-line" title=${bandNote(best.net)}>
                     ${best.name}: net ≈ ${formatFiat(coinFiat((best.net[0] + best.net[1]) / 2, energy.xmr_price), energy.currency)} per year at the current XMR price</p>`
+                : null
+            }
+            ${
+              !energy || !(energy.xmr_price > 0)
+                ? html`<p class="text-muted text-xs mt-1" id="xvb-fiat-missing">Fiat net unavailable: ${
+                    energy && energy.price_source && energy.price_source.feed
+                      ? "waiting for the price feed"
+                      : "set dashboard.energy.xmr_price or enable its price feed"
+                  }.</p>`
                 : null
             }
             <p class="text-muted text-xs mt-2">
@@ -143,7 +165,8 @@ export function XvbTierBlock({ calc, hr, coeffDay, energy, est }) {
         <div class="stat-grid">
             <${StatCard} label="Sustainable Tier" value=${t ? t.tier : "None"} cls="c-purple"
                          title="The highest XvB donor tier this hashrate sustains while leaving P2Pool its share — the same auto rule the donation controller uses." />
-            <${StatCard} label="Hashrate Cost" value=${t ? fmtHashrate(t.cost) : "—"}
+            <${StatCard} label="Hashrate Cost"
+                         value=${t ? fmtHashrate(t.cost) : hr > 0 ? "below the lowest tier" : "needs hashrate"}
                          title="Holding the tier means continuously donating about its threshold — hashrate that earns no P2Pool shares while donated." />
             ${
               calc.enabled

--- a/dashboard/mining_dashboard/web/worker_detail.py
+++ b/dashboard/mining_dashboard/web/worker_detail.py
@@ -254,7 +254,9 @@ def build_worker_detail(name, data, state_mgr, range_arg="all", window=None):
         "ip": worker.get("ip") if worker else None,  # OBSERVED only — the adopt-form prefill (#893)
         "status": worker.get("status") if worker else None,
         "hashrate": format_hashrate(worker.get("h60", 0)) if worker else None,
-        "rigforge": _rigforge_display(worker.get("rigforge")) if worker else None,
+        "rigforge": _rigforge_display(worker.get("rigforge"), worker.get("status") == "online")
+        if worker
+        else None,
         # {available, latest, url} | None — this rig runs an older RigForge (#596).
         "rigforge_update": rigforge_update_for(worker, (data or {}).get("rigforge_release")),
         "writable_keys": sorted(WORKER_WRITABLE_KEYS),

--- a/dashboard/tests/client/test_rigforge_freshness.py
+++ b/dashboard/tests/client/test_rigforge_freshness.py
@@ -1,0 +1,16 @@
+from datetime import UTC, datetime
+
+from mining_dashboard.client.rigforge_freshness import feed_stale
+from mining_dashboard.client.xmrig_client import parse_rigforge
+
+
+def test_generation_stamp_ages_and_old_or_missing_stamps_are_not_fresh():
+    payload = {"generated_at": "2026-09-07T05:00:00Z", "rigforge": {"version": "1.0.0"}}
+    generated = datetime(2026, 9, 7, 5, tzinfo=UTC).timestamp()
+    fresh = parse_rigforge(payload, now=generated + 30)
+    stale = parse_rigforge(payload, now=generated + 61)
+    legacy = parse_rigforge({"rigforge": {"version": "1.0.0"}}, now=generated + 30)
+    assert (fresh["age_sec"], fresh["stale"]) == (30, False)
+    assert (stale["age_sec"], stale["stale"]) == (61, True)
+    assert legacy["age_sec"] is None and legacy["stale"] is True
+    assert feed_stale({"stale": False}, now=generated + 30) is True

--- a/dashboard/tests/frontend/xvb_missing_inputs.test.mjs
+++ b/dashboard/tests/frontend/xvb_missing_inputs.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { XvbTierBlock } from "../../mining_dashboard/web/static/xvbview.mjs";
+import { render } from "./helpers/render.mjs";
+
+const calc = {
+  enabled: true,
+  max_fraction: 0.85,
+  estimates_available: false,
+  estimates_stale: false,
+  estimates_source: "none",
+  note: "raffle status",
+  tiers: [
+    {
+      name: "Vip (10.00 kH/s+)",
+      threshold: 10000,
+      expected_reward_year: null,
+      realized_reward_year: null,
+      assumed_reward_year_range: null,
+      win_odds_day: null,
+      players_avg: null,
+    },
+  ],
+};
+
+test("XvB calculator names every input missing from an unready fresh box (#1960)", () => {
+  const waiting = render(XvbTierBlock, {
+    calc,
+    hr: 0,
+    coeffDay: 0,
+    energy: { xmr_price: 0, price_source: { feed: true } },
+  });
+  assert.match(waiting, /Hashrate Cost<\/h5><p[^>]*>needs hashrate/);
+  assert.match(waiting, /Cost needs P2Pool network stats/);
+  assert.match(waiting, /XvB says waiting for reward feed/);
+  assert.match(waiting, /Fiat net unavailable: waiting for the price feed/);
+
+  const tooSmall = render(XvbTierBlock, {
+    calc,
+    hr: 5000,
+    coeffDay: 1e-7,
+    energy: { xmr_price: 0, price_source: { feed: false } },
+  });
+  assert.match(tooSmall, /Hashrate Cost<\/h5><p[^>]*>below the lowest tier/);
+  assert.match(tooSmall, /Net \(XvB says\)<\/h5><p[^>]*>insufficient hashrate/);
+  assert.match(tooSmall, /set dashboard\.energy\.xmr_price or enable its price feed/);
+});
+
+test("a fresh reward feed can truthfully omit a custom tier (#1960)", () => {
+  const customTier = render(XvbTierBlock, {
+    calc: { ...calc, estimates_available: true },
+    hr: 20000,
+    coeffDay: 1e-7,
+    energy: { xmr_price: 200, currency: "USD" },
+  });
+  assert.match(customTier, /XvB says no published reward for this tier/);
+  assert.doesNotMatch(customTier, /waiting for reward feed/);
+});

--- a/dashboard/tests/service/test_worker_proxy_liveness.py
+++ b/dashboard/tests/service/test_worker_proxy_liveness.py
@@ -1,0 +1,7 @@
+from mining_dashboard.service.data_helpers import _parse_proxy_list_worker
+
+
+def test_recent_accepted_share_keeps_worker_online_when_connection_count_lags():
+    row = ["rig", "10.0.0.1", 0, 5, 0, 0, 0, 970_000, 1.0, 2.0, 0, 0, 0]
+    assert _parse_proxy_list_worker(row, now=1000)["status"] == "online"
+    assert _parse_proxy_list_worker(row, now=1301)["status"] == "offline"

--- a/dashboard/tests/service/test_worker_refresh.py
+++ b/dashboard/tests/service/test_worker_refresh.py
@@ -14,6 +14,7 @@ Mutation-kill notes:
     the "stops on first matching version" test asserts the call count stops short of the cap.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
@@ -36,7 +37,10 @@ class FakeWorkerClient:
         version = self._versions.pop(0) if self._versions else self._versions_last()
         if version is None:
             return {}
-        return {"rigforge": {"version": version}}
+        return {
+            "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "rigforge": {"version": version},
+        }
 
     def _versions_last(self):
         return None
@@ -95,7 +99,10 @@ class TestRefreshWorkerAfterUpgrade:
                 self.calls += 1
                 if self.calls == 1:
                     raise TimeoutError("no route to host")
-                return {"rigforge": {"version": "1.12.0"}}
+                return {
+                    "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "rigforge": {"version": "1.12.0"},
+                }
 
         client = FlakyClient()
         ok = await worker_refresh.refresh_worker_after_upgrade(
@@ -115,6 +122,27 @@ class TestRefreshWorkerAfterUpgrade:
         )
         assert ok is True
         assert len(client.calls) == 2
+
+    async def test_matching_version_with_stale_stamp_is_not_success(self):
+        entry = {"name": "rig1", "ip": "10.0.0.5"}
+
+        class StaleClient:
+            async def get_stats(self, ip, name):
+                return {
+                    "generated_at": "2000-01-01T00:00:00Z",
+                    "rigforge": {"version": "1.12.0"},
+                }
+
+        ok = await worker_refresh.refresh_worker_after_upgrade(
+            {"workers": [entry]},
+            "rig1",
+            "v1.12.0",
+            worker_client=StaleClient(),
+            attempts=1,
+            sleep=_fake_sleep,
+        )
+        assert ok is False
+        assert entry["rigforge"]["stale"] is True
 
 
 class TestMaybeRefreshAfterUpgrade:

--- a/dashboard/tests/service/test_worker_snapshot_freshness.py
+++ b/dashboard/tests/service/test_worker_snapshot_freshness.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+from mining_dashboard.client.rigforge_freshness import feed_stale
+from mining_dashboard.service.data_service import DataService
+
+
+def test_stored_report_is_reaged_instead_of_trusting_cached_boolean():
+    report = {"generated_at": "2026-01-01T00:00:00Z", "stale": False}
+    assert feed_stale(report, now=1767225661) is True
+
+
+def test_restored_unstamped_agent_report_fails_closed():
+    state = MagicMock()
+    state.load_snapshot.return_value = {
+        "workers": [{"name": "rig", "rigforge": {"version": "1.2.3"}}]
+    }
+    service = DataService(state, MagicMock(), MagicMock())
+    assert service.latest_data["workers"][0]["rigforge"]["stale"] is True

--- a/dashboard/tests/web/test_infra_views.py
+++ b/dashboard/tests/web/test_infra_views.py
@@ -1,16 +1,7 @@
-"""Unit tests for the host/rig/node status sections (mining_dashboard/web/infra_views.py).
-
-Moved out of tests/web/test_views.py with the sections themselves (#1105). The test bodies are
-verbatim; the only edits are the three module-alias reads in ``TestBuildEnergy`` that follow their
-target from ``views`` to ``infra_views``.
-
-The shared builders — ``_SYNC_DONE``/``_BASE`` and the ``_metrics``, ``_sync``, ``_hashrate``,
-``_state_mgr`` and ``_data`` factories — are pytest fixtures in ``tests/web/conftest.py`` as of
-#1459. Each test that needs one takes it as a parameter; the call itself reads as it always did.
-What is deliberately NOT shared, and why, is written in that file.
-"""
+"""Unit tests for the host/rig/node status sections split from ``web/views.py`` (#1105)."""
 
 import time
+from datetime import UTC, datetime
 
 from mining_dashboard.service.metrics import _sync_metric
 from mining_dashboard.web.infra_views import (
@@ -26,6 +17,19 @@ from mining_dashboard.web.infra_views import (
 )
 from mining_dashboard.web.views import build_state
 from mining_dashboard.web.worker_detail import build_worker_detail
+
+
+def _fresh(report):
+    return {"generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), **report}
+
+
+def _versioned(worker, version):
+    return {**worker, "rigforge": _fresh({"version": version})}
+
+
+def _power(watts):
+    return _fresh({"power": {"watts": watts, "hs_per_watt": None}})
+
 
 # --- Sync display state mapping -------------------------------------------------------
 
@@ -270,33 +274,27 @@ class TestRigforgeUpdate:
     _W = {"name": "r", "ip": "10.0.0.1", "status": "online", "active_pool": "3333"}
 
     def test_behind_rig_gets_the_callout(self):
-        w = {**self._W, "rigforge": {"version": "1.11.1"}}
+        w = _versioned(self._W, "1.11.1")
         out = rigforge_update_for(w, self._REL)
         assert out == {"available": True, "latest": "v1.11.2", "url": "https://h/v1.11.2"}
 
     def test_current_rig_never_badges_its_own_version(self):
-        # The rig reports bare "1.11.2"; the tag is "v1.11.2" — equality must hold across the
-        # format difference (the #664 self-consistency guard, per-worker edition).
-        w = {**self._W, "rigforge": {"version": "1.11.2"}}
+        w = _versioned(self._W, "1.11.2")
         assert rigforge_update_for(w, self._REL) is None
 
     def test_newer_or_unparseable_rig_version_is_none(self):
-        assert rigforge_update_for({**self._W, "rigforge": {"version": "9.0.0"}}, self._REL) is None
-        assert (
-            rigforge_update_for({**self._W, "rigforge": {"version": "nightly"}}, self._REL) is None
-        )
+        assert rigforge_update_for(_versioned(self._W, "9.0.0"), self._REL) is None
+        assert rigforge_update_for(_versioned(self._W, "nightly"), self._REL) is None
 
     def test_no_version_or_no_release_is_none(self):
-        # A plain-:8080 rig reports no version: no badge, not a false "up to date". No cached
-        # release (check disabled / offline): same.
         assert rigforge_update_for(self._W, self._REL) is None
-        assert rigforge_update_for({**self._W, "rigforge": {"version": "1.11.1"}}, None) is None
+        assert rigforge_update_for(_versioned(self._W, "1.11.1"), None) is None
 
     def test_build_workers_attaches_per_row(self):
         rows = build_workers(
             [
-                {**self._W, "name": "behind", "rigforge": {"version": "1.11.1"}},
-                {**self._W, "name": "current", "rigforge": {"version": "1.11.2"}},
+                _versioned({**self._W, "name": "behind"}, "1.11.1"),
+                _versioned({**self._W, "name": "current"}, "1.11.2"),
                 {**self._W, "name": "plain"},
             ],
             self._REL,
@@ -307,12 +305,12 @@ class TestRigforgeUpdate:
         assert by["plain"] is None
 
     def test_build_workers_without_release_attaches_none(self):
-        rows = build_workers([{**self._W, "rigforge": {"version": "1.11.1"}}])
+        rows = build_workers([_versioned(self._W, "1.11.1")])
         assert rows[0]["rigforge_update"] is None
 
     def test_build_state_feeds_the_cached_release_through(self, _data, _state_mgr):
         data = _data(
-            workers=[{**self._W, "rigforge": {"version": "1.11.1"}}],
+            workers=[_versioned(self._W, "1.11.1")],
             rigforge_release=self._REL,
         )
         st = build_state(data, _state_mgr(), "all")
@@ -326,7 +324,7 @@ class TestRigforgeUpdate:
             d = build_worker_detail(
                 "r",
                 {
-                    "workers": [{**self._W, "rigforge": {"version": "1.11.1"}}],
+                    "workers": [_versioned(self._W, "1.11.1")],
                     "rigforge_release": self._REL,
                 },
                 sm,
@@ -372,6 +370,9 @@ class TestRigForgeDisplay:
     def _stats(self, disp):
         return {s["label"]: s for s in disp["stats"]}
 
+    def _display(self, report):
+        return _rigforge_display(_fresh(report))
+
     def test_none_for_plain_xmrig(self):
         assert _rigforge_display(None) is None
 
@@ -397,7 +398,7 @@ class TestRigForgeDisplay:
             },
             "watchdog": {"enabled": True, "thermal_hold": False, "temp_c": 62, "max_temp_c": 85},
         }
-        disp = _rigforge_display(parsed)
+        disp = self._display(parsed)
         assert disp["version"] == "1.7.0"
         texts = self._chip_texts(disp)
         assert "gov: performance" in texts
@@ -407,7 +408,6 @@ class TestRigForgeDisplay:
         assert "tune: perf" in texts
         assert "autotune → Sun 03:00" in texts
         assert "62°C / 85°C" in texts
-        # Nothing alarming here: no bad-variant chips.
         assert all(c["variant"] != "bad" for c in disp["chips"])
 
         # The detail table (#507) carries the same metrics as label/value pairs, row-for-row with
@@ -425,7 +425,7 @@ class TestRigForgeDisplay:
 
     def test_stats_split_label_from_value_and_colour_warn_states(self):
         # The label/value split powers the detail table; a bad/warn metric colours its own value.
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": "1.7.0",
                 "miner_down": True,
@@ -447,7 +447,7 @@ class TestRigForgeDisplay:
         assert stats["Governor"]["variant"] == "warn"
 
     def test_stats_empty_when_no_metrics_present(self):
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": None,
                 "miner_down": False,
@@ -465,7 +465,7 @@ class TestRigForgeDisplay:
         assert disp["stats"] == []
 
     def test_throttling_and_bad_governor_flag(self):
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": "1.7.0",
                 "miner_down": False,
@@ -486,7 +486,7 @@ class TestRigForgeDisplay:
 
     def test_nullable_fields_emit_no_chip(self):
         # No RAPL, no governor, disabled watchdog, no tune → only the fields that exist render.
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": None,
                 "miner_down": False,
@@ -505,7 +505,7 @@ class TestRigForgeDisplay:
         assert disp["chips"] == []
 
     def test_miner_down_chip(self):
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": "1.7.0",
                 "miner_down": True,
@@ -525,7 +525,7 @@ class TestRigForgeDisplay:
         assert disp["chips"][0]["variant"] == "bad"
 
     def test_thermal_hold_wins_over_temp_chip(self):
-        disp = _rigforge_display(
+        disp = self._display(
             {
                 "version": "1.7.0",
                 "miner_down": False,
@@ -648,7 +648,7 @@ class TestBuildEnergy:
     incomplete), and publishes the operator-set prices for the client to turn into cost/net."""
 
     def _worker(self, name, watts=None, hs=1000, active_pool="3333"):
-        rf = {"power": {"watts": watts, "hs_per_watt": None}} if watts is not None else None
+        rf = _power(watts) if watts is not None else None
         return {
             "name": name,
             "ip": "1.1.1.1",

--- a/dashboard/tests/web/test_server.py
+++ b/dashboard/tests/web/test_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +16,10 @@ SECURITY_HEADERS = [
     "Referrer-Policy",
     "Content-Security-Policy",
 ]
+
+
+def _fresh_version(version):
+    return {"version": version, "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")}
 
 
 @pytest.fixture
@@ -978,9 +983,7 @@ async def worker_client(aiohttp_client, control_spool, monkeypatch):
                 "status": "online",
                 "active_pool": "3333",
                 "h60": 5100,
-                # Bare rig-reported version (#596/#597) — the upgrade noop guard compares it
-                # (parsed) against the v-prefixed proposal.
-                "rigforge": {"version": "1.11.0"},
+                "rigforge": _fresh_version("1.11.0"),
             }
         ]
     }
@@ -1129,8 +1132,7 @@ class TestWorkerUpgrade:
         assert "spool dir gone" not in await resp.text()
 
     async def test_noop_when_rig_already_reports_the_version(self, worker_client, control_spool):
-        # The fixture rig reports bare "1.11.0"; proposing tag v1.11.0 must short-circuit —
-        # no spool, no host dial, no burn of the rig's own 6h upgrade throttle.
+        # Bare "1.11.0" and tag v1.11.0 must compare equal without a host dial.
         resp = await worker_client.post(
             "/api/control/worker-upgrade",
             json={"worker": "rig1", "version": "v1.11.0"},
@@ -1139,8 +1141,6 @@ class TestWorkerUpgrade:
         assert resp.status == 200
         assert (await resp.json())["status"] == "noop"
         assert list((control_spool / "requests").glob("*.json")) == []
-        # Nothing was ever asked of a rig — a local version comparison, not an upgrade attempt —
-        # so it gets no history row (#1014 is about recording real attempts, not every click).
         assert worker_client.sm.get_worker_config_history("rig1") == []
 
     async def test_route_absent_when_control_disabled(self, client):

--- a/dashboard/tests/web/test_worker_agent_freshness.py
+++ b/dashboard/tests/web/test_worker_agent_freshness.py
@@ -1,0 +1,59 @@
+from datetime import UTC, datetime
+
+from mining_dashboard.service.storage_service import StateManager
+from mining_dashboard.web.infra_views import build_workers
+from mining_dashboard.web.worker_detail import build_worker_detail
+
+
+def _worker(rigforge):
+    return {
+        "name": "r",
+        "ip": "1.1.1.1",
+        "status": "online",
+        "active_pool": "3333",
+        "accepted": 50,
+        "rigforge": rigforge,
+    }
+
+
+def _fresh(**values):
+    return {"generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"), **values}
+
+
+def test_proxy_online_wins_over_fresh_agent_miner_down():
+    row = build_workers([_worker(_fresh(version="1.7.0", miner_down=True))])[0]
+    assert row["status"] == "online"
+    assert row["rigforge"]["chips"][0]["text"] == "agent reports miner down"
+    assert row["rigforge"]["chips"][0]["variant"] == "warn"
+
+
+def test_worker_inspect_also_keeps_proxy_online_authoritative(monkeypatch):
+    from mining_dashboard.web import views
+
+    monkeypatch.setattr(views.config, "DASHBOARD_WORKERS", [])
+    state = StateManager(db_path=":memory:")
+    try:
+        detail = build_worker_detail(
+            "r",
+            {"workers": [_worker(_fresh(version="1.7.0", miner_down=True))]},
+            state,
+        )
+    finally:
+        state.close()
+    assert detail["rigforge"]["chips"][0]["text"] == "agent reports miner down"
+    assert detail["rigforge"]["chips"][0]["variant"] == "warn"
+
+
+def test_stale_agent_fields_are_hidden_and_cannot_drive_update_badge():
+    agent = {
+        "version": "1.7.0",
+        "miner_down": True,
+        "stale": True,
+        "age_sec": 3600,
+        "watchdog": {"enabled": True, "temp_c": 99},
+    }
+    row = build_workers([_worker(agent)], {"tag": "v2.0.0", "url": "https://h/v2.0.0"})[0]
+    assert row["status"] == "online"
+    assert row["rigforge"]["version"] is None
+    assert [c["text"] for c in row["rigforge"]["chips"]] == ["agent stale for 1h 0m"]
+    assert row["rigforge_update"] is None

--- a/dashboard/tests/web/test_worker_upgrade_freshness.py
+++ b/dashboard/tests/web/test_worker_upgrade_freshness.py
@@ -1,0 +1,51 @@
+import json
+from unittest.mock import MagicMock
+
+from mining_dashboard.web import server
+
+
+class _Request:
+    headers = {server.CONTROL_HEADER: "1"}
+    app = {
+        "latest_data": {
+            "workers": [
+                {
+                    "name": "rig",
+                    "rigforge": {
+                        "version": "1.2.3",
+                        "generated_at": "2020-01-01T00:00:00Z",
+                        "stale": False,
+                    },
+                }
+            ]
+        },
+        "state_manager": MagicMock(),
+        "_bg_tasks": set(),
+    }
+
+    async def json(self):
+        return {"worker": "rig", "version": "v1.2.3"}
+
+
+class _Task:
+    def add_done_callback(self, callback):
+        return None
+
+
+async def test_stale_version_cannot_short_circuit_worker_upgrade(monkeypatch):
+    submitted = []
+    monkeypatch.setattr(
+        server.control_service,
+        "submit_worker_upgrade",
+        lambda worker, version, actor: submitted.append((worker, version)) or "request-id",
+    )
+
+    def fake_task(coro):
+        coro.close()
+        return _Task()
+
+    monkeypatch.setattr(server.asyncio, "create_task", fake_task)
+    response = await server.handle_worker_upgrade(_Request())
+    assert response.status == 202
+    assert json.loads(response.text)["status"] == "pending"
+    assert submitted == [("rig", "v1.2.3")]

--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -13,7 +13,6 @@ dashboard/mining_dashboard/service/storage_service.py	1358
 dashboard/mining_dashboard/service/telegram_commands.py	1023
 dashboard/mining_dashboard/service/worker_config_store.py	448
 dashboard/mining_dashboard/sim/donation_model.py	539
-dashboard/mining_dashboard/web/infra_views.py	507
 dashboard/mining_dashboard/web/server.py	645
 dashboard/mining_dashboard/web/static/chart.mjs	681
 dashboard/mining_dashboard/web/static/components.mjs	1177

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -339,6 +339,13 @@ chips for that rig (see [Dashboard › Workers Alive](dashboard.md#workers-alive
 on `8080` sends no `rigforge` block and reads exactly as before — no chips, no error. Auth is
 unchanged: send the rig's `token` only if it sets an `ACCESS_TOKEN` (the read API is open otherwise).
 
+Current RigForge feeds stamp each response with UTC `generated_at`. Pithead ages that producer stamp,
+not the HTTP fetch: cached bytes can still arrive successfully after the refresh job freezes. Reports
+over a minute old show only their age; reports from older RigForge versions without the stamp show
+**agent freshness unknown**. In either case Pithead hides the report's miner state, version, health,
+power and temperature until a current stamped payload arrives. The proxy's connection and accepted
+shares remain the source for whether the worker is online and for worker-offline alerts.
+
 If the block also carries a `control` object — `{change_id, status, reason}`, mirroring the rig's
 own control-API `/status` response read-only — the dashboard reconciles it against the [Worker
 Inspect](dashboard.md#worker-inspect) change history (#579): a still-`accepted` row whose


### PR DESCRIPTION
Closes #1890. Closes #1960.

Worker status now follows the proxy's current connection and accepted-share evidence. RigForge's `generated_at` stamp ages its separate agent telemetry: reports older than 60 seconds, reports with invalid stamps, and older unstamped payloads show a stale or unknown agent state without overriding proxy liveness, raising a false worker-down alert, or proving a worker update.

The XvB calculator now names the missing input behind each unavailable result, including disabled or stale rewards, absent network statistics, insufficient hashrate, and unavailable price data.

Validation:

- pre-review full gates: dashboard 2,624 passed at 97.57% coverage; frontend 647 passed
- exact-head focused gates after review fixes: Python 105 passed; frontend 22 passed
- exact-head patch coverage: 98%
- Python, JS, Markdown, file-budget, docs-voice, and operator-string lints passed
- independent Sol-high security review: PASS at `83a76ff6378e1923c9575e12ac0b60328a37bcdc`
- independent Luna-high correctness verification: PASS at `83a76ff6378e1923c9575e12ac0b60328a37bcdc`
- Ponytail complexity review: Lean already. Ship.

Runtime proof with RigForge 1.17.1 remains for appliance integration; this PR validates the merged `generated_at` contract with parser and presentation tests and does not claim a live worker run.
