### PR TITLE
Improve appliance service diagnostics

### DIFF
--- a/dashboard/mining_dashboard/web/static/diagview.mjs
+++ b/dashboard/mining_dashboard/web/static/diagview.mjs
@@ -72,14 +72,28 @@ export class DiagnosticWaitTimeout extends Error {
 // result exists yet. Keep that uncertainty instead of borrowing the upgrade flow's version copy or
 // calling the runner wedged from elapsed time alone.
 export async function runDiag(path, body, label = "the diagnostics request", max = DIAG_POLL_MAX) {
-  const res = await fetch(`/api/control/${path}`, {
-    method: "POST",
-    headers: CONTROL_HEADERS,
-    body: JSON.stringify(body || {}),
-  });
+  let res;
+  try {
+    res = await fetch(`/api/control/${path}`, {
+      method: "POST",
+      headers: CONTROL_HEADERS,
+      body: JSON.stringify(body || {}),
+    });
+  } catch {
+    throw new Error(
+      `Could not submit ${label}: the dashboard could not reach the control service.`,
+    );
+  }
   if (!res.ok && res.status !== 202)
     throw new Error(`Could not submit ${label}: HTTP ${res.status}`);
-  const { id } = await res.json();
+  let id;
+  try {
+    ({ id } = await res.json());
+  } catch {
+    throw new Error(`Could not submit ${label}: the host returned an unreadable response.`);
+  }
+  if (typeof id !== "string" || !id)
+    throw new Error(`Could not submit ${label}: the host returned no request id.`);
   for (let i = 0; i < max; i++) {
     await new Promise((resolve) => setTimeout(resolve, DIAG_POLL_MS));
     let result;
@@ -90,7 +104,11 @@ export async function runDiag(path, body, label = "the diagnostics request", max
     }
     if (result.status === 202 || [502, 503, 504].includes(result.status)) continue;
     if (!result.ok) throw new Error(`Could not read ${label}: HTTP ${result.status}`);
-    return await result.json();
+    try {
+      return await result.json();
+    } catch {
+      throw new Error(`Could not read ${label}: the host returned an unreadable result.`);
+    }
   }
   throw new DiagnosticWaitTimeout(label);
 }

--- a/dashboard/mining_dashboard/web/static/diagview.mjs
+++ b/dashboard/mining_dashboard/web/static/diagview.mjs
@@ -1,27 +1,19 @@
 // Service Diagnostics card (#913 doctor detail, #943 log tail).
 //
-// WHY IT EXISTS: an appliance operator has no shell. Before this, they could see THAT a service
-// was unhealthy and never WHY — the only recourse was the support bundle or a physical console.
-// Both actions here are read-only asks: the host runs `doctor --json` or tails one container's
-// log, redacts it, and reports. Nothing on this card mutates the stack, which is why neither
-// action goes through the typed-confirm modal the committing verbs use.
+// One health-check request runs the host's existing `doctor --json` once. The result is grouped
+// here for reading; the host contract stays {status,message}, so a row's complete message is the
+// check and its remedy rather than a guessed third field. Recent logs stay separate, per-service
+// disclosures and are fetched only when the operator asks for one.
 //
-// THE CONTAINER LIST BELOW IS A CONVENIENCE, NOT THE AUTHORITY. The host's own allowlist is
-// PITHEAD_DIAG_CONTAINERS in lib/pithead/46a-control-diagnostics.sh, and it is deliberately
-// narrower than the compose set — `wallet-rpc` and `tari-wallet` are refused, because the
-// redactor is keyed to the launch-line leak class and the wallet daemons are the two whose
-// ordinary output most easily carries key material outside it. If this list ever drifts from the
-// host's, the host refuses and the panel shows that refusal verbatim rather than reinterpreting
-// it. Publishing the list from the host so the two CANNOT drift is still open as #1731 — both
-// shapes it proposes need a host-side change. Until then a drift test in
-// tests/frontend/diagview.test.mjs holds this list to the host's by exact membership, so a
-// divergence reds in CI rather than reaching an operator as a service the host then refuses.
+// The host remains the authority for both actions. It redacts the doctor document and every log
+// tail before either crosses into this container, clamps log output, and refuses services outside
+// its fixed allowlist. Preact interpolation is the final output-escaping boundary in the browser.
 
-import { pollResult } from "./configview.mjs";
 import { Component, html } from "./preact.mjs";
 
 const CONTROL_HEADERS = { "Content-Type": "application/json", "X-Pithead-Control": "1" };
-const DIAG_POLL_MAX = 40; // ~80s — doctor dials the node RPCs; a log tail answers far sooner.
+const DIAG_POLL_MS = 2000;
+const DIAG_POLL_MAX = 40; // ~80s — a wait limit, not proof that the host runner is stuck.
 
 export const DIAG_CONTAINERS = [
   "tor",
@@ -34,30 +26,80 @@ export const DIAG_CONTAINERS = [
   "docker-control",
   "caddy",
 ];
+export const DIAG_SERVICES = [
+  "tor",
+  "monerod",
+  "wallet-rpc",
+  "tari",
+  "tari-wallet",
+  ...DIAG_CONTAINERS.slice(3),
+];
 
-// POST an intent, then poll to a terminal result. Exported for node --test: this is the flow;
-// the component only maps its outcome onto UI state.
-export async function runDiag(path, body) {
+// Doctor has no section/name field. These narrow tokens group its existing messages for display;
+// one cross-service check may appear under more than one service, while unmatched checks remain
+// visible under Machine checks. No check is dropped or rewritten.
+const SERVICE_HINTS = {
+  tor: [/\btor\b/i, /\bonion\b/i, /\bsocks\b/i, /egress firewall/i],
+  monerod: [/\bmonerod\b/i, /\bmonero node\b/i, /monero.*synchron/i],
+  "wallet-rpc": [/\bwallet-rpc\b/i, /\bwallet rpc\b/i, /\bmonero wallet\b/i],
+  tari: [/\btari\b/i],
+  "tari-wallet": [/\btari-wallet\b/i, /\btari wallet\b/i],
+  p2pool: [/\bp2pool\b/i, /\bstratum\b/i, /\bsidechain\b/i],
+  "xmrig-proxy": [/\bxmrig(?:-proxy)?\b/i, /\bworker(?:s)?\b/i],
+  dashboard: [/\bdashboard\b/i],
+  "docker-proxy": [/\bdocker-proxy\b/i],
+  "docker-control": [
+    /\bdocker-control\b/i,
+    /\bcontrol channel\b/i,
+    /\bcontrol runner\b/i,
+    /\brunner units\b/i,
+    /\bpithead-control\b/i,
+  ],
+  caddy: [/\bcaddy\b/i, /\bcertificate\b/i],
+};
+
+export class DiagnosticWaitTimeout extends Error {
+  constructor(label) {
+    super(
+      `Stopped waiting for ${label}. The request may still be queued or running on the host; ` +
+        "this wait limit does not show that the control runner is stuck. Reload, then run the check again only after the earlier request has finished.",
+    );
+    this.name = "DiagnosticWaitTimeout";
+  }
+}
+
+// Diagnostics do not write an intermediate `running` result: HTTP 202 means only that no durable
+// result exists yet. Keep that uncertainty instead of borrowing the upgrade flow's version copy or
+// calling the runner wedged from elapsed time alone.
+export async function runDiag(path, body, label = "the diagnostics request", max = DIAG_POLL_MAX) {
   const res = await fetch(`/api/control/${path}`, {
     method: "POST",
     headers: CONTROL_HEADERS,
     body: JSON.stringify(body || {}),
   });
-  if (!res.ok && res.status !== 202) throw new Error(`HTTP ${res.status}`);
+  if (!res.ok && res.status !== 202)
+    throw new Error(`Could not submit ${label}: HTTP ${res.status}`);
   const { id } = await res.json();
-  return await pollResult(id, "running", DIAG_POLL_MAX);
+  for (let i = 0; i < max; i++) {
+    await new Promise((resolve) => setTimeout(resolve, DIAG_POLL_MS));
+    let result;
+    try {
+      result = await fetch(`/api/control/result?id=${encodeURIComponent(id)}`);
+    } catch {
+      continue;
+    }
+    if (result.status === 202 || [502, 503, 504].includes(result.status)) continue;
+    if (!result.ok) throw new Error(`Could not read ${label}: HTTP ${result.status}`);
+    return await result.json();
+  }
+  throw new DiagnosticWaitTimeout(label);
 }
 
-// doctor --json emits {version, exit, summary:{ok,warn,fail}, checks:[{status, message}]} —
-// doctor_json in lib/pithead/06-doctor.sh, which splits each report line on a TAB into exactly
-// those two fields. There is no per-check name: the message IS the check, so this renders two
-// columns, not three. Failures sort first, because a passing check is not why anyone opened this
-// card. A document of another shape yields no rows rather than throwing — an operator with no
-// shell has nowhere else to look, so the card must still render and say so.
 export function doctorRows(doc) {
   const checks = doc && doc.checks;
   if (!Array.isArray(checks)) return [];
-  const rank = (c) => (c.status === "fail" ? 0 : c.status === "warn" ? 1 : 2);
+  const rank = (c) =>
+    c.status === "fail" ? 0 : c.status === "warn" ? 1 : c.status === "info" ? 2 : 3;
   return checks
     .filter((c) => c && typeof c === "object")
     .map((c) => ({
@@ -67,8 +109,6 @@ export function doctorRows(doc) {
     .sort((a, b) => rank(a) - rank(b));
 }
 
-// The one-line headline doctor already computed, so the card does not recount what the host
-// counted. Returns null when the document carries no summary.
 export function doctorSummary(doc) {
   const s = doc && doc.summary;
   if (!s || typeof s !== "object") return null;
@@ -76,101 +116,195 @@ export function doctorSummary(doc) {
   return `${n(s.fail)} failing, ${n(s.warn)} warning, ${n(s.ok)} ok`;
 }
 
+const statusRank = (status) => ({ fail: 0, warn: 1, info: 2, ok: 3 })[status] ?? 4;
+
+export function groupDoctorRows(doc) {
+  const rows = doctorRows(doc);
+  const services = DIAG_SERVICES.map((name) => ({ name, checks: [] }));
+  const machine = [];
+  for (const row of rows) {
+    const matches = services.filter(({ name }) =>
+      SERVICE_HINTS[name].some((hint) => hint.test(row.message)),
+    );
+    if (matches.length) {
+      for (const service of matches) service.checks.push(row);
+    } else {
+      machine.push(row);
+    }
+  }
+  for (const service of services) {
+    service.status = service.checks.length
+      ? service.checks.reduce(
+          (worst, row) => (statusRank(row.status) < statusRank(worst) ? row.status : worst),
+          service.checks[0].status,
+        )
+      : "not checked";
+  }
+  return { services, machine };
+}
+
 const STATUS_CLS = { fail: "status-bad", warn: "status-warn", ok: "status-ok" };
 
 export class DiagnosticsPanel extends Component {
   constructor(props) {
     super(props);
-    // idle | running | done | failed
-    this.state = { phase: "idle", mode: null, result: null, container: DIAG_CONTAINERS[0] };
+    this.state = { healthPhase: "idle", healthResult: null, logs: {} };
   }
 
-  async run(mode) {
-    this.setState({ phase: "running", mode, result: null });
+  async runHealth() {
+    this.setState({ healthPhase: "waiting", healthResult: null });
     try {
-      const out =
-        mode === "doctor"
-          ? await runDiag("diag-doctor", {})
-          : await runDiag("diag-logs", { container: this.state.container, lines: 200 });
-      this.setState({ phase: out.status === "applied" ? "done" : "failed", result: out });
-    } catch (e) {
-      this.setState({ phase: "failed", result: { error: String(e) } });
+      const result = await runDiag("diag-doctor", {}, "the health check");
+      this.setState({
+        healthPhase: result.status === "applied" ? "done" : "failed",
+        healthResult: result,
+      });
+    } catch (error) {
+      this.setState({
+        healthPhase: "failed",
+        healthResult: { error: String(error.message || error) },
+      });
     }
   }
 
-  renderDoctor(result) {
-    const rows = doctorRows(result.doctor);
-    if (!rows.length) {
-      return html`<p class="text-muted">The host returned a report with no checks in it.</p>`;
+  async runLogs(container) {
+    this.setState((state) => ({
+      logs: { ...state.logs, [container]: { phase: "waiting", result: null } },
+    }));
+    try {
+      const result = await runDiag(
+        "diag-logs",
+        { container, lines: 200 },
+        `${container}'s recent log`,
+      );
+      this.setState((state) => ({
+        logs: {
+          ...state.logs,
+          [container]: { phase: result.status === "applied" ? "done" : "failed", result },
+        },
+      }));
+    } catch (error) {
+      this.setState((state) => ({
+        logs: {
+          ...state.logs,
+          [container]: { phase: "failed", result: { error: String(error.message || error) } },
+        },
+      }));
     }
-    const summary = doctorSummary(result.doctor);
-    return html`${summary ? html`<p class="text-muted text-xs">${summary}</p>` : null}
-    <div class="table-scroll"><table class="est-table">
-        <tbody>
-            ${rows.map(
-              (r) => html`<tr>
-                  <td class=${STATUS_CLS[r.status] || "text-muted"}>${r.status || "—"}</td>
-                  <td>${r.message}</td>
-              </tr>`,
-            )}
-        </tbody>
+  }
+
+  renderChecks(rows) {
+    if (!rows.length)
+      return html`<p class="text-muted text-xs">No service-specific check returned.</p>`;
+    return html`<div class="table-scroll"><table class="est-table">
+      <tbody>
+        ${rows.map(
+          (row) => html`<tr>
+            <td class=${STATUS_CLS[row.status] || "text-muted"}>${row.status || "—"}</td>
+            <td>${row.message}</td>
+          </tr>`,
+        )}
+      </tbody>
     </table></div>`;
   }
 
-  renderLogs(result) {
-    // `note` is the host's own words for "nothing came back" — show it rather than an empty box,
-    // which reads as a broken panel.
-    if (!result.lines) {
-      return html`<p class="text-muted">${result.note || "No log output."}</p>`;
+  renderLog(container) {
+    if (!DIAG_CONTAINERS.includes(container)) {
+      return html`<p class="text-muted text-xs">Its logs stay in the owner-only support bundle.</p>`;
     }
-    return html`<pre class="config-error-tail font-mono text-xs">${result.lines}</pre>`;
+    const log = this.state.logs[container] || { phase: "idle", result: null };
+    const busy = log.phase === "waiting";
+    const result = log.result;
+    return html`<details>
+      <summary>Recent log</summary>
+      <button class="btn-toggle" disabled=${busy} onClick=${() => this.runLogs(container)}>
+        ${result ? "Refresh recent log" : "Show recent log"}
+      </button>
+      ${busy ? html`<p class="text-muted">Waiting for the host to return ${container}'s recent log…</p>` : null}
+      ${
+        log.phase === "failed"
+          ? html`<p class="status-bad">${(result && (result.error || result.note)) || "The host failed to read this log."}</p>`
+          : null
+      }
+      ${
+        log.phase === "done"
+          ? result.lines
+            ? html`<pre class="config-error-tail font-mono text-xs">${result.lines}</pre>`
+            : html`<p class="text-muted">${result.note || "No log output."}</p>`
+          : null
+      }
+    </details>`;
   }
 
-  renderResult() {
-    const { mode, result } = this.state;
-    if (!result) return null;
-    return html`<div>
-        <p class="text-muted text-xs">${
-          mode === "doctor"
-            ? "Host health report."
-            : `Last 200 lines from ${result.container}, redacted on the host.`
-        }</p>
-        ${mode === "doctor" ? this.renderDoctor(result) : this.renderLogs(result)}
-    </div>`;
+  renderService(service, haveReport) {
+    return html`<section>
+      <h4>${service.name}
+        ${
+          haveReport
+            ? html`<span class=${STATUS_CLS[service.status] || "text-muted"}> — ${service.status}</span>`
+            : null
+        }
+      </h4>
+      ${
+        haveReport
+          ? this.renderChecks(service.checks)
+          : html`<p class="text-muted text-xs">Run the health check to see this service's checks.</p>`
+      }
+      ${this.renderLog(service.name)}
+    </section>`;
   }
 
   render() {
     if (!this.props.enabled) {
       return html`<div class="card">
-          <h3>Service diagnostics</h3>
-          <p>Diagnostics are off with the rest of the control channel. To enable them, set
-          <code>dashboard.control.enabled: true</code> in <code>config.json</code> on the host
-          and run <code>./pithead apply</code>. It requires a dashboard login.</p>
+        <h3>Service diagnostics</h3>
+        <p>Diagnostics are off with the rest of the control channel. To enable them, set
+        <code>dashboard.control.enabled: true</code> in <code>config.json</code> on the host
+        and run <code>./pithead apply</code>. It requires a dashboard login.</p>
       </div>`;
     }
-    const { phase, result } = this.state;
-    const busy = phase === "running";
+    const { healthPhase, healthResult } = this.state;
+    const haveReport = healthPhase === "done" && healthResult && healthResult.doctor;
+    const groups = groupDoctorRows(haveReport ? healthResult.doctor : null);
+    const reportRows = haveReport ? doctorRows(healthResult.doctor) : [];
+    const summary = haveReport ? doctorSummary(healthResult.doctor) : null;
     return html`<div class="card">
-        <h3>Service diagnostics</h3>
-        <p>Run the host's own health check, or read a recent, redacted slice of one service's
-        log. Both only read — nothing here changes the stack.</p>
-        <div class="config-actions">
-            <button class="btn-toggle active" disabled=${busy}
-                    onClick=${() => this.run("doctor")}>Run health check</button>
-            <select class="btn-toggle" disabled=${busy} value=${this.state.container}
-                    onChange=${(e) => this.setState({ container: e.target.value })}>
-                ${DIAG_CONTAINERS.map((c) => html`<option value=${c}>${c}</option>`)}
-            </select>
-            <button class="btn-toggle" disabled=${busy}
-                    onClick=${() => this.run("logs")}>Show recent log</button>
-        </div>
-        ${busy ? html`<p class="text-muted">Asking the host…</p>` : null}
-        ${
-          phase === "failed"
-            ? html`<p class="status-bad">${(result && (result.error || result.note)) || "The host runner reported a failure."}</p>`
-            : null
-        }
-        ${phase === "done" ? this.renderResult() : null}
+      <h3>Service diagnostics</h3>
+      <p>Run the host's read-only health check once. Every service and the machine checks appear
+      below; open a service's recent log only when you need it.</p>
+      <button class="btn-toggle active" disabled=${healthPhase === "waiting"}
+              onClick=${() => this.runHealth()}>Run health check</button>
+      ${
+        healthPhase === "waiting"
+          ? html`<p class="text-muted">Waiting for the host to return the health check…</p>`
+          : null
+      }
+      ${
+        healthPhase === "failed"
+          ? html`<p class="status-bad">${(healthResult && (healthResult.error || healthResult.note)) || "The host failed to run the health check."}</p>`
+          : null
+      }
+      ${summary ? html`<p class="text-muted text-xs">${summary}</p>` : null}
+      ${
+        haveReport && !reportRows.length
+          ? html`<p class="text-muted">The host returned a report with no checks in it.</p>`
+          : null
+      }
+      ${groups.services.map((service) => this.renderService(service, haveReport))}
+      ${
+        haveReport
+          ? html`<section>
+          <h4>Machine checks</h4>
+          ${
+            reportRows.length && groups.machine.length
+              ? this.renderChecks(groups.machine)
+              : reportRows.length
+                ? html`<p class="text-muted text-xs">Every returned check was service-specific.</p>`
+                : html`<p class="text-muted text-xs">No machine check returned.</p>`
+          }
+        </section>`
+          : null
+      }
     </div>`;
   }
 }

--- a/dashboard/tests/frontend/diagview.test.mjs
+++ b/dashboard/tests/frontend/diagview.test.mjs
@@ -206,6 +206,40 @@ test("submission and result HTTP failures name the diagnostics request", async (
   );
 });
 
+test("transport and malformed responses keep the diagnostics request context", async () => {
+  await assert.rejects(
+    () =>
+      withFastPoll(
+        async () => {
+          throw new TypeError("Failed to fetch");
+        },
+        () => runDiag("diag-logs", { container: "tor" }, "tor's recent log"),
+      ),
+    /Could not submit tor's recent log: the dashboard could not reach the control service/,
+  );
+
+  await assert.rejects(
+    () =>
+      withFastPoll(
+        async () => ({ status: 202, ok: false, json: async () => Promise.reject(new SyntaxError()) }),
+        () => runDiag("diag-doctor", {}, "the health check"),
+      ),
+    /Could not submit the health check: the host returned an unreadable response/,
+  );
+
+  await assert.rejects(
+    () =>
+      withFastPoll(
+        async (url) =>
+          url === "/api/control/diag-doctor"
+            ? { status: 202, ok: false, json: async () => ({ id: ID }) }
+            : { status: 200, ok: true, json: async () => Promise.reject(new SyntaxError()) },
+        () => runDiag("diag-doctor", {}, "the health check"),
+      ),
+    /Could not read the health check: the host returned an unreadable result/,
+  );
+});
+
 test("the idle card shows all services and offers logs only where the host can redact them", () => {
   const out = renderToString(inst().render());
   assert.equal((out.match(/Run health check/g) || []).length, 1);

--- a/dashboard/tests/frontend/diagview.test.mjs
+++ b/dashboard/tests/frontend/diagview.test.mjs
@@ -1,23 +1,16 @@
-// Service Diagnostics card (#913 doctor detail, #943 log tail): the POST + poll flow, the
-// doctor-document mapping, and the render states.
-//
-// The mapping tests are the load-bearing ones. doctor --json's shape is fixed by doctor_json in
-// lib/pithead/06-doctor.sh — {version, exit, summary:{ok,warn,fail}, checks:[{status, message}]},
-// where each check is a report line split on a TAB, so a check has a status and a message and NO
-// name. These tests pin that shape, so a card written against a guessed one fails here instead of
-// rendering a column of placeholders to an operator with no other way to look.
-//
-// Run with Node's built-in test runner:
-//     node --test dashboard/tests/frontend/*.test.mjs
+// Service Diagnostics card (#1961): one doctor request, all service/machine groups, on-demand
+// per-service logs, and truthful wait/failure states from the diagnostics control contract.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 import {
   DIAG_CONTAINERS,
+  DIAG_SERVICES,
   DiagnosticsPanel,
   doctorRows,
   doctorSummary,
+  groupDoctorRows,
   runDiag,
 } from "../../mining_dashboard/web/static/diagview.mjs";
 import { renderToString } from "./helpers/render.mjs";
@@ -41,176 +34,243 @@ async function withFastPoll(fetchStub, fn) {
   }
 }
 
-// --- the real doctor --json shape -------------------------------------------------------------
+function inst(props = { enabled: true }, state = {}) {
+  const panel = new DiagnosticsPanel(props);
+  panel.props = props;
+  panel.state = { ...panel.state, ...state };
+  panel.setState = (next) => {
+    const patch = typeof next === "function" ? next(panel.state, panel.props) : next;
+    panel.state = { ...panel.state, ...patch };
+  };
+  return panel;
+}
+
+function vnodeFacts(root) {
+  const tags = [];
+  const text = [];
+  const visit = (node) => {
+    if (node == null || node === false) return;
+    if (typeof node === "string" || typeof node === "number") {
+      text.push(String(node));
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    if (typeof node === "object") {
+      if (typeof node.type === "string") tags.push(node.type);
+      visit(node.props && node.props.children);
+    }
+  };
+  visit(root);
+  return { tags, text };
+}
 
 const DOCTOR_DOC = {
-  version: "1.19.3",
+  version: "2.0.0",
   exit: 2,
   summary: { ok: 3, warn: 1, fail: 2 },
   checks: [
-    { status: "ok", message: "docker compose is installed" },
-    { status: "fail", message: "monerod is not answering on 18081" },
-    { status: "warn", message: "tari is 400 blocks behind" },
-    { status: "ok", message: "tor control port responds" },
-    { status: "fail", message: "p2pool exited 3 minutes ago" },
-    { status: "ok", message: "config.json parses" },
+    { status: "fail", message: "monerod is not answering — restart monerod." },
+    { status: "warn", message: "Tor egress firewall is missing — run apply." },
+    { status: "ok", message: "Dashboard answers through Caddy." },
+    { status: "ok", message: "Free RAM: 8192 MiB available." },
+    { status: "fail", message: "p2pool is down — inspect its recent log." },
+    { status: "ok", message: "System clock is NTP-synchronized." },
   ],
 };
 
-test("doctorRows keeps status+message and carries no invented per-check name", () => {
+test("doctor rows preserve the host's status/message contract and failure-first order", () => {
   const rows = doctorRows(DOCTOR_DOC);
-  assert.equal(rows.length, 6);
-  for (const r of rows) {
-    assert.deepEqual(Object.keys(r).sort(), ["message", "status"]);
-    assert.ok(r.message.length > 0);
-  }
+  assert.deepEqual(rows.map((row) => row.status), ["fail", "fail", "warn", "ok", "ok", "ok"]);
+  for (const row of rows) assert.deepEqual(Object.keys(row).sort(), ["message", "status"]);
+  assert.match(rows[0].message, /restart monerod/);
+  assert.equal(doctorSummary(DOCTOR_DOC), "2 failing, 1 warning, 3 ok");
 });
 
-test("doctorRows sorts fail, then warn, then ok", () => {
-  const got = doctorRows(DOCTOR_DOC).map((r) => r.status);
-  assert.deepEqual(got, ["fail", "fail", "warn", "ok", "ok", "ok"]);
-});
-
-test("doctorRows preserves the message text verbatim", () => {
-  const rows = doctorRows(DOCTOR_DOC);
-  assert.deepEqual(
-    rows.filter((r) => r.status === "fail").map((r) => r.message).sort(),
-    ["monerod is not answering on 18081", "p2pool exited 3 minutes ago"],
-  );
-});
-
-test("doctorRows yields no rows for a document of another shape, and never throws", () => {
-  for (const doc of [null, undefined, {}, { checks: null }, { checks: "nope" }, { results: [] }]) {
-    assert.deepEqual(doctorRows(doc), [], JSON.stringify(doc));
-  }
-});
-
-test("doctorRows tolerates a malformed check without dropping the good ones", () => {
-  const rows = doctorRows({ checks: [null, "x", { status: "fail" }, { message: "m" }] });
-  assert.deepEqual(rows, [
+test("doctor rows tolerate another document shape without dropping valid siblings", () => {
+  for (const doc of [null, {}, { checks: null }, { results: [] }]) assert.deepEqual(doctorRows(doc), []);
+  assert.deepEqual(doctorRows({ checks: [null, "x", { status: "fail" }, { message: "m" }] }), [
     { status: "fail", message: "" },
     { status: "", message: "m" },
   ]);
 });
 
-test("doctorSummary reports the host's own counts, and null when there are none", () => {
-  assert.equal(doctorSummary(DOCTOR_DOC), "2 failing, 1 warning, 3 ok");
-  assert.equal(doctorSummary({}), null);
-  assert.equal(doctorSummary(null), null);
-  assert.equal(doctorSummary({ summary: {} }), "0 failing, 0 warning, 0 ok");
+test("one doctor document becomes every service plus remaining machine checks", () => {
+  const grouped = groupDoctorRows(DOCTOR_DOC);
+  assert.deepEqual(grouped.services.map(({ name }) => name), DIAG_SERVICES);
+  assert.equal(grouped.services.find(({ name }) => name === "monerod").status, "fail");
+  assert.equal(grouped.services.find(({ name }) => name === "tor").status, "warn");
+  assert.equal(grouped.services.find(({ name }) => name === "p2pool").status, "fail");
+  assert.equal(grouped.services.find(({ name }) => name === "tari").status, "not checked");
+  assert.deepEqual(grouped.machine.map(({ message }) => message), [
+    "Free RAM: 8192 MiB available.",
+    "System clock is NTP-synchronized.",
+  ]);
 });
 
-// --- the submit + poll flow ---------------------------------------------------------------
+test("an empty doctor report remains explicit instead of claiming every check was grouped", () => {
+  const out = renderToString(
+    inst(
+      { enabled: true },
+      {
+        healthPhase: "done",
+        healthResult: {
+          status: "applied",
+          doctor: { summary: { ok: 0, warn: 0, fail: 0 }, checks: [] },
+        },
+      },
+    ).render(),
+  );
+  assert.match(out, /host returned a report with no checks/);
+  assert.match(out, /No machine check returned/);
+  assert.doesNotMatch(out, /Every returned check was service-specific/);
+});
 
-test("runDiag posts the intent, skips 'running', and returns the terminal result", async () => {
-  let posted = null;
+test("a slow diagnostics request is submitted once and waits through pending to its result", async () => {
+  let posts = 0;
+  let polls = 0;
   const fetchStub = async (url, opts) => {
-    if (url === "/api/control/diag-logs") {
-      posted = { headers: opts.headers, body: JSON.parse(opts.body) };
+    if (url === "/api/control/diag-doctor") {
+      posts++;
+      assert.equal(opts.headers["X-Pithead-Control"], "1");
       return { status: 202, ok: false, json: async () => ({ id: ID }) };
     }
-    assert.match(url, new RegExp(`/api/control/result\\?id=${ID}`));
-    return posted.seen
-      ? okResult({ status: "applied", container: "tor", lines: "a\nb" })
-      : ((posted.seen = true), okResult({ status: "running" }));
+    polls++;
+    if (polls === 1) return { status: 202, ok: false, json: async () => ({ status: "pending" }) };
+    if (polls === 2) throw new TypeError("temporary disconnect");
+    return okResult({ status: "applied", doctor: DOCTOR_DOC });
   };
-  const out = await withFastPoll(fetchStub, () => runDiag("diag-logs", { container: "tor" }));
-  assert.equal(out.status, "applied");
-  assert.equal(out.lines, "a\nb");
-  assert.equal(posted.headers["X-Pithead-Control"], "1");
-  assert.deepEqual(posted.body, { container: "tor" });
+  const panel = inst();
+  await withFastPoll(fetchStub, () => panel.runHealth());
+  assert.equal(posts, 1);
+  assert.equal(panel.state.healthPhase, "done");
+  assert.equal(panel.state.healthResult.doctor, DOCTOR_DOC);
 });
 
-test("runDiag throws on a non-202 error status rather than polling a request it never made", async () => {
-  const fetchStub = async () => ({ status: 403, ok: false, json: async () => ({}) });
+test("a terminal host failure is a failed health check with the host's reason", async () => {
+  const fetchStub = async (url) =>
+    url === "/api/control/diag-doctor"
+      ? { status: 202, ok: false, json: async () => ({ id: ID }) }
+      : okResult({ status: "failed", error: "doctor did not return a readable report on this host." });
+  const panel = inst();
+  await withFastPoll(fetchStub, () => panel.runHealth());
+  assert.equal(panel.state.healthPhase, "failed");
+  assert.match(renderToString(panel.render()), /doctor did not return a readable report/);
+});
+
+test("a wait expiry keeps queued-vs-running unknown and does not invent a wedged runner", async () => {
+  const fetchStub = async (url) =>
+    url === "/api/control/diag-logs"
+      ? { status: 202, ok: false, json: async () => ({ id: ID }) }
+      : { status: 202, ok: false, json: async () => ({ status: "pending" }) };
+  const panel = inst();
+  await withFastPoll(fetchStub, () => panel.runLogs("tor"));
+  const message = panel.state.logs.tor.result.error;
+  assert.match(message, /tor's recent log/);
+  assert.match(message, /may still be queued or running/);
+  assert.match(message, /does not show that the control runner is stuck/);
+  assert.doesNotMatch(message, /version|upgrade|slow connection|wedged/i);
+});
+
+test("submission and result HTTP failures name the diagnostics request", async () => {
   await assert.rejects(
-    () => withFastPoll(fetchStub, () => runDiag("diag-doctor", {})),
-    /HTTP 403/,
+    () => withFastPoll(async () => ({ status: 403, ok: false }), () => runDiag("diag-doctor", {}, "the health check")),
+    /Could not submit the health check: HTTP 403/,
+  );
+  let first = true;
+  await assert.rejects(
+    () =>
+      withFastPoll(
+        async () => {
+          if (first) {
+            first = false;
+            return { status: 202, ok: false, json: async () => ({ id: ID }) };
+          }
+          return { status: 500, ok: false };
+        },
+        () => runDiag("diag-logs", { container: "tor" }, "tor's recent log"),
+      ),
+    /Could not read tor's recent log: HTTP 500/,
   );
 });
 
-// --- render states --------------------------------------------------------------------------
+test("the idle card shows all services and offers logs only where the host can redact them", () => {
+  const out = renderToString(inst().render());
+  assert.equal((out.match(/Run health check/g) || []).length, 1);
+  assert.equal((out.match(/<summary>Recent log<\/summary>/g) || []).length, DIAG_CONTAINERS.length);
+  assert.equal((out.match(/Show recent log/g) || []).length, DIAG_CONTAINERS.length);
+  for (const service of DIAG_SERVICES) assert.match(out, new RegExp(`<h4>${service}`));
+  assert.equal((out.match(/owner-only support bundle/g) || []).length, 2);
+});
 
-// Same shape backupview.test.mjs uses: the constructor sets state, but `props` has to be assigned
-// because renderToString walks a vnode, not a mounted component.
-function inst(props, state) {
-  const c = new DiagnosticsPanel(props);
-  c.props = props;
-  if (state) c.state = { ...c.state, ...state };
-  return c;
-}
+test("the health result renders service and machine failures with remedies, escaped", () => {
+  const hostile = {
+    ...DOCTOR_DOC,
+    checks: [...DOCTOR_DOC.checks, { status: "fail", message: "<script>machine failed</script> — fix it." }],
+  };
+  const view = inst(
+    { enabled: true },
+    { healthPhase: "done", healthResult: { status: "applied", doctor: hostile } },
+  ).render();
+  const out = renderToString(view);
+  const facts = vnodeFacts(view);
+  assert.match(out, /monerod is not answering — restart monerod/);
+  assert.match(out, /<h4>Machine checks<\/h4>/);
+  assert.ok(facts.text.includes("<script>machine failed</script> — fix it."));
+  assert.ok(!facts.tags.includes("script"));
+});
 
-test("the card explains how to turn the control channel on when it is off", () => {
+test("a service log remains per-service, uses contextual waiting copy, and escapes output", () => {
+  const waiting = renderToString(
+    inst({ enabled: true }, { logs: { tor: { phase: "waiting", result: null } } }).render(),
+  );
+  assert.match(waiting, /Waiting for the host to return tor's recent log/);
+  assert.doesNotMatch(waiting, /version|upgrade|slow connection/i);
+  const done = inst(
+    { enabled: true },
+    { logs: { tor: { phase: "done", result: { status: "applied", lines: "<token>\nready" } } } },
+  ).render();
+  const facts = vnodeFacts(done);
+  assert.ok(facts.text.includes("<token>\nready"));
+  assert.ok(!facts.tags.includes("token"));
+});
+
+test("two service log disclosures keep both results", async () => {
+  const fetchStub = async (url, opts) => {
+    if (url === "/api/control/diag-logs") {
+      const { container } = JSON.parse(opts.body);
+      return {
+        status: 202,
+        ok: false,
+        json: async () => ({ id: container === "tor" ? ID : ID.replace(/2/g, "3") }),
+      };
+    }
+    const container = url.includes(ID) ? "tor" : "monerod";
+    return okResult({ status: "applied", container, lines: `${container} ready` });
+  };
+  const panel = inst();
+  await withFastPoll(fetchStub, () => Promise.all([panel.runLogs("tor"), panel.runLogs("monerod")]));
+  assert.equal(panel.state.logs.tor.result.lines, "tor ready");
+  assert.equal(panel.state.logs.monerod.result.lines, "monerod ready");
+});
+
+test("the card explains how to enable diagnostics when the control channel is off", () => {
   const out = renderToString(inst({ enabled: false }).render());
   assert.match(out, /dashboard\.control\.enabled/);
   assert.doesNotMatch(out, /Run health check/);
 });
 
-test("the idle card offers both actions and every container the host allowlists", () => {
-  const out = renderToString(inst({ enabled: true }).render());
-  assert.match(out, /Run health check/);
-  assert.match(out, /Show recent log/);
-  for (const c of DIAG_CONTAINERS) assert.match(out, new RegExp(`<option value="${c}"`));
-});
-
-test("the picker's container list has not drifted from the host's allowlist (#1731)", () => {
-  // DIAG_CONTAINERS is a second copy of the host's PITHEAD_DIAG_CONTAINERS and this test is the
-  // only thing holding them together. Drift is not a security hole — the host still decides, and
-  // its refusal reaches the panel verbatim — but it offers an operator a service the host will
-  // refuse, or hides one it would serve, and both read as a dashboard bug.
-  //
-  // Read from the built `pithead` rather than lib/pithead/46a-control-diagnostics.sh, matching the
-  // editable/confirm drift tests in test_control_service.py. lint-pithead-parity is what makes the
-  // built file a faithful stand-in for the slice it was concatenated from.
+test("the browser service list has not drifted from the host's allowlist", () => {
   const pithead = readFileSync(new URL("../../../pithead", import.meta.url), "utf8");
-  const m = /readonly PITHEAD_DIAG_CONTAINERS="([^"]*)"/.exec(pithead);
-  assert.ok(m, "could not find PITHEAD_DIAG_CONTAINERS in pithead");
-  const hostList = m[1].split(/\s+/).filter(Boolean);
-  // The deepEqual below would also fail on an empty list, so this guard is here for its MESSAGE,
-  // not for the detection: it names the shape of the failure instead of printing a nine-element
-  // array against an empty one. It is reachable only when the regex matched an empty capture —
-  // the no-match case is already taken by the assertion above — so it does not say "the regex
-  // stopped matching", which would be false in the one case that can reach it.
-  assert.ok(
-    hostList.length > 0,
-    "the host allowlist parsed as empty — PITHEAD_DIAG_CONTAINERS was emptied, or the regex no longer captures its value",
-  );
-  // Membership, not order: the host tests the requested name for exact membership in a
-  // whitespace-separated list, so a reordering there is harmless and must not red this.
-  assert.deepEqual([...DIAG_CONTAINERS].sort(), [...hostList].sort());
-});
-
-test("the picker offers neither wallet daemon — the host refuses both", () => {
-  // Not cosmetic: bundle_redact_log is keyed to the launch-line leak class, and the wallet
-  // daemons are the two whose ordinary output most easily carries key material outside it.
+  const match = /readonly PITHEAD_DIAG_CONTAINERS="([^"]*)"/.exec(pithead);
+  assert.ok(match, "could not find PITHEAD_DIAG_CONTAINERS in pithead");
+  const hostList = match[1].split(/\s+/).filter(Boolean);
+  assert.ok(hostList.length > 0, "the host diagnostics allowlist parsed as empty");
+  assert.deepEqual([...DIAG_CONTAINERS].sort(), hostList.sort());
+  assert.ok(DIAG_SERVICES.includes("wallet-rpc"));
+  assert.ok(DIAG_SERVICES.includes("tari-wallet"));
   assert.ok(!DIAG_CONTAINERS.includes("wallet-rpc"));
   assert.ok(!DIAG_CONTAINERS.includes("tari-wallet"));
-});
-
-test("a rendered log tail shows the host's note rather than an empty box", () => {
-  const out = renderToString(
-    inst(
-      { enabled: true },
-      {
-        phase: "done",
-        mode: "logs",
-        result: { status: "applied", container: "tor", lines: "", note: "No log output — not running." },
-      },
-    ).render(),
-  );
-  assert.match(out, /No log output/);
-});
-
-test("a failed run surfaces the host's own reason, not a generic one", () => {
-  const out = renderToString(
-    inst(
-      { enabled: true },
-      {
-        phase: "failed",
-        mode: "logs",
-        result: { status: "rejected", error: "not a container this dashboard may read logs for." },
-      },
-    ).render(),
-  );
-  assert.match(out, /not a container this dashboard may read logs for/);
 });

--- a/dashboard/tests/frontend/diagview.test.mjs
+++ b/dashboard/tests/frontend/diagview.test.mjs
@@ -85,7 +85,17 @@ test("doctor rows preserve the host's status/message contract and failure-first 
   const rows = doctorRows(DOCTOR_DOC);
   assert.deepEqual(rows.map((row) => row.status), ["fail", "fail", "warn", "ok", "ok", "ok"]);
   for (const row of rows) assert.deepEqual(Object.keys(row).sort(), ["message", "status"]);
-  assert.match(rows[0].message, /restart monerod/);
+  assert.deepEqual(
+    rows.map((row) => row.message),
+    [
+      "monerod is not answering — restart monerod.",
+      "p2pool is down — inspect its recent log.",
+      "Tor egress firewall is missing — run apply.",
+      "Dashboard answers through Caddy.",
+      "Free RAM: 8192 MiB available.",
+      "System clock is NTP-synchronized.",
+    ],
+  );
   assert.equal(doctorSummary(DOCTOR_DOC), "2 failing, 1 warning, 3 ok");
 });
 
@@ -235,6 +245,41 @@ test("a service log remains per-service, uses contextual waiting copy, and escap
   const facts = vnodeFacts(done);
   assert.ok(facts.text.includes("<token>\nready"));
   assert.ok(!facts.tags.includes("token"));
+});
+
+test("a terminal log refusal and an empty-log note keep the host's exact explanation", () => {
+  const refused = renderToString(
+    inst(
+      { enabled: true },
+      {
+        logs: {
+          tor: {
+            phase: "failed",
+            result: {
+              status: "rejected",
+              error: "not a service this dashboard may read logs for.",
+            },
+          },
+        },
+      },
+    ).render(),
+  );
+  assert.match(refused, /not a service this dashboard may read logs for\./);
+
+  const empty = renderToString(
+    inst(
+      { enabled: true },
+      {
+        logs: {
+          tor: {
+            phase: "done",
+            result: { status: "applied", lines: "", note: "No log output — tor is not running." },
+          },
+        },
+      },
+    ).render(),
+  );
+  assert.match(empty, /No log output — tor is not running\./);
 });
 
 test("two service log disclosures keep both results", async () => {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -36,6 +36,14 @@ Service names for `logs` match the containers: `p2pool`, `xmrig-proxy`, `tor`, `
 `tari` only with `tari.mode: local`, and `wallet-rpc` / `tari-wallet` only when the matching
 `view_key` turns payout confirmation on. A service that isn't running has no logs to follow.
 
+On the appliance dashboard, **Advanced → Service diagnostics → Run health check** runs the same
+read-only `doctor` report once and groups its existing checks under each service and the machine.
+Open **Recent log** under a service to fetch its last 200 redacted lines on demand. A dashboard
+wait limit means the request may still be queued or running on the host; it does not by itself
+show that the control runner is stuck. The `wallet-rpc` and `tari-wallet` checks still appear,
+but their logs stay in the owner-only support bundle because their ordinary output can carry
+wallet material the browser log redactor cannot safely recognize.
+
 ### Appliance-only commands
 
 These exist on every install but only do something on [the appliance image](appliance.md), where the


### PR DESCRIPTION
## Summary

- Replace the split doctor/log controls with one **Run health check** action that submits the
  existing doctor request once and groups its unchanged messages under all services and machine
  checks.
- Keep recent logs as per-service, on-demand disclosures, preserving the host allowlist and
  owner-only support-bundle boundary for wallet services.
- Give health and log requests contextual wait, timeout, transport, parser, and terminal-failure
  copy without borrowing OS-update language or treating elapsed time as proof of a wedged runner.
- Document the appliance workflow in the shared operations guide.

## Security and compatibility

No endpoint, privileged action, dependency, host service, or redaction rule changes. All dynamic
doctor/log/error output remains Preact-interpolated text. The host remains authoritative for log
service membership, redaction, line count, and byte limits.

## Checks run

- `node --test dashboard/tests/frontend/diagview.test.mjs` — 16 passed
- `make test-frontend` — 648 passed
- `make lint-js lint-md lint-docs-voice lint-operator-strings lint-topology lint-file-budget` — passed
- `make test-patch-coverage` — passed, not applicable to the changed JavaScript source
- `git diff --check origin/develop...HEAD` — passed
- merge-tree with live `origin/develop` — clean
- Sol/high security/correctness review — PASS at the current head
- Luna/high verifier — PASS at the current head

The shared `docs/operations.md` edit is disclosed here. A full `make test` rerun stopped in its lint
prerequisite when local shellcheck exceeded the known 6 GiB cap (issue 1206); it did not reach the
tests. The affected stable-head suites above are green. No KVM, live appliance, or OS 1966 battery
PASS is claimed; OS 1966 retains that control-runner integration proof.

Closes #1961
