### PR TITLE
fix(dashboard): show configured local miner in topology

### DIFF
--- a/dashboard/mining_dashboard/service/egress.py
+++ b/dashboard/mining_dashboard/service/egress.py
@@ -262,9 +262,6 @@ def _shared_knobs():
 
 
 # --- Stack topology (#170, trust-boundary view) ----------------------------------------
-# The egress list above answers "is anything leaking?"; the topology answers "how is the whole
-# stack wired?" — every component and the route of each link (ingress, egress, internal). Same
-# config-derived routes, so the two views can never disagree (the summary is shared verbatim).
 
 
 def compute_topology(
@@ -276,10 +273,6 @@ def compute_topology(
     monero_clearnet_sync,
     tari_clearnet_sync,
     monero_route,
-    # Defaulted, unlike monero_route: the egress posture has no Tari RPC conn to route, so the
-    # two functions do not take identical knobs and the shared sweep fixtures splat into both.
-    # topology_from_config passes it, and test_topology_graph asserts that it does rather than
-    # trusting the signature to.
     tari_route=LOCAL,
     healthchecks_enabled,
     telegram_enabled,
@@ -289,6 +282,7 @@ def compute_topology(
     notify_sinks_private=False,
     xvb_standby_source="",
     tor_auto_heal=False,
+    local_miner_enabled=False,
 ):
     """Pure derivation of the stack topology. Returns ``{nodes, edges, summary}``.
 
@@ -384,6 +378,8 @@ def compute_topology(
         edge("dashboard", "tari", tari_route, "gRPC", "internal"),
         edge("dashboard", "docker", LOCAL, "container API", "internal"),
     ]
+    if local_miner_enabled:
+        edges.append(edge("local-miner", "xmrig-proxy", LOCAL, "local stratum", "ingress"))
     # Optional clearnet initial-sync paths (#183) bypass the Tor hub straight to the internet.
     if monero_clearnet_sync:
         edges.append(edge("monerod", "internet", CLEARNET, "clearnet IBD", "egress"))
@@ -400,7 +396,11 @@ def compute_topology(
         else:
             link["leak"] = True
 
-    nodes = topology_nodes(monero_route=monero_route, tari_route=tari_route)
+    nodes = topology_nodes(
+        monero_route=monero_route,
+        tari_route=tari_route,
+        local_miner_enabled=local_miner_enabled,
+    )
     return {"nodes": nodes, "edges": edges, "summary": posture["summary"]}
 
 
@@ -419,5 +419,6 @@ def topology_from_config():
         telegram_enabled=config.TELEGRAM_ENABLED,
         price_feed_enabled=config.DASHBOARD_ENERGY["price_feed"],
         xvb_standby_source=config.XVB_STANDBY_SOURCE,
+        local_miner_enabled=config.local_miner_enabled(),
         **_shared_knobs(),
     )

--- a/dashboard/mining_dashboard/service/topology_graph.py
+++ b/dashboard/mining_dashboard/service/topology_graph.py
@@ -38,9 +38,10 @@ NODE_ROUTES = (LOCAL, LAN, CLEARNET, UNKNOWN)
 # Nodes bracket the host components with the external actors they actually talk to. ``internal``
 # nodes (the socket proxies) only appear when the operator expands the internal mesh.
 TOPOLOGY_NODES = [
-    {"id": "rigs", "label": "Mining rigs", "zone": ZONE_CLIENTS},
+    {"id": "rigs", "label": "External rigs", "zone": ZONE_CLIENTS},
     {"id": "browser", "label": "Browser", "zone": ZONE_CLIENTS},
     {"id": "xmrig-proxy", "label": "xmrig-proxy", "zone": ZONE_HOST},
+    {"id": "local-miner", "label": "Built-in miner", "zone": ZONE_HOST},
     {"id": "caddy", "label": "caddy", "zone": ZONE_HOST},
     {"id": "dashboard", "label": "dashboard", "zone": ZONE_HOST},
     {"id": "p2pool", "label": "p2pool", "zone": ZONE_HOST},
@@ -93,7 +94,7 @@ def node_route(address, *, is_local):
     return LAN if (ip.is_private or ip.is_loopback or ip.is_link_local) else CLEARNET
 
 
-def topology_nodes(*, monero_route, tari_route):
+def topology_nodes(*, monero_route, tari_route, local_miner_enabled=False):
     """``TOPOLOGY_NODES`` with the two relocatable nodes marked local or remote (#1040).
 
     monerod and tari are the only nodes an operator can run somewhere else; every other node in
@@ -111,4 +112,5 @@ def topology_nodes(*, monero_route, tari_route):
     return [
         {**n, "remote": relocatable[n["id"]] != LOCAL} if n["id"] in relocatable else n
         for n in TOPOLOGY_NODES
+        if local_miner_enabled or n["id"] != "local-miner"
     ]

--- a/dashboard/mining_dashboard/web/static/topology.mjs
+++ b/dashboard/mining_dashboard/web/static/topology.mjs
@@ -18,6 +18,7 @@ export const POS = {
   rigs: { x: 12, y: 64, w: 88, h: 32 },
   browser: { x: 12, y: 150, w: 88, h: 32 },
   "xmrig-proxy": { x: 132, y: 64, w: 104, h: 32 },
+  "local-miner": { x: 132, y: 108, w: 104, h: 32 },
   caddy: { x: 132, y: 150, w: 104, h: 32 },
   dashboard: { x: 132, y: 226, w: 104, h: 32 },
   p2pool: { x: 262, y: 64, w: 92, h: 32 },

--- a/dashboard/tests/frontend/components.test.mjs
+++ b/dashboard/tests/frontend/components.test.mjs
@@ -822,8 +822,8 @@ test('ComponentHealth shows a Tor-only summary, the topology nodes, and the egre
     assert.match(html, /Stack Topology & Egress/);
     assert.match(html, /🛡️/); // safe shield, not the warning triangle
     assert.match(html, /All egress via Tor/);
-    // the StackTopology SVG renders its node labels...
-    assert.match(html, /Mining rigs/);
+    assert.match(html, /External rigs/);
+    assert.doesNotMatch(html, /Built-in miner/);
     assert.match(html, /monerod/);
     // ...and the per-component egress drawer lists each component.
     assert.match(html, /All connections \(per component\)/);

--- a/dashboard/tests/frontend/fixtures/state.json
+++ b/dashboard/tests/frontend/fixtures/state.json
@@ -599,7 +599,7 @@
     "nodes": [
       {
         "id": "rigs",
-        "label": "Mining rigs",
+        "label": "External rigs",
         "zone": "clients"
       },
       {

--- a/dashboard/tests/frontend/localminer_topology.test.mjs
+++ b/dashboard/tests/frontend/localminer_topology.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { clone, renderApp } from "./harness.mjs";
+
+test("the configured built-in miner is separate from external rigs (#1856)", () => {
+  const state = clone();
+  state.topology.nodes.push({ id: "local-miner", label: "Built-in miner", zone: "host" });
+  state.topology.edges.push({
+    from: "local-miner",
+    to: "xmrig-proxy",
+    route: "local",
+    label: "local stratum",
+    kind: "ingress",
+  });
+  const output = renderApp({ state });
+  assert.match(output, /Built-in miner/);
+  assert.match(output, /External rigs/);
+});

--- a/dashboard/tests/frontend/topology.test.mjs
+++ b/dashboard/tests/frontend/topology.test.mjs
@@ -20,7 +20,7 @@ import {
 // two drift, the server can emit an edge whose endpoint POS can't place and it vanishes from the
 // SVG silently (StackTopology._edge returns null when POS[id] is missing).
 const NODE_IDS = [
-    'rigs', 'browser', 'xmrig-proxy', 'caddy', 'dashboard',
+    'rigs', 'browser', 'xmrig-proxy', 'local-miner', 'caddy', 'dashboard',
     'p2pool', 'monerod', 'tari', 'docker', 'tor', 'internet',
 ];
 

--- a/dashboard/tests/service/test_egress.py
+++ b/dashboard/tests/service/test_egress.py
@@ -345,6 +345,7 @@ TOPOLOGY_NODE_IDS = {
     "rigs",
     "browser",
     "xmrig-proxy",
+    "local-miner",
     "caddy",
     "dashboard",
     "p2pool",
@@ -361,11 +362,10 @@ def test_topology_nodes_match_the_canonical_set():
 
 
 def test_every_edge_endpoint_is_a_placeable_node_for_all_configs():
-    # No config may emit an edge to/from a node the diagram can't place — that edge would silently
-    # disappear from the SVG. This is the contract that keeps "various configs show correctly".
+    # Every emitted endpoint must be placeable or its edge silently disappears from the SVG.
     for cfg in _all_configs():
         topo = compute_topology(**cfg)
-        assert {n["id"] for n in topo["nodes"]} == TOPOLOGY_NODE_IDS, cfg
+        assert {n["id"] for n in topo["nodes"]} == TOPOLOGY_NODE_IDS - {"local-miner"}, cfg
         for e in topo["edges"]:
             assert e["from"] in TOPOLOGY_NODE_IDS, (cfg, e)
             assert e["to"] in TOPOLOGY_NODE_IDS, (cfg, e)

--- a/dashboard/tests/service/test_local_miner_topology.py
+++ b/dashboard/tests/service/test_local_miner_topology.py
@@ -1,0 +1,17 @@
+from mining_dashboard.service import egress
+
+
+def test_local_miner_node_and_edge_follow_the_live_config(_topo, _edge, monkeypatch):
+    off = _topo(local_miner_enabled=False)
+    assert "local-miner" not in {n["id"] for n in off["nodes"]}
+    assert not any(edge["from"] == "local-miner" for edge in off["edges"])
+
+    on = _topo(local_miner_enabled=True)
+    node = next(n for n in on["nodes"] if n["id"] == "local-miner")
+    assert node == {"id": "local-miner", "label": "Built-in miner", "zone": "host"}
+    local = _edge(on, "local-miner", "xmrig-proxy")
+    assert (local["route"], local["kind"], local["label"]) == ("local", "ingress", "local stratum")
+    assert _edge(on, "rigs", "xmrig-proxy")["route"] == "incoming"
+
+    monkeypatch.setattr(egress.config, "local_miner_enabled", lambda: True)
+    assert "local-miner" in {n["id"] for n in egress.topology_from_config()["nodes"]}


### PR DESCRIPTION
Fixes #1856.

When the appliance’s built-in miner is enabled, the dashboard topology now shows it as a separate host component with a Local stratum edge to `xmrig-proxy`. The existing incoming miner aggregate is labelled “External rigs,” so it remains truthful and does not silently absorb the local miner. Disabled or missing local-miner configuration emits neither the local node nor its edge.

The derivation reads the existing fail-closed `local_miner_enabled()` configuration helper. It does not infer miner inventory or change the existing Incoming, onion-service, Tari, or egress classifications.

Validation:

- `uv run --locked --project dashboard --extra test python -m pytest -q dashboard/tests/service/test_local_miner_topology.py dashboard/tests/service/test_egress.py dashboard/tests/service/test_topology_graph.py` — 41 passed
- `node --test dashboard/tests/frontend/localminer_topology.test.mjs dashboard/tests/frontend/topology.test.mjs dashboard/tests/frontend/components.test.mjs` — 74 passed
- focused Ruff and Biome checks — passed
- `make lint-file-budget` — passed, including the gate self-test
- `git diff --check` — passed
- independent Sol/high security review — PASS at `c7ae41949b940257d3cff9049e2f076f962093ed`
- independent Luna/high correctness review — PASS at `c7ae41949b940257d3cff9049e2f076f962093ed`

No full dashboard suite or appliance runtime was repeated for this bounded graph-only change; GitHub CI remains the integration gate.
