### PR TITLE
test(integration): keep probe credentials out of process arguments

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -382,7 +382,7 @@ monero_caught_up() { # 0 caught up / 1 answered, behind / ANY other could-not-as
     rx 'u=$(grep -E "^MONERO_NODE_USERNAME=" .env 2>/dev/null | cut -d= -f2-);
         p=$(grep -E "^MONERO_NODE_PASSWORD=" .env 2>/dev/null | cut -d= -f2-);
         url=$(grep -E "^MONERO_RPC_URL=" .env 2>/dev/null | cut -d= -f2-); [ -n "$url" ] || url=$(jq -r "if (.monero.mode // \"local\") == \"remote\" and .monero.remote.host then \"http://\" + .monero.remote.host + \":\" + ((.monero.remote.rpc_port // 18081) | tostring) else \"http://127.0.0.1:18081\" end" config.json 2>/dev/null); [ -n "$url" ] || url="http://127.0.0.1:18081";
-        if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null);
+        if [ -n "$u" ]; then body=$(printf "user = %s\n" "$(printf "%s:%s" "$u" "$p" | jq -Rs .)" | curl -fsS --max-time 8 --digest -K - "$url/get_info" 2>/dev/null);
         else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi;
         [ -n "$body" ] || exit 2; printf "%s" "$body" | jq -e "(.status==\"OK\") and ((.synchronized==true) or (.target_height==0))" >/dev/null 2>&1; case $? in 0) exit 0 ;; 1) exit 1 ;; *) exit 2 ;; esac'
 }

--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -269,12 +269,11 @@ rx() {
     if [ "$IT_MODE" = "local" ]; then
         (cd "$IT_REMOTE_DIR" && bash -c "$snippet")
     else
-        local remote
+        local remote stdin_flag=(-n)
         remote="cd $(quote_arg "$IT_REMOTE_DIR") && { $snippet; }"
-        # -n: never read OUR stdin. rx runs inside `while read … done < <(scenario_matrix)` loops;
-        # an ssh that inherits stdin drains the loop's remaining input, silently running only the
-        # first scenario. rx never needs stdin (push_config has its own piped ssh), so -n is safe.
-        ssh -n "${IT_SSH_OPTS[@]}" "$IT_SSH_DEST" "$remote"
+        # Default -n protects scenario loops; --stdin opts in for a dedicated input pipe.
+        [ "${2:-}" != --stdin ] || stdin_flag=()
+        ssh "${stdin_flag[@]}" "${IT_SSH_OPTS[@]}" "$IT_SSH_DEST" "$remote"
     fi
 }
 

--- a/tests/integration/restore-proof.sh
+++ b/tests/integration/restore-proof.sh
@@ -119,7 +119,7 @@ u=$(grep -E '^MONERO_NODE_USERNAME=' .env 2>/dev/null | cut -d= -f2-)
 p=$(grep -E '^MONERO_NODE_PASSWORD=' .env 2>/dev/null | cut -d= -f2-)
 url=$(grep -E '^MONERO_RPC_URL=' .env 2>/dev/null | cut -d= -f2-)
 [ -n "$url" ] || url="http://127.0.0.1:18081"
-if [ -n "$u" ]; then body=$(curl -fsS --max-time 8 --digest -u "$u:$p" "$url/get_info" 2>/dev/null)
+if [ -n "$u" ]; then body=$(printf 'user = %s\n' "$(printf '%s:%s' "$u" "$p" | jq -Rs .)" | curl -fsS --max-time 8 --digest -K - "$url/get_info" 2>/dev/null)
 else body=$(curl -fsS --max-time 8 "$url/get_info" 2>/dev/null); fi
 printf '%s' "$body" | jq -e '.status=="OK"' >/dev/null 2>&1 && echo rpc-ok || echo rpc-fail
 PROBE

--- a/tests/integration/rig-supply.sh
+++ b/tests/integration/rig-supply.sh
@@ -38,12 +38,9 @@
 # legs will dial it — and reports which case it took, because "the harness does not report which case
 # it took" is half of what #1378 is about.
 #
-# On the token: run.sh already runs `curl -H "Authorization: Bearer $IT_RIG_TOKEN"` through rx(), which
-# under --local is a plain bash -c on the bench, so a short-lived bench-side argv is a hygiene level
-# this harness already accepts. What must NOT happen is the token landing in the argv of the detached
-# nohup'd runner, which lives for the whole run and is world-readable in /proc/PID/cmdline. So the
-# token travels on on_bench's STDIN and reaches the runner as an ENVIRONMENT entry (/proc/PID/environ
-# is owner-only). It never touches the bench's disk, the SSH command string, or any log.
+# The token travels on on_bench's STDIN and reaches the runner as an ENVIRONMENT entry
+# (/proc/PID/environ is owner-only). Probes feed curl configuration through stdin too, so neither
+# the shell/SSH command nor curl argv carries the token. It never touches the bench's disk or logs.
 
 # BORROWED FROM THE SOURCER, declared rather than left to be discovered: `ok`, `warn`, `on_miner` and
 # `on_bench` are defined in e2e.sh (:73/:74/:171/:172), which sources this file at :38 — BEFORE any of
@@ -103,10 +100,8 @@ rig_supply() {
     # Dial from the BENCH, not from here: the bench is the box run.sh's legs dial, and it is the one
     # whose reachability the phase depends on. The token travels on stdin and stays there — `curl -K -`
     # reads its config from stdin, so the bearer never enters curl's argv, which is world-readable at
-    # mode 444 in /proc/<curl>/cmdline for the life of the dial. run.sh's own rx() curl does put a token
-    # in a bench-side argv, and that is a level this harness already accepts — but "we already have this
-    # exposure" is an argument against blocking on it, not for adding another instance in new code.
-    if printf 'header = "Authorization: Bearer %s"\n' "$IT_RIG_TOKEN" |
+    # mode 444 in /proc/<curl>/cmdline for the life of the dial.
+    if printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "$IT_RIG_TOKEN" | jq -Rs .)" |
         on_bench "curl -fsS -o /dev/null --max-time 10 -K - $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")"; then
         ok "write phase supplied: $BENCH_HOST reached the rig control API at $RIG_HOST:$RIG_CONTROL_PORT"
     else

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -942,7 +942,7 @@ assert_xvb_over_tor() {
 # wiring api_state (which hits the app directly on 127.0.0.1:8000) can't prove: the route a real
 # scraper uses, behind the proxy and its basic_auth (#8). Only the bcrypt HASH of the dashboard
 # password lives in .env, so when a login is set the plaintext must come via IT_DASHBOARD_PASSWORD
-# (it stays out of logs/artifacts; it does ride the remote curl argv on the operator's own box) —
+# (it travels to curl as stdin configuration, outside shell/SSH/curl argv) —
 # without it the check skips rather than false-FAILs on the 401 Caddy returns by design.
 assert_metrics_via_caddy() {
     local host secure scheme port curl_auth="" body
@@ -967,10 +967,10 @@ assert_metrics_via_caddy() {
             it_skip_leg "/metrics via Caddy" "dashboard login is set — export IT_DASHBOARD_PASSWORD to test through it"
             return 0
         fi
-        curl_auth="-u $(quote_arg "$(env_on_box DASHBOARD_AUTH_USER):$IT_DASHBOARD_PASSWORD")"
+        curl_auth="$(printf 'user = %s\n' "$(printf '%s:%s' "$(env_on_box DASHBOARD_AUTH_USER)" "$IT_DASHBOARD_PASSWORD" | jq -Rs .)")"
     fi
     # -k: the LAN cert is Caddy's internal CA (tls internal); trust isn't what this asserts.
-    body="$(rx "curl -ksS --max-time 15 --resolve $(quote_arg "$host:$port:127.0.0.1") $curl_auth $(quote_arg "$scheme://$host/metrics")" 2>/dev/null)"
+    body="$(printf '%s\n' "$curl_auth" | rx "curl -ksS --max-time 15 -K - --resolve $(quote_arg "$host:$port:127.0.0.1") $(quote_arg "$scheme://$host/metrics")" 2>/dev/null)"
     if metrics_has_pithead_sample "$body"; then
         it_pass "/metrics serves pithead_ samples through Caddy (#379)"
     else
@@ -2391,14 +2391,14 @@ run_rigforge_reverse() { # <rig-name> <orig-max_temp_c-or-empty>
 # POST a change straight to the rig's control API from the bench (the same dial the host runner makes,
 # minus the dashboard) and echo the rig's change_id. Needs IT_RIG_TOKEN + RIG_HOST. Used only by #516.
 _rig_control_apply() { # <changes-json> -> echoes change_id
-    rx "curl -fsS --max-time 15 -X POST -H $(quote_arg "Authorization: Bearer ${IT_RIG_TOKEN:-}") -H 'Content-Type: application/json' --data $(quote_arg "$1") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/apply")" 2>/dev/null | jq -r '.change_id // empty' 2>/dev/null
+    printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 15 -K - -X POST -H 'Content-Type: application/json' --data $(quote_arg "$1") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/apply")" 2>/dev/null | jq -r '.change_id // empty' 2>/dev/null
 }
 
 # Poll the rig's /status for <change_id> reaching <want-status>. Returns 0 on match within the window.
 _rig_control_await() { # <change_id> <want-status> [timeout-s=30]
     local id="$1" want="$2" deadline=$((SECONDS + ${3:-30})) sbody
     while [ "$SECONDS" -lt "$deadline" ]; do
-        sbody="$(rx "curl -fsS --max-time 10 -H $(quote_arg "Authorization: Bearer ${IT_RIG_TOKEN:-}") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")" 2>/dev/null)"
+        sbody="$(printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 10 -K - $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")" 2>/dev/null)"
         if [ "$(printf '%s' "$sbody" | jq -r '.change_id // empty' 2>/dev/null)" = "$id" ] &&
             [ "$(printf '%s' "$sbody" | jq -r '.status // empty' 2>/dev/null)" = "$want" ]; then
             return 0

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -970,7 +970,7 @@ assert_metrics_via_caddy() {
         curl_auth="$(printf 'user = %s\n' "$(printf '%s:%s' "$(env_on_box DASHBOARD_AUTH_USER)" "$IT_DASHBOARD_PASSWORD" | jq -Rs .)")"
     fi
     # -k: the LAN cert is Caddy's internal CA (tls internal); trust isn't what this asserts.
-    body="$(printf '%s\n' "$curl_auth" | rx "curl -ksS --max-time 15 -K - --resolve $(quote_arg "$host:$port:127.0.0.1") $(quote_arg "$scheme://$host/metrics")" 2>/dev/null)"
+    body="$(printf '%s\n' "$curl_auth" | rx "curl -ksS --max-time 15 -K - --resolve $(quote_arg "$host:$port:127.0.0.1") $(quote_arg "$scheme://$host/metrics")" --stdin 2>/dev/null)"
     if metrics_has_pithead_sample "$body"; then
         it_pass "/metrics serves pithead_ samples through Caddy (#379)"
     else
@@ -2391,14 +2391,14 @@ run_rigforge_reverse() { # <rig-name> <orig-max_temp_c-or-empty>
 # POST a change straight to the rig's control API from the bench (the same dial the host runner makes,
 # minus the dashboard) and echo the rig's change_id. Needs IT_RIG_TOKEN + RIG_HOST. Used only by #516.
 _rig_control_apply() { # <changes-json> -> echoes change_id
-    printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 15 -K - -X POST -H 'Content-Type: application/json' --data $(quote_arg "$1") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/apply")" 2>/dev/null | jq -r '.change_id // empty' 2>/dev/null
+    printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 15 -K - -X POST -H 'Content-Type: application/json' --data $(quote_arg "$1") $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/apply")" --stdin 2>/dev/null | jq -r '.change_id // empty' 2>/dev/null
 }
 
 # Poll the rig's /status for <change_id> reaching <want-status>. Returns 0 on match within the window.
 _rig_control_await() { # <change_id> <want-status> [timeout-s=30]
     local id="$1" want="$2" deadline=$((SECONDS + ${3:-30})) sbody
     while [ "$SECONDS" -lt "$deadline" ]; do
-        sbody="$(printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 10 -K - $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")" 2>/dev/null)"
+        sbody="$(printf 'header = %s\n' "$(printf 'Authorization: Bearer %s' "${IT_RIG_TOKEN:-}" | jq -Rs .)" | rx "curl -fsS --max-time 10 -K - $(quote_arg "http://$RIG_HOST:$RIG_CONTROL_PORT/status")" --stdin 2>/dev/null)"
         if [ "$(printf '%s' "$sbody" | jq -r '.change_id // empty' 2>/dev/null)" = "$id" ] &&
             [ "$(printf '%s' "$sbody" | jq -r '.status // empty' 2>/dev/null)" = "$want" ]; then
             return 0

--- a/tests/integration/selftest-curl-credentials.sh
+++ b/tests/integration/selftest-curl-credentials.sh
@@ -21,6 +21,7 @@ mv "$TMP/bin/bash.fixed" "$TMP/bin/bash"
 cat >"$TMP/bin/ssh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" >>"$ARGV_LOG"
+for arg; do [ "$arg" != -n ] || exec </dev/null; done
 exec "$REAL_BASH" -c "${!#}"
 SH
 cat >"$TMP/bin/curl" <<'SH'
@@ -83,8 +84,11 @@ for IT_MODE in local ssh; do
     _rig_control_await fixture-change applied 1
     check_transport header "Authorization: Bearer $IT_RIG_TOKEN"
     # Same static command and stdin script that the restore's on_bench transports.
-    test "$(rx 'bash -s' <"$TMP/restore-probe")" = rpc-ok
+    test "$(rx 'bash -s' --stdin <"$TMP/restore-probe")" = rpc-ok
     check_transport user "fixture-user:$IT_DASHBOARD_PASSWORD"
 done
+# Ordinary SSH commands must still leave scenario-loop input unread.
+test -z "$(printf 'fixture loop input\n' | rx cat)"
+test "$(printf 'fixture pipe input\n' | rx cat --stdin)" = 'fixture pipe input'
 test "$IT_FAIL" -eq 0
-printf 'curl credential transport: 10 local/SSH probe checks passed\n'
+printf 'curl credential transport: 10 local/SSH probes and 2 stdin controls passed\n'

--- a/tests/integration/selftest-curl-credentials.sh
+++ b/tests/integration/selftest-curl-credentials.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Exercise the shipped matrix probes with fake transports: secrets must reach curl
+# stdin, never shell, SSH or curl argv. No server, credentials or Docker required.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir "$TMP/bin" "$TMP/box"
+REAL_BASH="$(command -v bash)"
+export REAL_BASH ARGV_LOG="$TMP/argv" CURL_CONFIG="$TMP/config"
+cat >"$TMP/bin/bash" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$ARGV_LOG"
+exec "$REAL_BASH" "$@"
+SH
+# Avoid recursively resolving the wrapper's own interpreter through PATH.
+sed "1s|.*|#!$REAL_BASH|" "$TMP/bin/bash" >"$TMP/bin/bash.fixed"
+mv "$TMP/bin/bash.fixed" "$TMP/bin/bash"
+cat >"$TMP/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$ARGV_LOG"
+exec "$REAL_BASH" -c "${!#}"
+SH
+cat >"$TMP/bin/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" >>"$ARGV_LOG"
+case " $* " in *' -K - '*) cat >"$CURL_CONFIG" ;; *) : >"$CURL_CONFIG" ;; esac
+case "${!#}" in
+*/get_info) printf '{"status":"OK","synchronized":true}\n' ;;
+*/metrics) printf 'pithead_up 1\n' ;;
+*/apply | */status) printf '{"change_id":"fixture-change","status":"applied"}\n' ;;
+*) exit 97 ;;
+esac
+SH
+chmod +x "$TMP/bin/"*
+export PATH="$TMP/bin:$PATH"
+export IT_MODE IT_REMOTE_DIR="$TMP/box" IT_SSH_DEST=fixture.invalid
+IT_DASHBOARD_PASSWORD='fixturesecret42"\tail'
+IT_RIG_TOKEN='fixturesecret42"\token'
+export RIG_HOST=worker.invalid RIG_CONTROL_PORT=8082
+printf 'MONERO_NODE_USERNAME=fixture-user\nMONERO_NODE_PASSWORD=%s\n' "$IT_DASHBOARD_PASSWORD" >"$TMP/box/.env"
+printf '{"monero":{"mode":"local"}}\n' >"$TMP/box/config.json"
+
+# These functions have no direct entry point; extract the actual shipped bodies.
+for name in assert_metrics_via_caddy _rig_control_apply _rig_control_await; do
+    body="$(sed -n "/^$name() {/,/^}/p" "$HERE/run.sh")"
+    test -n "$body"
+    eval "$body"
+done
+# The restore probe is sent as a literal stdin script by verify_restore_proof.
+sed -n "/^u=\$(grep -E '\^MONERO_NODE_USERNAME='/,/^PROBE$/p" "$HERE/restore-proof.sh" |
+    sed '$d' >"$TMP/restore-probe"
+test -s "$TMP/restore-probe"
+
+env_on_box() {
+    case "$1" in
+    HOST_IP) printf dashboard.invalid ;;
+    DASHBOARD_SECURE) printf false ;;
+    HOST_PORT) printf 80 ;;
+    DASHBOARD_AUTH_HASH_B64) printf configured ;;
+    DASHBOARD_AUTH_USER) printf fixture-user ;;
+    *) return 1 ;;
+    esac
+}
+check_transport() { # <config directive> <expected decoded credential>
+    if grep -Fq fixturesecret42 "$ARGV_LOG"; then
+        echo 'FAIL: fixture credential entered process argv' >&2
+        return 1
+    fi
+    test "$(sed "s/^$1 = //" "$CURL_CONFIG" | jq -r .)" = "$2"
+}
+
+for IT_MODE in local ssh; do
+    : >"$ARGV_LOG"
+    monero_caught_up
+    check_transport user "fixture-user:$IT_DASHBOARD_PASSWORD"
+    assert_metrics_via_caddy
+    check_transport user "fixture-user:$IT_DASHBOARD_PASSWORD"
+    test "$(_rig_control_apply '{"max_temp_c":75}')" = fixture-change
+    check_transport header "Authorization: Bearer $IT_RIG_TOKEN"
+    _rig_control_await fixture-change applied 1
+    check_transport header "Authorization: Bearer $IT_RIG_TOKEN"
+    # Same static command and stdin script that the restore's on_bench transports.
+    test "$(rx 'bash -s' <"$TMP/restore-probe")" = rpc-ok
+    check_transport user "fixture-user:$IT_DASHBOARD_PASSWORD"
+done
+test "$IT_FAIL" -eq 0
+printf 'curl credential transport: 10 local/SSH probe checks passed\n'

--- a/tests/integration/selftest-curl-credentials.sh
+++ b/tests/integration/selftest-curl-credentials.sh
@@ -73,6 +73,7 @@ check_transport() { # <config directive> <expected decoded credential>
     test "$(sed "s/^$1 = //" "$CURL_CONFIG" | jq -r .)" = "$2"
 }
 
+echo "== authenticated probes keep credentials in curl config stdin and ordinary SSH stdin untouched =="
 for IT_MODE in local ssh; do
     : >"$ARGV_LOG"
     monero_caught_up


### PR DESCRIPTION
## Summary

- keep Monero, dashboard, and RigForge integration credentials out of shell, SSH, and curl process arguments by passing curl configuration on standard input
- preserve standard input only for credential-bearing remote probes while ordinary remote commands retain SSH input isolation
- cover local and SSH transports with a semantics-matching fake plus positive and negative standard-input controls

Closes #1979.

## Checks

- credential transport self-test: 10 local/SSH probes and 2 standard-input controls passed
- focused Monero matrix self-test: 27 passed
- focused restore self-test: 26 passed
- Linux integration phase self-test: 80 passed, 0 failed
- changed-file syntax, formatting, ShellCheck, file-budget, and diff-hygiene checks passed
- independent Sol/high security and Luna/high verification passed at `b940b4ff6d0b24b83cc2ccac7f6f7417a947fc42`
- Ponytail complexity review: Lean already. Ship.

## Limits

No live credentials, SSH target, service, Docker workload, hardware, image build, or real integration matrix was used. The regression test uses isolated fake executables. Current-head CI remains required.
