### PR TITLE
chore(os): pin the released RigForge v1.17.1 companion

### DIFF
--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -204,7 +204,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=3f1d17e11d9f7fda5e64d8b0754ce38b79ebcb71
+ARG RIGFORGE_REF=538d0b125cc8af37333ded698cf30c89ac99ca1d
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \

--- a/os/rootfs/Dockerfile
+++ b/os/rootfs/Dockerfile
@@ -186,7 +186,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 # The built-in miner (#796): a pinned RigForge tree plus everything it needs, baked at image
 # build because nothing can be installed later — apt cannot run on the read-only root, and even
 # a rw-remount install leaves its /etc state (alternatives, ld.so.cache) on the volatile overlay
-# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.17.0 release
+# where the first reboot breaks the compiler. RIGFORGE_REF pins rigforge's v1.17.1 release
 # (by commit, not tag name, so a moved tag cannot change the bake); bump it release by release.
 # v1.16.0 is the floor for the HugePages pool ceiling: hugepages_pool_ceiling_mb (rigforge#398,
 # filed from #1103) is absent from v1.15.1's tree entirely, and declaring it into one fails OPEN —
@@ -204,7 +204,7 @@ RUN chmod +x /usr/local/bin/docker-compose /usr/local/bin/cosign \
 RUN apt-get install -y --no-install-recommends \
         git build-essential cmake libuv1-dev libssl-dev libhwloc-dev gettext-base python3 \
         linux-cpupower msr-tools
-ARG RIGFORGE_REF=efd23e440ce8a160a9251f59f0ebcc5faa7ad4f1
+ARG RIGFORGE_REF=3f1d17e11d9f7fda5e64d8b0754ce38b79ebcb71
 RUN curl -fsSL -o /tmp/rigforge.tar.gz \
         "https://github.com/p2pool-starter-stack/rigforge/archive/${RIGFORGE_REF}.tar.gz" \
     && mkdir -p /opt/rigforge \

--- a/tests/integration/fakes/contract/v1/PROVENANCE
+++ b/tests/integration/fakes/contract/v1/PROVENANCE
@@ -1,2 +1,2 @@
-ref=efd23e440ce8a160a9251f59f0ebcc5faa7ad4f1
-version=1.17.0
+ref=3f1d17e11d9f7fda5e64d8b0754ce38b79ebcb71
+version=1.17.1

--- a/tests/integration/fakes/contract/v1/PROVENANCE
+++ b/tests/integration/fakes/contract/v1/PROVENANCE
@@ -1,2 +1,2 @@
-ref=3f1d17e11d9f7fda5e64d8b0754ce38b79ebcb71
+ref=538d0b125cc8af37333ded698cf30c89ac99ca1d
 version=1.17.1

--- a/tests/integration/fakes/contract/v1/feed.json
+++ b/tests/integration/fakes/contract/v1/feed.json
@@ -1,4 +1,5 @@
 {
+  "generated_at": "NORMALIZED",
   "connection": {
     "accepted": 42,
     "failures": 0,


### PR DESCRIPTION
Pin the appliance worker to the published RigForge v1.17.1 source (`538d0b125cc8af37333ded698cf30c89ac99ca1d`) and refresh its vendored API contract from the same commit. This brings the API-refresh recovery and timer-status fixes into the next appliance image.

The companion release is published as latest; its named annotated tag resolves to the pinned commit. Both release archives were verified against all 35 runtime files from that source. The vendored feed and control status fixtures match the producer byte-for-byte.

Validation: 31 contract/freshness checks, pin-watch self-test, 10 image-ref checks and diff hygiene passed. Sol/high and Luna/high both passed the source checks at `88c9c5330c7d0d1988c9723b0c9c3e328c8d51e7`. Their remaining publication condition was independently resolved afterward by checking the published release, latest endpoint and remote annotated-tag dereference; the source did not change. Full combined image and OS tests follow on the integrated appliance candidate.
