### PR TITLE
test(integration): require valid preconditions and checked restoration

### DIFF
--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -5,8 +5,6 @@
 #   tests/integration/e2e.sh <branch> [options]
 #   tests/integration/e2e.sh claude/my-feature --mode matrix
 #
-# Deploys a branch to the dedicated bench checkout, runs the selected gate, then restores it.
-#   3. Takes a `pithead backup` of the live stack (the rollback anchor).
 #   4. Borrows a miner (set MINER_HOST): backs up its xmrig config and repoints it at the test bench so
 #      the live matrix has a real worker mining through this stack.
 #   5. Deploys the branch (`pithead upgrade` — re-renders configs AND rebuilds the branch's first-party
@@ -161,6 +159,8 @@ case "$MODE" in check | targeted | matrix) ;; *) die "--mode must be check|targe
 [ -z "$SCENARIO" ] || [ "$MODE" = matrix ] || die "--scenario is only supported with --mode matrix."
 [ -z "$SCENARIO" ] || printf '%s' "$SCENARIO" | grep -qE '^[a-z0-9-]+$' || die "--scenario contains unsupported characters: $SCENARIO"
 [ -z "$RIGFORGE_BOOTSTRAP_VERSION" ] || printf '%s' "$RIGFORGE_BOOTSTRAP_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || die "RIGFORGE_BOOTSTRAP_VERSION must be a vX.Y.Z tag."
+[ -z "$RIG_NAME" ] || printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$' || die "RIG_NAME contains unsupported characters."
+printf '%s' "$RIG_CONTROL_PORT" | grep -qE '^[0-9]{1,5}$' && [ "$RIG_CONTROL_PORT" -ge 1 ] && [ "$RIG_CONTROL_PORT" -le 65535 ] || die "RIG_CONTROL_PORT must be a TCP port 1-65535."
 
 # --- SSH helpers ------------------------------------------------------------
 # Keepalives so a quiet (but live) connection isn't dropped; BatchMode so we never hang on a prompt.
@@ -615,7 +615,7 @@ run_harness() {
     if [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ]; then
         rig_supply
         [ -n "$RIG_NAME" ] || die "Borrowed rig NAME unavailable from $RIGFORGE_CONFIG."
-        phases="$phases --rigforge --rigforge-control --rig-name $(quote_arg "$RIG_NAME")${RIG_HOST:+ --rig-host $(quote_arg "$RIG_HOST") --rig-control-port $RIG_CONTROL_PORT}${RIGFORGE_BOOTSTRAP_VERSION:+ --rigforge-bootstrap-version $(quote_arg "$RIGFORGE_BOOTSTRAP_VERSION")}"
+        phases="$phases --rigforge --rigforge-control --rig-name $(quote_arg "$RIG_NAME")${RIG_HOST:+ --rig-host $(quote_arg "$RIG_HOST") --rig-control-port $(quote_arg "$RIG_CONTROL_PORT")}${RIGFORGE_BOOTSTRAP_VERSION:+ --rigforge-bootstrap-version $(quote_arg "$RIGFORGE_BOOTSTRAP_VERSION")}"
     fi
     # #905: no borrowed miner means no worker will ever appear — tell the harness to SKIP its two
     # mining assertions (workers online, stratum hashes) instead of failing a healthy stack.

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -5,12 +5,7 @@
 #   tests/integration/e2e.sh <branch> [options]
 #   tests/integration/e2e.sh claude/my-feature --mode matrix
 #
-# What it does, end to end, then puts everything back the way it found it:
-#   1. Provisions a DEDICATED checkout on the test bench (/srv/code/pithead-e2e) — the canonical
-#      /srv/code/pithead is the baseline and is never git-touched.
-#   2. Fetches + checks out <branch> there, and seeds it with the LIVE release bundle's config.json/.env
-#      (falling back to the canonical checkout's if there's no live bundle) so it has the same wallet /
-#      secrets / onion keys / shared chains (just the branch's code).
+# Deploys a branch to the dedicated bench checkout, runs the selected gate, then restores it.
 #   3. Takes a `pithead backup` of the live stack (the rollback anchor).
 #   4. Borrows a miner (set MINER_HOST): backs up its xmrig config and repoints it at the test bench so
 #      the live matrix has a real worker mining through this stack.
@@ -54,6 +49,7 @@ WORKERS=1
 BORROW_MINER=1
 SKIP_PREFLIGHT=0
 KEEP=0
+SCENARIO=""
 BRANCH=""
 
 # --- Output -----------------------------------------------------------------
@@ -90,26 +86,19 @@ USAGE:
 
 OPTIONS:
   --mode <m>        targeted | check | matrix   (default: targeted)
-                      targeted — LEAN (default): validate the dashboard + the sync logic against
-                                 the EXISTING synced node — no full config sweep, no node re-sync.
-                                 = check + lifecycle (one controlled restart exercises the sync
-                                 gate / node-down failover), auth-fail-closed, RigForge read+control.
-                      check    — non-destructive: readiness + current live state only (pure reads).
-                      matrix   — the full destructive config matrix + lifecycle + fault-injection
-                                 + auth-fail-closed, with --safety-backup auto-rollback. Opt-in —
-                                 a full pre-release sweep; recreates containers across many configs.
+                      targeted — one canonical scenario, lifecycle, auth and RigForge.
+                      check — readiness/current-state reads. matrix — all destructive phases.
+  --scenario <name> with --mode matrix, run only this existing scenario plus the matrix-only phases
   --workers <n>     workers expected mining through the stack (default: 1 — the borrowed miner)
   --bench <host>    SSH host of the test bench to deploy onto (or set BENCH_HOST)
   --miner <host>    SSH host of the miner to borrow (or set MINER_HOST)
-  --no-miner        don't borrow a miner; the harness skips its two mining assertions
-                    (workers online, stratum hashes) with a logged notice — everything else binds
-  --skip-preflight  skip the bench-chains-synced pre-flight (a cold bench then fails the
-                    required-sync assertions as environment noise — use knowingly)
+  --no-miner        do not borrow a miner; skip its two mining assertions
+  --skip-preflight  skip the bench-chains-synced pre-flight
   --keep            don't restore at the end (leave the branch deployed + miner repointed — debugging)
   -h, --help        this help
 
 ENV OVERRIDES: BENCH_HOST, MINER_HOST, CANONICAL_DIR, E2E_DIR, MINER_XMRIG_CONFIG, GIT_REMOTE_URL, and
-  RIG_HOST, IT_RIG_TOKEN, RIG_CONTROL_PORT, RIGFORGE_CONFIG (#1378 — all default off the borrowed miner)
+  RIG_HOST, RIG_NAME, IT_RIG_TOKEN, RIG_CONTROL_PORT, RIGFORGE_CONFIG, RIGFORGE_BOOTSTRAP_VERSION
 
 EXAMPLES:
   tests/integration/e2e.sh claude/my-feature                 # targeted (the default), borrow the miner
@@ -127,6 +116,10 @@ while [ $# -gt 0 ]; do
         ;;
     --workers)
         WORKERS="$2"
+        shift 2
+        ;;
+    --scenario)
+        SCENARIO="$2"
         shift 2
         ;;
     --bench)
@@ -165,6 +158,9 @@ done
     die "A <branch> is required."
 }
 case "$MODE" in check | targeted | matrix) ;; *) die "--mode must be check|targeted|matrix (got '$MODE')." ;; esac
+[ -z "$SCENARIO" ] || [ "$MODE" = matrix ] || die "--scenario is only supported with --mode matrix."
+[ -z "$SCENARIO" ] || printf '%s' "$SCENARIO" | grep -qE '^[a-z0-9-]+$' || die "--scenario contains unsupported characters: $SCENARIO"
+[ -z "$RIGFORGE_BOOTSTRAP_VERSION" ] || printf '%s' "$RIGFORGE_BOOTSTRAP_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || die "RIGFORGE_BOOTSTRAP_VERSION must be a vX.Y.Z tag."
 
 # --- SSH helpers ------------------------------------------------------------
 # Keepalives so a quiet (but live) connection isn't dropped; BatchMode so we never hang on a prompt.
@@ -611,12 +607,16 @@ run_harness() {
     case "$MODE" in
     check) phases="--check" ;;
     targeted) phases="--scenario local-pruned-main-secure-tari --auth-fail-closed --lifecycle" ;; # readiness/check run inline first (below); NOT here — run.sh returns after --readiness
-    matrix) phases="--safety-backup --lifecycle --fault-injection --auth-fail-closed --hardening --subnet" ;;
+    matrix) phases="${SCENARIO:+--scenario $(quote_arg "$SCENARIO") }--safety-backup --lifecycle --fault-injection --auth-fail-closed --hardening --subnet" ;;
     esac
     # RigForge read (#185/#235/#260) + the WRITE paths (#513/#514/#516/#517/#1002b/#1236): both need a
     # REAL rig, both self-skip loudly without one. The write half was matrix-only until #1364. rig_supply
     # supplies its host + token (#1378) and ALWAYS returns rc 0, so this && cannot drop the flags.
-    [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ] && rig_supply && phases="$phases --rigforge --rigforge-control${RIG_HOST:+ --rig-host $RIG_HOST --rig-control-port $RIG_CONTROL_PORT}"
+    if [ "$BORROW_MINER" = "1" ] && [ "$MODE" != "check" ]; then
+        rig_supply
+        [ -n "$RIG_NAME" ] || die "Borrowed rig NAME unavailable from $RIGFORGE_CONFIG."
+        phases="$phases --rigforge --rigforge-control --rig-name $(quote_arg "$RIG_NAME")${RIG_HOST:+ --rig-host $(quote_arg "$RIG_HOST") --rig-control-port $RIG_CONTROL_PORT}${RIGFORGE_BOOTSTRAP_VERSION:+ --rigforge-bootstrap-version $(quote_arg "$RIGFORGE_BOOTSTRAP_VERSION")}"
+    fi
     # #905: no borrowed miner means no worker will ever appear — tell the harness to SKIP its two
     # mining assertions (workers online, stratum hashes) instead of failing a healthy stack.
     local no_mining=""

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -157,10 +157,10 @@ done
 }
 case "$MODE" in check | targeted | matrix) ;; *) die "--mode must be check|targeted|matrix (got '$MODE')." ;; esac
 [ -z "$SCENARIO" ] || [ "$MODE" = matrix ] || die "--scenario is only supported with --mode matrix."
-[ -z "$SCENARIO" ] || printf '%s' "$SCENARIO" | grep -qE '^[a-z0-9-]+$' || die "--scenario contains unsupported characters: $SCENARIO"
-[ -z "$RIGFORGE_BOOTSTRAP_VERSION" ] || printf '%s' "$RIGFORGE_BOOTSTRAP_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || die "RIGFORGE_BOOTSTRAP_VERSION must be a vX.Y.Z tag."
-[ -z "$RIG_NAME" ] || printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$' || die "RIG_NAME contains unsupported characters."
-printf '%s' "$RIG_CONTROL_PORT" | grep -qE '^[0-9]{1,5}$' && [ "$RIG_CONTROL_PORT" -ge 1 ] && [ "$RIG_CONTROL_PORT" -le 65535 ] || die "RIG_CONTROL_PORT must be a TCP port 1-65535."
+[[ -z "$SCENARIO" || "$SCENARIO" =~ ^[a-z0-9-]+$ ]] || die "--scenario contains unsupported characters: $SCENARIO"
+[[ -z "$RIGFORGE_BOOTSTRAP_VERSION" || "$RIGFORGE_BOOTSTRAP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "RIGFORGE_BOOTSTRAP_VERSION must be a vX.Y.Z tag."
+[[ -z "$RIG_NAME" || "$RIG_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || die "RIG_NAME contains unsupported characters."
+[[ "$RIG_CONTROL_PORT" =~ ^[0-9]{1,5}$ ]] && [ "$RIG_CONTROL_PORT" -ge 1 ] && [ "$RIG_CONTROL_PORT" -le 65535 ] || die "RIG_CONTROL_PORT must be a TCP port 1-65535."
 
 # --- SSH helpers ------------------------------------------------------------
 # Keepalives so a quiet (but live) connection isn't dropped; BatchMode so we never hang on a prompt.

--- a/tests/integration/e2e.sh
+++ b/tests/integration/e2e.sh
@@ -610,7 +610,7 @@ run_harness() {
     local phases
     case "$MODE" in
     check) phases="--check" ;;
-    targeted) phases="--auth-fail-closed --lifecycle" ;; # readiness/check run inline first (below); NOT here — run.sh returns after --readiness
+    targeted) phases="--scenario local-pruned-main-secure-tari --auth-fail-closed --lifecycle" ;; # readiness/check run inline first (below); NOT here — run.sh returns after --readiness
     matrix) phases="--safety-backup --lifecycle --fault-injection --auth-fail-closed --hardening --subnet" ;;
     esac
     # RigForge read (#185/#235/#260) + the WRITE paths (#513/#514/#516/#517/#1002b/#1236): both need a

--- a/tests/integration/rig-supply.sh
+++ b/tests/integration/rig-supply.sh
@@ -96,6 +96,11 @@ rig_supply() {
         warn "write phase UNDER-SUPPLIED (#1378): no rig host — set MINER_HOST or RIG_HOST."
         return 0
     fi
+    if ! printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$'; then
+        warn "write phase UNDER-SUPPLIED: $RIGFORGE_CONFIG did not provide a safe non-empty NAME for the borrowed rig."
+        RIG_NAME=""
+        return 0
+    fi
     if [ -z "$IT_RIG_TOKEN" ]; then
         if [ "$unpriv_rc" != 0 ]; then
             warn "write phase UNDER-SUPPLIED (#1466): could NOT READ $RIGFORGE_CONFIG on $MINER_HOST (read rc=$unpriv_rc, sudo -n rc=$sudo_rc). The read's own error is above."
@@ -104,11 +109,6 @@ rig_supply() {
             warn "write phase UNDER-SUPPLIED (#1378): no token in $RIGFORGE_CONFIG on $MINER_HOST, and IT_RIG_TOKEN is unset."
         fi
         warn "  The phase then runs only if the bench baseline already pins a descriptor for this rig, and #516's feed leg cannot run at all."
-        return 0
-    fi
-    if ! printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$'; then
-        warn "write phase UNDER-SUPPLIED: $RIGFORGE_CONFIG did not provide a safe non-empty NAME for the borrowed rig."
-        RIG_NAME=""
         return 0
     fi
     # Dial from the BENCH, not from here: the bench is the box run.sh's legs dial, and it is the one

--- a/tests/integration/rig-supply.sh
+++ b/tests/integration/rig-supply.sh
@@ -96,7 +96,7 @@ rig_supply() {
         warn "write phase UNDER-SUPPLIED (#1378): no rig host — set MINER_HOST or RIG_HOST."
         return 0
     fi
-    if ! printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$'; then
+    if [[ ! "$RIG_NAME" =~ ^[A-Za-z0-9._-]+$ ]]; then
         warn "write phase UNDER-SUPPLIED: $RIGFORGE_CONFIG did not provide a safe non-empty NAME for the borrowed rig."
         RIG_NAME=""
         return 0

--- a/tests/integration/rig-supply.sh
+++ b/tests/integration/rig-supply.sh
@@ -52,14 +52,16 @@ RIGFORGE_CONFIG="${RIGFORGE_CONFIG:-/opt/rigforge/config.json}"
 # luck, so an override here cannot silently dial a different port than the phase's legs do.
 RIG_CONTROL_PORT="${RIG_CONTROL_PORT:-8082}"
 RIG_HOST="${RIG_HOST:-}"
+RIG_NAME="${RIG_NAME:-}"
 IT_RIG_TOKEN="${IT_RIG_TOKEN:-}"
+RIGFORGE_BOOTSTRAP_VERSION="${RIGFORGE_BOOTSTRAP_VERSION:-}"
 
 # Resolve + prove the write phase's two inputs. ALWAYS returns 0, deliberately: the caller chains this
 # with && before appending the phase flags, and an under-supplied phase must still run — its
 # dashboard-side legs are real coverage, and turning a known gap into a failed release gate would be a
 # worse instrument than the one we are fixing. The warnings below are the honest report.
 rig_supply() {
-    local read_cmd unpriv_rc=0 sudo_rc=0
+    local read_cmd name_cmd unpriv_rc=0 sudo_rc=0 name_rc=0
     RIG_HOST="${RIG_HOST:-$MINER_HOST}"
     if [ -z "$IT_RIG_TOKEN" ]; then
         read_cmd="jq -r '.ACCESS_TOKEN // empty' $(quote_arg "$RIGFORGE_CONFIG")"
@@ -83,6 +85,13 @@ rig_supply() {
             }
         fi
     fi
+    if [ -z "$RIG_NAME" ]; then
+        name_cmd="jq -r '.NAME // empty' $(quote_arg "$RIGFORGE_CONFIG")"
+        RIG_NAME="$(on_miner "$name_cmd")" || name_rc=$?
+        if [ "$name_rc" != 0 ]; then
+            RIG_NAME="$(on_miner "sudo -n $name_cmd")" || RIG_NAME=""
+        fi
+    fi
     if [ -z "$RIG_HOST" ]; then
         warn "write phase UNDER-SUPPLIED (#1378): no rig host — set MINER_HOST or RIG_HOST."
         return 0
@@ -95,6 +104,11 @@ rig_supply() {
             warn "write phase UNDER-SUPPLIED (#1378): no token in $RIGFORGE_CONFIG on $MINER_HOST, and IT_RIG_TOKEN is unset."
         fi
         warn "  The phase then runs only if the bench baseline already pins a descriptor for this rig, and #516's feed leg cannot run at all."
+        return 0
+    fi
+    if ! printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$'; then
+        warn "write phase UNDER-SUPPLIED: $RIGFORGE_CONFIG did not provide a safe non-empty NAME for the borrowed rig."
+        RIG_NAME=""
         return 0
     fi
     # Dial from the BENCH, not from here: the bench is the box run.sh's legs dial, and it is the one

--- a/tests/integration/rigforge-upgrade.sh
+++ b/tests/integration/rigforge-upgrade.sh
@@ -204,6 +204,22 @@ _rigforge_upgrade_real_leg() { # <rig> <latest-tag>
     fi
 }
 
+# Explicit no-feed bootstrap. Return status is meaningful even though assertion helpers and the
+# real leg deliberately return zero after recording failures.
+rigforge_bootstrap() { # <rig> <target-tag>
+    local before="$IT_FAIL"
+    if _pred_rig_version_is "$1" "$2"; then
+        it_fail "bootstrap target requires a real version transition" "'$1' already reports $2"
+        return 1
+    fi
+    _rigforge_upgrade_real_leg "$1" "$2"
+    if [ "$IT_FAIL" -gt "$before" ] || ! _pred_rig_version_is "$1" "$2"; then
+        [ "$IT_FAIL" -gt "$before" ] || it_fail "bootstrap rig reports requested version" "'$1' does not report $2"
+        return 1
+    fi
+    return 0
+}
+
 # Dispatcher. Picks the branch from the DASHBOARD's verdict (#596 rigforge_update), which is the
 # same input the Worker Inspect upgrade button uses, so the leg selects the way a user's click
 # would rather than on a comparison of the harness's own devising.

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -2222,7 +2222,7 @@ run_rigforge_control() {
         ctrl_config="$(printf '%s' "$ctrl_config" | IT_RIG_TOKEN="${IT_RIG_TOKEN:-}" jq \
             --arg n "$rig" --arg h "$RIG_HOST" --argjson cp "$RIG_CONTROL_PORT" '
             del(.dashboard.workers)
-            | .workers.list = ((.workers.list // []) | map(select(.name != $n)) + [{name:$n, host:$h, control_port:$cp, token:env.IT_RIG_TOKEN}])')"
+            | .workers.list = ((.workers.list // []) | map(select(.name != $n)) + [{name:$n, host:$h, port:8081, control_port:$cp, token:env.IT_RIG_TOKEN}])')"
         it_step "injecting a workers.list[] descriptor for '$rig' at $RIG_HOST:$RIG_CONTROL_PORT (token masked in-container)"
     fi
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1255,14 +1255,9 @@ run_lifecycle() {
     fi
 }
 
-# Predicate: status reports a problem (non-zero) — used to detect node-down deterministically.
 _pred_status_down() { ! pithead status >/dev/null 2>&1; }
-
 # --- Fault-injection phase (--fault-injection) ------------------------------
-# Deliberately break monerod three ways and assert pithead's status verdicts plus the
-# dashboard's failover, then restore. Local mode only (needs a local monerod to break).
-# These are destructive-then-restored and slow (healthcheck + node-health debounce), so the
-# phase is opt-in.
+# Break local monerod three ways, assert status/failover, then restore; opt-in because debounces are slow.
 _monerod_is() { # _monerod_is <state> [<health>]
     local s
     s="$(service_state monerod)"
@@ -1272,6 +1267,11 @@ _pred_monerod_missing() { _monerod_is missing; }
 _pred_monerod_unhealthy() { _monerod_is running unhealthy; }
 _pred_monerod_healthy() { _monerod_is running healthy; }
 _pred_proxy_stopped() { [ "$(svc_state_of "$(service_state xmrig-proxy)")" != "running" ]; }
+_pred_failover_armed() {
+    local st
+    st="$(api_state)"
+    [ "$(jq_get "$st" '.monero_sync.reachable')" = "true" ] && [ "$(jq_get "$st" '.miner_released')" = "true" ] && [ "$(jq_get "$st" '.workers_rejected')" = "false" ] && [ "$(svc_state_of "$(service_state xmrig-proxy)")" = "running" ]
+}
 _pred_tor_stopped() { [ "$(svc_state_of "$(service_state tor)")" != "running" ]; }
 _pred_tor_healthy() {
     local s
@@ -1280,13 +1280,18 @@ _pred_tor_healthy() {
 }
 
 fault_node_down() {
+    if wait_for 180 5 "dashboard to observe monerod before failover fault" _pred_failover_armed; then
+        it_pass "node-down failover armed from a live monerod observation"
+    else
+        it_fail "node-down failover armed before fault" "dashboard never reported reachable monerod with the miner released and proxy admitted — fault not injected"
+        return
+    fi
     it_step "fault: stop monerod (required node down)…"
     rx "docker compose stop monerod" >/dev/null 2>&1
     wait_for 60 5 "status to report a problem" _pred_status_down || true
     pithead status >/dev/null 2>&1
     assert_rc "status non-zero when monerod is down" "$?" "1"
-    # The dashboard rejects workers (stops xmrig-proxy) after its node-health debounce so they
-    # fail over to backup pools (#31).
+    # After the node-health debounce, stopping xmrig-proxy sends workers to backup pools (#31).
     wait_for 180 10 "xmrig-proxy stopped by failover" _pred_proxy_stopped || true
     assert_eq "xmrig-proxy stopped for failover" "$(svc_state_of "$(service_state xmrig-proxy)")" "exited"
     it_step "recover: start monerod…"
@@ -1753,7 +1758,7 @@ run_hardening() {
         uuid_ok="$(_uuid4)"
         ok_cfg="$(printf '%s' "$ctrl_config" | jq -c '.dashboard.check_for_updates=false')"
         _spool_write "$cdir/requests/$uuid_ok.json" \
-            "$(jq -nc --argjson c "$ok_cfg" --arg id "$uuid_ok" '{id:$id,action:"preview",actor:"itest",config:$c}')"
+            "$(printf '%s' "$ok_cfg" | jq -c --arg id "$uuid_ok" '{id:$id,action:"preview",actor:"itest",config:.}')"
         # Wait for THIS preview to reach "previewed" before committing — mirrors production, where the
         # preview HTTP handler awaits its result and only then does the browser POST the commit. It also
         # confirms the runner CLAIMED the request (drained requests/), so the commit write below is a
@@ -1773,13 +1778,13 @@ run_hardening() {
             "$(rx "cat $(quote_arg "$cdir/audit/control.log") 2>/dev/null")" '"action":"commit"'
 
         # 3b. A SENSITIVE change (wallet swap) MUST be refused host-side, .env untouched — the
-        #     default-deny gate, exercised through the real spool rather than a unit test.
+        #     Use a checksum-valid fixture so this reaches approval, not address validation.
         local uuid_bad bad_cfg wallet_before
         uuid_bad="$(_uuid4)"
         wallet_before="$(env_on_box MONERO_WALLET_ADDRESS)"
-        bad_cfg="$(printf '%s' "$ctrl_config" | jq -c '.monero.wallet_address="4TESTWALLETdoNotUseHandsffGateRejectSensitiveKeyDefautDenyProbeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"')"
+        bad_cfg="$(printf '%s' "$ctrl_config" | jq -c '.monero.wallet_address="44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A"')"
         _spool_write "$cdir/requests/$uuid_bad.json" \
-            "$(jq -nc --argjson c "$bad_cfg" --arg id "$uuid_bad" '{id:$id,action:"preview",actor:"itest",config:$c}')"
+            "$(printf '%s' "$bad_cfg" | jq -c --arg id "$uuid_bad" '{id:$id,action:"preview",actor:"itest",config:.}')"
         st="$(_wait_control_status "$cdir" "$uuid_bad" "" 60 || echo timeout)"
         assert_eq "sensitive (wallet) spool preview staged host-side (#33)" "$st" "previewed"
         _spool_write "$cdir/requests/$uuid_bad.json" \
@@ -2210,7 +2215,7 @@ run_rigforge_control() {
 
     # Build the control-on config: enable the channel and ensure a login (control refuses without
     # one). Only mint a login when the box has none — an existing password hash is preserved across
-    # apply, so we never clobber a real one. The token rides --arg so it never hits a log or argv.
+    # apply, so we never clobber a real one. The token reaches jq through its process environment.
     local ctrl_config
     ctrl_config="$(printf '%s' "$BASELINE_CONFIG" | jq '.dashboard.control.enabled = true')"
     if [ -z "$(env_on_box DASHBOARD_AUTH_HASH_B64)" ]; then
@@ -2225,10 +2230,10 @@ run_rigforge_control() {
         # del() stays load-bearing: it drops a stray legacy key so a pre-2.0 baseline cannot trip
         # migrate_legacy_workers' both-set-to-different-values refusal on the apply below. The
         # baseline is restored verbatim at the end regardless.
-        ctrl_config="$(printf '%s' "$ctrl_config" | jq \
-            --arg n "$rig" --arg h "$RIG_HOST" --argjson cp "$RIG_CONTROL_PORT" --arg tok "${IT_RIG_TOKEN:-}" '
+        ctrl_config="$(printf '%s' "$ctrl_config" | IT_RIG_TOKEN="${IT_RIG_TOKEN:-}" jq \
+            --arg n "$rig" --arg h "$RIG_HOST" --argjson cp "$RIG_CONTROL_PORT" '
             del(.dashboard.workers)
-            | .workers.list = ((.workers.list // []) | map(select(.name != $n)) + [{name:$n, host:$h, control_port:$cp, token:$tok}])')"
+            | .workers.list = ((.workers.list // []) | map(select(.name != $n)) + [{name:$n, host:$h, control_port:$cp, token:env.IT_RIG_TOKEN}])')"
         it_step "injecting a workers.list[] descriptor for '$rig' at $RIG_HOST:$RIG_CONTROL_PORT (token masked in-container)"
     fi
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -335,11 +335,11 @@ parse_args() {
         it_err "Provide --host <user@host> or --local. See --help."
         exit 2
     fi
-    [ -z "$RIG_NAME" ] || printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$' || {
+    [[ -z "$RIG_NAME" || "$RIG_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || {
         it_err "--rig-name contains unsupported characters: $RIG_NAME"
         exit 2
     }
-    [ -z "$RIGFORGE_BOOTSTRAP_VERSION" ] || printf '%s' "$RIGFORGE_BOOTSTRAP_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
+    [[ -z "$RIGFORGE_BOOTSTRAP_VERSION" || "$RIGFORGE_BOOTSTRAP_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
         it_err "--rigforge-bootstrap-version must be a vX.Y.Z tag."
         exit 2
     }
@@ -2141,15 +2141,23 @@ run_subnet_scenario() {
 }
 
 # --- RigForge control phase (--rigforge-control) ----------------------------
-# POST a Worker Inspect config change to the LIVE dashboard's worker-apply route and echo the terminal
-# result JSON. Drives the full loop the tier-2 fake can't: dashboard -> host runner -> rig control API
-# -> back. The route needs the X-Pithead-Control CSRF header; the rig token stays host-side (#440), so
-# nothing secret rides this call. max-time exceeds the runner's own dial + status-poll budget so the
-# handler always returns a terminal-ish result rather than a 202 pending.
+# Drive Worker Inspect through the live dashboard-to-rig control path.
 _worker_apply() { # <worker> <changes-json>  -> echoes the dashboard result JSON
     local body
     body="$(jq -nc --arg w "$1" --argjson c "$2" '{worker:$w,changes:$c}')"
     rx "curl -fsS --max-time 60 -X POST -H 'Content-Type: application/json' -H 'X-Pithead-Control: 1' --data $(quote_arg "$body") http://127.0.0.1:8000/api/control/worker-apply" 2>/dev/null
+}
+
+_restore_rig_control_baseline() {
+    push_config "$BASELINE_CONFIG"
+    if ! pithead apply -y >"$OUT_DIR/rigforge-control.restore.log" 2>&1; then
+        it_fail "restore baseline after RigForge control" "see $OUT_DIR/rigforge-control.restore.log"
+        return 1
+    fi
+    if ! wait_status_ok 240; then
+        it_fail "baseline healthy after RigForge control restore" "status did not recover"
+        return 1
+    fi
 }
 
 # Real RigForge write coverage (#513/#514/#516/#517), destructive then restored. The only descriptor
@@ -2193,13 +2201,11 @@ run_rigforge_control() {
             else
                 it_skip_phase "rigforge-control" "rig '$rig' has no workers.list[] descriptor and no --rig-host + IT_RIG_TOKEN to inject one (#513/#514/#516/#517)"
             fi
-            return 0
+            return "$supplied"
         fi
     fi
 
-    # Build the control-on config: enable the channel and ensure a login (control refuses without
-    # one). Only mint a login when the box has none — an existing password hash is preserved across
-    # apply, so we never clobber a real one. The token reaches jq through its process environment.
+    # Enable control while preserving any existing login.
     local ctrl_config
     ctrl_config="$(printf '%s' "$BASELINE_CONFIG" | jq '.dashboard.control.enabled = true')"
     if [ -z "$(env_on_box DASHBOARD_AUTH_HASH_B64)" ]; then
@@ -2222,16 +2228,14 @@ run_rigforge_control() {
     it_step "apply with dashboard.control on + the rig pinned in workers.list[]…"
     if ! pithead apply -y >"$OUT_DIR/rigforge-control.apply.log" 2>&1; then
         it_fail "apply (control on + rig descriptor) succeeded" "see $OUT_DIR/rigforge-control.apply.log"
-        push_config "$BASELINE_CONFIG"
-        pithead apply -y >/dev/null 2>&1 || true
-        return 0
+        _restore_rig_control_baseline || true
+        return 1
     fi
     wait_status_ok 240 || true
     if [ -n "$RIGFORGE_BOOTSTRAP_VERSION" ]; then
         if ! rigforge_bootstrap "$rig" "$RIGFORGE_BOOTSTRAP_VERSION"; then
-            push_config "$BASELINE_CONFIG"
-            pithead apply -y >/dev/null 2>&1 || true
-            return 0
+            _restore_rig_control_baseline || true
+            return 1
         fi
     fi
     if ! wait_for 120 5 "dashboard to re-read the selected rig after control setup" _pred_rig_present "$rig"; then
@@ -2240,28 +2244,28 @@ run_rigforge_control() {
         else
             it_skip_phase "rigforge-control" "worker '$rig' no longer exposes an enriched feed"
         fi
-        push_config "$BASELINE_CONFIG"
-        pithead apply -y >/dev/null 2>&1 || true
-        return 0
+        _restore_rig_control_baseline || true
+        return 1
     fi
 
     if [ "$RUN_RIGFORGE" = 1 ]; then
+        local read_fails="$IT_FAIL"
         run_rigforge_integration "$rig"
         # shellcheck disable=SC2034  # read by lib.sh:it_fail after the nested phase changes it
         IT_CURRENT_SCENARIO="rigforge-control"
+        if [ "$IT_FAIL" -gt "$read_fails" ]; then
+            _restore_rig_control_baseline || true
+            return 1
+        fi
     fi
 
-    # ---- #514: the enriched READ path survives a populated (masked) descriptor ----
-    # With a token in workers.list[], the container reads it ONLY as {"__secret__":true}. The
-    # v1.5.2 regression stringified that sentinel into `Authorization: Bearer {'__secret__': True}`
-    # and every :8081 probe 401'd -> api_ok=false, feed gone. Assert both still resolve.
+    # A populated masked descriptor must preserve the enriched read path (#514).
     st="$(api_state)"
     assert_eq "rig api_ok true with a populated masked descriptor (#514, v1.5.2 regression)" \
         "$(printf '%s' "$st" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .api_ok) // empty' 2>/dev/null)" "true"
     assert_ne "rigforge feed still resolves with the token masked (#514)" \
         "$(printf '%s' "$st" | jq -r --arg n "$rig" 'first(.workers[]? | select(.name==$n) | .rigforge.version) // empty' 2>/dev/null)" ""
 
-    # ---- #513: the rig is editable, and a reversible Worker Inspect edit lands on the rig ----
     local detail
     detail="$(_worker_detail "$rig" || true)"
     assert_eq "Worker Inspect reports the rig editable with a descriptor (#508/#513)" \
@@ -2295,17 +2299,14 @@ run_rigforge_control() {
         [ "$status" = "applied" ] && rig_key_clear dash "$rig" max_temp_c # (#1379)
     fi
 
-    # ---- #1236/#1002b: the other writable keys, and the ones we deliberately refuse ----
     # Lives in rigforge-writable-keys.sh: the legs read each original from the rig's OWN reported
     # config (.rig_config, #1235/rigforge#253) rather than from a record of what we last pushed, and
     # the three keys not driven there carry their reasons with them.
     run_rigforge_writable_keys "$rig"
     run_rigforge_pools "$rig"
 
-    # ---- #516: a rig-side edit reflects in the dashboard's enriched feed + the masked prefill ----
     run_rigforge_reverse "$rig" "$orig_maxt"
 
-    # ---- #517: an auto-rollback (rigforge#236) is recorded end-to-end from the dashboard ----
     run_rigforge_rollback "$rig"
 
     # ---- #1002a/#1237: the one-click upgrade path, real when the rig is behind latest ----
@@ -2318,9 +2319,7 @@ run_rigforge_control() {
     # Restore: baseline config drops the injected descriptor + turns control back off (the end-of-run
     # restore_baseline would too; doing it here keeps the box clean even if a later phase is added).
     it_step "restoring baseline (control off, descriptor dropped)…"
-    push_config "$BASELINE_CONFIG"
-    pithead apply -y >/dev/null 2>&1 || it_warn "restore apply returned non-zero — check the box"
-    wait_status_ok 240 || true
+    _restore_rig_control_baseline
 }
 
 # Predicate: the rig is present in the live feed with its enriched block parsed.
@@ -2527,18 +2526,19 @@ main() {
         done < <(scenario_matrix)
     fi
 
+    local rig_control_ok=1
     if [ "$RUN_RIGFORGE_CONTROL" = "1" ]; then
-        run_rigforge_control
+        run_rigforge_control || rig_control_ok=0
     elif [ "$RUN_RIGFORGE" = "1" ]; then
         run_rigforge_integration
     fi
-    [ "$RUN_LIFECYCLE" = "1" ] && run_lifecycle
-    [ "$RUN_FAULTS" = "1" ] && run_fault_injection
-    [ "$RUN_AUTH_FAIL_CLOSED" = "1" ] && run_auth_fail_closed
-    [ "$RUN_HARDENING" = "1" ] && run_hardening
+    [ "$rig_control_ok" = 1 ] && [ "$RUN_LIFECYCLE" = "1" ] && run_lifecycle
+    [ "$rig_control_ok" = 1 ] && [ "$RUN_FAULTS" = "1" ] && run_fault_injection
+    [ "$rig_control_ok" = 1 ] && [ "$RUN_AUTH_FAIL_CLOSED" = "1" ] && run_auth_fail_closed
+    [ "$rig_control_ok" = 1 ] && [ "$RUN_HARDENING" = "1" ] && run_hardening
     # Subnet last among the destructive phases: it does a full down/up, so it re-establishes the
     # baseline stack cleanly before the end-of-run restore.
-    [ "$RUN_SUBNET" = "1" ] && run_subnet_scenario
+    [ "$rig_control_ok" = 1 ] && [ "$RUN_SUBNET" = "1" ] && run_subnet_scenario
 
     # Failure → roll the box back to the safety backup; success → leave it (restore_baseline
     # just puts config.json back to where we found it). Then drop the generated archive.

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -54,6 +54,8 @@ RUN_RIGFORGE=0
 RUN_RIGFORGE_CONTROL=0
 RUN_SUBNET=0
 RIG_HOST=""
+RIG_NAME=""
+RIGFORGE_BOOTSTRAP_VERSION=""
 RIG_CONTROL_PORT="8082"
 SAFETY_BACKUP=0
 SAFETY_ARCHIVE=""
@@ -142,30 +144,12 @@ MATRIX:
   --rigforge             also run the RigForge integration phase (#185/#235/#260): assert the
                          dashboard consumed a REAL rigforge rig's enriched feed and Worker Inspect
                          reads it. Non-destructive; self-skips if no rigforge rig is connected.
-  --rigforge-control     also run the RigForge control phase (#513/#514/#516/#517/#1002b/#1236), local
-                         mode only: with dashboard.control ON and workers.list[] populated for the
-                         borrowed rig (masked-token descriptor, #440/#506 — the box's pre-existing
-                         dashboard.workers[] alias was removed in 2.0.0, #1832, so a pre-2.0
-                         baseline is migrated to workers.list[] by this leg's apply), assert the enriched read path survives populated
-                         descriptors (#514) and the rig is editable (#508/#513), drive a reversible
-                         Worker Inspect edit end-to-end to the rig's control API on max_temp_c (#513),
-                         DONATION and watchdog_interval_min (#1236, read back from the rig's own
-                         reported config), and pools (#1002b, needs IT_RIG_POOLS_PROBE); reflect a
-                         rig-side edit back into the dashboard (#516), and record an auto-rollback
-                         (#517). autotune and watchdog are deliberately never driven — see
-                         docs/dev/integration-testing.md. Also drives the one-click RigForge upgrade
-                         (#1002a/#1237): when the dashboard offers this rig a newer release, POST it
-                         through /api/control/worker-upgrade and assert a REAL upgrade — the intent
-                         leaves the dashboard for the host runner, reaches an `applied` terminal, and
-                         the rig comes back reporting the new version; the already-up-to-date noop
-                         shortcut is then asserted on top of a precondition this run established.
-                         Not opt-in (it used to be, behind a flag no caller set); when the dashboard
-                         offers no newer release the leg self-skips with a classified reason.
-                         DESTRUCTIVE-then-restored. Needs a real rig
-                         with its control API opted in; each leg self-skips loudly without its
-                         prerequisites.
+  --rigforge-control     run the real RigForge control, reversible-write, and upgrade legs.
+                         DESTRUCTIVE-then-restored; local mode and an opted-in real rig required.
   --rig-host <h>         the borrowed rig's LAN host/IP for control dials — needed to inject a
                          workers.list[] descriptor when the box's baseline lacks one (#513/#514/#506).
+  --rig-name <name>      exact borrowed rig NAME from its protected RigForge config.
+  --rigforge-bootstrap-version <tag>  explicitly bootstrap that rig before feed-dependent checks.
   --rig-control-port <p> the rig's writable control API port (default: 8082, #185).
   --subnet               also run the moved-subnet phase (#201/#180), local mode only: bring the
                          stack DOWN then UP on a non-default network.subnet (10.84.0.0/24) — the one
@@ -304,6 +288,14 @@ parse_args() {
             RIG_HOST="$2"
             shift 2
             ;;
+        --rig-name)
+            RIG_NAME="$2"
+            shift 2
+            ;;
+        --rigforge-bootstrap-version)
+            RIGFORGE_BOOTSTRAP_VERSION="$2"
+            shift 2
+            ;;
         --rig-control-port)
             RIG_CONTROL_PORT="$2"
             shift 2
@@ -341,6 +333,18 @@ parse_args() {
 
     if [ "$IT_MODE" = "ssh" ] && [ -z "$IT_SSH_DEST" ]; then
         it_err "Provide --host <user@host> or --local. See --help."
+        exit 2
+    fi
+    [ -z "$RIG_NAME" ] || printf '%s' "$RIG_NAME" | grep -qE '^[A-Za-z0-9._-]+$' || {
+        it_err "--rig-name contains unsupported characters: $RIG_NAME"
+        exit 2
+    }
+    [ -z "$RIGFORGE_BOOTSTRAP_VERSION" ] || printf '%s' "$RIGFORGE_BOOTSTRAP_VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
+        it_err "--rigforge-bootstrap-version must be a vX.Y.Z tag."
+        exit 2
+    }
+    if [ -n "$RIGFORGE_BOOTSTRAP_VERSION" ] && [ -z "$RIG_NAME" ]; then
+        it_err "--rigforge-bootstrap-version requires --rig-name."
         exit 2
     fi
 }
@@ -1944,29 +1948,23 @@ summary() {
 }
 
 # --- RigForge integration phase (--rigforge) --------------------------------
-# The v1.5 dashboard <-> RigForge integration, validated against a REAL rig (the borrowed loaner) —
-# the one thing the tier-2 contract test (fakes/test_contract.py, #209) can't prove: that a real
-# RigForge v1.8.0 producer serves the enriched feed in the shape the dashboard consumes, and that the
-# LIVE dashboard reads it. Self-gates: if no worker exposes a rigforge enriched block (no real rig, or
-# its sister API is off), it warns and skips — it never fails the gate on a bench without a rigforge
-# rig. Non-destructive: it reads /api/state + /api/worker and checks the write path's fail-closed
-# guards; it does NOT push a config change to the borrowed rig (that stage->apply->RESTART->rollback
-# flow restarts a shared loaner and needs the rig's own control API opted in, so it's a manual runbook
-# step). Runs under the shared-bench flock like the rest of main() (rig_lock is already held).
-run_rigforge_integration() {
+# self-skips when the bench has no RigForge feed.
+run_rigforge_integration() { # [rig-name]
     # shellcheck disable=SC2034  # read by lib.sh:it_fail to label captured failures
     IT_CURRENT_SCENARIO="rigforge-integration"
     echo ""
     it_log "── RigForge integration phase (#185/#235/#260) ─────"
-    local st rig
+    local st rig="${1:-}"
     st="$(api_state)"
     if [ -z "$st" ]; then
-        it_skip_phase "rigforge-integration" "/api/state unreachable"
+        if [ -n "$rig" ]; then it_fail "dashboard state reachable for selected rig" "/api/state unreachable"; else it_skip_phase "rigforge-integration" "/api/state unreachable"; fi
         return 0
     fi
-    # A worker whose enriched rigforge block is present (version populated) = a real RigForge rig
-    # whose sister API the dashboard reached and parse_rigforge parsed (#235).
-    rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
+    [ -n "$rig" ] || rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
+    if [ -n "$rig" ] && ! printf '%s' "$st" | jq -e --arg n "$rig" 'any(.workers[]?; .name==$n and .rigforge.version != null)' >/dev/null 2>&1; then
+        it_fail "dashboard consumed the selected RigForge rig's enriched feed" "worker '$rig' has no enriched feed"
+        return 0
+    fi
     if [ -z "$rig" ]; then
         it_skip_phase "rigforge-integration" "no worker exposes a RigForge enriched feed (a real rigforge rig with api:enabled on :8081?); the parse contract is covered by the tier-2 test" "covered"
         return 0
@@ -2154,25 +2152,8 @@ _worker_apply() { # <worker> <changes-json>  -> echoes the dashboard result JSON
     rx "curl -fsS --max-time 60 -X POST -H 'Content-Type: application/json' -H 'X-Pithead-Control: 1' --data $(quote_arg "$body") http://127.0.0.1:8000/api/control/worker-apply" 2>/dev/null
 }
 
-# The v1.5 dashboard <-> RigForge WRITE surfaces that only a real rig with its control API opted in can
-# prove — the exact paths #508 (masked-token descriptor dropped -> not editable) and the v1.5.2
-# regression (masked sentinel stringified into the Bearer header -> :8081 probe 401) shipped through
-# because no live test drove them (#513/#514/#516/#517). With dashboard.control ON and the borrowed
-# rig pinned in workers.list[] (#506; its token seen only as the {"__secret__":true} sentinel inside
-# the container), this:
-#   #514  asserts the enriched READ path survives a populated masked descriptor (api_ok + rigforge feed)
-#   #513  asserts the rig is editable and drives a reversible Worker Inspect edit through to the rig
-#   #516  reflects a rig-side edit back into the dashboard's enriched feed + verifies the masked prefill
-#   #517  records an auto-rollback (rigforge#236) end-to-end from the dashboard
-# DESTRUCTIVE-then-restored (enables control + pins the descriptor, reverted at the end). Local mode
-# only; each leg self-skips LOUDLY without its prerequisites so a bench without the rig never fails.
-#
-# Descriptor shape (#506): workers.list[] is the only shape, and the one this leg injects. The
-# deprecated dashboard.workers[] fallback this leg used to honor as-is — cheap extra coverage of the
-# legacy read, kept "through v1.9" — was removed in 2.0.0 (#1832), so every read below resolves
-# workers.list[] alone. A box whose baseline still carries the old key is migrated in place by this
-# leg's own apply; the pre-apply probe below reads workers.list[] only, so on such a box the FIRST
-# run skips for want of a descriptor and a re-run finds the migrated one.
+# Real RigForge write coverage (#513/#514/#516/#517), destructive then restored. The only descriptor
+# shape is workers.list[]; explicit borrowed-rig inputs make missing setup a failure.
 run_rigforge_control() {
     # shellcheck disable=SC2034  # read by lib.sh:it_fail to label captured failures
     IT_CURRENT_SCENARIO="rigforge-control"
@@ -2188,27 +2169,30 @@ run_rigforge_control() {
         return 0
     fi
 
-    # A real RigForge rig must be connected + parsed into the feed (same gate as run_rigforge_integration).
-    local st rig
+    local st rig supplied=0
     st="$(api_state)"
-    rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
+    rig="$RIG_NAME"
+    if [ -n "$rig" ]; then
+        supplied=1
+    else
+        rig="$(printf '%s' "$st" | jq -r 'first(.workers[]? | select(.rigforge != null and .rigforge.version != null) | .name) // empty' 2>/dev/null)"
+    fi
     if [ -z "$rig" ]; then
         it_skip_phase "rigforge-control" "no worker exposes a RigForge enriched feed — the write paths need a real rig with its :8081 API on (#513/#514/#516/#517)"
         return 0
     fi
 
-    # The write path resolves the rig's host + token from workers.list[] (#506) — the deprecated
-    # dashboard.workers[] fallback was removed in 2.0.0 (#1832). Use the baseline's descriptor if it
-    # already pins this rig's host (the live-box case); otherwise inject one into workers.list[] from
-    # --rig-host + IT_RIG_TOKEN (local-only, so the token never leaves the bench). No source for
-    # either -> skip: we won't drive an edit we can't address, nor mutate what we can't restore.
     local have_host inject=0
     have_host="$(printf '%s' "$BASELINE_CONFIG" | jq -r --arg n "$rig" 'first((.workers.list // [])[] | select(.name==$n) | .host) // empty' 2>/dev/null)"
     if [ -z "$have_host" ]; then
         if [ -n "$RIG_HOST" ] && [ -n "${IT_RIG_TOKEN:-}" ]; then
             inject=1
         else
-            it_skip_phase "rigforge-control" "rig '$rig' has no workers.list[] descriptor and no --rig-host + IT_RIG_TOKEN to inject one (#513/#514/#516/#517)"
+            if [ "$supplied" = 1 ]; then
+                it_fail "supplied rig has host/token descriptor inputs" "'$rig' lacks a descriptor and --rig-host + IT_RIG_TOKEN"
+            else
+                it_skip_phase "rigforge-control" "rig '$rig' has no workers.list[] descriptor and no --rig-host + IT_RIG_TOKEN to inject one (#513/#514/#516/#517)"
+            fi
             return 0
         fi
     fi
@@ -2226,10 +2210,6 @@ run_rigforge_control() {
             it_fail "--rig-control-port is a port number" "got [$RIG_CONTROL_PORT]"
             return 0
         fi
-        # Inject into workers.list[] (#506), the only shape since 2.0.0 removed the alias (#1832).
-        # del() stays load-bearing: it drops a stray legacy key so a pre-2.0 baseline cannot trip
-        # migrate_legacy_workers' both-set-to-different-values refusal on the apply below. The
-        # baseline is restored verbatim at the end regardless.
         ctrl_config="$(printf '%s' "$ctrl_config" | IT_RIG_TOKEN="${IT_RIG_TOKEN:-}" jq \
             --arg n "$rig" --arg h "$RIG_HOST" --argjson cp "$RIG_CONTROL_PORT" '
             del(.dashboard.workers)
@@ -2247,8 +2227,29 @@ run_rigforge_control() {
         return 0
     fi
     wait_status_ok 240 || true
-    # Let the recreated dashboard re-poll the rig so its enriched feed + descriptor state are fresh.
-    wait_for 120 5 "dashboard to re-read the rig after the control apply" _pred_rig_present "$rig" || true
+    if [ -n "$RIGFORGE_BOOTSTRAP_VERSION" ]; then
+        if ! rigforge_bootstrap "$rig" "$RIGFORGE_BOOTSTRAP_VERSION"; then
+            push_config "$BASELINE_CONFIG"
+            pithead apply -y >/dev/null 2>&1 || true
+            return 0
+        fi
+    fi
+    if ! wait_for 120 5 "dashboard to re-read the selected rig after control setup" _pred_rig_present "$rig"; then
+        if [ "$supplied" = 1 ]; then
+            it_fail "supplied rig exposes its enriched feed after control setup" "worker '$rig' never appeared"
+        else
+            it_skip_phase "rigforge-control" "worker '$rig' no longer exposes an enriched feed"
+        fi
+        push_config "$BASELINE_CONFIG"
+        pithead apply -y >/dev/null 2>&1 || true
+        return 0
+    fi
+
+    if [ "$RUN_RIGFORGE" = 1 ]; then
+        run_rigforge_integration "$rig"
+        # shellcheck disable=SC2034  # read by lib.sh:it_fail after the nested phase changes it
+        IT_CURRENT_SCENARIO="rigforge-control"
+    fi
 
     # ---- #514: the enriched READ path survives a populated (masked) descriptor ----
     # With a token in workers.list[], the container reads it ONLY as {"__secret__":true}. The
@@ -2310,7 +2311,7 @@ run_rigforge_control() {
     # ---- #1002a/#1237: the one-click upgrade path, real when the rig is behind latest ----
     # No longer opt-in. The flag it used to sit behind was set by no caller, so the gate's only
     # upgrade coverage never ran; the leg now runs every time and says which branch it took.
-    run_rigforge_upgrade "$rig"
+    [ -n "$RIGFORGE_BOOTSTRAP_VERSION" ] || run_rigforge_upgrade "$rig"
 
     [ "$IT_FAIL" -gt "$fails_before" ] && capture_artifacts "rigforge-control" "$OUT_DIR"
 
@@ -2526,12 +2527,11 @@ main() {
         done < <(scenario_matrix)
     fi
 
-    # RigForge integration (#185/#235/#260) first — it's read-only and wants the freshly-mined
-    # state with the borrowed rig connected, before the destructive phases churn the stack.
-    [ "$RUN_RIGFORGE" = "1" ] && run_rigforge_integration
-    # rigforge-control mutates config + dials the rig; run it with the read-only rigforge phase's rig
-    # still connected, before the node-breaking phases churn the stack.
-    [ "$RUN_RIGFORGE_CONTROL" = "1" ] && run_rigforge_control
+    if [ "$RUN_RIGFORGE_CONTROL" = "1" ]; then
+        run_rigforge_control
+    elif [ "$RUN_RIGFORGE" = "1" ]; then
+        run_rigforge_integration
+    fi
     [ "$RUN_LIFECYCLE" = "1" ] && run_lifecycle
     [ "$RUN_FAULTS" = "1" ] && run_fault_injection
     [ "$RUN_AUTH_FAIL_CLOSED" = "1" ] && run_auth_fail_closed

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -2149,7 +2149,10 @@ _worker_apply() { # <worker> <changes-json>  -> echoes the dashboard result JSON
 }
 
 _restore_rig_control_baseline() {
-    push_config "$BASELINE_CONFIG"
+    if ! push_config "$BASELINE_CONFIG"; then
+        it_fail "write baseline after RigForge control" "could not restore config.json"
+        return 1
+    fi
     if ! pithead apply -y >"$OUT_DIR/rigforge-control.restore.log" 2>&1; then
         it_fail "restore baseline after RigForge control" "see $OUT_DIR/rigforge-control.restore.log"
         return 1
@@ -2309,9 +2312,6 @@ run_rigforge_control() {
 
     run_rigforge_rollback "$rig"
 
-    # ---- #1002a/#1237: the one-click upgrade path, real when the rig is behind latest ----
-    # No longer opt-in. The flag it used to sit behind was set by no caller, so the gate's only
-    # upgrade coverage never ran; the leg now runs every time and says which branch it took.
     [ -n "$RIGFORGE_BOOTSTRAP_VERSION" ] || run_rigforge_upgrade "$rig"
 
     [ "$IT_FAIL" -gt "$fails_before" ] && capture_artifacts "rigforge-control" "$OUT_DIR"

--- a/tests/integration/selftest-e2e-boundary.sh
+++ b/tests/integration/selftest-e2e-boundary.sh
@@ -30,6 +30,7 @@ rejected_before_ssh() { # <label> <env-name> <bad-value>
 echo "== e2e rejects launcher injection before SSH =="
 rejected_before_ssh "control port metacharacters never reach SSH" RIG_CONTROL_PORT '8082;touch'
 rejected_before_ssh "pre-supplied rig NAME metacharacters never reach SSH, even without a token" RIG_NAME 'rig;touch'
+rejected_before_ssh "a valid first line cannot hide a second rig NAME line" RIG_NAME $'rig\ninvalid;value'
 rejected_before_ssh "bootstrap target metacharacters never reach SSH" RIGFORGE_BOOTSTRAP_VERSION 'v1.17.2;touch'
 
 printf '\npassed: %s, failed: %s\n' "$IT_PASS" "$IT_FAIL"

--- a/tests/integration/selftest-e2e-boundary.sh
+++ b/tests/integration/selftest-e2e-boundary.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Prove launcher-only RigForge inputs are rejected before e2e.sh can call SSH.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+TMP="$(mktemp -d)"
+MARKER="$TMP/ssh-called"
+trap 'rm -r "$TMP"' EXIT
+cat >"$TMP/ssh" <<'SH'
+#!/usr/bin/env bash
+: >"$SSH_MARKER"
+exit 99
+SH
+chmod +x "$TMP/ssh"
+
+rejected_before_ssh() { # <label> <env-name> <bad-value>
+    rm -f "$MARKER"
+    env PATH="$TMP:/usr/bin:/bin" SSH_MARKER="$MARKER" BENCH_HOST=bench MINER_HOST=rig \
+        "$2=$3" bash "$HERE/e2e.sh" candidate --mode matrix >/dev/null 2>&1
+    local rc=$?
+    if [ "$rc" -ne 0 ] && [ ! -e "$MARKER" ]; then
+        it_pass "$1"
+    else
+        it_fail "$1" "rc=$rc ssh_called=$([ -e "$MARKER" ] && echo yes || echo no)"
+    fi
+}
+
+echo "== e2e rejects launcher injection before SSH =="
+rejected_before_ssh "control port metacharacters never reach SSH" RIG_CONTROL_PORT '8082;touch'
+rejected_before_ssh "pre-supplied rig NAME metacharacters never reach SSH, even without a token" RIG_NAME 'rig;touch'
+rejected_before_ssh "bootstrap target metacharacters never reach SSH" RIGFORGE_BOOTSTRAP_VERSION 'v1.17.2;touch'
+
+printf '\npassed: %s, failed: %s\n' "$IT_PASS" "$IT_FAIL"
+[ "$IT_FAIL" -eq 0 ]

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 #
-# Self-test for e2e.sh's phase composition (#1364): which run.sh phases each --mode actually
-# launches with. The defect this locks down was invisible because it was an ABSENCE — the
-# rigforge-control phase was gated on `--mode matrix` while docs/dev/releasing.md mandates
-# `--mode targeted` before every cut, so the whole dashboard-to-rig write surface
-# (#513/#514/#516/#517/#1002b/#1236) was never even REQUESTED by the gate that decides whether a
-# release ships. Nothing in the output mentioned it; there was no skip line to notice.
+# Self-test e2e.sh's exact per-mode phase composition (#1364).
 #
 # It runs the REAL run_harness out of e2e.sh (extracted, then evaluated against stubbed ssh) and
 # reads the phase list off the command that would have been launched — not off a re-implementation
@@ -63,12 +58,13 @@ drive_harness() { # <mode> <borrow_miner> [rig-token] -> "LAUNCH\t<cmd>" then "S
         # a hang reads as a mutation that survived. A pipeline still supplies its own stdin.
         exec </dev/null
         MODE="$1" BORROW_MINER="$2" WORKERS=1 BENCH_HOST=bench E2E_DIR=/srv/code/pithead-e2e
+        SCENARIO="${4:-}" RIGFORGE_BOOTSTRAP_VERSION="${5:-}"
         # rig_supply's inputs (#1378). MINER_HOST is what RIG_HOST defaults to; the token comes off
         # the stubbed on_miner, so the empty-token path is reachable by passing "".
-        MINER_HOST=rig1 RIG_HOST="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
+        MINER_HOST=rig1 RIG_HOST="" RIG_NAME="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
         STUB_TOKEN="${3-s3cr3t-tok3n}"
         LAUNCH_FILE="$lf" STDIN_FILE="$sf"
-        on_miner() { printf '%s' "$STUB_TOKEN"; }
+        on_miner() { case "$1" in *".NAME"*) printf rig1 ;; *) printf '%s' "$STUB_TOKEN" ;; esac }
         log() { :; }
         step() { :; }
         warn() { :; }
@@ -143,7 +139,7 @@ assert_eq "targeted requests the rigforge-control WRITE phase (#1364)" \
     "$(has_phase "$TARGETED" --rigforge-control)" "yes"
 assert_eq "targeted launches EXACTLY its documented phases, and nothing else" \
     "$(phase_set "$TARGETED")" \
-    "--auth-fail-closed --lifecycle --rig-control-port --rig-host --rigforge --rigforge-control --scenario 8082 local-pruned-main-secure-tari rig1 "
+    "--auth-fail-closed --lifecycle --rig-control-port --rig-host --rig-name --rigforge --rigforge-control --scenario 8082 local-pruned-main-secure-tari rig1 rig1 "
 
 echo "== --mode matrix keeps everything it had =="
 MATRIX="$(compose_phases matrix 1)"
@@ -151,7 +147,11 @@ assert_eq "matrix still requests the rigforge-control WRITE phase" \
     "$(has_phase "$MATRIX" --rigforge-control)" "yes"
 assert_eq "matrix launches EXACTLY its documented phases, and nothing else" \
     "$(phase_set "$MATRIX")" \
-    "--auth-fail-closed --fault-injection --hardening --lifecycle --rig-control-port --rig-host --rigforge --rigforge-control --safety-backup --subnet 8082 rig1 "
+    "--auth-fail-closed --fault-injection --hardening --lifecycle --rig-control-port --rig-host --rig-name --rigforge --rigforge-control --safety-backup --subnet 8082 rig1 rig1 "
+FOCUSED_MATRIX="$(compose_phases matrix 1 s3cr3t-tok3n local-pruned-main-secure-tari v1.17.2)"
+assert_eq "matrix accepts one scenario and explicit bootstrap target without dropping its phases" \
+    "$(phase_set "$FOCUSED_MATRIX")" \
+    "--auth-fail-closed --fault-injection --hardening --lifecycle --rig-control-port --rig-host --rig-name --rigforge --rigforge-bootstrap-version --rigforge-control --safety-backup --scenario --subnet 8082 local-pruned-main-secure-tari rig1 rig1 v1.17.2 "
 
 echo "== --mode check stays non-destructive (pure reads) =="
 CHECK="$(compose_phases check 1)"
@@ -215,7 +215,7 @@ echo "== rig_supply's rc-0 contract, which e2e.sh's && chain depends on (#1378) 
 rc_of() { # <miner-host> <token-from-rig> <dial-rc> -> rig_supply's exit code
     (
         MINER_HOST="$1" TOKEN_OUT="$2" DIAL_RC="$3"
-        RIG_HOST="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json BENCH_HOST=bench
+        RIG_HOST="" RIG_NAME=rig1 IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json BENCH_HOST=bench
         warn() { :; }
         ok() { :; }
         on_miner() { printf '%s' "$TOKEN_OUT"; }
@@ -245,7 +245,7 @@ echo "== rig_supply REPORTS which case it took, and says the right thing (#1378)
 report_of() { # <miner-host> <token-from-rig> <dial-rc> -> "WARN <msg>" / "OK <msg>" lines
     (
         MINER_HOST="$1" TOKEN_OUT="$2" DIAL_RC="$3"
-        RIG_HOST="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json BENCH_HOST=bench
+        RIG_HOST="" RIG_NAME=rig1 IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json BENCH_HOST=bench
         warn() { printf 'WARN %s\n' "$*"; }
         ok() { printf 'OK %s\n' "$*"; }
         on_miner() { printf '%s' "$TOKEN_OUT"; }
@@ -299,7 +299,7 @@ supply_of() { # <unpriv-out> <unpriv-rc> <sudo-out> <sudo-rc> -> report lines, f
     local f
     f="$(mktemp)"
     (
-        MINER_HOST=rig1 RIG_HOST="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
+        MINER_HOST=rig1 RIG_HOST="" RIG_NAME=rig1 IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
         BENCH_HOST=bench U_OUT="$1" U_RC="$2" S_OUT="$3" S_RC="$4" TRACE="$f"
         warn() { printf 'WARN %s\n' "$*"; }
         ok() { printf 'OK %s\n' "$*"; }
@@ -398,7 +398,7 @@ dial_of() { # -> the argv rig_supply's proof dial hands to curl on the bench
     local f
     f="$(mktemp)"
     (
-        MINER_HOST=rig1 RIG_HOST="" IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
+        MINER_HOST=rig1 RIG_HOST="" RIG_NAME=rig1 IT_RIG_TOKEN="" RIGFORGE_CONFIG=/opt/rigforge/config.json
         BENCH_HOST=bench DIAL_FILE="$f"
         warn() { :; }
         ok() { :; }
@@ -437,7 +437,7 @@ echo "== the flag e2e.sh emits is one run.sh actually parses =="
 # it kills the whole harness run. Assert the handshake rather than trusting the two files agree.
 # grep '^--' so the loop reads FLAGS only: since #1378 the list also carries their VALUES
 # (--rig-host <host>, --rig-control-port <port>), and a value is not something run.sh's parser sees.
-for flag in $(printf '%s %s %s %s' "$TARGETED" "$MATRIX" "$CHECK" "$NOMINER" | tr ' ' '\n' | grep '^--' | LC_ALL=C sort -u); do
+for flag in $(printf '%s %s %s %s %s' "$TARGETED" "$MATRIX" "$FOCUSED_MATRIX" "$CHECK" "$NOMINER" | tr ' ' '\n' | grep '^--' | LC_ALL=C sort -u); do
     assert_eq "run.sh's arg parser accepts '$flag'" \
         "$(grep -cE "^[[:space:]]*(\-\-[a-z-]+ \| )*${flag}\)" "$RUN_SRC" | awk '{print ($1>0)?"yes":"no"}')" "yes"
 done

--- a/tests/integration/selftest-e2e-phases.sh
+++ b/tests/integration/selftest-e2e-phases.sh
@@ -143,7 +143,7 @@ assert_eq "targeted requests the rigforge-control WRITE phase (#1364)" \
     "$(has_phase "$TARGETED" --rigforge-control)" "yes"
 assert_eq "targeted launches EXACTLY its documented phases, and nothing else" \
     "$(phase_set "$TARGETED")" \
-    "--auth-fail-closed --lifecycle --rig-control-port --rig-host --rigforge --rigforge-control 8082 rig1 "
+    "--auth-fail-closed --lifecycle --rig-control-port --rig-host --rigforge --rigforge-control --scenario 8082 local-pruned-main-secure-tari rig1 "
 
 echo "== --mode matrix keeps everything it had =="
 MATRIX="$(compose_phases matrix 1)"
@@ -165,7 +165,7 @@ NOMINER="$(compose_phases targeted 0)"
 assert_eq "no borrowed miner => no write phase (there is no rig to write to)" \
     "$(has_phase "$NOMINER" --rigforge-control)" "no"
 assert_eq "no borrowed miner => EXACTLY the rig-free phases, plus --no-mining-asserts (#905)" \
-    "$(phase_set "$NOMINER")" "--auth-fail-closed --lifecycle --no-mining-asserts "
+    "$(phase_set "$NOMINER")" "--auth-fail-closed --lifecycle --no-mining-asserts --scenario local-pruned-main-secure-tari "
 
 contains() { # <haystack> <needle> -> "yes" | "no"
     case "$1" in *"$2"*) echo yes ;; *) echo no ;; esac

--- a/tests/integration/selftest-failover-arm.sh
+++ b/tests/integration/selftest-failover-arm.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Pure control for the live node-down fault's pre-arm predicate.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+
+SRC="$(sed -n '/^_pred_failover_armed() {$/,/^}$/p' "$HERE/run.sh")"
+assert_eq "the failover-arm predicate is extractable" \
+    "$(printf '%s\n' "$SRC" | sed -n '1p;$p' | tr '\n' ' ')" \
+    "_pred_failover_armed() { } "
+
+arm_result() { # <reachable> <released> <rejected> <proxy-state>
+    local state proxy_state="$4"
+    state="$(jq -nc --argjson reachable "$1" --argjson released "$2" --argjson rejected "$3" \
+        '{monero_sync:{reachable:$reachable},miner_released:$released,workers_rejected:$rejected}')"
+    api_state() { printf '%s' "$state"; }
+    service_state() { printf '%s' "$proxy_state"; }
+    eval "$SRC"
+    _pred_failover_armed && echo armed || echo blocked
+}
+
+echo "== node-down injection waits for a live dashboard observation =="
+assert_eq "a live released stack arms node-down injection" \
+    "$(arm_result true true false 'running healthy')" "armed"
+assert_eq "an unseen monerod keeps node-down injection blocked" \
+    "$(arm_result false true false 'running healthy')" "blocked"
+assert_eq "an already-rejected proxy keeps a duplicate fault blocked" \
+    "$(arm_result true true true 'exited none')" "blocked"
+
+echo "== injected RigForge credentials stay out of jq argv =="
+CONTROL_SRC="$(sed -n '/^run_rigforge_control() {/,/^}$/p' "$HERE/run.sh")"
+assert_eq "the raw rig token is absent from jq arguments" \
+    "$(printf '%s' "$CONTROL_SRC" | grep -c -- '--arg tok')" "0"
+assert_contains "jq reads the protected process environment" "$CONTROL_SRC" 'token:env.IT_RIG_TOKEN'
+
+HARDENING_SRC="$(sed -n '/^run_hardening() {$/,/^}$/p' "$HERE/run.sh")"
+assert_eq "full preview configs reach jq on stdin" \
+    "$(printf '%s' "$HARDENING_SRC" | grep -c -- '--argjson c')" "0"

--- a/tests/integration/selftest-failover-arm.sh
+++ b/tests/integration/selftest-failover-arm.sh
@@ -29,6 +29,18 @@ assert_eq "an unseen monerod keeps node-down injection blocked" \
 assert_eq "an already-rejected proxy keeps a duplicate fault blocked" \
     "$(arm_result true true true 'exited none')" "blocked"
 
+echo "== node-down call site never injects an unarmed fault =="
+FAULT_SRC="$(sed -n '/^fault_node_down() {$/,/^}$/p' "$HERE/run.sh")"
+STOP_LOG="$(mktemp)"
+trap 'rm -f "$STOP_LOG"' EXIT
+wait_for() { return 1; }
+it_fail() { IT_FAIL=$((IT_FAIL + 1)); }
+rx() { printf '%s\n' "$*" >>"$STOP_LOG"; }
+eval "$FAULT_SRC"
+fault_node_down
+assert_eq "an unarmed fault records one failure" "$IT_FAIL" "1"
+assert_eq "an unarmed fault never calls docker compose stop" "$(grep -c 'stop monerod' "$STOP_LOG")" "0"
+
 echo "== injected RigForge credentials stay out of jq argv =="
 CONTROL_SRC="$(sed -n '/^run_rigforge_control() {/,/^}$/p' "$HERE/run.sh")"
 assert_eq "the raw rig token is absent from jq arguments" \

--- a/tests/integration/selftest-rigforge-control-barrier.sh
+++ b/tests/integration/selftest-rigforge-control-barrier.sh
@@ -16,15 +16,20 @@ eval "$CONTROL_SRC"
 TMP="$(mktemp -d)"
 trap 'rm -r "$TMP"' EXIT
 OUT_DIR="$TMP"
-BASELINE_CONFIG='{"dashboard":{"control":{"enabled":false}},"workers":{"list":[{"name":"rig1","host":"rig"}]}}'
+BASELINE_CONFIG='{"dashboard":{"control":{"enabled":false}},"workers":{"api_port":8080,"list":[]}}'
 IT_MODE=local RIG_NAME=rig1 RIG_HOST=rig RIG_CONTROL_PORT=8082 RIGFORGE_BOOTSTRAP_VERSION=""
+IT_RIG_TOKEN=$(printf '%032d' 0)
 RUN_RIGFORGE=1
 api_state() { printf '%s' '{"workers":[{"name":"rig1","rigforge":{"version":"1.17.2"}}]}'; }
 env_on_box() { case "$1" in COMPOSE_PROFILES) echo local_node ;; DASHBOARD_AUTH_HASH_B64) echo present ;; esac }
 has_compose_profile() { return 0; }
-PUSHES=0
+PUSHES=0 READ_PORT="" GLOBAL_PORT=""
 push_config() {
     PUSHES=$((PUSHES + 1))
+    if [ "$PUSHES" -eq 1 ]; then
+        READ_PORT=$(printf '%s' "$1" | jq -r '.workers.list[0].port')
+        GLOBAL_PORT=$(printf '%s' "$1" | jq -r '.workers.api_port')
+    fi
     [ "$PUSHES" -eq 1 ]
 }
 APPLIES=0
@@ -39,6 +44,8 @@ _worker_detail() { : >"$TMP/write-called"; }
 echo "== failed read blocks writes and checked unwind is visible =="
 run_rigforge_control >/dev/null 2>&1
 rc=$?
+assert_eq "injected RigForge descriptor selects the enriched API" "$READ_PORT" "8081"
+assert_eq "other workers retain their global API port" "$GLOBAL_PORT" "8080"
 assert_eq "failed nested read returns nonzero to main" "$rc" "1"
 assert_eq "failed nested read performs no later rig write" "$([ -e "$TMP/write-called" ] && echo yes || echo no)" "no"
 assert_eq "a failed baseline write prevents apply from validating stale config" "$APPLIES" "1"

--- a/tests/integration/selftest-rigforge-control-barrier.sh
+++ b/tests/integration/selftest-rigforge-control-barrier.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Drive the real RigForge control call site through a failed nested read and failed unwind.
+# shellcheck disable=SC2034  # globals are read by the eval'd production functions
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/integration/lib.sh
+source "$HERE/lib.sh"
+RESTORE_SRC="$(sed -n '/^_restore_rig_control_baseline() {$/,/^}$/p' "$HERE/run.sh")"
+CONTROL_SRC="$(sed -n '/^run_rigforge_control() {$/,/^}$/p' "$HERE/run.sh")"
+assert_eq "control helpers are extractable" \
+    "$(printf '%s\n%s\n' "$RESTORE_SRC" "$CONTROL_SRC" | grep -cE '^(_restore_rig_control_baseline|run_rigforge_control)\(\) \{$')" "2"
+eval "$RESTORE_SRC"
+eval "$CONTROL_SRC"
+
+TMP="$(mktemp -d)"
+trap 'rm -r "$TMP"' EXIT
+OUT_DIR="$TMP"
+BASELINE_CONFIG='{"dashboard":{"control":{"enabled":false}},"workers":{"list":[{"name":"rig1","host":"rig"}]}}'
+IT_MODE=local RIG_NAME=rig1 RIG_HOST=rig RIG_CONTROL_PORT=8082 RIGFORGE_BOOTSTRAP_VERSION=""
+RUN_RIGFORGE=1
+api_state() { printf '%s' '{"workers":[{"name":"rig1","rigforge":{"version":"1.17.2"}}]}'; }
+env_on_box() { case "$1" in COMPOSE_PROFILES) echo local_node ;; DASHBOARD_AUTH_HASH_B64) echo present ;; esac }
+has_compose_profile() { return 0; }
+push_config() { :; }
+APPLIES=0
+pithead() {
+    APPLIES=$((APPLIES + 1))
+    [ "$APPLIES" -eq 1 ]
+}
+wait_status_ok() { return 0; }
+wait_for() { return 0; }
+run_rigforge_integration() { it_fail "forced nested read failure" "control"; }
+_worker_detail() { : >"$TMP/write-called"; }
+
+echo "== failed read blocks writes and checked unwind is visible =="
+run_rigforge_control >/dev/null 2>&1
+rc=$?
+assert_eq "failed nested read returns nonzero to main" "$rc" "1"
+assert_eq "failed nested read performs no later rig write" "$([ -e "$TMP/write-called" ] && echo yes || echo no)" "no"
+assert_eq "control setup and baseline unwind each attempted apply" "$APPLIES" "2"
+assert_eq "nested read and failed cleanup are both visible" "$IT_FAIL" "2"
+
+MAIN_SRC="$(sed -n '/^main() {$/,/^}$/p' "$HERE/run.sh")"
+assert_contains "main gates later fault injection on successful RigForge control" "$MAIN_SRC" '[ "$rig_control_ok" = 1 ] && [ "$RUN_FAULTS" = "1" ]'
+printf '\nselftest-rigforge-control-barrier: PASS\n'
+# Two failures above are the deliberate product-counter stimulus, not selftest failures.
+[ "$rc" -eq 1 ] && [ ! -e "$TMP/write-called" ] && [ "$APPLIES" -eq 2 ] && [ "$IT_FAIL" -eq 2 ]

--- a/tests/integration/selftest-rigforge-control-barrier.sh
+++ b/tests/integration/selftest-rigforge-control-barrier.sh
@@ -22,11 +22,14 @@ RUN_RIGFORGE=1
 api_state() { printf '%s' '{"workers":[{"name":"rig1","rigforge":{"version":"1.17.2"}}]}'; }
 env_on_box() { case "$1" in COMPOSE_PROFILES) echo local_node ;; DASHBOARD_AUTH_HASH_B64) echo present ;; esac }
 has_compose_profile() { return 0; }
-push_config() { :; }
+PUSHES=0
+push_config() {
+    PUSHES=$((PUSHES + 1))
+    [ "$PUSHES" -eq 1 ]
+}
 APPLIES=0
 pithead() {
     APPLIES=$((APPLIES + 1))
-    [ "$APPLIES" -eq 1 ]
 }
 wait_status_ok() { return 0; }
 wait_for() { return 0; }
@@ -38,11 +41,11 @@ run_rigforge_control >/dev/null 2>&1
 rc=$?
 assert_eq "failed nested read returns nonzero to main" "$rc" "1"
 assert_eq "failed nested read performs no later rig write" "$([ -e "$TMP/write-called" ] && echo yes || echo no)" "no"
-assert_eq "control setup and baseline unwind each attempted apply" "$APPLIES" "2"
+assert_eq "a failed baseline write prevents apply from validating stale config" "$APPLIES" "1"
 assert_eq "nested read and failed cleanup are both visible" "$IT_FAIL" "2"
 
 MAIN_SRC="$(sed -n '/^main() {$/,/^}$/p' "$HERE/run.sh")"
 assert_contains "main gates later fault injection on successful RigForge control" "$MAIN_SRC" '[ "$rig_control_ok" = 1 ] && [ "$RUN_FAULTS" = "1" ]'
 printf '\nselftest-rigforge-control-barrier: PASS\n'
 # Two failures above are the deliberate product-counter stimulus, not selftest failures.
-[ "$rc" -eq 1 ] && [ ! -e "$TMP/write-called" ] && [ "$APPLIES" -eq 2 ] && [ "$IT_FAIL" -eq 2 ]
+[ "$rc" -eq 1 ] && [ ! -e "$TMP/write-called" ] && [ "$APPLIES" -eq 1 ] && [ "$IT_FAIL" -eq 2 ]

--- a/tests/integration/selftest-rigforge-upgrade.sh
+++ b/tests/integration/selftest-rigforge-upgrade.sh
@@ -259,5 +259,23 @@ answers '{"status":"pending","id":"q-1"}'
 _rigforge_upgrade_noop_leg rig1 v1.16.0 >/dev/null 2>&1
 want "a non-noop answer to a repeat click -> FAIL" 0 2 0 0 0
 
+echo "== explicit no-feed bootstrap =="
+snap
+rig_reports ""
+answers "$PENDING"
+queue_results applied
+comes_back_on "1.17.2"
+rigforge_bootstrap rig1 v1.17.2 >/dev/null 2>&1
+check "an explicit target drives the real leg and succeeds only after version readback" $?
+want "no-feed bootstrap records pending handoff, applied, and target version" 3 0 0 0 0
+
+snap
+rig_reports "1.17.2"
+rigforge_bootstrap rig1 v1.17.2 >/dev/null 2>&1
+brc=$?
+if [ "$brc" -ne 0 ]; then check "an already-target rig is not misreported as a real bootstrap" 0; else check "an already-target rig is not misreported as a real bootstrap" 1; fi
+want "already-target bootstrap records a failure and makes no assertions" 0 1 0 0 0
+check_no_posts "and it never POSTed a downgrade or noop"
+
 printf '\n%s: %d case(s), %d bad\n' "$([ "$BAD" -eq 0 ] && echo PASS || echo FAIL)" "$CASES" "$BAD"
 [ "$BAD" -eq 0 ]


### PR DESCRIPTION
The live integration gate could attempt failover before the dashboard had observed a healthy node, reject its wallet fixture before reaching the approval boundary, and skip a supplied RigForge rig whose enriched feed required an upgrade.

Require a healthy observation before fault injection, use a valid public documentation wallet fixture for the rejected-change probe, and bootstrap explicitly selected rigs through the existing upgrade path before enriched-read and reversible-control checks. Failed setup, reads or baseline restoration now block later destructive phases. A matrix scenario selector permits focused reruns while retaining the matrix phases and restoration.

Validation: independent native review passed the affected phase, upgrade, failover, wallet approval and failure-path checks; final baseline-write guard passed focused checks and independent static review. Syntax, formatting, generated parity and file budgets pass. The combined live rerun remains required before release acceptance. No manual acceptance issue is closed by this harness change.
