### PR TITLE
fix(installer): #1846 the reinstall pre-fill drops the login but keeps the switches that need it

### DIFF
--- a/docs/appliance.md
+++ b/docs/appliance.md
@@ -195,8 +195,11 @@ On either fresh start, the page opens with the previous install's answers alread
 wallet addresses, node locations, pool tier — read from the disk you are about to wipe, so you
 only change what you came to change. Its secrets never make the trip: the dashboard login,
 node passwords, view keys, worker tokens and alert credentials are left out, and anything the
-machine generates for itself is generated anew. If the old configuration cannot be read, the
-page opens blank.
+machine generates for itself is generated anew. The two switches that need that login come
+back at their defaults for the same reason: config editing from the dashboard, which the
+machine turns on again for you once a password exists, and publishing the dashboard as a Tor
+onion, which you tick again if you want it. If the old configuration cannot be read, the page
+opens blank.
 
 Type the disk's name to confirm.
 

--- a/lib/pithead/10-installer-preseed.sh
+++ b/lib/pithead/10-installer-preseed.sh
@@ -178,12 +178,23 @@ publish_disk_inventory() { # <spool-dir>
 # the fixed paths cannot reach), alert credentials, the ssh key. Wallet addresses, node modes
 # and hosts, the pool tier stay: those are the answers the operator came back for, and none of
 # them is a secret. Errs toward stripping more — a lost convenience beats a leaked credential.
+#
+# The two ENABLEMENTS go with the login, and that is the half this was missing (#1846). The
+# validator fails closed on dashboard.control.enabled and on dashboard.onion.enabled whenever
+# the password is empty — deliberately, since both are reachable control surfaces. Deleting the
+# login while leaving either switch on therefore publishes a pre-fill that CANNOT be submitted:
+# the page offers it back, "Generate a strong password for me" leaves the password empty because
+# the HOST generates one only AFTER the candidate has validated, and the first validation refuses
+# the operator's own answers. Dropping control.enabled costs nothing — apply_appliance_defaults
+# puts it back on any appliance whose password is non-empty. onion.enabled the operator re-ticks,
+# which is the same trade the paragraph above already makes.
 # rc non-zero when the file is not a usable config object; callers treat that as "no pre-fill".
 strip_config_secrets() { # <config-file> -> stripped JSON on stdout
     jq -e --argjson paths "$CONTROL_SECRET_PATHS" '
         delpaths($paths)
         | del(.dashboard.auth, .dashboard.workers, .workers, .telegram,
-              .healthchecks, .notifications, .ssh, .tari.spend_public_key)' "$1" 2>/dev/null
+              .healthchecks, .notifications, .ssh, .tari.spend_public_key,
+              .dashboard.control.enabled, .dashboard.onion.enabled)' "$1" 2>/dev/null
 }
 
 # Reinstall pre-fill (#794). When the offered targets include exactly one disk that already

--- a/pithead
+++ b/pithead
@@ -2375,12 +2375,23 @@ publish_disk_inventory() { # <spool-dir>
 # the fixed paths cannot reach), alert credentials, the ssh key. Wallet addresses, node modes
 # and hosts, the pool tier stay: those are the answers the operator came back for, and none of
 # them is a secret. Errs toward stripping more — a lost convenience beats a leaked credential.
+#
+# The two ENABLEMENTS go with the login, and that is the half this was missing (#1846). The
+# validator fails closed on dashboard.control.enabled and on dashboard.onion.enabled whenever
+# the password is empty — deliberately, since both are reachable control surfaces. Deleting the
+# login while leaving either switch on therefore publishes a pre-fill that CANNOT be submitted:
+# the page offers it back, "Generate a strong password for me" leaves the password empty because
+# the HOST generates one only AFTER the candidate has validated, and the first validation refuses
+# the operator's own answers. Dropping control.enabled costs nothing — apply_appliance_defaults
+# puts it back on any appliance whose password is non-empty. onion.enabled the operator re-ticks,
+# which is the same trade the paragraph above already makes.
 # rc non-zero when the file is not a usable config object; callers treat that as "no pre-fill".
 strip_config_secrets() { # <config-file> -> stripped JSON on stdout
     jq -e --argjson paths "$CONTROL_SECRET_PATHS" '
         delpaths($paths)
         | del(.dashboard.auth, .dashboard.workers, .workers, .telegram,
-              .healthchecks, .notifications, .ssh, .tari.spend_public_key)' "$1" 2>/dev/null
+              .healthchecks, .notifications, .ssh, .tari.spend_public_key,
+              .dashboard.control.enabled, .dashboard.onion.enabled)' "$1" 2>/dev/null
 }
 
 # Reinstall pre-fill (#794). When the offered targets include exactly one disk that already

--- a/tests/stack/test-appliance-install.sh
+++ b/tests/stack/test-appliance-install.sh
@@ -276,6 +276,8 @@ cat >"$SCS/prev.json" <<'PREV'
   "p2pool": {"pool": "main", "stratum_password": "LEAK-stratum"},
   "dashboard": {"timezone": "Europe/Berlin",
                 "auth": {"username": "LEAK-dashuser", "password": "LEAK-dashpw"},
+                "control": {"enabled": true},
+                "onion": {"enabled": true, "client_auth": true},
                 "workers": [{"name": "w0", "host": "h", "token": "LEAK-oldworker"}]},
   "workers": {"api_auth": true, "api_token": "LEAK-apitoken",
               "list": [{"name": "rig1", "host": "rig1.lan", "token": "LEAK-workertoken"}]},
@@ -294,6 +296,16 @@ assert_eq "remote node mode survives" "$(printf '%s' "$stripped" | jq -r '.tari.
 assert_eq "remote node host survives" "$(printf '%s' "$stripped" | jq -r '.tari.remote.host')" "tari.lan"
 assert_eq "pool tier survives" "$(printf '%s' "$stripped" | jq -r '.p2pool.pool')" "main"
 assert_eq "timezone survives" "$(printf '%s' "$stripped" | jq -r '.dashboard.timezone')" "Europe/Berlin"
+# Secret-free is not the same as SUBMITTABLE (#1846). parse_and_validate_config fails closed on
+# dashboard.control.enabled (:455) and dashboard.onion.enabled (:432) whenever the password is
+# empty — and this strip is what empties it. Leaving either switch on published a pre-fill the
+# page offers back and the first validation then refuses, which is how "Generate a strong
+# password for me" became unusable on a reinstall: the HOST generates one only AFTER validation.
+assert_eq "control.enabled goes with the login it needs" "$(printf '%s' "$stripped" | jq -r '.dashboard.control.enabled // "absent"')" "absent"
+assert_eq "onion.enabled goes with the login it needs" "$(printf '%s' "$stripped" | jq -r '.dashboard.onion.enabled // "absent"')" "absent"
+# The sibling that keeps the two above narrow: a dashboard answer that depends on NO credential is
+# still carried over, so this is not "strip the whole dashboard block and call it safe".
+assert_eq "client_auth, which needs no login, survives" "$(printf '%s' "$stripped" | jq -r '.dashboard.onion.client_auth')" "true"
 # Not-a-config shapes are refused, not partially stripped: rc != 0 means "no pre-fill".
 printf 'not json at all' >"$SCS/garbage.json"
 if run_sourced "$SANDBOX" strip_config_secrets "$SCS/garbage.json" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #1846