### PR TITLE
fix(wizard): #1868 cover the set-up-again screen's button, and widen the sweep that missed it

### DIFF
--- a/dashboard/mining_dashboard/web/static/savedrole.mjs
+++ b/dashboard/mining_dashboard/web/static/savedrole.mjs
@@ -47,7 +47,7 @@ export const SavedRoleScreen = ({ summary, kept, error, onKeep, onSetUpAgain }) 
                 html`<${Field} label=${r.label}><code class="wizard-mono">${r.value}</code><//>`,
             )}
             <${Err}>${error}<//>
-            <button type="button" onClick=${onKeep}>Keep it</button>
+            <button type="button" class="btn-toggle active" onClick=${onKeep}>Keep it</button>
             <button type="button" class="wizard-link" onClick=${onSetUpAgain}>Set up again</button>
             <${Note}>Setting it up again asks the same questions as a first boot, with this
             machine's answers already filled in. Its login and other secrets are never filled

--- a/dashboard/mining_dashboard/web/static/wizard.css
+++ b/dashboard/mining_dashboard/web/static/wizard.css
@@ -42,3 +42,33 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+/* The wizard's buttons take the dashboard's own skin (.btn-toggle / .btn-toggle.active) so the
+ * first page anyone sees matches the app it hands over to. That class is built for a segmented
+ * control — no border of its own, radius from its parent — so a standalone button needs the same
+ * adaptation the config modal already makes at `.config-modal-actions .btn-toggle`. Without any of
+ * it these fell through to the user-agent style, and Apply failed WCAG 2.5.8 target size at under
+ * 24px tall (#1868). min-height states that bar directly rather than leaving it to font metrics.
+ * `.wizard-link` is a button deliberately styled as text and keeps its own look. */
+.wizard-shell button:not(.wizard-link) {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-height: 32px;
+}
+
+.wizard-shell button:not(.wizard-link):disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* A section heading sat hard against the field above it and read as that field's label: h3 carries
+ * `margin: 0 0 15px` from dashboard.css, so the space above it was whatever the preceding help
+ * paragraph happened to leave — headings after a bare select got none. A heading that opens its
+ * own card still needs zero, which is what the :first-child reset is for (#1868). */
+.wizard-shell h3 {
+  margin-top: 22px;
+}
+
+.wizard-shell h3:first-child {
+  margin-top: 0;
+}

--- a/dashboard/mining_dashboard/web/static/wizard.mjs
+++ b/dashboard/mining_dashboard/web/static/wizard.mjs
@@ -80,7 +80,7 @@ export const Gate = ({ error, onSubmit }) => html`<div class="card">
                 spellcheck=${false} placeholder="pit-XXXXXX" />
         <//>
         <${Note}>Case doesn't matter, and the ${" "}<code>pit-</code>${" "}prefix is optional.<//>
-        <button type="submit">Continue</button>
+        <button type="submit" class="btn-toggle active">Continue</button>
     </form>
 </div>`;
 
@@ -206,7 +206,7 @@ export const Done = ({ status, handoff, installer, stick, rig, onAck }) => html`
             <p>This is what the machine will be.</p>
             ${rigCardFields(handoff).map((f) => html`<${Field} label=${f.label}><code class="wizard-mono">${f.value}</code><//>`)}
             <${Note}>${rigCardNote(handoff)}<//>
-            <button type="button" onClick=${onAck}>
+            <button type="button" class="btn-toggle active" onClick=${onAck}>
                 ${installer && !stick ? "Looks right — erase the disk and install" : "Looks right — save it"}</button>`
         : handoff
           ? html`<h3>Save this before anything else</h3>
@@ -215,7 +215,7 @@ export const Done = ({ status, handoff, installer, stick, rig, onAck }) => html`
             <${Field} label="Dashboard password"><code class="wizard-mono">${handoff.password}</code><//>
             <${Field} label="Dashboard address"><code class="wizard-mono">${handoff.dashboard}</code><//>
             <${Field} label="Point miners at"><code class="wizard-mono">${handoff.stratum}</code><//>
-            <button type="button" onClick=${onAck}>
+            <button type="button" class="btn-toggle active" onClick=${onAck}>
                 ${installer ? "I saved these — erase the disk and install" : "I saved these — start provisioning"}</button>
             <${Note}>${
               installer
@@ -571,7 +571,7 @@ export class WizardApp extends Component {
               html`<${RestoreSection} file=${this.state.restoreFile} passphrase=${restorePassphrase}
                 onFile=${(e) => this.setState({ restoreFile: e.target.files[0] || null })}
                 onPassphrase=${(e) => this.setState({ restorePassphrase: e.target.value })} />
-            <button type="submit" disabled=${submitting}>
+            <button type="submit" class="btn-toggle active" disabled=${submitting}>
                 ${submitting ? "Validating…" : "Restore and provision"}</button>`
             }
         </form>
@@ -846,7 +846,7 @@ export class WizardApp extends Component {
 
             ${
               diskPicked &&
-              html`<button type="submit" disabled=${(!rig && !!jsonError) || this.state.submitting}>
+              html`<button type="submit" class="btn-toggle active" disabled=${(!rig && !!jsonError) || this.state.submitting}>
                 ${
                   this.state.submitting
                     ? "Validating…"
@@ -877,8 +877,9 @@ export class WizardApp extends Component {
   }
 }
 
-// Mount only in a browser: node --test imports this module to render-probe the views, and a
-// bare `document` reference at import time would make the whole file untestable.
+// Mount only in a browser (node --test imports this module; a bare `document` would break that).
+// Clear #app: the shell ships the heading and "Loading…" inside it, and preact APPENDS (#1868).
 if (typeof document !== "undefined") {
+  document.getElementById("app").replaceChildren();
   render(html`<${WizardApp} />`, document.getElementById("app"));
 }

--- a/dashboard/tests/frontend/wizardshell.test.mjs
+++ b/dashboard/tests/frontend/wizardshell.test.mjs
@@ -7,7 +7,7 @@
 // A new file rather than wizard.test.mjs, which is at 765 against a 765 ceiling.
 
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import test from "node:test";
 
 const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
@@ -20,14 +20,36 @@ function ruleFor(css, selectorRe) {
   return m ? { selector: m[2].trim(), body: m[3] } : null;
 }
 
-test("wizard.mjs: every button declares a class, so none falls through to the browser default", () => {
-  // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag itself
-  // can hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
-  const tags = WIZARD_MJS.split("<button").slice(1).map((s) => s.slice(0, 200));
-  assert.ok(tags.length >= 7, `expected the wizard's buttons, found ${tags.length}`);
-  const bare = tags.filter((t) => !/class="(btn-toggle[^"]*|wizard-link)"/.test(t));
+// The wizard's view modules, found by the import they share rather than by a hand-kept list — a new
+// view that renders a button is then covered the day it is written. The first sweep here read only
+// wizard.mjs and was blind to savedrole.mjs's "Keep it", which is exactly this defect in a file the
+// needle never looked at.
+const STATIC = new URL("../../mining_dashboard/web/static/", import.meta.url);
+const VIEWS = readdirSync(STATIC)
+  .filter((f) => f.endsWith(".mjs"))
+  .map((f) => [f, readFileSync(new URL(f, STATIC), "utf8")])
+  .filter(([f, src]) => f === "wizard.mjs" || src.includes("./wizardparts.mjs"));
+
+test("every wizard view: a button declares a class, so none falls through to the browser default", () => {
+  // An enumeration that quietly found nothing would pass this test while proving nothing, so the
+  // root is asserted before the property is.
+  assert.ok(VIEWS.length >= 2, `expected the wizard's view modules, found ${VIEWS.length}`);
+  assert.ok(
+    VIEWS.some(([f]) => f === "savedrole.mjs"),
+    "savedrole.mjs no longer matches the wizard-view marker — widen the root, do not narrow the claim",
+  );
+  const bare = [];
+  for (const [file, src] of VIEWS) {
+    // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag can
+    // hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
+    for (const tag of src.split("<button").slice(1).map((s) => s.slice(0, 200))) {
+      if (!/class="(btn-toggle[^"]*|wizard-link)"/.test(tag)) {
+        bare.push(`${file}: <button${tag.split("\n")[0].trim()}`);
+      }
+    }
+  }
   assert.deepEqual(
-    bare.map((t) => t.split("\n")[0].trim()),
+    bare,
     [],
     "a button with no class renders as the user-agent control (#1868): give it the dashboard's " +
       "btn-toggle skin, or wizard-link if it is deliberately a text link",

--- a/dashboard/tests/frontend/wizardshell.test.mjs
+++ b/dashboard/tests/frontend/wizardshell.test.mjs
@@ -1,0 +1,73 @@
+// The wizard's shell and chrome (#1868), asserted the way workerview.test.mjs asserts dashboard.css:
+// parse the files and read what they declare. These are static assertions — no layout engine runs
+// here, so nothing below proves a rendered button measured 32 px. What they DO hold is the property
+// that broke: a control that carries no class at all falls through to the user-agent style, and a
+// mount that is never cleared keeps whatever the server shipped inside it.
+//
+// A new file rather than wizard.test.mjs, which is at 765 against a 765 ceiling.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
+const WIZARD_MJS = read("../../mining_dashboard/web/static/wizard.mjs");
+const WIZARD_CSS = read("../../mining_dashboard/web/static/wizard.css");
+const WIZARD_HTML = read("../../mining_dashboard/web/templates/wizard.html");
+
+function ruleFor(css, selectorRe) {
+  const m = css.match(new RegExp(`(^|\\})\\s*(${selectorRe.source})\\s*\\{([^}]*)\\}`, "m"));
+  return m ? { selector: m[2].trim(), body: m[3] } : null;
+}
+
+test("wizard.mjs: every button declares a class, so none falls through to the browser default", () => {
+  // Each opening tag, taken as the text after `<button` up to a comfortable bound: the tag itself
+  // can hold arrow functions, so scanning for the closing `>` would stop at the first `=>`.
+  const tags = WIZARD_MJS.split("<button").slice(1).map((s) => s.slice(0, 200));
+  assert.ok(tags.length >= 7, `expected the wizard's buttons, found ${tags.length}`);
+  const bare = tags.filter((t) => !/class="(btn-toggle[^"]*|wizard-link)"/.test(t));
+  assert.deepEqual(
+    bare.map((t) => t.split("\n")[0].trim()),
+    [],
+    "a button with no class renders as the user-agent control (#1868): give it the dashboard's " +
+      "btn-toggle skin, or wizard-link if it is deliberately a text link",
+  );
+});
+
+test("wizard.css: a standalone button gets the border and radius .btn-toggle takes from its parent", () => {
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+button:not\(\.wizard-link\)/);
+  assert.ok(rule, "expected a `.wizard-shell button:not(.wizard-link)` rule in wizard.css");
+  assert.match(rule.body, /border:\s*1px solid var\(--border\)/);
+  assert.match(rule.body, /border-radius:/);
+});
+
+test("wizard.css: the button's target size clears WCAG 2.2 SC 2.5.8 (24px) as a declared floor", () => {
+  const rule = ruleFor(WIZARD_CSS, /\.wizard-shell\s+button:not\(\.wizard-link\)/);
+  const mh = rule.body.match(/min-height:\s*(\d+)px/);
+  assert.ok(mh, "expected an explicit min-height rather than one implied by padding + line-height");
+  assert.ok(
+    Number(mh[1]) >= 24,
+    `min-height ${mh[1]}px is below the 24px target-size floor (SC 2.5.8)`,
+  );
+});
+
+test("wizard.mjs: the mount clears #app, which the shell deliberately ships non-empty", () => {
+  // The two halves are a pair: the template ships the heading and "Loading…" inside #app so a curl
+  // can recognize the page, and preact's render appends. Assert both, or a later edit to either one
+  // silently restores the residue.
+  assert.match(WIZARD_HTML, /<main[^>]*id="app"[^>]*>\s*<h1>/, "the shell still ships markup in #app");
+  const mount = WIZARD_MJS.slice(WIZARD_MJS.indexOf('typeof document !== "undefined"'));
+  const clearAt = mount.indexOf("replaceChildren()");
+  const renderAt = mount.indexOf("render(");
+  assert.ok(clearAt !== -1, "#app is never cleared, so the shell's markup outlives every stage");
+  assert.ok(clearAt < renderAt, "#app must be cleared BEFORE render, not after");
+});
+
+test("wizard.css: a section heading is spaced from the field above, but not when it opens a card", () => {
+  const h3 = ruleFor(WIZARD_CSS, /\.wizard-shell\s+h3/);
+  assert.ok(h3, "expected a `.wizard-shell h3` rule");
+  assert.match(h3.body, /margin-top:\s*[1-9]/, "a heading with no top margin reads as the label of the field above it");
+  const first = ruleFor(WIZARD_CSS, /\.wizard-shell\s+h3:first-child/);
+  assert.ok(first, "expected the :first-child reset");
+  assert.match(first.body, /margin-top:\s*0/);
+});


### PR DESCRIPTION
Closes #1868