### PR TITLE
Deprecate macOS as a development and test platform

### DIFF
--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -18,6 +18,13 @@ generates a list of what exists today (git-ignored — read it locally).
 
 ## Commands
 
+Run these on Linux. macOS is deprecated as a test platform (2026-09-10) and the shell suite refuses
+to start there: the assertions are written against GNU `sed`/`stat`, BSD tools differ without
+failing loudly, and a `grep` that is a ugrep shim silently matches nothing for a pattern holding a
+non-terminal `$`. A control run on an unmodified `develop` failed 43+ assertions on a Mac, so a
+result from there is not evidence either way. `PITHEAD_UNTRUSTED_MACOS_RUN=1` overrides the refusal
+for portability debugging, and is named for what the result is worth.
+
 ```bash
 make test                 # local gates; needs Docker, but no live test server
 make test-dashboard       # dashboard pytest + 80% coverage gate

--- a/docs/dev/testing-guide.md
+++ b/docs/dev/testing-guide.md
@@ -21,7 +21,7 @@ generates a list of what exists today (git-ignored — read it locally).
 Run these on Linux. macOS is deprecated as a test platform (2026-09-10) and the shell suite refuses
 to start there: the assertions are written against GNU `sed`/`stat`, BSD tools differ without
 failing loudly, and a `grep` that is a ugrep shim silently matches nothing for a pattern holding a
-non-terminal `$`. A control run on an unmodified `develop` failed 43+ assertions on a Mac, so a
+non-terminal `$`. A control run on an unmodified `develop` scored 3708 passed / 148 failed, so a
 result from there is not evidence either way. `PITHEAD_UNTRUSTED_MACOS_RUN=1` overrides the refusal
 for portability debugging, and is named for what the result is worth.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ dashboard, no Linux to set up.
 
 | Requirement | Recommendation |
 |---|---|
-| Operating system | Ubuntu Server 24.04 LTS is the supported platform. Other Linux distributions and macOS may work but aren't supported. |
+| Operating system | Ubuntu Server 24.04 LTS is the supported platform. Other Linux distributions may work but aren't supported. macOS is deprecated as of 2026-09-10 and is not tested; the installer refuses it. |
 | CPU | A processor with AVX2 support for RandomX performance. |
 | RAM | 16 GB minimum with HugePages enabled (~6 GB is reserved for RandomX); 32 GB for a full node or long uptimes. |
 | Disk | A pruned Monero node needs ~100 GB and a full one ~270 GB, plus ~150 GB for the Tari node (its chain is the biggest single consumer). Plan for ~330 GB (pruned) or ~530 GB (full) of SSD minimum. Both chains grow ~100+ GB/year, so a 2–4 TB drive is the set-and-forget choice. Running either node on another machine drops its share — see [Running a node elsewhere](hardware.md#running-a-node-elsewhere). |

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -179,8 +179,9 @@ e.g. to keep the Monero blockchain on a separate SSD. See
 
 ### Operating system & dependencies
 
-- Ubuntu Server 24.04 LTS is the officially supported platform. macOS and other Linux distros may
-  work but aren't officially supported.
+- Ubuntu Server 24.04 LTS is the officially supported platform. Other Linux distros may work but
+  aren't officially supported. macOS is deprecated as of 2026-09-10: the installer refuses it, the
+  test suite refuses to run on it, and the remaining Darwin code paths are untested.
 - The kernel/HugePages tuning is Linux-only. On Linux, making HugePages persistent edits GRUB and
   needs a reboot (you're prompted first, and can skip with `--skip-optimize`).
 - Required software: Docker Engine, Docker Compose v2, `jq`, and `openssl`. On Ubuntu, `./pithead

--- a/lib/pithead/05-doctor-checks.sh
+++ b/lib/pithead/05-doctor-checks.sh
@@ -124,7 +124,7 @@ check_local_miner_hugepages_blocked() {
 }
 
 # True (rc 0) when the host CPU advertises AVX2 — RandomX wants it, but it's performance-only,
-# not fatal. Linux reads /proc/cpuinfo; macOS reads sysctl's machdep CPU features.
+# not fatal. Linux reads /proc/cpuinfo; the macOS sysctl arm is DEPRECATED and untested (#2041).
 cpu_has_avx2() {
     if [ "$OS_TYPE" == "Darwin" ]; then
         sysctl -a 2>/dev/null | grep "machdep.cpu" | grep -q "AVX2"

--- a/lib/pithead/19-small-utilities.sh
+++ b/lib/pithead/19-small-utilities.sh
@@ -174,6 +174,8 @@ assert_safe_dir() {
     esac
 }
 
+# The Darwin arm here is DEPRECATED and untested (#2041): macOS is no longer a test platform, so
+# nothing exercises it. Left working rather than deleted; do not build on it.
 safe_sed() {
     local pattern="$1"
     local file="$2"

--- a/lib/pithead/33-render-env.sh
+++ b/lib/pithead/33-render-env.sh
@@ -301,7 +301,7 @@ render_env() {
     else
         tari_mem_limit=$(jq -r '.tari.mem_limit // "auto"' "$CONFIG_FILE")
         case "$tari_mem_limit" in
-        "" | auto)
+        "" | auto) # the Darwin sysctl arm below is DEPRECATED and untested (#2041)
             huge_mb=0
             if [ "$OS_TYPE" == "Darwin" ]; then
                 ram_mb=$(($(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576))

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -9,6 +9,24 @@
 # Mechanical move only: this is the SAME code that used to sit at the top of run.sh, moved
 # here verbatim so run.sh can source it. No behaviour changed.
 
+# macOS is deprecated as a test platform (#2041), and this refuses rather than warns because a
+# warning still leaves a pass/fail line behind that reads as a result. A failure here is not
+# evidence: a control run of this suite on an UNMODIFIED develop failed 43+ assertions on a Mac.
+# The assertions are written against GNU sed/stat semantics, and BSD tools do not fail loudly on
+# the difference — they produce wrong output that surfaces as an unrelated assertion elsewhere.
+# A `grep` that is a ugrep shim compounds it: a pattern with a non-terminal $ matches nothing at
+# all, silently. Two automated reviewers have already reversed correct verdicts on macOS runs.
+#
+# The escape hatch exists for someone deliberately debugging portability, and says in its own name
+# that the result is not to be trusted. CI is Linux, so this never fires there.
+if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" ]; then
+    echo "tests: macOS is not a supported test platform (#2041) — run these on Linux." >&2
+    echo "  A failure here would not be evidence: an unmodified develop fails 43+ assertions on macOS," >&2
+    echo "  because the assertions assume GNU sed/stat and BSD tools differ silently." >&2
+    echo "  To run anyway, knowing the result is untrustworthy: PITHEAD_UNTRUSTED_MACOS_RUN=1" >&2
+    exit 1
+fi
+
 # Every test-*.sh domain file is a FRAGMENT: run.sh sources it after this file, and it carries no
 # assertion primitives of its own. Run one directly and all 60-odd assert_* calls are "command not
 # found" while the file still exits 0 — a domain reporting success having executed nothing (#1657).

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -11,7 +11,7 @@
 
 # macOS is deprecated as a test platform (#2041), and this refuses rather than warns because a
 # warning still leaves a pass/fail line behind that reads as a result. A failure here is not
-# evidence: a control run of this suite on an UNMODIFIED develop failed 43+ assertions on a Mac.
+# evidence: a control run of this suite on an UNMODIFIED develop scored 3708 passed / 148 FAILED
 # The assertions are written against GNU sed/stat semantics, and BSD tools do not fail loudly on
 # the difference — they produce wrong output that surfaces as an unrelated assertion elsewhere.
 # A `grep` that is a ugrep shim compounds it: a pattern with a non-terminal $ matches nothing at
@@ -21,7 +21,7 @@
 # that the result is not to be trusted. CI is Linux, so this never fires there.
 if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" ]; then
     echo "tests: macOS is not a supported test platform (#2041) — run these on Linux." >&2
-    echo "  A failure here would not be evidence: an unmodified develop fails 43+ assertions on macOS," >&2
+    echo "  A failure here would not be evidence: unmodified develop scores 3708/148 FAILED on macOS," >&2
     echo "  because the assertions assume GNU sed/stat and BSD tools differ silently." >&2
     echo "  To run anyway, knowing the result is untrustworthy: PITHEAD_UNTRUSTED_MACOS_RUN=1" >&2
     exit 1

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -9,16 +9,10 @@
 # Mechanical move only: this is the SAME code that used to sit at the top of run.sh, moved
 # here verbatim so run.sh can source it. No behaviour changed.
 
-# macOS is deprecated as a test platform (#2041), and this refuses rather than warns because a
-# warning still leaves a pass/fail line behind that reads as a result. A failure here is not
-# evidence: a control run of this suite on an UNMODIFIED develop scored 3708 passed / 148 FAILED
-# The assertions are written against GNU sed/stat semantics, and BSD tools do not fail loudly on
-# the difference — they produce wrong output that surfaces as an unrelated assertion elsewhere.
-# A `grep` that is a ugrep shim compounds it: a pattern with a non-terminal $ matches nothing at
-# all, silently. Two automated reviewers have already reversed correct verdicts on macOS runs.
-#
-# The escape hatch exists for someone deliberately debugging portability, and says in its own name
-# that the result is not to be trusted. CI is Linux, so this never fires there.
+# macOS is deprecated as a test platform (#2041): the assertions assume GNU sed/stat, and BSD
+# tools differ without failing loudly. Refuses rather than warns, because a warning still leaves a
+# pass/fail line behind that reads as a result — which is how three reviewers reached wrong
+# verdicts. Evidence and the full reasoning are in #2041. CI is Linux; this never fires there.
 if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" ]; then
     echo "tests: macOS is not a supported test platform (#2041) — run these on Linux." >&2
     echo "  A failure here would not be evidence: unmodified develop scores 3708/148 FAILED on macOS," >&2

--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -9,18 +9,6 @@
 # Mechanical move only: this is the SAME code that used to sit at the top of run.sh, moved
 # here verbatim so run.sh can source it. No behaviour changed.
 
-# macOS is deprecated as a test platform (#2041): the assertions assume GNU sed/stat, and BSD
-# tools differ without failing loudly. Refuses rather than warns, because a warning still leaves a
-# pass/fail line behind that reads as a result — which is how three reviewers reached wrong
-# verdicts. Evidence and the full reasoning are in #2041. CI is Linux; this never fires there.
-if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" ]; then
-    echo "tests: macOS is not a supported test platform (#2041) — run these on Linux." >&2
-    echo "  A failure here would not be evidence: unmodified develop scores 3708/148 FAILED on macOS," >&2
-    echo "  because the assertions assume GNU sed/stat and BSD tools differ silently." >&2
-    echo "  To run anyway, knowing the result is untrustworthy: PITHEAD_UNTRUSTED_MACOS_RUN=1" >&2
-    exit 1
-fi
-
 # Every test-*.sh domain file is a FRAGMENT: run.sh sources it after this file, and it carries no
 # assertion primitives of its own. Run one directly and all 60-odd assert_* calls are "command not
 # found" while the file still exits 0 — a domain reporting success having executed nothing (#1657).
@@ -33,6 +21,20 @@ fi
 # tests/inventory.sh lists them as UNSOURCED) — they carry no marker check and must not gain one.
 # shellcheck disable=SC2034  # sourced library: this marker and the fixtures are read by run.sh
 STACK_SUITE=1
+
+# macOS is deprecated as a test platform (#2041): the assertions assume GNU sed/stat, and BSD
+# tools differ without failing loudly. Refuses rather than warns, because a warning still leaves a
+# pass/fail line behind that reads as a result — which is how three reviewers reached wrong
+# verdicts. Evidence and the full reasoning are in #2041. CI is Linux; this never fires there.
+# Keep this BELOW STACK_SUITE=1: a shellcheck directive is file-scoped only while nothing
+# executable precedes it, so moving this up collapses the disable=SC2034 above to one line.
+if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" ]; then
+    echo "tests: macOS is not a supported test platform (#2041) — run these on Linux." >&2
+    echo "  A failure here would not be evidence: unmodified develop scores 3708/148 FAILED on macOS," >&2
+    echo "  because the assertions assume GNU sed/stat and BSD tools differ silently." >&2
+    echo "  To run anyway, knowing the result is untrustworthy: PITHEAD_UNTRUSTED_MACOS_RUN=1" >&2
+    exit 1
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STACK="$ROOT/pithead"


### PR DESCRIPTION
Closes #2041.

macOS was already unsupported as a runtime — `install.sh:21-22` rejects non-Linux before bootstrapping, and the docs said it "may work but isn't supported". What remained was developer convenience: running the CLI and the suite on a Mac. That convenience now costs more than it returns, because **a failure on macOS carries no information**.

## The measurement

`make test-stack` on an **unmodified `develop`**, on a Mac:

```
pithead tests: 3708 passed, 148 failed
```

The base branch. No changes. 148 failures.

During review of #2005, three automated reviewers were misled by this host in three different ways:

- One ran the suite on macOS, reported **148 failures**, and reversed a correct verdict. That is the same 148 above — reproducing it on `develop` is what proves it was the host.
- One blamed `restore_canonicalize_derived` for 27 restore/wizard failures. That function **does not exist on `develop`**, where 21 of those same tests fail anyway.
- One searched with `grep -c '$(_qenvq'`. The host `grep` is a ugrep shim where a pattern holding a non-terminal `$` silently matches nothing: it returned **0** where the true count was **53**, and the reviewer filed "the function and all its call sites were deleted" as a blocking defect against working code.

The assertions are written against GNU `sed`/`stat`. BSD tools do not fail loudly on the difference — they produce wrong output that surfaces as an unrelated assertion somewhere else.

## What this does

**Refuses rather than warns.** A warning still leaves a pass/fail line behind that reads as a result, and that is precisely the failure mode above. The guard sits in `tests/stack/lib.sh`, which all 16 shell-suite entry points source, so `run.sh` and every standalone test are covered by one check. `PITHEAD_UNTRUSTED_MACOS_RUN=1` overrides it for portability debugging and is named for what such a result is worth.

**Deprecates the Darwin branches in place — nothing deleted.** `safe_sed`/`sudo_sed`, `cpu_has_avx2`'s sysctl arm, and render-env's `hw.memsize` arm each gain a note. Two of the three are in-place comment edits because `33-render-env.sh` sits exactly on its 494-line budget ceiling and ceilings only move down.

**Docs** carry a dated deprecation in `getting-started.md`, `hardware.md`, and the testing guide.

Left alone deliberately: `install.sh`'s hard gate is already correct, and the Linux-only skips for HugePages, systemd and the control runner are correct behaviour rather than macOS accommodation.

## Verification

| check | result |
|---|---|
| Shell suite on **Linux** | **3891 passed, 0 failed** — unchanged, the guard is inert there |
| Guard fires on macOS | `rc=1` from `run.sh` and from a standalone test |
| Escape hatch | `PITHEAD_UNTRUSTED_MACOS_RUN=1` proceeds and runs |
| `lint-docs-voice`, `lint-md`, `lint-path-references`, `lint-file-budget` | pass |

The Linux run was at `9e547d72`; the delta to the tip is comment and `echo` text only, no logic.

## Not in scope

No CI change — pithead has no macOS runner; all 19 GitHub-hosted jobs are `ubuntu-latest`. RigForge, which does have a `macos-14` job and a native macOS e2e, is tracked separately in p2pool-starter-stack/rigforge#493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
