### PR TITLE
docs(os): reconcile KNOWN-ISSUES with the issue tracker — #976/#913 stale, two gaps filed (#2044, #2045), #2043 added

### DIFF
--- a/docs/dev/appliance-release.md
+++ b/docs/dev/appliance-release.md
@@ -304,10 +304,12 @@ see this: the harness disables Secure Boot because our GRUB is unsigned.*
 at `http://pithead.local` and at the IP it printed. Expected: both load the token gate, and
 the machine stays reachable by name after the monitor is unplugged.
 
-Note what this case does **not** prove: the install is not headless today, because the token
-exists only on the console. A monitor (or serial line) is required at least once. Pre-seeding
-the token or a whole config from the stick's FAT partition is the fix, and it is not built —
-see KNOWN-ISSUES.
+Note what this case does **not** prove: it walks the non-preseeded path, where the token exists
+only on the console, so a monitor (or serial line) is required at least once. Pre-seeding the
+token or a whole config from the stick's FAT partition **is** built — `pithead-token.txt` /
+`pithead-config.json` on the ESP, read by `lib/pithead/10-installer-preseed.sh` and carried onto
+the target by `os/installer/pithead-install`, with the `install` and `media` phases covering it.
+What is still unbuilt is choosing the target disk headlessly — see KNOWN-ISSUES (#979).
 
 KVM analog: `--phase install` automates the mechanics of M3 and M5 (inventory, guards,
 copy completeness, target boot, and reinstall preserving `/data`). The manual cases remain

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -8,8 +8,8 @@ tip being cut, not a dated badge here: the 2026-08 waves each found real product
 tip whose previous run had passed. The last fully-green run of the original five phases was
 2026-07-25 (boot 4/4, update 15/15, provision 21/21, install 33/33, fault 11/11, no brick in
 any run). **The current tip is not green.** A `--phase all` run reports 135 passed and 6
-failed, five of them one defect: the stack never comes up after provisioning, on `develop`
-as well as on the branch it was found against (#2043). The per-phase assertion list is in
+failed, five of them one defect: the stack never comes up after provisioning (#2043). The
+per-phase assertion list is in
 [the release doc's battery table](../docs/dev/appliance-release.md#the-automated-battery).
 The image ships the ESP and slot A only (636 MB);
 systemd-repart builds slot B and /data on the target's own disk, and `/data` measured
@@ -352,11 +352,13 @@ defect and not an OS-update one. Built and covered is not proven.
   records for the OS-update path.
 - **The appliance does not currently complete provisioning under KVM (#2043).** The wizard
   submit and `setup` succeed — leg 4 captures a dashboard login — and then no containers ever
-  appear; the media leg waited 25 minutes for zero containers. It reproduces on `develop`, so
-  it is not a branch artefact, and the A/B updater itself is healthy (boot, identity survival,
-  install to the spare slot, commit across reboot, operator rollback and the rig role all
-  pass). Until this is root-caused, every leg that asserts on a running stack is unproven
-  rather than passing.
+  appear; the media leg waited 25 minutes for zero containers. The `provision` leg was
+  controlled against `develop` and fails there identically, so it is not a branch artefact —
+  but #2043 states its own limit and this entry keeps it: one leg was controlled, not five.
+  The other four share the symptom and probably the cause. The A/B updater itself is healthy
+  (boot, identity survival, install to the spare slot, commit across reboot, operator rollback,
+  disk install and the rig role all pass). Until this is root-caused, every leg that asserts on
+  a running stack is unproven rather than passing.
 - **Only the wizard image is baked in (#978).** The rest of the stack still pulls at
   provision time, so the plan's "first boot works offline" property is partial: the setup
   page works without a network, provisioning does not. Baking the full set roughly triples

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -9,8 +9,7 @@ tip whose previous run had passed. The last fully-green run of the original five
 2026-07-25 (boot 4/4, update 15/15, provision 21/21, install 33/33, fault 11/11, no brick in
 any run). **The current tip is not green.** A `--phase all` run reports 135 passed and 6
 failed, five of them one defect: the stack never comes up after provisioning, on `develop`
-as well as on the branch it was found against (#2043). Every leg below that asserts on a
-running stack should be read against that, not against a badge. The per-phase assertion list is in
+as well as on the branch it was found against (#2043). The per-phase assertion list is in
 [the release doc's battery table](../docs/dev/appliance-release.md#the-automated-battery).
 The image ships the ESP and slot A only (636 MB);
 systemd-repart builds slot B and /data on the target's own disk, and `/data` measured
@@ -324,18 +323,11 @@ just the restore path would fix nothing restore-specific and leave the identical
 fresh setup. See [Recovering from a backup](../docs/appliance.md#recovering-from-a-backup) for
 the operator-facing contract this restores.
 
-**Fixed — the dashboard OS-update action is built and its battery legs exist (#976).** The
-user-reachable path is an OS-update control in the dashboard header driving check → resumable
-Tor download to `/data` → local verification (signature, `compatible`, downgrade/floor) → slot
-install → an explicit confirmed reboot, with the boot health gate committing and a persisted
-verdict banner after. Every verb is host-side through the control channel and refuses off the
-appliance; the DIY one-click upgrade still refuses on the appliance, because a tarball upgrade
-would silently revert at the next boot. Both checks this entry used to wait on are written:
-`tests/os/run.sh` leg 4 drives the same A/B cycle through the dashboard action end to end, and
-the `provision` phase asserts `os_update` is present in `/api/state` — the control renders, or
-the leg fails. What those legs have not yet done is pass: leg 4 currently stops at "stack never
-came up", which is #2043's defect and not an OS-update one. Built and covered is not proven;
-see the Open section.
+**Fixed — the dashboard OS-update action shipped, and so did the two checks it waited on
+(#976).** `tests/os/run.sh` leg 4 drives the A/B cycle through the dashboard action end to end,
+and the `provision` phase asserts `os_update` is present in `/api/state` — the control renders,
+or the leg fails. Neither has passed: leg 4 stops at "stack never came up", which is #2043's
+defect and not an OS-update one. Built and covered is not proven.
 
 ## Open
 

--- a/os/KNOWN-ISSUES.md
+++ b/os/KNOWN-ISSUES.md
@@ -7,7 +7,10 @@ provision, media, rig, fault and reset — and "green" means the full battery pa
 tip being cut, not a dated badge here: the 2026-08 waves each found real product bugs on a
 tip whose previous run had passed. The last fully-green run of the original five phases was
 2026-07-25 (boot 4/4, update 15/15, provision 21/21, install 33/33, fault 11/11, no brick in
-any run). The per-phase assertion list is in
+any run). **The current tip is not green.** A `--phase all` run reports 135 passed and 6
+failed, five of them one defect: the stack never comes up after provisioning, on `develop`
+as well as on the branch it was found against (#2043). Every leg below that asserts on a
+running stack should be read against that, not against a badge. The per-phase assertion list is in
 [the release doc's battery table](../docs/dev/appliance-release.md#the-automated-battery).
 The image ships the ESP and slot A only (636 MB);
 systemd-repart builds slot B and /data on the target's own disk, and `/data` measured
@@ -278,9 +281,9 @@ the node count the same way RigForge does, preferring `lscpu`, then the kernel's
 then the socket count, and declares nothing when it reads more than one node. Node count is not
 socket count in either direction: the bench guest reports four sockets and one node.
 
-**Still open on #1103:** whether a co-located miner on a reduced-RAM box mines usefully or thrashes
-is unanswered. Answering it needs synced chains rather than another KVM guest, because the sync gate
-holds the stratum the miner dials.
+**Still open on #1103, now tracked as #2045:** whether a co-located miner on a reduced-RAM box
+mines usefully or thrashes is unanswered. Answering it needs synced chains rather than another KVM
+guest, because the sync gate holds the stratum the miner dials.
 
 **Fixed — the hugepage pool had a second writer, and the ceiling bounded only the first (#1724).**
 The ceiling above is declared to RigForge, so it binds the sizer's write. The miner is a writer too:
@@ -321,6 +324,19 @@ just the restore path would fix nothing restore-specific and leave the identical
 fresh setup. See [Recovering from a backup](../docs/appliance.md#recovering-from-a-backup) for
 the operator-facing contract this restores.
 
+**Fixed — the dashboard OS-update action is built and its battery legs exist (#976).** The
+user-reachable path is an OS-update control in the dashboard header driving check → resumable
+Tor download to `/data` → local verification (signature, `compatible`, downgrade/floor) → slot
+install → an explicit confirmed reboot, with the boot health gate committing and a persisted
+verdict banner after. Every verb is host-side through the control channel and refuses off the
+appliance; the DIY one-click upgrade still refuses on the appliance, because a tarball upgrade
+would silently revert at the next boot. Both checks this entry used to wait on are written:
+`tests/os/run.sh` leg 4 drives the same A/B cycle through the dashboard action end to end, and
+the `provision` phase asserts `os_update` is present in `/api/state` — the control renders, or
+the leg fails. What those legs have not yet done is pass: leg 4 currently stops at "stack never
+came up", which is #2043's defect and not an OS-update one. Built and covered is not proven;
+see the Open section.
+
 ## Open
 
 - **Installing to a disk still needs a human (#979).** Pre-seeding (`pithead-token.txt` /
@@ -333,21 +349,22 @@ the operator-facing contract this restores.
   trio closed the sharpest losses: dashboard backup export (#908), restore at setup
   (#909), and the media config channel (#910) — which also carries the settings the
   dashboard never exposes, so "changing these later means reinstalling" no longer holds.
-  What remains rides the post-GA fast-follows: out-of-band approval at the commit gate
-  (#911), fleet descriptor editing (#912), and the CLI remainder on the dashboard (#913).
-- **The dashboard OS-update action is built but not yet battery-proven (#976).** The
-  user-reachable path exists: an OS-update control in the dashboard header drives
-  check → resumable Tor download to `/data` → local verification (signature,
-  `compatible`, downgrade/floor) → slot install → an explicit confirmed reboot, with
-  the boot health gate committing and a persisted verdict banner after. Every verb is
-  host-side through the control channel and refuses off the appliance; the DIY
-  one-click upgrade still refuses on the appliance (a tarball upgrade would silently
-  revert at the next boot). What remains before this line moves to Resolved: the
-  battery's `phase_update` leg 4 (the dashboard-driven A/B cycle, resume, and the
-  refusals) and the `provision` presence check must pass on the KVM bench.
-- **The manual hardware battery has not been run.** Everything above is KVM. Secure Boot,
-  real disks, headless discovery and a genuine power cut are exactly what a VM cannot
-  show — M1-M10 in the release doc must pass on a physical box before an image ships.
+  The CLI remainder is on the dashboard too now — support bundle, doctor detail, rotations
+  (#913). What remains rides the post-GA fast-follows: out-of-band approval at the commit gate
+  (#911) and fleet descriptor editing (#912).
+- **The manual hardware battery has not been run (#2044).** Everything above is KVM. Secure
+  Boot, real disks, headless discovery and a genuine power cut are exactly what a VM cannot
+  show — M1–M10, M15 and M16 in the release doc must pass on a physical box before an image
+  ships. (M11–M14 were the rig-role steps; #1886 moved their automatable parts into the `rig`
+  phase.) #394's gate list still does not name this battery — the same omission #976's own title
+  records for the OS-update path.
+- **The appliance does not currently complete provisioning under KVM (#2043).** The wizard
+  submit and `setup` succeed — leg 4 captures a dashboard login — and then no containers ever
+  appear; the media leg waited 25 minutes for zero containers. It reproduces on `develop`, so
+  it is not a branch artefact, and the A/B updater itself is healthy (boot, identity survival,
+  install to the spare slot, commit across reboot, operator rollback and the rig role all
+  pass). Until this is root-caused, every leg that asserts on a running stack is unproven
+  rather than passing.
 - **Only the wizard image is baked in (#978).** The rest of the stack still pulls at
   provision time, so the plan's "first boot works offline" property is partial: the setup
   page works without a network, provisioning does not. Baking the full set roughly triples


### PR DESCRIPTION
## What

An audit of every gap in `os/KNOWN-ISSUES.md` against the issue tracker, and the doc brought
back in line with it. Two gaps that were tracked only in prose are now filed.

`os/KNOWN-ISSUES.md` is the only KNOWN-ISSUES-shaped file in the repo (`git ls-files` across
the tree). `docs/privacy.md` carries a "Local trust boundary & known limitations" section and
`docs/operations.md` one stated caveat; both are checked below, and neither needs a new issue.

## Audit result

| Gap in the doc | Tracker state | Action |
|---|---|---|
| Installing to a disk needs a human | #979 OPEN | correct, unchanged |
| Host-CLI surface unreachable (#786) | #786 OPEN, but #913 CLOSED 2026-09-04 | prose corrected |
| Dashboard OS-update "not yet battery-proven" | **#976 CLOSED 2026-08-18** | moved to Resolved, honestly |
| Manual hardware battery not run | **no issue at all** | filed **#2044** |
| "Still open on #1103" | **#1103 CLOSED**, residual orphaned | filed **#2045** |
| Only the wizard image is baked in | #978 OPEN | correct, unchanged |
| — | #2043 OPEN, absent from the doc | added to Open |

## The two corrections that change what a reader believes

**The doc read as if the battery were green.** The Status header explains that "green" means
the full battery passing on the tip being cut — and then stops, so the next thing a reader
meets is a Resolved section forty entries long. #2043 reports a `--phase all` run at 135
passed / 6 failed, five of them one defect (the stack never comes up after provisioning),
reproducing on `develop`. The header now says so, and points at it.

**#976 was closed while the doc still listed it as Open.** Both checks the entry was waiting
on exist in the tree: `tests/os/run.sh` leg 4 drives the same A/B cycle through the dashboard
OS-update action end to end, and `tests/os/phases/provision-initial.sh` asserts `os_update` is
present in `/api/state`. So it moves to Resolved — but the entry says what "resolved" does and
does not mean here: the legs are written, and leg 4 currently stops at "stack never came up",
which is #2043's defect, not an OS-update one. Built and covered is not proven.

## New issues

- **#2044** — the manual hardware battery (M1–M10, M15, M16) has never been run, and #394's
  gate list does not name it. This was the only entry in the Open section with no issue number,
  and it is the same omission #976's own title records for the OS-update path. The doc's M-list
  is corrected too: M11–M14 were the rig-role steps, and #1886 moved their automatable parts
  into the `rig` phase.
- **#2045** — the question #1103 left behind: whether a co-located miner on a reduced-RAM box
  mines usefully or thrashes. The tier's refusal currently rests on memory arithmetic, not on a
  hashrate measurement, and answering it needs synced chains rather than another KVM guest.

## A stale claim in `docs/dev/appliance-release.md`, found on the way

Grepping cross-references to the file this branch edits turned up one that contradicts it.
The M2 case said:

> Pre-seeding the token or a whole config from the stick's FAT partition is the fix, and it is
> not built — see KNOWN-ISSUES.

KNOWN-ISSUES says the opposite, and KNOWN-ISSUES is right: `lib/pithead/10-installer-preseed.sh`
reads `pithead-token.txt`, `os/installer/pithead-install:258` carries the seeds onto the target,
and the `install` and `media` phases cover it at tier 4, with tier-3 coverage in
`tests/stack/appliance/`. Corrected in `3b669bc6` — M2 walks the non-preseeded path, and headless
*disk selection* is the part still unbuilt (#979).

## Checked and deliberately not filed

- **`docs/privacy.md` › the monerod RPC credential in p2pool's argv (#57).** #57 is closed
  (COMPLETED) but its body records the limitation and why it is not fixable without removing RPC
  auth or an upstream p2pool change. The doc's pointer is accurate; the limitation stands as
  documented.
- **`docs/privacy.md` › a remote node sits inside your trust boundary.** Documented as an
  inherent property of `tari.mode: remote`, with operator guidance and a link to Configuration ›
  Trust boundary — not as an unfixed defect. #1446 already covers the related coverage gap.
- **`docs/operations.md` › the xmrig-proxy healthcheck.** A bounded, stated trade-off (a rare
  false ✓ instead of a permanent false ✗, on a release you are about to update past), with the
  condition that triggers it named.

## Verification

Docs-only diff, two files. Run on this branch's head:

- `make lint-md` — 0 errors, 50 files
- `make lint-docs-voice` — no banned words in 45 prose docs
- `make lint-path-references` — every named repo path resolves
- `make lint-file-budget` — OK

**Not run, and why:** `make lint-topology` fails its own self-test on this host — but it fails
identically on `origin/develop`'s copy of the script, so it is not this diff, and macOS was
deprecated as a test platform on 2026-09-10 (#2042) precisely because a failure there carries
no information. The four checks above were also run on macOS; they are pure text checks and CI
will re-run them on Linux. The added lines carry no `user@host`, IP literal, or `.local`
hostname (grepped).

Every issue state in the table above was read from the tracker with `gh issue view`, not from
memory or from the doc. Each factual claim added to the doc is quoted from either #2043's body
or the file it names (`tests/os/run.sh:14`,
`tests/os/phases/provision-initial.sh:161-164`, `docs/dev/appliance-release.md:366` and `:467`).

**Over-engineering pass:** `/ponytail-review` run on the diff; two findings, both applied in
`7a550be8`. The #976 Resolved entry was re-telling the whole OS-update feature path — six lines
copied out of the Open bullet it replaces — and now carries only what closed it and what that
does not mean; and one sentence of reader instruction in the Status header was cut as fact-free.
Net -8 lines. No new files, no new sections, no abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

