### PR TITLE
test(stack): scrub the operator's PITHEAD_* knobs from the suite environment (#1922)

### DIFF
--- a/tests/stack/lib.sh
+++ b/tests/stack/lib.sh
@@ -36,6 +36,19 @@ if [ "$(uname -s)" = "Darwin" ] && [ "${PITHEAD_UNTRUSTED_MACOS_RUN:-0}" != "1" 
     exit 1
 fi
 
+# The operator's PITHEAD_* knobs must not reach the assertions (#1922). Scripts the suite SOURCES read
+# them at source time -- release.sh:52-53 sets REGISTRY/IMAGE_PREFIX before any function runs -- so a
+# test that asserts a default was really asserting whatever the caller exported. That made release.sh's
+# own blocking `make test` gate red exactly when release.sh was used the way its PITHEAD_REGISTRY knob
+# documents: a LAN-registry RC cut. Derived from the live environment rather than a hand-kept list, so a
+# knob added to release.sh tomorrow is scrubbed without touching this line. A test that WANTS a knob set
+# assigns it in its own subshell, which still works. PITHEAD_UNTRUSTED_MACOS_RUN is kept: it is the
+# operator's answer to the refusal above, and run.sh re-sources this file in nested `bash` (#1330).
+for _knob in $(compgen -e -X '!PITHEAD_*'); do
+    [ "$_knob" = PITHEAD_UNTRUSTED_MACOS_RUN ] || unset "$_knob"
+done
+unset _knob
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 STACK="$ROOT/pithead"
 PASS=0

--- a/tests/stack/release/test-release.sh
+++ b/tests/stack/release/test-release.sh
@@ -63,6 +63,39 @@ assert_eq "image_for builds the GHCR image name" \
         image_for dashboard
     )" \
     "ghcr.io/p2pool-starter-stack/pithead-dashboard"
+# Firing control for the assertion above (#1922). On a clean shell that assertion is green whether or
+# not the suite scrubs the operator's knobs, so by itself it cannot see the bug it exists to catch:
+# release.sh reads REGISTRY and IMAGE_PREFIX at SOURCE time, so `make test` invoked from the shell that
+# cuts a LAN-registry release used to redden it -- release.sh's own gate, red exactly when release.sh
+# is driven as documented. A separate `bash` process is the only real isolation (#1330): a `( ... )`
+# subshell inherits THIS process's variable table, already scrubbed by lib.sh, and would pass on the
+# unfixed tree. Both knobs are set because unsetting only PITHEAD_REGISTRY leaves PITHEAD_IMAGE_PREFIX
+# reddening the identical line.
+# shellcheck disable=SC2016  # the inner script is deliberately unexpanded; paths arrive as $1/$2
+assert_eq "the operator's PITHEAD_* knobs do not reach the assertions (#1922)" \
+    "$(PITHEAD_REGISTRY=reg.invalid:5000/ops PITHEAD_IMAGE_PREFIX=ops- bash -c '
+        r="$1" rel="$2"   # named BEFORE `set --`, which clears the positionals
+        source "$r/tests/stack/lib.sh" >/dev/null 2>&1 || exit
+        cd "$r" || exit
+        set --
+        source "$rel" 2>/dev/null
+        set +eu
+        image_for dashboard
+    ' _ "$ROOT" "$REL")" \
+    "ghcr.io/p2pool-starter-stack/pithead-dashboard"
+# The other half of release.sh:52 -- the knob is a documented feature, and the scrub above must not be
+# "fixed" one day by hardcoding the default. This fails if a set PITHEAD_REGISTRY stops being honoured.
+# shellcheck disable=SC1090
+assert_eq "image_for honours a set PITHEAD_REGISTRY" \
+    "$(
+        cd "$ROOT" || exit
+        set --
+        export PITHEAD_REGISTRY=reg.invalid:5000/ops
+        source "$REL" 2>/dev/null
+        set +eu
+        image_for dashboard
+    )" \
+    "reg.invalid:5000/ops/pithead-dashboard"
 # --draft (#44): documented in --help, and --help stops at the comment header (a too-wide sed range
 # used to leak the script body, e.g. `set -euo pipefail`, into the help output).
 assert_contains "release --help documents --draft" "$(bash "$REL" --help 2>&1)" "--draft"


### PR DESCRIPTION
Closes #1922.

## The bug, reproduced on Linux

`scripts/release/release.sh:52-53` reads `PITHEAD_REGISTRY` / `PITHEAD_IMAGE_PREFIX` at **source** time, and `tests/stack/release/test-release.sh` sources the script to assert `image_for` builds the GHCR default. The assertion was therefore asserting whatever the caller exported — so `release.sh --draft --rc 1` against a LAN registry reddened release.sh's **own** blocking `make test` gate, exactly when release.sh was driven the way its documented knob says. The RC1 cut worked around it by hand with `--skip-tests`.

Release domain, 2×2 over tree × environment, run on Linux (base is the exact parent of this commit):

| tree | clean env | `PITHEAD_REGISTRY` exported |
|---|---|---|
| `a4b5b60c` (base) | 37 passed / 0 failed | **36 passed / 1 failed** |
| `6a5bd07d` (this PR) | 39 / 0 | 39 / 0 |

The single red is the assertion the issue names:

```
✗ image_for builds the GHCR image name
    expected [ghcr.io/p2pool-starter-stack/pithead-dashboard], got [reg.invalid:5000/ops/pithead-dashboard]
```

`base + clean` being green is what makes this an experiment rather than an anecdote: the red is caused by the environment, not by a broken base.

## Why not the fix the issue proposed

The issue proposed `env -u PITHEAD_REGISTRY` at the call site. That does not fix even the one line it names: `PITHEAD_IMAGE_PREFIX` reddens it identically (measured, `ghcr.io/p2pool-starter-stack/zz-dashboard`), and every future default-asserting test would have to repeat the incantation.

Fixed once in `tests/stack/lib.sh` instead — four lines, derived from the live environment rather than a hand-kept knob list, so a knob added to release.sh tomorrow is covered without editing that line. `PITHEAD_UNTRUSTED_MACOS_RUN` is kept: it is the operator's answer to the #2041 refusal immediately above it, and `run.sh` re-sources `lib.sh` in nested `bash` (#1330).

## Blast radius

- `tests/os/` — the appliance battery genuinely inherits `PITHEAD_REGISTRY` / `PITHEAD_REGISTRY_CA` (#2043: without them it provisions zero containers). It never sources `tests/stack/lib.sh`. Checked, not assumed.
- The Makefile exports no `PITHEAD_*`; CI passes `PITHEAD_UPDATER` only as a Docker build-arg.
- `make test-compose` runs `tests/stack/standalone/test_compose.sh`, which does **not** route through `lib.sh` and so is not covered by the scrub — but it asserts only that `docker-compose.yml`'s interpolations *resolve*, never that they resolve to the GHCR default, so an exported knob still passes it. `dashboard/`, `tests/netwatch/` and `tests/fakes/` read the knob nowhere.

## The two added assertions are non-vacuous

The pre-existing default assertion is green on a clean shell whether or not the scrub exists — by itself it cannot see the bug it exists to catch. The control exports both knobs into a **separate `bash` process**; a `( … )` subshell inherits this process's already-scrubbed variable table and would pass on the unfixed tree (the #1330 reasoning). Controlled pair against the unpatched `lib.sh`: unfixed yields `reg.invalid:5000/ops/ops-dashboard`, fixed yields the GHCR default.

The second assertion covers the other half of `release.sh:52` — a **set** `PITHEAD_REGISTRY` is still honoured — so the scrub cannot later be "fixed" by hardcoding the default.

## Verification

- CI: all 22 checks green on this head, including `Shell tests (pithead suite)` — the full shell suite on Linux, clean environment.
- Bench: the 2×2 above, which is the case CI cannot run (CI never exports the knob).
- Local: `lint-file-budget`, `lint-path-references`, `lint-operator-strings`, `lint-topology`, plus pinned `shfmt` 3.13.1 and `shellcheck` 0.11.0 over both changed files.

macOS runs were discarded rather than reported: the suite refuses to run on Darwin (#2041) because the assertions assume GNU tooling, so a result from there is not evidence in either direction.

Over-engineering pass: one candidate cut, the `# shellcheck disable=SC2016`, was tested and kept — stripping it produces two real SC2016 hits at default severity. The scrub itself went from a 7-line `case` loop to 4 lines via `compgen -e -X`. Skipped: per-knob `env -u` at call sites, and any change to `release.sh` — the script's behaviour is correct; the test's environment control was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
