### PR TITLE
Pin jq, add sudo, un-blind one grep, and bump uv off two HIGH CVEs (#2086, #2084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         # Curl the pinned installer (same posture as hadolint below); avoids a mutable-tag action.
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"   # deterministic install dir (runners may set CARGO_HOME)
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # download then run, never a pipe: the pipeline's status is sh's, which is 0 on empty input, so a failed download passed this step (#1788)
+          curl -LsSf https://astral.sh/uv/0.12.13/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # download then run, never a pipe: the pipeline's status is sh's, which is 0 on empty input, so a failed download passed this step (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Dashboard tests + coverage gate (emits coverage.xml)
         run: make test-dashboard
@@ -364,7 +364,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"   # deterministic install dir (runners may set CARGO_HOME)
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
+          curl -LsSf https://astral.sh/uv/0.12.13/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: ruff check + format --check (config in dashboard/pyproject.toml + root ruff.toml)
         # Single source of truth: the Makefile `lint-py` target, which runs ruff via uv from the
@@ -406,7 +406,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
+          curl -LsSf https://astral.sh/uv/0.12.13/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Audit workflows (injection, token scope, self-hosted-runner risks)
         run: uvx zizmor@1.25.2 --offline .github/workflows/
@@ -444,7 +444,7 @@ jobs:
       - name: Install uv (pinned)
         run: |
           export UV_INSTALL_DIR="$HOME/.local/bin"
-          curl -LsSf https://astral.sh/uv/0.10.10/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
+          curl -LsSf https://astral.sh/uv/0.12.13/install.sh -o /tmp/uv-install.sh; sh /tmp/uv-install.sh # never a pipe — see the dashboard job's copy (#1788)
           echo "$UV_INSTALL_DIR" >> "$GITHUB_PATH"
       - name: Lint docs voice, operator strings, topology classes, file budget, pithead build/trivy parity, then JS/CSS (Biome), YAML, Markdown, proto (buf), TOML (taplo)
         # Single source of truth: the Makefile targets. REPO-LOCAL GATES FIRST (#1746): local checks run before network-backed surface linters.

--- a/.github/workflows/test-images.yml
+++ b/.github/workflows/test-images.yml
@@ -80,7 +80,22 @@ jobs:
       # the lint gate depends on. The two bench images above are a different class: tiny, and they
       # run where real keys and chain data live. This one ships to no user and no bench.
       # It is still BUILT here, so a broken Dockerfile still reds, and Dependabot still bumps its
-      # base digest. uv's own currency gap is tracked separately as #2084.
+      # base digest.
+      #
+      # The scope was checked rather than assumed, because #2084 was filed believing this skipped
+      # only `usr/local/bin/uv` and `usr/local/bin/uvx` and scanned the rest. It does not — the `if`
+      # below skips the whole image — and the difference matters, because "remove the skip and the
+      # image scans clean" is not reachable. Measured on the built image, fixable HIGH/CRITICAL only
+      # (the gate's own scope), 2026-09-11:
+      #
+      #   debian 12.13 (os-pkgs)   6      usr/bin/gh                   2
+      #   Node.js (base image)    20      docker-buildx                1
+      #   usr/local/bin/shfmt     20      usr/local/bin/uv + uvx       4
+      #
+      # 53 across seven targets, and clearing shfmt's 20 means breaking the version `lint-sh`
+      # refuses to run without. A narrow skip would have to name every one of those targets, which
+      # is this `if` with more lines. uv's own pair went 4 -> 0 in #2084, measured on the digests
+      # directly, since this gate would not have reported it either way.
       - name: Scan image for CVEs (Trivy)
         if: matrix.service != 'test-runner'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -38,7 +38,7 @@ COPY mining_dashboard/ ./mining_dashboard/
 # here (and in test) but never into production.
 # ==========================================================================
 FROM base AS build
-COPY --from=ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44ba994e327b8fe7ed72beef1aaa7d2c4c795fd406d1dbf328bacb2f1c5 /uv /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.13@sha256:b485bd65cc2cf1c9a93b3554012c9c3778cf7b1b5fd3d3096ce9e1226c97e1e6 /uv /bin/
 RUN --mount=type=cache,target=/root/.cache/uv uv sync --locked
 
 # ==========================================================================

--- a/dashboard/mining_dashboard/client/tari/Readme.md
+++ b/dashboard/mining_dashboard/client/tari/Readme.md
@@ -7,6 +7,6 @@ The Tari gRPC client and its generated protobuf stubs.
 Ensure `base_node.proto` and `types.proto` are in the `proto/` subdirectory, then run:
 
 ```bash
-docker run --rm -v "$PWD":/work -w /work ghcr.io/astral-sh/uv:0.10.10-python3.11-trixie-slim \
+docker run --rm -v "$PWD":/work -w /work ghcr.io/astral-sh/uv:0.12.13-python3.11-trixie-slim \
   /bin/bash -c "uvx --from grpcio-tools python -m grpc_tools.protoc -Iproto --python_out=generated --grpc_python_out=generated proto/*.proto && sed -i 's/^import.*_pb2/from . \0/' generated/*_pb2*.py"
 ```

--- a/docs/dev/release-server.md
+++ b/docs/dev/release-server.md
@@ -145,8 +145,8 @@ sudo install -m 0755 "/tmp/shellcheck-v$SC/shellcheck" /usr/local/bin/shellcheck
 sudo curl -fsSL -o /usr/local/bin/shfmt "https://github.com/mvdan/sh/releases/download/v$SF/shfmt_v${SF}_linux_amd64"
 sudo chmod 0755 /usr/local/bin/shfmt
 
-# uv 0.10.10 (pinned installer; brings uvx, and adds ~/.local/bin to PATH)
-curl -LsSf https://astral.sh/uv/0.10.10/install.sh | sh
+# uv 0.12.13 (pinned installer; brings uvx, and adds ~/.local/bin to PATH)
+curl -LsSf https://astral.sh/uv/0.12.13/install.sh | sh
 ```
 
 ### The release signing key

--- a/docs/dev/testing-strategy.md
+++ b/docs/dev/testing-strategy.md
@@ -265,7 +265,7 @@ daemon. A tier that needs something the container cannot supply says so.
 |---|---|---|
 | 1 — dashboard pytest | `uv` only; it fetches the CPython pinned by `dashboard/.python-version`. No Docker, any OS. | Yes |
 | 1 — frontend `node --test` | Node 20. No Docker, any OS. | Yes |
-| 1 — shell suite (`tests/stack/`) | **Linux, GNU coreutils, non-root**, and a longer tool list than it looks: `bash`, `jq`, `e2fsprogs`, a system `python3` on PATH, `gh`, `xxd`, and a **UTF-8 locale**. Refuses on Darwin (#2041); root bypasses the permission-denied fixtures. Every one of those four last items fails *quietly* when absent — see the note below. | Yes — the container is how a non-Linux host runs this at all |
+| 1 — shell suite (`tests/stack/`) | **Linux, GNU coreutils, non-root**, and a longer tool list than it looks: `bash`, `jq` **1.7 or newer**, `e2fsprogs`, a system `python3` on PATH, `gh`, `xxd`, `sudo`, and a **UTF-8 locale**. Refuses on Darwin (#2041); root bypasses the permission-denied fixtures. Every one of those four last items fails *quietly* when absent — see the note below. | Yes — the container is how a non-Linux host runs this at all |
 | 1 — netwatch selftest | Docker: it builds the pinned harness images and asks each tool for its version. | Yes (host daemon via the socket) |
 | 2 — fakes contract | `uv` only. Docker-free by design. | Yes |
 | 3 — mini-stack | Docker, Compose v2, **and buildx**. Without the buildx plugin Compose falls back to the classic builder, which rejects the `RUN --mount=type=cache` in `dashboard/Dockerfile`, and the tier dies at `docker compose build failed` with nothing naming the cause. The driver must also reach the fakes' host-published ports — from inside a container that is `PITHEAD_TEST_HOST`, not `127.0.0.1`. | Yes |
@@ -283,6 +283,8 @@ failure class the image exists to remove:
 | `gh` | `release-smoke.sh` exits at source time, so `upgraded_install_dir` is never defined and the #1068 assertions read an empty path. |
 | `xxd` | `build/tor/healthcheck-selftest.sh` symlinks each command the tor image ships; `command -v` yields empty, `ln` links to nothing, and the PATH-isolation case returns the wrong verdict (#1372). |
 | A UTF-8 locale | `grep` calls the generated `pithead` a binary file and prints `binary file matches` instead of the line, so the #1084 cosign-pin assertion reads a live pin as absent. |
+| `jq` **1.6** (present, wrong version — Debian bookworm's) | 1.7 preserves number literals and 1.6 does not: `echo '{"height": 100.0}' \| jq '.height\|tostring'` renders `100` under 1.6 and `"100.0"` under 1.7. `integral JSON floats do not pass as integer heights` reads `expected [protocol], got [ok]` (#2086). The container pins 1.7.1 — what ubuntu-24.04 runs — by sha256 for this reason. |
+| `sudo` | `tests/stack/appliance/test-appliance-wizard-spool.sh` builds a real root/page UID boundary with `setpriv`. It refuses to count itself as passed without both (`real root/page boundary requires sudo and setpriv` -> `not run`), which is the honest shape — but the tier is incomplete until the host supplies them. The container does; see `tests/runner/Dockerfile` for why that is a smaller grant than the Docker socket it already holds. |
 
 Two host-level constraints apply to the container itself:
 

--- a/tests/runner/Dockerfile
+++ b/tests/runner/Dockerfile
@@ -121,8 +121,10 @@ RUN arch="$(dpkg --print-architecture)" \
     && install -m 0755 /tmp/jq /usr/local/bin/jq \
     && rm -f /tmp/jq
 
-# uv, pinned to the digest ci.yml installs (#2078: one uv, one lock, both sides).
-COPY --from=ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44ba994e327b8fe7ed72beef1aaa7d2c4c795fd406d1dbf328bacb2f1c5 /uv /uvx /usr/local/bin/
+# uv, pinned to the digest ci.yml installs (#2078: one uv, one lock, both sides). 0.10.10 carried
+# two fixable HIGH CVEs in its own vendored Rust deps (quinn-proto GHSA-4w2j-m93h-cj5j,
+# rustls-webpki GHSA-82j2-j2ch-gfr8) — measured on this exact digest, clean on this one (#2084).
+COPY --from=ghcr.io/astral-sh/uv:0.12.13@sha256:b485bd65cc2cf1c9a93b3554012c9c3778cf7b1b5fd3d3096ce9e1226c97e1e6 /uv /uvx /usr/local/bin/
 
 # The suite expects a NON-ROOT user: several fixtures assert permission-denied, and root bypasses
 # every one of them — they would pass while proving nothing. UID/GID come from the invoking host so

--- a/tests/runner/Dockerfile
+++ b/tests/runner/Dockerfile
@@ -46,6 +46,14 @@ ARG SHELLCHECK_SHA256_aarch64=12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e2
 # nothing, and the case that should prove PATH isolation reports the wrong verdict instead.
 # docker-cli + compose plugin: test-compose, test-mini-stack, test-netwatch and lint-proto all
 # shell out to docker. The daemon is the HOST's, reached through the mounted socket.
+# sudo: ONE fixture needs real root — tests/stack/appliance/test-appliance-wizard-spool.sh builds a
+# genuine root/page UID boundary with setpriv and refuses to count itself as passed without it
+# (`bad ... "not run"`, #2086). It is a deliberate widening and worth naming rather than slipping
+# in: this container is already handed the host's Docker socket, which is host-root-equivalent by
+# itself (`docker run -v /:/host --privileged` is one command away), so NOPASSWD root INSIDE the
+# container grants strictly less than it already holds. The default user stays non-root, so the
+# permission-denied fixtures that root would silently bypass are untouched.
+# jq is deliberately NOT in this list — it is pinned from upstream below; see that block for why.
 # The two keyrings below are fetched over TLS with no fingerprint pin — the method each vendor
 # documents, and weaker than the byte-exact sha256 pins this file uses for shellcheck and shfmt.
 # Named rather than hidden: it is trust-on-first-use against download.docker.com and
@@ -56,8 +64,8 @@ ARG SHELLCHECK_SHA256_aarch64=12b331c1d2db6b9eb13cfca64306b1b157a86eb69db83023e2
 # with nothing pointing at the real cause. Measured, not guessed (#2078).
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash ca-certificates coreutils curl e2fsprogs findutils git gnupg jq make \
-    openssh-client python3 xxd \
+    bash ca-certificates coreutils curl e2fsprogs findutils git gnupg make \
+    openssh-client python3 sudo xxd \
     procps tar xz-utils \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
@@ -89,6 +97,30 @@ RUN arch="$(dpkg --print-architecture)" \
     && install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck \
     && rm -rf /tmp/shfmt /tmp/sc.tar.xz "/tmp/shellcheck-v${SHELLCHECK_VERSION}"
 
+# jq, pinned the same way and for the same reason the image exists (#2086). Debian bookworm's is
+# 1.6; ubuntu-24.04 — what CI runs — has 1.7.1, and the two disagree on a value the suite asserts:
+#   echo '{"height": 100.0}' | jq '.height|tostring'   ->  1.6: 100     1.7: "100.0"
+# 1.7 preserves the number literal. `integral JSON floats do not pass as integer heights` turns on
+# exactly that, and read `expected [protocol], got [ok]` under 1.6 — a tool version silently
+# changing a verdict, which is the failure class this image exists to remove. No Makefile variable
+# to read: unlike shellcheck and shfmt, no gate enforces a jq version, and CI's copy is whatever
+# ubuntu-24.04 preinstalls, so the version is written here against that.
+ARG JQ_VERSION=1.7.1
+# sha256s from the release's own sha256sum.txt, per arch — a version bumped without its hash fails
+# the build loudly rather than installing something unverified.
+ARG JQ_SHA256_amd64=5942c9b0934e510ee61eb3e30273f1b3fe2590df93933a93d7c58b81d19c8ff5
+ARG JQ_SHA256_arm64=4dd2d8a0661df0b22f1bb9a1f9830f06b6f3b8f7d91211a1ef5d7c4f06a8b4a5
+RUN arch="$(dpkg --print-architecture)" \
+    && case "$arch" in \
+    amd64) jq_sha="$JQ_SHA256_amd64" ;; \
+    arm64) jq_sha="$JQ_SHA256_arm64" ;; \
+    *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/jq "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-${arch}" \
+    && echo "${jq_sha}  /tmp/jq" | sha256sum -c - \
+    && install -m 0755 /tmp/jq /usr/local/bin/jq \
+    && rm -f /tmp/jq
+
 # uv, pinned to the digest ci.yml installs (#2078: one uv, one lock, both sides).
 COPY --from=ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44ba994e327b8fe7ed72beef1aaa7d2c4c795fd406d1dbf328bacb2f1c5 /uv /uvx /usr/local/bin/
 
@@ -107,6 +139,14 @@ RUN groupadd -g "$PITHEAD_GID" pithead 2>/dev/null || true; \
     mkdir -p /home/pithead && chown -R "$PITHEAD_UID:$PITHEAD_GID" /home/pithead \
     && [ "$(stat -c %u /home/pithead)" = "$PITHEAD_UID" ] \
     && [ "$(stat -c %g /home/pithead)" = "$PITHEAD_GID" ]
+# The sudo grant, keyed to the UID rather than the name: the useradd above is allowed to fail on a
+# collision, so on a host
+# whose uid already exists in the base image there is no user called `pithead` and a name-keyed rule
+# would be inert — sudo would refuse and the fixture would still report `not run`, which is the
+# exact silent-wrong-verdict shape this image exists to remove.
+RUN printf '#%s ALL=(ALL) NOPASSWD: ALL\n' "$PITHEAD_UID" > /etc/sudoers.d/pithead \
+    && chmod 0440 /etc/sudoers.d/pithead \
+    && visudo -cf /etc/sudoers.d/pithead
 USER $PITHEAD_UID:$PITHEAD_GID
 ENV HOME=/home/pithead
 # npx and uvx download on first use, exactly as they do in CI. The runner script keeps HOME on a

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -332,7 +332,7 @@ else
     bad "control: the pre-fix data-dir verdict was NOT caught" "instrument cannot fail; the assertions below prove nothing"
 fi
 
-_dd_line=$(grep -n 'Data dir from .env not found' "$STACK" | head -1)
+_dd_line=$(grep -a -n 'Data dir from .env not found' "$STACK" | head -1)
 if [ -z "$_dd_line" ]; then
     bad "the data-dir verdict is present in the shipped artifact (#1776)" "no line matched -- the message was renamed and the assertions below are vacuous"
 else


### PR DESCRIPTION
Two issues, one commit each. Both are about the test-runner image (#2078/#2083) telling the truth.

## #2086 — `make test-stack` in the container was 3970/3, not clean

pithead#2083's body and merge commit both say `tests/stack` went "60 failures to 0". That figure was read off a run still in progress; all three surviving failures land later in the suite than the point it was taken. The true starting figure is **60 -> 3**.

**1. `jq` was the one unpinned tool** in an image whose entire purpose is removing "a tool version silently changes a verdict". Debian bookworm ships 1.6, ubuntu-24.04 (CI) runs 1.7.1, and they disagree on a value the suite asserts:

```
echo '{"height": 100.0}' | jq '.height|tostring'
  1.6 -> 100        1.7 -> "100.0"
```

Now installed from the upstream release at **1.7.1** with a per-arch sha256 taken from that release's own `sha256sum.txt` — the same shape as the shellcheck and shfmt pins two blocks up.

**2. `tests/stack/run.sh:335` lacked `-a`.** Same defect #2083 fixed in `scripts/release/preflight.sh` and two sites in `tests/stack/test-config.sh`, missed here. Only the shape that **captures** matched text is vulnerable — `grep -q`/`grep -c` over the same file are not — so a sweep keyed on "greps `$STACK`" over-reports. Swept the repo for the capturing shape: this site and no other. Left uncommented to match the two sibling sites in `test-config.sh`, and because `run.sh` sits exactly on its recorded 440-line ceiling.

**3. The image had `setpriv` but no `sudo`**, so the real root/page UID-boundary fixture reported `not run` — correctly refusing to count itself as passed. **Decision: added**, and argued rather than slipped in. This container is already handed the host's Docker socket, which is host-root-equivalent on its own (`docker run -v /:/host --privileged` is one command away), so NOPASSWD root *inside* it grants strictly less than it already holds. The default user stays non-root, so the permission-denied fixtures root would bypass are untouched. The rule is keyed to the **UID, not the name** `pithead`: the `useradd` above it is allowed to fail on a collision, and a name-keyed rule would be silently inert on exactly the hosts that need it.

### Evidence — a controlled pair, read from finished logs on a macOS host

| image | `run.sh` | result |
|---|---|---|
| old (jq 1.6, no sudo) | this PR's | **3978 passed, 2 failed** |
| this PR's | this PR's | **3980 passed, 0 failed**, rc 0 |

The first row isolates the grep fix: the four data-dir rows it un-vacuums all pass, and the only survivors are the two the image itself had to fix. Built image verified in place: `jq-1.7.1`, `uv 0.12.13`, `sudo -n true` succeeds.

## #2084 — uv 0.10.10 carried two fixable HIGH CVEs

```
ghcr.io/astral-sh/uv:0.10.10@sha256:cbe0a44b…   uv -> 2 HIGH   uvx -> 2 HIGH
ghcr.io/astral-sh/uv:0.12.13@sha256:b485bd65…   uv -> 0        uvx -> 0
```
(quinn-proto GHSA-4w2j-m93h-cj5j, rustls-webpki GHSA-82j2-j2ch-gfr8; both `fixed`, so `--ignore-unfixed` does not hide them.)

**Five sites held the pin, not the three #2084 names.** The two it missed are the worse kind of stale — instructions a person follows by hand: `docs/dev/release-server.md` and `dashboard/.../tari/Readme.md`. All move together. (`ci.yml` also installs by **version only**; there is no sha256 on those four lines, contrary to the issue's description.)

`uv 0.12.13 lock --check` resolves `dashboard/uv.lock` unchanged.

### Declined: removing the Trivy skip — measured, not deferred

#2084 believed `test-images.yml` skipped only `usr/local/bin/uv` and `uvx` and scanned the rest. It does not: the `if:` skips the **whole image**. And "the image scans clean" is unreachable — built image, fixable HIGH/CRITICAL only:

| target | fixable |
|---|---|
| debian 12.13 (os-pkgs) | 6 |
| Node.js (base image) | 20 |
| `usr/local/bin/shfmt` | 20 |
| `usr/bin/gh` | 2 |
| `docker-buildx` | 1 |
| `usr/local/bin/uv` + `uvx` | **4 -> 0** |

53 across seven targets. Clearing shfmt's 20 means breaking the version `lint-sh` refuses to run without — #2083's structural argument, and it holds. A narrow skip would have to name every remaining target, i.e. the present `if` written longhand. The real concern behind the ask — that the scan cannot tell *fixed* from *hidden* — is answered by measuring uv directly on both digests, and `test-images.yml` now carries the table so nobody re-derives it.

## Checks run

`shfmt`, `shellcheck --severity=warning` on the changed shell file; `lint-file-budget` (`run.sh` held at exactly 440), `lint-md`, `lint-yaml`; CI's pinned hadolint v2.12.0 on both changed Dockerfiles — `dashboard/Dockerfile` clean, `tests/runner/Dockerfile`'s one DL3046 reproduces byte-for-byte on `origin/develop` and is outside CI's hadolint scope anyway. Not run: `make test` in full — `lint-sh` peaks at 7.20 GiB and this engine has 3.8.

Over-engineering pass cut 6 lines: a `jq --version` assertion the per-arch sha256 already guarantees, and three paragraphs that restated their neighbours.

Closes #2086
Closes #2084

🤖 Generated with [Claude Code](https://claude.com/claude-code)