### PR TITLE
fix(egress): the Tor-only egress firewall must prove itself, and doctor must be able to fail (#2059)

### DIFF
--- a/docs/dev/file-budget.tsv
+++ b/docs/dev/file-budget.tsv
@@ -71,7 +71,7 @@ tests/stack/control/test-control-upgrade.sh	795
 tests/stack/dashboard/test-dashboard-onion.sh	422
 tests/stack/dashboard/test-dashboard.sh	591
 tests/stack/doctor/test-doctor.sh	507
-tests/stack/run.sh	440
+tests/stack/run.sh	407
 tests/stack/secrets/test-secrets.sh	401
 tests/stack/standalone/test_compose.sh	462
 tests/stack/test-backup.sh	476

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -43,7 +43,12 @@ by channel:
   survives netavark reprogramming its own table.
 
 `pithead doctor` reads whichever mechanism the running engine uses and checks the drop is in a chain
-that is actually hooked at forward, so it cannot report enforced while the rules are orphaned.
+that is actually hooked at forward, so it cannot report enforced while the rules are orphaned. The
+install reads the same live state back before it reports success, so "Tor-only egress enforced" in
+the log means the rules were found in the kernel, not that the install command exited zero. A host
+whose engine has no firewall backend installed at all cannot enforce anything, so `doctor` FAILs
+there rather than skipping the check — on the appliance that is what stops a slot with no firewall
+from committing itself as healthy.
 
 The allow-set matches on IPv4 addresses because the mining bridge is IPv4-only by design. On the
 appliance path the firewall also fences IPv6: if the mining network ever gains an IPv6 subnet, an

--- a/lib/pithead/02-tor-egress.sh
+++ b/lib/pithead/02-tor-egress.sh
@@ -94,6 +94,59 @@ mining_net_ipv6_bridge() {
     printf '%s' "$br"
 }
 
+# Read the LIVE enforcement state back out of the kernel. Single-sourced on purpose (#2059): it is
+# what `apply` proves its own install with AND what `doctor` reports, so the two can no longer
+# disagree about what "installed" means. Before this, apply logged "Tor-only egress enforced"
+# straight off a zero exit from the install command and doctor kept a second, differently-shaped
+# copy of the probe — an appliance that installed nothing shipped green behind both.
+#
+# The hook, not merely a rule: the failure #855 was about is a DROP sitting in a chain no packet
+# traverses, which is exactly what a base chain hooked at forward CANNOT be.
+#
+# rc 0 = enforced. 1 = definitively NOT enforced (we read the ruleset; the rules are not in it).
+# 2 = CANNOT be enforced at all (the backend's tool is absent — not an unknown, a certainty that
+# nothing is dropping). 3 = genuinely unreadable (no passwordless sudo), the only verdict that is
+# an honest "I cannot tell". Callers act on all four differently; collapsing 2 into 3 is how a
+# fail-open box passed the A/B commit gate.
+tor_egress_enforced() {
+    local out
+    if [ "$(container_engine)" = "podman" ]; then
+        command -v nft >/dev/null 2>&1 || return 2
+        # `nft list table` returns rc 1 both when the table is missing AND when sudo -n is refused; a
+        # cheap `list tables` probe (succeeds whether or not our table exists) tells the two apart, so
+        # a sudo refusal can't masquerade as a missing firewall (a false "not enforced").
+        sudo -n nft list tables >/dev/null 2>&1 || return 3
+        out=$(sudo -n nft list table inet "$TOR_EGRESS_NFT_TABLE" 2>/dev/null) || return 1
+        printf '%s\n' "$out" | grep -q 'hook forward' || return 1
+        printf '%s\n' "$out" | grep -qw drop || return 1
+        return 0
+    fi
+    command -v iptables >/dev/null 2>&1 || return 2
+    # Same two-probe shape as the nft branch above, and for the same reason: `-S DOCKER-USER` fails
+    # both when sudo is refused AND when the chain does not exist. A bare `-S` (which lists whatever
+    # is there) separates them, so a deleted DOCKER-USER reads as NOT ENFORCED rather than as an
+    # unreadable ruleset doctor would skip past.
+    sudo -n iptables -S >/dev/null 2>&1 || return 3
+    out=$(sudo -n iptables -S DOCKER-USER 2>/dev/null) || return 1
+    printf '%s\n' "$out" | grep -qF -- "$TOR_EGRESS_TAG" || return 1
+    return 0
+}
+
+# An install may only CLAIM success once the kernel agrees. Every failure line carries a stable
+# `egress-apply:<reason>` token because the #2059 diagnostics read a BOUNDED journal excerpt — a
+# token is what lets that excerpt name which exit fired instead of leaving the next battery to
+# guess between exits that need opposite fixes.
+tor_egress_verify_or_warn() { # <success message>
+    local rc=0
+    tor_egress_enforced || rc=$?
+    case "$rc" in
+    0) log "$1" ;;
+    1) warn "egress-apply:verify-absent — the Tor-egress rules installed without error but are NOT in the live ruleset. Clearnet egress is NOT fail-closed." ;;
+    2) warn "egress-apply:verify-no-tool — the Tor-egress rules cannot be read back because the backend's tool is not on PATH. Clearnet egress is NOT fail-closed." ;;
+    *) warn "egress-apply:verify-unreadable — the Tor-egress rules installed, but reading them back needs passwordless sudo, so enforcement is UNPROVEN." ;;
+    esac
+}
+
 # Remove every rule we previously installed — idempotent, config-agnostic, engine-agnostic. Clears
 # BOTH backends so a re-apply (or an engine change) can't leave a stale set behind: drop the nft
 # table if present, then delete the tagged DOCKER-USER rules if present.
@@ -140,35 +193,41 @@ apply_tor_egress_firewall() {
     fi
 }
 
-# Appliance/netavark path: load the independent nft table (atomic, idempotent-replace).
+# Appliance/netavark path: load the independent nft table (atomic, idempotent-replace), then PROVE
+# it landed before saying so.
 apply_tor_egress_nft() { # <subnet> <tor_ip>
-    local subnet="$1" tor_ip="$2" br rc
+    local subnet="$1" tor_ip="$2" br rc=0
     if ! command -v nft >/dev/null 2>&1; then
-        warn "nftables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
+        warn "egress-apply:nft-missing — nftables not found, cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
         return 0
     fi
     # mining_net is IPv4-only by design, so br is empty and the ruleset stays v4-only. If it ever
     # gains an IPv6 subnet we key a v6 fail-closed drop on its bridge interface. rc 3 means v6 is
     # present but the bridge couldn't be resolved — refuse rather than load a v4-only firewall we'd
     # then wrongly report as fail-closed (a v6 clearnet leak would fall through policy accept).
-    br=$(mining_net_ipv6_bridge)
-    rc=$?
+    #
+    # `|| rc=$?`, not a bare assignment followed by `rc=$?` (#2059): the program runs under
+    # `set -Eeuo pipefail`, where `br=$(f)` with a non-zero f is a failing simple command — errexit
+    # fires and the shell is GONE before the next line can read $?. The refusal below was therefore
+    # unreachable, and a v6-capable mining_net killed `up` mid-stack_up with rc 3 and no message at
+    # all. Guarding the assignment is what makes the branch it guards able to run.
+    br=$(mining_net_ipv6_bridge) || rc=$?
     if [ "$rc" -eq 3 ]; then
-        warn "mining_net has an IPv6 subnet but its bridge interface could not be resolved — REFUSING to install a v4-only egress firewall that would leave IPv6 clearnet un-fenced. Recreate mining_net or set network.tor_egress_firewall=false to acknowledge."
+        warn "egress-apply:v6-bridge-unresolved — mining_net has an IPv6 subnet but its bridge interface could not be resolved. REFUSING to install a v4-only egress firewall that would leave IPv6 clearnet un-fenced. Recreate mining_net or set network.tor_egress_firewall=false to acknowledge."
         return 0
     fi
     if ! render_tor_egress_nft "$subnet" "$tor_ip" "$br" | sudo nft -f - 2>/dev/null; then
-        warn "Could not install the Tor-egress firewall (needs root + nftables). Stack runs, but clearnet egress is NOT fail-closed."
+        warn "egress-apply:nft-load-failed — could not install the Tor-egress firewall (needs root + nftables). Stack runs, but clearnet egress is NOT fail-closed."
         return 0
     fi
-    log "Tor-only egress enforced: clearnet dials from $subnet${br:+ (IPv4) and via $br (IPv6)} dropped except via Tor ($tor_ip)."
+    tor_egress_verify_or_warn "Tor-only egress enforced: clearnet dials from $subnet${br:+ (IPv4) and via $br (IPv6)} dropped except via Tor ($tor_ip)."
 }
 
 # DIY/Docker path: insert the tagged rules into DOCKER-USER, which Docker jumps to from FORWARD.
 apply_tor_egress_iptables() { # <subnet> <tor_ip>
     local subnet="$1" tor_ip="$2" pos=1 rule
     if ! command -v iptables >/dev/null 2>&1; then
-        warn "iptables not found — cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
+        warn "egress-apply:iptables-missing — iptables not found, cannot enforce Tor-only egress. The stack runs, but clearnet egress is NOT fail-closed."
         return 0
     fi
     # DOCKER-USER may not exist yet on a first-ever `up` (Docker creates it with its first network).
@@ -178,11 +237,11 @@ apply_tor_egress_iptables() { # <subnet> <tor_ip>
     while IFS= read -r rule; do
         # shellcheck disable=SC2086  # intentional word-splitting of the rule body
         if ! sudo iptables -I DOCKER-USER "$pos" -m comment --comment "$TOR_EGRESS_TAG" $rule 2>/dev/null; then
-            warn "Could not install the Tor-egress firewall (needs root + iptables). Stack runs, but clearnet egress is NOT fail-closed."
+            warn "egress-apply:iptables-insert-failed — could not install the Tor-egress firewall (needs root + iptables). Stack runs, but clearnet egress is NOT fail-closed."
             remove_tor_egress_firewall
             return 0
         fi
         pos=$((pos + 1))
     done < <(tor_egress_rules "$subnet" "$tor_ip")
-    log "Tor-only egress enforced: clearnet dials from $subnet dropped except via Tor ($tor_ip)."
+    tor_egress_verify_or_warn "Tor-only egress enforced: clearnet dials from $subnet dropped except via Tor ($tor_ip)."
 }

--- a/lib/pithead/21-doctor-stack-checks.sh
+++ b/lib/pithead/21-doctor-stack-checks.sh
@@ -32,7 +32,16 @@ check_tor_running() {
 # doctor (#383): verify the #270 fail-closed egress rules are ACTUALLY installed while the stack
 # runs. `down` removes them, and a host reboot silently drops them while `restart: unless-stopped`
 # brings every container back — that reboot gap is the state this catches. Read-only: `sudo -n`
-# never prompts; every can't-check path degrades to an info line, only a confirmed absence FAILs.
+# never prompts.
+#
+# "Every can't-check path degrades to an info line" was the rule here, and it is what let a
+# fail-open appliance mark its own A/B slot good (#2059). os/overlay/pithead-boot gates the commit
+# on this exit code precisely because doctor "FAILs on a missing egress firewall" — but a podman
+# host with no `nft` on PATH took the info door, doctor exited 0, and a leaking slot committed.
+#
+# "I cannot READ the rules" (no passwordless sudo) and "there ARE no rules, because the tool that
+# installs them is absent" are not the same verdict, and only the first is an honest unknown. The
+# second is a certainty that nothing is dropping, so it FAILs like any other confirmed absence.
 check_egress_firewall_installed() {
     local enabled
     enabled=$(env_get TOR_EGRESS_FIREWALL 2>/dev/null)
@@ -48,55 +57,22 @@ check_egress_firewall_installed() {
         dr_info "Tor-egress firewall check skipped — the tor container isn't running."
         return 0
     fi
-    if [ "$(container_engine)" = "podman" ]; then
-        check_egress_firewall_nft
-    else
-        check_egress_firewall_iptables
+    # Single-sourced with apply (lib/pithead/02-tor-egress.sh): the same tor_egress_enforced()
+    # that an install proves itself with is what reports here, so doctor and the boot log can no
+    # longer disagree about what "installed" means — the disagreement #855 shipped.
+    local rc=0 how="nftables (inet $TOR_EGRESS_NFT_TABLE)" reread="sudo nft list table inet $TOR_EGRESS_NFT_TABLE"
+    if [ "$(container_engine)" != "podman" ]; then
+        how="iptables ($TOR_EGRESS_TAG in DOCKER-USER)"
+        reread="sudo iptables -S DOCKER-USER | grep $TOR_EGRESS_TAG"
     fi
+    tor_egress_enforced || rc=$?
+    case "$rc" in
+    0) dr_ok "Tor-only egress firewall is installed — clearnet dials from the stack are fail-closed via $how." ;;
+    1) dr_fail_surface "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them." "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a reboot in which the rules were lost but the containers came back. Restarting this machine reinstalls them." ;;
+    2) dr_fail_surface "Tor-only egress CANNOT be enforced — the $how backend's command is not installed on this host, so nothing is dropping clearnet dials from the stack. Install it and run './pithead up', or set network.tor_egress_firewall=false to acknowledge running without it." "Tor-only egress CANNOT be enforced on this machine — the firewall command it needs is missing, so clearnet dials from the stack are not being dropped." ;;
+    *) dr_info_surface "Tor-egress firewall check skipped — reading the rules needs passwordless sudo. Verify manually: '$reread'." "Tor-egress firewall check skipped — the firewall rules could not be read on this machine." ;;
+    esac
     return 0
-}
-
-# Appliance/netavark probe. The failure this whole fix is about — a DROP that exists in a chain no
-# packet traverses — is exactly what a base chain hooked at forward CANNOT be: if the table carries a
-# `hook forward` chain with a `drop`, forwarded packets DO pass through it. So we assert the hook and
-# the drop, not merely that some rule exists somewhere.
-check_egress_firewall_nft() {
-    local ruleset
-    if ! command -v nft >/dev/null 2>&1; then
-        dr_info "Tor-egress firewall check skipped — no nftables."
-        return 0
-    fi
-    # `nft list table` returns rc 1 both when the table is missing AND when sudo -n is refused; a
-    # cheap `list tables` probe (succeeds whether or not our table exists) tells the two apart, so a
-    # sudo refusal can't masquerade as a missing firewall (a false FAIL).
-    if ! sudo -n nft list tables >/dev/null 2>&1; then
-        dr_info_surface "Tor-egress firewall check skipped — reading nftables needs passwordless sudo. Verify manually: 'sudo nft list table inet $TOR_EGRESS_NFT_TABLE'." "Tor-egress firewall check skipped — the nftables rules could not be read on this machine."
-        return 0
-    fi
-    ruleset=$(sudo -n nft list table inet "$TOR_EGRESS_NFT_TABLE" 2>/dev/null) || ruleset=""
-    if printf '%s\n' "$ruleset" | grep -q 'hook forward' && printf '%s\n' "$ruleset" | grep -qw drop; then
-        dr_ok "Tor-only egress firewall is installed — clearnet dials from the stack are fail-closed via nftables (inet $TOR_EGRESS_NFT_TABLE)."
-    else
-        dr_fail_surface "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them." "Tor-only egress firewall is MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a reboot in which the rules were lost but the containers came back. Restarting this machine reinstalls them."
-    fi
-}
-
-# DIY/Docker probe: the tagged rules in DOCKER-USER, which Docker's FORWARD jump traverses.
-check_egress_firewall_iptables() {
-    local rules
-    if ! command -v iptables >/dev/null 2>&1; then
-        dr_info "Tor-egress firewall check skipped — no iptables."
-        return 0
-    fi
-    if ! rules=$(sudo -n iptables -S DOCKER-USER 2>/dev/null); then
-        dr_info_surface "Tor-egress firewall check skipped — reading iptables needs passwordless sudo. Verify manually: 'sudo iptables -S DOCKER-USER | grep $TOR_EGRESS_TAG'." "Tor-egress firewall check skipped — the iptables rules could not be read on this machine."
-        return 0
-    fi
-    if printf '%s\n' "$rules" | grep -qF -- "$TOR_EGRESS_TAG"; then
-        dr_ok "Tor-only egress firewall rules are installed — clearnet dials from the stack are fail-closed."
-    else
-        dr_fail_surface "Tor-only egress firewall rules are MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a host reboot (the rules are gone but the containers auto-restarted). Run './pithead up' to reinstall them." "Tor-only egress firewall rules are MISSING while the stack runs — clearnet egress is NOT fail-closed. This happens after a reboot in which the rules were lost but the containers came back. Restarting this machine reinstalls them."
-    fi
 }
 
 # doctor (#383): something must actually LISTEN on the stratum port while xmrig-proxy runs — the

--- a/lib/pithead/50-control-runner-provisioning.sh
+++ b/lib/pithead/50-control-runner-provisioning.sh
@@ -44,8 +44,10 @@ control_units_owner_dir() {
 provision_control_runner() {
     [ "$OS_TYPE" == "Linux" ] || return 0
     command -v systemctl >/dev/null 2>&1 || return 0
-    local unit_dir
+    local unit_dir engine
     unit_dir=$(control_unit_dir)
+    # The engine this install was provisioned WITH, pinned into the unit below (#2059).
+    engine=$(container_engine)
     # Enablement must be --runtime wherever the units are runtime units: on the appliance's
     # read-only root, systemd cannot write the /etc symlink a persistent enable needs.
     local -a enable_args=(enable --now)
@@ -80,8 +82,14 @@ provision_control_runner() {
     # Already installed for this checkout — keep the routine apply sudo-free. (-F: both paths
     # are literals — versioned dirs carry dots (pithead-v1.9.3), and the glob star must not
     # read as a regex repeat.)
+    #
+    # The engine pin is part of the skip condition, not just the template (#2059). A unit written
+    # before that pin existed matches on its glob and ExecStart alone, so a template-only fix would
+    # be silently inert on every box already provisioned — including the one the defect was measured
+    # on. Falling through costs one sudo write, once, and then converges.
     if grep -qsF "PathExistsGlob=$CONTROL_DIR/requests/*.json" "$unit_dir/pithead-control.path" &&
-        grep -qsF "ExecStart=$PWD/pithead control-run-pending" "$unit_dir/pithead-control.service"; then
+        grep -qsF "ExecStart=$PWD/pithead control-run-pending" "$unit_dir/pithead-control.service" &&
+        grep -qsF "Environment=PITHEAD_ENGINE=$engine" "$unit_dir/pithead-control.service"; then
         return 0
     fi
     # The grep above is an idempotence skip, not an ownership check. The removal branch got its
@@ -118,6 +126,21 @@ Description=pithead dashboard control runner (#33)
 Type=oneshot
 User=root
 WorkingDirectory=$PWD
+# Pin the engine (#2059). A systemd unit does NOT read /etc/environment — that is PAM, for login
+# shells — so the appliance image's own PITHEAD_ENGINE pin never reaches a unit, which is why
+# pithead-boot, pithead-firstboot and pithead-setup-again each set it explicitly. This unit is
+# rendered here rather than shipped in os/overlay/, and it was the one that did not.
+#
+# Without it container_engine() falls through to probing, and the probe prefers docker — which
+# EXISTS on the appliance, as podman-docker ships /usr/bin/docker as a shim onto podman. So every
+# dashboard-driven apply took the DOCKER branch on a podman/netavark box: it deleted the live
+# inet pithead_egress table and reinstalled the rules into DOCKER-USER, a chain netavark never
+# jumps to, leaving clearnet egress fail-open with the boot log reporting it enforced. That is
+# #855's failure mode arriving through the one path #855 did not cover.
+#
+# DETECTED, never hardcoded to podman: the same renderer runs on the DIY channel, where docker is
+# the correct answer. What the unit inherits is whatever the install itself was provisioned with.
+Environment=PITHEAD_ENGINE=$engine
 ExecStart=$PWD/pithead control-run-pending
 EOF
     sudo tee "$unit_dir/pithead-control.path" >/dev/null <<EOF

--- a/tests/stack/control/test-control-provisioning.sh
+++ b/tests/stack/control/test-control-provisioning.sh
@@ -149,3 +149,71 @@ assert_contains "install: own drifted unit -> converged (rewritten in place)" \
 assert_contains "install: no units at all -> fresh install unaffected by the guard" \
     "$(pci_run - "$PCI/mine")" "sudo:tee $PCI/units/pithead-control.service"
 unset PCI pci_run out
+
+echo "== unit: the rendered control unit PINS the engine it was provisioned with (#2059) =="
+# The #2059 root cause, measured on the bench: pithead-control.service was the ONE pithead unit
+# with no PITHEAD_ENGINE. A systemd unit does not read /etc/environment (that is PAM), so the
+# appliance image's pin never reached it, container_engine() fell through to probing, and the probe
+# prefers `docker` — which EXISTS there as podman-docker's shim. Every dashboard-driven apply then
+# took the Docker branch on a podman/netavark box: it deleted the live `inet pithead_egress` table
+# and reinstalled into DOCKER-USER, a chain netavark never jumps to. Two doctor runs four seconds
+# apart on the same guest proved the variable: engine pinned -> exit 0, unpinned -> FAIL.
+#
+# These write for real (a sudo that execs) rather than recording calls, because the assertions are
+# about the unit's CONTENT, not about whether tee was reached.
+PCE="$SANDBOX/pce"
+mkdir -p "$PCE/units" "$PCE/bin" "$PCE/mine/data/control"
+printf '#!/usr/bin/env bash\n[ "$1" = "-s" ] && { echo Linux; exit 0; }\nexec uname "$@"\n' >"$PCE/bin/uname"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PCE/bin/systemctl"
+printf '#!/usr/bin/env bash\nexec "$@"\n' >"$PCE/bin/sudo"
+chmod +x "$PCE/bin/uname" "$PCE/bin/systemctl" "$PCE/bin/sudo"
+
+pce_run() { # <engine> — render into $PCE/units with PITHEAD_ENGINE pinned to <engine>
+    (
+        cd "$PCE/mine" || exit
+        PATH="$PCE/bin:$PATH"
+        # shellcheck disable=SC1090
+        source "$STACK"
+        set +e
+        log() { :; }
+        PITHEAD_ENGINE="$1" PITHEAD_UNIT_DIR="$PCE/units" DASHBOARD_CONTROL_ENABLED=true \
+            CONTROL_DIR="$PCE/mine/data/control" provision_control_runner >/dev/null 2>&1
+    )
+}
+pce_seed_matching_path() { printf '[Path]\nPathExistsGlob=%s/data/control/requests/*.json\n' "$PCE/mine" >"$PCE/units/pithead-control.path"; }
+
+rm -f "$PCE/units"/*
+pce_run podman
+assert_contains "control unit pins the engine on a podman install" \
+    "$(cat "$PCE/units/pithead-control.service")" "Environment=PITHEAD_ENGINE=podman"
+# DETECTED, not hardcoded: the same renderer runs on the DIY Docker channel, where docker is right.
+# A fix that pinned podman unconditionally would break every Docker host, and would pass a test
+# that only ever checked the appliance.
+rm -f "$PCE/units"/*
+pce_run docker
+assert_contains "control unit pins DOCKER on a docker install, not a hardcoded podman" \
+    "$(cat "$PCE/units/pithead-control.service")" "Environment=PITHEAD_ENGINE=docker"
+assert_not_contains "the docker render carries no podman pin" \
+    "$(grep '^Environment=' "$PCE/units/pithead-control.service")" "podman"
+
+# THE ONE THAT NEARLY GOT AWAY. The idempotence skip returns early when the .path glob and the
+# ExecStart both match — which a unit written BEFORE the pin existed does. So a template-only fix
+# is silently inert on every already-provisioned box, including the one the defect was measured on.
+# The pin is part of the skip condition for exactly this reason.
+rm -f "$PCE/units"/*
+pce_seed_matching_path
+printf '[Service]\nType=oneshot\nUser=root\nWorkingDirectory=%s\nExecStart=%s/pithead control-run-pending\n' \
+    "$PCE/mine" "$PCE/mine" >"$PCE/units/pithead-control.service"
+pce_run podman
+assert_contains "a pre-pin unit is RE-RENDERED, not skipped (the fix reaches existing installs)" \
+    "$(cat "$PCE/units/pithead-control.service")" "Environment=PITHEAD_ENGINE=podman"
+
+# Control for the row above: the skip must still hold once the unit is correct, or the "fix" is
+# just a deleted idempotence check that rewrites the unit on every apply.
+pce_seed_matching_path
+cp "$PCE/units/pithead-control.service" "$PCE/units/.before"
+pce_run podman
+assert_eq "an already-pinned unit is still skipped (idempotence not simply removed)" \
+    "$(cmp -s "$PCE/units/.before" "$PCE/units/pithead-control.service" && echo same || echo rewritten)" "same"
+unset PCE
+unset -f pce_run pce_seed_matching_path

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -89,45 +89,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-recovery-address-gates.sh" && domain_
 _d0=$((PASS + FAIL)) && source "$HERE/test-p2pool-tari-off.sh" && domain_ran test-p2pool-tari-off.sh "$_d0" "$?" || domain_ran test-p2pool-tari-off.sh "$_d0" "$?"
 # shellcheck source=tests/stack/test-tari-mode-off.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-tari-mode-off.sh" && domain_ran test-tari-mode-off.sh "$_d0" "$?" || domain_ran test-tari-mode-off.sh "$_d0" "$?"
-# xmrig-proxy wrapper entrypoint: optional stratum access-password (#152). The flag moved out of the
-# compose command (a `${VAR:+--flag}` list element rendered a stray '' positional arg when the password
-# was unset — xmrig-proxy warns `unsupported non-option argument ''`) into this wrapper, which appends
-# it only when PROXY_STRATUM_PASSWORD is set. Exercise the real script with a stub xmrig-proxy on PATH
-# that echoes its argv, so the set/unset branch is actually run.
-XP_ENTRY="$ROOT/build/xmrig-proxy/entrypoint.sh"
-xp_argv() { # <password value> -> the argv the wrapper would exec
-    local d
-    mk_tmpdir d
-    printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
-    chmod +x "$d/xmrig-proxy"
-    PATH="$d:$PATH" PROXY_STRATUM_PASSWORD="$1" sh "$XP_ENTRY" --http-no-restricted --donate-level=0
-    rm -rf "$d"
-}
-assert_eq "xmrig-proxy entrypoint: unset password appends no flag (#152)" \
-    "$(xp_argv '')" "[--http-no-restricted][--donate-level=0]"
-assert_eq "xmrig-proxy entrypoint: set password appends --access-password (#152)" \
-    "$(xp_argv 's3cret')" "[--http-no-restricted][--donate-level=0][--access-password=s3cret]"
-# #261: the TLS cert flags append only when the toggle is on AND both keypair files exist at the
-# mount (PROXY_TLS_MOUNT overrides the fixed /tls so the suite can use a temp dir).
-xp_tls_argv() { # <PROXY_STRATUM_TLS value> <tls dir>
-    local d
-    mk_tmpdir d
-    printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
-    chmod +x "$d/xmrig-proxy"
-    PATH="$d:$PATH" PROXY_STRATUM_PASSWORD='' PROXY_STRATUM_TLS="$1" PROXY_TLS_MOUNT="$2" sh "$XP_ENTRY" -b 0.0.0.0:3333
-    rm -rf "$d"
-}
-mk_tmpdir XPTLS
-printf 'cert' >"$XPTLS/cert.pem"
-printf 'key' >"$XPTLS/key.pem"
-assert_eq "xmrig-proxy entrypoint: TLS on + keypair appends the cert flags (#261)" \
-    "$(xp_tls_argv true "$XPTLS")" "[-b][0.0.0.0:3333][--tls-cert=$XPTLS/cert.pem][--tls-cert-key=$XPTLS/key.pem]"
-assert_eq "xmrig-proxy entrypoint: TLS off appends nothing (#261)" \
-    "$(xp_tls_argv false "$XPTLS")" "[-b][0.0.0.0:3333]"
-rm -f "$XPTLS/key.pem"
-assert_eq "xmrig-proxy entrypoint: TLS on but keypair incomplete appends nothing (#261)" \
-    "$(xp_tls_argv true "$XPTLS")" "[-b][0.0.0.0:3333]"
-rm -rf "$XPTLS"
+
+# shellcheck source=tests/stack/test-xmrig-proxy-entrypoint.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-xmrig-proxy-entrypoint.sh" && domain_ran test-xmrig-proxy-entrypoint.sh "$_d0" "$?" || domain_ran test-xmrig-proxy-entrypoint.sh "$_d0" "$?"
 
 # shellcheck source=tests/stack/test-tor-network.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-tor-network.sh" && domain_ran test-tor-network.sh "$_d0" "$?" || domain_ran test-tor-network.sh "$_d0" "$?"

--- a/tests/stack/run.sh
+++ b/tests/stack/run.sh
@@ -96,6 +96,9 @@ _d0=$((PASS + FAIL)) && source "$HERE/test-xmrig-proxy-entrypoint.sh" && domain_
 # shellcheck source=tests/stack/test-tor-network.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/test-tor-network.sh" && domain_ran test-tor-network.sh "$_d0" "$?" || domain_ran test-tor-network.sh "$_d0" "$?"
 
+# shellcheck source=tests/stack/test-tor-egress-enforcement.sh disable=SC2015
+_d0=$((PASS + FAIL)) && source "$HERE/test-tor-egress-enforcement.sh" && domain_ran test-tor-egress-enforcement.sh "$_d0" "$?" || domain_ran test-tor-egress-enforcement.sh "$_d0" "$?"
+
 # shellcheck source=tests/stack/control/test-control-core.sh disable=SC2015
 _d0=$((PASS + FAIL)) && source "$HERE/control/test-control-core.sh" && domain_ran test-control-core.sh "$_d0" "$?" || domain_ran test-control-core.sh "$_d0" "$?"
 

--- a/tests/stack/test-tor-egress-enforcement.sh
+++ b/tests/stack/test-tor-egress-enforcement.sh
@@ -1,0 +1,119 @@
+# shellcheck shell=bash
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
+# Tor-egress ENFORCEMENT domain (#2059): does the product's stated security property hold at the one
+# place a shell can check it — the rules the kernel is actually holding?
+#
+# Split out of test-tor-network.sh (which owns the RENDERER and the transport switch) because these
+# assert a different thing about the same subsystem: not "is the right ruleset produced" but "did
+# anything confirm it landed, and does the machine say so when it did not". A fail-open appliance
+# shipped green through every battery to date precisely because nothing asked the second question —
+# apply logged "Tor-only egress enforced" off a zero exit from the install command, and doctor's
+# can't-check paths all degraded to info, so a box with no firewall exited 0 into the A/B commit
+# gate that os/overlay/pithead-boot uses to decide whether a slot is healthy enough to keep.
+#
+# Both halves now read the live state through one tor_egress_enforced(), so they belong in one
+# domain rather than on either side of an apply/doctor line they no longer sit across. Self-
+# contained stubs on purpose: a fragment that borrowed the neighbouring domain's $NFW/$DRBIN would
+# pass or fail on the order run.sh happens to source files in.
+# Sourced by tests/stack/run.sh.
+
+# A PATH with every *sbin* directory removed, so a test can drive the "privileged tool is not
+# installed" branch without uninstalling anything. nft and iptables both live in /usr/sbin; grep,
+# tr and printf — which sourcing pithead needs — do not, so what remains is still a working shell
+# environment. Callers pair this with an assertion that the tool really did disappear: a helper
+# that silently stopped working would otherwise turn a branch test into a tautology.
+path_without_sbin() {
+    local d out="" IFS=:
+    for d in $PATH; do
+        case "$d" in *sbin*) ;; *) out="${out:+$out:}$d" ;; esac
+    done
+    printf '%s' "$out"
+}
+
+EGV="$SANDBOX/egress-enforcement"
+mkdir -p "$EGV/bin" "$EGV/bin-nonft"
+# sudo that strips its OWN flags. The `exec "$@"` stub the renderer domain uses would try to exec
+# `-n`, which makes every readback read as "unreadable" and hides the branches under test here.
+cat >"$EGV/bin/sudo" <<'SUDO'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do case "$1" in -n | -H | -E) shift ;; *) break ;; esac; done
+exec "$@"
+SUDO
+# nft: `-f` always loads. The readback reports the table only when NFT_LIVE=1, so "the install
+# command exited zero" and "the rules are live" can disagree — the appliance's measured state.
+cat >"$EGV/bin/nft" <<'NFT'
+#!/usr/bin/env bash
+case "$*" in
+-f*)
+    cat >>"${NFT_RULESET:-/dev/null}"
+    exit 0
+    ;;
+"list tables")
+    echo "table inet netavark"
+    exit 0
+    ;;
+"list table inet pithead_egress")
+    [ "${NFT_LIVE:-0}" = 1 ] || exit 1
+    printf '%s\n' 'table inet pithead_egress {' '  chain forward {' \
+        '    type filter hook forward priority -5; policy accept;' \
+        '    ip saddr 172.28.0.0/24 drop' '  }' '}'
+    exit 0
+    ;;
+esac
+exit 0
+NFT
+# container_is_running shells out to `docker` whatever the engine is (podman-docker on the
+# appliance), so the doctor rows below need it to answer for the tor container.
+cat >"$EGV/bin/docker" <<'DOCKER'
+#!/usr/bin/env bash
+name=$(printf '%s' "$*" | sed -n 's/.*name=\^\([a-z0-9-]*\)\$.*/\1/p')
+case " ${RUNNING_CONTAINERS:-} " in *" $name "*) echo cid123 ;; esac
+exit 0
+DOCKER
+chmod +x "$EGV/bin/sudo" "$EGV/bin/nft" "$EGV/bin/docker"
+cp "$EGV/bin/sudo" "$EGV/bin/docker" "$EGV/bin-nonft/"
+printf 'NETWORK_SUBNET=172.28.0.0/24\nNETWORK_PREFIX=172.28.0\nTOR_EGRESS_FIREWALL=true\n' >"$EGV/.env"
+
+echo "== the #858 refusal must survive errexit, the way production runs it (#2059) =="
+# tests/stack/lib.sh's run_sourced does `set +e` before calling — precisely the condition production
+# does NOT have. pithead runs under `set -Eeuo pipefail`, where `br=$(mining_net_ipv6_bridge)` with a
+# non-zero return is a FAILING SIMPLE COMMAND: errexit fires and the shell is gone before the next
+# line can read $?. So the #858 refusal was green in the renderer domain and DEAD in the product — a
+# v6-capable mining_net killed `up` mid-stack_up with rc 3 and no message at all. Driving it with
+# errexit ON is the only way an assertion about that branch means anything.
+printf '#!/usr/bin/env bash\necho '"'"'[{"name":"mining_net","subnets":[{"subnet":"fd00:dead:beef::/64"}]}]'"'"'\n' >"$EGV/bin/podman"
+chmod +x "$EGV/bin/podman"
+: >"$EGV/nft.ruleset"
+ee_out="$(cd "$EGV" && PITHEAD_ENGINE=podman PATH="$EGV/bin:$PATH" NFT_RULESET="$EGV/nft.ruleset" bash -c "source '$STACK'; apply_tor_egress_firewall" 2>&1)"
+assert_rc "the refusal returns cleanly under errexit (it no longer dies at the assignment)" "$?" "0"
+assert_contains "the refusal under errexit still reaches its REFUSING warning" "$ee_out" "REFUSING"
+assert_eq "the refusal under errexit loads no ruleset (no half-open v4-only firewall)" "$(cat "$EGV/nft.ruleset")" ""
+rm -f "$EGV/bin/podman"
+
+echo "== apply only CLAIMS enforcement after reading the rules back (#2059) =="
+# The load succeeds and the live table is absent — the disagreement measured on the appliance. The
+# old code logged "Tor-only egress enforced" here, which is the line the whole defect hid behind.
+egv_out="$(PITHEAD_ENGINE=podman NFT_LIVE=0 PATH="$EGV/bin:$PATH" run_sourced "$EGV" apply_tor_egress_firewall 2>&1)"
+assert_not_contains "a load that did not land never claims 'Tor-only egress enforced'" "$egv_out" "Tor-only egress enforced"
+assert_contains "...and names which exit it took, for the bounded journal excerpt" "$egv_out" "egress-apply:verify-absent"
+# Same code, table live: the claim is earned, and no failure token rides along with it.
+egv_out="$(PITHEAD_ENGINE=podman NFT_LIVE=1 PATH="$EGV/bin:$PATH" run_sourced "$EGV" apply_tor_egress_firewall 2>&1)"
+assert_contains "a verified install DOES claim enforcement" "$egv_out" "Tor-only egress enforced"
+assert_not_contains "...and carries no egress-apply failure token" "$egv_out" "egress-apply:"
+
+echo "== a missing backend tool is NAMED by apply and FAILED by doctor (#2059) =="
+# nft lives in /usr/sbin, so dropping the sbin dirs removes the real one; $EGV/bin-nonft carries the
+# rest of the stubs without the nft stub. The precondition is asserted rather than assumed — a
+# helper that silently stopped working would turn both rows below into tautologies.
+assert_eq "harness: nft really is absent from the no-nft PATH" \
+    "$(PATH="$EGV/bin-nonft:$(path_without_sbin)" command -v nft 2>/dev/null || echo absent)" "absent"
+notool_out="$(PITHEAD_ENGINE=podman PATH="$EGV/bin-nonft:$(path_without_sbin)" run_sourced "$EGV" apply_tor_egress_firewall 2>&1)"
+assert_contains "no nft on PATH -> apply names that exit" "$notool_out" "egress-apply:nft-missing"
+assert_not_contains "no nft on PATH -> apply never claims enforcement" "$notool_out" "Tor-only egress enforced"
+# And the doctor half: engine podman with no nft binary means the firewall CANNOT be enforced, so
+# nothing is dropping. That used to take the same info-skip door as a sudo refusal — which is how a
+# leaking slot exited 0 and marked itself good. A missing tool is a CONFIRMED absence, not an
+# unknown; only a sudo refusal is an honest "I cannot tell", and that one still skips.
+notool_out="$(PITHEAD_ENGINE=podman RUNNING_CONTAINERS="tor" PATH="$EGV/bin-nonft:$(path_without_sbin)" run_sourced "$EGV" check_egress_firewall_installed 2>&1)"
+assert_contains "doctor (podman): no nft binary -> FAIL, not a skip" "$notool_out" "CANNOT be enforced"
+assert_not_contains "doctor (podman): a missing tool is not reported as a sudo problem" "$notool_out" "passwordless sudo"

--- a/tests/stack/test-xmrig-proxy-entrypoint.sh
+++ b/tests/stack/test-xmrig-proxy-entrypoint.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+: "${STACK_SUITE:?is unset: this file is a tests/stack/run.sh fragment, not a script — run tests/stack/run.sh}"
+# xmrig-proxy wrapper-entrypoint domain (#152/#261): the argv build/xmrig-proxy/entrypoint.sh execs.
+# Lifted verbatim out of run.sh, which is a domain REGISTRY and had this one block of test content
+# inlined in it. Sourced by tests/stack/run.sh.
+
+echo "== unit: xmrig-proxy wrapper entrypoint argv (#152/#261) =="
+# xmrig-proxy wrapper entrypoint: optional stratum access-password (#152). The flag moved out of the
+# compose command (a `${VAR:+--flag}` list element rendered a stray '' positional arg when the password
+# was unset — xmrig-proxy warns `unsupported non-option argument ''`) into this wrapper, which appends
+# it only when PROXY_STRATUM_PASSWORD is set. Exercise the real script with a stub xmrig-proxy on PATH
+# that echoes its argv, so the set/unset branch is actually run.
+XP_ENTRY="$ROOT/build/xmrig-proxy/entrypoint.sh"
+xp_argv() { # <password value> -> the argv the wrapper would exec
+    local d
+    mk_tmpdir d
+    printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
+    chmod +x "$d/xmrig-proxy"
+    PATH="$d:$PATH" PROXY_STRATUM_PASSWORD="$1" sh "$XP_ENTRY" --http-no-restricted --donate-level=0
+    rm -rf "$d"
+}
+assert_eq "xmrig-proxy entrypoint: unset password appends no flag (#152)" \
+    "$(xp_argv '')" "[--http-no-restricted][--donate-level=0]"
+assert_eq "xmrig-proxy entrypoint: set password appends --access-password (#152)" \
+    "$(xp_argv 's3cret')" "[--http-no-restricted][--donate-level=0][--access-password=s3cret]"
+# #261: the TLS cert flags append only when the toggle is on AND both keypair files exist at the
+# mount (PROXY_TLS_MOUNT overrides the fixed /tls so the suite can use a temp dir).
+xp_tls_argv() { # <PROXY_STRATUM_TLS value> <tls dir>
+    local d
+    mk_tmpdir d
+    printf '#!/bin/sh\nfor a in "$@"; do printf "[%%s]" "$a"; done\n' >"$d/xmrig-proxy"
+    chmod +x "$d/xmrig-proxy"
+    PATH="$d:$PATH" PROXY_STRATUM_PASSWORD='' PROXY_STRATUM_TLS="$1" PROXY_TLS_MOUNT="$2" sh "$XP_ENTRY" -b 0.0.0.0:3333
+    rm -rf "$d"
+}
+mk_tmpdir XPTLS
+printf 'cert' >"$XPTLS/cert.pem"
+printf 'key' >"$XPTLS/key.pem"
+assert_eq "xmrig-proxy entrypoint: TLS on + keypair appends the cert flags (#261)" \
+    "$(xp_tls_argv true "$XPTLS")" "[-b][0.0.0.0:3333][--tls-cert=$XPTLS/cert.pem][--tls-cert-key=$XPTLS/key.pem]"
+assert_eq "xmrig-proxy entrypoint: TLS off appends nothing (#261)" \
+    "$(xp_tls_argv false "$XPTLS")" "[-b][0.0.0.0:3333]"
+rm -f "$XPTLS/key.pem"
+assert_eq "xmrig-proxy entrypoint: TLS on but keypair incomplete appends nothing (#261)" \
+    "$(xp_tls_argv true "$XPTLS")" "[-b][0.0.0.0:3333]"
+rm -rf "$XPTLS"


### PR DESCRIPTION
**Closes #2059.** Root cause found on the bench, fixed, and the fix's own reach tested.

## The root cause

`pithead-control.service` was the one pithead unit with **no `PITHEAD_ENGINE`**. `pithead-boot`,
`pithead-firstboot` and `pithead-setup-again` each set it explicitly; this unit is rendered by the
CLI rather than shipped in `os/overlay/`, and it was missed. A systemd unit does not read
`/etc/environment` — that is PAM, for login shells — so the appliance image's own pin never reached
it either.

`container_engine()` then falls through to probing, and the probe prefers `docker`. **`docker`
exists on the appliance**: `os/rootfs/Dockerfile` installs `podman-docker`, which ships
`/usr/bin/docker` as a shim onto podman. So every dashboard-driven apply resolved `docker` on a
podman/netavark box and took the Docker branch: `remove_tor_egress_firewall` (engine-agnostic)
deleted the live `inet pithead_egress` table, and the rules went into **DOCKER-USER — the chain
netavark never jumps to.** #855's failure mode, through the one path #855 did not cover.

**Measured, not inferred.** One apply from `_SYSTEMD_UNIT=pithead-control.service`, in order,
all inside one second:

```
nft delete table inet pithead_egress
iptables-save
iptables -N DOCKER-USER
iptables -I DOCKER-USER 1..7      ← ending "-s <subnet> -j DROP" at position 7
iptables -S ; iptables -S DOCKER-USER
```

No nft load after the delete. Table absent at the next two probes, clearnet dial succeeded, and it
returned only after the reboot — when `pithead-boot`, which *does* pin the engine, ran its own `up`.

The battery also ran the experiment for us: **two doctor runs, four seconds apart, one guest.** The
commit gate invokes `PITHEAD_ENGINE=podman ./pithead doctor --json` and passed at 16:06:15; the
control runner, unpinned, failed at 16:06:19. One variable between them.

## The fix

`Environment=PITHEAD_ENGINE=<detected engine>` on the rendered unit — **detected, never hardcoded**,
because the same renderer runs on the DIY Docker channel where `docker` is correct. The unit
inherits whatever the install was provisioned with.

The pin is part of the **idempotence skip**, not just the template. The skip returns early when the
`.path` glob and `ExecStart` both match — which every unit written before this commit does — so a
template-only fix would have been **silently inert on every already-provisioned box, including the
one this was measured on.** A paired row asserts the skip still holds once a unit is correct, so the
fix cannot be mistaken for a deleted idempotence check.

## Also in this PR

The earlier commit makes the firewall **prove itself**: `tor_egress_enforced()` reads live kernel
state, both backends report through it, and every failure carries an `egress-apply:<reason>` token
so a bounded journal excerpt names which exit fired. `doctor` no longer info-skips a *missing*
backend tool — a confirmed absence FAILs; only an unreadable ruleset still skips. That is what made
this root cause findable: the token count and the verified install at firstboot are how we knew the
first apply was genuine and a *later* one destroyed it.

Note its limitation, stated plainly: that readback branches on the same `container_engine()` as the
install, so it **cannot** catch a misdetected engine. The engine pin is what closes the issue.

## What this does not claim — corrected after the bench ran

An earlier revision of this description said the two rows the previous head regressed would turn
green with the engine pinned, because a false `dr_fail` was their trigger. **That prediction was
stated before the run, scored against it, and was wrong.** Both rows are still red on this head, and
the full unit + system journals show they are *two different mechanisms*, neither of them the one I
named:

**The benign-setting and hostname-approval rows are not this PR.** The control runner is killed from
outside by `SIGTERM`, in a stop-path → `daemon-reload` → start-path sequence issued by a `systemctl`
running in an **SSH session on the host** (the reload client's unit is `ssh.service`, not the
runner's cgroup). The same triplet ran twice more in the same job when no control service was
running, so it is a routine of whatever drives the guest; the third time it landed mid-request. The
apply was 3.4 s into `compose up` when it died. That is a test-harness defect and it gets its own
issue.

**The doctor row is a consequence of this fix being correct.** Unpinned, the runner resolved `docker`
and took the iptables branch, where an absent `DOCKER-USER` info-skips. Pinned, it correctly takes
the nft branch — where an absent table has always been a FAIL, on `develop` as much as here. During
the ~30 s window after a reboot before `pithead-boot` reinstalls the firewall (measured: table absent
at 10 s uptime, present by 31 s; the control run starts inside it), doctor reports the truth: not
enforced. It exits non-zero, and **a failing `doctor` takes the control runner down instead of
returning a `failed` result** — child aborts, parent dies 2 ms later, `Result=exit-code`, no signal.

That last fact is **pre-existing and exposed by this PR, not introduced by it**, and it is the one
thing here I have not been able to explain: the same failing-doctor path survives on a head without
this fix, and I cannot yet reconcile that. It is filed separately with the journal artifacts rather
than guessed at in a commit. Three mechanisms I proposed for it were refuted by measurement and
withdrawn; I am not shipping a fourth.

## Verification

`make test-stack` in the pinned Linux image: **4014 passed, 0 failed** (3997 on this branch's
merge-base, measured; +17, none removed).

**Firing controls, both directions.** Reverting only `lib/pithead/02-tor-egress.sh` and
`21-doctor-stack-checks.sh`, tests kept: 4004 / 6 failed. Reverting only
`lib/pithead/50-control-runner-provisioning.sh`, tests kept: 4011 / 3 failed — the discriminating
rows and only those.

**tier4-e2e `mode=check`** on the previous head: **67 passed, 0 failed**, including
`doctor: egress firewall installed (#383)` and the #274/#270 no-clearnet-leak row. The Docker
channel is unaffected.

**tier4-kvm `phases=provision`** on `a35769e75a` (jobs 24/25) reproduced the defect with the full
six-probe diagnostic block, which is what located it, and confirmed the row passing there — but
that was before `35b9e8b0`, `03948e7d`, `4f4cc64a` and `58384fb9` rewrote `tor_egress_enforced()`
itself (both the nft and iptables branches: structural JSON precedence checking instead of two
independent greps, a here-string instead of a `grep -q` behind a pipe, and the iptables
reachability/precedence walk). A prior review correctly flagged that no tier4-kvm run existed for
the rewritten logic or for this branch's actual head.

**tier4-kvm `phases=provision` on this head, `c09ad06d`** (job 80, `baseline_verified: true`):
against a *real kernel*, `direct clearnet dial from a mining container is dropped — Tor-only
egress is enforced` **passes**, and `egress through Tor's SOCKS still works` passes alongside it —
the rewritten detection logic is confirmed against live nftables/iptables state, not fixture text.

Job 80 also shows 8 unrelated failures (a doctor/control-runner report row, a dashboard-backup
row, a hostname-commit row, four rows in the Tari-off leg, and the known `v99.0.0` migration-tag
environmental failure). None of these are new: the same nightly `tier4-kvm` run on `develop`
itself, **before** this fix (job 71, commit `c7b53696`), shows the identical 8 rows red — *and*
shows `clearnet egress is FAIL-OPEN — monerod reached 1.1.1.1 directly, bypassing Tor` failing,
which this branch's job 80 does not. The 8 shared failures are pre-existing and already tracked:
#2093 (doctor kills the control runner), #2097 and #2094 (hostname commit SIGTERM'd by the OS
battery's own SSH session), #2111 (the Tari-off leg's four rows). The migration-tag failure is a
`v99.0.0`-tag lookup against origin, unrelated to this branch's code.

**Update — real-kernel coverage at the actual PR head.** A review return correctly noted that job 80
predates this PR's last functional commit, `55f714ce`, which rewrites the nft branch's
unconditional-accept shadow check (the exact mechanism the security review found falsifiable via
`counter accept`/`log accept`). **tier4-kvm `phases=provision`, job 87, commit `0744ebed`
(this PR's head), `baseline_verified: true`:** against a real kernel, both egress assertions pass —
`direct clearnet dial from a mining container is dropped — Tor-only egress is enforced` and
`egress through Tor's SOCKS still works` — confirming the rewritten (and security-fixed) detection
logic on live nftables/netavark state, not fixture text. The same 8 unrelated rows are red, in the
same categories, for the same already-tracked reasons as job 80 above; nothing new appeared.

## Security review found a real false-"enforced" bug, fixed

A `security-reviewer` pass over the rewritten `tor_egress_enforced()` found that the nft branch's
unconditional-accept shadow check matched a rule's whole statement list byte-for-byte against a
bare `accept` — so `counter accept` and `log accept`, the standard nftables idioms for a visible,
audited allow-all, read as "conditional," and a drop shadowed by either one still reported
"enforced" while traffic actually passed. That is the exact failure mode this PR exists to close,
just reached through a different rule shape than #855's.

Fixed at `55f714ce`: the check now asks whether any statement ahead of the verdict carries a real
`match` condition (address, port, protocol, ct state — everything nftables actually filters on
surfaces under that key in `nft -j` output), not whether the rule is byte-identical to a bare
accept. Two new fixtures in `tests/stack/test-tor-egress-enforcement.sh` reproduce the bug and its
fix directly (`counter accept` must still read as shadowing; a genuinely scoped `match`+accept
must not). Also quotes `$subnet` into a literal `grep` instead of splicing it into a shell `case`
glob, so a glob metacharacter in `NETWORK_SUBNET` can't change what matches (low-severity nit,
same pass).

Rebuilt (`scripts/build-pithead.sh`) and `shellcheck --severity=warning` clean on the generated CLI
(pinned version 0.11.0, matches CI). **bench-ci tier1 `targets=test-stack`, job 81, commit
`55f714ce`**: `conclusion: success`, `exit_code: 0`, `baseline_verified: true` — the fix and both
new fixtures pass on Linux (macOS is not a trusted platform for this suite, #2041).

The same review also found, and I am shipping disclosed rather than blocking on: the iptables
branch's foreign-rule shadow check recognizes a rule scoped to exactly the mining subnet, but not
one scoped to a wider network that contains it (a supernet) — filed as
[pithead#2117](https://github.com/p2pool-starter-stack/pithead/issues/2117) with the exact case
and the CIDR-containment fix to make. This predates this PR's rewrite (the code's own comment
already called it a "KNOWN GAP"); closing it needs real CIDR arithmetic I have no remaining bench
budget in this session to validate against real hardware, and the alternative — flagging every
`-s`-scoped foreign rule — would cry wolf on every host that shares `DOCKER-USER` with another
Compose project, per the code's own reasoning. Documented for operators in `docs/privacy.md`:

> **Known limitation, Docker (DIY) channel only** (tracked in
> [pithead#2117](https://github.com/p2pool-starter-stack/pithead/issues/2117)): the enforcement
> check above walks `DOCKER-USER` looking for a rule that would shadow our DROP, but it only
> recognizes a foreign rule as shadowing when that rule is unscoped or scoped to exactly the mining
> subnet. A foreign rule scoped to a *wider* network that happens to contain the mining subnet —
> written by something else that shares the chain, such as ufw-docker or a second Compose project —
> is not recognized, so `pithead doctor` can report "Tor-only egress enforced" while that wider rule
> is actually the one deciding. This only matters if something else on the same host also writes
> rules into `DOCKER-USER`; the podman/netavark appliance path does not have this gap. To check for
> it by hand, run `sudo iptables -S DOCKER-USER` and look above the `pithead-tor-egress`-tagged
> `DROP` line: if any `ACCEPT` or `RETURN` rule there is scoped with `-s` to a network wider than
> your mining subnet, that rule can shadow the DROP no matter what `doctor` reports. If you find one,
> narrow or remove it — `pithead` cannot do this for you.

## Commits

1. `test(stack)` — pure move of an inlined test block out of `run.sh`, to make budget room for a
   new domain to register. CONTRIBUTING's one legal path for that.
2. `fix(egress)` — the firewall proves itself; doctor can fail; reason tokens.
3. `fix(control)` — the engine pin. The root cause.
4. `fix(egress)` (`35b9e8b0`) — the iptables backend must prove reachability (the `FORWARD ->
   DOCKER-USER` jump), not just rule presence.
5. `fix(egress)` (`03948e7d`) — a `grep -q` behind a pipe fires the guard on a successful match
   under `pipefail`; switched to a here-string.
6. `fix(egress)` (`4f4cc64a`) — "enforced" must mean the installed DROP is what decides: the nft
   branch now checks structurally (JSON, hook + precedence) instead of two independent greps that
   a table satisfies when the hooked chain only accepts and some other chain merely contains the
   word "drop".
7. `fix(egress)` (`58384fb9`) — closes four gaps a re-review found in commits 4–6: the iptables
   precedence walk, jq/tool-absence handling, and the doctor-facing warning strings for the two new
   return codes (4: rules present but unreachable; 5: reachable but shadowed by a foreign rule).
8. `fix(egress)` (`55f714ce`) — closes a false-"enforced" gap a security review found in commit 6:
   `counter accept`/`log accept` above the drop now still count as shadowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




